### PR TITLE
Add checks for region updates

### DIFF
--- a/source/braille.py
+++ b/source/braille.py
@@ -2505,7 +2505,7 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 			for region in self._regionsPendingUpdate:
 				from treeInterceptorHandler import TreeInterceptor
 				if isinstance(region.obj, TreeInterceptor) and not region.obj.isAlive:
-					log.debugWarning("Skipping region update for died tree interceptor")
+					log.debug("Skipping region update for died tree interceptor")
 					continue
 				try:
 					region.update()

--- a/source/braille.py
+++ b/source/braille.py
@@ -2016,7 +2016,7 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 	queuedWrite: Optional[List[int]] = None
 	queuedWriteLock: threading.Lock
 	ackTimerHandle: int
-	_regionsPendingUpdate: Set[Region]
+	_regionsPendingUpdate: Set[Union[NVDAObjectRegion, TextInfoRegion]]
 	"""
 	Regions pending an update.
 	Regions are added by L{handleUpdate} and L{handleCaretMove} and cleared in L{_handlePendingUpdate}.

--- a/source/braille.py
+++ b/source/braille.py
@@ -530,7 +530,7 @@ class Region(object):
 		"""
 
 	def __repr__(self):
-		return f"{self.__class__.__name__} ({self.obj!r})"
+		return f"{self.__class__.__name__} ({self.rawText!r})"
 
 
 class TextRegion(Region):

--- a/source/braille.py
+++ b/source/braille.py
@@ -529,6 +529,10 @@ class Region(object):
 		@type start: bool
 		"""
 
+	def __repr__(self):
+		return f"{self.__class__.__name__} ({self.obj!r})"
+
+
 class TextRegion(Region):
 	"""A simple region containing a string of text.
 	"""
@@ -2499,7 +2503,18 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 			scrollTo: Optional[TextInfoRegion] = None
 			self.mainBuffer.saveWindow()
 			for region in self._regionsPendingUpdate:
-				region.update()
+				from treeInterceptorHandler import TreeInterceptor
+				if isinstance(region.obj, TreeInterceptor) and not region.obj.isAlive:
+					log.debugWarning("Skipping region update for died tree interceptor")
+					continue
+				try:
+					region.update()
+				except Exception:
+					log.debugWarning(
+						f"Region update failed for {region}, object probably died",
+						exc_info=True
+					)
+					continue
 				if isinstance(region, TextInfoRegion) and region.pendingCaretUpdate:
 					scrollTo = region
 					region.pendingCaretUpdate = False


### PR DESCRIPTION
### Link to issue number:
Fixes #15391
Fixup of #15163

### Summary of the issue:
Since #15163, it is much more likely that braille tries to update a region for an object that no longer exists. This is no problem at all, however in that case, the region should simply be ignored for updating and a debug warning should be logged instead.

### Description of user facing changes
No errors in de log while browsing

### Description of development approach
a try/except around region.update, with an extra check to avoid updating regions for tree interceptors that have died.

### Testing strategy:
Browsed with Firefox for some minutes, wasn't able to reproduce the issue any longer.

### Known issues with pull request:
None known

### Change log entries:
None needed

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
