### PR TITLE
Add support for SysListView32 controls with a native UIA implementation

### DIFF
--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -1216,6 +1216,10 @@ class UIA(Window):
 			else:
 				clsList.append(winConsoleUIA._DiffBasedWinTerminalUIA)
 
+		elif "SysListView32" in self.windowClassName:
+			from . import sysListView32
+			sysListView32.findExtraOverlayClasses(self, clsList)
+
 		# Add editableText support if UIA supports a text pattern
 		if self.TextInfo==UIATextInfo:
 			if UIAHandler.autoSelectDetectionAvailable:

--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -1216,7 +1216,7 @@ class UIA(Window):
 			else:
 				clsList.append(winConsoleUIA._DiffBasedWinTerminalUIA)
 
-		elif "SysListView32" in self.windowClassName:
+		elif self.normalizeWindowClassName(self.windowClassName) == "SysListView32":
 			from . import sysListView32
 			sysListView32.findExtraOverlayClasses(self, clsList)
 

--- a/source/NVDAObjects/UIA/sysListView32.py
+++ b/source/NVDAObjects/UIA/sysListView32.py
@@ -20,7 +20,7 @@ def findExtraOverlayClasses(obj: NVDAObject, clsList: List[Type[NVDAObject]]) ->
 	UIAControlType = obj.UIAElement.cachedControlType
 	if UIAControlType == UIAHandler.UIA.UIA_ListItemControlTypeId:
 		clsList.insert(0, SysListViewItem)
-	if UIAControlType == UIAHandler.UIA.UIA_ListControlTypeId:
+	elif UIAControlType == UIAHandler.UIA.UIA_ListControlTypeId:
 		clsList.insert(0, SysListViewList)
 
 

--- a/source/NVDAObjects/UIA/sysListView32.py
+++ b/source/NVDAObjects/UIA/sysListView32.py
@@ -6,6 +6,7 @@
 
 """Module for native UIA implementations of SysListView32, e.g. in Windows Forms."""
 
+from comtypes import COMError
 import config
 from config.configFlags import ReportTableHeaders
 import UIAHandler
@@ -84,3 +85,21 @@ class SysListViewItem(RowWithFakeNavigation, ListItem):
 		if val == UIAHandler.handler.reservedNotSupportedValue:
 			return super().rowNumber
 		return val + 1
+
+	def _get_positionInfo(self):
+		info = super().positionInfo or {}
+		itemIndex = 0
+		try:
+			itemIndex = self.rowNumber
+		except (COMError, NotImplementedError):
+			pass
+		if itemIndex > 0:
+			info['indexInGroup'] = itemIndex
+			itemCount = 0
+			try:
+				itemCount = self.parent.rowCount
+			except (COMError, NotImplementedError):
+				pass
+			if itemCount > 0:
+				info['similarItemsInGroup'] = itemCount
+		return info

--- a/source/NVDAObjects/UIA/sysListView32.py
+++ b/source/NVDAObjects/UIA/sysListView32.py
@@ -68,7 +68,7 @@ class SysListViewItem(RowWithFakeNavigation, ListItem):
 			textList.append(text)
 		return "; ".join(textList)
 
-	def _get_rowNumber(self):
+	def _get_indexInParent(self):
 		parent = self.parent
 		if not isinstance(parent, SysListViewList) or self.childCount == 0:
 			return super().rowNumber
@@ -83,14 +83,14 @@ class SysListViewItem(RowWithFakeNavigation, ListItem):
 			True
 		)
 		if val == UIAHandler.handler.reservedNotSupportedValue:
-			return super().rowNumber
-		return val + 1
+			return super().indexInParent
+		return val
 
 	def _get_positionInfo(self):
 		info = super().positionInfo or {}
 		itemIndex = 0
 		try:
-			itemIndex = self.rowNumber
+			itemIndex = self.indexInParent + 1
 		except (COMError, NotImplementedError):
 			pass
 		if itemIndex > 0:

