### PR TITLE
Updated user guide with missing key commands and details to log file and app modules

### DIFF
--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2795,9 +2795,9 @@ When this happens, the previous NVDA session's log file is moved to ``%temp%\nvd
 
 You can also copy a fragment of the current log file to the clipboard without opening the log viewer.
 %kc:beginInclude
-|| Name | Desktop key | Laptop key | Touch | Description |
-| Open log viewer | ``NVDA+f1`` | ``NVDA+f1`` | None | Opens the log viewer and displays developer information about the current navigator object. |
-| Copy a fragment of the log to the clipboard | ``NVDA+control+shift+f1``  | ``NVDA+control+shift+f1`` | None | When this command is pressed once, it sets a starting point for the log content that should be captured. When pressed a second time, it copies the log content since the start point to your clipboard. |
+|| Name | key | Description |
+| Open log viewer | ``NVDA+f1`` | Opens the log viewer and displays developer information about the current navigator object. |
+| Copy a fragment of the log to the clipboard | ``NVDA+control+shift+f1`` | When this command is pressed once, it sets a starting point for the log content that should be captured. When pressed a second time, it copies the log content since the start point to your clipboard. |
 %kc:endInclude
 
 ++ Speech Viewer ++[SpeechViewer]
@@ -2877,11 +2877,10 @@ Specifically, following issues can be solved by running this tool:
 This item, once activated, reloads app modules and global plugins without restarting NVDA, which can be useful for developers.
 
 The following NVDA key commands may also be useful:
-
 %kc:beginInclude
