### PR TITLE
Place the "Don't show this message again" checkbox to the left of it.

### DIFF
--- a/source/gui/_addonStoreGui/controls/messageDialogs.py
+++ b/source/gui/_addonStoreGui/controls/messageDialogs.py
@@ -240,13 +240,15 @@ class _SafetyWarningDialog(
 
 		sHelper.sizer.AddSpacer(SPACE_BETWEEN_VERTICAL_DIALOG_ITEMS)
 
-		self.dontShowAgainCheckbox = sHelper.addLabeledControl(
-			pgettext(
-				"addonStore",
-				# Translators: The label of a checkbox in the add-on store warning dialog
-				"&Don't show this message again"
+		self.dontShowAgainCheckbox = sHelper.addItem(
+			wx.CheckBox(
+				self,
+				label=pgettext(
+					"addonStore",
+					# Translators: The label of a checkbox in the add-on store warning dialog
+					"&Don't show this message again"
+				),
 			),
-			wx.CheckBox,
 		)
 
 		bHelper = sHelper.addDialogDismissButtons(ButtonHelper(wx.HORIZONTAL))

--- a/source/gui/guiHelper.py
+++ b/source/gui/guiHelper.py
@@ -136,7 +136,6 @@ def associateElements(firstElement: wx.Control, secondElement: wx.Control) -> wx
 	# likely a labelled control from LabeledControlHelper
 	if isinstance(firstElement, wx.StaticText) and isinstance(secondElement, (
 		wx.Button,
-		wx.CheckBox,
 		wx.Choice,
 		wx.Slider,
 		wx.SpinCtrl,
@@ -146,6 +145,12 @@ def associateElements(firstElement: wx.Control, secondElement: wx.Control) -> wx
 		sizer.Add(firstElement, flag=wx.ALIGN_CENTER_VERTICAL)
 		sizer.AddSpacer(SPACE_BETWEEN_ASSOCIATED_CONTROL_HORIZONTAL)
 		sizer.Add(secondElement)
+	elif isinstance(firstElement, wx.StaticText) and isinstance(secondElement, wx.CheckBox):
+		# checkbox should go first, and label should go after
+		sizer = wx.BoxSizer(wx.HORIZONTAL)
+		sizer.Add(secondElement)
+		sizer.AddSpacer(SPACE_BETWEEN_ASSOCIATED_CONTROL_HORIZONTAL)
+		sizer.Add(firstElement, flag=wx.ALIGN_CENTER_VERTICAL)
 	# staticText and (ListCtrl, ListBox or TreeCtrl)
 	elif isinstance(firstElement, wx.StaticText) and isinstance(secondElement, (wx.ListCtrl,wx.ListBox,wx.TreeCtrl)):
 		sizer = wx.BoxSizer(wx.VERTICAL)


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:

Fixes #15426

### Summary of the issue:

The "Don't show this message again" checkbox in the "Add-on Store Warning" dialogue box should be on the left side of its label, but is currently on the right side of its label.

### Description of user facing changes

Visually the "Don't show this message again" checkbox is located to the left of its label.

### Description of development approach

Change the way to add `CheckBox` from `addLabeledControl` to `addItem` to be consistent with other GUIs.

### Testing strategy:

Visual check.

### Known issues with pull request:

none

### Change log entries:

Not needed

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