--- a/source/NVDAObjects/UIA/sysListView32.py
+++ b/source/NVDAObjects/UIA/sysListView32.py
@@ -6,15 +6,17 @@
 
 """Module for native UIA implementations of SysListView32, e.g. in Windows Forms."""
 
+from typing import Dict, List, Optional, Type
 from comtypes import COMError
 import config
 from config.configFlags import ReportTableHeaders
 import UIAHandler
+from .. import NVDAObject
 from ..behaviors import RowWithFakeNavigation
 from . import ListItem, UIA
 
 
-def findExtraOverlayClasses(obj, clsList):
+def findExtraOverlayClasses(obj: NVDAObject, clsList: List[Type[NVDAObject]]) -> None:
 	UIAControlType = obj.UIAElement.cachedControlType
 	if UIAControlType == UIAHandler.UIA.UIA_ListItemControlTypeId:
 		clsList.insert(0, SysListViewItem)
@@ -28,7 +30,7 @@ class SysListViewList(UIA):
 
 class SysListViewItem(RowWithFakeNavigation, ListItem):
 
-	def _get_name(self):
+	def _get_name(self) -> str:
 		parent = self.parent
 		if not isinstance(parent, SysListViewList) or self.childCount <= 1:
 			return super().name
@@ -72,10 +74,10 @@ class SysListViewItem(RowWithFakeNavigation, ListItem):
 			textList.append(text)
 		return "; ".join(textList)
 
-	def _get_indexInParent(self):
+	def _get_indexInParent(self) -> Optional[int]:
 		parent = self.parent
 		if not isinstance(parent, SysListViewList) or self.childCount == 0:
