### PR TITLE
Add-on store: Fix translations for add-ons installed from add-on store

### DIFF
--- a/source/_addonStore/dataManager.py
+++ b/source/_addonStore/dataManager.py
@@ -33,8 +33,9 @@ from NVDAState import WritePaths
 from .models.addon import (
 	AddonStoreModel,
 	CachedAddonsModel,
+	InstalledAddonStoreModel,
 	_createAddonGUICollection,
-	_createStoreModelFromData,
+	_createInstalledStoreModelFromData,
 	_createStoreCollectionFromJson,
 )
 from .models.channel import Channel
@@ -272,7 +273,7 @@ class _DataManager:
 		with open(addonCachePath, 'w') as cacheFile:
 			json.dump(addonData.asdict(), cacheFile, ensure_ascii=False)
 
-	def _getCachedInstalledAddonData(self, addonId: str) -> Optional[AddonStoreModel]:
+	def _getCachedInstalledAddonData(self, addonId: str) -> Optional[InstalledAddonStoreModel]:
 		addonCachePath = os.path.join(self._installedAddonDataCacheDir, f"{addonId}.json")
 		if not os.path.exists(addonCachePath):
 			return None
@@ -280,7 +281,7 @@ class _DataManager:
 			cacheData = json.load(cacheFile)
 		if not cacheData:
 			return None
-		return _createStoreModelFromData(cacheData)
+		return _createInstalledStoreModelFromData(cacheData)
 
 
 class _InstalledAddonsCache(AutoPropertyObject):

--- a/source/_addonStore/models/addon.py
+++ b/source/_addonStore/models/addon.py
@@ -110,62 +110,13 @@ class _AddonGUIModel(SupportsAddonState, SupportsVersionCheck, Protocol):
 		return jsonData
 
 
-@dataclasses.dataclass(frozen=True)
-class AddonManifestModel(_AddonGUIModel):
-	"""Can be displayed in the add-on store GUI.
-	Comes from add-on manifest.
-	"""
-	addonId: str
-	addonVersionName: str
-	channel: Channel
-	homepage: Optional[str]
-	minNVDAVersion: MajorMinorPatch
-	lastTestedVersion: MajorMinorPatch
-	_manifest: "AddonManifest"
-	legacy: bool = False
-	"""
-	Legacy add-ons contain invalid metadata
-	and should not be accessible through the add-on store.
-	"""
-
-	@property
-	def displayName(self) -> str:
-		return self._manifest["summary"]
-
-	@property
-	def description(self) -> str:
-		return self._manifest["description"]
-
-	@property
-	def publisher(self) -> str:
-		return self._manifest["author"]
-
-
-@dataclasses.dataclass(frozen=True)  # once created, it should not be modified.
-class AddonStoreModel(_AddonGUIModel):
-	"""
-	Data from an add-on from the add-on store.
-	"""
-	addonId: str
-	displayName: str
-	description: str
-	publisher: str
-	addonVersionName: str
-	channel: Channel
-	homepage: Optional[str]
+class _AddonStoreModel(_AddonGUIModel):
 	license: str
 	licenseURL: Optional[str]
 	sourceURL: str
 	URL: str
 	sha256: str
 	addonVersionNumber: MajorMinorPatch
-	minNVDAVersion: MajorMinorPatch
-	lastTestedVersion: MajorMinorPatch
-	legacy: bool = False
-	"""
-	Legacy add-ons contain invalid metadata
-	and should not be accessible through the add-on store.
-	"""
 
 	@property
 	def tempDownloadPath(self) -> str:
@@ -210,6 +161,102 @@ class AddonStoreModel(_AddonGUIModel):
 		)
 
 
