### PR TITLE
Correct syntax error stopping update check dialog from opening when a previous update had been downloaded and there are incompatible add-ons.

### DIFF
--- a/source/updateCheck.py
+++ b/source/updateCheck.py
@@ -380,7 +380,7 @@ class UpdateResultDialog(
 				backCompatToAPIVersion=self.backCompatTo
 			))
 			if showAddonCompat:
-				message += + "\n\n" + getAddonCompatibilityMessage()
+				message += "\n\n" + getAddonCompatibilityMessage()
 				confirmationCheckbox = sHelper.addItem(wx.CheckBox(
 					self,
 					label=getAddonCompatibilityConfirmationMessage()


### PR DESCRIPTION
### Link to issue number:
Fixes #15028 
Fixes #15284

### Summary of the issue:
the Check For Updates dialog fails to open if a previous update has already been downloaded (is pending) and there are incompatible add-ons.
This is due to a syntax error when concatinating a string.
```
x += + y
```
The second plus is invalid and not necessary.

### Description of user facing changes
the Check For Updates dialog will no longer fail to open if a previous update has already been downloaded (is pending) and there are incompatible add-ons.

### Description of development approach
Remove the invalid plus character.

### Testing strategy:
* Create try build
* Install try build
* Ensure one or more add-ons are installed that are incompatible with 2023.X.
* Open python console, and set versionInfo.updateVersionType to 'beta', versionInfo.version to '2022.4', and then run updateCheck.initialize()
* Download the offered update from the dialog that automatically appears, but dismiss it before actually installing it.
* Restart NVDA.
* Open python console, and set versionInfo.updateVersionType to 'beta', versionInfo.version to '2022.4', and then run updateCheck.initialize()
* A dialog should automatically appear asking if you want to install the pending update already downloaded. The dialog will also mention that there are incompatible add-ons. This is the string that was failing.

### Known issues with pull request:
None known.

### Change log entries:
New features
Changes
Bug fixes
For Developers

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
