### PR TITLE
Start 2024.1 dev cycle

### DIFF
--- a/source/buildVersion.py
+++ b/source/buildVersion.py
@@ -65,8 +65,8 @@ def formatVersionForGUI(year, major, minor):
 
 # Version information for NVDA
 name = "NVDA"
-version_year = 2023
-version_major = 3
+version_year = 2024
+version_major = 1
 version_minor = 0
 version_build = 0  # Should not be set manually. Set in 'sconscript' provided by 'appVeyor.yml'
 version=_formatDevVersionString()

--- a/source/versionInfo.py
+++ b/source/versionInfo.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2006-2022 NV Access Limited
+# Copyright (C) 2006-2024 NV Access Limited
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -15,7 +15,7 @@ from buildVersion import *
 longName = _("NonVisual Desktop Access")
 description = _("A free and open source screen reader for Microsoft Windows")
 url = "https://www.nvaccess.org/"
-copyrightYears = "2006-2023"
+copyrightYears = "2006-2024"
 copyright = _("Copyright (C) {years} NVDA Contributors").format(
 	years=copyrightYears)
 aboutMessage = _(

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -4,6 +4,32 @@ What's New in NVDA
 %!includeconf: ../changes.t2tconf
 %!includeconf: ./locale.t2tconf
 
+= 2024.1 =
+
+== New Features ==
+
+
+== Changes ==
+
+
+== Bug Fixes ==
+
+
+== Changes for Developers ==
+Please refer to [the developer guide https://www.nvaccess.org/files/nvda/documentation/developerGuide.html#API] for information on NVDA's API deprecation and removal process.
+
+- Note: this is an Add-on API compatibility breaking release.
+Add-ons will need to be re-tested and have their manifest updated.
+-
+
+=== API Breaking Changes ===
+These are breaking API changes.
+Please open a GitHub issue if your Add-on has an issue with updating to the new API.
+
+
+=== Deprecations ===
+
+
 = 2023.3 =
 
 == New Features ==


### PR DESCRIPTION
Start the dev cycle for the 2024.1 release.
This will be a compatibility breaking release.

Complete:
- [x] New section in the change log.
- [x] Update [`nvdaAPIVersions.json` to include the next version](https://github.com/nvaccess/addon-datastore-transform)
  - Re-run the last "Transform NVDA addons to views" on [addon-datastore](https://github.com/nvaccess/addon-datastore/actions) to regenerate projections (views) for the add-on datastore API.
- [x] Update NVDA version in `master`
- [x] Bump the add-on API compatibility (separate PR): https://github.com/nvaccess/nvda/pull/15367

On merge:
- [x] Update auto milestone ID