+@dataclasses.dataclass(frozen=True)
+class AddonManifestModel(_AddonGUIModel):
+	"""Can be displayed in the add-on store GUI.
+	Comes from add-on manifest.
+	"""
+	addonId: str
+	addonVersionName: str
+	channel: Channel
+	homepage: Optional[str]
+	minNVDAVersion: MajorMinorPatch
+	lastTestedVersion: MajorMinorPatch
+	_manifest: "AddonManifest"
+	legacy: bool = False
+	"""
+	Legacy add-ons contain invalid metadata
+	and should not be accessible through the add-on store.
+	"""
+
+	@property
+	def displayName(self) -> str:
+		return self._manifest["summary"]
+
+	@property
+	def description(self) -> str:
+		return self._manifest["description"]
+
+	@property
+	def publisher(self) -> str:
+		return self._manifest["author"]
+
+
+@dataclasses.dataclass(frozen=True)  # once created, it should not be modified.
+class InstalledAddonStoreModel(_AddonStoreModel):
+	"""
+	Data from an add-on installed from the add-on store.
+	"""
+	addonId: str
+	publisher: str
+	addonVersionName: str
+	channel: Channel
+	homepage: Optional[str]
+	license: str
+	licenseURL: Optional[str]
+	sourceURL: str
+	URL: str
+	sha256: str
+	addonVersionNumber: MajorMinorPatch
+	minNVDAVersion: MajorMinorPatch
+	lastTestedVersion: MajorMinorPatch
+	legacy: bool = False
+	"""
+	Legacy add-ons contain invalid metadata
+	and should not be accessible through the add-on store.
+	"""
+
+	@property
+	def _manifest(self) -> "AddonManifest":
+		from ..dataManager import addonDataManager
+		return addonDataManager._installedAddonsCache.installedAddons[self.name].manifest
+
+	@property
+	def displayName(self) -> str:
+		return self._manifest["summary"]
+
+	@property
+	def description(self) -> str:
+		return self._manifest["description"]
+
+
+@dataclasses.dataclass(frozen=True)  # once created, it should not be modified.
+class AddonStoreModel(_AddonStoreModel):
+	"""
+	Data from an add-on from the add-on store.
+	"""
+	addonId: str
+	displayName: str
+	description: str
+	publisher: str
+	addonVersionName: str
+	channel: Channel
+	homepage: Optional[str]
+	license: str
+	licenseURL: Optional[str]
+	sourceURL: str
+	URL: str
+	sha256: str
+	addonVersionNumber: MajorMinorPatch
+	minNVDAVersion: MajorMinorPatch
+	lastTestedVersion: MajorMinorPatch
+	legacy: bool = False
+	"""
+	Legacy add-ons contain invalid metadata
+	and should not be accessible through the add-on store.
+	"""
+
+
 @dataclasses.dataclass
 class CachedAddonsModel:
 	cachedAddonData: "AddonGUICollectionT"
@@ -217,6 +264,25 @@ class CachedAddonsModel:
 	cachedLanguage: str
 	# AddonApiVersionT or the string .network._LATEST_API_VER
 	nvdaAPIVersion: Union[addonAPIVersion.AddonApiVersionT, str]
+
+
+def _createInstalledStoreModelFromData(addon: Dict[str, Any]) -> InstalledAddonStoreModel:
+	return InstalledAddonStoreModel(
+		addonId=addon["addonId"],
+		publisher=addon["publisher"],
+		channel=Channel(addon["channel"]),
+		addonVersionName=addon["addonVersionName"],
+		addonVersionNumber=MajorMinorPatch(**addon["addonVersionNumber"]),
+		homepage=addon.get("homepage"),
+		license=addon["license"],
+		licenseURL=addon.get("licenseURL"),
+		sourceURL=addon["sourceURL"],
+		URL=addon["URL"],
+		sha256=addon["sha256"],
+		minNVDAVersion=MajorMinorPatch(**addon["minNVDAVersion"]),
+		lastTestedVersion=MajorMinorPatch(**addon["lastTestedVersion"]),
+		legacy=addon.get("legacy", False),
+	)
 
 
 def _createStoreModelFromData(addon: Dict[str, Any]) -> AddonStoreModel:

--- a/source/_addonStore/models/status.py
+++ b/source/_addonStore/models/status.py
@@ -184,13 +184,13 @@ def getStatus(model: "_AddonGUIModel") -> Optional[AvailableAddonStatus]:
 			# and another for enabled/disabled.
 			return storeState
 
-	addonStoreData = addonDataManager._getCachedInstalledAddonData(model.addonId)
+	addonStoreInstalledData = addonDataManager._getCachedInstalledAddonData(model.addonId)
 	if isinstance(model, AddonStoreModel):
 		# If the listed add-on is installed from a side-load
 		# and not available on the add-on store
 		# the type will not be AddonStoreModel
-		if addonStoreData is not None:
-			if model.addonVersionNumber > addonStoreData.addonVersionNumber:
+		if addonStoreInstalledData is not None:
+			if model.addonVersionNumber > addonStoreInstalledData.addonVersionNumber:
 				return AvailableAddonStatus.UPDATE
 		else:
 			# Parsing from a side-loaded add-on

--- a/source/_addonStore/models/version.py
+++ b/source/_addonStore/models/version.py
@@ -38,8 +38,10 @@ class SupportsVersionCheck(Protocol):
 	- addonHandler.Addon
 	- addonHandler.AddonBundle
 	- _addonStore.models._AddonGUIModel
+	- _addonStore.models._AddonStoreModel
 	- _addonStore.models.AddonManifestModel
 	- _addonStore.models.AddonStoreModel
