### PR TITLE
Fix background downloading of add-ons

### DIFF
--- a/source/_addonStore/dataManager.py
+++ b/source/_addonStore/dataManager.py
@@ -49,7 +49,7 @@ from .network import (
 if TYPE_CHECKING:
 	from addonHandler import Addon as AddonHandlerModel  # noqa: F401
 	# AddonGUICollectionT must only be imported when TYPE_CHECKING
-	from .models.addon import AddonGUICollectionT  # noqa: F401
+	from .models.addon import AddonGUICollectionT, _AddonStoreModel  # noqa: F401
 	from gui._addonStoreGui.viewModels.addonList import AddonListItemVM  # noqa: F401
 	from gui.message import DisplayableError  # noqa: F401
 
@@ -69,7 +69,8 @@ def initialize():
 class _DataManager:
 	_cacheLatestFilename: str = "_cachedLatestAddons.json"
 	_cacheCompatibleFilename: str = "_cachedCompatibleAddons.json"
-	_downloadsPendingInstall: Set[Tuple["AddonListItemVM", os.PathLike]] = set()
+	_downloadsPendingInstall: Set[Tuple["AddonListItemVM[_AddonStoreModel]", os.PathLike]] = set()
+	_downloadsPendingCompletion: Set["AddonListItemVM[_AddonStoreModel]"] = set()
 
 	def __init__(self):
 		self._lang = languageHandler.getLanguage()
@@ -123,7 +124,7 @@ class _DataManager:
 		cacheHash = response.json()
 		return cacheHash
 
-	def _cacheCompatibleAddons(self, addonData: str, cacheHash: str):
+	def _cacheCompatibleAddons(self, addonData: str, cacheHash: Optional[str]):
 		if not NVDAState.shouldWriteToDisk():
 			return
 		if not addonData or not cacheHash:
@@ -137,7 +138,7 @@ class _DataManager:
 		with open(self._cacheCompatibleFile, 'w', encoding='utf-8') as cacheFile:
 			json.dump(cacheData, cacheFile, ensure_ascii=False)
 
-	def _cacheLatestAddons(self, addonData: str, cacheHash: str):
+	def _cacheLatestAddons(self, addonData: str, cacheHash: Optional[str]):
 		if not NVDAState.shouldWriteToDisk():
 			return
 		if not addonData or not cacheHash:

--- a/source/_addonStore/models/addon.py
+++ b/source/_addonStore/models/addon.py
@@ -98,6 +98,7 @@ class _AddonGUIModel(SupportsAddonState, SupportsVersionCheck, Protocol):
 		return f"{self.addonId}-{self.channel}"
 
 	def asdict(self) -> Dict[str, Any]:
+		assert dataclasses.is_dataclass(self)
 		jsonData = dataclasses.asdict(self)
 		for field in jsonData:
 			# dataclasses.asdict parses NamedTuples to JSON arrays,
@@ -110,6 +111,15 @@ class _AddonGUIModel(SupportsAddonState, SupportsVersionCheck, Protocol):
 
 
 class _AddonStoreModel(_AddonGUIModel):
+	addonId: str
+	displayName: str
+	description: str
+	addonVersionName: str
+	channel: Channel
+	homepage: Optional[str]
+	minNVDAVersion: MajorMinorPatch
+	lastTestedVersion: MajorMinorPatch
+	legacy: bool
 	publisher: str
 	license: str
 	licenseURL: Optional[str]
@@ -145,6 +155,7 @@ class _AddonStoreModel(_AddonGUIModel):
 	def isPendingInstall(self) -> bool:
 		"""True if this addon has not yet been fully installed."""
 		from ..dataManager import addonDataManager
+		assert addonDataManager
 		nameInDownloadsPendingInstall = filter(
 			lambda m: m[0].model.name == self.name,
 			# add-ons which have been downloaded but
@@ -240,6 +251,7 @@ class InstalledAddonStoreModel(_AddonManifestModel, _AddonStoreModel):
 	@property
 	def manifest(self) -> "AddonManifest":
 		from ..dataManager import addonDataManager
+		assert addonDataManager
 		return addonDataManager._installedAddonsCache.installedAddons[self.name].manifest
 
 
@@ -273,7 +285,7 @@ class AddonStoreModel(_AddonStoreModel):
 @dataclasses.dataclass
 class CachedAddonsModel:
 	cachedAddonData: "AddonGUICollectionT"
-	cacheHash: str
+	cacheHash: Optional[str]
 	cachedLanguage: str
 	# AddonApiVersionT or the string .network._LATEST_API_VER
 	nvdaAPIVersion: Union[addonAPIVersion.AddonApiVersionT, str]

--- a/source/_addonStore/models/status.py
+++ b/source/_addonStore/models/status.py
@@ -8,7 +8,6 @@ import os
 from pathlib import Path
 from typing import (
 	Dict,
-	Optional,
 	OrderedDict,
 	Set,
 	TYPE_CHECKING,
@@ -51,6 +50,7 @@ class AvailableAddonStatus(DisplayStringEnum):
 	""" Values to represent the status of add-ons within the NVDA add-on store.
 	Although related, these are independent of the states in L{addonHandler}
 	"""
+	UNKNOWN = enum.auto()
 	PENDING_REMOVE = enum.auto()
 	AVAILABLE = enum.auto()
 	UPDATE = enum.auto()
@@ -120,6 +120,8 @@ class AvailableAddonStatus(DisplayStringEnum):
 			self.ENABLED: pgettext("addonStore", "Enabled"),
 			# Translators: Status for addons shown in the add-on store dialog
 			self.RUNNING: pgettext("addonStore", "Enabled"),
+			# Translators: Status for addons shown in the add-on store dialog
+			self.UNKNOWN: pgettext("addonStore", "Unknown status"),
 		}
 
 
@@ -144,7 +146,7 @@ class AddonStateCategory(str, enum.Enum):
 	"""Add-ons that are blocked from running because they are incompatible"""
 
 
-def getStatus(model: "_AddonGUIModel") -> Optional[AvailableAddonStatus]:
+def getStatus(model: "_AddonGUIModel") -> AvailableAddonStatus:
 	from addonHandler import (
 		state as addonHandlerState,
 	)
@@ -213,8 +215,8 @@ def getStatus(model: "_AddonGUIModel") -> Optional[AvailableAddonStatus]:
 	if addonHandlerModel.isEnabled:
 		return AvailableAddonStatus.ENABLED
 
-	log.debugWarning(f"Add-on in unknown state: {model.addonId}")
-	return None
+	log.error(f"Add-on in unknown state: {model.addonId}")
+	return AvailableAddonStatus.UNKNOWN
 
 
 _addonStoreStateToAddonHandlerState: OrderedDict[
@@ -341,6 +343,7 @@ _statusFilters: OrderedDict[_StatusFilterKey, Set[AvailableAddonStatus]] = Order
 		AvailableAddonStatus.PENDING_INCOMPATIBLE_ENABLED,
 		AvailableAddonStatus.INCOMPATIBLE_DISABLED,
 		AvailableAddonStatus.INCOMPATIBLE_ENABLED,
+		AvailableAddonStatus.UNKNOWN,
 	},
 })
 """A dictionary where the keys are a status to filter by,

--- a/source/_addonStore/network.py
+++ b/source/_addonStore/network.py
@@ -3,6 +3,10 @@
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
+# Needed for type hinting Future
+# Can be removed in a future version of python (3.8+)
+from __future__ import annotations
+
 from concurrent.futures import (
 	Future,
 	ThreadPoolExecutor,
@@ -28,7 +32,6 @@ from NVDAState import WritePaths
 from utils.security import sha256_checksum
 
 from .models.addon import (
-	AddonStoreModel,
 	_AddonGUIModel,
 	_AddonStoreModel,
 )
@@ -37,6 +40,7 @@ from .models.channel import Channel
 
 if TYPE_CHECKING:
 	from gui.message import DisplayableError
+	from gui._addonStoreGui.viewModels.addonList import AddonListItemVM
 
 
 _BASE_URL = "https://nvaccess.org/addonStore"
@@ -61,21 +65,28 @@ def _getCacheHashURL() -> str:
 
 
 class AddonFileDownloader:
-	OnCompleteT = Callable[[AddonStoreModel, Optional[os.PathLike]], None]
+	OnCompleteT = Callable[
+		["AddonListItemVM[_AddonStoreModel]", Optional[os.PathLike]],
+		None
+	]
 
 	def __init__(self):
-		self.progress: Dict[AddonStoreModel, int] = {}  # Number of chunks received
+		self.progress: Dict["AddonListItemVM[_AddonStoreModel]", int] = {}  # Number of chunks received
 		self._pending: Dict[
-			Future,
+			Future[Optional[os.PathLike]],
 			Tuple[
-				AddonStoreModel,
+				"AddonListItemVM[_AddonStoreModel]",
 				AddonFileDownloader.OnCompleteT,
 				"DisplayableError.OnDisplayableErrorT"
 			]
 		] = {}
-		self.complete: Dict[AddonStoreModel, os.PathLike] = {}  # Path to downloaded file
+		self.complete: Dict[
+			"AddonListItemVM[_AddonStoreModel]",
+			# Path to downloaded file
+			Optional[os.PathLike]
+		] = {}
 		self._executor = ThreadPoolExecutor(
-			max_workers=1,
+			max_workers=10,
 			thread_name_prefix="AddonDownloader",
 		)
 
@@ -85,20 +96,21 @@ class AddonFileDownloader:
 
 	def download(
 			self,
-			addonData: AddonStoreModel,
+			addonData: "AddonListItemVM[_AddonStoreModel]",
 			onComplete: OnCompleteT,
 			onDisplayableError: "DisplayableError.OnDisplayableErrorT",
 	):
 		self.progress[addonData] = 0
-		f: Future = self._executor.submit(
+		assert self._executor
+		f: Future[Optional[os.PathLike]] = self._executor.submit(
 			self._download, addonData,
 		)
 		self._pending[f] = addonData, onComplete, onDisplayableError
 		f.add_done_callback(self._done)
 
-	def _done(self, downloadAddonFuture: Future):
+	def _done(self, downloadAddonFuture: Future[Optional[os.PathLike]]):
 		isCancelled = downloadAddonFuture not in self._pending
-		addonId = "CANCELLED" if isCancelled else self._pending[downloadAddonFuture][0].addonId
+		addonId = "CANCELLED" if isCancelled else self._pending[downloadAddonFuture][0].model.addonId
 		log.debug(f"Done called for {addonId}")
 		if isCancelled:
 			log.debug("Download was cancelled, not calling onComplete")
@@ -108,6 +120,7 @@ class AddonFileDownloader:
 			return
 		addonData, onComplete, onDisplayableError = self._pending[downloadAddonFuture]
 		downloadAddonFutureException = downloadAddonFuture.exception()
+		cacheFilePath: Optional[os.PathLike]
 		if downloadAddonFutureException:
 			cacheFilePath = None
 			from gui.message import DisplayableError
@@ -120,10 +133,12 @@ class AddonFileDownloader:
 					displayableError=downloadAddonFutureException
 				)
 		else:
-			cacheFilePath: Optional[os.PathLike] = downloadAddonFuture.result()
+			cacheFilePath = downloadAddonFuture.result()
 
-		del self._pending[downloadAddonFuture]
-		del self.progress[addonData]
+		# If canceled after our previous isCancelled check,
+		# then _pending and progress will be empty.
+		self._pending.pop(downloadAddonFuture, None)
+		self.progress.pop(addonData, None)
 		self.complete[addonData] = cacheFilePath
 		onComplete(addonData, cacheFilePath)
 
@@ -131,12 +146,17 @@ class AddonFileDownloader:
 		log.debug("Cancelling all")
 		for f in self._pending.keys():
 			f.cancel()
+		assert self._executor
 		self._executor.shutdown(wait=False)
 		self._executor = None
 		self.progress.clear()
 		self._pending.clear()
 
-	def _downloadAddonToPath(self, addonData: AddonStoreModel, downloadFilePath: str) -> bool:
+	def _downloadAddonToPath(
+			self,
+			addonData: "AddonListItemVM[_AddonStoreModel]",
+			downloadFilePath: str
+	) -> bool:
 		"""
 		@return: True if the add-on is downloaded successfully,
 		False if the download is cancelled
