### PR TITLE
Add-on store: Fix up loading message

### DIFF
--- a/source/gui/_addonStoreGui/controls/details.py
+++ b/source/gui/_addonStoreGui/controls/details.py
@@ -201,7 +201,7 @@ class AddonDetails(
 			self.otherDetailsTextCtrl.SetValue("")
 			if not details:
 				self.contentsPanel.Hide()
-				if self._detailsVM._isLoading:
+				if self._detailsVM._listVM._isLoading:
 					self.updateAddonName(AddonDetails._loadingAddonsLabelText)
 				else:
 					self.updateAddonName(AddonDetails._noAddonSelectedLabelText)

--- a/source/gui/_addonStoreGui/controls/storeDialog.py
+++ b/source/gui/_addonStoreGui/controls/storeDialog.py
@@ -309,6 +309,8 @@ class AddonStoreDialog(SettingsDialog):
 			self.includeIncompatibleCtrl.Disable()
 
 	def onListTabPageChange(self, evt: wx.EVT_CHOICE):
+		self.searchFilterCtrl.SetValue("")
+
 		self._storeVM._filterEnabledDisabled = EnabledStatus.ALL
 		self.enabledFilterCtrl.SetSelection(0)
 

--- a/source/gui/_addonStoreGui/viewModels/addonList.py
+++ b/source/gui/_addonStoreGui/viewModels/addonList.py
@@ -127,9 +127,9 @@ class AddonListItemVM:
 
 
 class AddonDetailsVM:
-	def __init__(self, listItem: Optional[AddonListItemVM] = None):
-		self._listItem: Optional[AddonListItemVM] = listItem
-		self._isLoading: bool = False
+	def __init__(self, listVM: AddonListVM):
+		self._listVM = listVM
+		self._listItem: Optional[AddonListItemVM] = listVM.getSelection()
 		self.updated = extensionPoints.Action()  # triggered by setting L{self._listItem}
 
 	@property
@@ -158,6 +158,7 @@ class AddonListVM:
 			addons: List[AddonListItemVM],
 			storeVM: "AddonStoreVM",
 	):
+		self._isLoading: bool = False
 		self._addons: CaseInsensitiveDict[AddonListItemVM] = CaseInsensitiveDict()
 		self._storeVM = storeVM
 		self.itemUpdated = extensionPoints.Action()

--- a/source/gui/_addonStoreGui/viewModels/store.py
+++ b/source/gui/_addonStoreGui/viewModels/store.py
@@ -98,7 +98,7 @@ class AddonStoreVM:
 			storeVM=self,
 		)
 		self.detailsVM: AddonDetailsVM = AddonDetailsVM(
-			listItem=self.listVM.getSelection()
+			listVM=self.listVM
 		)
 		self.actionVMList = self._makeActionsList()
 		self.listVM.selectionChanged.register(self._onSelectedItemChanged)
@@ -370,7 +370,7 @@ class AddonStoreVM:
 			raise NotImplementedError(f"Unhandled status filter key {self._filteredStatusKey}")
 
 	def _getAvailableAddonsInBG(self):
-		self.detailsVM._isLoading = True
+		self.listVM._isLoading = True
 		self.listVM.resetListItems([])
 		log.debug("getting available addons in the background")
 		assert addonDataManager
@@ -393,7 +393,9 @@ class AddonStoreVM:
 		self._availableAddons = availableAddons
 		self.listVM.resetListItems(self._createListItemVMs())
 		self.detailsVM.listItem = self.listVM.getSelection()
-		self.detailsVM._isLoading = False
+		self.listVM._isLoading = False
+		# ensure calling on the main thread.
+		core.callLater(delay=0, callable=self.detailsVM.updated.notify, addonDetailsVM=self.detailsVM)
 		log.debug("completed refresh")
 
 	def cancelDownloads(self):


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/wiki/Contributing.
-->

### Link to issue number:
Fixes #14975 
Fixes #15184

### Summary of the issue:
Sometimes the add-on store incorrectly reports "Loading add-ons" when it should report "No add-on selected".
This happens when no add-ons are found. When an add-on is found, the text is correctly replaced with the add-ons name.

When switching tabs, the add-on search filter should be reset.

### Description of user facing changes
Fix bug where "No add-on selected" should be reported instead of "loading add-ons".

When switching tabs, the add-on search filter is now reset.

### Description of development approach
Notify the details panel to update when the add-on list loading is complete. Previously, this would only refresh when an add-on was found.

### Testing strategy:
Test STR in #14975 and #15184

### Known issues with pull request:
None
### Change log entries:
N/A

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
