### PR TITLE
Add-on store: correctly refresh cache when filtering incompatible add-ons

### DIFF
--- a/source/_addonStore/dataManager.py
+++ b/source/_addonStore/dataManager.py
@@ -7,6 +7,7 @@
 # Can be removed in a future version of python (3.8+)
 from __future__ import annotations
 
+from copy import deepcopy
 import json
 import os
 import pathlib
@@ -220,7 +221,7 @@ class _DataManager:
 
 		if self._compatibleAddonCache is None:
 			return _createAddonGUICollection()
-		return self._compatibleAddonCache.cachedAddonData
+		return deepcopy(self._compatibleAddonCache.cachedAddonData)
 
 	def getLatestAddons(
 			self,
@@ -258,7 +259,7 @@ class _DataManager:
 
 		if self._latestAddonCache is None:
 			return _createAddonGUICollection()
-		return self._latestAddonCache.cachedAddonData
+		return deepcopy(self._latestAddonCache.cachedAddonData)
 
 	def _deleteCacheInstalledAddon(self, addonId: str):
 		addonCachePath = os.path.join(self._installedAddonDataCacheDir, f"{addonId}.json")

--- a/source/gui/_addonStoreGui/viewModels/addonList.py
+++ b/source/gui/_addonStoreGui/viewModels/addonList.py
@@ -164,7 +164,7 @@ class AddonListVM:
 			storeVM: "AddonStoreVM",
 	):
 		self._isLoading: bool = False
-		self._addons: CaseInsensitiveDict[AddonListItemVM] = CaseInsensitiveDict()
+		self._addons: CaseInsensitiveDict[AddonListItemVM[_AddonGUIModel]] = CaseInsensitiveDict()
 		self._storeVM = storeVM
 		self.itemUpdated = extensionPoints.Action()
 		self.updated = extensionPoints.Action()

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -57,6 +57,9 @@ What's New in NVDA
   - The braille cursor and selection indicators will now always be updated correctly after showing or hiding respective indicators with a gesture. (#15115)
   - Fixed bug where Albatross braille displays try to initialize although another braille device has been connected. (#15226)
   -
+- Add-on Store:
+  - Fix bug where unchecking "include incompatible add-ons" would result in incompatible add-ons still being listed in the store. (#15411)
+  -
 - Fixed support for System List view (``SysListView32``) controls in Windows Forms applications. (#15283)
 - NVDA once again announces calculation results in the Windows 32bit calculator on Server, LTSC and LTSB versions of Windows. (#15284)
 -


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Fixes #15411

### Summary of the issue:
When unchecking 'Include incompatible add-ons', incompatible add-ons are still included in the list.
This is due to the cache of the compatible add-ons being updated to include incompatible add-ons.
This is due to a referencing problem, where the listed add-ons and the compatible add-on cache used the same reference.

### Description of user facing changes
Unchecking "include incompatible add-ons" should now correctly return the list to only show compatible add-ons

### Description of development approach
A copy of the cache should be used instead, to prevent external functions from updating the cached copy.

### Testing strategy:
Manually test STR in #15411

### Known issues with pull request:
None

### Change log entries:
refer to diff

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