-|| Name | Desktop key | Laptop key | Touch | Description |
-| Reload plugins | ``control+f3`` | ``NVDA+control+f3`` | None | Reloads NVDA's global plugins and app modules. |
-| Report loaded app module and executable | ``NVDA+control+f1`` | ``NVDA+control+f1`` | None | Report the name of the app module, if any, and the name of the executable associated to the active application which has the keyboard focus. |
+|| Name | key | Description |
+| Reload plugins | ``NVDA+control+f3`` | Reloads NVDA's global plugins and app modules. |
+| Report loaded app module and executable | ``NVDA+control+f1`` | Report the name of the app module, if any, and the name of the executable associated to the active application which has the keyboard focus. |
 %kc:endInclude
 
 + Supported Speech Synthesizers +[SupportedSpeechSynths]

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2784,11 +2784,10 @@ You can browse installed incompatible add-ons using the [incompatible add-ons ta
 + Extra Tools +[ExtraTools]
 
 ++ Log Viewer ++[LogViewer]
-The log viewer, found under Tools in the NVDA menu, allows you to view all the logging output that has occurred up until now from when you last started NVDA.
+The log viewer, found under Tools in the NVDA menu, allows you to view all the logging output that has occurred since the last session of NVDA was started.
 
 Apart from reading the content, you can also Save a copy of the log file, or refresh the viewer so that it loads new log output generated after the Log viewer was opened.
-
-These actions are available under the viewer's Log menu.
+These actions are available under the Log viewer's menu.
 
 The file which is displayed when you open the log viewer is saved on your computer at the file location ``%temp%\nvda.log``.
 A new log file is created each time NVDA is started.

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2874,7 +2874,7 @@ Specifically, following issues can be solved by running this tool:
 
 ++ Reload plugins ++[ReloadPlugins]
 This item, once activated, reloads app modules and global plugins without restarting NVDA, which can be useful for developers.
-You can also find out whether the  application that you focus has an associated app module.
+You can also find out whether the application that you focus has an associated app module.
 
 %kc:beginInclude
 || Name | Desktop key | Laptop key | Touch | Description |

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2792,7 +2792,8 @@ These actions are available under the viewer's Log menu.
 The file which is displayed when you open the log viewer is saved on your computer at the file location ``%temp%\nvda.log``.
 
 A new log file is created each time NVDA is started.
-When this happens, the previous NVDA session's log file is moved to ``%temp%/nvda-old.log``.
+When this happens, the previous NVDA session's log file is moved to ``%temp%\nvda-old.log``.
+
 
 You can also copy a fragment of the current log file to the clipboard without opening the log viewer.
 %kc:beginInclude

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2786,7 +2786,8 @@ You can browse installed incompatible add-ons using the [incompatible add-ons ta
 ++ Log Viewer ++[LogViewer]
 The log viewer, found under Tools in the NVDA menu, allows you to view all the logging output that has occurred up until now from when you last started NVDA.
 
-Apart from reading the content, you can also Save a copy of the log file, or refresh the viewer so that it shows the most recent output since the Log viewer was opened.
+Apart from reading the content, you can also Save a copy of the log file, or refresh the viewer so that it loads new log output generated after the Log viewer was opened.
+
 These actions are available under the viewer's Log menu.
 The file which is displayed when you open the log viewer is saved on your computer at the file location ``%temp%/nvda.log``.
 A new log file is created each time NVDA is started.

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2878,7 +2878,7 @@ This item, once activated, reloads app modules and global plugins without restar
 
 The following NVDA key commands may also be useful:
 %kc:beginInclude
-|| Name | key | Description |
+|| Name | Key | Description |
 | Reload plugins | ``NVDA+control+f3`` | Reloads NVDA's global plugins and app modules. |
 | Report loaded app module and executable | ``NVDA+control+f1`` | Report the name of the app module, if any, and the name of the executable associated with the application which has the keyboard focus. |
 %kc:endInclude

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2878,7 +2878,8 @@ You can also find out whether the  application that you focus has an associated 
 
 %kc:beginInclude
 || Name | Desktop key | Laptop key | Touch | Description |
-| Report loaded plugin and executable | ctrl+nvda+f1 | ctrl+nvda+f1 | none | Use this command while you focus an  application To hear the name of the app module integrated in NVDA - if any - and the name of the executable of the currently running application. In case there is no app module integrated in NVDA for the focused application, you will only hear the name of the executable. |
+| Report loaded plugin and executable | ctrl+nvda+f1 | ctrl+nvda+f1 | none | Report the name of the app module associated to the current application, if any, and the name of the executable of the currently running application. |
+
 | Reload plugins | ctrl+nvda+f3 | ctrl+nvda+f3 | none | this command reloads NVDA's global plugins and app modules. |
 %kc:endInclude
 

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2784,7 +2784,7 @@ You can browse installed incompatible add-ons using the [incompatible add-ons ta
 + Extra Tools +[ExtraTools]
 
 ++ Log Viewer ++[LogViewer]
-The log viewer, found under Tools in the NVDA menu, allows you to view all the logging output that has occurred since the last session of NVDA was started.
+The log viewer, found under Tools in the NVDA menu, allows you to view the logging output that has occurred since the last session of NVDA was started.
 
 Apart from reading the content, you can also Save a copy of the log file, or refresh the viewer so that it loads new log output generated after the Log viewer was opened.
 These actions are available under the Log viewer's menu.

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2873,13 +2873,11 @@ Specifically, following issues can be solved by running this tool:
 
 ++ Reload plugins ++[ReloadPlugins]
 This item, once activated, reloads app modules and global plugins without restarting NVDA, which can be useful for developers.
-
 You can also find out whether the  application that you focus has an associated app module.
 
 %kc:beginInclude
 || Name | Desktop key | Laptop key | Touch | Description |
 | Report loaded plugin and executable | ctrl+nvda+f1 | ctrl+nvda+f1 | none | Report the name of the app module associated to the current application, if any, and the name of the executable of the currently running application. |
-
 | Reload plugins | ctrl+nvda+f3 | ctrl+nvda+f3 | none | this command reloads NVDA's global plugins and app modules. |
 %kc:endInclude
 

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2785,20 +2785,18 @@ You can browse installed incompatible add-ons using the [incompatible add-ons ta
 
 ++ Log Viewer ++[LogViewer]
 The log viewer, found under Tools in the NVDA menu, allows you to view all the logging output that has occurred up until now from when you last started NVDA.
-%kc:beginInclude
-Using NVDA+F1 will open the log viewer and display developer information about the current navigator object.
-%kc:endInclude
 
 Apart from reading the content, you can also Save a copy of the log file, or refresh the viewer so that it shows the most recent output since the Log viewer was opened.
 These actions are available under the viewer's Log menu.
 The file which is opened when you press NVDA+f1 is saved on your computer in the temporary folder "%temp%" of your Windows and is called NVDA.log.
 A log file is also saved in case NVDA crashes. The file is called NVDA_old.log and is saved in the same location.
 
-You can also copy some content of the log without opening the log viewer.
+You can also copy some content of the log without opening the log viewer and paste the content from your clipboard anywhere you want.
 %kc:beginInclude
-Press CTRL+NVDA+Shift+F1 to set the starting point for the content that should be copied, do the action that you want to review the log for and press CTRL+NVDA+Shift+F1 again to set the end point and to place  the content between starting point and end point in your clipboard.
+|| Name | Desktop key | Laptop key | Touch | Description |
+| Open log viewer | nvda+f1 | nvda+f1 | none | this will open the log viewer and display developer information about the current navigator object. |
+| Copy a fragment of the log to the clipboard | ctrl+nvda+shift+f1  | ctrl+nvda+shift+f1 | none | This command pressed once, sets the starting point for the content that should be copied. Pressed a second time after you do an action, sets the end point and places the content between starting point and end point in your clipboard. |
 %kc:endInclude
-Now you can paste the content anywhere you want.
 
 ++ Speech Viewer ++[SpeechViewer]
 For sighted software developers or people demoing NVDA to sighted audiences, a floating window is available that allows you to view all the text that NVDA is currently speaking.
@@ -2878,8 +2876,9 @@ This item, once activated, reloads app modules and global plugins without restar
 
 You can also find out whether the  application that you focus has an app module integrated in NVDA or not.
 %kc:beginInclude
-Press ctrl+NVDA+f1 while you focus an  application To hear the name of the app module integrated in NVDA - if any - and the name of the executable of the currently running application.
-In case there is no app module integrated in NVDA for the focused application, you will only hear the name of the executable.
+|| Name | Desktop key | Laptop key | Touch | Description |
+| Report loaded plugin and executable | ctrl+nvda+f1 | ctrl+nvda+f1 | none | Use this command while you focus an  application To hear the name of the app module integrated in NVDA - if any - and the name of the executable of the currently running application. In case there is no app module integrated in NVDA for the focused application, you will only hear the name of the executable. |
+| Reload plugins | ctrl+nvda+f3 | ctrl+nvda+f3 | none | this command reloads NVDA's global plugins and app modules. |
 %kc:endInclude
 
 + Supported Speech Synthesizers +[SupportedSpeechSynths]

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2879,7 +2879,7 @@ The following NVDA key commands may also be useful:
 
 %kc:beginInclude
 || Name | Desktop key | Laptop key | Touch | Description |
-| Report loaded plugin and executable | ``NVDA+control+f1`` | ``NVDA+control+f1`` | None | Report the name of the app module associated to the current application, if any, and the name of the executable of the currently running application. |
+| Report loaded app module and executable | ``NVDA+control+f1`` | ``NVDA+control+f1`` | None | Report the name of the app module, if any, and the name of the executable associated to the active application which has the keyboard focus. |
 | Reload plugins | ``control+f3`` | ``NVDA+control+f3`` | None | Reloads NVDA's global plugins and app modules. |
 %kc:endInclude
 

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2879,8 +2879,8 @@ The following NVDA key commands may also be useful:
 
 %kc:beginInclude
 || Name | Desktop key | Laptop key | Touch | Description |
-| Report loaded app module and executable | ``NVDA+control+f1`` | ``NVDA+control+f1`` | None | Report the name of the app module, if any, and the name of the executable associated to the active application which has the keyboard focus. |
 | Reload plugins | ``control+f3`` | ``NVDA+control+f3`` | None | Reloads NVDA's global plugins and app modules. |
+| Report loaded app module and executable | ``NVDA+control+f1`` | ``NVDA+control+f1`` | None | Report the name of the app module, if any, and the name of the executable associated to the active application which has the keyboard focus. |
 %kc:endInclude
 
 + Supported Speech Synthesizers +[SupportedSpeechSynths]

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2875,6 +2875,8 @@ Specifically, following issues can be solved by running this tool:
 
 ++ Reload plugins ++[ReloadPlugins]
 This item, once activated, reloads app modules and global plugins without restarting NVDA, which can be useful for developers.
+App modules manage how NVDA interacts with specific applications.
+Global plugins manage how NVDA interacts with all applications.
 
 The following NVDA key commands may also be useful:
 %kc:beginInclude

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2787,7 +2787,7 @@ You can browse installed incompatible add-ons using the [incompatible add-ons ta
 The log viewer, found under Tools in the NVDA menu, allows you to view the logging output that has occurred since the latest session of NVDA was started.
 
 Apart from reading the content, you can also Save a copy of the log file, or refresh the viewer so that it loads new log output generated after the Log viewer was opened.
-These actions are available under the Log submenu in the log viewer.
+These actions are available under the Log menu in the log viewer.
 
 The file which is displayed when you open the log viewer is saved on your computer at the file location ``%temp%\nvda.log``.
 A new log file is created each time NVDA is started.

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2789,11 +2789,10 @@ The log viewer, found under Tools in the NVDA menu, allows you to view all the l
 Apart from reading the content, you can also Save a copy of the log file, or refresh the viewer so that it loads new log output generated after the Log viewer was opened.
 
 These actions are available under the viewer's Log menu.
-The file which is displayed when you open the log viewer is saved on your computer at the file location ``%temp%\nvda.log``.
 
+The file which is displayed when you open the log viewer is saved on your computer at the file location ``%temp%\nvda.log``.
 A new log file is created each time NVDA is started.
 When this happens, the previous NVDA session's log file is moved to ``%temp%\nvda-old.log``.
-
 
 You can also copy a fragment of the current log file to the clipboard without opening the log viewer.
 %kc:beginInclude

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2795,7 +2795,7 @@ When this happens, the previous NVDA session's log file is moved to ``%temp%/nvd
 You can also copy a fragment of the current log file to the clipboard without opening the log viewer.
 %kc:beginInclude
 || Name | Desktop key | Laptop key | Touch | Description |
-| Open log viewer | ``NVDA+f1`` | ``NVDA+f1`` | None | This will open the log viewer and display developer information about the current navigator object. |
+| Open log viewer | ``NVDA+f1`` | ``NVDA+f1`` | None | Opens the log viewer and displays developer information about the current navigator object. |
 | Copy a fragment of the log to the clipboard | ``NVDA+control+shift+f1``  | ``NVDA+control+shift+f1`` | None | When this command is pressed once, it sets a starting point for the log content that should be captured. When pressed a second time, it copies the log content since the start point to your clipboard. |
 %kc:endInclude
 

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2785,10 +2785,20 @@ You can browse installed incompatible add-ons using the [incompatible add-ons ta
 
 ++ Log Viewer ++[LogViewer]
 The log viewer, found under Tools in the NVDA menu, allows you to view all the logging output that has occurred up until now from when you last started NVDA.
+%kc:beginInclude
 Using NVDA+F1 will open the log viewer and display developer information about the current navigator object.
+%kc:endInclude
 
 Apart from reading the content, you can also Save a copy of the log file, or refresh the viewer so that it shows the most recent output since the Log viewer was opened.
 These actions are available under the viewer's Log menu.
+The file which is opened when you press NVDA+f1 is saved on your computer in the temporary folder "%temp%" of your Windows and is called NVDA.log.
+A log file is also saved in case NVDA crashes. The file is called NVDA_old.log and is saved in the same location.
+
+You can also copy some content of the log without opening the log viewer.
+%kc:beginInclude
+Press CTRL+NVDA+Shift+F1 to set the starting point for the content that should be copied, do the action that you want to review the log for and press CTRL+NVDA+Shift+F1 again to set the end point and to place  the content between starting point and end point in your clipboard.
+%kc:endInclude
+Now you can paste the content anywhere you want.
 
 ++ Speech Viewer ++[SpeechViewer]
 For sighted software developers or people demoing NVDA to sighted audiences, a floating window is available that allows you to view all the text that NVDA is currently speaking.
@@ -2865,6 +2875,12 @@ Specifically, following issues can be solved by running this tool:
 
 ++ Reload plugins ++[ReloadPlugins]
 This item, once activated, reloads app modules and global plugins without restarting NVDA, which can be useful for developers.
+
+You can also find out whether the  application that you focus has an app module integrated in NVDA or not.
+%kc:beginInclude
+Press ctrl+NVDA+f1 while you focus an  application To hear the name of the app module integrated in NVDA - if any - and the name of the executable of the currently running application.
+In case there is no app module integrated in NVDA for the focused application, you will only hear the name of the executable.
+%kc:endInclude
 
 + Supported Speech Synthesizers +[SupportedSpeechSynths]
 This section contains information about the speech synthesizers supported by NVDA.

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2795,8 +2795,8 @@ When this happens, the previous NVDA session's log file is moved to ``%temp%/nvd
 You can also copy a fragment of the current log file to the clipboard without opening the log viewer.
 %kc:beginInclude
 || Name | Desktop key | Laptop key | Touch | Description |
-| Open log viewer | nvda+f1 | nvda+f1 | none | this will open the log viewer and display developer information about the current navigator object. |
-| Copy a fragment of the log to the clipboard | ctrl+nvda+shift+f1  | ctrl+nvda+shift+f1 | none | This command pressed once, sets the starting point for the content that should be copied. Pressed a second time after you do an action, sets the end point and places the content between starting point and end point in your clipboard. |
+| Open log viewer | ``NVDA+f1`` | ``NVDA+f1`` | None | This will open the log viewer and display developer information about the current navigator object. |
+| Copy a fragment of the log to the clipboard | ``NVDA+control+shift+f1``  | ``NVDA+control+shift+f1`` | None | When this command is pressed once, it sets a starting point for the log content that should be captured. When pressed a second time, it copies the log content since the start point to your clipboard. |
 %kc:endInclude
 
 ++ Speech Viewer ++[SpeechViewer]

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2792,7 +2792,7 @@ The file which is displayed when you open the log viewer is saved on your comput
 A new log file is created each time NVDA is started.
 When this happens, the previous NVDA session's log file is moved to ``%temp%/nvda-old.log``.
 
-You can also copy some content of the current log file without opening the log viewer and paste the content from your clipboard anywhere you want.
+You can also copy a fragment of the current log file to the clipboard without opening the log viewer.
 %kc:beginInclude
 || Name | Desktop key | Laptop key | Touch | Description |
 | Open log viewer | nvda+f1 | nvda+f1 | none | this will open the log viewer and display developer information about the current navigator object. |

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2874,7 +2874,8 @@ Specifically, following issues can be solved by running this tool:
 ++ Reload plugins ++[ReloadPlugins]
 This item, once activated, reloads app modules and global plugins without restarting NVDA, which can be useful for developers.
 
-You can also find out whether the  application that you focus has an app module integrated in NVDA or not.
+You can also find out whether the  application that you focus has an associated app module.
+
 %kc:beginInclude
 || Name | Desktop key | Laptop key | Touch | Description |
 | Report loaded plugin and executable | ctrl+nvda+f1 | ctrl+nvda+f1 | none | Use this command while you focus an  application To hear the name of the app module integrated in NVDA - if any - and the name of the executable of the currently running application. In case there is no app module integrated in NVDA for the focused application, you will only hear the name of the executable. |

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2789,7 +2789,8 @@ The log viewer, found under Tools in the NVDA menu, allows you to view all the l
 Apart from reading the content, you can also Save a copy of the log file, or refresh the viewer so that it loads new log output generated after the Log viewer was opened.
 
 These actions are available under the viewer's Log menu.
-The file which is displayed when you open the log viewer is saved on your computer at the file location ``%temp%/nvda.log``.
+The file which is displayed when you open the log viewer is saved on your computer at the file location ``%temp%\nvda.log``.
+
 A new log file is created each time NVDA is started.
 When this happens, the previous NVDA session's log file is moved to ``%temp%/nvda-old.log``.
 

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2789,7 +2789,8 @@ The log viewer, found under Tools in the NVDA menu, allows you to view all the l
 Apart from reading the content, you can also Save a copy of the log file, or refresh the viewer so that it shows the most recent output since the Log viewer was opened.
 These actions are available under the viewer's Log menu.
 The file which is displayed when you open the log viewer is saved on your computer at the file location ``%temp%/nvda.log``.
-This log file is also saved when a new session of NVDA is started or when NVDA crashes. The file is automatically renamaed to NVDA_old.log and a new NVDA log file is generated when the new NVDA session starts.
+A new log file is created each time NVDA is started.
+When this happens, the previous NVDA session's log file is moved to ``%temp%/nvda-old.log``.
 
 You can also copy some content of the current log file without opening the log viewer and paste the content from your clipboard anywhere you want.
 %kc:beginInclude

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2788,7 +2788,7 @@ The log viewer, found under Tools in the NVDA menu, allows you to view all the l
 
 Apart from reading the content, you can also Save a copy of the log file, or refresh the viewer so that it shows the most recent output since the Log viewer was opened.
 These actions are available under the viewer's Log menu.
-The file which is displayed when you open the log viewer is saved on your computer in the temporary folder "%temp%" of your Windows and is called NVDA.log.
+The file which is displayed when you open the log viewer is saved on your computer at the file location ``%temp%/nvda.log``.
 This log file is also saved when a new session of NVDA is started or when NVDA crashes. The file is automatically renamaed to NVDA_old.log and a new NVDA log file is generated when the new NVDA session starts.
 
 You can also copy some content of the current log file without opening the log viewer and paste the content from your clipboard anywhere you want.

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2795,7 +2795,7 @@ When this happens, the previous NVDA session's log file is moved to ``%temp%\nvd
 
 You can also copy a fragment of the current log file to the clipboard without opening the log viewer.
 %kc:beginInclude
-|| Name | key | Description |
+|| Name | Key | Description |
 | Open log viewer | ``NVDA+f1`` | Opens the log viewer and displays developer information about the current navigator object. |
 | Copy a fragment of the log to the clipboard | ``NVDA+control+shift+f1`` | When this command is pressed once, it sets a starting point for the log content that should be captured. When pressed a second time, it copies the log content since the start point to your clipboard. |
 %kc:endInclude

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2880,7 +2880,7 @@ The following NVDA key commands may also be useful:
 %kc:beginInclude
 || Name | key | Description |
 | Reload plugins | ``NVDA+control+f3`` | Reloads NVDA's global plugins and app modules. |
-| Report loaded app module and executable | ``NVDA+control+f1`` | Report the name of the app module, if any, and the name of the executable associated to the active application which has the keyboard focus. |
+| Report loaded app module and executable | ``NVDA+control+f1`` | Report the name of the app module, if any, and the name of the executable associated with the application which has the keyboard focus. |
 %kc:endInclude
 
 + Supported Speech Synthesizers +[SupportedSpeechSynths]

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2784,7 +2784,7 @@ You can browse installed incompatible add-ons using the [incompatible add-ons ta
 + Extra Tools +[ExtraTools]
 
 ++ Log Viewer ++[LogViewer]
-The log viewer, found under Tools in the NVDA menu, allows you to view the logging output that has occurred since the current session of NVDA was started.
+The log viewer, found under Tools in the NVDA menu, allows you to view the logging output that has occurred since the latest session of NVDA was started.
 
 Apart from reading the content, you can also Save a copy of the log file, or refresh the viewer so that it loads new log output generated after the Log viewer was opened.
 These actions are available under the Log submenu in the log viewer.

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2787,7 +2787,7 @@ You can browse installed incompatible add-ons using the [incompatible add-ons ta
 The log viewer, found under Tools in the NVDA menu, allows you to view the logging output that has occurred since the current session of NVDA was started.
 
 Apart from reading the content, you can also Save a copy of the log file, or refresh the viewer so that it loads new log output generated after the Log viewer was opened.
-These actions are available under the Log viewer's menu.
+These actions are available under the Log submenu in the log viewer.
 
 The file which is displayed when you open the log viewer is saved on your computer at the file location ``%temp%\nvda.log``.
 A new log file is created each time NVDA is started.

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2878,8 +2878,8 @@ You can also find out whether the application that you focus has an associated a
 
 %kc:beginInclude
 || Name | Desktop key | Laptop key | Touch | Description |
-| Report loaded plugin and executable | ctrl+nvda+f1 | ctrl+nvda+f1 | none | Report the name of the app module associated to the current application, if any, and the name of the executable of the currently running application. |
-| Reload plugins | ctrl+nvda+f3 | ctrl+nvda+f3 | none | this command reloads NVDA's global plugins and app modules. |
+| Report loaded plugin and executable | ``NVDA+control+f1`` | ``NVDA+control+f1`` | None | Report the name of the app module associated to the current application, if any, and the name of the executable of the currently running application. |
+| Reload plugins | ``control+f3`` | ``NVDA+control+f3`` | None | Reloads NVDA's global plugins and app modules. |
 %kc:endInclude
 
 + Supported Speech Synthesizers +[SupportedSpeechSynths]

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2784,7 +2784,7 @@ You can browse installed incompatible add-ons using the [incompatible add-ons ta
 + Extra Tools +[ExtraTools]
 
 ++ Log Viewer ++[LogViewer]
-The log viewer, found under Tools in the NVDA menu, allows you to view the logging output that has occurred since the last session of NVDA was started.
+The log viewer, found under Tools in the NVDA menu, allows you to view the logging output that has occurred since the current session of NVDA was started.
 
 Apart from reading the content, you can also Save a copy of the log file, or refresh the viewer so that it loads new log output generated after the Log viewer was opened.
 These actions are available under the Log viewer's menu.

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2788,10 +2788,10 @@ The log viewer, found under Tools in the NVDA menu, allows you to view all the l
 
 Apart from reading the content, you can also Save a copy of the log file, or refresh the viewer so that it shows the most recent output since the Log viewer was opened.
 These actions are available under the viewer's Log menu.
-The file which is opened when you press NVDA+f1 is saved on your computer in the temporary folder "%temp%" of your Windows and is called NVDA.log.
-A log file is also saved in case NVDA crashes. The file is called NVDA_old.log and is saved in the same location.
+The file which is displayed when you open the log viewer is saved on your computer in the temporary folder "%temp%" of your Windows and is called NVDA.log.
+This log file is also saved when a new session of NVDA is started or when NVDA crashes. The file is automatically renamaed to NVDA_old.log and a new NVDA log file is generated when the new NVDA session starts.
 
-You can also copy some content of the log without opening the log viewer and paste the content from your clipboard anywhere you want.
+You can also copy some content of the current log file without opening the log viewer and paste the content from your clipboard anywhere you want.
 %kc:beginInclude
 || Name | Desktop key | Laptop key | Touch | Description |
 | Open log viewer | nvda+f1 | nvda+f1 | none | this will open the log viewer and display developer information about the current navigator object. |

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2874,7 +2874,8 @@ Specifically, following issues can be solved by running this tool:
 
 ++ Reload plugins ++[ReloadPlugins]
 This item, once activated, reloads app modules and global plugins without restarting NVDA, which can be useful for developers.
-You can also find out whether the application that you focus has an associated app module.
+
+The following NVDA key commands may also be useful:
 
 %kc:beginInclude
 || Name | Desktop key | Laptop key | Touch | Description |


### PR DESCRIPTION
### Link to issue number:
fixes #14410 
fixes #1506 
fixes #5261 
### Summary of the issue:
Some commands wore not documented in the user guide although they are useful for users as well.

### Description of user facing changes
Added documentation for ctrl+nvda+f1 and ctrl+nvda+shift+f1 in the coresponding sections.

### Testing strategy:
Checked that key commands reference is updated as well.

### Known issues with pull request:
None

### Change log entries:
Updates to the user guide (#14410, #1506)

