### PR TITLE
Fix profile upgrade step for excluded displays

### DIFF
--- a/source/config/profileUpgradeSteps.py
+++ b/source/config/profileUpgradeSteps.py
@@ -365,6 +365,12 @@ def upgradeConfigFrom_10_to_11(profile: ConfigObj) -> None:
 		log.debug("enableHidBrailleSupport not present in config, no action taken.")
 		return
 	if configobj.validate.is_integer(hidSetting) == 2:  # HID standard support disabled
+		if 'braille' not in profile:
+			profile['braille'] = {}
+		if 'auto' not in profile['braille']:
+			profile['braille']['auto'] = {}
+		if 'excludedDisplays' not in profile['braille']['auto']:
+			profile['braille']['auto']['excludedDisplays'] = []
 		profile['braille']['auto']['excludedDisplays'] += ["hidBrailleStandard"]
 		log.debug(
 			"hidBrailleStandard added to braille display auto detection excluded displays. "


### PR DESCRIPTION
### Link to issue number:
Closes #15370

### Summary of the issue:
The profile upgrade step for excluded displays can fail severely if keys don't exist in the profile.

### Description of user facing changes
Crashes or upgrade failures no longer occur.

### Description of development approach
Add extra checks for key existence.

### Testing strategy:
Removed the auto section from the braille configuration and ensured that the profile upgrade was executed correctly on launch.

### Known issues with pull request:
None known

### Change log entries:
None needed

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
