### PR TITLE
No longer classify (rich) edit classes as bad for UIA

### DIFF
--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -309,7 +309,7 @@ class UIATextInfo(textInfos.TextInfo):
 		if fetchAnnotationTypes:
 			annotationTypes=fetcher.getValue(UIAHandler.UIA_AnnotationTypesAttributeId,ignoreMixedValues=ignoreMixedValues)
 			# Some UIA implementations return a single value rather than a tuple.
-			# Always mutate to a tuple to allow for a generic x in y matching 
+			# Always mutate to a tuple to allow for a generic x in y matching
 			if not isinstance(annotationTypes,tuple):
 				annotationTypes=(annotationTypes,)
 			if formatConfig["reportSpellingErrors"]:
@@ -357,7 +357,7 @@ class UIATextInfo(textInfos.TextInfo):
 			a mixed attribute value signifying that the caller may want to try again with a smaller range.
 		@return: The indent formatting informations corresponding to what has been retrieved via the fetcher.
 		"""
-		
+
 		formatField = textInfos.FormatField()
 		val = fetcher.getValue(UIAHandler.UIA_IndentationFirstLineAttributeId, ignoreMixedValues=ignoreMixedValues)
 		uiaIndentFirstLine = val if isinstance(val, float) else None
@@ -387,14 +387,14 @@ class UIATextInfo(textInfos.TextInfo):
 		if uiaIndentTrailing:
 			formatField['right-indent'] = self._getIndentValueDisplayString(uiaIndentTrailing)
 		return formatField
-	
+
 	def _getIndentValueDisplayString(self, val: float) -> str:
 		"""A function returning the string to display in formatting info.
 		@param val: an indent value measured in points, fetched via
 			an UIAHandler.UIA_Indentation*AttributeId attribute.
 		@return: The string used in formatting information to report the length of an indentation.
 		"""
-		
+
 		# convert points to inches (1pt = 1/72 in)
 		val /= 72.0
 		if languageHandler.useImperialMeasurements():
@@ -406,7 +406,7 @@ class UIATextInfo(textInfos.TextInfo):
 			# Translators: a measurement in centimetres
 			valText = _("{val:.2f} cm").format(val=val)
 		return valText
-	
+
 	# C901 '__init__' is too complex
 	# Note: when working on getPropertiesBraille, look for opportunities to simplify
 	# and move logic out into smaller helper functions.
@@ -593,9 +593,9 @@ class UIATextInfo(textInfos.TextInfo):
 		@param formatConfig: a dictionary of NVDA document formatting configuration keys
 			with values set to true for those types that should be fetched.
 		@param UIAFormatUnits: the UI Automation text units (in order of resolution) that should be used to split the text so as to avoid mixed attribute values. This is None by default.
-			If the parameter is a list of 1 or more units, The range will be split by the first unit in the list, and this method will be recursively run on each subrange, with the remaining units in this list given as the value of this parameter. 
+			If the parameter is a list of 1 or more units, The range will be split by the first unit in the list, and this method will be recursively run on each subrange, with the remaining units in this list given as the value of this parameter.
 			If this parameter is an empty list, then formatting and text is fetched for the entire range, but any mixed attribute values are ignored and no splitting occures.
-			If this parameter is None, text and formatting is fetched for the entire range in one go, but if mixed attribute values are found, it will split by the first unit in self.UIAFormatUnits, and run this method recursively on each subrange, providing the remaining units from self.UIAFormatUnits as the value of this parameter. 
+			If this parameter is None, text and formatting is fetched for the entire range in one go, but if mixed attribute values are found, it will split by the first unit in self.UIAFormatUnits, and run this method recursively on each subrange, providing the remaining units from self.UIAFormatUnits as the value of this parameter.
 		"""
 		debug = UIAHandler._isDebug() and log.isEnabledFor(log.DEBUG)
 		if debug:
@@ -858,7 +858,7 @@ class UIATextInfo(textInfos.TextInfo):
 					log.debug("Yielding final text")
 				for field in self._getTextWithFields_text(tempRange,formatConfig):
 					yield field
