### PR TITLE
Retain aliases lost in #15121

### DIFF
--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -23,6 +23,7 @@ import speech
 import queueHandler
 import core
 from typing import (
+	Any,
 	Optional,
 	Type,
 )
@@ -93,6 +94,28 @@ DONATE_URL = "http://www.nvaccess.org/donate/"
 mainFrame: Optional["MainFrame"] = None
 """Set by initialize. Should be used as the parent for "top level" dialogs.
 """
+
+
+def __getattr__(attrName: str) -> Any:
+	"""Module level `__getattr__` used to preserve backward compatibility."""
+	from gui.settingsDialogs import AutoSettingsMixin, SettingsPanel
+	if attrName == "AutoSettingsMixin" and NVDAState._allowDeprecatedAPI():
+		log.warning(
+			"Importing AutoSettingsMixin from here is deprecated. "
+			"Import AutoSettingsMixin from gui.settingsDialogs instead. ",
+			# Include stack info so testers can report warning to add-on author.
+			stack_info=True,
+		)
+		return AutoSettingsMixin
+	if attrName == "SettingsPanel" and NVDAState._allowDeprecatedAPI():
+		log.warning(
+			"Importing SettingsPanel from here is deprecated. "
+			"Import SettingsPanel from gui.settingsDialogs instead. ",
+			# Include stack info so testers can report warning to add-on author.
+			stack_info=True,
+		)
+		return SettingsPanel
+	raise AttributeError(f"module {repr(__name__)} has no attribute {repr(attrName)}")
 
 
 class MainFrame(wx.Frame):
@@ -198,6 +221,14 @@ class MainFrame(wx.Frame):
 			messageBox(_("The settings panel you tried to open is unavailable on this system."),_("Error"),style=wx.OK | wx.ICON_ERROR)
 
 		self.postPopup()
+
+	if NVDAState._allowDeprecatedAPI():
+		def _popupSettingsDialog(self, dialog: Type[SettingsDialog], *args, **kwargs):
+			log.warning(
+				"_popupSettingsDialog is deprecated, use popupSettingsDialog instead.",
+				stack_info=True,
+			)
+			self.popupSettingsDialog(dialog, *args, **kwargs)
 
 	@blockAction.when(blockAction.Context.SECURE_MODE)
 	def onDefaultDictionaryCommand(self, evt):
@@ -344,7 +375,10 @@ class MainFrame(wx.Frame):
 
 	if NVDAState._allowDeprecatedAPI():
 		def onAddonsManagerCommand(self, evt: wx.MenuEvent):
