### PR TITLE
Add-on store: display author and add-on id in details

### DIFF
--- a/source/_addonStore/models/addon.py
+++ b/source/_addonStore/models/addon.py
@@ -59,7 +59,6 @@ class _AddonGUIModel(SupportsAddonState, SupportsVersionCheck, Protocol):
 	addonId: str
 	displayName: str
 	description: str
-	publisher: str
 	addonVersionName: str
 	channel: Channel
 	homepage: Optional[str]
@@ -111,6 +110,7 @@ class _AddonGUIModel(SupportsAddonState, SupportsVersionCheck, Protocol):
 
 
 class _AddonStoreModel(_AddonGUIModel):
+	publisher: str
 	license: str
 	licenseURL: Optional[str]
 	sourceURL: str
@@ -161,53 +161,11 @@ class _AddonStoreModel(_AddonGUIModel):
 		)
 
 
-@dataclasses.dataclass(frozen=True)
-class AddonManifestModel(_AddonGUIModel):
-	"""Can be displayed in the add-on store GUI.
-	Comes from add-on manifest.
-	"""
+class _InstalledAddonModel(_AddonGUIModel):
 	addonId: str
 	addonVersionName: str
 	channel: Channel
 	homepage: Optional[str]
-	minNVDAVersion: MajorMinorPatch
-	lastTestedVersion: MajorMinorPatch
-	_manifest: "AddonManifest"
-	legacy: bool = False
-	"""
-	Legacy add-ons contain invalid metadata
-	and should not be accessible through the add-on store.
-	"""
-
-	@property
-	def displayName(self) -> str:
-		return self._manifest["summary"]
-
-	@property
-	def description(self) -> str:
-		return self._manifest["description"]
-
-	@property
-	def publisher(self) -> str:
-		return self._manifest["author"]
-
-
-@dataclasses.dataclass(frozen=True)  # once created, it should not be modified.
-class InstalledAddonStoreModel(_AddonStoreModel):
-	"""
-	Data from an add-on installed from the add-on store.
-	"""
-	addonId: str
-	publisher: str
-	addonVersionName: str
-	channel: Channel
-	homepage: Optional[str]
-	license: str
-	licenseURL: Optional[str]
-	sourceURL: str
-	URL: str
-	sha256: str
-	addonVersionNumber: MajorMinorPatch
 	minNVDAVersion: MajorMinorPatch
 	lastTestedVersion: MajorMinorPatch
 	legacy: bool = False
@@ -232,6 +190,49 @@ class InstalledAddonStoreModel(_AddonStoreModel):
 	@property
 	def author(self) -> str:
 		return self._manifest["author"]
+
+
+@dataclasses.dataclass(frozen=True)
+class AddonManifestModel(_InstalledAddonModel):
+	"""An externally installed add-on.
+	Data comes from add-on manifest.
+	"""
+	addonId: str
+	addonVersionName: str
+	channel: Channel
+	homepage: Optional[str]
+	minNVDAVersion: MajorMinorPatch
+	lastTestedVersion: MajorMinorPatch
+	legacy: bool = False
+	"""
+	Legacy add-ons contain invalid metadata
+	and should not be accessible through the add-on store.
+	"""
+
+
+@dataclasses.dataclass(frozen=True)  # once created, it should not be modified.
+class InstalledAddonStoreModel(_InstalledAddonModel, _AddonStoreModel):
+	"""
+	Data from an add-on installed from the add-on store.
+	"""
+	addonId: str
+	publisher: str
+	addonVersionName: str
+	channel: Channel
+	homepage: Optional[str]
+	license: str
+	licenseURL: Optional[str]
+	sourceURL: str
+	URL: str
+	sha256: str
+	addonVersionNumber: MajorMinorPatch
+	minNVDAVersion: MajorMinorPatch
+	lastTestedVersion: MajorMinorPatch
+	legacy: bool = False
+	"""
+	Legacy add-ons contain invalid metadata
+	and should not be accessible through the add-on store.
+	"""
 
 
 @dataclasses.dataclass(frozen=True)  # once created, it should not be modified.
@@ -322,7 +323,6 @@ def _createGUIModelFromManifest(addon: "AddonHandlerBaseModel") -> AddonManifest
 		homepage=homepage,
 		minNVDAVersion=MajorMinorPatch(*addon.minimumNVDAVersion),
 		lastTestedVersion=MajorMinorPatch(*addon.lastTestedNVDAVersion),
-		_manifest=addon.manifest
 	)
 
 

--- a/source/_addonStore/models/addon.py
+++ b/source/_addonStore/models/addon.py
@@ -229,6 +229,10 @@ class InstalledAddonStoreModel(_AddonStoreModel):
 	def description(self) -> str:
 		return self._manifest["description"]
 
