### PR TITLE
Fixup #14924: again use weak references for waitable timer functions

### DIFF
--- a/source/hwIo/ioThread.py
+++ b/source/hwIo/ioThread.py
@@ -186,7 +186,7 @@ class IoThread(threading.Thread):
 			reference = BoundMethodWeakref(func) if ismethod(func) else AnnotatableWeakref(func)
 			reference.funcName = repr(func)
 
-		self._apcStore[internalParam] = (func or reference, param)
+		self._apcStore[internalParam] = (reference or func, param)
 		return internalParam
 
 	def queueAsApc(


### PR DESCRIPTION
### Link to issue number:
Fixup of #14924 

### Summary of the issue:
In #14627, we introduced weak references for APCs called as part of a waitable timer. In #14924, this was made more robust by using a single internal APC func. However in the porting process, a part of the logic was reversed, therefore in the internal APC store, we still stored strong rather than weak references.

### Description of user facing changes
None.

### Description of development approach
Store references instead of functions in the apc store.

### Testing strategy:
- [ ] Ensure that ack packets are still properly handled on handy tech displays

### Known issues with pull request:
None known

### Change log entries:
None needed, introduced in 2023.2 dev cycle.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
