### PR TITLE
Fix WASAPI option enabling/disabling when restoring advanced options

### DIFF
--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -3233,6 +3233,7 @@ class AdvancedPanelControls(
 		self.wasapiComboBox.resetToConfigSpecDefault()
 		self.soundVolFollowCheckBox.SetValue(self.soundVolFollowCheckBox.defaultValue)
 		self.soundVolSlider.SetValue(self.soundVolSlider.defaultValue)
+		self._onWASAPIChange()
 		self.logCategoriesList.CheckedItems = self.logCategoriesList.defaultCheckedItems
 		self.playErrorSoundCombo.SetSelection(self.playErrorSoundCombo.defaultValue)
 		self._defaultsRestored = True


### PR DESCRIPTION
### Link to issue number:
None; fix-up of one of the recent WASAPI PRs.
### Summary of the issue:
The following advanced options are greyed out or not depending if they are applicable: "Volume of NVDA sounds" and "Volume of NVDA sounds follows voice volume". If they are applicable or not depends on other options: "Use WASAPI for audio output" and "Volume of NVDA sounds" respectively. Unfortunately, when pressing the "Restore defaults" button of the advanced panel, the options are reset to there default values, but they are not greyed out / ungreyed accordingly.

### Description of user facing changes
When pressing the restore default button in advanced panel, WASAPI advanced options will now be greyed out or not according to if they are applicable or not.

### Description of development approach
Just call the update function `self._onWASAPIChange()` when restoring the values.

### Testing strategy:
Manual tests
### Known issues with pull request:
None
### Change log entries:
Probably not needed for this small fix.
### Code Review Checklist:

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
