### PR TITLE
Group strings in add-on store with pgettext

### DIFF
--- a/source/gui/_addonStoreGui/controls/messageDialogs.py
+++ b/source/gui/_addonStoreGui/controls/messageDialogs.py
@@ -217,7 +217,7 @@ class _SafetyWarningDialog(
 
 	def __init__(self, parent: wx.Window):
 		# Translators: The warning of a dialog
-		super().__init__(parent, title=_("Add-on Store Warning"))
+		super().__init__(parent, title=pgettext("addonStore", "Add-on Store Warning"))
 		mainSizer = wx.BoxSizer(wx.VERTICAL)
 		sHelper = BoxSizerHelper(self, orientation=wx.VERTICAL)
 
@@ -252,7 +252,7 @@ class _SafetyWarningDialog(
 		bHelper = sHelper.addDialogDismissButtons(ButtonHelper(wx.HORIZONTAL))
 
 		# Translators: The label of a button in a dialog
-		okButton = bHelper.addButton(self, wx.ID_OK, label=_("&OK"))
+		okButton = bHelper.addButton(self, wx.ID_OK, label=pgettext("addonStore", "&OK"))
 		okButton.Bind(wx.EVT_BUTTON, self.onOkButton)
 
 		mainSizer.Add(sHelper.sizer, border=BORDER_FOR_DIALOGS, flag=wx.ALL)

--- a/source/gui/_addonStoreGui/controls/storeDialog.py
+++ b/source/gui/_addonStoreGui/controls/storeDialog.py
@@ -162,7 +162,7 @@ class AddonStoreDialog(SettingsDialog):
 		self.bindHelpEvent("AddonStoreFilterChannel", self.channelFilterCtrl)
 
 		# Translators: The label of a checkbox to filter the list of add-ons in the add-on store dialog.
-		incompatibleAddonsLabel = _("Include &incompatible add-ons")
+		incompatibleAddonsLabel = pgettext("addonStore", "Include &incompatible add-ons")
 		self.includeIncompatibleCtrl = cast(wx.CheckBox, filterCtrlsLine0.addItem(
 			wx.CheckBox(self, label=incompatibleAddonsLabel)
 		))


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/wiki/Contributing.
-->

### Link to issue number:
None

### Summary of the issue:
Some translatable strings in the add-on store  didn't use pgettext grouping

### Description of user facing changes


### Description of development approach
Fix missing strings that weren't correctly grouped with pgettext
