### PR TITLE
Add-on store: add warning dialog

### DIFF
--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -313,7 +313,7 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 	playErrorSound = integer(0, 1, default=0)
 
 [addonStore]
-	acknowledgedWarning = boolean(default=false)
+	showWarning = boolean(default=true)
 """
 
 #: The configuration specification

--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -311,6 +311,9 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 	cancelExpiredFocusSpeech = integer(0, 2, default=0)
 	# 0:Only in test versions, 1:yes
 	playErrorSound = integer(0, 1, default=0)
+
+[addonStore]
+	acknowledgedWarning = boolean(default=false)
 """
 
 #: The configuration specification

--- a/source/gui/_addonStoreGui/controls/messageDialogs.py
+++ b/source/gui/_addonStoreGui/controls/messageDialogs.py
@@ -22,6 +22,7 @@ from gui.guiHelper import (
 	BoxSizerHelper,
 	BORDER_FOR_DIALOGS,
 	ButtonHelper,
+	SPACE_BETWEEN_VERTICAL_DIALOG_ITEMS,
 )
 from gui.message import messageBox
 import windowUtils
@@ -234,21 +235,28 @@ class _SafetyWarningDialog(
 			self.scaleFactor * 600
 		)
 
+		sHelper.sizer.AddSpacer(SPACE_BETWEEN_VERTICAL_DIALOG_ITEMS)
+
+		self.dontShowAgainCheckbox = sHelper.addLabeledControl(
+			pgettext(
+				"addonStore",
+				# Translators: The label of a checkbox in the add-on store warning dialog
+				"&Don't show this message again"
+			),
+			wx.CheckBox,
+		)
+
 		bHelper = sHelper.addDialogDismissButtons(ButtonHelper(wx.HORIZONTAL))
 
 		# Translators: The label of a button in a dialog
-		acknowledgeButton = bHelper.addButton(self, wx.ID_OK, label=_("&Acknowledge"))
-		acknowledgeButton.Bind(wx.EVT_BUTTON, self.onAcknowledgeButton)
-
-		# Translators: The label of a button to remind the user later about performing some action.
-		remindMeButton = bHelper.addButton(self, wx.ID_CANCEL, label=_("Remind me &later"))
-		remindMeButton.SetFocus()
+		okButton = bHelper.addButton(self, wx.ID_OK, label=_("&OK"))
+		okButton.Bind(wx.EVT_BUTTON, self.onOkButton)
 
 		mainSizer.Add(sHelper.sizer, border=BORDER_FOR_DIALOGS, flag=wx.ALL)
 		self.Sizer = mainSizer
 		mainSizer.Fit(self)
 		self.CentreOnScreen()
 
-	def onAcknowledgeButton(self, evt: wx.CommandEvent):
-		config.conf["addonStore"]["acknowledgedWarning"] = True
+	def onOkButton(self, evt: wx.CommandEvent):
+		config.conf["addonStore"]["showWarning"] = not self.dontShowAgainCheckbox.GetValue()
 		self.EndModal(wx.ID_OK)

