### PR TITLE
Fix some issues where an NVDAObject is used where a Window is expected

### DIFF
--- a/source/NVDAObjects/__init__.py
+++ b/source/NVDAObjects/__init__.py
@@ -1481,17 +1481,20 @@ This code is executed if a gain focus event is received by this object.
 		info.extend(self.appModule.devInfo)
 		return info
 
-	def _get_sleepMode(self):
+	# Typing information for auto property _get_sleepMode
+	sleepMode: bool
+
+	# Don't cache sleepMode, as it is derived from a property which might change
+	# and we want the changed value immediately.
+	_cache_sleepMode = False
+
+	def _get_sleepMode(self) -> bool:
 		"""Whether NVDA should sleep for this object (e.g. it is self-voicing).
 		If C{True}, all  events and script requests for this object are silently dropped.
-		@rtype: bool
 		"""
 		if self.appModule:
 			return self.appModule.sleepMode
 		return False
-	# Don't cache sleepMode, as it is derived from a property which might change
-	# and we want the changed value immediately.
-	_cache_sleepMode = False
 
 	def _get_mathMl(self):
 		"""Obtain the MathML markup for an object containing math content.

--- a/source/api.py
+++ b/source/api.py
@@ -9,7 +9,6 @@ Functions should mostly refer to getting an object (NVDAObject) or a position (T
 """
 
 import typing
-from NVDAObjects.window import Window
 
 import config
 import textInfos
@@ -19,6 +18,7 @@ from logHandler import log
 import ui
 import treeInterceptorHandler
 import NVDAObjects
+from NVDAObjects.window import Window
 import winUser
 import controlTypes
 import eventHandler

--- a/source/api.py
+++ b/source/api.py
@@ -9,6 +9,7 @@ Functions should mostly refer to getting an object (NVDAObject) or a position (T
 """
 
 import typing
+from NVDAObjects.window import Window
 
 import config
 import textInfos
@@ -111,7 +112,8 @@ def setFocusObject(obj: NVDAObjects.NVDAObject) -> bool:  # noqa: C901
 				log.error(
 					"Never ending focus ancestry:"
 					f" last object: {tempObj.name}, {controlTypes.Role(tempObj.role).displayString},"
-					f" window class {tempObj.windowClassName}, application name {tempObj.appModule.appName}"
+					f" window class {tempObj.windowClassName if isinstance(tempObj, Window) else type(tempObj)}, "
+					f"application name {tempObj.appModule.appName}"
 				)
 			except:
 				pass

--- a/source/eventHandler.py
+++ b/source/eventHandler.py
@@ -309,8 +309,10 @@ def executeEvent(
 		sleepMode = obj.sleepMode
 		# Handle possible virtual desktop name change event.
 		# More effective in Windows 10 Version 1903 and later.
+		from NVDAObjects.window import Window
 		if (
 			eventName == "nameChange"
+			and isinstance(obj, Window)
 			and obj.windowClassName == "#32769"
 			and _canAnnounceVirtualDesktopNames
 		):

--- a/source/keyboardHandler.py
+++ b/source/keyboardHandler.py
@@ -154,8 +154,8 @@ def shouldUseToUnicodeEx(focus: Optional["NVDAObject"] = None):
 			)
 			# or the focus is within a UWP app, where WM_CHAR never gets sent
 			or (
-				not isinstance(focus, Window)
-				or focus.windowClassName.startswith('Windows.UI.Core')
+				isinstance(focus, Window)
+				and focus.windowClassName.startswith('Windows.UI.Core')
 			)
 			# Or this is a console with keyboard support, where WM_CHAR messages are doubled
 			or isinstance(focus, KeyboardHandlerBasedTypedCharSupport)

--- a/source/keyboardHandler.py
+++ b/source/keyboardHandler.py
@@ -1,5 +1,4 @@
 # -*- coding: UTF-8 -*-
-# keyboardHandler.py
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
@@ -8,7 +7,6 @@
 """Keyboard support"""
 
 import ctypes
-import sys
 import time
 import re
 import typing
@@ -19,7 +17,6 @@ from typing import (
 	Any,
 )
 
-import wx
 import winVersion
 import winUser
 import vkCodes
@@ -28,7 +25,6 @@ import speech
 import ui
 from keyLabels import localizedKeyLabels
 from logHandler import log
-import queueHandler
 import config
 from config.configFlags import NVDAKey
 import api
@@ -41,6 +37,7 @@ from contextlib import contextmanager
 import threading
 
 if typing.TYPE_CHECKING:
+	from NVDAObjects import NVDAObject  # noqa: F401
 	from watchdog import WatchdogObserver
 
 _watchdogObserver: typing.Optional["WatchdogObserver"] = None
@@ -136,10 +133,11 @@ def getNVDAModifierKeys() -> List[Tuple[int, Optional[bool]]]:
 	return keys
 
 
-def shouldUseToUnicodeEx(focus=None):
+def shouldUseToUnicodeEx(focus: Optional["NVDAObject"] = None):
 	"Returns whether to use ToUnicodeEx to determine typed characters."
 	if not focus:
 		focus = api.getFocusObject()
+	from NVDAObjects.window import Window
 	from NVDAObjects.behaviors import KeyboardHandlerBasedTypedCharSupport
 	return (
 		# This is only possible in Windows 10 1607 and above
@@ -147,9 +145,18 @@ def shouldUseToUnicodeEx(focus=None):
 		and (  # Either of
 			# We couldn't inject in-process, and its not a legacy console window without keyboard support.
 			# console windows have their own specific typed character support.
-			(not focus.appModule.helperLocalBindingHandle and focus.windowClassName != 'ConsoleWindowClass')
+			(
+				not focus.appModule.helperLocalBindingHandle
+				and (
+					not isinstance(focus, Window)
+					or focus.windowClassName != 'ConsoleWindowClass'
+				)
+			)
 			# or the focus is within a UWP app, where WM_CHAR never gets sent
-			or focus.windowClassName.startswith('Windows.UI.Core')
+			or (
+				not isinstance(focus, Window)
+				or focus.windowClassName.startswith('Windows.UI.Core')
+			)
 			# Or this is a console with keyboard support, where WM_CHAR messages are doubled
 			or isinstance(focus, KeyboardHandlerBasedTypedCharSupport)
 		)


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Fixes #15395 

### Summary of the issue:
There are many instances in NVDA where we implicitly or explicitly (with typing) expect an `NVDAObject` but code uses properties only available for a `NVDAObjects.window.Window`.
This is because most objects are `Window`s and usually these implicit expectations are safe.
This PR attempts to catch some known instances where these expectations are not safe.

### Description of user facing changes
Fix error when switching to the secure desktop

### Description of development approach
Improve typing and catch some likely cases where a `Window` should not be expected

### Testing strategy:
Test using the secure desktop, check log for errors

### Known issues with pull request:
There are other instances where this is the case.
Future work such as improved typing will help weed out these problems.

### Change log entries:
None, unreleased regression

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
