### PR TITLE
Revert #15121 "Make gui.MainFrame.popupSettingsDialog part of the public API", fixes vision providers, OCR, and perhaps other things

### DIFF
--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -24,7 +24,6 @@ import queueHandler
 import core
 from typing import (
 	Optional,
-	Type,
 )
 import systemUtils
 from .message import (
@@ -42,25 +41,9 @@ from .speechDict import (
 # Be careful when removing, and only do in a compatibility breaking release.
 from .exit import ExitDialog
 from .settingsDialogs import (
-	BrailleDisplaySelectionDialog,
-	BrailleSettingsPanel,
-	BrowseModePanel,
-	DocumentFormattingPanel,
-	GeneralSettingsPanel,
-	InputCompositionPanel,
-	KeyboardSettingsPanel,
-	MouseSettingsPanel,
-	MultiCategorySettingsDialog,
-	NVDASettingsDialog,
-	ObjectPresentationPanel,
 	SettingsDialog,
-	SpeechSettingsPanel,
-	SpeechSymbolsDialog,
-	SynthesizerSelectionDialog,
-	TouchInteractionPanel,
-	ReviewCursorPanel,
-	UwpOcrPanel,
 )
+from .settingsDialogs import *
 from .startupDialogs import WelcomeDialog
 from .inputGestures import InputGesturesDialog
 from . import logViewer
@@ -186,7 +169,7 @@ class MainFrame(wx.Frame):
 			messageBox(_("Could not save configuration - probably read only file system"),_("Error"),wx.OK | wx.ICON_ERROR)
 
 	@blockAction.when(blockAction.Context.MODAL_DIALOG_OPEN)
-	def popupSettingsDialog(self, dialog: Type[SettingsDialog], *args, **kwargs):
+	def _popupSettingsDialog(self, dialog, *args, **kwargs):
 		self.prePopup()
 		try:
 			dialog(self, *args, **kwargs).Show()
@@ -201,15 +184,15 @@ class MainFrame(wx.Frame):
 
 	@blockAction.when(blockAction.Context.SECURE_MODE)
 	def onDefaultDictionaryCommand(self, evt):
-		self.popupSettingsDialog(DefaultDictionaryDialog)
+		self._popupSettingsDialog(DefaultDictionaryDialog)
 
 	@blockAction.when(blockAction.Context.SECURE_MODE)
 	def onVoiceDictionaryCommand(self, evt):
-		self.popupSettingsDialog(VoiceDictionaryDialog)
+		self._popupSettingsDialog(VoiceDictionaryDialog)
 
 	@blockAction.when(blockAction.Context.SECURE_MODE)
 	def onTemporaryDictionaryCommand(self, evt):
-		self.popupSettingsDialog(TemporaryDictionaryDialog)
+		self._popupSettingsDialog(TemporaryDictionaryDialog)
 
 	@blockAction.when(blockAction.Context.SECURE_MODE)
 	def onExecuteUpdateCommand(self, evt):
@@ -218,13 +201,13 @@ class MainFrame(wx.Frame):
 			from addonHandler import getIncompatibleAddons
 			if any(getIncompatibleAddons(apiVersion, backCompatToAPIVersion)):
 				confirmUpdateDialog = updateCheck.UpdateAskInstallDialog(
-					parent=mainFrame,
+					parent=gui.mainFrame,
 					destPath=destPath,
 					version=version,
 					apiVersion=apiVersion,
 					backCompatTo=backCompatToAPIVersion
 				)
-				runScriptModalDialog(confirmUpdateDialog)
+				gui.runScriptModalDialog(confirmUpdateDialog)
 			else:
 				updateCheck.executePendingUpdate()
 
@@ -249,57 +232,57 @@ class MainFrame(wx.Frame):
 				log.error("NVDA already in process of exiting, this indicates a logic error.")
 
 	def onNVDASettingsCommand(self,evt):
-		self.popupSettingsDialog(NVDASettingsDialog)
+		self._popupSettingsDialog(NVDASettingsDialog)
 
 	def onGeneralSettingsCommand(self,evt):
-		self.popupSettingsDialog(NVDASettingsDialog, GeneralSettingsPanel)
+		self._popupSettingsDialog(NVDASettingsDialog, GeneralSettingsPanel)
 
 	def onSelectSynthesizerCommand(self,evt):
-		self.popupSettingsDialog(SynthesizerSelectionDialog)
+		self._popupSettingsDialog(SynthesizerSelectionDialog)
 
 	def onSpeechSettingsCommand(self,evt):
-		self.popupSettingsDialog(NVDASettingsDialog, SpeechSettingsPanel)
+		self._popupSettingsDialog(NVDASettingsDialog, SpeechSettingsPanel)
 
 	def onSelectBrailleDisplayCommand(self,evt):
-		self.popupSettingsDialog(BrailleDisplaySelectionDialog)
+		self._popupSettingsDialog(BrailleDisplaySelectionDialog)
 
 	def onBrailleSettingsCommand(self,evt):
-		self.popupSettingsDialog(NVDASettingsDialog, BrailleSettingsPanel)
+		self._popupSettingsDialog(NVDASettingsDialog, BrailleSettingsPanel)
 
 	def onKeyboardSettingsCommand(self,evt):
-		self.popupSettingsDialog(NVDASettingsDialog, KeyboardSettingsPanel)
+		self._popupSettingsDialog(NVDASettingsDialog, KeyboardSettingsPanel)
 
 	def onMouseSettingsCommand(self,evt):
-		self.popupSettingsDialog(NVDASettingsDialog, MouseSettingsPanel)
+		self._popupSettingsDialog(NVDASettingsDialog, MouseSettingsPanel)
 
 	def onTouchInteractionCommand(self,evt):
-		self.popupSettingsDialog(NVDASettingsDialog, TouchInteractionPanel)
+		self._popupSettingsDialog(NVDASettingsDialog, TouchInteractionPanel)
 
 	def onReviewCursorCommand(self,evt):
-		self.popupSettingsDialog(NVDASettingsDialog, ReviewCursorPanel)
+		self._popupSettingsDialog(NVDASettingsDialog, ReviewCursorPanel)
 
 	def onInputCompositionCommand(self,evt):
-		self.popupSettingsDialog(NVDASettingsDialog, InputCompositionPanel)
+		self._popupSettingsDialog(NVDASettingsDialog, InputCompositionPanel)
 
 	def onObjectPresentationCommand(self,evt):
-		self.popupSettingsDialog(NVDASettingsDialog, ObjectPresentationPanel)
+		self._popupSettingsDialog(NVDASettingsDialog, ObjectPresentationPanel)
 
 	def onBrowseModeCommand(self,evt):
-		self.popupSettingsDialog(NVDASettingsDialog, BrowseModePanel)
+		self._popupSettingsDialog(NVDASettingsDialog, BrowseModePanel)
 
 	def onDocumentFormattingCommand(self,evt):
-		self.popupSettingsDialog(NVDASettingsDialog, DocumentFormattingPanel)
+		self._popupSettingsDialog(NVDASettingsDialog, DocumentFormattingPanel)
 
 	def onUwpOcrCommand(self, evt):
-		self.popupSettingsDialog(NVDASettingsDialog, UwpOcrPanel)
+		self._popupSettingsDialog(NVDASettingsDialog, UwpOcrPanel)
 
 	@blockAction.when(blockAction.Context.SECURE_MODE)
 	def onSpeechSymbolsCommand(self, evt):
-		self.popupSettingsDialog(SpeechSymbolsDialog)
+		self._popupSettingsDialog(SpeechSymbolsDialog)
 
 	@blockAction.when(blockAction.Context.SECURE_MODE)
 	def onInputGesturesCommand(self, evt):
-		self.popupSettingsDialog(InputGesturesDialog)
+		self._popupSettingsDialog(InputGesturesDialog)
 
 	def onAboutCommand(self,evt):
 		# Translators: The title of the dialog to show about info for NVDA.
@@ -355,11 +338,16 @@ class MainFrame(wx.Frame):
 		blockAction.Context.RUNNING_LAUNCHER,
 	)
 	def onAddonStoreCommand(self, evt: wx.MenuEvent):
+		self.prePopup()
 		from ._addonStoreGui import AddonStoreDialog
 		from ._addonStoreGui.viewModels.store import AddonStoreVM
 		_storeVM = AddonStoreVM()
 		_storeVM.refresh()
-		self.popupSettingsDialog(AddonStoreDialog, _storeVM)
+		try:
+			AddonStoreDialog(mainFrame, _storeVM).Show()
+		except SettingsDialog.MultiInstanceErrorWithDialog as errorWithDialog:
+			errorWithDialog.dialog.SetFocus()
+		self.postPopup()
 
 	def onReloadPluginsCommand(self, evt):
 		import appModuleHandler, globalPluginHandler
@@ -374,8 +362,8 @@ class MainFrame(wx.Frame):
 	)
 	def onCreatePortableCopyCommand(self,evt):
 		self.prePopup()
