### PR TITLE
Align horizontally checkbox in add-on store GUI

### DIFF
--- a/source/gui/guiHelper.py
+++ b/source/gui/guiHelper.py
@@ -349,6 +349,9 @@ class BoxSizerHelper:
 				keywordArgs["flag"] = keywordArgs.get("flag", 0) | wx.EXPAND
 			else:
 				raise NotImplementedError("Adding PathSelectionHelper to a horizontal BoxSizerHelper is not implemented")
+		elif isinstance(item, wx.CheckBox):
+			if self.sizer.GetOrientation() == wx.HORIZONTAL:
+				keywordArgs["flag"] = keywordArgs.get("flag", 0) | wx.EXPAND
 		elif isinstance(item, LabeledControlHelper):
 			raise NotImplementedError("Use addLabeledControl instead")
 


### PR DESCRIPTION
### Link to issue number:

Fixes #15018

### Summary of the issue:
In the add-on store, the "include incompatible add-ons" checkbox is not aligned with the combobox at its left.

### Description of user facing changes
The checkbox will be aligned horizontally.

### Description of development approach
In the guiHelper, added the wx.EXPAND flag so that it is centered vertically in the sizer.

I do not know if other items may benefit from this flag; we could add them in the if clause if / when needed in the future. such Horizontal sizers are less common in NVDA's GUI however.

### Testing strategy:
Visual check.

### Known issues with pull request:
None

### Change log entries:
Not needed
### Code Review Checklist:


- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
