### PR TITLE
Fix context menu bouncing in Edge browse mode

### DIFF
--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -583,6 +583,7 @@ class BrowseModeTreeInterceptor(treeInterceptorHandler.TreeInterceptor):
 	def script_passThrough(self,gesture):
 		if not config.conf["virtualBuffers"]["autoFocusFocusableElements"]:
 			self._focusLastFocusableObject()
+			api.processPendingEvents(processEventQueue=True)
 		gesture.send()
 	# Translators: the description for the passThrough script on browseMode documents.
 	script_passThrough.__doc__ = _("Passes gesture through to the application")

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -23,6 +23,7 @@ What's New in NVDA
 
 == Bug Fixes ==
 - Fix crash in Microsoft Word when Document formatting options "report headings" and "report comments and notes" were not enabled. (#15019)
+- NVDA will no longer jump back to the last browse mode position when opening the context menu in Microsoft Edge. (#15309)
 -
 
 == Changes for Developers ==


### PR DESCRIPTION
### Link to issue number:
Fixes #15309 

### Summary of the issue:
In Edge browse mode, when opening the context menu, NVDA many times goes back to browse mode.

### Description of user facing changes
NVDA will no correctly focus the context menu opened from Edge browse mode.

### Description of development approach
The issue behind this is as follows. Take a link as example:

1. Disabling the option `Automatically set system focus to focusable elements` ensures that an object only gets focus when strictly necessary. This is the case when opening the context menu, because otherwise, the context menu would open for the wrong object.
2. When opening the context menu on the link, NVDA calls script_passThrough
3. script_passThrough calls setFocus on the link's object and sends the gesture.
4. Two focus events are fired, one for the link in the document and one for the context menu
5. NVDA first processes the context menu event and after that, the link object event
6. Focus bounces from the context menu back to the link.

There is a very trivial fix for this. With calling `api.processPendingEvents`, we ensure that NVDA first processes the event generated by setFocus before executing the gesture.

### Testing strategy:
Tested the str from #15309 

### Known issues with pull request:
None known

### Change log entries:
Bug fixes
- NVDA will no longer bounce back to the last browse mode position when opening the context menu in Microsoft Edge. (#15309)

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/devDocs/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
