### PR TITLE
Add-on store: Fix handling of external add-ons

### DIFF
--- a/source/_addonStore/models/addon.py
+++ b/source/_addonStore/models/addon.py
@@ -161,13 +161,17 @@ class _AddonStoreModel(_AddonGUIModel):
 		)
 
 
-class _InstalledAddonModel(_AddonGUIModel):
+class _AddonManifestModel(_AddonGUIModel):
+	"""Get data from an add-on's manifest.
+	Can be from an add-on bundle or installed add-on.
+	"""
 	addonId: str
 	addonVersionName: str
 	channel: Channel
 	homepage: Optional[str]
 	minNVDAVersion: MajorMinorPatch
 	lastTestedVersion: MajorMinorPatch
+	manifest: AddonManifest
 	legacy: bool = False
 	"""
 	Legacy add-ons contain invalid metadata
@@ -175,27 +179,22 @@ class _InstalledAddonModel(_AddonGUIModel):
 	"""
 
 	@property
-	def _manifest(self) -> "AddonManifest":
-		from ..dataManager import addonDataManager
-		return addonDataManager._installedAddonsCache.installedAddons[self.name].manifest
-
-	@property
 	def displayName(self) -> str:
-		return self._manifest["summary"]
+		return self.manifest["summary"]
 
 	@property
 	def description(self) -> str:
-		return self._manifest["description"]
+		return self.manifest["description"]
 
 	@property
 	def author(self) -> str:
-		return self._manifest["author"]
+		return self.manifest["author"]
 
 
-@dataclasses.dataclass(frozen=True)
-class AddonManifestModel(_InstalledAddonModel):
-	"""An externally installed add-on.
-	Data comes from add-on manifest.
+@dataclasses.dataclass(frozen=True)  # once created, it should not be modified.
+class AddonManifestModel(_AddonManifestModel):
+	"""Get data from an add-on's manifest.
+	Can be from an add-on bundle or installed add-on.
 	"""
 	addonId: str
 	addonVersionName: str
@@ -203,6 +202,7 @@ class AddonManifestModel(_InstalledAddonModel):
 	homepage: Optional[str]
 	minNVDAVersion: MajorMinorPatch
 	lastTestedVersion: MajorMinorPatch
+	manifest: AddonManifest
 	legacy: bool = False
 	"""
 	Legacy add-ons contain invalid metadata
@@ -211,7 +211,7 @@ class AddonManifestModel(_InstalledAddonModel):
 
 
 @dataclasses.dataclass(frozen=True)  # once created, it should not be modified.
-class InstalledAddonStoreModel(_InstalledAddonModel, _AddonStoreModel):
+class InstalledAddonStoreModel(_AddonManifestModel, _AddonStoreModel):
 	"""
 	Data from an add-on installed from the add-on store.
 	"""
@@ -233,6 +233,11 @@ class InstalledAddonStoreModel(_InstalledAddonModel, _AddonStoreModel):
 	Legacy add-ons contain invalid metadata
 	and should not be accessible through the add-on store.
 	"""
+
+	@property
+	def manifest(self) -> "AddonManifest":
+		from ..dataManager import addonDataManager
+		return addonDataManager._installedAddonsCache.installedAddons[self.name].manifest
 
 
 @dataclasses.dataclass(frozen=True)  # once created, it should not be modified.
@@ -323,6 +328,7 @@ def _createGUIModelFromManifest(addon: "AddonHandlerBaseModel") -> AddonManifest
 		homepage=homepage,
 		minNVDAVersion=MajorMinorPatch(*addon.minimumNVDAVersion),
 		lastTestedVersion=MajorMinorPatch(*addon.lastTestedNVDAVersion),
+		manifest=addon.manifest,
 	)
 
 

--- a/source/gui/_addonStoreGui/controls/details.py
+++ b/source/gui/_addonStoreGui/controls/details.py
@@ -7,7 +7,7 @@ import wx
 
 from _addonStore.models.addon import (
 	_AddonStoreModel,
-	_InstalledAddonModel,
+	_AddonManifestModel,
 )
 from gui import guiHelper
 from gui.dpiScalingHelper import DpiScalingHelperMixinWithoutInit
@@ -225,7 +225,7 @@ class AddonDetails(
 						pgettext("addonStore", "Publisher:"),
 						details.publisher
 					)
-				if isinstance(details, _InstalledAddonModel):
+				if isinstance(details, _AddonManifestModel):
 					# Author comes from the manifest, and is only available for installed add-ons.
 					self._appendDetailsLabelValue(
 						# Translators: Label for an extra detail field for the selected add-on. In the add-on store dialog.

--- a/source/gui/_addonStoreGui/controls/messageDialogs.py
+++ b/source/gui/_addonStoreGui/controls/messageDialogs.py
@@ -13,7 +13,7 @@ import addonAPIVersion
 from _addonStore.models.addon import (
 	_AddonGUIModel,
 	_AddonStoreModel,
-	_InstalledAddonModel,
+	_AddonManifestModel,
 )
 from gui.addonGui import ErrorAddonInstallDialog
 from gui.message import messageBox
@@ -175,7 +175,7 @@ def _showAddonInfo(addon: _AddonGUIModel) -> None:
 	if isinstance(addon, _AddonStoreModel):
 		# Translators: the publisher part of the About Add-on information
 		message.append(pgettext("addonStore", "Publisher: {publisher}\n").format(publisher=addon.publisher))
-	if isinstance(addon, _InstalledAddonModel):
+	if isinstance(addon, _AddonManifestModel):
 		# Translators: the author part of the About Add-on information
 		message.append(pgettext("addonStore", "Author: {author}\n").format(author=addon.author))
 	if addon.homepage:

--- a/source/gui/_addonStoreGui/viewModels/addonList.py
+++ b/source/gui/_addonStoreGui/viewModels/addonList.py
@@ -22,7 +22,7 @@ from requests.structures import CaseInsensitiveDict
 from _addonStore.models.addon import (
 	_AddonGUIModel,
 	_AddonStoreModel,
-	_InstalledAddonModel,
+	_AddonManifestModel,
 )
 from _addonStore.models.status import (
 	_StatusFilterKey,
@@ -303,7 +303,7 @@ class AddonListVM:
 			term = term.casefold()
 			model = detailsVM.model
 			inPublisher = isinstance(model, _AddonStoreModel) and term in model.publisher.casefold()
-			inAuthor = isinstance(model, _InstalledAddonModel) and term in model.author.casefold()
+			inAuthor = isinstance(model, _AddonManifestModel) and term in model.author.casefold()
 			return (
 				term in model.displayName.casefold()
 				or term in model.description.casefold()


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/wiki/Contributing.
-->

### Link to issue number:
Fixes #15218

### Summary of the issue:
Add-ons which were being installed from an external source were treated like an installed add-on.
This resulted in trying to get manifest information for the installed add-ons collection, rather than the bundle that the install is coming from.
When trying to install an incompatible add-on from an external source, an error is raised, as manifest data is not fetched correctly.
This prevents the confirmation dialog from appearing and prevents the user from installing incompatible add-ons from external sources.

### Description of user facing changes
Add-ons which are incompatible can be installed from an external source.

### Description of development approach
Instead, use the manifest data from the external add-on bundle.

### Testing strategy:
Manually test STR in #15218
Smoke test installing add-ons using the [manual test plan] (https://github.com/nvaccess/nvda/blob/master/tests/manual/addonStore.md)

### Known issues with pull request:
None
### Change log entries:
N/A

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
