### PR TITLE
Fix up Eurobraille device detection and gestures

### DIFF
--- a/source/bdDetect.py
+++ b/source/bdDetect.py
@@ -690,10 +690,10 @@ def initialize():
 		"VID_C251&PID_1132",  # Reserved
 	})
 	addUsbDevices("eurobraille", KEY_SERIAL, {
-		"VID_28AC&PID_0012",  # b.note
-		"VID_28AC&PID_0013",  # b.note 2
-		"VID_28AC&PID_0020",  # b.book internal
-		"VID_28AC&PID_0021",  # b.book external
+		"VID_28AC&PID_0012",  # bnote
+		"VID_28AC&PID_0013",  # bnote 2
+		"VID_28AC&PID_0020",  # bbook internal
+		"VID_28AC&PID_0021",  # bbook external
 	})
 
 	addBluetoothDevices("eurobraille", lambda m: m.id.startswith("Esys"))

--- a/source/brailleDisplayDrivers/eurobraille/constants.py
+++ b/source/brailleDisplayDrivers/eurobraille/constants.py
@@ -121,8 +121,8 @@ DEVICE_TYPES: Dict[int, str] = {
 	0x0f: "Esytime 32 standard",
 	0x10: "Esytime evo 32",
 	0x11: "Esytime evo 32 standard",
-	0x12: "b.note",
-	0x13: "b.note 2",
-	0x14: "b.book",
-	0x15: "b.book 2"
+	0x12: "bnote",
+	0x13: "bnote 2",
+	0x14: "bbook",
+	0x15: "bbook 2"
 }

--- a/source/brailleDisplayDrivers/eurobraille/driver.py
+++ b/source/brailleDisplayDrivers/eurobraille/driver.py
@@ -48,7 +48,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver, ScriptableObject):
 		return braille.getSerialPorts()
 
 	def __init__(self, port="Auto"):
-		super(BrailleDisplayDriver, self).__init__()
+		super().__init__()
 		self.numCells = 0
 		self.deviceType = None
 		self._deviceData = {}
@@ -121,7 +121,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver, ScriptableObject):
 			if self.deviceType.startswith(("bnote", "bbook")):
 				# reset identifier to bnote / bbook with current COM port
 				self._sendPacket(constants.EB_SYSTEM, constants.EB_CONNECTION_NAME, b'')
-			super(BrailleDisplayDriver, self).terminate()
+			super().terminate()
 		finally:
 			# We must sleep before closing the port as not doing this can leave
 			# the display in a bad state where it can not be re-initialized.
@@ -190,7 +190,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver, ScriptableObject):
 
 	def _handleAck(self, frame: int):
 		try:
-			super(BrailleDisplayDriver, self)._handleAck()
+			super()._handleAck()
 		except NotImplementedError:
 			log.debugWarning(f"Received ACK for frame {frame} while ACK handling is disabled")
 		else:

--- a/source/brailleDisplayDrivers/eurobraille/driver.py
+++ b/source/brailleDisplayDrivers/eurobraille/driver.py
@@ -101,7 +101,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver, ScriptableObject):
 				# A display responded.
 				log.info("Found {device} connected via {type} ({port})".format(
 					device=self.deviceType, type=portType, port=port))
-				if self.deviceType.startswith(("b.note", "b.book")):
+				if self.deviceType.startswith(("bnote", "bbook")):
 					# send identifier to bnote / bbook with current COM port
 					comportNumber = f'{int(re.match(".*?([0-9]+)$", port).group(1)):02d}'
 					identifier = f"NVDA/{comportNumber}".encode()
@@ -118,7 +118,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver, ScriptableObject):
 
 	def terminate(self):
 		try:
-			if self.deviceType.startswith(("b.note", "b.book")):
+			if self.deviceType.startswith(("bnote", "bbook")):
 				# reset identifier to bnote / bbook with current COM port
 				self._sendPacket(constants.EB_SYSTEM, constants.EB_CONNECTION_NAME, b'')
 			super(BrailleDisplayDriver, self).terminate()
@@ -325,7 +325,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver, ScriptableObject):
 
 	scriptCategory = SCRCAT_BRAILLE
 
-	def script_toggleHidKeyboardInput(self, gesture):
+	def script_toggleHidKeyboardInput(self, gesture: inputCore.InputGesture):
 		def announceUnavailableMessage():
 			# Translators: Message when HID keyboard simulation is unavailable.
 			ui.message(_("HID keyboard input simulation is unavailable."))

--- a/source/brailleDisplayDrivers/eurobraille/gestures.py
+++ b/source/brailleDisplayDrivers/eurobraille/gestures.py
@@ -3,22 +3,27 @@
 # See the file COPYING for more details.
 # Copyright (C) 2017-2023 NV Access Limited, Babbage B.V., Eurobraille
 
+from typing import TYPE_CHECKING
 import braille
 import brailleInput
 import inputCore
 from . import constants
+
+if TYPE_CHECKING:
+	from .driver import BrailleDisplayDriver
+
 
 GestureMapEntries = {
 	"globalCommands.GlobalCommands": {
 		"braille_routeTo": ("br(eurobraille):routing",),
 		"braille_reportFormatting": ("br(eurobraille):doubleRouting",),
 		"braille_scrollBack": (
-			"br(eurobraille.b.note):joystick1Left",
+			"br(eurobraille.bnote):joystick1Left",
 			"br(eurobraille):switch1Left",
 			"br(eurobraille):l1",
 		),
 		"braille_scrollForward": (
-			"br(eurobraille.b.note):joystick1Right",
+			"br(eurobraille.bnote):joystick1Right",
 			"br(eurobraille):switch1Right",
 			"br(eurobraille):l8",
 		),
@@ -151,8 +156,8 @@ class InputGesture(braille.BrailleDisplayGesture, brailleInput.BrailleInputGestu
 
 	source = constants.name
 
-	def __init__(self, display):
-		super(InputGesture, self).__init__()
+	def __init__(self, display: "BrailleDisplayDriver"):
+		super().__init__()
 		self.model = display.deviceType.lower().split(" ")[0]
 		keysDown = dict(display.keysDown)
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/wiki/Contributing.
-->

### Link to issue number:
Fixes #15204

### Summary of the issue:
Device names with a period in them are invalid.
This causes an error when loading the input gestures dialog.

### Description of user facing changes
Error should no longer be logged when opening input gestures dialog

### Description of development approach
Change device names from `b.book` and `b.note` to `bbook` and `bnote`

### Testing strategy:
Confirm with testers that `b.book` and `b.note` still work as expected

### Known issues with pull request:
None
### Change log entries:
N/A

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
