### PR TITLE
Revert no longer classify (rich) edit classes as bad for UIA

### DIFF
--- a/source/UIAHandler/__init__.py
+++ b/source/UIAHandler/__init__.py
@@ -90,9 +90,13 @@ badUIAWindowClassNames = (
 	"WuDuiListView",
 	"ComboBox",
 	"msctls_progress32",
+	"Edit",
 	"CommonPlacesWrapperWndClass",
 	"SysMonthCal32",
 	"SUPERGRID",  # Outlook 2010 message list
+	"RichEdit",
+	"RichEdit20",
+	"RICHEDIT50W",
 	"Button",
 	# #8944: The Foxit UIA implementation is incomplete and should not be used for now.
 	"FoxitDocWnd",

--- a/source/appModules/dllhost.py
+++ b/source/appModules/dllhost.py
@@ -11,11 +11,12 @@ This simply imports a proper class from the explorer app module, and maps it to 
 
 import appModuleHandler
 import controlTypes
+from NVDAObjects.window.edit import Edit
 from .explorer import ReadOnlyEditBox
 
 class AppModule(appModuleHandler.AppModule):
 
 	def chooseNVDAObjectOverlayClasses(self, obj, clsList):
 		windowClass = obj.windowClassName
-		if windowClass == "Edit" and controlTypes.State.READONLY in obj.states:
+		if windowClass == "Edit" and Edit in clsList and controlTypes.State.READONLY in obj.states:
 			clsList.insert(0, ReadOnlyEditBox)

--- a/source/appModules/explorer.py
+++ b/source/appModules/explorer.py
@@ -24,7 +24,7 @@ from NVDAObjects import NVDAObject
 from NVDAObjects.IAccessible import IAccessible, List
 from NVDAObjects.UIA import UIA
 from NVDAObjects.behaviors import ToolTip
-from NVDAObjects.window.edit import RichEdit50, EditTextInfo
+from NVDAObjects.window.edit import RichEdit50, Edit, EditTextInfo
 import config
 from winAPI.types import HWNDValT
 
@@ -224,7 +224,8 @@ class UIProperty(UIA):
 			return value
 		return value.replace(CHAR_LTR_MARK,'').replace(CHAR_RTL_MARK,'')
 
-class ReadOnlyEditBox(IAccessible):
+
+class ReadOnlyEditBox(Edit):
 #Used for read-only edit boxes in a properties window.
 #These can contain dates that include unwanted left-to-right and right-to-left indicator characters.
 
@@ -296,11 +297,11 @@ class AppModule(appModuleHandler.AppModule):
 			clsList.insert(0, ExplorerToolTip)
 			return
 
-		if windowClass == "Edit" and controlTypes.State.READONLY in obj.states:
+		if windowClass == "Edit" and Edit in clsList and controlTypes.State.READONLY in obj.states:
 			clsList.insert(0, ReadOnlyEditBox)
 			return # Optimization: return early to avoid comparing class names and roles that will never match.
 
-		if windowClass == "SysListView32":
+		if windowClass == "SysListView32" and isinstance(obj, IAccessible):
 			if(
 				role == controlTypes.Role.MENUITEM
 				or(
@@ -320,7 +321,7 @@ class AppModule(appModuleHandler.AppModule):
 			clsList.insert(0, StartButton)
 			return # Optimization: return early to avoid comparing class names and roles that will never match.
 
-		if windowClass == 'RICHEDIT50W' and obj.windowControlID == 256:
+		if windowClass == 'RICHEDIT50W' and RichEdit50 in clsList and obj.windowControlID == 256:
 			clsList.insert(0, MetadataEditField)
 			return  # Optimization: return early to avoid comparing class names and roles that will never match.
 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -39,7 +39,6 @@ What's New in NVDA
   - The advanced setting to enable support for HID braille has been removed in favor of a new option.
   You can now disable specific drivers for braille display auto detection in the braille display selection dialog. (#15196)
   -
-- Rich edit controls in applications such as Wordpad now use UI Automation (UIA) when the application advertises native support for this. (#15314)
 -
 
 
@@ -54,7 +53,6 @@ What's New in NVDA
   -
 - Braille:
   - The braille cursor and selection indicators will now always be updated correctly after showing or hiding respective indicators with a gesture. (#15115)
-  - NVDA will no longer be sluggish in rich edit controls when braille is enabled, such as in MemPad. (#14285)
   - Fixed bug where Albatross braille displays try to initialize although another braille device has been connected. (#15226)
   -
 - Fixed support for System List view (``SysListView32``) controls in Windows Forms applications. (#15283)


### PR DESCRIPTION
### Link to issue number:
Reintroduces #14285
Fixes #15375
Fixes #15330
Reverts #15314

### Summary of the issue:
In #15314, edit and rich edit classes were no longer classified as bad for UIA. This caused the following issues:

1. Read only edit fields in Explorer no longer read correctly, as they inherrit from both UIA and IAccessible
2. UIA adds a redundant name of RichEdit Control to RichEdit controls.

Generally spoken, removing these classes from the bad UIA classes list meant an API breaking change because Edit objects using UIA instead of legacy Edit support behave differently with regard to overriding and filtering texts, including LTR and RTL marks.

### Description of user facing changes
Reverted #15314. Most notably, the lag as reported in #14285 will unfortunately be reintroduced for now.

### Description of development approach
1. Re-add the bad UIA class names again.
2. Addressed issues in the explorer appmodule as pointed out in #15375.
    * Most notably, changed class inheritance from IAccessible to Edit
    * Added some small checks to overlay selection to ensure SysListView overlays won't be added on SysListView objects that don't use MSAA

### Testing strategy:
Tested str from #15375 and #15330

### Known issues with pull request:
None known

### Change log entries:
In pr

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