@@ -144,7 +164,7 @@ class AddonFileDownloader:
 		if not NVDAState.shouldWriteToDisk():
 			return False
 
-		with requests.get(addonData.URL, stream=True) as r:
+		with requests.get(addonData.model.URL, stream=True) as r:
 			with open(downloadFilePath, 'wb') as fd:
 				# Most add-ons are small. This value was chosen quite arbitrarily, but with the intention to allow
 				# interrupting the download. This is particularly important on a slow connection, to provide
@@ -159,15 +179,16 @@ class AddonFileDownloader:
 					if addonData in self.progress:  # Removed when the download should be cancelled.
 						self.progress[addonData] += 1
 					else:
-						log.debug(f"Cancelled download: {addonData.addonId}")
+						log.debug(f"Cancelled download: {addonData.model.addonId}")
 						return False  # The download was cancelled
 		return True
 
-	def _download(self, addonData: AddonStoreModel) -> Optional[os.PathLike]:
+	def _download(self, listItem: "AddonListItemVM[_AddonStoreModel]") -> Optional[os.PathLike]:
 		from gui.message import DisplayableError
 		# Translators: A title for a dialog notifying a user of an add-on download failure.
 		_addonDownloadFailureMessageTitle = pgettext("addonStore", "Add-on download failure")
 