-		from . import installerGui
-		d = installerGui.PortableCreaterDialog(mainFrame)
+		import gui.installerGui
+		d=gui.installerGui.PortableCreaterDialog(gui.mainFrame)
 		d.Show()
 		self.postPopup()
 
@@ -384,7 +372,7 @@ class MainFrame(wx.Frame):
 		blockAction.Context.MODAL_DIALOG_OPEN,
 	)
 	def onInstallCommand(self, evt):
-		from . import installerGui
+		from gui import installerGui
 		installerGui.showInstallGui()
 
 	@blockAction.when(
@@ -426,7 +414,7 @@ class MainFrame(wx.Frame):
 	def onConfigProfilesCommand(self, evt):
 		self.prePopup()
 		from .configProfiles import ProfilesDialog
-		ProfilesDialog(mainFrame).Show()
+		ProfilesDialog(gui.mainFrame).Show()
 		self.postPopup()
 
 


### PR DESCRIPTION
### Link to issue number:

Fixes #15142
Fixes #15141
Fixes #15148
Fixes #15147
reopens #15120 

### Summary of the issue:

PR #15121 to fix #15120 had various unexpected side effects.

1. It broke vision providers settings, and maybe vision providers in general.
2. Some reports of it breaking OCR.
3. The text of the commit appears to reference another issue entirely, as reported by @nvdaes.
4. While of debatable concern, @ruifontes reported in [nvda-addons](https://groups.io/g/nvda-addons) that it breaks over 30 add-ons, because it doesn't include an alias to the old private method. That alone may not be a good reason to revert, but see above.

### Description of user facing changes

Fix vision providers and related infrastructure.

### Description of development approach

Revert a8b79c76ea960b3f4288b17ec9f854caf492321c. This restores prior behavior in alphas, by fixing whatever was caused by the import changes demanded by linting the old code from #15121.

### Testing strategy:

Minimally tested the STR from the various issues listed above.

### Known issues with pull request:

None. A more deliberate approach may be needed to #15120, to avoid such side effects.

### Change log entries:

Change in alpha, none needed.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