-		else: #no children 
+		else: #no children
 			if debug:
 				log.debug("no children")
 				log.debug("Yielding text")
@@ -969,7 +969,7 @@ class UIA(Window):
 	def _get__coreCycleUIAPropertyCacheElementCache(self):
 		"""
 		A dictionary per core cycle that is ready to map UIA property IDs to UIAElements with that property already cached.
-		An example of where multiple cache elements may exist would be where the UIA NVDAObject was instantiated with a UIA element already containing a UI Automation cache (appropriate for generating control fields) but another UIA NVDAObject property (E.g. states) has a set of UIA properties of its own which should be bulk-fetched, and did not exist in the original cache. 
+		An example of where multiple cache elements may exist would be where the UIA NVDAObject was instantiated with a UIA element already containing a UI Automation cache (appropriate for generating control fields) but another UIA NVDAObject property (E.g. states) has a set of UIA properties of its own which should be bulk-fetched, and did not exist in the original cache.
 		"""
 		return {}
 
@@ -993,7 +993,7 @@ class UIA(Window):
 		"""
 		elementCache=self._coreCycleUIAPropertyCacheElementCache
 		if elementCache:
-			# Ignore any IDs we already have cached values or cache UIAElements for 
+			# Ignore any IDs we already have cached values or cache UIAElements for
 			IDs={x for x in IDs if  x not in elementCache}
 		if len(IDs)<2:
 			# Creating  a UIA cache request for 1 or 0 properties is pointless
@@ -1092,7 +1092,7 @@ class UIA(Window):
 					isinstance(self.parent, spartanEdge.EdgeHTMLRootContainer)
 					or not isinstance(self.parent, spartanEdge.EdgeNode)
 				)
-			): 
+			):
 				clsList.append(spartanEdge.EdgeHTMLRoot)
 			elif self.role==controlTypes.Role.LIST:
 				clsList.append(spartanEdge.EdgeList)
@@ -1136,7 +1136,7 @@ class UIA(Window):
 		elif UIAClassName=="UIItem":
 			clsList.append(UIItem)
 		elif UIAClassName=="SensitiveSlider":
-			clsList.append(SensitiveSlider) 
+			clsList.append(SensitiveSlider)
 		if UIAControlType==UIAHandler.UIA_TreeItemControlTypeId:
 			clsList.append(TreeviewItem)
 		if UIAControlType==UIAHandler.UIA_MenuItemControlTypeId:
@@ -1226,13 +1226,16 @@ class UIA(Window):
 		clsList.append(UIA)
 
 		if self.UIAIsWindowElement:
-			super(UIA,self).findOverlayClasses(clsList)
+			super().findOverlayClasses(clsList)
 			if self.UIATextPattern:
-				#Since there is a UIA text pattern, there is no need to use the win32 edit support at all
+				# Since there is a UIA text pattern, there is no need to use the win32 edit support at all.
+				# However, UIA classifies (rich) edit controls with a role of document and doesn't add a multiline state.
+				# Remove any win32 Edit class and insert EditBase to keep backwards compatibility with win32.
 				import NVDAObjects.window.edit
 				for x in list(clsList):
-					if issubclass(x,NVDAObjects.window.edit.Edit):
+					if issubclass(x, NVDAObjects.window.edit.Edit):
 						clsList.remove(x)
+						clsList.insert(0, NVDAObjects.window.edit.EditBase)
 
 	@classmethod
 	def kwargsFromSuper(cls, kwargs, relation=None, ignoreNonNativeElementsWithFocus=True):
@@ -1290,7 +1293,7 @@ class UIA(Window):
 	def __init__(self,windowHandle=None,UIAElement=None,initialUIACachedPropertyIDs=None):
 		"""
 		An NVDAObject for a UI Automation element.
-		@param windowHandle: if a UIAElement is not specifically given, then this windowHandle is used to fetch its root UIAElement 
+		@param windowHandle: if a UIAElement is not specifically given, then this windowHandle is used to fetch its root UIAElement
 		@type windowHandle: int
 		@param UIAElement: the UI Automation element that should be represented by this NVDAObject
 		The UI Automation element must have been created with a L{UIAHandler.handler.baseCacheRequest}
