### PR TITLE
Always use utf-8 for addon store caches

### DIFF
--- a/source/_addonStore/dataManager.py
+++ b/source/_addonStore/dataManager.py
@@ -281,9 +281,7 @@ class _DataManager:
 			with open(addonCachePath, 'r', encoding='utf-8') as cacheFile:
 				cacheData = json.load(cacheFile)
 		except Exception:
-			log.exception(f"Invalid cached installed add-on data")
-			if NVDAState.shouldWriteToDisk():
-				os.remove(addonCachePath)
+			log.exception("Invalid cached installed add-on data")
 			return None
 		if not cacheData:
 			return None

--- a/source/_addonStore/dataManager.py
+++ b/source/_addonStore/dataManager.py
@@ -134,7 +134,7 @@ class _DataManager:
 			"cachedLanguage": self._lang,
 			"nvdaAPIVersion": addonAPIVersion.CURRENT,
 		}
-		with open(self._cacheCompatibleFile, 'w') as cacheFile:
+		with open(self._cacheCompatibleFile, 'w', encoding='utf-8') as cacheFile:
 			json.dump(cacheData, cacheFile, ensure_ascii=False)
 
 	def _cacheLatestAddons(self, addonData: str, cacheHash: str):
@@ -148,14 +148,14 @@ class _DataManager:
 			"cachedLanguage": self._lang,
 			"nvdaAPIVersion": _LATEST_API_VER,
 		}
-		with open(self._cacheLatestFile, 'w') as cacheFile:
+		with open(self._cacheLatestFile, 'w', encoding='utf-8') as cacheFile:
 			json.dump(cacheData, cacheFile, ensure_ascii=False)
 
 	def _getCachedAddonData(self, cacheFilePath: str) -> Optional[CachedAddonsModel]:
 		if not os.path.exists(cacheFilePath):
 			return None
 		try:
-			with open(cacheFilePath, 'r') as cacheFile:
+			with open(cacheFilePath, 'r', encoding='utf-8') as cacheFile:
 				cacheData = json.load(cacheFile)
 		except Exception:
 			log.exception(f"Invalid add-on store cache")
@@ -270,15 +270,21 @@ class _DataManager:
 		if not addonData:
 			return
 		addonCachePath = os.path.join(self._installedAddonDataCacheDir, f"{addonData.addonId}.json")
-		with open(addonCachePath, 'w') as cacheFile:
+		with open(addonCachePath, 'w', encoding='utf-8') as cacheFile:
 			json.dump(addonData.asdict(), cacheFile, ensure_ascii=False)
 
 	def _getCachedInstalledAddonData(self, addonId: str) -> Optional[InstalledAddonStoreModel]:
 		addonCachePath = os.path.join(self._installedAddonDataCacheDir, f"{addonId}.json")
 		if not os.path.exists(addonCachePath):
 			return None
-		with open(addonCachePath, 'r') as cacheFile:
-			cacheData = json.load(cacheFile)
+		try:
+			with open(addonCachePath, 'r', encoding='utf-8') as cacheFile:
+				cacheData = json.load(cacheFile)
+		except Exception:
+			log.exception(f"Invalid cached installed add-on data")
+			if NVDAState.shouldWriteToDisk():
+				os.remove(addonCachePath)
+			return None
 		if not cacheData:
 			return None
 		return _createInstalledStoreModelFromData(cacheData)


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/wiki/Contributing.
-->

### Link to issue number:

Closes #15231 

### Summary of the issue:
If NVDA language is set to Serbian, the cache could get corrupted while reading or writing do to the encoding not specified while opening the file.

### Description of user facing changes
NVDA add-on store works with Serbian. Also, If the cached installed addon data is invalid, the exception will be logged similar to the add-on store cache, instead of preventing the add-on store from launching.

### Description of development approach
- open all files in _addonStore\dataManager.py in utf-8.
- If the file is unable to be opened, or json.load fails, the exception will be logged.

### Testing strategy:
Installed multiple add-ons, with Serbian translation and without, while NVDA's language is set to Serbian.

### Known issues with pull request:
None.

### Change log entries:
New features
Changes
Bug fixes
- Fixed a bug causing the add-on store not to work if the NVDA language is set to Serbian: #15231 
For Developers

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
