### PR TITLE
Update braille when tethered to review but review cursor does not follow caret

### DIFF
--- a/source/braille.py
+++ b/source/braille.py
@@ -2468,6 +2468,16 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 		if shouldAutoTether:
 			self.setTether(TetherTo.FOCUS.value, auto=True)
 		if self._tether != TetherTo.FOCUS.value:
+			# However, braille display content is updated in case where:
+	# braille is tethered to review, review cursor does not follow system caret,
+			# and navigator object is focus object or its ancestor.
+			if (
+				not config.conf["reviewCursor"]["followCaret"]
+				and config.conf["braille"]["tetherTo"] == TetherTo.REVIEW.value
+			):
+				navigatorObject: NVDAObject = api.getNavigatorObject()
+				if navigatorObject == api.getFocusObject() or navigatorObject in api.getFocusAncestors():
+					self.handleUpdate(navigatorObject)
 			return
 		region = self.mainBuffer.regions[-1] if self.mainBuffer.regions else None
 		if region and region.obj==obj:

--- a/source/braille.py
+++ b/source/braille.py
@@ -2469,7 +2469,7 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 			self.setTether(TetherTo.FOCUS.value, auto=True)
 		if self._tether != TetherTo.FOCUS.value:
 			# However, braille display content is updated in case where:
