### PR TITLE
Fixes to address hangs caused by WASAPI idle checks

### DIFF
--- a/nvdaHelper/local/wasapi.cpp
+++ b/nvdaHelper/local/wasapi.cpp
@@ -413,7 +413,10 @@ UINT64 WasapiPlayer::getPlayPos() {
 	UINT64 pos;
 	HRESULT hr = clock->GetPosition(&pos, nullptr);
 	if (FAILED(hr)) {
-		return 0;
+		// If we get an error, playback has probably been interrupted; e.g. because
+		// the device disconnected. Treat this as if playback has finished so we
+		// don't wait forever and so that we fire any pending callbacks.
+		return sentMs;
 	}
 	return pos * 1000 / clockFreq;
 }

--- a/source/nvwave.py
+++ b/source/nvwave.py
@@ -883,6 +883,8 @@ class WasapiWavePlayer(garbageHandler.TrackedObject):
 		if self._audioDucker:
 			self._audioDucker.enable()
 		feedId = c_uint() if onDone else None
+		# Never treat this instance as idle while we're feeding.
+		self._lastActiveTime = None
 		NVDAHelper.localLib.wasPlay_feed(
 			self._player,
 			data,
@@ -913,6 +915,7 @@ class WasapiWavePlayer(garbageHandler.TrackedObject):
 		if self._audioDucker:
 			self._audioDucker.disable()
 		NVDAHelper.localLib.wasPlay_stop(self._player)
+		self._lastActiveTime = None
 		self._isPaused = False
 		self._doneCallbacks = {}
 		self._setVolumeFromConfig()
@@ -930,8 +933,11 @@ class WasapiWavePlayer(garbageHandler.TrackedObject):
 			NVDAHelper.localLib.wasPlay_pause(self._player)
 		else:
 			NVDAHelper.localLib.wasPlay_resume(self._player)
-			self._lastActiveTime = time.time()
-			self._scheduleIdleCheck()
+			# If self._lastActiveTime is None, either no audio has been fed yet or audio
+			# is currently being fed. Either way, we shouldn't touch it.
+			if self._lastActiveTime:
+				self._lastActiveTime = time.time()
+				self._scheduleIdleCheck()
 		self._isPaused = switch
 
 	def setVolume(
@@ -1002,6 +1008,8 @@ class WasapiWavePlayer(garbageHandler.TrackedObject):
 		stillActiveStream = False
 		for player in cls._instances.values():
 			if not player._lastActiveTime or player._isPaused:
+				# Either no audio has been fed yet, audio is currently being fed or the
+				# player is paused. Don't treat this player as idle.
 				continue
 			if player._lastActiveTime <= threshold:
 				NVDAHelper.localLib.wasPlay_idle(player._player)


### PR DESCRIPTION
### Link to issue number:
Fixes #15150.

### Summary of the issue:
When WASAPI is enabled, NVDA sometimes hangs and cannot be recovered, especially when switching audio devices. The freezes all occur in `WasapiWavePlayer._idleCheck` when calling `wasPlay_idle`.

### Description of user facing changes
Fixed the hangs.

### Description of development approach
1. If getting the playback position fails with an error, playback has probably been interrupted; e.g. because the device disconnected. Treat this as if playback has finished so we don't wait forever and so that we fire any pending callbacks.
2. Never treat a stream as idle while we're feeding audio to it. Aside from this not making any sense, we might otherwise try to sync and stop it in the main thread, which could cause hangs or crashes.

### Testing strategy:
I'm unable to reproduce this, so I asked several people to test try builds in #15150. They report that this addresses the problem for them.
I also verified (using beeps in the code, now removed) that streams are still correctly treated as idle when they should be.

### Known issues with pull request:
None.

### Change log entries:
Bug fixes
When WASAPI is enabled, NVDA no longer hangs occasionally, especially when switching audio devices.

### Code Review Checklist:

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
