### PR TITLE
Fix for  Eurobraille gesture logging during input help

### DIFF
--- a/source/brailleDisplayDrivers/eurobraille/gestures.py
+++ b/source/brailleDisplayDrivers/eurobraille/gestures.py
@@ -1,7 +1,7 @@
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-# Copyright (C) 2017-2023 NV Access Limited, Babbage B.V., Eurobraille
+# Copyright (C) 2017-2023 NV Access Limited, Babbage B.V., Eurobraille, Cyrille Bougot
 
 import braille
 import brailleInput
@@ -164,7 +164,7 @@ class InputGesture(braille.BrailleDisplayGesture, brailleInput.BrailleInputGestu
 					# 0x1000 is backspace, 0x2000 is space
 					self.dots = groupKeysDown & 0xff
 					self.space = groupKeysDown & 0x200
-				names.extend(f"dot{((i + 1) for i in range(8) if (groupKeysDown &0xff) & (1 << i))}")
+				names.extend(f"dot{i + 1}" for i in range(8) if (groupKeysDown & 0xff) & (1 << i))
 				if groupKeysDown & 0x200:
 					names.append("space")
 				if groupKeysDown & 0x100:

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2295,7 +2295,7 @@ Microsoft Excel's UI automation implementation is ever changing, and  versions o
   Default (Enabled), Disabled, Enabled
 :
 
-This option selects whether NVDA reports changes in some dynamic web content in Braille.
+This option selects whether NVDA reports changes in some dynamic web content in braille.
 Disabling this option is equivalent to NVDA's behaviour in versions 2023.1 and earlier, which only reported these content changes in speech.
 
 ==== Speak passwords in all enhanced terminals ====[AdvancedSettingsWinConsoleSpeakPasswords]

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2295,7 +2295,7 @@ Microsoft Excel's UI automation implementation is ever changing, and  versions o
   Default (Enabled), Disabled, Enabled
 :
 
-This option selects whether NVDA reports changes in some dynamic web content in braille.
+This option selects whether NVDA reports changes in some dynamic web content in Braille.
 Disabling this option is equivalent to NVDA's behaviour in versions 2023.1 and earlier, which only reported these content changes in speech.
 
 ==== Speak passwords in all enhanced terminals ====[AdvancedSettingsWinConsoleSpeakPasswords]


### PR DESCRIPTION
### Link to issue number:
None
Fix-up of #14690

### Summary of the issue:
In input help mode, when pressing a dot key on the braille keyboard of Esys, I get the following in the log:

```
INFO - inputCore.InputManager._handleInputHelp (11:32:45.222) - MainThread (15120):
Input help: gesture br(eurobraille.esys):d+o+t+<+g+e+n+e+r+a+t+o+r+ +o+b+j+e+c+t+ +I+n+p+u+t+G+e+s+t+u+r+e+.+_+_+i+n+i+t+_+_+.+<+l+o+c+a+l+s+>+.+<+g+e+n+e+x+p+r+>+ +a+t+ +0+x+0+8+A+2+9+9+F+0+>, bound to script braille_dots on globalCommands.GlobalCommands
```

### Description of user facing changes
Fixed the logged message
### Description of development approach
Small fix in code (see diff)
### Testing strategy:
Checked the log when pressing dot key:
```
INFO - inputCore.InputManager._handleInputHelp (11:31:48.871) - MainThread (6896):
Input help: gesture br(eurobraille.esys):dot5, bound to script braille_dots on globalCommands.GlobalCommands
```

### Known issues with pull request:
None
### Change log entries:
Not needed, fixing an unreleased (and minor) bug.
### Code Review Checklist:


- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.

### Note
I am not used to braille code at all; @FalkoBabbage or @leonardder you may want to check it (even if the fix is small).
