### PR TITLE
Remove nvdaHelper readme from devDocs sconscript

### DIFF
--- a/projectDocs/dev/developerGuide/sconscript
+++ b/projectDocs/dev/developerGuide/sconscript
@@ -31,12 +31,6 @@ devDocs_nvdaHelper = env.Command(
 env.Alias('devDocs_nvdaHelper', devDocs_nvdaHelper)
 env.Clean('devDocs_nvdaHelper', devDocs_nvdaHelper)
 
-devDocs_nvdaHelper_readme = env.Command(
-	target=devDocsOutputDir.File('nvdaHelper_readme.md'),
-	source=env.File('../../../nvdaHelper/readme.md'),
-	action=Copy('$TARGET', '$SOURCE')
-)
-
 ignorePaths = [
 	'_buildVersion.py',
 	'comInterfaces',
@@ -81,5 +75,5 @@ sphinxHtml = env.Command(
 	]]
 )
 devDocs_nvda = env.Command(devDocsOutputDir.Dir('NVDA'), sphinxHtml, Move('$TARGET', '$SOURCE'))
-env.Alias('devDocs', [devGuide, devDocs_nvda, devDocs_nvdaHelper_readme])
-env.Clean('devDocs', [devGuide, devDocs_nvda, devDocs_nvdaHelper_readme])
+env.Alias('devDocs', [devGuide, devDocs_nvda])
+env.Clean('devDocs', [devGuide, devDocs_nvda])


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Follow up to #14633
### Summary of the issue:
The internal link to the nvdaHelper readme was removed from the developerGuide in favour of a static link to the GitHub repository in #14633

The relevant code in the sconscript for the developerGuide can be safely removed.
