### PR TITLE
Reintroduce Improve shortcut key reporting (#14900)

### DIFF
--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -29,7 +29,10 @@ import controlTypes
 import api
 import textInfos
 import speech
-from speech import sayAll
+from speech import (
+	sayAll,
+	shortcutKeys,
+)
 from NVDAObjects import NVDAObject, NVDAObjectTextInfo
 import globalVars
 from logHandler import log
@@ -2605,12 +2608,13 @@ class GlobalCommands(ScriptableObject):
 	def script_reportFocusObjectAccelerator(self, gesture: inputCore.InputGesture) -> None:
 		obj = api.getFocusObject()
 		if obj.keyboardShortcut:
-			res = obj.keyboardShortcut
+			shortcut = obj.keyboardShortcut
+			shortcutKeys.speakKeyboardShortcuts(shortcut)
+			braille.handler.message(shortcut)
 		else:
 			# Translators: reported when a user requests the accelerator key
 			# of the currently focused object, but there is none set.
-			res = _("No shortcut key")
-		ui.message(res)
+			ui.message(_("No shortcut key"))
 
 	@script(
 		# Translators: Input help mode message for toggle mouse tracking command.

--- a/source/speech/shortcutKeys.py
+++ b/source/speech/shortcutKeys.py
@@ -1,0 +1,144 @@
+# A part of NonVisual Desktop Access (NVDA)
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+# Copyright (C) 2023 NV Access Limited, Cyrille Bougot
+
+"""Functions to create speech sequences for shortcut keys.
+"""
+
+
+import re
+
+import characterProcessing
+from logHandler import log
+
+from .commands import CharacterModeCommand
+from .types import SpeechSequence
+from typing import (
+	Optional,
+	List,
+	Tuple,
+)
+
+
+def speakKeyboardShortcuts(keyboardShortcutsStr: Optional[str]) -> None:
+	from .speech import speak
+	speak(getKeyboardShortcutsSpeech(keyboardShortcutsStr))
+
+
+def getKeyboardShortcutsSpeech(keyboardShortcutsStr: Optional[str]) -> SpeechSequence:
+	"""Gets the speech sequence for a shortcuts string containing one or more shortcuts.
+	@param keyboardShortcutsStr: the shortcuts string.
+	"""
+	
+	SHORTCUT_KEY_LIST_SEPARATOR = '  '
+	seq = []
+	if not keyboardShortcutsStr:
+		return seq
+	try:
+		for shortcutKeyStr in keyboardShortcutsStr.split(SHORTCUT_KEY_LIST_SEPARATOR):
+			seq.extend(_getKeyboardShortcutSpeech(shortcutKeyStr))
+			seq.append(SHORTCUT_KEY_LIST_SEPARATOR)
+		seq.pop()  # Remove last SHORTCUT_KEY_LIST_SEPARATOR in the sequence
+	except Exception:
+		log.warning(
+			f'Error parsing keyboard shortcut "{keyboardShortcutsStr}", reporting the string as a fallback.',
+			exc_info=True,
+		)
+		return [keyboardShortcutsStr]
+
+	# Merge consecutive strings in the list when possible
+	seqOut = []
+	for item in seq:
+		if len(seqOut) > 0 and isinstance(seqOut[-1], str) and isinstance(item, str):
+			seqOut[-1] = seqOut[-1] + item
+		else:
+			seqOut.append(item)
+
+	return seqOut
+
+
+def _getKeyboardShortcutSpeech(keyboardShortcut: str) -> SpeechSequence:
+	"""Gets the speech sequence for a single shortcut string.
+	@param keyboardShortcut: the shortcuts string.
+	"""
+
+	if ', ' in keyboardShortcut:
+		keyList, separators = _splitSequentialShortcut(keyboardShortcut)
+	elif '+' in keyboardShortcut and len(keyboardShortcut) > 1:
+		keyList, separator = _splitShortcut(keyboardShortcut)
+		separators = [separator] * (len(keyList) - 1)
+	else:
+		return _getKeySpeech(keyboardShortcut)
+
+	seq = []
+	for key, sep in zip(keyList[:-1], separators):
+		seq.extend(_getKeySpeech(key))
+		seq.append(sep)
+	seq.extend(_getKeySpeech(keyList[-1]))
+	return seq
+
+
+def _getKeySpeech(key: str) -> SpeechSequence:
+	"""Gets the speech sequence for a string describing a key.
+	@param key: the key string.
+	"""
+
+	if len(key) > 1:
+		return [key]
+	from .speech import getCurrentLanguage
+	locale = getCurrentLanguage()
+	keySymbol = characterProcessing.processSpeechSymbol(locale, key)
+	if keySymbol != key:
+		return [keySymbol]
+	return [
+		CharacterModeCommand(True),
+		key,
+		CharacterModeCommand(False),
+	]
+
+
+def _splitShortcut(shortcut: str) -> Tuple[List[str], str]:
+	"""Splits a string representing a shortcut key combination.
+	@param shortcut: the shortcut to split.
+		It may be of the form "NVDA+R" or "NVDA + R", i.e. key names separated by "+" symbol with or without
+		space around it.
+	@return: 2-tuple containing the list of the keys and the separator used between them.
+		E.g. (['NVDA', 'R'], ' + ')
+	"""
+	
+	if ' + ' in shortcut:
+		separator = ' + '
+	elif '+' in shortcut:
+		separator = '+'
+	else:
+		raise RuntimeError(f'The shortcut "{shortcut}" needs to contain a "+" symbol.')
+	if shortcut[-1] == '+':  # E.g. "Ctrl+Shift++"
+		keyList = shortcut[:-1].split(separator)
+		keyList[-1] = keyList[-1] + '+'
+	else:
+		keyList = shortcut.split(separator)
+	return keyList, separator
+
+
+def _splitSequentialShortcut(shortcut: str) -> Tuple[List[str], List[str]]:
+	"""Splits a string representing a sequantial shortcut key combination (the ones found in ribbons).
+	@param shortcut: the shortcut to split.
+		It should be of the form "Alt, F, L, Y 1" i.e. key names separated by comma symbol or space.
+	@return: 2-tuple containing the list of the keys and the list separators used between each key in the list.
+		E.g.: (['Alt', 'F', 'L', 'Y', '1'], [', ', ', ', ', ', ' '])
+	"""
+
+	keys = []
+	separators = []
+	RE_SEQ_SHORTCUT_SPLITTING = re.compile(r'^(?P<key>[^, ]+)(?P<sep> |, )(?P<tail>.+)')
+	tail = shortcut
+	while len(tail) > 0:
+		m = RE_SEQ_SHORTCUT_SPLITTING.match(tail)
+		if not m:
+			keys.append(tail)
+			return keys, separators
+		keys.append(m['key'])
+		separators.append(m['sep'])
+		tail = m['tail']
+	raise RuntimeError(f'Wrong sequential shortcut string format: {shortcut}')

--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -35,6 +35,7 @@ from .commands import (
 	EndUtteranceCommand,
 	CharacterModeCommand,
 )
+from .shortcutKeys import getKeyboardShortcutsSpeech
 
 from . import types
 from .types import (
@@ -1743,8 +1744,7 @@ def getPropertiesSpeech(  # noqa: C901
 		textList.append(description)
 	# sometimes keyboardShortcut key is present but value is None
 	keyboardShortcut: Optional[str] = propertyValues.get('keyboardShortcut')
-	if keyboardShortcut:
-		textList.append(keyboardShortcut)
+	textList.extend(getKeyboardShortcutsSpeech(keyboardShortcut))
 	if includeTableCellCoords and cellCoordsText:
 		textList.append(cellCoordsText)
 	if cellCoordsText or rowNumber or columnNumber:

--- a/tests/system/robot/startupShutdownNVDA.py
+++ b/tests/system/robot/startupShutdownNVDA.py
@@ -76,7 +76,7 @@ def quits_from_menu(showExitDialog=True):
 			actualSpeech,
 			"\n".join([
 				"Exit NVDA  dialog",
-				"What would you like to do?  combo box  Exit  collapsed  Alt plus d"
+				"What would you like to do?  combo box  Exit  collapsed  Alt plus  d"
 			])
 		)
 		_builtIn.sleep(1)  # the dialog is not always receiving the enter keypress, wait a little for it
@@ -105,7 +105,7 @@ def quits_from_keyboard():
 		actualSpeech,
 		"\n".join([
 			"Exit NVDA  dialog",
-			"What would you like to do?  combo box  Exit  collapsed  Alt plus d"
+			"What would you like to do?  combo box  Exit  collapsed  Alt plus  d"
 		])
 	)
 	_builtIn.sleep(1)  # the dialog is not always receiving the enter keypress, wait a little longer for it
@@ -143,7 +143,7 @@ def read_welcome_dialog():
 				"NVDA, get help and access other NVDA functions."
 			),
 			"Options  grouping",
-			"Keyboard layout:  combo box  desktop  collapsed  Alt plus k"
+			"Keyboard layout:  combo box  desktop  collapsed  Alt plus  k"
 		])
 	)
 	_builtIn.sleep(1)  # the dialog is not always receiving the enter keypress, wait a little longer for it