@@ -1348,7 +1351,7 @@ class UIA(Window):
 	_lastLiveRegionChangeInfo=(None,None) #: Keeps track of the last live region change (text, time)
 	def _get__shouldAllowUIALiveRegionChangeEvent(self):
 		"""
-		This property decides whether  a live region change event should be allowed. It compaires live region event with the last one received, only allowing the event if the text (name) is different, or if the time since the last one is at least 0.5 seconds. 
+		This property decides whether  a live region change event should be allowed. It compaires live region event with the last one received, only allowing the event if the text (name) is different, or if the time since the last one is at least 0.5 seconds.
 		"""
 		oldText,oldTime=self._lastLiveRegionChangeInfo
 		newText=self.name
@@ -1359,7 +1362,7 @@ class UIA(Window):
 		return True
 
 	def _getUIAPattern(self,ID,interface,cache=False):
-		punk=self.UIAElement.GetCachedPattern(ID) if cache else self.UIAElement.GetCurrentPattern(ID) 
+		punk=self.UIAElement.GetCachedPattern(ID) if cache else self.UIAElement.GetCurrentPattern(ID)
 		if punk:
 			return punk.QueryInterface(interface)
 
@@ -1737,7 +1740,7 @@ class UIA(Window):
 		# UIA NVDAObjects can only be considered content if UI Automation considers them both a control and content.
 		if presentationType==self.presType_content and not (self.UIAElement.cachedIsContentElement and self.UIAElement.cachedIsControlElement):
 			presentationType=self.presType_layout
-		return presentationType 
+		return presentationType
 
 	def correctAPIForRelation(self, obj, relation=None):
 		if obj and self.windowHandle != obj.windowHandle and not obj.UIAElement.cachedNativeWindowHandle:
@@ -2166,7 +2169,7 @@ class TreeviewItem(UIA):
 	def _get__level(self):
 		level=0
 		obj=self
-		while obj: 
+		while obj:
 			level+=1
 			parent=obj.parent=obj.parent
 			if not parent or parent==obj or parent.role!=controlTypes.Role.TREEVIEWITEM:
@@ -2324,7 +2327,7 @@ class ToolTip(ToolTip, UIA):
 
 
 #WpfTextView fires name state changes once a second, plus when IUIAutomationTextRange::GetAttributeValue is called.
-#This causes major lags when using this control with Braille in NVDA. (#2759) 
+#This causes major lags when using this control with Braille in NVDA. (#2759)
 #For now just ignore the events.
 class WpfTextView(UIA):
 
@@ -2379,7 +2382,7 @@ class NetUIDropdownAnchor(UIA):
 	def _get_name(self):
 		name=super(NetUIDropdownAnchor,self).name
 		# In MS Office 2010, these combo boxes had no name.
-		# However, the name can be found as the direct previous sibling label element. 
+		# However, the name can be found as the direct previous sibling label element.
 		if not name and self.previous and self.previous.role==controlTypes.Role.STATICTEXT:
 			name=self.previous.name
 		return name

--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -309,7 +309,7 @@ class UIATextInfo(textInfos.TextInfo):
 		if fetchAnnotationTypes:
 			annotationTypes=fetcher.getValue(UIAHandler.UIA_AnnotationTypesAttributeId,ignoreMixedValues=ignoreMixedValues)
 			# Some UIA implementations return a single value rather than a tuple.
-			# Always mutate to a tuple to allow for a generic x in y matching
+			# Always mutate to a tuple to allow for a generic x in y matching 
 			if not isinstance(annotationTypes,tuple):
 				annotationTypes=(annotationTypes,)
 			if formatConfig["reportSpellingErrors"]:
