### PR TITLE
Fix issues with UIA (Rich)Edit implementations

### DIFF
--- a/source/appModules/explorer.py
+++ b/source/appModules/explorer.py
@@ -1,6 +1,5 @@
-# -*- coding: UTF-8 -*-
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2006-2023 NV Access Limited, Joseph Lee, Łukasz Golonka, Julien Cochuyt
+# Copyright (C) 2006-2023 NV Access Limited, Joseph Lee, Łukasz Golonka, Julien Cochuyt, Leonard de Ruijter
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -224,16 +223,6 @@ class UIProperty(UIA):
 			return value
 		return value.replace(CHAR_LTR_MARK,'').replace(CHAR_RTL_MARK,'')
 
-class ReadOnlyEditBox(IAccessible):
-#Used for read-only edit boxes in a properties window.
-#These can contain dates that include unwanted left-to-right and right-to-left indicator characters.
-
-	def _get_windowText(self):
-		windowText = super(ReadOnlyEditBox, self).windowText
-		if windowText is not None:
-			return windowText.replace(CHAR_LTR_MARK,'').replace(CHAR_RTL_MARK,'')
-		return windowText
-
 
 class MetadataEditField(RichEdit50):
 	""" Used for metadata edit fields in Windows Explorer in Windows 7.
@@ -296,11 +285,7 @@ class AppModule(appModuleHandler.AppModule):
 			clsList.insert(0, ExplorerToolTip)
 			return
 
-		if windowClass == "Edit" and controlTypes.State.READONLY in obj.states:
-			clsList.insert(0, ReadOnlyEditBox)
-			return # Optimization: return early to avoid comparing class names and roles that will never match.
-
-		if windowClass == "SysListView32":
+		if isinstance(obj, IAccessible) and windowClass == "SysListView32":
 			if(
 				role == controlTypes.Role.MENUITEM
 				or(
@@ -320,7 +305,7 @@ class AppModule(appModuleHandler.AppModule):
 			clsList.insert(0, StartButton)
 			return # Optimization: return early to avoid comparing class names and roles that will never match.
 
-		if windowClass == 'RICHEDIT50W' and obj.windowControlID == 256:
+		if windowClass == 'RICHEDIT50W' and RichEdit50 in clsList and obj.windowControlID == 256:
 			clsList.insert(0, MetadataEditField)
 			return  # Optimization: return early to avoid comparing class names and roles that will never match.
 


### PR DESCRIPTION
### Link to issue number:
Fixes #15375
Fixes #15330 
Followup for #15314
Partially reverts #8643
Reopens #8361

### Summary of the issue:
#15314 no longer classified Edit and RichEdit classes as bad for UIA. This caused two problems:

1. Read only edit fields in Explorer no longer read correctly, as they inherrit from both UIA and IAccessible
2. UIA adds a redundant name of RichEdit Control to these objects.

While investigating these issues, I discovered that Windows 11 mimics the value in the name when renaming a file in Explorer.

### Description of user facing changes
1. No longer redundantly announce RichEdit Control for Rich Edit Controls.
2. Working edit fields in Explorer, with the expense of left-to-right and right-to-left marks being reported again when applicable (see below)
3. Suppress the name of the control when it copies the value.

### Description of development approach
1/3. I added a new EditUIA overlay class that inherrits from EditBase and UIA. This has a custom implementation for the name property.
2. Removed the ReadOnlyEditBox class from the explorer appmodule. Note, as this class is used in the appModule and only for specific purposes, I wouldn't classify this as API breaking and think we must remain pragmatic on this point.

### Testing strategy:
Tested str from fixed issues.

### Known issues with pull request:
Removing the ReadOnlyEditBox class from explorer partly reverts #8643. This means left-to-right and right-to-left marks are again being read in some edit controls. The problem with the fix in #8643 was that modified the windowText and therefore caused offset errors when navigating through these controls (i.e. if the text starts with one of these marks, caret reporting would be off by one and result in an error at the end of the line). This was acknowledged by @lukaszgo1 in https://github.com/nvaccess/nvda/issues/15375#issuecomment-1706545010. Note that at least in the security tab, there are focusabble fields like this.

### Change log entries:
None needed.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
