### PR TITLE
Fixup 'Temporary Copy restrictions' in the user guide

### DIFF
--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -347,9 +347,13 @@ The installed copy is also able to create a portable copy of itself at any time.
 The portable copy also has the ability to install itself on any computer at a later time.
 However, if you wish to copy NVDA onto read-only media such as a CD, you should just copy the download package.
 Running the portable version directly from read-only media is not supported at this time.
-Using the temporary copy of NVDA is also an option (e.g. for demonstration purposes), though starting NVDA in this way each time can become very time consuming.
 
-Apart from the inability to automatically start during and/or after log-on, the portable and temporary copies of NVDA also have the following restrictions:
+The [NVDA installer #StepsForRunningTheDownloadLauncher] can be used as a temporary copy of NVDA.
+Temporary copies prevent saving NVDA configuration such as settings or input gestures.
+This includes blocking usage of the [Add-on Store #AddonsManager].
+
+Portable and temporary copies of NVDA have the following restrictions:
+- The inability to automatically start during and/or after log-on.
 - The inability to interact with applications running with administrative privileges, unless of course NVDA itself has been run also with these privileges (not recommended).
 - The inability to read User Account Control (UAC) screens when trying to start an application with administrative privileges.
 - Windows 8 and later: the inability to support input from a touchscreen.

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -350,7 +350,7 @@ Running the portable version directly from read-only media is not supported at t
 
 The [NVDA installer #StepsForRunningTheDownloadLauncher] can be used as a temporary copy of NVDA.
 Temporary copies prevent saving NVDA configuration such as settings or input gestures.
-This includes blocking usage of the [Add-on Store #AddonsManager].
+This includes disabling usage of the [Add-on Store #AddonsManager].
 
 Portable and temporary copies of NVDA have the following restrictions:
 - The inability to automatically start during and/or after log-on.


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/wiki/Contributing.
-->

### Link to issue number:
None

### Summary of the issue:
#13985 introduced new restrictions for temporary copies of NVDA, preventing the add-on store from opening and preventing writing to disk.
These should be explained in the user guide
### Description of user facing changes
N/A
### Description of development approach
Simplified some of the structure in the user guide, including explaining what a temporary copy is.


### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [ ] Pull Request description:
  - description is up to date
  - change log entries
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [ ] API is compatible with existing add-ons.
- [ ] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [ ] Security precautions taken.