-	# braille is tethered to review, review cursor does not follow system caret,
+			# braille is tethered to review, review cursor does not follow system caret,
 			# and navigator object is focus object or its ancestor.
 			if (
 				not config.conf["reviewCursor"]["followCaret"]

--- a/source/braille.py
+++ b/source/braille.py
@@ -2468,16 +2468,12 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 		if shouldAutoTether:
 			self.setTether(TetherTo.FOCUS.value, auto=True)
 		if self._tether != TetherTo.FOCUS.value:
-			# However, braille display content is updated in case where:
+			# Braille display content is updated in case where:
 			# braille is tethered to review, review cursor does not follow system caret,
-			# and navigator object is focus object or its ancestor.
-			if (
-				not config.conf["reviewCursor"]["followCaret"]
-				and config.conf["braille"]["tetherTo"] == TetherTo.REVIEW.value
-			):
-				navigatorObject: NVDAObject = api.getNavigatorObject()
-				if navigatorObject == api.getFocusObject() or navigatorObject in api.getFocusAncestors():
-					self.handleUpdate(navigatorObject)
+			# and focus object is navigator object.
+			if not config.conf["reviewCursor"]["followCaret"]:
+				if obj == api.getNavigatorObject():
+					self.handleUpdate(obj)
 			return
 		region = self.mainBuffer.regions[-1] if self.mainBuffer.regions else None
 		if region and region.obj==obj:

--- a/source/review.py
+++ b/source/review.py
@@ -162,15 +162,20 @@ def handleCaretMove(pos: Union[textInfos.TextInfo, NVDAObject, TreeInterceptor])
 	"""
 	Instructs the review position to be updated due to caret movement.
 	Note: When braille is explicitly tethered to review, and review cursor
-	does not follow system caret, braille display is however updated
-	if content of current navigator object changes.
+	does not follow system caret, braille display is however updated if:
+
+	- navigator object is focus object or its ancestor and
+	- content of navigator object changes.
+
 	@param pos: Either a TextInfo instance at the caret position,
 	or an NVDAObject or TreeInterceptor who's caret position should be retrieved.
 	@type pos: L{textInfos.TextInfo} or L{NVDAObject} or L{TreeInterceptor}
 	"""
 	if not config.conf["reviewCursor"]["followCaret"]:
 		if config.conf["braille"]["tetherTo"] == TetherTo.REVIEW.value:
-			braille.handler.handleUpdate(api.getNavigatorObject())
+			navigatorObject: NVDAObject = api.getNavigatorObject()
+			if navigatorObject == api.getFocusObject() or navigatorObject in api.getFocusAncestors():
+				braille.handler.handleUpdate(navigatorObject)
 		return
 	if isinstance(pos,textInfos.TextInfo):
 		info=pos

--- a/source/review.py
+++ b/source/review.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2013-2023 NV Access Limited, Burman's Computer and Education Ltd.
+# Copyright (C) 2013-2022 NV Access Limited
 # This file may be used under the terms of the GNU General Public License, version 2 or later.
 # For more details see: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -10,19 +10,14 @@ from typing import (
 
 import api
 from baseObject import ScriptableObject
-import braille
 import winUser
 from logHandler import log
 from NVDAObjects import NVDAObject, NVDAObjectTextInfo
 from NVDAObjects.window import Window
-from treeInterceptorHandler import (
-	DocumentTreeInterceptor,
-	TreeInterceptor,
-)
+from treeInterceptorHandler import DocumentTreeInterceptor
 from displayModel import DisplayModelTextInfo
 import textInfos
 import config
-from config.configFlags import TetherTo
 
 def getObjectPosition(obj):
 	"""
@@ -157,25 +152,13 @@ def nextMode(prev=False,startMode=None):
 	label=setCurrentMode(newMode)
 	return label or nextMode(prev=prev,startMode=newMode)
 
-
-def handleCaretMove(pos: Union[textInfos.TextInfo, NVDAObject, TreeInterceptor]) -> None:
+def handleCaretMove(pos):
 	"""
 	Instructs the review position to be updated due to caret movement.
-	Note: When braille is explicitly tethered to review, and review cursor
-	does not follow system caret, braille display is however updated if:
-
-	- navigator object is focus object or its ancestor and
-	- content of navigator object changes.
-
-	@param pos: Either a TextInfo instance at the caret position,
-	or an NVDAObject or TreeInterceptor who's caret position should be retrieved.
+	@param pos: Either a TextInfo instance at the caret position, or an NVDAObject or TeeInterceptor who's caret position should be retreaved.
 	@type pos: L{textInfos.TextInfo} or L{NVDAObject} or L{TreeInterceptor}
 	"""
 	if not config.conf["reviewCursor"]["followCaret"]:
-		if config.conf["braille"]["tetherTo"] == TetherTo.REVIEW.value:
-			navigatorObject: NVDAObject = api.getNavigatorObject()
-			if navigatorObject == api.getFocusObject() or navigatorObject in api.getFocusAncestors():
-				braille.handler.handleUpdate(navigatorObject)
 		return
 	if isinstance(pos,textInfos.TextInfo):
 		info=pos


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/wiki/Contributing.
-->

### Link to issue number:
15115
### Summary of the issue:
I think use case is mainly with terminal software like Putty or Teraterm when remotely managing Linux systems from command line using non-graphical user interface (typically shell like bash).

Caret is not always "real cursor", and following caret may be useless or harmful because it may lead to wrong location in window. Content of terminal window is often explored with review cursor.

When using review cursor, so that it does not follow caret, gives better possibilities to review window content because key presses or other things which trigger cursor movement do not affect on review position. However, although content which braille display is currently showing would change for example due to key press, braille display is not updated automatically. Automatic update would facilitate detection of changes and thus remote management.
### Description of user facing changes
When braille is explicitly tethered to review, and review cursor does not follow system caret, braille display content is updated if:

- focus object is navigator object and
- content which should be shown on braille display changes or updates due to caret movement.

At the moment I think a setting for this would be somewhat redundant. Currently there is no changes in user guide because it does not seem to define braille behavior when braille is tethered to review and review cursor does not follow system caret.
### Description of development approach
Implementation is in BrailleHandler.handleCaretMove function in braille.py.
### Testing strategy:
Tested with Putty and Albatross 80 model.
### Known issues with pull request:
none
### Change log entries:
New features
Changes
When braille is explicitly tethered to review and review cursor does not follow system caret, braille display content is updated if:

- focus object is navigator object and
- content which should be shown on braille display changes or updates due to caret movement.
Bug fixes
For Developers

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
