### PR TITLE
Fixes for change log of NVDA 2023.3

### DIFF
--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -18,13 +18,9 @@ There's also been bug fixes for the Add-on Store, Microsoft Office, Microsoft Ed
 
 == New Features ==
 - Enhanced sound management:
-  - NVDA will now output audio via the Windows Audio Session API (WASAPI), which may improve the responsiveness, performance and stability of NVDA speech and sounds. (#14697, #11169, #11615, #5096, #10185, #11061)
-  - WASAPI usage can be disabled in Advanced settings.
-  If WASAPI is enabled, the following Advanced settings can also be configured.
-    - An option to have the volume of NVDA sounds and beeps follow the volume setting of the voice you are using. (#1409)
-    - An option to separately configure the volume of NVDA sounds. (#1409, #15038)
-    -
-  - Note: WASAPI is incompatible with version 1.15 and older of Tony's enhancement add-on. (#15402)
+  - NVDA will now output audio via the Windows Audio Session API (WASAPI) by default, which may improve the responsiveness, performance and stability of NVDA speech and sounds. (#14697, #11169, #11615, #5096, #10185, #11061)
+  - WASAPI usage can still be disabled in Advanced settings.
+  - Note: WASAPI is incompatible with version 1.15 and older of Tony's enhancement add-on. If you have such a version installed, it will be disabled. (#15402)
   -
 - NVDA is now able to continually update the result when performing optical character recognition (OCR), speaking new text as it appears. (#2797)
   - To enable this functionality, enable the option "Periodically refresh recognized content" in the Windows OCR category of NVDA's settings dialog.

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -24,7 +24,7 @@ There's also been bug fixes for the Add-on Store, Microsoft Office, Microsoft Ed
     - An option to have the volume of NVDA sounds and beeps follow the volume setting of the voice you are using. (#1409)
     - An option to separately configure the volume of NVDA sounds. (#1409, #15038)
     -
-  - Note: WASAPI is incompatible with version 1.51 and older of Tony's enhancement add-on. (#15402)
+  - Note: WASAPI is incompatible with version 1.15 and older of Tony's enhancement add-on. (#15402)
   -
 - NVDA is now able to continually update the result when performing optical character recognition (OCR), speaking new text as it appears. (#2797)
   - To enable this functionality, enable the option "Periodically refresh recognized content" in the Windows OCR category of NVDA's settings dialog.


### PR DESCRIPTION

### Link to issue number:
None
### Summary of the issue:
* In the change log, the incompatible version of Tony's Enhancements add-on indicates 1.51 instead of 1.15
* WASAPI changes description is almost what was written for the previous version; some information is not required anymore

### Description of user facing changes
* Fix typo on version for incompatible Tony's Enhancmeents
* Removed the announcement of the two options available with WASAPI (NVDA sounds volume follows voice volume and configure separately sound volume) since it was already present in previous version and nothing has changed on this point. Note that these options are even still in advanced settings (protected with an "I understand" checkbox), thus not easily discoverable; maybe another announcement can be done when these options migrate in an unprotected dedicated panel?
* Indicates that Tony's Enhancements <= 1.15 will be disabled since it is quite an unusual process and thus deserves to be explicit in the change log.



### Description of development approach
N/A
### Testing strategy:
Check the generated file.
### Known issues with pull request:
None
### Change log entries:
None
### Code Review Checklist:

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