--- a/tests/unit/test_speechShortcutKeys.py
+++ b/tests/unit/test_speechShortcutKeys.py
@@ -1,0 +1,161 @@
+# A part of NonVisual Desktop Access (NVDA)
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+# Copyright (C) 2023 NV Access Limited, Cyrille Bougot
+
+"""Unit tests for the speech.shortcutKeys module.
+"""
+
+import unittest
+
+from speech.shortcutKeys import (
+	_getKeyboardShortcutSpeech,
+	getKeyboardShortcutsSpeech,
+)
+from speech.commands import CharacterModeCommand
+
+
+class Test_getKeyboardShortcutSpeech(unittest.TestCase):
+
+	def test_simpleLetterKey(self):
+		"""A shortcut consisting in only one letter."""
+
+		expected = repr([
+			CharacterModeCommand(True),
+			'A',
+			CharacterModeCommand(False),
+		])
+		output = _getKeyboardShortcutSpeech(
+			keyboardShortcut='A',
+		)
+		self.assertEqual(repr(output), expected)
+
+	def test_simpleSymbolKey(self):
+		"""A shortcut consisting in only one symbol present in symbols.dic."""
+
+		expected = repr([
+			'question',
+		])
+		output = _getKeyboardShortcutSpeech(
+			keyboardShortcut='?',
+		)
+		self.assertEqual(repr(output), expected)
+
+	def test_simpleKeyName(self):
+		"""A shortcut consisting in only a key name."""
+
+		expected = repr([
+			'Space',
+		])
+		output = _getKeyboardShortcutSpeech(
+			keyboardShortcut='Space',
+		)
+		self.assertEqual(repr(output), expected)
+
+	def test_modifiersAndLetterKey(self):
+		"""A shortcut consisting in modifiers and a letter key."""
+
+		expected = repr([
+			'Ctrl',
+			'+',
+			'Shift',
+			'+',
+			CharacterModeCommand(True),
+			'A',
+			CharacterModeCommand(False),
+		])
+		output = _getKeyboardShortcutSpeech(
+			keyboardShortcut='Ctrl+Shift+A',
+		)
+		self.assertEqual(repr(output), expected)
+
+	def test_modifierAndSymbolKey(self):
+		"""A shortcut consisting in modifiers and a symbol present in symbols.dic."""
+
+		expected = repr([
+			'Ctrl',
+			'+',
+			'slash',
+		])
+		output = _getKeyboardShortcutSpeech(
+			keyboardShortcut='Ctrl+/',
+		)
+		self.assertEqual(repr(output), expected)
+
+	def test_modifierAndPlusKey(self):
+		"""A shortcut consisting in modifiers and the + (plus) key in last position."""
+
+		expected = repr([
+			'Ctrl',
+			'+',
+			'plus',
+		])
+		output = _getKeyboardShortcutSpeech(
+			keyboardShortcut='Ctrl++',
+		)
+		self.assertEqual(repr(output), expected)
+
+	def test_modifierAndPlusKeyDescription(self):
+		"""A shortcut consisting in a modifier and the description of the + (plus) key both joined with
+		a plus surrounded by spaces. (found in Windows Magnifier)
+		"""
+
+		expected = repr([
+			'Touche de logo Windows',
+			' + ',
+			'Plus (+)',
+		])
+		output = _getKeyboardShortcutSpeech(
+			keyboardShortcut='Touche de logo Windows + Plus (+)',
+		)
+		self.assertEqual(repr(output), expected)
+
+	def test_sequentialShortcutCombiningSpacesAndCommas(self):
+		"""A sequential shortcut found in ribbons (e.g. Word)."""
+
+		expected = repr([
+			'Alt',
+			', ',
+			CharacterModeCommand(True),
+			'L',
+			CharacterModeCommand(False),
+			', ',
+			CharacterModeCommand(True),
+			'M',
+			CharacterModeCommand(False),
+			' ',
+			CharacterModeCommand(True),
+			'F',
+			CharacterModeCommand(False),
+		])
+		output = _getKeyboardShortcutSpeech(
+			keyboardShortcut='Alt, L, M F',
+		)
+		self.assertEqual(repr(output), expected)
+
+
+class Test_getKeyboardShortcutsSpeech(unittest.TestCase):
+
+	def test_twoShortcutKeys(self):
+		"""A shortcut key indication indicating two shortcut keys (a sequential one and a simultaneous one)
+		as found in ribbons (e.g. Word).
+		"""
+
+		expected = repr([
+			'Alt, ',
+			CharacterModeCommand(True),
+			'L',
+			CharacterModeCommand(False),
+			', ',
+			CharacterModeCommand(True),
+			'C',
+			CharacterModeCommand(False),
+			'  Ctrl+',
+			CharacterModeCommand(True),
+			'C',
+			CharacterModeCommand(False),
+		])
+		output = getKeyboardShortcutsSpeech(
+			keyboardShortcutsStr='Alt, L, C  Ctrl+C',
+		)
+		self.assertEqual(repr(output), expected)

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -13,7 +13,8 @@ What's New in NVDA
 
 
 == Bug Fixes ==