+		addonData = listItem.model
 		log.debug(f"starting download: {addonData.addonId}")
 		cacheFilePath = addonData.cachedDownloadPath
 		if os.path.exists(cacheFilePath):
@@ -175,11 +196,11 @@ class AddonFileDownloader:
 			os.remove(cacheFilePath)
 
 		inProgressFilePath = addonData.tempDownloadPath
-		if addonData not in self.progress:
+		if listItem not in self.progress:
 			log.debug("the download was cancelled before it started.")
 			return None  # The download was cancelled
 		try:
-			if not self._downloadAddonToPath(addonData, inProgressFilePath):
+			if not self._downloadAddonToPath(listItem, inProgressFilePath):
 				return None  # The download was cancelled
 		except requests.exceptions.RequestException as e:
 			log.debugWarning(f"Unable to download addon file: {e}")
@@ -218,7 +239,7 @@ class AddonFileDownloader:
 		return cast(os.PathLike, cacheFilePath)
 
 	@staticmethod
-	def _checkChecksum(addonFilePath: str, addonData: _AddonStoreModel) -> Optional[os.PathLike]:
+	def _checkChecksum(addonFilePath: str, addonData: _AddonStoreModel) -> bool:
 		with open(addonFilePath, "rb") as f:
 			sha256Addon = sha256_checksum(f)
 		return sha256Addon.casefold() == addonData.sha256.casefold()

