### PR TITLE
MS Word object model: Always fetch range information

### DIFF
--- a/nvdaHelper/remote/winword.cpp
+++ b/nvdaHelper/remote/winword.cpp
@@ -1164,7 +1164,7 @@ void winword_getTextInRange_helper(HWND hwnd, winword_getTextInRange_args* args)
 				L"\x0003",
 				1
 			)
-			&&pDispatchParagraph
+			&& pDispatchParagraph
 		) {
 			_com_dispatch_raw_propget(
 				pDispatchParagraph,

--- a/nvdaHelper/remote/winword.cpp
+++ b/nvdaHelper/remote/winword.cpp
@@ -1145,11 +1145,33 @@ void winword_getTextInRange_helper(HWND hwnd, winword_getTextInRange_args* args)
 		IDispatchPtr pDispatchParagraphs=NULL;
 	IDispatchPtr pDispatchParagraph=NULL;
 	IDispatchPtr pDispatchParagraphRange=NULL;
-	if(formatConfig&formatConfig_reportComments||initialFormatConfig&formatConfig_reportHeadings) {
-		if(_com_dispatch_raw_propget(pDispatchRange,wdDISPID_RANGE_PARAGRAPHS,VT_DISPATCH,&pDispatchParagraphs)==S_OK&&pDispatchParagraphs) {
-			if(_com_dispatch_raw_method(pDispatchParagraphs,wdDISPID_PARAGRAPHS_ITEM,DISPATCH_METHOD,VT_DISPATCH,&pDispatchParagraph,L"\x0003",1)==S_OK&&pDispatchParagraph) {
-				_com_dispatch_raw_propget(pDispatchParagraph,wdDISPID_PARAGRAPH_RANGE,VT_DISPATCH,&pDispatchParagraphRange);
-			}
+	if (
+		S_OK == _com_dispatch_raw_propget(
+			pDispatchRange,
+			wdDISPID_RANGE_PARAGRAPHS,
+			VT_DISPATCH,
+			&pDispatchParagraphs
+		)
+		&& pDispatchParagraphs
+	) {
+		if(
+			S_OK == _com_dispatch_raw_method(
+				pDispatchParagraphs,
+				wdDISPID_PARAGRAPHS_ITEM,
+				DISPATCH_METHOD,
+				VT_DISPATCH,
+				&pDispatchParagraph,
+				L"\x0003",
+				1
+			)
+			&&pDispatchParagraph
+		) {
+			_com_dispatch_raw_propget(
+				pDispatchParagraph,
+				wdDISPID_PARAGRAPH_RANGE,
+				VT_DISPATCH,
+				&pDispatchParagraphRange
+			);
 		}
 	}
 	vector<pair<long,long> > commentVector;

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -22,7 +22,8 @@ What's New in NVDA
 
 
 == Bug Fixes ==
-
+- Fix crash in Microsoft Word when Document formatting options "report headings" and "report comments and notes" were not enabled. (#15019)
+-
 
 == Changes for Developers ==
 Please refer to [the developer guide https://www.nvaccess.org/files/nvda/documentation/developerGuide.html#API] for information on NVDA's API deprecation and removal process.


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/wiki/Contributing.
-->

### Link to issue number:
Fixes #15019 

### Summary of the issue:
NVDA only fetches object text range information if "report headings" and "report comments and notes" are enabled.
This only happens when using the object model.
This causes a crash when attempting to update the caret, as we try to fetch range information that hasn't been generated by nvdaHelper.

### Description of user facing changes
Fix crash in Microsoft Word when Document formatting options "report headings" and "report comments and notes" were not enabled.
### Description of development approach
Always fetch range information, regardless of these options.
### Testing strategy:
Test STR in #15019  with UIA and Object model
### Known issues with pull request:
None
### Change log entries:
```t2t
Bug fixes
- Fix crash in Microsoft Word when Document formatting options "report headings" and "report comments and notes" were not enabled. (#15019)
```

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
