### PR TITLE
Fix braille extension points not properly unregistered for braille viewer

### DIFF
--- a/source/brailleViewer/__init__.py
+++ b/source/brailleViewer/__init__.py
@@ -66,13 +66,14 @@ def destroyBrailleViewer():
 	global _brailleGui
 	d: Optional[BrailleViewerFrame] = _brailleGui
 	_brailleGui = None  # protect against re-entrance
-	if d and not d.isDestroyed:
+	if d is not None:
 		import braille  # imported late to avoid a circular import.
-		updateBrailleDisplayedUnregistered = braille.pre_writeCells.unregister(d.updateBrailleDisplayed)
-		assert updateBrailleDisplayedUnregistered
+		if not d.isDestroyed:
+			updateBrailleDisplayedUnregistered = braille.pre_writeCells.unregister(d.updateBrailleDisplayed)
+			assert updateBrailleDisplayedUnregistered
+			d.saveInfoAndDestroy()
 		getDisplaySizeUnregistered = braille.filter_displaySize.unregister(_getDisplaySize)
 		assert getDisplaySizeUnregistered
-		d.saveInfoAndDestroy()
 
 
 def _onGuiDestroyed():

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -121,6 +121,7 @@ eSpeak-NG, LibLouis braille translator, and Unicode CLDR have been updated.
   - In Browse mode, NVDA will no longer incorrectly ignore focus moving to a parent or child control e.g. moving from a control to its parent list item or gridcell. (#14611)
     - Note however that this fix only applies when the Automatically set focus to focusable elements" option in Browse Mode settings is turned off (which is the default).
     -
+  - When no braille display is connected and the braille viewer is closed by pressing ``alt+f4`` or clicking the close button, the display size of the braille subsystem will again be reset to no cells. (#15214)
   -
 - Fixes for Windows 11:
   - NVDA can once again announce Notepad status bar contents. (#14573)
@@ -145,6 +146,7 @@ eSpeak-NG, LibLouis braille translator, and Unicode CLDR have been updated.
 - Displaying the OCR settings will not fail on some systems anymore. (#15017)
 - Fix bug related to saving and loading the NVDA configuration, including switching synthesizers. (#14760)
 - Fix bug causing text review "flick up" touch gesture to move pages rather than move to previous line. (#15127)
+- 
 -
 
 


### PR DESCRIPTION
### Link to issue number:
Fixes regression from #14503

### Summary of the issue:
As part of #14503, braille extension points have been added that are used by the braille viewer. However when destroying the braille viewer by pressing alt+f4, the display size filter handler was never unregistered, resulting in the braille handler still assuming 40 braille cells even though no display was connected.

### Description of user facing changes
Braille handler connectly restores to 0 cells again after disabling the braille viewer with alt+f4 when no braille display is connected.

### Description of development approach
1. Changed if check on the dialog to `is not None` explicitly. wx gives a destroyed window a bool value of False, so the boolean check would work.
2. Ensure braille.filter_displaySize is unregistered when destroyBrailleViewer is called when the window is already destroyed. Note that destroying the window will unregister braille.pre_writeCells properly, so that unregistration can be limited to an undestroyed window only.

### Testing strategy:
Tested closing the braille viewer either by toggling from the menu or by closing it with alt+f4.

### Known issues with pull request:
None known

### Change log entries:
Bug fixes
- When no braille display is connected and the braille viewer is closed by pressing alt+f4 or clicking the close button, the display size of the braille subsystem will again be reset to no cells.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
