### PR TITLE
Documentation fix-up for new winAPI.secureDesktop.post_secureDesktopStateChange extensionPoint

### DIFF
--- a/projectDocs/dev/developerGuide/developerGuide.t2t
+++ b/projectDocs/dev/developerGuide/developerGuide.t2t
@@ -1030,6 +1030,10 @@ For examples of how to define and use new extension points, please see the code 
 || Type | Extension Point | Description |
 | ``Action`` | ``pre_handleWindowMessage`` | Notifies when NVDA receives a window message, allowing components to perform an action when certain system events occur. |
 
+++ winAPI.secureDesktop ++[winAPI_secureDesktopExtPts]
+|| Type | Extension Point | Description |
+| ``Action`` | ``winAPI.secureDesktop.post_secureDesktopStateChange`` | Notifies when the user has switched to/from the secure desktop |
+
 ++ bdDetect ++[bdDetectExtPts]
 || Type | Extension Point | Description |
 | ``Chain`` | ``scanForDevices`` | Can be iterated to scan for braille devices. |

--- a/projectDocs/dev/developerGuide/developerGuide.t2t
+++ b/projectDocs/dev/developerGuide/developerGuide.t2t
@@ -970,7 +970,7 @@ The sections below provide the list of currently defined extension points in NVD
 Please see code documentation in the associated files, or the code itself, for further explanation.
 The section titles below represent the package or module in which the listed extension points are defined.
 
-For examples of how to define and use new extension points, please see the code documentation of the ``extensionPoints`` module.
+For examples of how to define and use new extension points, please see the code documentation of the ``extensionPoints`` package.
 
 ++ braille ++[brailleExtPts]
 || Type | Extension Point | Description |

--- a/source/winAPI/secureDesktop.py
+++ b/source/winAPI/secureDesktop.py
@@ -26,7 +26,7 @@ def onSecureDesktopChange(isSecureDesktop: bool):
 	pass
 
 post_secureDesktopStateChange.register(onSecureDesktopChange)
-post_secureDesktopStateChange.notify(isSecureDesktop=True)
+# Later, when no longer needed:
 post_secureDesktopStateChange.unregister(onSecureDesktopChange)
 ```
 """

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -27,7 +27,7 @@ Add-ons will need to be re-tested and have their manifest updated.
 These are breaking API changes.
 Please open a GitHub issue if your Add-on has an issue with updating to the new API.
 
-- ``SecureDesktopNVDAObject`` has been removed.
+- ``IAccessibleHandler.SecureDesktopNVDAObject`` has been removed.
 Instead, when NVDA is running on the user profile, track the existence of the secure desktop with the extension point: ``winAPI.secureDesktop.post_secureDesktopStateChange``. (#14488)
 
 === Deprecations ===


### PR DESCRIPTION

### Link to issue number:

Fix-up of #14488 

### Summary of the issue:

In #14488, no documentation for the new extensionPoint was added to the master list of extension points in the developer guide.
(I wish there was a way to remind of this when contributing extensionPoint creations)

Additionally, I noticed an oddity in the documentation of the extensionPoint itself, which may or may not be intended.

### Description of user facing changes

Improved documentation for developers.

### Description of development approach

* Added a new section to the Developer Guide chapter on Extension Points, listing the new `Action`, `winAPI.secureDesktop.post_secureDesktopStateChange`.
* Fixed a terminology error in the head section of the chapter (I had previously called extensionPoints a module, when it should have been a package).
* Noticed that in the usage example given in the `winAPI.secureDesktop` module docstring, there was a call to `notify()`. AFAIK, the general consumer of this extensionPoint, who registers something to it, shouldn't also be calling `notify` on it. I removed that example line, replacing it with a comment to put the subsequent `unregister()` call in context. **@seanbudd please check my reasoning**.

### Testing strategy:

None needed.

### Known issues with pull request:

None.

### Change log entries:

None.

### Code Review Checklist:
- [X] Pull Request description:
  - description is up to date
  - change log entries
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [ ] API is compatible with existing add-ons.
- [X] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [ ] Security precautions taken.