-
+- Reporting of object shortcut keys has been improved. (#10807)
+-
 
 == Changes for Developers ==
 Please refer to [the developer guide https://www.nvaccess.org/files/nvda/documentation/developerGuide.html#API] for information on NVDA's API deprecation and removal process.

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -249,13 +249,11 @@ eSpeak-NG, LibLouis braille translator, and Unicode CLDR have been updated.
 - When forcing UIA support with certain terminal and consoles, a bug is fixed which caused a freeze and the log file to be spammed. (#14689)
 - NVDA will no longer refuse to save the configuration after a configuration reset. (#13187)
 - When running a temporary version from the launcher, NVDA will not mislead users into thinking they can save the configuration. (#14914)
-- Reporting of object shortcut keys has been improved. (#10807)
 - NVDA now generally responds slightly faster to commands and focus changes. (#14928)
 - Displaying the OCR settings will not fail on some systems anymore. (#15017)
 - Fix bug related to saving and loading the NVDA configuration, including switching synthesizers. (#14760)
 - Fix bug causing text review "flick up" touch gesture to move pages rather than move to previous line. (#15127)
 - 
--
 
 
 == Changes for Developers ==

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -249,11 +249,13 @@ eSpeak-NG, LibLouis braille translator, and Unicode CLDR have been updated.
 - When forcing UIA support with certain terminal and consoles, a bug is fixed which caused a freeze and the log file to be spammed. (#14689)
 - NVDA will no longer refuse to save the configuration after a configuration reset. (#13187)
 - When running a temporary version from the launcher, NVDA will not mislead users into thinking they can save the configuration. (#14914)
+- Reporting of object shortcut keys has been improved. (#10807)
 - NVDA now generally responds slightly faster to commands and focus changes. (#14928)
 - Displaying the OCR settings will not fail on some systems anymore. (#15017)
 - Fix bug related to saving and loading the NVDA configuration, including switching synthesizers. (#14760)
 - Fix bug causing text review "flick up" touch gesture to move pages rather than move to previous line. (#15127)
 - 
+-
 
 
 == Changes for Developers ==


### PR DESCRIPTION
### Link to issue number:
Fixes #10807
Reintroduce the changes of PR #14900 that were reverted in #15237.

### Summary of the issue:
See #14900 for the initial issue.

#14900 had to be reverted since it caused any speech sequence containing a character mode command to spell the whole speech sequence with Code Factory driver. Although the issue is in the driver and not NVDA, it has been decided to wait for an API-breaking release to issue this fix so that Code Factory synth users be not impacted by this bug.

### Description of user facing changes
Same as #14900, that is:

Shortcut key reporting will be improved in some cases. This applies to on-demand reporting (shift+numpad2) as well as when "Report Object Shortcut Keys" option is checked in Object presentation settings.
The cases where it should be improved are:
* punctuation key, e.g. "." (dot)
* letter keys when the name of the letter is not spoken the same way as the equivalent one-letter word, e.g. "à" or "y" in French.
Braille reporting should remain unchanged.

### Description of development approach
Revert #15237 to reintroduce the changes in #14900 and remove change log modifications.

### Testing strategy:
Re-execute the tests in #14900.
### Known issues with pull request:
In addition to limitations listed in #14900:
This PR will trigger again Code Factory synthesizer's bug. The bug has already been reported to Code Factory; so they will have the opportunity to fix it for 2024.1 release.

### Change log entries:
Bug fixes
`Reporting of object shortcut keys has been improved. (#10807)`

### Code Review Checklist:


- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
