### PR TITLE
Add-on store: Fix up bugs with multi downloads

### DIFF
--- a/source/_addonStore/models/status.py
+++ b/source/_addonStore/models/status.py
@@ -8,6 +8,7 @@ import os
 from pathlib import Path
 from typing import (
 	Dict,
+	Optional,
 	OrderedDict,
 	Set,
 	TYPE_CHECKING,
@@ -21,7 +22,7 @@ from logHandler import log
 from NVDAState import WritePaths
 from utils.displayString import DisplayStringEnum
 
-from .version import SupportsVersionCheck
+from .version import MajorMinorPatch, SupportsVersionCheck
 
 if TYPE_CHECKING:
 	from .addon import _AddonGUIModel  # noqa: F401
@@ -146,20 +147,18 @@ class AddonStateCategory(str, enum.Enum):
 	"""Add-ons that are blocked from running because they are incompatible"""
 
 
-def getStatus(model: "_AddonGUIModel") -> AvailableAddonStatus:
-	from addonHandler import (
-		state as addonHandlerState,
-	)
+def _getDownloadableStatus(model: "_AddonGUIModel") -> Optional[AvailableAddonStatus]:
 	from ..dataManager import addonDataManager
 	assert addonDataManager is not None
-	from .addon import AddonStoreModel
-	from .version import MajorMinorPatch
-	addonHandlerModel = model._addonHandlerModel
+
+	if model.name in (d.model.name for d in addonDataManager._downloadsPendingCompletion):
+		return AvailableAddonStatus.DOWNLOADING
 
 	if model.name in (d.model.name for d, _ in addonDataManager._downloadsPendingInstall):
 		return AvailableAddonStatus.DOWNLOAD_SUCCESS
 
-	if addonHandlerModel is None:
+	if model._addonHandlerModel is None:
+		# add-on is not installed
 		if model.isPendingInstall:
 			return AvailableAddonStatus.DOWNLOAD_SUCCESS
 
@@ -170,8 +169,56 @@ def getStatus(model: "_AddonGUIModel") -> AvailableAddonStatus:
 		# Any compatible add-on which is not installed should be listed as available
 		return AvailableAddonStatus.AVAILABLE
 
+	return None
+
+
+def _getUpdateStatus(model: "_AddonGUIModel") -> Optional[AvailableAddonStatus]:
+	from .addon import AddonStoreModel
+	from ..dataManager import addonDataManager
+	assert addonDataManager is not None
+
+	if not isinstance(model, AddonStoreModel):
+		# If the listed add-on is installed from a side-load
+		# and not available on the add-on store
+		# the type will not be AddonStoreModel
+		return None
+
+	addonStoreInstalledData = addonDataManager._getCachedInstalledAddonData(model.addonId)
+	if addonStoreInstalledData is not None:
+		if model.addonVersionNumber > addonStoreInstalledData.addonVersionNumber:
+			return AvailableAddonStatus.UPDATE
+	else:
+		# Parsing from a side-loaded add-on
+		try:
+			manifestAddonVersion = MajorMinorPatch._parseVersionFromVersionStr(model._addonHandlerModel.version)
+		except ValueError:
+			# Parsing failed to get a numeric version.
+			# Ideally a numeric version would be compared,
+			# however the manifest only has a version string.
+			# Ensure the user is aware that it may be a downgrade or reinstall.
+			# Encourage users to re-install or upgrade the add-on from the add-on store.
+			return AvailableAddonStatus.REPLACE_SIDE_LOAD
+
+		if model.addonVersionNumber > manifestAddonVersion:
+			return AvailableAddonStatus.UPDATE
+
+	return None
+
+
+def getStatus(model: "_AddonGUIModel") -> AvailableAddonStatus:
+	from addonHandler import state as addonHandlerState
+
+	downloadableStatus = _getDownloadableStatus(model)
+	if downloadableStatus:
+		# Is this available in the add-on store and not installed?
+		return downloadableStatus
+	else:
+		# Add-on is currently installed or pending restart
+		addonHandlerModel = model._addonHandlerModel
+		assert addonHandlerModel
+
 	for storeState, handlerStateCategories in _addonStoreStateToAddonHandlerState.items():
-		# Match addonHandler states early for installed add-ons.
+		# Match special addonHandler states early for installed add-ons.
 		# Includes enabled, pending enabled, disabled, e.t.c.
 		if all(
 			model.addonId in addonHandlerState[stateCategory]
@@ -186,28 +233,10 @@ def getStatus(model: "_AddonGUIModel") -> AvailableAddonStatus:
 			# and another for enabled/disabled.
 			return storeState
 
-	addonStoreInstalledData = addonDataManager._getCachedInstalledAddonData(model.addonId)
-	if isinstance(model, AddonStoreModel):
-		# If the listed add-on is installed from a side-load
-		# and not available on the add-on store
-		# the type will not be AddonStoreModel
-		if addonStoreInstalledData is not None:
-			if model.addonVersionNumber > addonStoreInstalledData.addonVersionNumber:
-				return AvailableAddonStatus.UPDATE
-		else:
-			# Parsing from a side-loaded add-on
-			try:
-				manifestAddonVersion = MajorMinorPatch._parseVersionFromVersionStr(addonHandlerModel.version)
-			except ValueError:
-				# Parsing failed to get a numeric version.
-				# Ideally a numeric version would be compared,
-				# however the manifest only has a version string.
-				# Ensure the user is aware that it may be a downgrade or reinstall.
-				# Encourage users to re-install or upgrade the add-on from the add-on store.
-				return AvailableAddonStatus.REPLACE_SIDE_LOAD
-
-			if model.addonVersionNumber > manifestAddonVersion:
-				return AvailableAddonStatus.UPDATE
+	updateStatus = _getUpdateStatus(model)
+	if updateStatus:
+		# Can add-on be updated?
+		return updateStatus
 
 	if addonHandlerModel.isRunning:
 		return AvailableAddonStatus.RUNNING

--- a/source/_addonStore/network.py
+++ b/source/_addonStore/network.py
@@ -109,7 +109,7 @@ class AddonFileDownloader:
 		f.add_done_callback(self._done)
 
 	def _done(self, downloadAddonFuture: Future[Optional[os.PathLike]]):
-		isCancelled = downloadAddonFuture not in self._pending
+		isCancelled = downloadAddonFuture.cancelled() or downloadAddonFuture not in self._pending
 		addonId = "CANCELLED" if isCancelled else self._pending[downloadAddonFuture][0].model.addonId
 		log.debug(f"Done called for {addonId}")
 		if isCancelled:
@@ -144,7 +144,8 @@ class AddonFileDownloader:
 
 	def cancelAll(self):
 		log.debug("Cancelling all")
-		for f in self._pending.keys():
+		futuresCopy = self._pending.copy()
+		for f in futuresCopy.keys():
 			f.cancel()
 		assert self._executor
 		self._executor.shutdown(wait=False)

--- a/source/gui/_addonStoreGui/viewModels/store.py
+++ b/source/gui/_addonStoreGui/viewModels/store.py
@@ -330,7 +330,10 @@ class AddonStoreVM:
 			listItemVM: AddonListItemVM[_AddonStoreModel],
 			fileDownloaded: Optional[PathLike]
 	):
-		addonDataManager._downloadsPendingCompletion.remove(listItemVM)
+		try:
+			addonDataManager._downloadsPendingCompletion.remove(listItemVM)
+		except KeyError:
+			log.debug("Download already completed")
 
 		if fileDownloaded is None:
 			# Download may have been cancelled or otherwise failed
@@ -369,7 +372,10 @@ class AddonStoreVM:
 		listItemVM.status = AvailableAddonStatus.INSTALLED
 		addonDataManager._cacheInstalledAddon(listItemVM.model)
 		# Clean up download file
-		os.remove(fileDownloaded)
+		try:
+			os.remove(fileDownloaded)
+		except FileNotFoundError:
+			pass
 		log.debug(f"{listItemVM.Id} status: {listItemVM.status}")
 
 	def refresh(self):

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -40,7 +40,7 @@ What's New in NVDA
   - The advanced setting to enable support for HID braille has been removed in favor of a new option.
   You can now disable specific drivers for braille display auto detection in the braille display selection dialog. (#15196)
   -
-- Add-on Store: Installed add-ons will now be listed in the Available Add-ons tab, if they are still available in the store. (#15374)
+- Add-on Store: Installed add-ons will now be listed in the Available Add-ons tab, if they are available in the store. (#15374)
 - Some shortcut keys have been updated in the NVDA menu. (#15364)
 -
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Fixup of #15379 

### Summary of the issue:
There are some bugs with downloading multiple add-ons at once:
- when switching tab "downloading" status is lost
- if downloads are cancelled and restarted subsequently some errors occur

### Description of user facing changes
When switching tab "downloading" status is no longer lost.
Make cancelling downloads safer

### Description of development approach
Minor changes
### Testing strategy:
Tested via #15350 
### Known issues with pull request:
None
### Change log entries:
N/A

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
