### PR TITLE
Migrate contributing wiki to repository

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -16,14 +16,15 @@ There are several approaches you may take for this:
 Forming a group can help you to get good coverage, brainstorm on what should be tested, and perhaps learn new ways to use NVDA.
 
 ## Issue triage and investigation:
-You can also make non-code contributions by helping process incoming GitHub issues. For information on this please see the [triage process](https://github.com/nvaccess/nvda/wiki/Triage-process) and [issue triage help](https://github.com/nvaccess/nvda/wiki/Issue-triage-help) on the wiki.
+You can also make non-code contributions by helping process incoming GitHub issues. For information on this please see the [triage process](../projectDocs/issues/triage.md).
 
 ## Code/Docs contributions
 
 If you are new to the project, or looking for some way to help take a look at:
-- [label:"good first issue" ](https://github.com/nvaccess/nvda/issues?q=label%3A%22good+first+issue%22)
-- [label:closed/needs-new-author ](https://github.com/nvaccess/nvda/issues?q=label%3Aclosed%2Fneeds-new-author)
-- [label:Abandoned ](https://github.com/nvaccess/nvda/issues?q=label%3AAbandoned)
+- [label:"good first issue"](https://github.com/nvaccess/nvda/issues?q=label%3A%22good+first+issue%22)
+- [label:component/documentation](https://github.com/nvaccess/nvda/issues?q=label%3Acomponent%2Fdocumentation)
+- [label:closed/needs-new-author](https://github.com/nvaccess/nvda/issues?q=label%3Aclosed%2Fneeds-new-author)
+- [label:Abandoned](https://github.com/nvaccess/nvda/issues?q=label%3AAbandoned)
 
 ### Guidelines:
 - For anything other than minor bug fixes, please comment on an existing issue or create a new issue providing details about your proposed change.
@@ -31,10 +32,11 @@ If you are new to the project, or looking for some way to help take a look at:
 - Include information about use cases, design, user experience, etc.
   - This allows us to discuss these aspects and any other concerns that might arise, thus potentially avoiding a great deal of wasted time.
 - It is recommended to wait for acceptance of your proposal before you start coding.
+  - A `triaged` label is an indicator that an issue is ready for a fix.
   - Please understand that we very likely will not accept changes that are not discussed first.
-  - Consider starting a discussion on mailing lists (EG NVDA developers) to see if there is interest.
+  - Consider starting a [GitHub discussion](https://github.com/nvaccess/nvda/discussions) or [mailing list topic](https://groups.io/g/nvda-devel/topics) to see if there is interest.
 - A minor/trivial change which definitely wouldn't require design, user experience or implementation discussion, you can just create a pull request rather than using an issue first.
-  - E.G. a fix for a typo/obvious coding error or a simple synthesizer/braille display driver
+  - e.g. a fix for a typo/obvious coding error or a simple synthesizer/braille display driver
   - This should be fairly rare.
 - If in doubt, use an issue first. Use this issue to discuss the alternatives you have considered in regards to implementation, design, and user experience. Then give people time to offer feedback.
 
@@ -45,7 +47,7 @@ If you are new to the project, or looking for some way to help take a look at:
    However, this branch will not be updated when the official master branch is updated.
    To ensure your work is always based on the latest commit in the official master branch, it is recommended that your master branch be linked to the official master branch, rather than the master branch in your GitHub fork.
    If you have cloned your GitHub fork, you can do this from the command line as follows:
-   ```
+   ```sh
    # Add a remote for the NV Access repository.
    git remote add nvaccess https://github.com/nvaccess/nvda.git
    # Fetch the nvaccess branches.
@@ -77,64 +79,12 @@ If you are new to the project, or looking for some way to help take a look at:
    This process requires core NVDA developers to understand the intent of the change, read the code changes, asking questions or suggesting changes.
    Please participate in this process, answering questions, and discussing the changes.
    Being proactive will really help to speed up the process of code review.
-   When the PR is approved it will be merged, and the change will be active in the next Alpha build.
+   When the PR is approved it will be merged, and the change will be active in the next alpha build.
 
-#### 6. Feedback from Alpha users
-   After a PR is merged, watch for feedback from Alpha users / testers.
+#### 6. Feedback from alpha users
+   After a PR is merged, watch for feedback from alpha users / testers.
    You may have to follow up to address bugs or missed use-cases.
 
 ## Code Style
 
-Code style is enforced with the flake8 linter, see [`tests/lint/readme.md`](https://github.com/nvaccess/nvda/tree/master/tests/lint) for more information.
-
-### Encoding
-* Where Python files contain non-ASCII characters, they should be encoded in UTF-8.
-    * There should be no Unicode BOM at the start of the file, as this unfortunately breaks one of the translation tools we use (`xgettext`). Instead, include this as the first line of the file (only if the file contains non-ASCII characters):
-        ```
-        # -*- coding: UTF-8 -*-
-        ```
-    * This coding comment must also be included if strings in the code (even strings that aren't translatable) contain escape sequences that produce non-ASCII characters; e.g. `"\xff"`. This is particularly relevant for braille display drivers. This is due to a `gettext` bug; see https://github.com/nvaccess/nvda/issues/2592#issuecomment-155299911.
-* Most files should contain `CRLF` line endings, as this is a Windows project and can't be used on Unix-like operating systems.
-
-### Indentation
-* Indentation must be done with tabs (one per level), not spaces.
-* When splitting a single statement over multiple lines, just indent one or more additional levels. Don't use vertical alignment; e.g. lining up with the bracket on the previous line.
-  - Be aware that this requires a new-line after an opening parenthesis/bracket/brace if you intend to split the statement over multiple lines.
-  - For the parameter list of function definitions, double indent, this differentiates the parameters and the body of the function.
-
-### Identifier Names
-* Use descriptive names
-  - name constants to avoid "magic numbers" and hint at intent or origin of the value. Consider, what does this represent?
-* Functions, variables, properties, etc. should use mixed case to separate words, starting with a lower case letter; e.g. `speakText`.
-* Boolean functions or variables
-  - should try to use the positive form of the language (to avoid double negatives like `shouldNotDoSomething = False`)
-  - start with a "question word" to hint at their boolean nature. EG `shouldX`, `isX`, `hasX`
-* Classes should use mixed case to separate words, starting with an upper case letter; e.g. `BrailleHandler`.
-* Constants should be all upper case, separating words with underscores; e.g. `LANGS_WITH_CONJUNCT_CHARS`.
-* Event handlers are prefixed with "event_", and are often in the form "event_ACTION" or "event_OBJECT_ACTION". Where OBJECT refers to the class type that the ACTION refers to.
-* Extension points:
-  * `Action`: Prefixed with `pre_` or `post_` to specify that handlers are being notified before / after the action has taken place.
-  * `Decider`: Prefixed with `should_` to turn them into a question eg `should_doSomething`
-  * `Filter`: TBD. Ideally follows a similar style the others, and communicates if the filtering happens before or after some action. It would also be nice to have a naming scheme that differentiates it from the others.
-
-### Translatable Strings
-* All strings that could be presented to the user should be marked as translatable using the `_()` function; e.g. `_("Text review")`.
-* All translatable strings should have a preceding translators comment describing the purpose of the string for translators. For example:
-```
-# Translators: The name of a category of NVDA commands.
-SCRCAT_TEXTREVIEW = _("Text review")
-```
-* Lengthy translatable strings can be split across multiple lines, taking advantage of Python's implicit line joining inside parentheses. Translators comment can span multiple lines as well. For example:
-```
-self.copySettingsButton = wx.Button(
-	self,
-	label=_(
-		# Translators: The label for a button in general settings to copy
-		# current user settings to system settings (to allow current
-		# settings to be used in secure screens such as User Account
-		# Control (UAC) dialog).
-		"Use currently saved settings during sign-in and on secure screens"
-		" (requires administrator privileges)"
-	)
-)
-```
+Refer to [our coding standards document](../projectDocs/dev/codingStandards.md)

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -16,7 +16,8 @@ There are several approaches you may take for this:
 Forming a group can help you to get good coverage, brainstorm on what should be tested, and perhaps learn new ways to use NVDA.
 
 ## Issue triage and investigation:
-You can also make non-code contributions by helping process incoming GitHub issues. For information on this please see the [triage process](../projectDocs/issues/triage.md).
+You can also make non-code contributions by helping process incoming GitHub issues.
+For information on this please see the [triage process](../projectDocs/issues/triage.md).
 
 ## Code/Docs contributions
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,4 +1,140 @@
-The NVDA project is open to contributions, thank you for your interest!
+# Contributing to NVDA
+There are several ways in which you can contribute to the NVDA project:
+- By testing NVDA
+- Issue triage and investigation
+- Code or documentation contributions
 
-Please first [read our guide to contributing](https://github.com/nvaccess/nvda/wiki/Contributing) on the NVDA
-GitHub Wiki.
+## Testing
+
+Testing alpha / beta / and release candidates help to ensure the quality of the NVDA.
+User / community testing is particularly important for languages other than English.
+There are several approaches you may take for this:
+- Unfocused usage: Just use NVDA as you normally would, and try to complete everyday tasks.
+- Recent change focused testing: By following the changes that are being made to NVDA and purposefully testing these changes and looking for edge-cases.
+- Regression testing: Testing older features and behavior to look for unintended regressions in behavior that don't seem related to recent changes.
+
+Forming a group can help you to get good coverage, brainstorm on what should be tested, and perhaps learn new ways to use NVDA.
+
+## Issue triage and investigation:
+You can also make non-code contributions by helping process incoming GitHub issues. For information on this please see the [triage process](https://github.com/nvaccess/nvda/wiki/Triage-process) and [issue triage help](https://github.com/nvaccess/nvda/wiki/Issue-triage-help) on the wiki.
+
+## Code/Docs contributions
+
+If you are new to the project, or looking for some way to help take a look at:
+- [label:"good first issue" ](https://github.com/nvaccess/nvda/issues?q=label%3A%22good+first+issue%22)
+- [label:closed/needs-new-author ](https://github.com/nvaccess/nvda/issues?q=label%3Aclosed%2Fneeds-new-author)
+- [label:Abandoned ](https://github.com/nvaccess/nvda/issues?q=label%3AAbandoned)
+
+### Guidelines:
+- For anything other than minor bug fixes, please comment on an existing issue or create a new issue providing details about your proposed change.
+- Unrelated changes should be addressed in separate issues.
+- Include information about use cases, design, user experience, etc.
+  - This allows us to discuss these aspects and any other concerns that might arise, thus potentially avoiding a great deal of wasted time.
+- It is recommended to wait for acceptance of your proposal before you start coding.
+  - Please understand that we very likely will not accept changes that are not discussed first.
+  - Consider starting a discussion on mailing lists (EG NVDA developers) to see if there is interest.
+- A minor/trivial change which definitely wouldn't require design, user experience or implementation discussion, you can just create a pull request rather than using an issue first.
+  - E.G. a fix for a typo/obvious coding error or a simple synthesizer/braille display driver
+  - This should be fairly rare.
+- If in doubt, use an issue first. Use this issue to discuss the alternatives you have considered in regards to implementation, design, and user experience. Then give people time to offer feedback.
+
+
+### GitHub process:
+#### 1. "fork" the NVDA repository on GitHub
+   When you fork the repository, GitHub will create a copy of the master branch.
+   However, this branch will not be updated when the official master branch is updated.
+   To ensure your work is always based on the latest commit in the official master branch, it is recommended that your master branch be linked to the official master branch, rather than the master branch in your GitHub fork.
+   If you have cloned your GitHub fork, you can do this from the command line as follows:
+   ```
+   # Add a remote for the NV Access repository.
+   git remote add nvaccess https://github.com/nvaccess/nvda.git
+   # Fetch the nvaccess branches.
+   git fetch nvaccess
+   # Switch to the local master branch.
+   git checkout master
+   # Set the local master to use the nvaccess master as its upstream.
+   git branch -u nvaccess/master
+   # Update the local master.
+   git pull
+   ```
+
+#### 2. Use a separate "topic" branch for each contribution
+   All code should usually be based on the latest commit in the official master branch at the time you start the work unless the code is entirely dependent on the code for another issue.
+   If you are adding a feature or changing something that will be noticeable to the user, you should update the User Guide accordingly.
+
+#### 3. Run unit tests and lint check
+   - Run `rununittests` (`rununittests.bat`) before you open your Pull Request, and make sure all the unit tests pass.
+   - If possible for your PR, please consider creating a set of unit tests to test your changes.
+   - The lint check ensures your changes comply with our code style expectations. Use `runlint nvaccess/master` (`runlint.bat`)
+
+#### 4. Create a Pull Request (PR)
+   When you think a contribution is ready, or you would like feedback, open a draft pull request.
+   Please fill out the Pull Request Template, including the checklist of considerations.
+   The checklist asks you to confirm that you have thought about each of the items, if any of the items are missing it is helpful to explain elsewhere in the PR why it has been left out.
+   When you would like a review, mark the PR as "ready for review".
+
+#### 5. Participate in the code review process
+   This process requires core NVDA developers to understand the intent of the change, read the code changes, asking questions or suggesting changes.
+   Please participate in this process, answering questions, and discussing the changes.
+   Being proactive will really help to speed up the process of code review.
+   When the PR is approved it will be merged, and the change will be active in the next Alpha build.
+
+#### 6. Feedback from Alpha users
+   After a PR is merged, watch for feedback from Alpha users / testers.
+   You may have to follow up to address bugs or missed use-cases.
+
+## Code Style
+
+Code style is enforced with the flake8 linter, see [`tests/lint/readme.md`](https://github.com/nvaccess/nvda/tree/master/tests/lint) for more information.
+
+### Encoding
+* Where Python files contain non-ASCII characters, they should be encoded in UTF-8.
+    * There should be no Unicode BOM at the start of the file, as this unfortunately breaks one of the translation tools we use (`xgettext`). Instead, include this as the first line of the file (only if the file contains non-ASCII characters):
+        ```
+        # -*- coding: UTF-8 -*-
+        ```
+    * This coding comment must also be included if strings in the code (even strings that aren't translatable) contain escape sequences that produce non-ASCII characters; e.g. `"\xff"`. This is particularly relevant for braille display drivers. This is due to a `gettext` bug; see https://github.com/nvaccess/nvda/issues/2592#issuecomment-155299911.
+* Most files should contain `CRLF` line endings, as this is a Windows project and can't be used on Unix-like operating systems.
+
+### Indentation
+* Indentation must be done with tabs (one per level), not spaces.
+* When splitting a single statement over multiple lines, just indent one or more additional levels. Don't use vertical alignment; e.g. lining up with the bracket on the previous line.
+  - Be aware that this requires a new-line after an opening parenthesis/bracket/brace if you intend to split the statement over multiple lines.
+  - For the parameter list of function definitions, double indent, this differentiates the parameters and the body of the function.
+
+### Identifier Names
+* Use descriptive names
+  - name constants to avoid "magic numbers" and hint at intent or origin of the value. Consider, what does this represent?
+* Functions, variables, properties, etc. should use mixed case to separate words, starting with a lower case letter; e.g. `speakText`.
+* Boolean functions or variables
+  - should try to use the positive form of the language (to avoid double negatives like `shouldNotDoSomething = False`)
+  - start with a "question word" to hint at their boolean nature. EG `shouldX`, `isX`, `hasX`
+* Classes should use mixed case to separate words, starting with an upper case letter; e.g. `BrailleHandler`.
+* Constants should be all upper case, separating words with underscores; e.g. `LANGS_WITH_CONJUNCT_CHARS`.
+* Event handlers are prefixed with "event_", and are often in the form "event_ACTION" or "event_OBJECT_ACTION". Where OBJECT refers to the class type that the ACTION refers to.
+* Extension points:
+  * `Action`: Prefixed with `pre_` or `post_` to specify that handlers are being notified before / after the action has taken place.
+  * `Decider`: Prefixed with `should_` to turn them into a question eg `should_doSomething`
+  * `Filter`: TBD. Ideally follows a similar style the others, and communicates if the filtering happens before or after some action. It would also be nice to have a naming scheme that differentiates it from the others.
+
+### Translatable Strings
+* All strings that could be presented to the user should be marked as translatable using the `_()` function; e.g. `_("Text review")`.
+* All translatable strings should have a preceding translators comment describing the purpose of the string for translators. For example:
+```
+# Translators: The name of a category of NVDA commands.
+SCRCAT_TEXTREVIEW = _("Text review")
+```
+* Lengthy translatable strings can be split across multiple lines, taking advantage of Python's implicit line joining inside parentheses. Translators comment can span multiple lines as well. For example:
+```
+self.copySettingsButton = wx.Button(
+	self,
+	label=_(
+		# Translators: The label for a button in general settings to copy
+		# current user settings to system settings (to allow current
+		# settings to be used in secure screens such as User Account
+		# Control (UAC) dialog).
+		"Use currently saved settings during sign-in and on secure screens"
+		" (requires administrator privileges)"
+	)
+)
+```

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@ Please also note that the NVDA project has a Citizen and Contributor Code of Con
 
 Please initially open PRs as a draft.
 When you would like a review, mark the PR as "ready for review". 
-See https://github.com/nvaccess/nvda/wiki/Contributing.
+See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
 -->
 
 ### Link to issue number:

--- a/projectDocs/dev/codingStandards.md
+++ b/projectDocs/dev/codingStandards.md
@@ -1,25 +1,19 @@
 ## Code Style
 
-Python code style is enforced with the flake8 linter, see
-[`tests/lint/readme.md`](https://github.com/nvaccess/nvda/tree/master/tests/lint)
-for more information.
+Python code style is enforced with the flake8 linter, see [`tests/lint/readme.md`](https://github.com/nvaccess/nvda/tree/master/tests/lint/readme.md) for more information.
 
 ### Encoding
 * Where Python files contain non-ASCII characters, they should be encoded in UTF-8.
-    * There should be no Unicode BOM at the start of the file, as this unfortunately breaks one of
-      the translation tools we use (`xgettext`).
-      Instead, include this as the first line of the file (only if the file contains non-ASCII
-      characters):
-        ```
+    * There should be no Unicode BOM at the start of the file, as this unfortunately breaks one of the translation tools we use (`xgettext`).
+    Instead, include this as the first line of the file, only if the file contains non-ASCII characters:
+        ```py
         # -*- coding: UTF-8 -*-
         ```
-    * This coding comment must also be included if strings in the code (even strings that aren't
-      translatable) contain escape sequences that produce non-ASCII characters; e.g. `"\xff"`.
-      This is particularly relevant for braille display drivers.
-      This is due to a `gettext` bug; see
-      https://github.com/nvaccess/nvda/issues/2592#issuecomment-155299911.
-* Most files should contain `CRLF` line endings, as this is a Windows project and can't be used on
-  Unix-like operating systems.
+    * This coding comment must also be included if strings in the code (even strings that aren't translatable) contain escape sequences that produce non-ASCII characters; e.g. `"\xff"`.
+    This is particularly relevant for braille display drivers.
+    This is due to a `gettext` bug; see [comment on #2592](https://github.com/nvaccess/nvda/issues/2592#issuecomment-155299911).
+* New files should contain `LF` line endings, however NVDA currently uses a mix of LF and CRLF line endings.
+See issue [#12387](https://github.com/nvaccess/nvda/issues/12387).
 
 ### Indentation
 * Indentation must be done with tabs (one per level), not spaces.
@@ -34,20 +28,20 @@ for more information.
 * Use descriptive names
   - name constants to avoid "magic numbers" and hint at intent or origin of the value.
     Consider, what does this represent?
-* Functions, variables, properties, etc. use mixed case to separate words, starting with a lower
-  case letter; e.g. `speakText`.
+* Functions, variables, properties, etc. should use mixed case to separate words, starting with a lower case letter;
+  - e.g. `speakText`.
 * Boolean functions or variables
-  - Prefer positive form of the language.
+  - Use the positive form of the language.
     Avoid double negatives like `shouldNotDoSomething = False`
-  - Start with a "question word" to hint at their boolean nature. EG `shouldX`, `isX`, `hasX`
+  - Start with a "question word" to hint at their boolean nature.
+  - e.g. `shouldX`, `isX`, `hasX`
 * Classes should use mixed case to separate words, starting with an upper case letter;
-  - E.G. `BrailleHandler`.
+  - e.g. `BrailleHandler`.
 * Constants should be all upper case, separating words with underscores;
-  - E.G. `LANGS_WITH_CONJUNCT_CHARS`.
-  - Avoid unnecesary shared prefixes in constants. Instead, use an enum for related constants.
+  - e.g. `LANGS_WITH_CONJUNCT_CHARS`.
 * Event handlers are prefixed with "event_", subsequent words in camel case.
   Note, `object` and `action` are separated by underscores.
-  - E.G.: `event_action` or `event_object_action`.
+  - e.g.: `event_action` or `event_object_action`.
   - `object` refers to the class type that the `action` refers to.
   - Examples: `event_caret`, `event_appModule_gainFocus`
 * Extension points:
@@ -55,11 +49,11 @@ for more information.
     - Prefixed with `pre_` or `post_` to specify that handlers are being notified before / after the
       action has taken place.
   * `Decider`
-    - Prefixed with `should_` to turn them into a question eg `should_doSomething`
+    - Prefixed with `should_` to turn them into a question e.g. `should_doSomething`
   * `Filter`
-    - TBD. Ideally follows a similar style the others, and communicates if the filtering happens
-      before or after some action.
-    - It would also be nice to have a naming scheme that differentiates it from the others.
+    - Prefixed with `filter_` e.g. `filter_displaySize_preRefresh`
+    - Should describe the filtering action and the data being returned
+    - Should communicate if the filtering happens before or after some action
 * Enums should be formatted using the expected mix of above eg:
   ```python
   class ExampleGroupOfData(Enum):
@@ -69,19 +63,18 @@ for more information.
   ```
 
 ### Translatable Strings
-* All strings that could be presented to the user should be marked as translatable using the `_()`
-  function; e.g. `_("Text review")`.
-* All translatable strings should have a preceding translators comment describing the purpose of the
-  string for translators. For example:
-```
+* All strings that could be presented to the user should be marked as translatable using the `_()` function
+  - e.g. `_("Text review")`.
+* All translatable strings should have a preceding translators comment describing the purpose of the string for translators.
+For example:
+```py
 # Translators: The name of a category of NVDA commands.
 SCRCAT_TEXTREVIEW = _("Text review")
 ```
-* Lengthy translatable strings can be split across multiple lines, taking advantage of Python's
-  implicit line joining inside parentheses.
-  Translators comment can span multiple lines as well.
-  For example:
-```
+* Lengthy translatable strings can be split across multiple lines, taking advantage of Python's implicit line joining inside parentheses.
+Translators comment can span multiple lines as well.
+For example:
+```py
 self.copySettingsButton = wx.Button(
 	self,
 	label=_(

--- a/readme.md
+++ b/readme.md
@@ -37,7 +37,7 @@ You can also get direct support from NV Access. See the [NV Access](http://www.n
 * [NVDA Add-ons coordination and support center](https://github.com/nvdaaddons): all about NVDA's addons environment
 * [NVDA Add-ons Template](https://github.com/nvdaaddons/AddonTemplate): A repository for generating the Add-ons template
 * [Translating NVDA](https://github.com/nvaccess/nvda/wiki/Translating): Information about how to translate NVDA into another language
-* [Contributing to NVDA](https://github.com/nvaccess/nvda/wiki/Contributing): Guidelines for contributing to the NVDA source code
+* [Contributing to NVDA](./.github/CONTRIBUTING.md): Suggestions on how to contribute to the NVDA project, including issue triage, development and documentation.
 * [NVDA commits email list](https://lists.sourceforge.net/lists/listinfo/nvda-commits): Notifications for all commits to the Git repository
 * [Old email archives](http://nabble.nvda-project.org/Development-f1.html): contain discussions about NVDA development
 
@@ -319,4 +319,4 @@ For more details (including filtering and exclusion of tests) see `tests/system/
 
 ## Contributing to NVDA
 
-If you would like to contribute code or documentation to NVDA, you can read more information in our [contributing guide](https://github.com/nvaccess/nvda/wiki/Contributing).
+If you would like to contribute code or documentation to NVDA, you can read more information in our [contributing guide](./.github/CONTRIBUTING.md).


### PR DESCRIPTION
### Summary of the issue:
 NV Access is intending to move most of the wiki into the repository, so changes are tracked better and easier to propose.
The contributing wiki page is a prime candidate for migration.
The contributing wiki, and project README are somewhat difficult to navigate and follow.
As part of a wider goal of making these simpler, migrating them to the repository is a required first step.

### Description of user facing changes
The Contributing wiki page was merged back to `CONTRIBUTING.md`.
- https://github.com/nvaccess/nvda/wiki/Contributing

A large amount of this wiki page was duplicated in `codingStandards.md`.
These sections were merged and updated in `codingStandards.md`.

Additionally, some grammar and formatting fixes were made

### Future work
The contributing wiki should be split out further, so it just acts a central nexus for links to ways to contribute to NVDA in various ways: e.g.:
- issue triage
- translating
- testing
- documentation
- development
