### PR TITLE
Review documentation for 2023.3

### DIFF
--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -5,10 +5,20 @@ What's New in NVDA
 %!includeconf: ./locale.t2tconf
 
 = 2023.3 =
+This release includes improvements to performance, responsiveness and stability of audio output.
+
+NVDA can now periodically refresh OCR results, speaking new text as it appears.
+This can be configured in the Windows OCR category of NVDA's settings dialog.
+
+There's been several braille fixes, improving device detection and caret movement.
+It is now possible to opt-out unwanted drivers from automatic detection, to improve autodetection performance.
+There are also new BRLTTY commands.
+
+There's also been bug fixes for the Add-on Store, Microsoft Office, Microsoft Edge context menus, and Windows Calculator.
 
 == New Features ==
 - Enhanced sound management:
-  - NVDA will now output audio via the Windows Audio Session API (WASAPI), which may improve the responsiveness, performance and stability of NVDA speech and sounds. (#14697)
+  - NVDA will now output audio via the Windows Audio Session API (WASAPI), which may improve the responsiveness, performance and stability of NVDA speech and sounds. (#14697, #11169, #11615, #5096, #10185, #11061)
   - WASAPI usage can be disabled in Advanced settings.
   If WASAPI is enabled, the following Advanced settings can also be configured.
     - An option to have the volume of NVDA sounds and beeps follow the volume setting of the voice you are using. (#1409)
@@ -30,12 +40,13 @@ What's New in NVDA
   - When the text in a terminal changes without updating the caret, the text on a braille display will now properly update when positioned on a changed line.
   This includes situations where braille is tethered to review. (#15115)
   - More BRLTTY key bindings are now mapped to NVDA commands (#6483):
-    - learn: toggle NVDA input help
-    - prefmenu: open the NVDA menu
-    - prefload/prefsave: Load/save NVDA configuration
-    - time: Show time
-    - say_line: Speak the current line where the review cursor is located
-    - say_below: Say all using review cursor
+    - ``learn``: toggle NVDA input help
+    - ``prefmenu``: open the NVDA menu
+    - ``prefload``/``prefsave``: Load/save NVDA configuration
+    - ``time``: Show time
+    - ``say_line``: Speak the current line where the review cursor is located
+    - ``say_below``: Say all using review cursor
+    -
   - The BRLTTY driver is only available when a BRLTTY instance with BrlAPI enabled is running. (#15335)
   - The advanced setting to enable support for HID braille has been removed in favor of a new option.
   You can now disable specific drivers for braille display auto detection in the braille display selection dialog. (#15196)
@@ -64,7 +75,7 @@ What's New in NVDA
   - Fix bug preventing incompatible add-ons which are installed and enabled being upgraded or replaced using the external install tool. (#15417)
   -
 - Fixed support for System List view (``SysListView32``) controls in Windows Forms applications. (#15283)
-- NVDA once again announces calculation results in the Windows 32bit calculator on Server, LTSC and LTSB versions of Windows. (#15284)
+- NVDA once again announces calculation results in the Windows 32bit calculator on Server, LTSC and LTSB versions of Windows. (#15230)
 -
 
 == Changes for Developers ==

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -819,14 +819,14 @@ To toggle single letter navigation on and off for the current document, press NV
 
 In addition to the quick navigation commands listed above, NVDA has commands that have no default keys assigned.
 To use these commands, you first need to assign gestures to them using the [Input Gestures dialog #InputGestures].
-Here is a list of available commands
+Here is a list of available commands:
 - Article
 - Grouping
 - Tab
 -
-Keep in mind that there are two commands for each type of element, for moving forward in the document and backward in the document, and you must assign gestures to both commands in order to be able to quickly navigate in both directions.
 
-For example, if you want to use the ``y`` / ``shift+y`` keys to quickly navigate through tabs, you would do the following
+Keep in mind that there are two commands for each type of element, for moving forward in the document and backward in the document, and you must assign gestures to both commands in order to be able to quickly navigate in both directions.
+For example, if you want to use the ``y`` / ``shift+y`` keys to quickly navigate through tabs, you would do the following:
 
 + Open input gestures dialog from browse mode.
 + Find "moves to the next tab" item in the Browse mode section.
@@ -3901,18 +3901,18 @@ Following are the BRLTTY command assignments for NVDA.
 Please see the [BRLTTY key binding lists https://brltty.app/doc/KeyBindings/] for information about how BRLTTY commands are mapped to controls on braille displays.
 %kc:beginInclude
 || Name | BRLTTY command |
-| Scroll braille display back | fwinlt (go left one window) |
-| Scroll braille display forward | fwinrt (go right one window) |
-| Move braille display to previous line | lnup (go up one line) |
-| Move braille display to next line | lndn (go down one line) |
-| Route to braille cell | route (bring cursor to character) |
-| Toggle input help | learn (enter/leave command learn mode) |
-| Open the NVDA menu | prefmenu (enter/leave preferences menu) |
-| Revert configuration | prefload (restore preferences from disk) |
-| Save configuration | prefsave (save preferences to disk) |
-| Report time | time (show current date and time) |
-| Speak the line where the review cursor is located | say_line (speak current line) |
-| Say all using review cursor | say_below (speak from current line through bottom of screen) |
+| Scroll braille display back | ``fwinlt`` (go left one window) |
+| Scroll braille display forward | ``fwinrt`` (go right one window) |
+| Move braille display to previous line | ``lnup`` (go up one line) |
+| Move braille display to next line | ``lndn`` (go down one line) |
+| Route to braille cell | ``route`` (bring cursor to character) |
+| Toggle input help | ``learn`` (enter/leave command learn mode) |
+| Open the NVDA menu | ``prefmenu`` (enter/leave preferences menu) |
+| Revert configuration | ``prefload`` (restore preferences from disk) |
+| Save configuration | ``prefsave`` (save preferences to disk) |
+| Report time | ``time`` (show current date and time) |
+| Speak the line where the review cursor is located | ``say_line`` (speak current line) |
+| Say all using review cursor | ``say_below`` (speak from current line through bottom of screen) |
 %kc:endInclude
 
 ++ Tivomatic Caiku Albatross 46/80 ++[Albatross]


### PR DESCRIPTION
**Must be a squash merge**

Comparison command:
`git diff release-2023.2...docsFor2023.3 -- "**/en/*.t2t" "**/developerGuide.t2t"`

Common mistakes to check for:
- Issue/PR reference in changes file is incorrect
- Incorrect spelling.
- Lists not terminated with a final `-` on a new line, matching indentation
- List items not indented by a multiple of 2 spaces
- Single grave marks ` instead of double grave marks ``
- Shortcuts added without code markdown, use two 'grave' characters (` ``NVDA+d`` `)
- Double spaces
- Inconsistent use of single vs double quote.