@@ -357,7 +357,7 @@ class UIATextInfo(textInfos.TextInfo):
 			a mixed attribute value signifying that the caller may want to try again with a smaller range.
 		@return: The indent formatting informations corresponding to what has been retrieved via the fetcher.
 		"""
-
+		
 		formatField = textInfos.FormatField()
 		val = fetcher.getValue(UIAHandler.UIA_IndentationFirstLineAttributeId, ignoreMixedValues=ignoreMixedValues)
 		uiaIndentFirstLine = val if isinstance(val, float) else None
@@ -387,14 +387,14 @@ class UIATextInfo(textInfos.TextInfo):
 		if uiaIndentTrailing:
 			formatField['right-indent'] = self._getIndentValueDisplayString(uiaIndentTrailing)
 		return formatField
-
+	
 	def _getIndentValueDisplayString(self, val: float) -> str:
 		"""A function returning the string to display in formatting info.
 		@param val: an indent value measured in points, fetched via
 			an UIAHandler.UIA_Indentation*AttributeId attribute.
 		@return: The string used in formatting information to report the length of an indentation.
 		"""
-
+		
 		# convert points to inches (1pt = 1/72 in)
 		val /= 72.0
 		if languageHandler.useImperialMeasurements():
@@ -406,7 +406,7 @@ class UIATextInfo(textInfos.TextInfo):
 			# Translators: a measurement in centimetres
 			valText = _("{val:.2f} cm").format(val=val)
 		return valText
-
+	
 	# C901 '__init__' is too complex
 	# Note: when working on getPropertiesBraille, look for opportunities to simplify
 	# and move logic out into smaller helper functions.
@@ -593,9 +593,9 @@ class UIATextInfo(textInfos.TextInfo):
 		@param formatConfig: a dictionary of NVDA document formatting configuration keys
 			with values set to true for those types that should be fetched.
 		@param UIAFormatUnits: the UI Automation text units (in order of resolution) that should be used to split the text so as to avoid mixed attribute values. This is None by default.
-			If the parameter is a list of 1 or more units, The range will be split by the first unit in the list, and this method will be recursively run on each subrange, with the remaining units in this list given as the value of this parameter.
+			If the parameter is a list of 1 or more units, The range will be split by the first unit in the list, and this method will be recursively run on each subrange, with the remaining units in this list given as the value of this parameter. 
 			If this parameter is an empty list, then formatting and text is fetched for the entire range, but any mixed attribute values are ignored and no splitting occures.
-			If this parameter is None, text and formatting is fetched for the entire range in one go, but if mixed attribute values are found, it will split by the first unit in self.UIAFormatUnits, and run this method recursively on each subrange, providing the remaining units from self.UIAFormatUnits as the value of this parameter.
+			If this parameter is None, text and formatting is fetched for the entire range in one go, but if mixed attribute values are found, it will split by the first unit in self.UIAFormatUnits, and run this method recursively on each subrange, providing the remaining units from self.UIAFormatUnits as the value of this parameter. 
 		"""
 		debug = UIAHandler._isDebug() and log.isEnabledFor(log.DEBUG)
 		if debug:
@@ -858,7 +858,7 @@ class UIATextInfo(textInfos.TextInfo):
 					log.debug("Yielding final text")
 				for field in self._getTextWithFields_text(tempRange,formatConfig):
 					yield field
-		else: #no children
+		else: #no children 
 			if debug:
 				log.debug("no children")
 				log.debug("Yielding text")
@@ -969,7 +969,7 @@ class UIA(Window):
 	def _get__coreCycleUIAPropertyCacheElementCache(self):
 		"""
 		A dictionary per core cycle that is ready to map UIA property IDs to UIAElements with that property already cached.
-		An example of where multiple cache elements may exist would be where the UIA NVDAObject was instantiated with a UIA element already containing a UI Automation cache (appropriate for generating control fields) but another UIA NVDAObject property (E.g. states) has a set of UIA properties of its own which should be bulk-fetched, and did not exist in the original cache.
+		An example of where multiple cache elements may exist would be where the UIA NVDAObject was instantiated with a UIA element already containing a UI Automation cache (appropriate for generating control fields) but another UIA NVDAObject property (E.g. states) has a set of UIA properties of its own which should be bulk-fetched, and did not exist in the original cache. 
 		"""
 		return {}
 
