### PR TITLE
Fix context menu focus for Edge downloads

### DIFF
--- a/source/UIAHandler/__init__.py
+++ b/source/UIAHandler/__init__.py
@@ -1203,7 +1203,7 @@ class UIAHandler(COMObject):
 			return windowHandle
 		if _isDebug():
 			log.debug(
-				" locating nearest ancestor windowHandle "
+				"Locating nearest ancestor windowHandle "
 				f"for element {self.getUIAElementDebugString(UIAElement)}"
 			)
 		try:

--- a/source/UIAHandler/__init__.py
+++ b/source/UIAHandler/__init__.py
@@ -1237,6 +1237,10 @@ class UIAHandler(COMObject):
 		try:
 			window = new.cachedNativeWindowHandle
 		except COMError:
+			if _isDebug():
+				log.debugWarning(
+					"Unable to get cachedNativeWindowHandle from found ancestor element", exc_info=True
+				)
 			return None
 		if _isDebug():
 			log.debug(

--- a/source/UIAHandler/__init__.py
+++ b/source/UIAHandler/__init__.py
@@ -1237,7 +1237,7 @@ class UIAHandler(COMObject):
 		try:
 			window = new.cachedNativeWindowHandle
 		except COMError:
-			window = None
+			return None
 		if _isDebug():
 			log.debug(
 				"Found ancestor element "

--- a/source/eventHandler.py
+++ b/source/eventHandler.py
@@ -502,7 +502,7 @@ def shouldAcceptEvent(eventName, windowHandle=None):
 	if (
 		# #5504: In Office >= 2013 with the ribbon showing only tabs,
 		# when a tab is expanded, the window we get from the focus object is incorrect.
-		# This window isn't beneath the foreground window,
+		# This window isn't beneath the foreground window.
 		wClass == "NetUIHWND" and fgClassName in ("Net UI Tool Window Layered", "Net UI Tool Window")
 		or (
 			# #14916: The context menu in the Edge download window isn't beneath the foreground window.

--- a/source/eventHandler.py
+++ b/source/eventHandler.py
@@ -499,11 +499,15 @@ def shouldAcceptEvent(eventName, windowHandle=None):
 
 	fg = winUser.getForegroundWindow()
 	fgClassName=winUser.getClassName(fg)
-	if wClass == "NetUIHWND" and fgClassName in ("Net UI Tool Window Layered","Net UI Tool Window"):
+	if (
 		# #5504: In Office >= 2013 with the ribbon showing only tabs,
 		# when a tab is expanded, the window we get from the focus object is incorrect.
 		# This window isn't beneath the foreground window,
-		# so our foreground application checks fail.
+		wClass == "NetUIHWND" and fgClassName in ("Net UI Tool Window Layered", "Net UI Tool Window")
+		# #14916: The context menu in the Edge download window isn't beneath the foreground window.
+		or wClass == "Chrome_WidgetWin_2" and fgClassName == "Chrome_WidgetWin_2"
+	):
+		# Our foreground application checks fail.
 		# Just compare the root owners.
 		if winUser.getAncestor(windowHandle, winUser.GA_ROOTOWNER) == winUser.getAncestor(fg, winUser.GA_ROOTOWNER):
 			return True

--- a/source/eventHandler.py
+++ b/source/eventHandler.py
@@ -504,8 +504,11 @@ def shouldAcceptEvent(eventName, windowHandle=None):
 		# when a tab is expanded, the window we get from the focus object is incorrect.
 		# This window isn't beneath the foreground window,
 		wClass == "NetUIHWND" and fgClassName in ("Net UI Tool Window Layered", "Net UI Tool Window")
-		# #14916: The context menu in the Edge download window isn't beneath the foreground window.
-		or wClass == "Chrome_WidgetWin_2" and fgClassName == "Chrome_WidgetWin_2"
+		or (
+			# #14916: The context menu in the Edge download window isn't beneath the foreground window.
+			wClass == fgClassName
+			and wClass.startswith("Chrome_WidgetWin_") and fgClassName.startswith("Chrome_WidgetWin_")
+		)
 	):
 		# Our foreground application checks fail.
 		# Just compare the root owners.

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -28,6 +28,7 @@ What's New in NVDA
 - NVDA will no longer jump back to the last browse mode position when opening the context menu in Microsoft Edge. (#15309)
 - Fixed support for System List view (``SysListView32``) controls in Windows Forms applications. (#15283)
 - NVDA will no longer be sluggish in rich edit controls when braille is enabled, such as in MemPad. (#14285)
+- NVDA is once again able to read context menus of downloads in Microsoft Edge. (#14916)
 -
 
 == Changes for Developers ==


### PR DESCRIPTION
Note, created against beta because this issue can be pretty annoying and it is a relatively small fix with a major positive impact for Edge users.

### Link to issue number:
Fixes #14916 

### Summary of the issue:
When opening the context menu from the Edge downloads window, NVDA doesn't reflect this.

### Description of user facing changes
Context menu is read again.

### Description of development approach
1. It looks like the context menu items aren't direct children of the foreground window, therefore we compare the root of the foreground and the root of the focus window instead.
2. Fixed a typo in a UIAHandler debug string
3. Ensured that `UIAHandler.getNearestWindowHandle` returns when a cached window handle couldn't be fetched from an UIAElement due to a COMError.

### Testing strategy:
Tested that the context menu of a download item in Edge reads again.

### Known issues with pull request:
The first item in the menu is read twice. I've tried to fix this without success. It looks like our duplicate focus event logic doesn't kick in properly. Note that Edge firing duplicate events is a bug on their end anyway.

### Change log entries:
Bug fixes
- NVDA is once again able to read the context menu of downloads in Microsoft Edge. (#14916)

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
