### PR TITLE
Create helper function to show custom modal dialogs safer

### DIFF
--- a/source/gui/_addonStoreGui/controls/messageDialogs.py
+++ b/source/gui/_addonStoreGui/controls/messageDialogs.py
@@ -158,7 +158,7 @@ def _shouldEnableWhenAddonTooOldDialog(
 	lastTestedNVDAVersion=addonAPIVersion.formatForGUI(addon.lastTestedNVDAVersion),
 	NVDAVersion=addonAPIVersion.formatForGUI(addonAPIVersion.CURRENT)
 	)
-	res = displayDialogAsModal( ErrorAddonInstallDialogWithYesNoButtons(
+	res = displayDialogAsModal(ErrorAddonInstallDialogWithYesNoButtons(
 		parent=parent,
 		# Translators: The title of a dialog presented when an error occurs.
 		title=pgettext("addonStore", "Add-on not compatible"),

--- a/source/gui/_addonStoreGui/controls/messageDialogs.py
+++ b/source/gui/_addonStoreGui/controls/messageDialogs.py
@@ -24,7 +24,7 @@ from gui.guiHelper import (
 	ButtonHelper,
 	SPACE_BETWEEN_VERTICAL_DIALOG_ITEMS,
 )
-from gui.message import messageBox
+from gui.message import displayDialogAsModal, messageBox
 import windowUtils
 
 if TYPE_CHECKING:
@@ -81,13 +81,14 @@ def _shouldProceedWhenInstalledAddonVersionUnknown(
 	lastTestedNVDAVersion=addonAPIVersion.formatForGUI(addon.lastTestedNVDAVersion),
 	NVDAVersion=addonAPIVersion.formatForGUI(addonAPIVersion.CURRENT)
 	)
-	return ErrorAddonInstallDialogWithYesNoButtons(
+	res = displayDialogAsModal(ErrorAddonInstallDialogWithYesNoButtons(
 		parent=parent,
 		# Translators: The title of a dialog presented when an error occurs.
 		title=pgettext("addonStore", "Add-on not compatible"),
 		message=incompatibleMessage,
 		showAddonInfoFunction=lambda: _showAddonInfo(addon)
-	).ShowModal() == wx.YES
+	))
+	return res == wx.YES
 
 
 def _shouldProceedToRemoveAddonDialog(
@@ -127,13 +128,14 @@ def _shouldInstallWhenAddonTooOldDialog(
 	lastTestedNVDAVersion=addonAPIVersion.formatForGUI(addon.lastTestedNVDAVersion),
 	NVDAVersion=addonAPIVersion.formatForGUI(addonAPIVersion.CURRENT)
 	)
-	return ErrorAddonInstallDialogWithYesNoButtons(
+	res = displayDialogAsModal(ErrorAddonInstallDialogWithYesNoButtons(
 		parent=parent,
 		# Translators: The title of a dialog presented when an error occurs.
 		title=pgettext("addonStore", "Add-on not compatible"),
 		message=incompatibleMessage,
 		showAddonInfoFunction=lambda: _showAddonInfo(addon)
-	).ShowModal() == wx.YES
+	))
+	return res == wx.YES
 
 
 def _shouldEnableWhenAddonTooOldDialog(
@@ -156,13 +158,14 @@ def _shouldEnableWhenAddonTooOldDialog(
 	lastTestedNVDAVersion=addonAPIVersion.formatForGUI(addon.lastTestedNVDAVersion),
 	NVDAVersion=addonAPIVersion.formatForGUI(addonAPIVersion.CURRENT)
 	)
-	return ErrorAddonInstallDialogWithYesNoButtons(
+	res = displayDialogAsModal( ErrorAddonInstallDialogWithYesNoButtons(
 		parent=parent,
 		# Translators: The title of a dialog presented when an error occurs.
 		title=pgettext("addonStore", "Add-on not compatible"),
 		message=incompatibleMessage,
 		showAddonInfoFunction=lambda: _showAddonInfo(addon)
-	).ShowModal() == wx.YES
+	))
+	return res == wx.YES
 
 
 def _showAddonInfo(addon: _AddonGUIModel) -> None:

--- a/source/gui/_addonStoreGui/controls/storeDialog.py
+++ b/source/gui/_addonStoreGui/controls/storeDialog.py
@@ -367,7 +367,7 @@ class AddonStoreDialog(SettingsDialog):
 			defaultDir="c:",
 			style=wx.FD_OPEN,
 		)
-		if fd.ShowModal() != wx.ID_OK:
+		if displayDialogAsModal(fd) != wx.ID_OK:
 			return
 		addonPath = fd.GetPath()
 		try:

--- a/source/gui/_addonStoreGui/controls/storeDialog.py
+++ b/source/gui/_addonStoreGui/controls/storeDialog.py
@@ -28,7 +28,7 @@ from gui import (
 	guiHelper,
 	addonGui,
 )
-from gui.message import DisplayableError
+from gui.message import DisplayableError, displayDialogAsModal
 from gui.settingsDialogs import SettingsDialog
 from logHandler import log
 
@@ -53,7 +53,7 @@ class AddonStoreDialog(SettingsDialog):
 		self._actionsContextMenu = _ActionsContextMenu(self._storeVM)
 		super().__init__(parent, resizeable=True, buttons={wx.CLOSE})
 		if config.conf["addonStore"]["showWarning"]:
-			_SafetyWarningDialog(parent).ShowModal()
+			displayDialogAsModal(_SafetyWarningDialog(parent))
 		self.Maximize()
 
 	def _enterActivatesOk_ctrlSActivatesApply(self, evt: wx.KeyEvent):

--- a/source/gui/addonGui.py
+++ b/source/gui/addonGui.py
@@ -23,6 +23,7 @@ import addonHandler
 import globalVars
 from . import guiHelper
 from . import nvdaControls
+from .message import displayDialogAsModal
 from .dpiScalingHelper import DpiScalingHelperMixinWithoutInit
 import gui.contextHelp
 
@@ -269,7 +270,7 @@ class AddonsDialog(
 		# Translators: the label for the NVDA add-on package file type in the Choose add-on dialog.
 		wildcard=(_("NVDA Add-on Package (*.{ext})")+"|*.{ext}").format(ext=addonHandler.BUNDLE_EXTENSION),
 		defaultDir="c:", style=wx.FD_OPEN)
-		if fd.ShowModal() != wx.ID_OK:
+		if displayDialogAsModal(fd) != wx.ID_OK:
 			return
 		addonPath = fd.GetPath()
 		if installAddon(self, addonPath):
@@ -446,10 +447,10 @@ class AddonsDialog(
 		os.startfile(ADDONS_URL)
 
 	def onIncompatAddonsShowClick(self, evt):
-		IncompatibleAddonsDialog(
+		displayDialogAsModal(IncompatibleAddonsDialog(
 			parent=self,
 			# the defaults from the addon GUI are fine. We are testing against the running version.
-		).ShowModal()
+		))
 
 
 # C901 'installAddon' is too complex (16)
@@ -601,13 +602,13 @@ def _showAddonRequiresNVDAUpdateDialog(
 		NVDAVersion=addonAPIVersion.formatForGUI(addonAPIVersion.CURRENT)
 	)
 	from gui._addonStoreGui.controls.messageDialogs import _showAddonInfo
-	ErrorAddonInstallDialog(
+	displayDialogAsModal(ErrorAddonInstallDialog(
 		parent=parent,
 		# Translators: The title of a dialog presented when an error occurs.
 		title=_("Add-on not compatible"),
 		message=incompatibleMessage,
 		showAddonInfoFunction=lambda: _showAddonInfo(bundle._addonGuiModel)
-	).ShowModal()
+	))
 
 
 def _showConfirmAddonInstallDialog(
@@ -622,13 +623,13 @@ def _showConfirmAddonInstallDialog(
 	).format(**bundle.manifest)
 
 	from gui._addonStoreGui.controls.messageDialogs import _showAddonInfo
-	return ConfirmAddonInstallDialog(
+	return displayDialogAsModal(ConfirmAddonInstallDialog(
 		parent=parent,
 		# Translators: Title for message asking if the user really wishes to install an Addon.
 		title=_("Add-on Installation"),
 		message=confirmInstallMessage,
 		showAddonInfoFunction=lambda: _showAddonInfo(bundle._addonGuiModel)
-	).ShowModal()
+	))
 
 
 class IncompatibleAddonsDialog(

--- a/source/gui/exit.py
+++ b/source/gui/exit.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2006-2022 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Mesar Hameed, Joseph Lee,
+# Copyright (C) 2006-2023 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Mesar Hameed, Joseph Lee,
 # Thomas Stivers, Babbage B.V., Accessolutions, Julien Cochuyt, Cyrille Bougot
 # This file may be used under the terms of the GNU General Public License, version 2 or later.
 # For more details see: https://www.gnu.org/licenses/gpl-2.0.html
@@ -18,6 +18,7 @@ import weakref
 import wx
 
 from . import guiHelper
+from .message import displayDialogAsModal
 from .startupDialogs import WelcomeDialog
 
 
@@ -150,7 +151,7 @@ class ExitDialog(wx.Dialog):
 						apiVersion=apiVersion,
 						backCompatTo=backCompatTo
 					)
-					confirmUpdateDialog.ShowModal()
+					displayDialogAsModal(confirmUpdateDialog)
 				else:
 					updateCheck.executePendingUpdate()
 		wx.CallAfter(self.Destroy)

--- a/source/gui/installerGui.py
+++ b/source/gui/installerGui.py
@@ -6,7 +6,6 @@
 
 import os
 
-import shellapi
 import winUser
 import wx
 import config
@@ -20,6 +19,7 @@ import gui.contextHelp
 from gui.dpiScalingHelper import DpiScalingHelperMixinWithoutInit
 import systemUtils
 from NVDAState import WritePaths
+from .message import displayDialogAsModal
 
 
 def _canPortableConfigBeCopied() -> bool:
@@ -274,7 +274,7 @@ class InstallerDialog(
 			parent=self,
 			# the defaults from the installer are fine. We are testing against the running version.
 		)
-		incompatibleAddons.ShowModal()
+		displayDialogAsModal(incompatibleAddons)
 
 
 class InstallingOverNewerVersionDialog(

--- a/source/gui/message.py
+++ b/source/gui/message.py
@@ -36,6 +36,41 @@ def isModalMessageBoxActive() -> bool:
 		return _messageBoxCounter != 0
 
 
+def displayDialogAsModal(
+		dialog: wx.Dialog
+) -> int:
+	"""Display a dialog as modal.
+	@return: Same as for wx.MessageBox.
+
+	`displayDialogAsModal` is a function which blocks the calling thread,
+	until a user responds to the modal dialog.
+	This function should be used when an answer is required before proceeding.
+
+	It's possible for multiple message boxes to be open at a time.
+	Before opening a new messageBox, use `isModalMessageBoxActive`
+	to check if another messageBox modal response is still pending.
+
+	Because an answer is required to continue after a modal messageBox is opened,
+	some actions such as shutting down are prevented while NVDA is in a possibly uncertain state.
+	"""
+	from gui import mainFrame
+	global _messageBoxCounter
+	with _messageBoxCounterLock:
+		_messageBoxCounter += 1
+
+	try:
+		if not dialog.GetParent():
+			mainFrame.prePopup()
+		res = dialog.ShowModal()
+	finally:
+		if not dialog.GetParent():
+			mainFrame.postPopup()
+		with _messageBoxCounterLock:
+			_messageBoxCounter -= 1
+
+	return res
+
+
 def messageBox(
 		message: str,
 		caption: str = wx.MessageBoxCaptionStr,

--- a/source/gui/message.py
+++ b/source/gui/message.py
@@ -36,9 +36,7 @@ def isModalMessageBoxActive() -> bool:
 		return _messageBoxCounter != 0
 
 
-def displayDialogAsModal(
-		dialog: wx.Dialog
-) -> int:
+def displayDialogAsModal(dialog: wx.Dialog) -> int:
 	"""Display a dialog as modal.
 	@return: Same as for wx.MessageBox.
 

--- a/source/updateCheck.py
+++ b/source/updateCheck.py
@@ -48,6 +48,7 @@ import synthDriverHandler  # noqa: E402
 import braille
 import gui
 from gui import guiHelper
+from gui.message import displayDialogAsModal  # noqa: E402
 from addonHandler import getCodeAddon, AddonError, getIncompatibleAddons
 from _addonStore.models.version import (  # noqa: E402
 	getAddonCompatibilityMessage,
@@ -464,7 +465,7 @@ class UpdateResultDialog(
 			APIVersion=self.apiVersion,
 			APIBackwardsCompatToVersion=self.backCompatTo
 		)
-		incompatibleAddons.ShowModal()
+		displayDialogAsModal(incompatibleAddons)
 
 
 class UpdateAskInstallDialog(
@@ -540,7 +541,7 @@ class UpdateAskInstallDialog(
 			APIVersion=self.apiVersion,
 			APIBackwardsCompatToVersion=self.backCompatTo
 		)
-		incompatibleAddons.ShowModal()
+		displayDialogAsModal(incompatibleAddons)
 
 	def onInstallButton(self, evt):
 		_executeUpdate(self.destPath)


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/wiki/Contributing.
-->

### Link to issue number:
Raised in https://github.com/nvaccess/nvda/pull/15246#issuecomment-1665296600

### Summary of the issue:
Sometimes a custom modal dialog is required, instead of just using `gui.message.messageBox`.
For example, adding additional buttons or controls instead of just message text and ok/cancel/yes/no buttons.
However `gui.message.messageBox` adds special handling to ensure users are warned if actions are blocked by an open modal dialog.

### Description of user facing changes
Users are warned when trying to perform a task (e.g opening the NVDA menu) when modal dialogs from the add-on store are waiting a response.
Other modal dialogs have also been addressed, unless they are non-blocking (i.e. started in a separate thread).
These might be worth addressing too, on a case-by-case basis.

### Description of development approach
Create a helper function to show a dialog as a modal dialog, while performing the necessary handling of `messageBox`

### Testing strategy:
Test opening various Add-on store dialogs and performing `nvda+n`

### Known issues with pull request:
There are other dialogs in NVDA with this problem, however most are addressed in this PR.

### Change log entries:
N/A

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
