### PR TITLE
Add-on store: fix bug with external installs

### DIFF
--- a/source/_addonStore/dataManager.py
+++ b/source/_addonStore/dataManager.py
@@ -301,5 +301,5 @@ class _InstalledAddonsCache(AutoPropertyObject):
 			if addonStoreData:
 				addons[addonStoreData.channel][addonId] = addonStoreData
 			else:
-				addons[Channel.STABLE][addonId] = self.installedAddons[addonId]._addonGuiModel
+				addons[Channel.EXTERNAL][addonId] = self.installedAddons[addonId]._addonGuiModel
 		return addons

--- a/source/addonHandler/__init__.py
+++ b/source/addonHandler/__init__.py
@@ -478,22 +478,6 @@ class Addon(AddonBase):
 		state[AddonStateCategory.BLOCKED].discard(self.name)
 		state.save()
 
-		if (
-			# Don't delete add-on store cache if its an upgrade pending,
-			# the add-on manager has already replaced the cache file.
-			not self.isPendingInstall
-			# However, if the add-on store cache is out of date,
-			# and is being replaced by an external install
-			# we should remove the cached add-on.
-			or (
-				self._addonStoreData
-				and self._addonStoreData.addonVersionName != self.version
-			)
-		):
-			from _addonStore.dataManager import addonDataManager
-			assert addonDataManager
-			addonDataManager._deleteCacheInstalledAddon(self.name)
-
 	def addToPackagePath(self, package):
 		""" Adds this L{Addon} extensions to the specific package path if those exist.
 		This allows the addon to "run" / be available because the package is able to search its path,

--- a/source/gui/_addonStoreGui/viewModels/store.py
+++ b/source/gui/_addonStoreGui/viewModels/store.py
@@ -240,6 +240,7 @@ class AddonStoreVM:
 
 	def removeAddon(self, listItemVM: AddonListItemVM) -> None:
 		if _shouldProceedToRemoveAddonDialog(listItemVM.model):
+			addonDataManager._deleteCacheInstalledAddon(listItemVM.model.name)
 			listItemVM.model._addonHandlerModel.requestRemove()
 			self.refresh()
 			listItemVM.status = getStatus(listItemVM.model)

--- a/source/gui/addonGui.py
+++ b/source/gui/addonGui.py
@@ -456,7 +456,8 @@ class AddonsDialog(
 # Note: when working on installAddon, look for opportunities to simplify
 # and move logic out into smaller helper functions.
 def installAddon(parentWindow: wx.Window, addonPath: str) -> bool:  # noqa: C901
-	""" Installs the addon at path.
+	""" Installs the addon bundle at path.
+	Only used for installing external add-on bundles.
 	Any error messages / warnings are presented to the user via a GUI message box.
 	If attempting to install an addon that is pending removal, it will no longer be pending removal.
 	@return True on success or False on failure.
@@ -550,6 +551,10 @@ def installAddon(parentWindow: wx.Window, addonPath: str) -> bool:  # noqa: C901
 		with doneAndDestroy(progressDialog):
 			gui.ExecAndPump(addonHandler.installAddonBundle, bundle)
 			if prevAddon:
+				from _addonStore.dataManager import addonDataManager
+				assert addonDataManager
+				# External install should remove cached add-on
+				addonDataManager._deleteCacheInstalledAddon(prevAddon.name)
 				prevAddon.requestRemove()
 			return True
 	except:


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/wiki/Contributing.
-->

### Link to issue number:
None

### Summary of the issue:
The add-on store cache for an installed addon should be deleted in the following scenarios:
- when removing an add-on
- when installing an external version of an add-on

This was not reflected correctly in the code


Additionally, external add-ons were incorrectly grouped as stable add-ons in some cases


### Description of user facing changes
Fix bug where add-on store cache would be incorrectly deleted or incorrectly retained in various scenarios.

### Description of development approach
Delete add-on cache file when removing or updating an add-on from an external source.

### Testing strategy:
Test updating various add-ons

### Known issues with pull request:
None

### Change log entries:
N/a

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