@@ -993,7 +993,7 @@ class UIA(Window):
 		"""
 		elementCache=self._coreCycleUIAPropertyCacheElementCache
 		if elementCache:
-			# Ignore any IDs we already have cached values or cache UIAElements for
+			# Ignore any IDs we already have cached values or cache UIAElements for 
 			IDs={x for x in IDs if  x not in elementCache}
 		if len(IDs)<2:
 			# Creating  a UIA cache request for 1 or 0 properties is pointless
@@ -1092,7 +1092,7 @@ class UIA(Window):
 					isinstance(self.parent, spartanEdge.EdgeHTMLRootContainer)
 					or not isinstance(self.parent, spartanEdge.EdgeNode)
 				)
-			):
+			): 
 				clsList.append(spartanEdge.EdgeHTMLRoot)
 			elif self.role==controlTypes.Role.LIST:
 				clsList.append(spartanEdge.EdgeList)
@@ -1136,7 +1136,7 @@ class UIA(Window):
 		elif UIAClassName=="UIItem":
 			clsList.append(UIItem)
 		elif UIAClassName=="SensitiveSlider":
-			clsList.append(SensitiveSlider)
+			clsList.append(SensitiveSlider) 
 		if UIAControlType==UIAHandler.UIA_TreeItemControlTypeId:
 			clsList.append(TreeviewItem)
 		if UIAControlType==UIAHandler.UIA_MenuItemControlTypeId:
@@ -1226,7 +1226,7 @@ class UIA(Window):
 		clsList.append(UIA)
 
 		if self.UIAIsWindowElement:
-			super().findOverlayClasses(clsList)
+			super(UIA,self).findOverlayClasses(clsList)
 			if self.UIATextPattern:
 				# Since there is a UIA text pattern, there is no need to use the win32 edit support at all.
 				# However, UIA classifies (rich) edit controls with a role of document and doesn't add a multiline state.
@@ -1293,7 +1293,7 @@ class UIA(Window):
 	def __init__(self,windowHandle=None,UIAElement=None,initialUIACachedPropertyIDs=None):
 		"""
 		An NVDAObject for a UI Automation element.
-		@param windowHandle: if a UIAElement is not specifically given, then this windowHandle is used to fetch its root UIAElement
+		@param windowHandle: if a UIAElement is not specifically given, then this windowHandle is used to fetch its root UIAElement 
 		@type windowHandle: int
 		@param UIAElement: the UI Automation element that should be represented by this NVDAObject
 		The UI Automation element must have been created with a L{UIAHandler.handler.baseCacheRequest}
@@ -1351,7 +1351,7 @@ class UIA(Window):
 	_lastLiveRegionChangeInfo=(None,None) #: Keeps track of the last live region change (text, time)
 	def _get__shouldAllowUIALiveRegionChangeEvent(self):
 		"""
-		This property decides whether  a live region change event should be allowed. It compaires live region event with the last one received, only allowing the event if the text (name) is different, or if the time since the last one is at least 0.5 seconds.
+		This property decides whether  a live region change event should be allowed. It compaires live region event with the last one received, only allowing the event if the text (name) is different, or if the time since the last one is at least 0.5 seconds. 
 		"""
 		oldText,oldTime=self._lastLiveRegionChangeInfo
 		newText=self.name
@@ -1362,7 +1362,7 @@ class UIA(Window):
 		return True
 
 	def _getUIAPattern(self,ID,interface,cache=False):
-		punk=self.UIAElement.GetCachedPattern(ID) if cache else self.UIAElement.GetCurrentPattern(ID)
+		punk=self.UIAElement.GetCachedPattern(ID) if cache else self.UIAElement.GetCurrentPattern(ID) 
 		if punk:
 			return punk.QueryInterface(interface)
 
