### PR TITLE
Fix symbol description for braille 4 5 6

### DIFF
--- a/source/locale/en/symbols.dic
+++ b/source/locale/en/symbols.dic
@@ -419,7 +419,7 @@ _	line	most
 ⠵	braille 1 3 5 6
 ⠶	braille 2 3 5 6
 ⠷	braille 1 2 3 5 6
-⠸	braille 1 2 3
+⠸	braille 4 5 6
 ⠹	braille 1 4 5 6
 ⠺	braille 2 4 5 6
 ⠻	braille 1 2 4 5 6


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/wiki/Contributing.
-->

### Link to issue number:
Fixes #15282 

### Summary of the issue:
User error caused the unicode braille symbol for the 4 5 6 dots to be incorrectly labelled as 1 2 3

### Description of user facing changes
Fix pronunciation of the unicode 4 5  6 braille symbol
