### PR TITLE
Add-on store: use separate translation strings for the status filter key

### DIFF
--- a/source/_addonStore/models/status.py
+++ b/source/_addonStore/models/status.py
@@ -255,22 +255,39 @@ class _StatusFilterKey(DisplayStringEnum):
 
 	@property
 	def _displayStringLabels(self) -> Dict["_StatusFilterKey", str]:
-		return {k: v.replace('&', '') for (k, v) in self._displayStringLabelsWithAccelerators.items()}
+		return {
+			# Translators: The label of a tab to display installed add-ons in the add-on store.
+			# Ensure the translation matches the label for the add-on list which includes an accelerator key.
+			self.INSTALLED: pgettext("addonStore", "Installed add-ons"),
+			# Translators: The label of a tab to display updatable add-ons in the add-on store.
+			# Ensure the translation matches the label for the add-on list which includes an accelerator key.
+			self.UPDATE: pgettext("addonStore", "Updatable add-ons"),
+			# Translators: The label of a tab to display available add-ons in the add-on store.
+			# Ensure the translation matches the label for the add-on list which includes an accelerator key.
+			self.AVAILABLE: pgettext("addonStore", "Available add-ons"),
+			# Translators: The label of a tab to display incompatible add-ons in the add-on store.
+			# Ensure the translation matches the label for the add-on list which includes an accelerator key.
+			self.INCOMPATIBLE: pgettext("addonStore", "Installed incompatible add-ons"),
+		}
 
 	@property
 	def _displayStringLabelsWithAccelerators(self) -> Dict["_StatusFilterKey", str]:
 		return {
-			# Translators: The label of a tab to display installed add-ons in the add-on store and the label of the
-			# add-ons list in the corresponding panel (preferably use the same accelerator key for the four labels)
+			# Translators: The label of the add-ons list in the corresponding panel.
+			# Preferably use the same accelerator key for the four labels.
+			# Ensure the translation matches the label for the add-on tab which has the accelerator key removed.
 			self.INSTALLED: pgettext("addonStore", "Installed &add-ons"),
-			# Translators: The label of a tab to display updatable add-ons in the add-on store and the label of the
-			# add-ons list in the corresponding panel (preferably use the same accelerator key for the four labels)
+			# Translators: The label of the add-ons list in the corresponding panel.
+			# Preferably use the same accelerator key for the four labels.
+			# Ensure the translation matches the label for the add-on tab which has the accelerator key removed.
 			self.UPDATE: pgettext("addonStore", "Updatable &add-ons"),
-			# Translators: The label of a tab to display available add-ons in the add-on store and the label of the
-			# add-ons list in the corresponding panel (preferably use the same accelerator key for the four labels)
+			# Translators: The label of the add-ons list in the corresponding panel.
+			# Preferably use the same accelerator key for the four labels.
+			# Ensure the translation matches the label for the add-on tab which has the accelerator key removed.
 			self.AVAILABLE: pgettext("addonStore", "Available &add-ons"),
-			# Translators: The label of a tab to display incompatible add-ons in the add-on store and the label of the
-			# add-ons list in the corresponding panel (preferably use the same accelerator key for the four labels)
+			# Translators: The label of the add-ons list in the corresponding panel.
+			# Preferably use the same accelerator key for the four labels.
+			# Ensure the translation matches the label for the add-on tab which has the accelerator key removed.
 			self.INCOMPATIBLE: pgettext("addonStore", "Installed incompatible &add-ons"),
 		}
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/wiki/Contributing.
-->

### Link to issue number:
Fixes #15258 

### Summary of the issue:
The add-on store has 2 sets of strings which are identical, except the inclusion of the an accelerator key.
The add-on tabs (e.g. "Available add-ons") do not have an accelerator key, as they are navigated with `control+tab`.
The add-on list is labelled as "Available &add-ons" so the list can easily be reached with `alt+a`.
Previously, NVDA stripped the ampersand, and otherwise used the same translation strings.
For Chinese, the method of stripping the accelerator key ampersand is not ideal.
For example, translating "Updatable &add-ons" into Simplified Chinese is "可更新的插件(&A)".
For the add-on tabs, this becomes  "可更新的插件(A)" where it should be  "可更新的插件".

### Description of user facing changes
Translation strings are now separate, allowing Chinese translators to translate the strings as  "可更新的插件(&A)" and  "可更新的插件"

### Description of development approach
Translation strings are now separate, allowing Chinese translators to translate the strings as  "可更新的插件(&A)" and  "可更新的插件"

### Testing strategy:
Test viewing the tabs in NVDA and using the accelerator keys

### Known issues with pull request:
None
### Change log entries:
N/a
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
