### PR TITLE
Force incompatibility for NVDAExtensionGlobalPlugin versions 12.0.8 or below

### DIFF
--- a/source/addonHandler/addonVersionCheck.py
+++ b/source/addonHandler/addonVersionCheck.py
@@ -1,6 +1,6 @@
 # -*- coding: UTF-8 -*-
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2018-2023 NV Access Limited
+# Copyright (C) 2018-2023 NV Access Limited, Cyrille Bougot
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -19,6 +19,7 @@ if version_year < 2024:
 		from _addonStore.models.addon import _AddonManifestModel, _AddonStoreModel
 		from _addonStore.models.version import MajorMinorPatch
 		forceDisabledAddons = {
+			"NVDAExtensionGlobalPlugin": MajorMinorPatch(12, 0, 8),
 			"tonysEnhancements": MajorMinorPatch(1, 15),
 		}
 		if isinstance(addon, _AddonStoreModel):

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -24,7 +24,12 @@ There's also been bug fixes for the Add-on Store, Microsoft Office, Microsoft Ed
     - An option to have the volume of NVDA sounds and beeps follow the volume setting of the voice you are using. (#1409)
     - An option to separately configure the volume of NVDA sounds. (#1409, #15038)
     -
-  - Note: WASAPI is incompatible with version 1.51 and older of Tony's enhancement add-on. (#15402)
+  - Note: WASAPI is incompatible with some add-ons.
+  Compatible updates are available for these add-ons, please update them before updating NVDA.
+  Incompatible versions of these add-ons will be disabled when updating NVDA:
+    - Tony's Enhancements version 1.15 or older. (#15402)
+    - NVDA global commands extension 12.0.8 or older. (#15443)
+    -
   -
 - NVDA is now able to continually update the result when performing optical character recognition (OCR), speaking new text as it appears. (#2797)
   - To enable this functionality, enable the option "Periodically refresh recognized content" in the Windows OCR category of NVDA's settings dialog.


### PR DESCRIPTION
### Link to issue number:

Follow-up of #15402

See https://github.com/nvaccess/nvda/pull/15402#issuecomment-1713170165

### Summary of the issue:

As with Tony's Enhancements add-on, "NVDA global commands extension" add-on (name = NVDAExtensionGlobalPlugin) version 12.0.8 or below causes speech muted with WASAPI, so with NVDA 2023.3beta1.

This add-on is not in NVDA store but is popular in French community as well as in international community; it is translated in 10 languages.

A fix release (13.0) has already been created by the author @paulber19 on August 20. But we cannot ensure that people will have updated before updating NVDA.

### Description of user facing changes
No problem when running NVDA with NVDAExtensionGlobalPlugin 12.0.8: NVDA is speaking.
### Description of development approach
Added this add-on and its version in the list to force incompatibility.
### Testing strategy:
Before coding the fix:
* Checked the issue: NVDA not speaking with this add-on

After coding the fix:
* Checked that NVDA starts and speaks; the add-on is disabled (incompatible) in the add-on store.

### Known issues with pull request:
This fix should be removed for 2024.1 as it was done with Tony's add-on.
This should be done resolving the merge conflict that will occur when merging beta to master.


### Change log entries:
New features
Changes

Replace:
`Note: WASAPI is incompatible with version 1.51 and older of Tony's enhancement add-on. (#15402)` (or similar)
with:
`Note: WASAPI is incompatible with some add-ons (Tony's Enhancements version 1.15 or older, NVDA global commands extension 12.0.8 or older). If you have such a version installed, it will be disabled. (#15402, #15443)`

### Code Review Checklist:


- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
