### PR TITLE
Add-on store: support localisation for installed add-ons

### DIFF
--- a/source/_addonStore/models/addon.py
+++ b/source/_addonStore/models/addon.py
@@ -56,8 +56,10 @@ class _AddonGUIModel(SupportsAddonState, SupportsVersionCheck, Protocol):
 	May come from manifest or add-on store data.
 	"""
 	addonId: str
-	displayName: str
-	description: str
+	_displayName: str
+	"""Untranslated displayName"""
+	_description: str
+	"""Untranslated description"""
 	publisher: str
 	addonVersionName: str
 	channel: Channel
@@ -69,6 +71,24 @@ class _AddonGUIModel(SupportsAddonState, SupportsVersionCheck, Protocol):
 	Legacy add-ons contain invalid metadata
 	and should not be accessible through the add-on store.
 	"""
+
+	@property
+	def displayName(self) -> str:
+		installedAddon = self._addonHandlerModel
+		if installedAddon:
+			# Fetches translated string
+			return installedAddon.manifest["summary"]
+		else:
+			return self._displayName
+
+	@property
+	def description(self) -> str:
+		installedAddon = self._addonHandlerModel
+		if installedAddon:
+			# Fetches translated string
+			return installedAddon.manifest["description"]
+		else:
+			return self._description
 
 	@property
 	def minimumNVDAVersion(self) -> addonAPIVersion.AddonApiVersionT:
@@ -115,8 +135,8 @@ class AddonGUIModel(_AddonGUIModel):
 	May come from manifest or add-on store data.
 	"""
 	addonId: str
-	displayName: str
-	description: str
+	_displayName: str
+	_description: str
 	publisher: str
 	addonVersionName: str
 	channel: Channel
@@ -136,8 +156,8 @@ class AddonStoreModel(_AddonGUIModel):
 	Data from an add-on from the add-on store.
 	"""
 	addonId: str
-	displayName: str
-	description: str
+	_displayName: str
+	_description: str
 	publisher: str
 	addonVersionName: str
 	channel: Channel
