### PR TITLE
Restore numpad gestures for move in flatten view of object hierarchy commands for all keyboard layouts

### DIFF
--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -3820,7 +3820,7 @@ class GlobalCommands(ScriptableObject):
 		category=SCRCAT_OBJECTNAVIGATION,
 		gestures=(
 			"ts(object):flickright",
-			"kb(desktop):NVDA+numpad3",
+			"kb:NVDA+numpad3",
 			"kb(laptop):shift+NVDA+]",
 		),
 	)
@@ -3858,7 +3858,7 @@ class GlobalCommands(ScriptableObject):
 		category=SCRCAT_OBJECTNAVIGATION,
 		gestures=(
 			"ts(object):flickleft",
-			"kb(desktop):NVDA+numpad9",
+			"kb:NVDA+numpad9",
 			"kb(laptop):shift+NVDA+[",
 		),
 	)


### PR DESCRIPTION
### Link to issue number:
Closes #15185
Follow-up of #15065.

### Summary of the issue:

New gestures to move in flattened object hierarchy have been added in #15065: nvda+numpad3/9 for desktop layout and shift+NVDA+[ / ] for laptop layout.

Although mainly used with desktop layout, object nav-related gestures associated to numpad are usually bound to all keyboard layout (desktop and laptop). This allows for example users to have NVDA to be configured with laptop layout for a laptop computer without numpad on its keyboard, but to use the numpad gestures in case an external keyboard with numpad is plugged in.

### Description of user facing changes
The gestures NVDA+numpad3/9 for the new flattened object navigation commands will now be available both in laptop and in desktop mode.

As done for other obj nav gestures, the user guide (and the change log) still advertises numpad gestures for desktop layout only.

### Description of development approach
Changed the gesture definition.
### Testing strategy:
* Tested these gestures in both laptop and desktop modes
* Also tested input help.

### Known issues with pull request:
I have used:
`git grep "desktop.*numpad"`
and found two other places where numpad shortcuts are used in desktop only:
* NVDAObjects/window/_msOfficeChart.py
* NVDAObjects/window/excel.py

However, I have not been able to test them. They seem to be part of rarely used code and nobody complained of it until now. So I have not changed them.

### Change log entries:
Not needed (unreleased feature)

### Code Review Checklist:

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
