### PR TITLE
Add-on store: don't show help button if not available

### DIFF
--- a/source/addonHandler/__init__.py
+++ b/source/addonHandler/__init__.py
@@ -621,7 +621,7 @@ class Addon(AddonBase):
 			if func:
 				func(*args,**kwargs)
 
-	def getDocFilePath(self, fileName=None):
+	def getDocFilePath(self, fileName: Optional[str] = None) -> Optional[str]:
 		r"""Get the path to a documentation file for this add-on.
 		The file should be located in C{doc\lang\file} inside the add-on,
 		where C{lang} is the language code and C{file} is the requested file name.
@@ -630,9 +630,7 @@ class Addon(AddonBase):
 		An add-on can specify a default documentation file name
 		via the docFileName parameter in its manifest.
 		@param fileName: The requested file name or C{None} for the add-on's default.
-		@type fileName: str
 		@return: The path to the requested file or C{None} if it wasn't found.
-		@rtype: str
 		"""
 		if not fileName:
 			fileName = self.manifest["docFileName"]

--- a/source/gui/_addonStoreGui/viewModels/store.py
+++ b/source/gui/_addonStoreGui/viewModels/store.py
@@ -201,11 +201,16 @@ class AddonStoreVM:
 				# Translators: Label for an action that opens help for the selected addon
 				displayName=pgettext("addonStore", "&Help"),
 				actionHandler=self.helpAddon,
-				validCheck=lambda aVM: aVM.model.isInstalled and self._filteredStatusKey in (
-					# Showing help in the updatable add-ons view is misleading
-					# as we can only fetch the add-on help from the installed version.
-					_StatusFilterKey.INSTALLED,
-					_StatusFilterKey.INCOMPATIBLE,
+				validCheck=lambda aVM: (
+					aVM.model.isInstalled
+					and self._filteredStatusKey in (
+						# Showing help in the updatable add-ons view is misleading
+						# as we can only fetch the add-on help from the installed version.
+						_StatusFilterKey.INSTALLED,
+						_StatusFilterKey.INCOMPATIBLE,
+					)
+					and aVM.model._addonHandlerModel is not None
+					and aVM.model._addonHandlerModel.getDocFilePath() is not None
 				),
 				listItemVM=selectedListItem
 			),
@@ -236,7 +241,9 @@ class AddonStoreVM:
 		]
 
 	def helpAddon(self, listItemVM: AddonListItemVM) -> None:
+		assert listItemVM.model._addonHandlerModel is not None
 		path = listItemVM.model._addonHandlerModel.getDocFilePath()
+		assert path is not None
 		startfile(path)
 
 	def removeAddon(self, listItemVM: AddonListItemVM) -> None:


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/wiki/Contributing.
-->

### Link to issue number:
Fixes #15257 

### Summary of the issue:
For an installed add-on the add-on store displays the help button, even if no help is available.

### Description of user facing changes
Hide the help button if no help is available

### Description of development approach
Fix typing and explicitly check if a help doc is available when determining if to display the help button

### Testing strategy:
Test with the add-ons and STR in #15257 

### Known issues with pull request:
If there's no help available for the selected NVDA language or english, the help button will not be shown.
NVDA will not fallback to available languages or than english.

### Change log entries:
N/A
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [ ] Pull Request description:
  - description is up to date
  - change log entries
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [ ] API is compatible with existing add-ons.
- [ ] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [ ] Security precautions taken.
