### PR TITLE
Re-enable WASAPI by default

### DIFF
--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -57,7 +57,7 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 # Audio settings
 [audio]
 	audioDuckingMode = integer(default=0)
-	WASAPI = featureFlag(optionsEnum="BoolFlag", behaviorOfDefault="disabled")
+	WASAPI = featureFlag(optionsEnum="BoolFlag", behaviorOfDefault="enabled")
 	soundVolumeFollowsVoice = boolean(default=false)
 	soundVolume = integer(default=100, min=0, max=100)
 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -7,6 +7,14 @@ What's New in NVDA
 = 2023.3 =
 
 == New Features ==
+- Enhanced sound management:
+  - NVDA will now output audio via the Windows Audio Session API (WASAPI), which may improve the responsiveness, performance and stability of NVDA speech and sounds. (#14697)
+  - WASAPI usage can be disabled in Advanced settings.
+  If WASAPI is enabled, the following Advanced settings can also be configured.
+    - An option to have the volume of NVDA sounds and beeps follow the volume setting of the voice you are using. (#1409)
+    - An option to separately configure the volume of NVDA sounds. (#1409, #15038)
+    -
+  -
 - A new option in Document Formatting settings, "Ignore blank lines for line indentation reporting". (#13394)
 -
 

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2363,9 +2363,9 @@ With several historically popular GUI APIs, the text may be rendered with a tran
 
 ==== Use WASAPI for audio output ====[WASAPI]
 : Default
-  Disabled
+  Enabled
 : Options
-  Disabled, Enabled
+  Default (Enabled), Disabled, Enabled
 :
 
 This option enables audio output via the Windows Audio Session API (WASAPI).


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/wiki/Contributing.
-->

### Link to issue number:
Reintroduces #14697 
Closes #10185
Closes #11061
Closes #11615

### Summary of the issue:
WASAPI usage should be reenabled by default on alpha so wider testing can occur

### Description of user facing changes
WASAPI is re-enabled - refer to #14697 for benefits

### Description of development approach
change feature flag default value to enabled

### Testing strategy:
Alpha testing

### Known issues with pull request:
#15150 is a known issue with WASAPI

### Change log entries:
refer to diff

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
