### PR TITLE
Fixup #15222: User Guide temporary copies

### DIFF
--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -349,7 +349,7 @@ However, if you wish to copy NVDA onto read-only media such as a CD, you should 
 Running the portable version directly from read-only media is not supported at this time.
 
 The [NVDA installer #StepsForRunningTheDownloadLauncher] can be used as a temporary copy of NVDA.
-Temporary copies prevent saving NVDA configuration such as settings or input gestures.
+Temporary copies prevent saving NVDA settings.
 This includes disabling usage of the [Add-on Store #AddonsManager].
 
 Portable and temporary copies of NVDA have the following restrictions:


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/wiki/Contributing.
-->

### Link to issue number:
Fixup #15222 due to https://github.com/nvaccess/nvda/pull/15222#discussion_r1278864060

### Summary of the issue:
NVDA does not currently prevent saving input gestures when running a temporary copy.
The user guide was edited in #15222 to incorrectly suggest that input gestures are not saved when running a temporary copy.

### Description of user facing changes
Fix user guide to be more accurate 

### Description of development approach

### Testing strategy:

### Known issues with pull request:
Note: NVDA shouldn't ever write config to disk when running in kiosk mode: e.g. on secure screens, as a kiosk, or running as launcher.
However, this is not the current state.
This will be addressed in an upcoming release