@@ -211,8 +231,8 @@ class CachedAddonsModel:
 def _createStoreModelFromData(addon: Dict[str, Any]) -> AddonStoreModel:
 	return AddonStoreModel(
 		addonId=addon["addonId"],
-		displayName=addon["displayName"],
-		description=addon["description"],
+		_displayName=addon["displayName"],
+		_description=addon["description"],
 		publisher=addon["publisher"],
 		channel=Channel(addon["channel"]),
 		addonVersionName=addon["addonVersionName"],
@@ -230,14 +250,14 @@ def _createStoreModelFromData(addon: Dict[str, Any]) -> AddonStoreModel:
 
 
 def _createGUIModelFromManifest(addon: "AddonHandlerBaseModel") -> AddonGUIModel:
-	homepage = addon.manifest.get("url")
+	homepage: Optional[str] = addon.manifest.get("url")
 	if homepage == "None":
 		# Manifest strings can be set to "None"
 		homepage = None
 	return AddonGUIModel(
 		addonId=addon.name,
-		displayName=addon.manifest["summary"],
-		description=addon.manifest["description"],
+		_displayName=addon.manifest["summary"],
+		_description=addon.manifest["description"],
 		publisher=addon.manifest["author"],
 		channel=Channel.EXTERNAL,
 		addonVersionName=addon.version,

--- a/source/_addonStore/models/addon.py
+++ b/source/_addonStore/models/addon.py
@@ -111,7 +111,7 @@ class _AddonGUIModel(SupportsAddonState, SupportsVersionCheck, Protocol):
 
 
 @dataclasses.dataclass(frozen=True)
-class AddonManifestGUIModel(_AddonGUIModel):
+class AddonManifestModel(_AddonGUIModel):
 	"""Can be displayed in the add-on store GUI.
 	Comes from add-on manifest.
 	"""
@@ -240,12 +240,12 @@ def _createStoreModelFromData(addon: Dict[str, Any]) -> AddonStoreModel:
 	)
 
 
-def _createGUIModelFromManifest(addon: "AddonHandlerBaseModel") -> AddonManifestGUIModel:
+def _createGUIModelFromManifest(addon: "AddonHandlerBaseModel") -> AddonManifestModel:
 	homepage: Optional[str] = addon.manifest.get("url")
 	if homepage == "None":
 		# Manifest strings can be set to "None"
 		homepage = None
-	return AddonManifestGUIModel(
+	return AddonManifestModel(
 		addonId=addon.name,
 		channel=Channel.EXTERNAL,
 		addonVersionName=addon.version,

--- a/source/_addonStore/models/status.py
+++ b/source/_addonStore/models/status.py
@@ -25,7 +25,7 @@ from utils.displayString import DisplayStringEnum
 from .version import SupportsVersionCheck
 
 if TYPE_CHECKING:
-	from .addon import AddonGUIModel  # noqa: F401
+	from .addon import AddonManifestGUIModel  # noqa: F401
 	from addonHandler import AddonsState  # noqa: F401
 
 
@@ -144,7 +144,7 @@ class AddonStateCategory(str, enum.Enum):
 	"""Add-ons that are blocked from running because they are incompatible"""
 
 
-def getStatus(model: "AddonGUIModel") -> Optional[AvailableAddonStatus]:
+def getStatus(model: "AddonManifestGUIModel") -> Optional[AvailableAddonStatus]:
 	from addonHandler import (
 		state as addonHandlerState,
 	)

--- a/source/_addonStore/models/status.py
+++ b/source/_addonStore/models/status.py
@@ -25,7 +25,7 @@ from utils.displayString import DisplayStringEnum
 from .version import SupportsVersionCheck
 
 if TYPE_CHECKING:
-	from .addon import AddonManifestGUIModel  # noqa: F401
+	from .addon import _AddonGUIModel  # noqa: F401
 	from addonHandler import AddonsState  # noqa: F401
 
 
@@ -144,7 +144,7 @@ class AddonStateCategory(str, enum.Enum):
 	"""Add-ons that are blocked from running because they are incompatible"""
 
 
-def getStatus(model: "AddonManifestGUIModel") -> Optional[AvailableAddonStatus]:
+def getStatus(model: "_AddonGUIModel") -> Optional[AvailableAddonStatus]:
 	from addonHandler import (
 		state as addonHandlerState,
 	)

--- a/source/_addonStore/models/version.py
+++ b/source/_addonStore/models/version.py
@@ -37,7 +37,7 @@ class SupportsVersionCheck(Protocol):
 	""" Examples implementing this protocol include:
 	- addonHandler.Addon
 	- addonHandler.AddonBundle
-	- _addonStore.models.AddonGUIModel
+	- _addonStore.models.AddonManifestGUIModel
 	- _addonStore.models.AddonStoreModel
 	"""
 	minimumNVDAVersion: addonAPIVersion.AddonApiVersionT

--- a/source/_addonStore/models/version.py
+++ b/source/_addonStore/models/version.py
@@ -38,7 +38,7 @@ class SupportsVersionCheck(Protocol):
 	- addonHandler.Addon
 	- addonHandler.AddonBundle
 	- _addonStore.models._AddonGUIModel
-	- _addonStore.models.AddonManifestGUIModel
+	- _addonStore.models.AddonManifestModel
 	- _addonStore.models.AddonStoreModel
 	"""
 	minimumNVDAVersion: addonAPIVersion.AddonApiVersionT

--- a/source/_addonStore/models/version.py
+++ b/source/_addonStore/models/version.py
@@ -37,6 +37,7 @@ class SupportsVersionCheck(Protocol):
 	""" Examples implementing this protocol include:
 	- addonHandler.Addon
 	- addonHandler.AddonBundle
+	- _addonStore.models._AddonGUIModel
 	- _addonStore.models.AddonManifestGUIModel
 	- _addonStore.models.AddonStoreModel
 	"""

--- a/source/addonHandler/__init__.py
+++ b/source/addonHandler/__init__.py
@@ -57,7 +57,7 @@ from .packaging import (
 
 if TYPE_CHECKING:
 	from _addonStore.models.addon import (  # noqa: F401
-		AddonGUIModel,
+		AddonManifestGUIModel,
 		AddonHandlerModelGeneratorT,
 		AddonStoreModel,
 	)
@@ -392,7 +392,7 @@ class AddonBase(SupportsAddonState, SupportsVersionCheck, ABC):
 		return addonDataManager._getCachedInstalledAddonData(self.name)
 
 	@property
-	def _addonGuiModel(self) -> "AddonGUIModel":
+	def _addonGuiModel(self) -> "AddonManifestGUIModel":
 		from _addonStore.models.addon import _createGUIModelFromManifest
 		return _createGUIModelFromManifest(self)
 

--- a/source/addonHandler/__init__.py
+++ b/source/addonHandler/__init__.py
@@ -57,7 +57,7 @@ from .packaging import (
 
 if TYPE_CHECKING:
 	from _addonStore.models.addon import (  # noqa: F401
-		AddonManifestGUIModel,
+		AddonManifestModel,
 		AddonHandlerModelGeneratorT,
 		AddonStoreModel,
 	)
@@ -392,7 +392,7 @@ class AddonBase(SupportsAddonState, SupportsVersionCheck, ABC):
 		return addonDataManager._getCachedInstalledAddonData(self.name)
 
 	@property
-	def _addonGuiModel(self) -> "AddonManifestGUIModel":
+	def _addonGuiModel(self) -> "AddonManifestModel":
 		from _addonStore.models.addon import _createGUIModelFromManifest
 		return _createGUIModelFromManifest(self)
 

--- a/source/gui/_addonStoreGui/controls/messageDialogs.py
+++ b/source/gui/_addonStoreGui/controls/messageDialogs.py
@@ -10,7 +10,7 @@ from typing import (
 import wx
 
 import addonAPIVersion
-from _addonStore.models.addon import AddonGUIModel
+from _addonStore.models.addon import AddonManifestGUIModel
 from gui.addonGui import ErrorAddonInstallDialog
 from gui.message import messageBox
 
@@ -49,7 +49,7 @@ class ErrorAddonInstallDialogWithYesNoButtons(ErrorAddonInstallDialog):
 
 def _shouldProceedWhenInstalledAddonVersionUnknown(
 		parent: wx.Window,
-		addon: AddonGUIModel
+		addon: AddonManifestGUIModel
 ) -> bool:
 	# an installed add-on should have an addon Handler Model
 	assert addon._addonHandlerModel
@@ -97,7 +97,7 @@ def _shouldProceedToRemoveAddonDialog(
 
 def _shouldInstallWhenAddonTooOldDialog(
 		parent: wx.Window,
-		addon: AddonGUIModel
+		addon: AddonManifestGUIModel
 ) -> bool:
 	incompatibleMessage = pgettext(
 		"addonStore",
@@ -126,7 +126,7 @@ def _shouldInstallWhenAddonTooOldDialog(
 
 def _shouldEnableWhenAddonTooOldDialog(
 		parent: wx.Window,
-		addon: AddonGUIModel
+		addon: AddonManifestGUIModel
 ) -> bool:
 	incompatibleMessage = pgettext(
 		"addonStore",
@@ -153,7 +153,7 @@ def _shouldEnableWhenAddonTooOldDialog(
 	).ShowModal() == wx.YES
 
 
-def _showAddonInfo(addon: AddonGUIModel) -> None:
+def _showAddonInfo(addon: AddonManifestGUIModel) -> None:
 	message = [
 		pgettext(
 			"addonStore",

--- a/source/gui/_addonStoreGui/controls/messageDialogs.py
+++ b/source/gui/_addonStoreGui/controls/messageDialogs.py
@@ -10,7 +10,7 @@ from typing import (
 import wx
 
 import addonAPIVersion
-from _addonStore.models.addon import AddonManifestGUIModel
+from _addonStore.models.addon import _AddonGUIModel
 from gui.addonGui import ErrorAddonInstallDialog
 from gui.message import messageBox
 
@@ -49,7 +49,7 @@ class ErrorAddonInstallDialogWithYesNoButtons(ErrorAddonInstallDialog):
 
 def _shouldProceedWhenInstalledAddonVersionUnknown(
 		parent: wx.Window,
-		addon: AddonManifestGUIModel
+		addon: _AddonGUIModel
 ) -> bool:
 	# an installed add-on should have an addon Handler Model
 	assert addon._addonHandlerModel
@@ -97,7 +97,7 @@ def _shouldProceedToRemoveAddonDialog(
 
 def _shouldInstallWhenAddonTooOldDialog(
 		parent: wx.Window,
-		addon: AddonManifestGUIModel
+		addon: _AddonGUIModel
 ) -> bool:
 	incompatibleMessage = pgettext(
 		"addonStore",
@@ -126,7 +126,7 @@ def _shouldInstallWhenAddonTooOldDialog(
 
 def _shouldEnableWhenAddonTooOldDialog(
 		parent: wx.Window,
-		addon: AddonManifestGUIModel
+		addon: _AddonGUIModel
 ) -> bool:
 	incompatibleMessage = pgettext(
 		"addonStore",
@@ -153,7 +153,7 @@ def _shouldEnableWhenAddonTooOldDialog(
 	).ShowModal() == wx.YES
 
 
-def _showAddonInfo(addon: AddonManifestGUIModel) -> None:
+def _showAddonInfo(addon: _AddonGUIModel) -> None:
 	message = [
 		pgettext(
 			"addonStore",

--- a/source/gui/_addonStoreGui/viewModels/addonList.py
+++ b/source/gui/_addonStoreGui/viewModels/addonList.py
@@ -20,7 +20,7 @@ from typing import (
 from requests.structures import CaseInsensitiveDict
 
 from _addonStore.models.addon import (
-	AddonManifestGUIModel,
+	_AddonGUIModel,
 )
 from _addonStore.models.status import (
 	_StatusFilterKey,
@@ -86,15 +86,15 @@ class AddonListField(_AddonListFieldData, Enum):
 class AddonListItemVM:
 	def __init__(
 			self,
-			model: AddonManifestGUIModel,
+			model: _AddonGUIModel,
 			status: AvailableAddonStatus = AvailableAddonStatus.AVAILABLE
 	):
-		self._model: AddonManifestGUIModel = model  # read-only
+		self._model: _AddonGUIModel = model  # read-only
 		self._status: AvailableAddonStatus = status  # modifications triggers L{updated.notify}
 		self.updated = extensionPoints.Action()  # Notify of changes to VM, argument: addonListItemVM
 
 	@property
-	def model(self) -> AddonManifestGUIModel:
+	def model(self) -> _AddonGUIModel:
 		return self._model
 
 	@property

--- a/source/gui/_addonStoreGui/viewModels/addonList.py
+++ b/source/gui/_addonStoreGui/viewModels/addonList.py
@@ -20,7 +20,7 @@ from typing import (
 from requests.structures import CaseInsensitiveDict
 
 from _addonStore.models.addon import (
-	AddonGUIModel,
+	AddonManifestGUIModel,
 )
 from _addonStore.models.status import (
 	_StatusFilterKey,
@@ -86,15 +86,15 @@ class AddonListField(_AddonListFieldData, Enum):
 class AddonListItemVM:
 	def __init__(
 			self,
-			model: AddonGUIModel,
+			model: AddonManifestGUIModel,
 			status: AvailableAddonStatus = AvailableAddonStatus.AVAILABLE
 	):
-		self._model: AddonGUIModel = model  # read-only
+		self._model: AddonManifestGUIModel = model  # read-only
 		self._status: AvailableAddonStatus = status  # modifications triggers L{updated.notify}
 		self.updated = extensionPoints.Action()  # Notify of changes to VM, argument: addonListItemVM
 
 	@property
-	def model(self) -> AddonGUIModel:
+	def model(self) -> AddonManifestGUIModel:
 		return self._model
 
 	@property


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/wiki/Contributing.
-->

### Link to issue number:
Part of #14973

### Summary of the issue:
Installed add-ons do not have their display name and description localised, even if localised manifests exist for the installed add-on.

### Description of user facing changes
Reinstate localisation for installed add-ons of the display name and description

### Description of development approach
Fetch translated strings from the localised manifests

### Testing strategy:
Ensure add-on with localisations is correctly displayed in the installed add-ons tab of the store.
Available and updatable add-ons rely on the strings to be translated when fetching from the store.

### Known issues with pull request:
Available add-ons are not localised:
This should be fixed by https://github.com/nvaccess/addon-datastore/pull/1095

### Change log entries:
N/A

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