--- a/source/gui/_addonStoreGui/viewModels/addonList.py
+++ b/source/gui/_addonStoreGui/viewModels/addonList.py
@@ -12,9 +12,11 @@ from enum import Enum
 from locale import strxfrm
 from typing import (
 	FrozenSet,
+	Generic,
 	List,
 	Optional,
 	TYPE_CHECKING,
+	TypeVar,
 )
 
 from requests.structures import CaseInsensitiveDict
@@ -92,18 +94,21 @@ class AddonListField(_AddonListFieldData, Enum):
 	)
 
 
-class AddonListItemVM:
+_AddonModelT = TypeVar("_AddonModelT", bound=_AddonGUIModel)
+
+
+class AddonListItemVM(Generic[_AddonModelT]):
 	def __init__(
 			self,
-			model: _AddonGUIModel,
+			model: _AddonModelT,
 			status: AvailableAddonStatus = AvailableAddonStatus.AVAILABLE
 	):
-		self._model: _AddonGUIModel = model  # read-only
+		self._model: _AddonModelT = model  # read-only
 		self._status: AvailableAddonStatus = status  # modifications triggers L{updated.notify}
 		self.updated = extensionPoints.Action()  # Notify of changes to VM, argument: addonListItemVM
 
 	@property
-	def model(self) -> _AddonGUIModel:
+	def model(self) -> _AddonModelT:
 		return self._model
 
 	@property

