### PR TITLE
Remove hack to disable tony's enhancements

### DIFF
--- a/source/addonHandler/addonVersionCheck.py
+++ b/source/addonHandler/addonVersionCheck.py
@@ -7,32 +7,9 @@
 from typing import TYPE_CHECKING
 
 import addonAPIVersion
-from buildVersion import version_year
 
 if TYPE_CHECKING:
 	from _addonStore.models.version import SupportsVersionCheck  # noqa: F401
-
-
-if version_year < 2024:
-	def _isAddonForceDisabled(addon: "SupportsVersionCheck") -> bool:
-		from addonHandler import AddonBase as AddonHandlerModel
-		from _addonStore.models.addon import _AddonManifestModel, _AddonStoreModel
-		from _addonStore.models.version import MajorMinorPatch
-		forceDisabledAddons = {
-			"tonysEnhancements": MajorMinorPatch(1, 15),
-		}
-		if isinstance(addon, _AddonStoreModel):
-			addonVersion = addon.addonVersionNumber
-		elif isinstance(addon, AddonHandlerModel):
-			addonVersion = MajorMinorPatch._parseVersionFromVersionStr(addon.version)
-		elif isinstance(addon, _AddonManifestModel):
-			addonVersion = MajorMinorPatch._parseVersionFromVersionStr(addon.addonVersionName)
-		else:
-			raise NotImplementedError(f"Unexpected type for addon: {addon.name}, type: {type(addon)}")
-		return (
-			addon.name in forceDisabledAddons
-			and addonVersion <= forceDisabledAddons[addon.name]
-		)
 
 
 def hasAddonGotRequiredSupport(
@@ -52,9 +29,6 @@ def isAddonTested(
 	"""True if this add-on is tested for the given API version.
 	By default, the current version of NVDA is evaluated.
 	"""
-	if version_year < 2024:
-		if _isAddonForceDisabled(addon):
-			return False
 	return addon.lastTestedNVDAVersion >= backwardsCompatToVersion
 
 


### PR DESCRIPTION
Removes hack introduced in #15402 

This removes the hack introduced for 2023.3 from 2024.1.
The hack in 2023.3 specifically recognises older versions of the add-on as incompatible.
The hack is not necessary with 2024.1, as the usual incompatibility warning applies when updating