### PR TITLE
Don't hide installed add-ons in available add-ons list

### DIFF
--- a/source/_addonStore/models/status.py
+++ b/source/_addonStore/models/status.py
@@ -303,28 +303,30 @@ class _StatusFilterKey(DisplayStringEnum):
 			raise e
 
 
+_installedAddonStatuses: Set[AvailableAddonStatus] = {
+	AvailableAddonStatus.UPDATE,
+	AvailableAddonStatus.REPLACE_SIDE_LOAD,
+	AvailableAddonStatus.INSTALLED,
+	AvailableAddonStatus.PENDING_DISABLE,
+	AvailableAddonStatus.PENDING_INCOMPATIBLE_DISABLED,
+	AvailableAddonStatus.PENDING_INCOMPATIBLE_ENABLED,
+	AvailableAddonStatus.INCOMPATIBLE_ENABLED,
+	AvailableAddonStatus.INCOMPATIBLE_DISABLED,
+	AvailableAddonStatus.DISABLED,
+	AvailableAddonStatus.PENDING_ENABLE,
+	AvailableAddonStatus.PENDING_REMOVE,
+	AvailableAddonStatus.RUNNING,
+	AvailableAddonStatus.ENABLED,
+	AvailableAddonStatus.DOWNLOAD_SUCCESS,
+}
+
 _statusFilters: OrderedDict[_StatusFilterKey, Set[AvailableAddonStatus]] = OrderedDict({
-	_StatusFilterKey.INSTALLED: {
-		AvailableAddonStatus.UPDATE,
-		AvailableAddonStatus.REPLACE_SIDE_LOAD,
-		AvailableAddonStatus.INSTALLED,
-		AvailableAddonStatus.PENDING_DISABLE,
-		AvailableAddonStatus.PENDING_INCOMPATIBLE_DISABLED,
-		AvailableAddonStatus.PENDING_INCOMPATIBLE_ENABLED,
-		AvailableAddonStatus.INCOMPATIBLE_ENABLED,
-		AvailableAddonStatus.INCOMPATIBLE_DISABLED,
-		AvailableAddonStatus.DISABLED,
-		AvailableAddonStatus.PENDING_ENABLE,
-		AvailableAddonStatus.PENDING_REMOVE,
-		AvailableAddonStatus.RUNNING,
-		AvailableAddonStatus.ENABLED,
-		AvailableAddonStatus.DOWNLOAD_SUCCESS,
-	},
+	_StatusFilterKey.INSTALLED: _installedAddonStatuses,
 	_StatusFilterKey.UPDATE: {
 		AvailableAddonStatus.UPDATE,
 		AvailableAddonStatus.REPLACE_SIDE_LOAD,
 	},
-	_StatusFilterKey.AVAILABLE: {
+	_StatusFilterKey.AVAILABLE: _installedAddonStatuses.union({
 		AvailableAddonStatus.INCOMPATIBLE,
 		AvailableAddonStatus.AVAILABLE,
 		AvailableAddonStatus.UPDATE,
@@ -335,7 +337,7 @@ _statusFilters: OrderedDict[_StatusFilterKey, Set[AvailableAddonStatus]] = Order
 		AvailableAddonStatus.INSTALLING,
 		AvailableAddonStatus.INSTALL_FAILED,
 		AvailableAddonStatus.INSTALLED,
-	},
+	}),
 	_StatusFilterKey.INCOMPATIBLE: {
 		AvailableAddonStatus.PENDING_INCOMPATIBLE_DISABLED,
 		AvailableAddonStatus.PENDING_INCOMPATIBLE_ENABLED,

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -40,6 +40,7 @@ What's New in NVDA
   You can now disable specific drivers for braille display auto detection in the braille display selection dialog. (#15196)
   -
 - Rich edit controls in applications such as Wordpad now use UI Automation (UIA) when the application advertises native support for this. (#15314)
+- Add-on Store: Installed add-ons will now be listed in the Available Add-ons tab, if they are still available in the store. (#15374)
 -
 
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Fixes #15374

### Summary of the issue:
At present, if you use the available add-ons category, add-ons already installed are not shown in the list. 
This is causing confusion, where users expect add-ons to listed in the available add-ons tab, regardless if installed.

The main use case is the following user story:
I am a user who has installed VeryCoolAddon. I want to recommend a friend to use it. I check in the add-on store via the "Add-on catalog" tab (formerly "Available add-ons" tab) that the add-on is still in the store and its version. Note: add-ons may be removed from the store for various reasons, so you cannot be certain if the add-on is still available in the add-on store if it is already installed.

### Description of user facing changes
add-ons which are already installed will no longer be hidden in the available add-ons list

### Description of development approach
Include all the same statuses in the installed add-ons tab in the available add-ons tab. (#15374)

### Testing strategy:
Manual testing

### Known issues with pull request:
None
### Change log entries:
Changes
- Add-on Store: Installed add-ons will now be listed in the Available Add-ons tab, if they are still available in the store.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
