### PR TITLE
Ensure fallback to NoBraille if configured display cannot be initialized

### DIFF
--- a/source/braille.py
+++ b/source/braille.py
@@ -2195,7 +2195,7 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 				log.debugWarning(f"Couldn't initialize display driver {name!r}", exc_info=True)
 			fallbackDisplayClass = _getDisplayDriver(NO_BRAILLE_DISPLAY_NAME)
 			# Only initialize the fallback if it is not already set
-			if self.display.__class__ == fallbackDisplayClass:
+			if self.display.__class__ != fallbackDisplayClass:
 				self._setDisplay(fallbackDisplayClass, isFallback=False)
 			return False
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/wiki/Contributing.
-->

### Link to issue number:
Addresses issue introduced by pr #14524 

### Summary of the issue:
Reports from users that if a specifically configured braille display cannot be initialized on start-up, then the Braille category in the NVDA settings dialog is broken and does not show a valid braille driver (noBraille or otherwise).

### Description of user facing changes
The Braille category in NVDA settings will continue to be usable if the configured Braille display cannot be initialized on start-up.

### Description of development approach
In `braille.handler.setDisplayByName`  if setting the display failed, the display is not set to NoBraille if the display was (not) already NoBraille. Previously this logic was incorrectly reversed.
 
### Testing strategy:
* Set braille driver to something that does not exist.
* Restart NVDA.
* Try to open the Braille category in NVDA settings.

### Known issues with pull request:
None known.

### Change log entries:
New features
Changes
Bug fixes
For Developers

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
