### PR TITLE
Fix issue with parsing version string when checking if add-on is force disabled

### DIFF
--- a/source/addonHandler/addonVersionCheck.py
+++ b/source/addonHandler/addonVersionCheck.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 
 import addonAPIVersion
 from buildVersion import version_year
+from logHandler import log
 
 if TYPE_CHECKING:
 	from _addonStore.models.version import SupportsVersionCheck  # noqa: F401
@@ -24,11 +25,18 @@ if version_year < 2024:
 		if isinstance(addon, _AddonStoreModel):
 			addonVersion = addon.addonVersionNumber
 		elif isinstance(addon, AddonHandlerModel):
-			addonVersion = MajorMinorPatch._parseVersionFromVersionStr(addon.version)
+			try:
+				addonVersion = MajorMinorPatch._parseVersionFromVersionStr(addon.version)
+			except ValueError:
+				return False
 		elif isinstance(addon, _AddonManifestModel):
-			addonVersion = MajorMinorPatch._parseVersionFromVersionStr(addon.addonVersionName)
+			try:
+				addonVersion = MajorMinorPatch._parseVersionFromVersionStr(addon.addonVersionName)
+			except ValueError:
+				return False
 		else:
-			raise NotImplementedError(f"Unexpected type for addon: {addon.name}, type: {type(addon)}")
+			log.error(f"Unexpected type for addon: {addon.name}, type: {type(addon)}")
+			return False
 		return (
 			addon.name in forceDisabledAddons
 			and addonVersion <= forceDisabledAddons[addon.name]


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Fixes #15440
Fixup of #15402 

### Summary of the issue:
Some add-ons have version strings which we cannot parse for ordering.
When checking if an add-on should be force disabled, we don't handle the case where the version string cannot be parsed.
If a version string cannot be parsed, we should assume the add-on should not be force disabled, instead of throwing an error

### Description of user facing changes
Add-ons which have unparsable version strings now work again

### Description of development approach
If a version string cannot be parsed, we should assume the add-on should not be force disabled,  instead of throwing an error

### Testing strategy:
Test STR of #15440
### Known issues with pull request:

### Change log entries:
N/A unreleased regression

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