-			return super().rowNumber
+			return super().indexInParent
 		childCacheRequest = UIAHandler.handler.baseCacheRequest.clone()
 		childCacheRequest.addProperty(UIAHandler.UIA.UIA_GridItemRowPropertyId)
 		element = UIAHandler.handler.baseTreeWalker.GetFirstChildElementBuildCache(
@@ -90,7 +92,7 @@ class SysListViewItem(RowWithFakeNavigation, ListItem):
 			return super().indexInParent
 		return val
 
-	def _get_positionInfo(self):
+	def _get_positionInfo(self) -> Dict[str, int]:
 		info = super().positionInfo or {}
 		itemIndex = 0
 		try:

--- a/source/NVDAObjects/UIA/sysListView32.py
+++ b/source/NVDAObjects/UIA/sysListView32.py
@@ -1,0 +1,86 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2023 NV Access Limited, Leonard de Ruijter
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+
+
+"""Module for native UIA implementations of SysListView32, e.g. in Windows Forms."""
+
+import config
+from config.configFlags import ReportTableHeaders
+import UIAHandler
+from ..behaviors import RowWithFakeNavigation
+from . import ListItem, UIA
+
+
+def findExtraOverlayClasses(obj, clsList):
+	UIAControlType = obj.UIAElement.cachedControlType
+	if UIAControlType == UIAHandler.UIA.UIA_ListItemControlTypeId:
+		clsList.insert(0, SysListViewItem)
+	if UIAControlType == UIAHandler.UIA.UIA_ListControlTypeId:
+		clsList.insert(0, SysListViewList)
+
+
+class SysListViewList(UIA):
+	...
+
+
+class SysListViewItem(RowWithFakeNavigation, ListItem):
+
+	def _get_name(self):
+		parent = self.parent
+		if not isinstance(parent, SysListViewList) or self.childCount == 0:
+			return super().name
+		childrenCacheRequest = UIAHandler.handler.baseCacheRequest.clone()
+		childrenCacheRequest.addProperty(UIAHandler.UIA.UIA_NamePropertyId)
+		childrenCacheRequest.addProperty(UIAHandler.UIA.UIA_TableItemColumnHeaderItemsPropertyId)
+		childrenCacheRequest.TreeScope = UIAHandler.TreeScope_Children
+		cachedChildren = self.UIAElement.buildUpdatedCache(childrenCacheRequest).getCachedChildren()
+		if not cachedChildren:
+			# There are no children
+			return super().name
+		textList = []
+		for index in range(cachedChildren.length):
+			e = cachedChildren.getElement(index)
+			name = e.cachedName
+			columnHeaderTextList = []
+			if name and config.conf['documentFormatting']['reportTableHeaders'] in (
+				ReportTableHeaders.ROWS_AND_COLUMNS,
+				ReportTableHeaders.COLUMNS,
+			) and index > 0:
+				columnHeaderItems = e.getCachedPropertyValueEx(
+					UIAHandler.UIA.UIA_TableItemColumnHeaderItemsPropertyId,
+					True
+				)
+			else:
+				columnHeaderItems = None
+			if columnHeaderItems:
+				columnHeaderItems = columnHeaderItems.QueryInterface(UIAHandler.IUIAutomationElementArray)
+				for innerIndex in range(columnHeaderItems.length):
+					columnHeaderItem = columnHeaderItems.getElement(innerIndex)
+					columnHeaderTextList.append(columnHeaderItem.currentName)
+			columnHeaderText = " ".join(columnHeaderTextList)
+			if columnHeaderText:
+				text = f"{columnHeaderText} {name}"
+			else:
+				text = name
+			textList.append(text)
+		return "; ".join(textList)
+
+	def _get_rowNumber(self):
+		parent = self.parent
+		if not isinstance(parent, SysListViewList) or self.childCount == 0:
+			return super().rowNumber
+		childCacheRequest = UIAHandler.handler.baseCacheRequest.clone()
+		childCacheRequest.addProperty(UIAHandler.UIA.UIA_GridItemRowPropertyId)
+		element = UIAHandler.handler.baseTreeWalker.GetFirstChildElementBuildCache(
+			self.UIAElement,
+			childCacheRequest
+		)
+		val = element.getCachedPropertyValueEx(
+			UIAHandler.UIA.UIA_GridItemRowPropertyId,
+			True
+		)
+		if val == UIAHandler.handler.reservedNotSupportedValue:
+			return super().rowNumber
+		return val + 1

--- a/source/NVDAObjects/UIA/sysListView32.py
+++ b/source/NVDAObjects/UIA/sysListView32.py
@@ -29,7 +29,7 @@ class SysListViewItem(RowWithFakeNavigation, ListItem):
 
 	def _get_name(self):
 		parent = self.parent
-		if not isinstance(parent, SysListViewList) or self.childCount == 0:
+		if not isinstance(parent, SysListViewList) or self.childCount <= 1:
 			return super().name
 		childrenCacheRequest = UIAHandler.handler.baseCacheRequest.clone()
 		childrenCacheRequest.addProperty(UIAHandler.UIA.UIA_NamePropertyId)

--- a/source/NVDAObjects/UIA/sysListView32.py
+++ b/source/NVDAObjects/UIA/sysListView32.py
@@ -45,10 +45,14 @@ class SysListViewItem(RowWithFakeNavigation, ListItem):
 			e = cachedChildren.getElement(index)
 			name = e.cachedName
 			columnHeaderTextList = []
-			if name and config.conf['documentFormatting']['reportTableHeaders'] in (
-				ReportTableHeaders.ROWS_AND_COLUMNS,
-				ReportTableHeaders.COLUMNS,
-			) and index > 0:
+			if (
+				name
+				and config.conf['documentFormatting']['reportTableHeaders'] in (
+					ReportTableHeaders.ROWS_AND_COLUMNS,
+					ReportTableHeaders.COLUMNS,
+				)
+				and index > 0
+			):
 				columnHeaderItems = e.getCachedPropertyValueEx(
 					UIAHandler.UIA.UIA_TableItemColumnHeaderItemsPropertyId,
 					True

--- a/source/NVDAObjects/__init__.py
+++ b/source/NVDAObjects/__init__.py
@@ -11,6 +11,7 @@ as well as the associated TextInfo class."""
 import time
 import typing
 from typing import (
+	Dict,
 	Optional,
 )
 import weakref
@@ -283,7 +284,7 @@ class NVDAObject(documentBase.TextContainerObject, baseObject.ScriptableObject, 
 		"""
 		raise NotImplementedError
 
-	def findOverlayClasses(self, clsList: typing.List["NVDAObject"]) -> None:
+	def findOverlayClasses(self, clsList: typing.List[typing.Type["NVDAObject"]]) -> None:
 		"""
 		Chooses overlay classes which should be added to this object's class structure,
 		after the object has been initially instantiated.
@@ -1044,10 +1045,12 @@ Tries to force this object to take the focus.
 		"""
 		return None
 
-	def _get_positionInfo(self):
+	#: Type definition for auto prop '_get_positionInfo'
+	positionInfo: Dict[str, int]
+
+	def _get_positionInfo(self) -> Dict[str, int]:
 		"""Retrieves position information for this object such as its level, its index with in a group, and the number of items in that group.
 		@return: a dictionary containing any of level, groupIndex and similarItemsInGroup.
-		@rtype: dict
 		"""
 		return {}
 
@@ -1074,10 +1077,12 @@ Tries to force this object to take the focus.
 			self.isProtected=isProtected
 		return isProtected
 
-	def _get_indexInParent(self):
+	#: Type definition for auto prop '_get_indexInParent'
+	indexInParent: Optional[int]
+
+	def _get_indexInParent(self) -> Optional[int]:
 		"""The index of this object in its parent object.
 		@return: The 0 based index, C{None} if there is no parent.
-		@rtype: int
 		@raise NotImplementedError: If not supported by the underlying object.
 		"""
 		raise NotImplementedError

--- a/source/UIAHandler/__init__.py
+++ b/source/UIAHandler/__init__.py
@@ -97,7 +97,6 @@ badUIAWindowClassNames = (
 	"RichEdit",
 	"RichEdit20",
 	"RICHEDIT50W",
-	"SysListView32",
 	"Button",
 	# #8944: The Foxit UIA implementation is incomplete and should not be used for now.
 	"FoxitDocWnd",

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -24,7 +24,7 @@ What's New in NVDA
 == Bug Fixes ==
 - Fix crash in Microsoft Word when Document formatting options "report headings" and "report comments and notes" were not enabled. (#15019)
 - NVDA will no longer jump back to the last browse mode position when opening the context menu in Microsoft Edge. (#15309)
-- Fixed support for System List view controls in Windows Forms applications. (#15283)
+- Fixed support for System List view (``SysListView32``) controls in Windows Forms applications. (#15283)
 -
 
 == Changes for Developers ==

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -24,6 +24,7 @@ What's New in NVDA
 == Bug Fixes ==
 - Fix crash in Microsoft Word when Document formatting options "report headings" and "report comments and notes" were not enabled. (#15019)
 - NVDA will no longer jump back to the last browse mode position when opening the context menu in Microsoft Edge. (#15309)
+- Fixed support for System List view controls in Windows Forms applications. (#15283)
 -
 
 == Changes for Developers ==


### PR DESCRIPTION
### Link to issue number:
Fixes #15283 

### Summary of the issue:
.NET 7 Win Forms has a native implementation for SysListView32 controls. This conflicts with us listing SysListView32 as a bad UIA Class name.

### Description of user facing changes
Win forms project in #15283 now works as expected for the most part.

### Description of development approach
Implemented SysListView32 in a new UIA module. Note that UIA seems to expose the following tree by default:
- A list object
- Children for the list items having the ListItem control type, but neither GridItem nor TableItem patterns
- Sub items containing both GridItem and TableItem patterns.

I did the following:

1. Introduced fetching of children text and column headers, mostly based on the Outlook app module
2. Implement position info based on row number of the first child and total row count of parent

### Testing strategy:
1. Tested in the win forms project in #15283 
2. By forcing Good Uia Window, tested in the TweeseCake client as well as in CleanMgr. Note that these still take the IAccessible implementation by default as expected,desired.

### Known issues with pull request:
Row navigation doesn't work in the Win Forms project, but this seems to be an issue in Win Forms not properly implementing SetFocus/InvokePattern.

### Change log entries:
Bug fixes
- Fixed support for SysListView32 controls in Windows Forms applications. (#15283)

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