--- a/source/gui/_addonStoreGui/controls/messageDialogs.py
+++ b/source/gui/_addonStoreGui/controls/messageDialogs.py
@@ -242,7 +242,6 @@ class _SafetyWarningDialog(
 
 		# Translators: The label of a button to remind the user later about performing some action.
 		remindMeButton = bHelper.addButton(self, wx.ID_CANCEL, label=_("Remind me &later"))
-		# remindMeButton.Bind(wx.EVT_BUTTON, self.onLaterButton)
 		remindMeButton.SetFocus()
 
 		mainSizer.Add(sHelper.sizer, border=BORDER_FOR_DIALOGS, flag=wx.ALL)
@@ -253,8 +252,3 @@ class _SafetyWarningDialog(
 	def onAcknowledgeButton(self, evt: wx.CommandEvent):
 		config.conf["addonStore"]["acknowledgedWarning"] = True
 		self.EndModal(wx.ID_OK)
-
-	# def onLaterButton(self, evt: wx.CommandEvent):
-	# 	# evt.Skip() is called since wx.ID_CANCEL is used as the ID for the Ask Later button,
-	# 	# wx automatically ends the modal itself.
-	# 	evt.Skip()

--- a/source/gui/_addonStoreGui/controls/storeDialog.py
+++ b/source/gui/_addonStoreGui/controls/storeDialog.py
@@ -84,7 +84,7 @@ class AddonStoreDialog(SettingsDialog):
 
 		self.warningTextCtrl = wx.TextCtrl(
 			self,
-			style = 0  # purely to allow subsequent items to line up.
+			style=0  # purely to allow subsequent items to line up.
 			| wx.TE_MULTILINE  # details will require multiple lines
 			| wx.TE_READONLY  # the details shouldn't be user editable
 			| wx.TE_RICH2
@@ -299,7 +299,8 @@ class AddonStoreDialog(SettingsDialog):
 		# Translators: Warning that is displayed in the Add-on Store.
 		"Add-ons are created by the NVDA community and are not vetted by NV Access. "
 		"NV Access cannot be held responsible for add-on behavior. "
-		"The functionality of add-ons is unrestricted and can include accessing your personal data or even the entire system. "
+		"The functionality of add-ons is unrestricted and can include "
+		"accessing your personal data or even the entire system. "
 	)
 
 	@property

--- a/source/gui/_addonStoreGui/controls/storeDialog.py
+++ b/source/gui/_addonStoreGui/controls/storeDialog.py
@@ -52,7 +52,7 @@ class AddonStoreDialog(SettingsDialog):
 		self._storeVM.onDisplayableError.register(self.handleDisplayableError)
 		self._actionsContextMenu = _ActionsContextMenu(self._storeVM)
 		super().__init__(parent, resizeable=True, buttons={wx.CLOSE})
-		if not config.conf["addonStore"]["acknowledgedWarning"]:
+		if config.conf["addonStore"]["showWarning"]:
 			_SafetyWarningDialog(parent).ShowModal()
 		self.Maximize()
 

--- a/source/gui/guiHelper.py
+++ b/source/gui/guiHelper.py
@@ -46,7 +46,8 @@ class myDialog(wx.Dialog):
 from contextlib import contextmanager
 from typing import (
 	Optional,
-	TypeVar
+	TypeVar,
+	Union,
 )
 
 import wx
@@ -287,7 +288,7 @@ class BoxSizerHelper:
 			self,
 			parent: wx.Dialog,
 			orientation: Optional[int] = None,
-			sizer: Optional[wx.BoxSizer, wx.StaticBoxSizer] = None
+			sizer: Optional[Union[wx.BoxSizer, wx.StaticBoxSizer]] = None
 	):
 		""" Init. Pass in either orientation OR sizer.
 			@param parent: An instance of the parent wx window. EG wx.Dialog


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/wiki/Contributing.
-->

### Link to issue number:
None

### Summary of the issue:
Users should be informed of the risk of installing add-ons

### Description of user facing changes
When opening the add-on store, a warning dialog is shown.
There is a checkbox to not show the warning again.

### Description of development approach
Uses similar approach to the user stats dialog
Move banner creation to helper function

Added typing to `guiHelper.BoxSizerHelper`. Fix bug where if a `StaticBoxSizer` is used with an intflag of buttons, `BoxSizerHelper.addDialogDismissButtons` wouldn't work correctly

Add support for creating labelled checkboxes using the `BoxSizerHelper`, `LabelledControlHelper` and `associateElements`

### Testing strategy:
Test banner using `--disable-addons`
Test with sample code in source code for `addDialogDismissButtons` bug.
Test the warning nag - ensure the checkbox to hide the warning works

### Known issues with pull request:
None
### Change log entries:
N/A
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