-			log.warning("onAddonsManagerCommand is deprecated, use onAddonStoreCommand instead.")
+			log.warning(
+				"onAddonsManagerCommand is deprecated, use onAddonStoreCommand instead.",
+				stack_info=True,
+			)
 			self.onAddonStoreCommand(evt)
 
 	@blockAction.when(

--- a/source/visionEnhancementProviders/NVDAHighlighter.py
+++ b/source/visionEnhancementProviders/NVDAHighlighter.py
@@ -1,7 +1,7 @@
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-# Copyright (C) 2018-2022 NV Access Limited, Babbage B.V., Takuya Nishimoto
+# Copyright (C) 2018-2023 NV Access Limited, Babbage B.V., Takuya Nishimoto
 
 """Default highlighter based on GDI Plus."""
 from typing import Optional, Tuple
@@ -15,7 +15,11 @@ from vision.visionHandlerExtensionPoints import EventExtensionPoints
 from vision import providerBase
 from windowUtils import CustomWindow
 import wx
-import gui
+from gui.settingsDialogs import (
+	AutoSettingsMixin,
+	SettingsPanel,
+	VisionProviderStateControl,
+)
 import api
 from ctypes import byref, WinError
 from ctypes.wintypes import COLORREF, MSG
@@ -239,16 +243,14 @@ class NVDAHighlighterSettings(providerBase.VisionEnhancementProviderSettings):
 
 
 class NVDAHighlighterGuiPanel(
-		gui.AutoSettingsMixin,
-		gui.SettingsPanel
+		AutoSettingsMixin,
+		SettingsPanel
 ):
 	
 	_enableCheckSizer: wx.BoxSizer
 	_enabledCheckbox: wx.CheckBox
 	
 	helpId = "VisionSettingsFocusHighlight"
-
-	from gui.settingsDialogs import VisionProviderStateControl
 
 	def __init__(
 			self,

--- a/source/visionEnhancementProviders/readme.md
+++ b/source/visionEnhancementProviders/readme.md
@@ -33,8 +33,7 @@ These are used to save / load settings for the provider.
 
 A GUI can be built automatically from the DriverSettings objects accessed via the VisionEnhancementProviderSettings.
 Alternatively the provider can supply a custom settings panel implementation via the getSettingsPanelClass class method.
-A custom settings panel must return a class type derived from gui.SettingsPanel which will take responsibility for
-building the GUI.
+A custom settings panel must return a class type derived from `gui.settingsDialogs.SettingsPanel` which will take responsibility for building the GUI.
 For an example see NVDAHighlighter or ScreenCurtain.
 
 #### Automatic GUI building

--- a/source/visionEnhancementProviders/screenCurtain.py
+++ b/source/visionEnhancementProviders/screenCurtain.py
@@ -1,7 +1,7 @@
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-# Copyright (C) 2018-2019 NV Access Limited, Babbage B.V., Leonard de Ruijter
+# Copyright (C) 2018-2023 NV Access Limited, Babbage B.V., Leonard de Ruijter
 
 """Screen curtain implementation based on the windows magnification API.
 The Magnification API has been marked by MS as unsupported for WOW64 applications such as NVDA. (#12491)
@@ -17,7 +17,12 @@ from ctypes.wintypes import BOOL
 from autoSettingsUtils.driverSetting import BooleanDriverSetting
 from autoSettingsUtils.autoSettings import SupportedSettingType
 import wx
-import gui
+from gui.nvdaControls import MessageDialog
+from gui.settingsDialogs import (
+	AutoSettingsMixin,
+	SettingsPanel,
+	VisionProviderStateControl,
+)
 from logHandler import log
 from typing import Optional, Type
 import nvwave
@@ -141,7 +146,7 @@ warnOnLoadText = _(
 )
 
 
-class WarnOnLoadDialog(gui.nvdaControls.MessageDialog):
+class WarnOnLoadDialog(MessageDialog):
 
 	showWarningOnLoadCheckBox: wx.CheckBox
 	noButton: wx.Button
@@ -152,7 +157,7 @@ class WarnOnLoadDialog(gui.nvdaControls.MessageDialog):
 			parent,
 			title=_("Warning"),
 			message=warnOnLoadText,
-			dialogType=gui.nvdaControls.MessageDialog.DIALOG_TYPE_WARNING
+			dialogType=MessageDialog.DIALOG_TYPE_WARNING
 	):
 		self._settingsStorage = screenCurtainSettingsStorage
 		super().__init__(parent, title, message, dialogType)
@@ -215,16 +220,14 @@ class WarnOnLoadDialog(gui.nvdaControls.MessageDialog):
 
 
 class ScreenCurtainGuiPanel(
-		gui.AutoSettingsMixin,
-		gui.SettingsPanel,
+	AutoSettingsMixin,
+	SettingsPanel,
 ):
 
 	_enabledCheckbox: wx.CheckBox
 	_enableCheckSizer: wx.BoxSizer
 	
 	helpId = "VisionSettingsScreenCurtain"
-
-	from gui.settingsDialogs import VisionProviderStateControl
 
 	def __init__(
 			self,

--- a/source/visionEnhancementProviders/screenCurtain.py
+++ b/source/visionEnhancementProviders/screenCurtain.py
@@ -220,8 +220,8 @@ class WarnOnLoadDialog(MessageDialog):
 
 
 class ScreenCurtainGuiPanel(
-	AutoSettingsMixin,
-	SettingsPanel,
+		AutoSettingsMixin,
+		SettingsPanel,
 ):
 
 	_enabledCheckbox: wx.CheckBox


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/wiki/Contributing.
-->

### Link to issue number:
Follow up to #15121

Fixes https://github.com/nvaccess/nvda/issues/15142
Fixes https://github.com/nvaccess/nvda/issues/15141
Fixes https://github.com/nvaccess/nvda/issues/15148
Fixes https://github.com/nvaccess/nvda/issues/15147

### Summary of the issue:
PR #15121 to fix #15120 had various unexpected side effects.
This is due to symbols that were previously star imported into `gui/__init__.py` being removed.
Add-ons and the vision enhancements core module relied on these symbols being imported.
While there was no API breaking changes, these changes affected over 30 add-ons

### Description of user facing changes
Fix up issue with vision enhancement providers, such as opening the relevant settings panels.

### Description of development approach
Add aliases for `SettingsPanel, AutoSettingsMixin, _popupSettingsDialog` in `gui`

### Testing strategy:
Test importing aliases from python console

### Known issues with pull request:
None
### Change log entries:
N/A
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