@@ -1740,7 +1740,7 @@ class UIA(Window):
 		# UIA NVDAObjects can only be considered content if UI Automation considers them both a control and content.
 		if presentationType==self.presType_content and not (self.UIAElement.cachedIsContentElement and self.UIAElement.cachedIsControlElement):
 			presentationType=self.presType_layout
-		return presentationType
+		return presentationType 
 
 	def correctAPIForRelation(self, obj, relation=None):
 		if obj and self.windowHandle != obj.windowHandle and not obj.UIAElement.cachedNativeWindowHandle:
@@ -2169,7 +2169,7 @@ class TreeviewItem(UIA):
 	def _get__level(self):
 		level=0
 		obj=self
-		while obj:
+		while obj: 
 			level+=1
 			parent=obj.parent=obj.parent
 			if not parent or parent==obj or parent.role!=controlTypes.Role.TREEVIEWITEM:
@@ -2327,7 +2327,7 @@ class ToolTip(ToolTip, UIA):
 
 
 #WpfTextView fires name state changes once a second, plus when IUIAutomationTextRange::GetAttributeValue is called.
-#This causes major lags when using this control with Braille in NVDA. (#2759)
+#This causes major lags when using this control with Braille in NVDA. (#2759) 
 #For now just ignore the events.
 class WpfTextView(UIA):
 
@@ -2382,7 +2382,7 @@ class NetUIDropdownAnchor(UIA):
 	def _get_name(self):
 		name=super(NetUIDropdownAnchor,self).name
 		# In MS Office 2010, these combo boxes had no name.
-		# However, the name can be found as the direct previous sibling label element.
+		# However, the name can be found as the direct previous sibling label element. 
 		if not name and self.previous and self.previous.role==controlTypes.Role.STATICTEXT:
 			name=self.previous.name
 		return name

--- a/source/NVDAObjects/window/edit.py
+++ b/source/NVDAObjects/window/edit.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2006-2022 NV Access Limited, Babbage B.V., Cyrille Bougot
+# Copyright (C) 2006-2023 NV Access Limited, Babbage B.V., Cyrille Bougot, Leonard de Ruijter
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -83,8 +83,8 @@ CFE_ITALIC=2
 CFE_UNDERLINE=4
 CFE_STRIKEOUT=8
 CFE_PROTECTED=16
-CFE_SUBSCRIPT=0x00010000 # Superscript and subscript are 
-CFE_SUPERSCRIPT=0x00020000 #  mutually exclusive			 
+CFE_SUBSCRIPT=0x00010000 # Superscript and subscript are
+CFE_SUPERSCRIPT=0x00020000 #  mutually exclusive
 
 SCF_SELECTION=0x1
 
@@ -176,7 +176,7 @@ class EditTextInfo(textInfos.offsets.OffsetsTextInfo):
 			res=watchdog.cancellableSendMessage(self.obj.windowHandle,winUser.EM_POSFROMCHAR,offset,None)
 			point=locationHelper.Point(winUser.GET_X_LPARAM(res),winUser.GET_Y_LPARAM(res))
 		# A returned coordinate can be a negative value if
-		# the specified character is not displayed in the edit control's client area. 
+		# the specified character is not displayed in the edit control's client area.
 		# If the specified index is greater than the index of the last character in the control,
 		# the control returns -1.
 		if point.x <0 or point.y <0:
@@ -289,7 +289,7 @@ class EditTextInfo(textInfos.offsets.OffsetsTextInfo):
 			if charFormat is None: charFormat=self._getCharFormat(offset)
 			formatField["link"]=bool(charFormat.dwEffects&CFM_LINK)
 		return formatField,(startOffset,endOffset)
