### PR TITLE
When announcing calculation result in Win32 calculator rely on name change events

### DIFF
--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -57,6 +57,7 @@ What's New in NVDA
   - Fixed bug where Albatross braille displays try to initialize although another braille device has been connected. (#15226)
   -
 - Fixed support for System List view (``SysListView32``) controls in Windows Forms applications. (#15283)
+- NVDA once again announces calculation results in the Windows 32bit calculator on Server, LTSC and LTSB versions of Windows. (#15284)
 -
 
 == Changes for Developers ==


### PR DESCRIPTION
Opened against beta, since this PR fixes regression from the 2023.2 
### Link to issue number:
Fixes #15230
### Summary of the issue:
NVDA's calculation announcements for Win32 calculator relies on a list of predefined keyboard commands, which, when pressed, causes the new value of the display to be announced. This assumes that at the time when gesture is sent the calculator had enough time to  process it, and display the result of the calculation. While this worked before prior to #14708, after this PR NVDA no longer sleeps after sending gestures, therefore the value on calculator's display had not enough time to be updated. For users this means that after performing calculations the outdated value was read.
### Description of user facing changes
NVDA once again announces correct results of the calculation.
### Description of development approach
Rather than announcing the display value immediately after user pressed a key, NVDA now sets a flag signaling that the given command causes result of a calculation to appear. This flag is checked in the name change event for the display. If it is set the result is announced and the flag is restored to its default value.
While at it I have also updated the copyright header of the module based on its log in VCS.
### Testing strategy:
- Ensured that correct result are again announced, with both keyboard echo, and announcement of command keys enabled and disabled.
- Got confirmation from reporters running Windows 8.1 and Windows 10 21H2 (x86) build 19044.3324 that the issue is fixed for them.
### Known issues with pull request:
None known.
### Change log entries:
Bug fixes
- NVDA once again announces calculation results in the calculator on Server, LTSC and LTSB versions of Windows.

### Code Review Checklist:


- [X] Pull Request description:
  - description is up to date
  - change log entries
- [X] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [X] API is compatible with existing add-ons.
- [X] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [X] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [X] Security precautions taken.