+	@property
+	def author(self) -> str:
+		return self._manifest["author"]
+
 
 @dataclasses.dataclass(frozen=True)  # once created, it should not be modified.
 class AddonStoreModel(_AddonStoreModel):

--- a/source/gui/_addonStoreGui/controls/details.py
+++ b/source/gui/_addonStoreGui/controls/details.py
@@ -6,8 +6,8 @@
 import wx
 
 from _addonStore.models.addon import (
-	InstalledAddonStoreModel,
 	_AddonStoreModel,
+	_InstalledAddonModel,
 )
 from gui import guiHelper
 from gui.dpiScalingHelper import DpiScalingHelperMixinWithoutInit
@@ -218,15 +218,15 @@ class AddonDetails(
 					self.defaultStyle
 				)
 
-				self._appendDetailsLabelValue(
-					# Translators: Label for an extra detail field for the selected add-on. In the add-on store dialog.
-					pgettext("addonStore", "Publisher:"),
-					details.publisher
-				)
-				if isinstance(details, InstalledAddonStoreModel):
-					# The author and publisher fields are both available in this case.
-					# Publisher comes from add-on store data, author comes from the manifest.
-					# For externally installed add-ons, the publisher field uses the author manifest field.
+				if isinstance(details, _AddonStoreModel):
+					# Publisher comes from the add-on store JSON.
+					self._appendDetailsLabelValue(
+						# Translators: Label for an extra detail field for the selected add-on. In the add-on store dialog.
+						pgettext("addonStore", "Publisher:"),
+						details.publisher
+					)
+				if isinstance(details, _InstalledAddonModel):
+					# Author comes from the manifest, and is only available for installed add-ons.
 					self._appendDetailsLabelValue(
 						# Translators: Label for an extra detail field for the selected add-on. In the add-on store dialog.
 						pgettext("addonStore", "Author:"),

--- a/source/gui/_addonStoreGui/controls/details.py
+++ b/source/gui/_addonStoreGui/controls/details.py
@@ -6,6 +6,7 @@
 import wx
 
 from _addonStore.models.addon import (
+	InstalledAddonStoreModel,
 	_AddonStoreModel,
 )
 from gui import guiHelper
@@ -222,6 +223,22 @@ class AddonDetails(
 					pgettext("addonStore", "Publisher:"),
 					details.publisher
 				)
+				if isinstance(details, InstalledAddonStoreModel):
+					# The author and publisher fields are both available in this case.
+					# Publisher comes from add-on store data, author comes from the manifest.
+					# For externally installed add-ons, the publisher field uses the author manifest field.
+					self._appendDetailsLabelValue(
+						# Translators: Label for an extra detail field for the selected add-on. In the add-on store dialog.
+						pgettext("addonStore", "Author:"),
+						details.author
+					)
+
+				self._appendDetailsLabelValue(
+					# Translators: Label for an extra detail field for the selected add-on. In the add-on store dialog.
+					pgettext("addonStore", "ID:"),
+					details.addonId
+				)
+
 				currentStatusKey = self._actionsContextMenu._storeVM._filteredStatusKey
 				if currentStatusKey not in AddonListField.currentAddonVersionName.hideStatuses:
 					self._appendDetailsLabelValue(

--- a/source/gui/_addonStoreGui/controls/messageDialogs.py
+++ b/source/gui/_addonStoreGui/controls/messageDialogs.py
@@ -10,7 +10,11 @@ from typing import (
 import wx
 
 import addonAPIVersion
-from _addonStore.models.addon import _AddonGUIModel
+from _addonStore.models.addon import (
+	_AddonGUIModel,
+	_AddonStoreModel,
+	_InstalledAddonModel,
+)
 from gui.addonGui import ErrorAddonInstallDialog
 from gui.message import messageBox
 
@@ -160,28 +164,32 @@ def _showAddonInfo(addon: _AddonGUIModel) -> None:
 			# Translators: message shown in the Addon Information dialog.
 			"{summary} ({name})\n"
 			"Version: {version}\n"
-			"Publisher: {publisher}\n"
 			"Description: {description}\n"
 			).format(
 		summary=addon.displayName,
 		name=addon.addonId,
 		version=addon.addonVersionName,
-		publisher=addon.publisher,
 		description=addon.description,
 		)
 	]
+	if isinstance(addon, _AddonStoreModel):
+		# Translators: the publisher part of the About Add-on information
+		message.append(pgettext("addonStore", "Publisher: {publisher}\n").format(publisher=addon.publisher))
+	if isinstance(addon, _InstalledAddonModel):
+		# Translators: the author part of the About Add-on information
+		message.append(pgettext("addonStore", "Author: {author}\n").format(author=addon.author))
 	if addon.homepage:
 		# Translators: the url part of the About Add-on information
-		message.append(pgettext("addonStore", "Homepage: {url}").format(url=addon.homepage))
+		message.append(pgettext("addonStore", "Homepage: {url}\n").format(url=addon.homepage))
 	minimumNVDAVersion = addonAPIVersion.formatForGUI(addon.minimumNVDAVersion)
 	message.append(
 		# Translators: the minimum NVDA version part of the About Add-on information
-		pgettext("addonStore", "Minimum required NVDA version: {}").format(minimumNVDAVersion)
+		pgettext("addonStore", "Minimum required NVDA version: {}\n").format(minimumNVDAVersion)
 	)
 	lastTestedNVDAVersion = addonAPIVersion.formatForGUI(addon.lastTestedNVDAVersion)
 	message.append(
 		# Translators: the last NVDA version tested part of the About Add-on information
-		pgettext("addonStore", "Last NVDA version tested: {}").format(lastTestedNVDAVersion)
+		pgettext("addonStore", "Last NVDA version tested: {}\n").format(lastTestedNVDAVersion)
 	)
 	# Translators: title for the Addon Information dialog
 	title = pgettext("addonStore", "Add-on Information")

--- a/source/gui/_addonStoreGui/viewModels/addonList.py
+++ b/source/gui/_addonStoreGui/viewModels/addonList.py
@@ -21,6 +21,8 @@ from requests.structures import CaseInsensitiveDict
 
 from _addonStore.models.addon import (
 	_AddonGUIModel,
+	_AddonStoreModel,
+	_InstalledAddonModel,
 )
 from _addonStore.models.status import (
 	_StatusFilterKey,
@@ -54,13 +56,13 @@ class AddonListField(_AddonListFieldData, Enum):
 		150,
 	)
 	currentAddonVersionName = (
-		# Translators: The name of the column that contains the installed addons version string.
+		# Translators: The name of the column that contains the installed addon's version string.
 		pgettext("addonStore", "Installed version"),
 		100,
 		frozenset({_StatusFilterKey.AVAILABLE}),
 	)
 	availableAddonVersionName = (
-		# Translators: The name of the column that contains the available addons version string.
+		# Translators: The name of the column that contains the available addon's version string.
 		pgettext("addonStore", "Available version"),
 		100,
 		frozenset({_StatusFilterKey.INCOMPATIBLE, _StatusFilterKey.INSTALLED}),
@@ -71,9 +73,16 @@ class AddonListField(_AddonListFieldData, Enum):
 		50,
 	)
 	publisher = (
-		# Translators: The name of the column that contains the addons publisher.
+		# Translators: The name of the column that contains the addon's publisher.
 		pgettext("addonStore", "Publisher"),
-		100
+		100,
+		frozenset({_StatusFilterKey.INCOMPATIBLE, _StatusFilterKey.INSTALLED})
+	)
+	author = (
+		# Translators: The name of the column that contains the addon's author.
+		pgettext("addonStore", "Author"),
+		100,
+		frozenset({_StatusFilterKey.AVAILABLE, _StatusFilterKey.UPDATE})
 	)
 	status = (
 		# Translators: The name of the column that contains the status of the addon.
@@ -292,10 +301,14 @@ class AddonListVM:
 		def _containsTerm(detailsVM: AddonListItemVM, term: str) -> bool:
 			term = term.casefold()
 			model = detailsVM.model
+			inPublisher = isinstance(model, _AddonStoreModel) and term in model.publisher.casefold()
+			inAuthor = isinstance(model, _InstalledAddonModel) and term in model.author.casefold()
 			return (
 				term in model.displayName.casefold()
 				or term in model.description.casefold()
-				or term in model.publisher.casefold()
+				or term in model.addonId.casefold()
+				or inPublisher
+				or inAuthor
 			)
 
 		filtered = (

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2665,7 +2665,7 @@ To list add-ons only for specific channels, change the "Channel" filter selectio
 To search add-ons, use the "Search" text box.
 You can reach it by pressing ``shift+tab`` from the list of add-ons, or by pressing ``alt+s`` from anywhere in the Add-on Store interface.
 Type a keyword or two for the kind of add-on you're looking for, then ``tab`` back to the list of add-ons.
-Add-ons will be listed if the search text can be found in the display name, publisher or description.
+Add-ons will be listed if the search text can be found in the add-on ID, display name, publisher, author or description.
 
 ++ Add-on actions ++[AddonStoreActions]
 Add-ons have associated actions, such as install, help, disable, and remove.


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/wiki/Contributing.
-->

### Link to issue number:
Raised in https://github.com/nvaccess/nvda/discussions/14912#discussioncomment-6046486

### Summary of the issue:
A user may wish to discover the internal ID of an add-on.
For an add-on installed from the datastore, both `publisher` and `author` fields can be displayed.

### Description of user facing changes
Display the add-on ID in the details panel.
Show the "author" field for add-ons installed from the datastore.

### Description of development approach

### Testing strategy:
Tested viewing the details of internally and externally installed add-ons.

### Known issues with pull request:
None
### Change log entries:
N/A

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