-	
+
 	def _setFormatFieldColor(
 			self,
 			charFormat: Union[CharFormat2AStruct, CharFormat2WStruct],
@@ -313,7 +313,7 @@ class EditTextInfo(textInfos.offsets.OffsetsTextInfo):
 		else:
 			rgb = charFormat.crBackColor
 			formatField["background-color"] = colors.RGB.fromCOLORREF(rgb)
-	
+
 	def _getSelectionOffsets(self):
 		if self.obj.editAPIVersion>=1:
 			charRange=CharRangeStruct()
@@ -602,7 +602,7 @@ class ITextDocumentTextInfo(textInfos.TextInfo):
 			formatField['background-color'] = _("Unknown color")
 		else:
 			formatField["background-color"] = colors.RGB.fromCOLORREF(bkColor)
-	
+
 	def _expandFormatRange(self, textRange, formatConfig):
 		startLimit=self._rangeObj.start
 		endLimit=self._rangeObj.end
@@ -640,7 +640,7 @@ class ITextDocumentTextInfo(textInfos.TextInfo):
 			pass
 		if label:
 			return label
-		# Outlook 2003 and Outlook Express write the embedded object text to the display with GDI thus we can use display model 
+		# Outlook 2003 and Outlook Express write the embedded object text to the display with GDI thus we can use display model
 		left,top=embedRangeObj.GetPoint(comInterfaces.tom.tomStart)
 		right,bottom=embedRangeObj.GetPoint(comInterfaces.tom.tomEnd|TA_BOTTOM)
 		# Outlook Express bug: when expanding to the first embedded object on lines after the first, the range's start coordinates are the start coordinates of the previous character (on the line above)
@@ -836,7 +836,24 @@ class ITextDocumentTextInfo(textInfos.TextInfo):
 		self.obj.ITextSelectionObject.start=self._rangeObj.start
 		self.obj.ITextSelectionObject.end=self._rangeObj.end
 
-class Edit(EditableTextWithAutoSelectDetection, Window):
+
+class EditBase(Window):
+	""""Base class for Edit and Rich Edit controls, shared by legacy and UIA implementations."""
+
+	def _get_value(self):
+		return None
+
+	def _get_role(self):
+		return controlTypes.Role.EDITABLETEXT
+
+	def _get_states(self):
+		states = super()._get_states()
+		if self.windowStyle & winUser.ES_MULTILINE:
+			states.add(controlTypes.State.MULTILINE)
+		return states
+
+
+class Edit(EditableTextWithAutoSelectDetection, EditBase):
 
 	editAPIVersion=0
 	editValueUnit=textInfos.UNIT_LINE
@@ -866,12 +883,6 @@ class Edit(EditableTextWithAutoSelectDetection, Window):
 				self._ITextSelectionObject=None
 		return self._ITextSelectionObject
 
-	def _get_value(self):
-		return None
-
-	def _get_role(self):
-		return controlTypes.Role.EDITABLETEXT
-
 	def event_caret(self):
 		global selOffsetsAtLastCaretEvent
 		#Fetching formatting and calculating word offsets needs to move the caret, so try to ignore these events
@@ -890,11 +901,6 @@ class Edit(EditableTextWithAutoSelectDetection, Window):
 	def event_valueChange(self):
 		self.event_textChange()
 
-	def _get_states(self):
-		states = super(Edit, self)._get_states()
-		if self.windowStyle & winUser.ES_MULTILINE:
-			states.add(controlTypes.State.MULTILINE)
-		return states
 
 class RichEdit(Edit):
 	editAPIVersion=1

--- a/source/NVDAObjects/window/edit.py
+++ b/source/NVDAObjects/window/edit.py
@@ -75,18 +75,20 @@ class TextRangeStruct(ctypes.Structure):
 		('lpstrText',ctypes.c_char_p),
 	]
 
-CFM_LINK=0x20
-CFE_AUTOBACKCOLOR=0x4000000
-CFE_AUTOCOLOR=0x40000000
-CFE_BOLD=1
-CFE_ITALIC=2
-CFE_UNDERLINE=4
-CFE_STRIKEOUT=8
-CFE_PROTECTED=16
-CFE_SUBSCRIPT=0x00010000 # Superscript and subscript are
-CFE_SUPERSCRIPT=0x00020000 #  mutually exclusive
 
