### PR TITLE
Update CODEOWNERS to cover project documentation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -44,3 +44,12 @@
 
 # For changes to the userGuide auto request review from userDocs team
 /user_docs/en/userGuide.t2t @nvaccess/userDocs
+
+# For various project documentation, require appropriate teams
+/projectDocs/community/ @nvaccess/userDocs
+/projectDocs/testing/ @nvaccess/userDocs @nvaccess/developers
+/projectDocs/issues/ @nvaccess/userDocs @nvaccess/developers
+readme.md @nvaccess/userDocs @nvaccess/developers
+security.md @nvaccess/userDocs @nvaccess/developers
+CODE_OF_CONDUCT.md @nvaccess/userDocs @nvaccess/developers
+.github/CONTRIBUTING.md @nvaccess/userDocs @nvaccess/developers


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Follow up to #15337

### Summary of the issue:
Update CODEOWNERS to cover project documentation.
Request a review from our documentation reviewers (Quentin) when modifying relevant project documentation.