--- a/source/gui/_addonStoreGui/viewModels/store.py
+++ b/source/gui/_addonStoreGui/viewModels/store.py
@@ -13,6 +13,7 @@ from os import (
 )
 import os
 from typing import (
+	Iterable,
 	List,
 	Optional,
 	cast,
@@ -62,6 +63,7 @@ from .addonList import (
 
 class AddonStoreVM:
 	def __init__(self):
+		assert addonDataManager
 		self._installedAddons = addonDataManager._installedAddonsCache.installedAddonGUICollection
 		self._availableAddons = _createAddonGUICollection()
 		self.hasError = extensionPoints.Action()
@@ -224,7 +226,12 @@ class AddonStoreVM:
 			AddonActionVM(
 				# Translators: Label for an action that opens the license for the selected addon
 				displayName=pgettext("addonStore", "&License"),
-				actionHandler=lambda aVM: startfile(cast(_AddonStoreModel, aVM.model).licenseURL),
+				actionHandler=lambda aVM: startfile(
+					cast(
+						str,
+						cast(_AddonStoreModel, aVM.model).licenseURL
+					)
+				),
 				validCheck=lambda aVM: (
 					isinstance(aVM.model, _AddonStoreModel)
 					and aVM.model.licenseURL is not None
@@ -246,9 +253,12 @@ class AddonStoreVM:
 		assert path is not None
 		startfile(path)
 
-	def removeAddon(self, listItemVM: AddonListItemVM) -> None:
+	def removeAddon(self, listItemVM: AddonListItemVM[_AddonGUIModel]) -> None:
+		assert addonDataManager
+		assert listItemVM.model
 		if _shouldProceedToRemoveAddonDialog(listItemVM.model):
 			addonDataManager._deleteCacheInstalledAddon(listItemVM.model.name)
+			assert listItemVM.model._addonHandlerModel is not None
 			listItemVM.model._addonHandlerModel.requestRemove()
 			self.refresh()
 			listItemVM.status = getStatus(listItemVM.model)
@@ -278,11 +288,11 @@ class AddonStoreVM:
 		try:
 			listItemVM.model._addonHandlerModel.enable(shouldEnable)
 		except addonHandler.AddonError:
-			log.debug(exc_info=True)
 			if shouldEnable:
 				errorMessage = self._enableErrorMessage
 			else:
 				errorMessage = self._disableErrorMessage
+			log.debug(errorMessage, exc_info=True)
 			displayableError = DisplayableError(
 				displayMessage=errorMessage.format(addon=listItemVM.model.displayName)
 			)
@@ -309,16 +319,19 @@ class AddonStoreVM:
 		if _shouldProceedWhenInstalledAddonVersionUnknown(mainFrame, listItemVM.model):
 			self.getAddon(listItemVM)
 
-	def getAddon(self, listItemVM: AddonListItemVM) -> None:
+	def getAddon(self, listItemVM: AddonListItemVM[_AddonStoreModel]) -> None:
+		assert addonDataManager
+		addonDataManager._downloadsPendingCompletion.add(listItemVM)
 		listItemVM.status = AvailableAddonStatus.DOWNLOADING
 		log.debug(f"{listItemVM.Id} status: {listItemVM.status}")
-		self._downloader.download(listItemVM.model, self._downloadComplete, self.onDisplayableError)
+		self._downloader.download(listItemVM, self._downloadComplete, self.onDisplayableError)
 
-	def _downloadComplete(self, addonDetails: AddonStoreModel, fileDownloaded: Optional[PathLike]):
-		listItemVM: Optional[AddonListItemVM] = self.listVM._addons[addonDetails.listItemVMId]
-		if listItemVM is None:
-			log.error(f"No list item VM for addon with id: {addonDetails.addonId}")
-			return
+	def _downloadComplete(
+			self,
+			listItemVM: AddonListItemVM[_AddonStoreModel],
+			fileDownloaded: Optional[PathLike]
+	):
+		addonDataManager._downloadsPendingCompletion.remove(listItemVM)
 
 		if fileDownloaded is None:
 			# Download may have been cancelled or otherwise failed
@@ -329,6 +342,7 @@ class AddonStoreVM:
 		listItemVM.status = AvailableAddonStatus.DOWNLOAD_SUCCESS
 		log.debug(f"Queuing add-on for install on dialog exit: {listItemVM.Id}")
 		# Add-ons can have "installTasks", which often call the GUI assuming they are on the main thread.
+		assert addonDataManager
 		addonDataManager._downloadsPendingInstall.add((listItemVM, fileDownloaded))
 
 	def installPending(self):
@@ -406,8 +420,9 @@ class AddonStoreVM:
 		log.debug("completed refresh")
 
 	def cancelDownloads(self):
-		for a in self._downloader.progress.keys():
-			self.listVM._addons[a.listItemVMId].status = AvailableAddonStatus.AVAILABLE
+		while addonDataManager._downloadsPendingCompletion:
+			listItem = addonDataManager._downloadsPendingCompletion.pop()
+			listItem.status = AvailableAddonStatus.AVAILABLE
 		self._downloader.cancelAll()
 
 	def _filterByEnabledKey(self, model: _AddonGUIModel) -> bool:


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Fixes https://github.com/nvaccess/nvda/issues/15347

### Summary of the issue:
https://github.com/nvaccess/nvda/issues/15347 raises 2 issues with handling the results of downloading add-ons when the add-on list has been refreshed by switching to a different add-on list view tab.
This is due to the download task relying on an add-on being visible in the add-on list.

### Description of user facing changes
Installing add-ons and then switching tabs should not result in any errors and downloads should be successful

### Description of development approach

- Up the max workers for downloading to 10, meaning up to 10 add-ons can be downloaded simultaneously
- Fix handling of completed downloads to be safer, use the list view model for downloading rather than just the add-on model so that the context of the add-on list view is not needed
- Fix up various misleading typing annotations
- Add an "UNKNOWN" category for add-on status rather than just causing an error, this will allow add-ons with an unknown status to appear in the incompatible add-ons tab instead of just being hidden

### Testing strategy:
Tested STR in #15347 with help from #15350 to stress test large downloads of multiple add-ons

### Known issues with pull request:
None

### Change log entries:
Bug fixes
```
* Fixed add-on store bug when downloading multiple add-ons (#15347)
* Fixed add-on store bug when downloading add-ons and changing tabs (#15347)
```

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
