### PR TITLE
Gracefully ignore NVDANotInitializedError when scheduling WASAPI idle check.

### DIFF
--- a/source/nvwave.py
+++ b/source/nvwave.py
@@ -970,10 +970,16 @@ class WasapiWavePlayer(garbageHandler.TrackedObject):
 	@classmethod
 	def _scheduleIdleCheck(cls):
 		if not cls._isIdleCheckPending:
-			core.callLater(
-				cls._IDLE_CHECK_INTERVAL,
-				cls._idleCheck
-			)
+			try:
+				core.callLater(
+					cls._IDLE_CHECK_INTERVAL,
+					cls._idleCheck
+				)
+			except core.NVDANotInitializedError:
+				# This can happen when playing the start sound. We close the stream after
+				# playing a sound anyway, so it's okay that this first idle check doesn't
+				# run.
+				pass
 			cls._isIdleCheckPending = True
 
 	@classmethod


### PR DESCRIPTION
### Link to issue number:
Fixes #15143.

### Summary of the issue:
When playing the start sound, NVDA can fail with this error:

```
  File "nvwave.pyc", line 975, in _scheduleIdleCheck
  File "core.pyc", line 928, in callLater
core.NVDANotInitializedError: Cannot schedule callable, wx.App is not initialized
```

### Description of user facing changes
Fixed the error.

### Description of development approach
Feeding WASAPI audio schedules an idle check, which uses core.callLater. That will fail if the wx.App isn't initialised yet.

We now just catch this and ignore it. playWaveFile closes the stream after playing anyway, so this first idle check isn't important.

### Testing strategy:
I'm not able to reproduce this on my system. This is likely because of timing differences. This problem is a race condition between the main thread and the playWaveFile thread.

I tested that NVDA starts without problems. However, we'll need the user who reported this (@ultrasound1372) to provide feedback on a try build to be sure that this works.

### Known issues with pull request:
None.

### Change log entries:
None, since this regression never landed in a release.

### Code Review Checklist:

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