+	- _addonStore.models.InstalledAddonStoreModel
 	"""
 	minimumNVDAVersion: addonAPIVersion.AddonApiVersionT
 	lastTestedNVDAVersion: addonAPIVersion.AddonApiVersionT

--- a/source/_addonStore/network.py
+++ b/source/_addonStore/network.py
@@ -27,7 +27,11 @@ import NVDAState
 from NVDAState import WritePaths
 from utils.security import sha256_checksum
 
-from .models.addon import AddonStoreModel
+from .models.addon import (
+	AddonStoreModel,
+	_AddonGUIModel,
+	_AddonStoreModel,
+)
 from .models.channel import Channel
 
 
@@ -214,13 +218,13 @@ class AddonFileDownloader:
 		return cast(os.PathLike, cacheFilePath)
 
 	@staticmethod
-	def _checkChecksum(addonFilePath: str, addonData: AddonStoreModel) -> Optional[os.PathLike]:
+	def _checkChecksum(addonFilePath: str, addonData: _AddonStoreModel) -> Optional[os.PathLike]:
 		with open(addonFilePath, "rb") as f:
 			sha256Addon = sha256_checksum(f)
 		return sha256Addon.casefold() == addonData.sha256.casefold()
 
 	@staticmethod
-	def _getCacheFilenameForAddon(addonData: AddonStoreModel) -> str:
+	def _getCacheFilenameForAddon(addonData: _AddonGUIModel) -> str:
 		return f"{addonData.addonId}-{addonData.addonVersionName}.nvda-addon"
 
 	def __del__(self):

--- a/source/addonHandler/__init__.py
+++ b/source/addonHandler/__init__.py
@@ -59,7 +59,7 @@ if TYPE_CHECKING:
 	from _addonStore.models.addon import (  # noqa: F401
 		AddonManifestModel,
 		AddonHandlerModelGeneratorT,
-		AddonStoreModel,
+		InstalledAddonStoreModel,
 	)
 
 MANIFEST_FILENAME = "manifest.ini"
@@ -386,7 +386,7 @@ class AddonBase(SupportsAddonState, SupportsVersionCheck, ABC):
 		...
 
 	@property
-	def _addonStoreData(self) -> Optional["AddonStoreModel"]:
+	def _addonStoreData(self) -> Optional["InstalledAddonStoreModel"]:
 		from _addonStore.dataManager import addonDataManager
 		assert addonDataManager
 		return addonDataManager._getCachedInstalledAddonData(self.name)

--- a/source/gui/_addonStoreGui/controls/details.py
+++ b/source/gui/_addonStoreGui/controls/details.py
@@ -6,7 +6,7 @@
 import wx
 
 from _addonStore.models.addon import (
-	AddonStoreModel,
+	_AddonStoreModel,
 )
 from gui import guiHelper
 from gui.dpiScalingHelper import DpiScalingHelperMixinWithoutInit
@@ -257,7 +257,7 @@ class AddonDetails(
 						details.homepage
 					)
 
-				if isinstance(details, AddonStoreModel):
+				if isinstance(details, _AddonStoreModel):
 					self._appendDetailsLabelValue(
 						# Translators: Label for an extra detail field for the selected add-on. In the add-on store dialog.
 						pgettext("addonStore", "License:"),

--- a/source/gui/_addonStoreGui/viewModels/store.py
+++ b/source/gui/_addonStoreGui/viewModels/store.py
@@ -26,6 +26,7 @@ from _addonStore.models.addon import (
 	AddonStoreModel,
 	_createAddonGUICollection,
 	_AddonGUIModel,
+	_AddonStoreModel,
 )
 from _addonStore.models.channel import (
 	Channel,
@@ -218,9 +219,9 @@ class AddonStoreVM:
 			AddonActionVM(
 				# Translators: Label for an action that opens the license for the selected addon
 				displayName=pgettext("addonStore", "&License"),
-				actionHandler=lambda aVM: startfile(cast(AddonStoreModel, aVM.model).licenseURL),
+				actionHandler=lambda aVM: startfile(cast(_AddonStoreModel, aVM.model).licenseURL),
 				validCheck=lambda aVM: (
-					isinstance(aVM.model, AddonStoreModel)
+					isinstance(aVM.model, _AddonStoreModel)
 					and aVM.model.licenseURL is not None
 				),
 				listItemVM=selectedListItem
@@ -228,8 +229,8 @@ class AddonStoreVM:
 			AddonActionVM(
 				# Translators: Label for an action that opens the source code for the selected addon
 				displayName=pgettext("addonStore", "Source &Code"),
-				actionHandler=lambda aVM: startfile(cast(AddonStoreModel, aVM.model).sourceURL),
-				validCheck=lambda aVM: isinstance(aVM.model, AddonStoreModel),
+				actionHandler=lambda aVM: startfile(cast(_AddonStoreModel, aVM.model).sourceURL),
+				validCheck=lambda aVM: isinstance(aVM.model, _AddonStoreModel),
 				listItemVM=selectedListItem
 			),
 		]


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/wiki/Contributing.
-->

### Link to issue number:
Closes #14973 

### Summary of the issue:
Add-ons installed from the add-on store used the untranslated add-on store JSON strings.
As of #15137, only add-ons that were installed from an external source had translated strings.

### Description of user facing changes
Add-ons installed from the add-on store will have translated strings.

### Description of development approach
Create a separate model for add-ons fetched from the add-on store, and add-ons cached after being installed from the add-on store.
Data fetched from the add-on store should be translated. Installed cached data for an add-on will be whatever language is used when the fetched add-on store data is cached. As such, we should defer to the translated manifests for installed add-ons.

### Testing strategy:
Check that an add-on installed from the add-on store has translated strings

### Known issues with pull request:
None

### Change log entries:
N/A

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