-SCF_SELECTION=0x1
+CFM_LINK = 0x20
+CFE_AUTOBACKCOLOR = 0x4000000
+CFE_AUTOCOLOR = 0x40000000
+CFE_BOLD = 1
+CFE_ITALIC = 2
+CFE_UNDERLINE = 4
+CFE_STRIKEOUT = 8
+CFE_PROTECTED = 16
+CFE_SUBSCRIPT = 0x00010000  # Superscript and subscript are
+CFE_SUPERSCRIPT = 0x00020000  # mutually exclusive
+
+SCF_SELECTION = 0x1
+
 
 class CharFormat2WStruct(ctypes.Structure):
 	_fields_=[
@@ -640,7 +642,8 @@ class ITextDocumentTextInfo(textInfos.TextInfo):
 			pass
 		if label:
 			return label
-		# Outlook 2003 and Outlook Express write the embedded object text to the display with GDI thus we can use display model
+		# Outlook 2003 and Outlook Express write the embedded object text to the display with GDI
+		# thus we can use display model
 		left,top=embedRangeObj.GetPoint(comInterfaces.tom.tomStart)
 		right,bottom=embedRangeObj.GetPoint(comInterfaces.tom.tomEnd|TA_BOTTOM)
 		# Outlook Express bug: when expanding to the first embedded object on lines after the first, the range's start coordinates are the start coordinates of the previous character (on the line above)

--- a/source/UIAHandler/__init__.py
+++ b/source/UIAHandler/__init__.py
@@ -90,13 +90,9 @@ badUIAWindowClassNames = (
 	"WuDuiListView",
 	"ComboBox",
 	"msctls_progress32",
-	"Edit",
 	"CommonPlacesWrapperWndClass",
 	"SysMonthCal32",
 	"SUPERGRID",  # Outlook 2010 message list
-	"RichEdit",
-	"RichEdit20",
-	"RICHEDIT50W",
 	"SysListView32",
 	"Button",
 	# #8944: The Foxit UIA implementation is incomplete and should not be used for now.

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -19,12 +19,15 @@ What's New in NVDA
 -
 
 == Changes ==
+- Rich edit controls in applications such as Wordpad now use UI Automation (UIA) when the application advertises native support for this. (#15314)
+-
 
 
 == Bug Fixes ==
 - Fix crash in Microsoft Word when Document formatting options "report headings" and "report comments and notes" were not enabled. (#15019)
 - NVDA will no longer jump back to the last browse mode position when opening the context menu in Microsoft Edge. (#15309)
 - Fixed support for System List view (``SysListView32``) controls in Windows Forms applications. (#15283)
+- NVDA will no longer be sluggish in rich edit controls when braille is enabled, such as in MemPad. (#14285)
 -
 
 == Changes for Developers ==


### PR DESCRIPTION
### Link to issue number:
Fixes #14285

### Summary of the issue:
There are reports of NVDA being sluggish in Rich Edit controls. In https://github.com/nvaccess/nvda/commit/d5a3383bb2, rich edit classes were classified as bad for UIA for us to always use the win32 implementation. However, our support for UIA text editing is good enough for this restriction to be lifted, as this also solves the reported sluggishness.

### Description of user facing changes
Using UIA instead of win32 API's under the hood.

### Description of development approach
* Moved the role, value and states overrides to a base class in window.edit
* Rather than simply removing win32 edit classes when using UIA, insert the EditBase class as well. This ensures that role is reported as editable text rather than document, and that the multiline state is added. This ensures backwards compatibility as long as code authors don't match against MSAA specific properties.

### Testing strategy:
* [x] Tests by @rehakp as part of https://github.com/nvaccess/nvda/issues/14285
* [x] Test that UIA is now used in Wordpad and works as expected

### Known issues with pull request:
I'm not sure whether we should consider this API breaking. In theory, an app module could use IAccessible specific properties to match against a specific implementation of a control, but I think this risk is negligible.

### Change log entries:
Changes
- Rich Edit controls in applications such as Wordpad now use UI Automation (UIA) when the application advertises native support for this.
Bug fixes
- NVDA will now longer be sluggish in rich edit controls when braille is enabled, such as in MemPad. (#14285)

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [ ] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
