### PR TITLE
Review documentation changes for 2023.2

### DIFF
--- a/devDocs/userGuideStandards.md
+++ b/devDocs/userGuideStandards.md
@@ -13,7 +13,7 @@ The principles outlined in ["The Documentation System" guide for reference mater
 
 ## Feature settings
 
-Feature flags should be included using the following format.
+Feature flags, comboboxes and checkboxes should be included using the following format.
 
 `FeatureDescriptionAnchor` should not include the settings category.
 Once the anchor is set it cannot be updated, while settings may move categories.

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -5,17 +5,17 @@ What's New in NVDA
 %!includeconf: ./locale.t2tconf
 
 = 2023.2 =
-This release most notably introduces the Add-on Store.
+This release introduces the Add-on Store to replace the Add-ons Manager.
 In the Add-on Store you can browse, search, install and update community add-ons.
-You can also manually override incompatibility issues with outdated add-ons.
+You can now manually override incompatibility issues with outdated add-ons at your own risk.
 
-New features include added input gestures and improved Braille support.
-There is improved support for reporting formatting in Microsoft Office.
+There are new Braille features, commands, and display support.
+There are also new input gestures for OCR and flattened object navigation.
+Navigating and reporting formatting in Microsoft Office is improved.
 
 There are many bug fixes, particularly for Braille, Microsoft Office, web browsers and Windows 11.
 
-eSpeak, LibLouis, and Unicode CLDR have been updated.
-
+eSpeak-NG, LibLouis Braille translator, and Unicode CLDR have been updated.
 
 == New Features ==
 - Add-on Store has been added to NVDA. (#13985)

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -152,7 +152,7 @@ eSpeak, LibLouis, and Unicode CLDR have been updated.
 Please refer to [the developer guide https://www.nvaccess.org/files/nvda/documentation/developerGuide.html#API] for information on NVDA's API deprecation and removal process.
 
 - Suggested conventions have been added to the add-on manifest specification.
-These are optional for NVDA compatibility, but are encouraged or required for submitting to the add-on store. (#14754)
+These are optional for NVDA compatibility, but are encouraged or required for submitting to the Add-on Store. (#14754)
   - Use ``lowerCamelCase`` for the name field.
   - Use ``<major>.<minor>.<patch>`` format for the version field (required for add-on datastore).
   - Use ``https://`` as the schema for the url field (required for add-on datastore).

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -10,6 +10,7 @@ In the Add-on Store you can browse, search, install and update community add-ons
 You can also manually override incompatibility issues with outdated add-ons.
 
 New features include added input gestures and improved Braille support.
+There is improved support for reporting formatting in Microsoft Office.
 
 There are many bug fixes, particularly for Braille, Microsoft Office, web browsers and Windows 11.
 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -5,6 +5,16 @@ What's New in NVDA
 %!includeconf: ./locale.t2tconf
 
 = 2023.2 =
+This release most notably introduces the Add-on Store.
+In the Add-on Store you can browse, search, install and update community add-ons.
+You can also manually override incompatibility issues with outdated add-ons.
+
+New features include added input gestures and improved Braille support.
+
+There are many bug fixes, particularly for Braille, Microsoft Office, web browsers and Windows 11.
+
+eSpeak, LibLouis, and Unicode CLDR have been updated.
+
 
 == New Features ==
 - Add-on Store has been added to NVDA. (#13985)
@@ -32,17 +42,17 @@ What's New in NVDA
   Please refer to the NVDA User Guide for a full list. (#14714)
   -
 - Added pronunciation of Unicode symbols:
-  - braille symbols such as "⠐⠣⠃⠗⠇⠐⠜". (#14548)
-  - Mac Option key symbol "⌥". (#14682)
+  - Braille symbols such as ``⠐⠣⠃⠗⠇⠐⠜``. (#13778)
+  - Mac Option key symbol ``⌥``. (#14682)
   -
 - Added gestures for Tivomatic Caiku Albatross Braille displays. (#14844, #15002)
-  - showing the braille settings dialog
+  - showing the Braille settings dialog
   - accessing the status bar
-  - cycling the braille cursor shape
-  - cycling the braille show messages mode
-  - toggling the braille cursor on/off
-  - toggling the "braille show selection indicator" state
-  - cycling the "braille move system caret when routing review cursor" mode. (#15122)
+  - cycling the Braille cursor shape
+  - cycling the Braille show messages mode
+  - toggling the Braille cursor on/off
+  - toggling the "Braille show selection indicator" state
+  - cycling the "Braille move system caret when routing review cursor" mode. (#15122)
   -
 - Microsoft Office features:
   - When highlighted text is enabled Document Formatting, highlight colours are now reported in Microsoft Word. (#7396, #12101, #5866)
@@ -58,7 +68,7 @@ What's New in NVDA
     -
   - There is a known issue with intermittent crashing when WASAPI is enabled. (#15150)
   -
-- In Mozilla Firefox and Google Chrome, NVDA now reports when a control opens a dialog, grid, list or tree if the author has specified this using aria-haspopup. (#14709)
+- In Mozilla Firefox and Google Chrome, NVDA now reports when a control opens a dialog, grid, list or tree if the author has specified this using ``aria-haspopup``. (#8235)
 - It is now possible to use system variables (such as ``%temp%`` or ``%homepath%``) in the path specification while creating portable copies of NVDA. (#14680)
 - In Windows 10 May 2019 Update and later, NVDA can announce virtual desktop names when opening, changing, and closing them. (#5641)
 - A system wide parameter has been added to allow users and system administrators to force NVDA to start in secure mode. (#10018)
@@ -66,41 +76,45 @@ What's New in NVDA
 
 
 == Changes ==
-- eSpeak NG has been updated to 1.52-dev commit ``ed9a7bcf``. (#15036)
-- Updated LibLouis braille translator to [3.26.0 https://github.com/liblouis/liblouis/releases/tag/v3.26.0]. (#14970)
-- CLDR has been updated to version 43.0. (#14918)
-- Dash and em-dash symbols will always be sent to the synthesizer. (#13830)
-- LibreOffice changes:
-  - When reporting the review cursor location, the current cursor/caret location is now reported relative to the current page in LibreOffice Writer for LibreOffice versions >= 7.6, similar to what is done for Microsoft Word. (#11696)
-  - Announcement of the status bar (e.g. triggered by ``NVDA+end``) works for LibreOffice. (#11698)
+- Component updates:
+  - eSpeak NG has been updated to 1.52-dev commit ``ed9a7bcf``. (#15036)
+  - Updated LibLouis Braille translator to [3.26.0 https://github.com/liblouis/liblouis/releases/tag/v3.26.0]. (#14970)
+  - CLDR has been updated to version 43.0. (#14918)
   -
+- LibreOffice changes:
+  - When reporting the review cursor location, the current cursor/caret location is now reported relative to the current page in LibreOffice Writer 7.6 and newer, similar to what is done for Microsoft Word. (#11696)
+  - Announcement of the status bar (e.g. triggered by ``NVDA+end``) works for LibreOffice. (#11698)
+  - When moving to a different cell in LibreOffice Calc, NVDA no longer incorrectly announces the coordinates of the previously focused cell when cell coordinate announcement is disabled in NVDA's settings. (#15098)
+  -
+- Braille changes:
+  - When using a Braille Display via the Standard HID Braille driver, the dpad can be used to emulate the arrow keys and enter.
+  Also ``space+dot1`` and ``space+dot4`` now map to up and down arrow respectively. (#14713)
+  - Updates to dynamic web content (ARIA live regions) are now displayed in Braille.
+  This can be disabled in the Advanced Settings panel. (#7756)
+  -
+- Dash and em-dash symbols will always be sent to the synthesizer. (#13830)
 - Distance reported in Microsoft Word will now honour the unit defined in Word's advanced options even when using UIA to access Word documents. (#14542)
 - NVDA responds faster when moving the cursor in edit controls. (#14708)
-- When using a Braille Display via the Standard HID braille driver, the dpad can be used to emulate the arrow keys and enter.
-Also ``space+dot1`` and ``space+dot4`` now map to up and down arrow respectively. (#14713)
 - Script for reporting the destination of a link now reports from the caret / focus position rather than the navigator object. (#14659)
-- Portable copy creation no longer requires that a drive letter be entered as part of the absolute path. (#14681)
+- Portable copy creation no longer requires that a drive letter be entered as part of the absolute path. (#14680)
 - If Windows is configured to display seconds in the system tray clock, using ``NVDA+f12`` to report the time now honors that setting. (#14742)
 - NVDA will now report unlabeled groupings that have useful position information, such as in recent versions of Microsoft Office 365 menus. (#14878)
-- Updates to dynamic web content (ARIA live regions) are now displayed in Braille.
-This can be disabled in the Advanced Settings panel. (#7756)
-- When moving to a different cell in LibreOffice Calc, NVDA no longer incorrectly announces the coordinates of the previously focused cell when cell coordinate announcement is disabled in NVDA's settings. (#15098)
 -
 
 
 == Bug Fixes ==
 - Braille:
-  - Several stability fixes to input/output for braille displays, resulting in less frequent errors and crashes of NVDA. (#14627)
-  - NVDA will no longer unnecessarily switch to no braille multiple times during auto detection, resulting in a cleaner log and less overhead. (#14524)
+  - Several stability fixes to input/output for Braille displays, resulting in less frequent errors and crashes of NVDA. (#14627)
+  - NVDA will no longer unnecessarily switch to no Braille multiple times during auto detection, resulting in a cleaner log and less overhead. (#14524)
   - NVDA will now switch back to USB if a HID Bluetooth device (such as the HumanWare Brailliant or APH Mantis) is automatically detected and an USB connection becomes available.
   This only worked for Bluetooth Serial ports before. (#14524)
   -
 - Web browsers:
   - NVDA no longer occasionally causes Mozilla Firefox to crash or stop responding. (#14647)
-  - In Mozilla Firefox and Google Chrome, typed characters are no longer reported in some text boxes even when speak typed characters is disabled. (#14666)
+  - In Mozilla Firefox and Google Chrome, typed characters are no longer reported in some text boxes even when speak typed characters is disabled. (#8442)
   - You can now use browse mode in Chromium Embedded Controls where it was not possible previously. (#13493, #8553)
   - In Mozilla Firefox, moving the mouse over text after a link now reliably reports the text. (#9235)
-  - The destination of graphic links is now correctly reported in Chrome and Edge. (#14779)
+  - The destination of graphic links is now reported accurately in more cases in Chrome and Edge. (#14783)
   - When trying to report the URL for a link without a href attribute NVDA is no longer silent.
   Instead NVDA reports that the link has no destination. (#14723)
   - In Browse mode, NVDA will no longer incorrectly ignore focus moving to a parent or child control e.g. moving from a control to its parent list item or gridcell. (#14611)
@@ -115,7 +129,7 @@ This can be disabled in the Advanced Settings panel. (#7756)
   -
 - Microsoft Office fixes:
   - When rapidly moving through cells in Excel, NVDA is now less likely to report the wrong cell or selection. (#14983, #12200, #12108)
-  - When landing on an Excel cell from outside a work sheet, braille and focus highlighter are no longer needlessly updated to the object that had focus previously. (#15136)
+  - When landing on an Excel cell from outside a work sheet, Braille and focus highlighter are no longer needlessly updated to the object that had focus previously. (#15136)
   - NVDA no longer fails to announce focusing password fields in Microsoft Excel and Outlook. (#14839)
   -
 - For symbols which do not have a symbol description in the current locale, the default English symbol level will be used. (#14558, #14417)
@@ -137,11 +151,10 @@ This can be disabled in the Advanced Settings panel. (#7756)
 Please refer to [the developer guide https://www.nvaccess.org/files/nvda/documentation/developerGuide.html#API] for information on NVDA's API deprecation and removal process.
 
 - Suggested conventions have been added to the add-on manifest specification.
-These are optional for NVDA compatibility, but are encouraged or required for submitting to the add-on store.
-The new suggested conventions are:
-  - Using ``lowerCamelCase`` for the name field.
-  - Using ``<major>.<minor>.<patch>`` format for the version field (required for add-on datastore).
-  - Using ``https://`` as the schema for the url field (required for add-on datastore).
+These are optional for NVDA compatibility, but are encouraged or required for submitting to the add-on store. (#14754)
+  - Use ``lowerCamelCase`` for the name field.
+  - Use ``<major>.<minor>.<patch>`` format for the version field (required for add-on datastore).
+  - Use ``https://`` as the schema for the url field (required for add-on datastore).
   -
 - Added a new extension point type called ``Chain``, which can be used to iterate over iterables returned by registered handlers. (#14531)
 - Added the ``bdDetect.scanForDevices`` extension point.

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -9,13 +9,13 @@ This release introduces the Add-on Store to replace the Add-ons Manager.
 In the Add-on Store you can browse, search, install and update community add-ons.
 You can now manually override incompatibility issues with outdated add-ons at your own risk.
 
-There are new Braille features, commands, and display support.
+There are new braille features, commands, and display support.
 There are also new input gestures for OCR and flattened object navigation.
 Navigating and reporting formatting in Microsoft Office is improved.
 
-There are many bug fixes, particularly for Braille, Microsoft Office, web browsers and Windows 11.
+There are many bug fixes, particularly for braille, Microsoft Office, web browsers and Windows 11.
 
-eSpeak-NG, LibLouis Braille translator, and Unicode CLDR have been updated.
+eSpeak-NG, LibLouis braille translator, and Unicode CLDR have been updated.
 
 == New Features ==
 - Add-on Store has been added to NVDA. (#13985)
@@ -26,34 +26,34 @@ eSpeak-NG, LibLouis Braille translator, and Unicode CLDR have been updated.
   -
 - New input gestures:
   - An unbound gesture to cycle through the available languages for Windows OCR. (#13036)
-  - An unbound gesture to cycle through the Braille show messages modes. (#14864)
-  - An unbound gesture to toggle showing the selection indicator for Braille. (#14948)
+  - An unbound gesture to cycle through the braille show messages modes. (#14864)
+  - An unbound gesture to toggle showing the selection indicator for braille. (#14948)
   - Added default keyboard gesture assignments to move to the next or previous object in a flattened view of the object hierarchy. (#15053)
     - Desktop: ``NVDA+numpad9`` and ``NVDA+numpad3`` to move to the previous and next objects respectively.
     - Laptop: ``shift+NVDA+[`` and ``shift+NVDA+]`` to move to the previous and next objects respectively.
     -
   -
-- New Braille features:
-  - Added support for the Help Tech Activator Braille display. (#14917)
+- New braille features:
+  - Added support for the Help Tech Activator braille display. (#14917)
   - A new option to toggle showing the selection indicator (dots 7 and 8). (#14948)
-  - A new option to optionally move the system caret or focus when changing the review cursor position with Braille routing keys. (#14885, #3166)
-  - When pressing ``numpad2`` three times to report the numerical value of the character at the position of the review cursor, the information is now also provided in Braille. (#14826)
-  - Added support for the ``aria-brailleroledescription`` ARIA 1.3 attribute, allowing web authors to override the type of an element shown on the Braille display. (#14748)
-  - Baum Braille driver: added several Braille chord gestures for performing common keyboard commands such as ``windows+d`` and ``alt+tab``.
+  - A new option to optionally move the system caret or focus when changing the review cursor position with braille routing keys. (#14885, #3166)
+  - When pressing ``numpad2`` three times to report the numerical value of the character at the position of the review cursor, the information is now also provided in braille. (#14826)
+  - Added support for the ``aria-brailleroledescription`` ARIA 1.3 attribute, allowing web authors to override the type of an element shown on the braille display. (#14748)
+  - Baum braille driver: added several braille chord gestures for performing common keyboard commands such as ``windows+d`` and ``alt+tab``.
   Please refer to the NVDA User Guide for a full list. (#14714)
   -
 - Added pronunciation of Unicode symbols:
-  - Braille symbols such as ``⠐⠣⠃⠗⠇⠐⠜``. (#13778)
+  - braille symbols such as ``⠐⠣⠃⠗⠇⠐⠜``. (#13778)
   - Mac Option key symbol ``⌥``. (#14682)
   -
-- Added gestures for Tivomatic Caiku Albatross Braille displays. (#14844, #15002)
-  - showing the Braille settings dialog
+- Added gestures for Tivomatic Caiku Albatross braille displays. (#14844, #15002)
+  - showing the braille settings dialog
   - accessing the status bar
-  - cycling the Braille cursor shape
-  - cycling the Braille show messages mode
-  - toggling the Braille cursor on/off
-  - toggling the "Braille show selection indicator" state
-  - cycling the "Braille move system caret when routing review cursor" mode. (#15122)
+  - cycling the braille cursor shape
+  - cycling the braille show messages mode
+  - toggling the braille cursor on/off
+  - toggling the "braille show selection indicator" state
+  - cycling the "braille move system caret when routing review cursor" mode. (#15122)
   -
 - Microsoft Office features:
   - When highlighted text is enabled Document Formatting, highlight colours are now reported in Microsoft Word. (#7396, #12101, #5866)
@@ -79,7 +79,7 @@ eSpeak-NG, LibLouis Braille translator, and Unicode CLDR have been updated.
 == Changes ==
 - Component updates:
   - eSpeak NG has been updated to 1.52-dev commit ``ed9a7bcf``. (#15036)
-  - Updated LibLouis Braille translator to [3.26.0 https://github.com/liblouis/liblouis/releases/tag/v3.26.0]. (#14970)
+  - Updated LibLouis braille translator to [3.26.0 https://github.com/liblouis/liblouis/releases/tag/v3.26.0]. (#14970)
   - CLDR has been updated to version 43.0. (#14918)
   -
 - LibreOffice changes:
@@ -88,9 +88,9 @@ eSpeak-NG, LibLouis Braille translator, and Unicode CLDR have been updated.
   - When moving to a different cell in LibreOffice Calc, NVDA no longer incorrectly announces the coordinates of the previously focused cell when cell coordinate announcement is disabled in NVDA's settings. (#15098)
   -
 - Braille changes:
-  - When using a Braille Display via the Standard HID Braille driver, the dpad can be used to emulate the arrow keys and enter.
+  - When using a braille display via the Standard HID braille driver, the dpad can be used to emulate the arrow keys and enter.
   Also ``space+dot1`` and ``space+dot4`` now map to up and down arrow respectively. (#14713)
-  - Updates to dynamic web content (ARIA live regions) are now displayed in Braille.
+  - Updates to dynamic web content (ARIA live regions) are now displayed in braille.
   This can be disabled in the Advanced Settings panel. (#7756)
   -
 - Dash and em-dash symbols will always be sent to the synthesizer. (#13830)
@@ -105,8 +105,8 @@ eSpeak-NG, LibLouis Braille translator, and Unicode CLDR have been updated.
 
 == Bug Fixes ==
 - Braille:
-  - Several stability fixes to input/output for Braille displays, resulting in less frequent errors and crashes of NVDA. (#14627)
-  - NVDA will no longer unnecessarily switch to no Braille multiple times during auto detection, resulting in a cleaner log and less overhead. (#14524)
+  - Several stability fixes to input/output for braille displays, resulting in less frequent errors and crashes of NVDA. (#14627)
+  - NVDA will no longer unnecessarily switch to no braille multiple times during auto detection, resulting in a cleaner log and less overhead. (#14524)
   - NVDA will now switch back to USB if a HID Bluetooth device (such as the HumanWare Brailliant or APH Mantis) is automatically detected and an USB connection becomes available.
   This only worked for Bluetooth Serial ports before. (#14524)
   -
@@ -130,7 +130,7 @@ eSpeak-NG, LibLouis Braille translator, and Unicode CLDR have been updated.
   -
 - Microsoft Office fixes:
   - When rapidly moving through cells in Excel, NVDA is now less likely to report the wrong cell or selection. (#14983, #12200, #12108)
-  - When landing on an Excel cell from outside a work sheet, Braille and focus highlighter are no longer needlessly updated to the object that had focus previously. (#15136)
+  - When landing on an Excel cell from outside a work sheet, braille and focus highlighter are no longer needlessly updated to the object that had focus previously. (#15136)
   - NVDA no longer fails to announce focusing password fields in Microsoft Excel and Outlook. (#14839)
   -
 - For symbols which do not have a symbol description in the current locale, the default English symbol level will be used. (#14558, #14417)

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2292,7 +2292,7 @@ Microsoft Excel's UI automation implementation is ever changing, and  versions o
 : Default
   Enabled
 : Options
-  Disabled, Enabled
+  Default (Enabled), Disabled, Enabled
 :
 
 This option selects whether NVDA reports changes in some dynamic web content in Braille.
@@ -2327,7 +2327,7 @@ However, in terminals, when inserting or deleting a character in the middle of a
 : Default
   Diffing
 : Options
-  Diffing, UIA notifications
+  Default (Diffing), Diffing, UIA notifications
 :
 
 This option selects how NVDA determines what text is "new" (and thus what to speak when "report dynamic content changes" is enabled) in Windows Terminal and the WPF Windows Terminal control used in Visual Studio 2022.
@@ -2633,7 +2633,7 @@ To access the Add-on Store from anywhere, assign a custom gesture using the [Inp
 
 ++ Browsing add-ons ++[AddonStoreBrowsing]
 When opened, the Add-on Store displays a list of add-ons.
-If you have not installed an add-on before, the add-on store will open to a list of add-ons available to install.
+If you have not installed an add-on before, the Add-on Store will open to a list of add-ons available to install.
 If you have installed add-ons, the list will display currently installed add-ons.
 
 Selecting an add-on, by moving to it with the up and down arrow keys, will display the details for the add-on.
@@ -2666,7 +2666,7 @@ Add-ons can be distributed through up to four channels:
 Suggested for early adopters.
 - Dev: This channel is suggested to be used by add-on developers to test unreleased API changes.
 NVDA alpha testers may need to use a "Dev" version of their add-ons.
-- External: Add-ons installed from external sources, outside of the add-on store.
+- External: Add-ons installed from external sources, outside of the Add-on Store.
 -
 
 To list add-ons only for specific channels, change the "Channel" filter selection.

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -1709,7 +1709,7 @@ Disabling this option allows speech to be heard while simultaneously reading Bra
   Default (Enabled), Enabled, Disabled
 :
 
-This setting determines if selection indicator (dots 7 and 8) is shown in braille display.
+This setting determines if selection indicator (dots 7 and 8) is shown by the braille display.
 The option is enabled by default so the selection indicator is shown.
 The selection indicator might be a distraction while reading.
 Disabling this option may improve readability.
@@ -3664,11 +3664,11 @@ Due to this, and to maintain compatibility with other screen readers in Taiwan, 
 
 ++ Eurobraille displays ++[Eurobraille]
 The b.book, b.note, Esys, Esytime and Iris displays from Eurobraille are supported by NVDA.  
-These devices have a Braille keyboard with 10 keys. 
+These devices have a braille keyboard with 10 keys. 
 Of the two keys placed like a space bar, the left key is corresponding to the backspace key and the right key to the space key.
 Connected via USB, these devices have one stand-alone USB keyboard. 
-It is possible to enable/disable this keyboard with the checkbox "HID Keyboard simulation" in Braille setting panel. 
-The Braille keyboard describes below is the braille keyboard when this checkbox is not checked.
+It is possible to enable/disable this keyboard with the checkbox "HID Keyboard simulation" in braille setting panel. 
+The braille keyboard describes below is the braille keyboard when this checkbox is not checked.
 Following are the key assignments for these displays with NVDA. 
 Please see the display's documentation for descriptions of where these keys can be found.
 

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -488,7 +488,7 @@ To get to the NVDA menu from anywhere in Windows while NVDA is running, you may 
 - Perform a 2-finger double-tap on the touch screen.
 - Access the system tray by pressing ``Windows+b``, ``downArrow`` to the NVDA icon, and press ``enter``.
 - Alternatively, access the system tray by pressing ``Windows+b``, ``downArrow`` to the NVDA icon, and open the context menu by pressing the ``applications`` key located next to the right control key on most keyboards.
-On a keyboard without an ``applications`` key, press ``shift+F10`` instead.
+On a keyboard without an ``applications`` key, press ``shift+f10`` instead.
 - Right-click on the NVDA icon located in the Windows system tray
 -
 When the menu comes up, You can use the arrow keys to navigate the menu, and the ``enter`` key to activate an item.
@@ -1638,7 +1638,7 @@ The same applies to [object review #ObjectReview].
 You can also set this option to only move the caret when tethered automatically.
 In that case, pressing a cursor routing key will only move the system caret or focus when NVDA is tethered to the review cursor automatically, whereas no movement will occur when manually tethered to the review cursor.
 
-This option is shown only if "[tether braille #BrailleTether]" is set to "Automatically" or "To review".
+This option is shown only if "[tether braille #BrailleTether]" is set to "automatically" or "to review".
 
 To toggle move system caret when routing review cursor from anywhere, please assign a custom gesture using the [Input Gestures dialog #InputGestures].
 
@@ -1710,8 +1710,8 @@ Disabling this option allows speech to be heard while simultaneously reading Bra
 :
 
 This setting determines if selection indicator (dots 7 and 8) is shown in braille display.
-The option is enabled by default so selection indicator is shown.
-Selection indicator might be a distraction while reading.
+The option is enabled by default so the selection indicator is shown.
+The selection indicator might be a distraction while reading.
 Disabling this option may improve readability.
 
 To toggle show selection from anywhere, please assign a custom gesture using the [Input Gestures dialog #InputGestures].
@@ -2361,7 +2361,7 @@ With several historically popular GUI APIs, the text may be rendered with a tran
 : Default
   Disabled
 : Options
-  Disabled, Enabled
+  Default (Disabled), Enabled, Disabled
 :
 
 This option enables audio output via the Windows Audio Session API (WASAPI).
@@ -2369,11 +2369,16 @@ WASAPI is a more modern audio framework which may improve the responsiveness, pe
 After changing this option, you will need to restart NVDA for the change to take effect.
 
 ==== Volume of NVDA sounds follows voice volume ====[SoundVolumeFollowsVoice]
+: Default
+  Disabled
+: Options
+  Disabled, Enabled
+:
+
 When this option is enabled, the volume of NVDA sounds and beeps will follow the volume setting of the voice you are using.
 If you decrease the volume of the voice, the volume of sounds will decrease.
 Similarly, if you increase the volume of the voice, the volume of sounds will increase.
 This option only takes effect when "Use WASAPI for audio output" is enabled.
-This option is disabled by default.
 
 ==== Volume of NVDA sounds ====[SoundVolume]
 This slider allows you to set the volume of NVDA sounds and beeps.
@@ -2440,9 +2445,9 @@ You can filter the symbols by entering the symbol or a part of the symbol's repl
 - The Replacement field allows you to change the text that should be spoken in place of this symbol.
 - Using the Level field, you can adjust the lowest symbol level at which this symbol should be spoken (none, some, most or all).
 You can also set the level to character; in this case the symbol will not be spoken regardless of the symbol level in use, with the following two exceptions:
- - When navigating character by character.
- - When NVDA is spelling any text containing that symbol.
- -
+  - When navigating character by character.
+  - When NVDA is spelling any text containing that symbol.
+  -
 - The Send actual symbol to synthesizer field specifies when the symbol itself (in contrast to its replacement) should be sent to the synthesizer.
 This is useful if the symbol causes the synthesizer to pause or change the inflection of the voice.
 For example, a comma causes the synthesizer to pause.
@@ -2668,7 +2673,7 @@ To list add-ons only for specific channels, change the "Channel" filter selectio
 
 +++ Searching for add-ons +++[AddonStoreFilterSearch]
 To search add-ons, use the "Search" text box.
-You can reach it by pressing ``shift+tab`` from the list of add-ons, or by pressing ``alt+s`` from anywhere in the Add-on Store interface.
+You can reach it by pressing ``shift+tab`` from the list of add-ons.
 Type a keyword or two for the kind of add-on you're looking for, then ``tab`` back to the list of add-ons.
 Add-ons will be listed if the search text can be found in the add-on ID, display name, publisher, author or description.
 
@@ -2782,7 +2787,7 @@ For more information, please see the [NVDA Developer Guide https://www.nvaccess.
 
 ++ Add-on Store ++
 This will open the [NVDA Add-on Store #AddonsManager].
-For more information, read the in-depth chapter: [Add-ons and the Add-on Store #AddonsManager].
+For more information, read the in-depth section: [Add-ons and the Add-on Store #AddonsManager].
 
 ++ Create portable copy ++[CreatePortableCopy]
 This will open a dialog which allows you to create a portable copy of NVDA out of the installed version.
@@ -3092,20 +3097,20 @@ Following are the key assignments for these displays with NVDA.
 Please see your display's documentation for descriptions of where these keys can be found.
 %kc:beginInclude
 || Name | Key |
-| Scroll braille display back | d2 |
-| Scroll braille display forward | d5 |
-| Move braille display to previous line | d1 |
-| Move braille display to next line | d3 |
-| Route to braille cell | routing |
-| shift+tab key | space+dot1+dot3 |
-| tab key | space+dot4+dot6 |
-| alt key | space+dot1+dot3+dot4 (space+m) |
-| escape key | space+dot1+dot5 (space+e) |
-| windows key | space+dot3+dot4 |
-| alt+tab key | space+dot2+dot3+dot4+dot5 (space+t) |
-| NVDA Menu | space+dot1+dot3+dot4+dot5 (space+n) |
-| windows+d key (minimize all applications) | space+dot1+dot4+dot5 (space+d) |
-| Say all | space+dot1+dot2+dot3+dot4+dot5+dot6 |
+| Scroll braille display back | ``d2`` |
+| Scroll braille display forward | ``d5`` |
+| Move braille display to previous line | ``d1`` |
+| Move braille display to next line | ``d3`` |
+| Route to braille cell | ``routing`` |
+| ``shift+tab`` key | ``space+dot1+dot3`` |
+| ``tab`` key | ``space+dot4+dot6`` |
+| ``alt`` key | ``space+dot1+dot3+dot4 (space+m)`` |
+| ``escape`` key | ``space+dot1+dot5 (space+e)`` |
+| ``windows`` key | ``space+dot3+dot4`` |
+| ``alt+tab`` key | ``space+dot2+dot3+dot4+dot5 (space+t)`` |
+| NVDA Menu | ``space+dot1+dot3+dot4+dot5 (space+n)`` |
+| ``windows+d`` key (minimize all applications) | ``space+dot1+dot4+dot5 (space+d)`` |
+| Say all | ``space+dot1+dot2+dot3+dot4+dot5+dot6`` |
 
 For displays which have a joystick:
 || Name | Key |
@@ -3659,11 +3664,11 @@ Due to this, and to maintain compatibility with other screen readers in Taiwan, 
 
 ++ Eurobraille displays ++[Eurobraille]
 The b.book, b.note, Esys, Esytime and Iris displays from Eurobraille are supported by NVDA.  
-These devices have a braille keyboard with 10 keys. 
+These devices have a Braille keyboard with 10 keys. 
 Of the two keys placed like a space bar, the left key is corresponding to the backspace key and the right key to the space key.
-Connected via USB, these devices have one stand-alone usb keyboard. 
-It is possible to enable/disable this keyboard with the checkbox ‘HID Keyboard simulation’ in braille setting panel. 
-The braille keyboard describes below is the braille keyboard when this checkbox is not checked.
+Connected via USB, these devices have one stand-alone USB keyboard. 
+It is possible to enable/disable this keyboard with the checkbox "HID Keyboard simulation" in Braille setting panel. 
+The Braille keyboard describes below is the braille keyboard when this checkbox is not checked.
 Following are the key assignments for these displays with NVDA. 
 Please see the display's documentation for descriptions of where these keys can be found.
 


### PR DESCRIPTION
**Must be a squash merge**

Comparison command:
`git diff --stat release-2023.1...docsFor2023.2 -- "**/en/*.t2t" "**/developerGuide.t2t"`

Common mistakes to check for:
- Issue/PR reference in changes file is incorrect
- Incorrect spelling.
- Lists not terminated with a final `-` on a new line, matching indentation
- List items not indented by a multiple of 2 spaces
- Single grave marks ` instead of double grave marks ``
- Shortcuts added without code markdown, use two 'grave' characters (` ``NVDA+d`` `)
- Double spaces
- Inconsistent use of single vs double quote.