### PR TITLE
Fixed mistake in f-string Eurobraille

### DIFF
--- a/source/brailleDisplayDrivers/eurobraille/driver.py
+++ b/source/brailleDisplayDrivers/eurobraille/driver.py
@@ -214,7 +214,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver, ScriptableObject):
 			elif 0x14 <= deviceType <= 0x15:
 				self.keys = constants.KEYS_BBOOK
 			else:
-				log.debugWarning("fUnknown device identifier {data}")
+				log.debugWarning(f"Unknown device identifier {data}")
 		elif packetType == constants.EB_SYSTEM_DISPLAY_LENGTH:
 			self.numCells = ord(data)
 		elif packetType == constants.EB_SYSTEM_FRAME_LENGTH:


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/wiki/Contributing.
-->

### Link to issue number:
Fix-up for #14690 
### Summary of the issue:
f-string was written as "f ...." instead of f"...." 
### Description of user facing changes

### Description of development approach

### Testing strategy:
None
### Known issues with pull request:

### Change log entries:
New features
Changes
Bug fixes
For Developers

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [ ] Pull Request description:
  - description is up to date
  - change log entries
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [ ] API is compatible with existing add-ons.
- [ ] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [ ] Security precautions taken.
