### PR TITLE
Cancel write with the correct overlapped structure when closing hwIo.IoBase

### DIFF
--- a/source/hwIo/base.py
+++ b/source/hwIo/base.py
@@ -153,7 +153,7 @@ class IoBase(object):
 		if hasattr(self, "_file") and self._file is not INVALID_HANDLE_VALUE:
 			ctypes.windll.kernel32.CancelIoEx(self._file, byref(self._readOl))
 		if hasattr(self, "_writeFile") and self._writeFile not in (self._file, INVALID_HANDLE_VALUE):
-			ctypes.windll.kernel32.CancelIoEx(self._writeFile, byref(self._readOl))
+			ctypes.windll.kernel32.CancelIoEx(self._writeFile, byref(self._writeOl))
 		winKernel.closeHandle(self._recvEvt)
 
 	def __del__(self):


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/wiki/Contributing.
-->

### Link to issue number:
If merged, should fix #14872. This is not yet sure, but even if it doesn't fix the issue, it is a bug anyway.

### Summary of the issue:
When closing a hwIo device, CancelIoEx is called to cancel pending i/o. It is however erroneously called twice for the overlapped structure used for reading, never for writing. Theoretically this can cause deadlocks if a thread called GetOverlappedResult just before closing the device. This might be the underlying issue of #14872.

### Description of user facing changes
Hopefully. no longer braille display termination freezes.

### Description of development approach
use self._writeOl instead of self._readOl when cancelling writing.

### Testing strategy:
- [ ] Requires tests by @CyrilleB79.

### Known issues with pull request:
None known,

### Change log entries:
Bug fixes
- NVDA no longer intermittently freezes when reloading the configuration with braille enabled. (#14872)

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
