### PR TITLE
Ensure tabbing through messages in Windows Mail does not get stuck on the same link

### DIFF
--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -1688,7 +1688,8 @@ class BrowseModeDocumentTreeInterceptor(documentBase.DocumentWithTableNavigation
 				self._replayFocusEnteredEvents()
 				nextHandler()
 			focusInfo.collapse()
-			self._set_selection(focusInfo, reason=OutputReason.FOCUS)
+			if self._focusEventMustUpdateCaretPosition:
+				self._set_selection(focusInfo, reason=OutputReason.FOCUS)
 		else:
 			# The virtual caret was already at the focused node.
 			if not self.passThrough:

--- a/source/cursorManager.py
+++ b/source/cursorManager.py
@@ -98,6 +98,12 @@ class CursorManager(documentBase.TextContainerObject,baseObject.ScriptableObject
 	@type selection: L{textInfos.TextInfo}
 	"""
 
+	# Whether or not 'gainFocus' events handled by this CursorManager should update the caret position.
+	# If NVDA fully manages the caret (such as for reviewCursorManagers and virtualBuffers) then they should.
+	# However if the caret is managed by the application,
+	# We trust that the application will move the caret itself if firing focus events on inner content.
+	_focusEventMustUpdateCaretPosition = False
+
 	# Translators: the script category for browse mode
 	scriptCategory=SCRCAT_BROWSEMODE
 
@@ -505,6 +511,10 @@ class ReviewCursorManager(CursorManager):
 	This cursor manager maintains its own caret and selection information.
 	Thus, the underlying text range need not support updating the caret or selection.
 	"""
+
+	# As NVDA manages the caret virtually,
+	# It is necessary for 'gainFocus' events to update the caret.
+	_focusEventMustUpdateCaretPosition = True
 
 	def initCursorManager(self):
 		super(ReviewCursorManager, self).initCursorManager()

--- a/source/virtualBuffers/__init__.py
+++ b/source/virtualBuffers/__init__.py
@@ -409,6 +409,10 @@ class VirtualBuffer(browseMode.BrowseModeDocumentTreeInterceptor):
 
 	TextInfo=VirtualBufferTextInfo
 
+	# As NVDA manages the caret virtually,
+	# It is necessary for 'gainFocus' events to update the caret.
+	_focusEventMustUpdateCaretPosition = True
+
 	#: Maps root identifiers (docHandle and ID) to buffers.
 	rootIdentifiers = weakref.WeakValueDictionary()
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/wiki/Contributing.
-->

### Link to issue number:
Fixes #15211

### Summary of the issue:
After merging of pr #14611, tabbing through a message in Windows Mail would cause the caret / focus to get stuck and not move forward to the next element in tab order.
This seems to be because BrowseModeDocument's  gainFocus event updates the caret to the position of the element in the document that just gained focus. This is appropriate for web documents where NVDA manages the caret itself, but not for documents where the caret is managed by the application, such as the MS Word mail message viewer.
This has most likely been a problem in some way for a long time, but pr #14611 made it much more obvious as it greatly increased the amount of focus events within documents now spoken / handled.
 
### Description of user facing changes
NVDA no longer gets stuck when tabbing through a message in Windows Mail.

### Description of development approach
Suppressing of caret movement in BrowseModeDocument's gainFocus event is controled by a new private variable on the CursorManager class. It is False by default, which does not allow the caret movement to occur. However, for ReviewCursorManager and VirtualBuffer classes, it is True, allowing the existing caret movement behaviour, as in these situations the caret is managed entirely by NVDA.
This then means that in the cases where a CursorManager is used that is not VirtualBuffer or ReviewCursorManager, which is just Microsoft Word browse mode, NVDA will not move the caret itself on gainFocus events, as the application itself will already do this.


### Testing strategy:
* Tab through a message in Windows Mail that has several links. Ensure that NvDA speaks / moves to each link in tern and does not get stuck on the same one.
* Tab through the google.com web page in Firefox, Chrome and Edge, inclduing Edge via UIA, and ensure that the caret continues to move along with the focus and does not stay where it was last left with the arrow keys.

### Known issues with pull request:
This is a very quick fix, that addresses a specific issue for a 2023.2 beta. It may be possible to abstract this wanted behaviour in a cleaner way from the ground up, but this is the smallest code change with the least impact.

### Change log entries:
New features
Changes
Bug fixes
For Developers

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x ] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
