### PR TITLE
Add-on store: support Windows language for translations

### DIFF
--- a/source/_addonStore/dataManager.py
+++ b/source/_addonStore/dataManager.py
@@ -71,7 +71,7 @@ class _DataManager:
 	_downloadsPendingInstall: Set[Tuple["AddonListItemVM", os.PathLike]] = set()
 
 	def __init__(self):
-		self._lang = languageHandler.getLanguage()
+		self._lang = languageHandler._findSupportedGettextLocale()
 		self._preferredChannel = Channel.ALL
 		self._cacheLatestFile = os.path.join(WritePaths.addonStoreDir, _DataManager._cacheLatestFilename)
 		self._cacheCompatibleFile = os.path.join(WritePaths.addonStoreDir, _DataManager._cacheCompatibleFilename)

--- a/source/languageHandler.py
+++ b/source/languageHandler.py
@@ -379,7 +379,9 @@ def _findSupportedGettextLocale() -> str:
 	if localeName in foundLocales:
 		# return original cased version
 		return foundLocales.intersection({localeName}).pop()
-	if len(foundLocales) != 1:
+	if len(foundLocales) == 0:
+		return "en"
+	elif len(foundLocales) >= 1:
 		log.warning(
 			f"Expected to find 1 supported locale: {foundLocales}"
 		)


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/wiki/Contributing.
-->

### Link to issue number:
Fixes #14973

### Summary of the issue:
When using a Windows language, `appArgs.language` will be set to whatever locale Windows is using, i.e. `es_ES`.
When requesting `es_ES` translations via gettext, translations for `es` are used.
As such, `es_ES` is set as the language, but gettext and NVDA doesn't support the `ES` locale.
This causes the add-on store to attempt to fetch data for `es_ES` while only `es` data exists, falling back to english.

### Description of user facing changes
Add-on store will show translated data even if the default windows language is being used by NVDA.

### Description of development approach
Added a function similar to `listNVDALocales`, which finds a list of the available locales in NVDA which match the current language.

### Testing strategy:
Test that Windows language is supported on a non-English copy of Windows

Tested the value returned by `_findSupportedGettextLocale` for various localeNames.

### Known issues with pull request:
Note: as `pt` translations are included by add-ons, but not NVDA. This means that data is inaccessible, as only a supported NVDA language will be fetchable for add-on store available add-on data..

### Change log entries:
N/A

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
