### PR TITLE
Create audio panel for new sound settings

### DIFF
--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -1132,7 +1132,7 @@ class SynthesizerSelectionDialog(SettingsDialog):
 
 		newSynth=self.synthNames[self.synthList.GetSelection()]
 		if not setSynth(newSynth):
-			_synthWarningDialog()
+			_synthWarningDialog(newSynth.name)
 			return
 
 		# Reinitialize the tones module to update the audio device
@@ -2554,7 +2554,7 @@ class DocumentNavigationPanel(SettingsPanel):
 		self.paragraphStyleCombo.saveCurrentValueToConf()
 
 
-def _synthWarningDialog():
+def _synthWarningDialog(newSynth: str):
 	gui.messageBox(
 		# Translators: This message is presented when
 		# NVDA is unable to load the selected synthesizer.
@@ -2563,7 +2563,6 @@ def _synthWarningDialog():
 		# NVDA is unable to load the selected synthesizer.
 		_("Synthesizer Error"),
 		wx.OK | wx.ICON_WARNING,
-		self
 	)
 
 
@@ -2632,7 +2631,7 @@ class AudioPanel(SettingsPanel):
 			config.conf["speech"]["outputDevice"] = self.deviceList.GetStringSelection()
 			currentSynth = getSynth()
 			if not setSynth(currentSynth.name):
-				_synthWarningDialog()
+				_synthWarningDialog(currentSynth.name)
 
 			# Reinitialize the tones module to update the audio device
 			import tones

--- a/tests/checkPot.py
+++ b/tests/checkPot.py
@@ -62,7 +62,6 @@ EXPECTED_MESSAGES_WITHOUT_COMMENTS = {
 	'Use this profile for:',
 	'This change requires administrator privileges.',
 	'Insufficient Privileges',
-	'Synthesizer Error',
 	'word',
 	'Taskbar',
 	'%s items',

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -18,12 +18,9 @@ There's also been bug fixes for the Add-on Store, Microsoft Office, Microsoft Ed
 
 == New Features ==
 - Enhanced sound management:
+  - An option in Audio settings to have the volume of NVDA sounds and beeps follow the volume setting of the voice you are using. (#1409)
+  - An option in Audio settings to separately configure the volume of NVDA sounds. (#1409, #15038)
   - NVDA will now output audio via the Windows Audio Session API (WASAPI), which may improve the responsiveness, performance and stability of NVDA speech and sounds. (#14697, #11169, #11615, #5096, #10185, #11061)
-  - WASAPI usage can be disabled in Advanced settings.
-  If WASAPI is enabled, the following Advanced settings can also be configured.
-    - An option to have the volume of NVDA sounds and beeps follow the volume setting of the voice you are using. (#1409)
-    - An option to separately configure the volume of NVDA sounds. (#1409, #15038)
-    -
   - Note: WASAPI is incompatible with some add-ons.
   Compatible updates are available for these add-ons, please update them before updating NVDA.
   Incompatible versions of these add-ons will be disabled when updating NVDA:

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -6,6 +6,7 @@ What's New in NVDA
 
 = 2023.3 =
 This release includes improvements to performance, responsiveness and stability of audio output.
+Options have been added to control the volume of NVDA sounds and beeps, or to have them follow the volume of the voice you are using.
 
 NVDA can now periodically refresh OCR results, speaking new text as it appears.
 This can be configured in the Windows OCR category of NVDA's settings dialog.

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -1557,19 +1557,6 @@ This may be useful for someone who wishes to only use NVDA with braille, or perh
 ==== Output device ====[SelectSynthesizerOutputDevice]
 This option allows you to choose the audio device that NVDA should instruct the selected synthesizer to speak through.
 
-%kc:setting
-==== Audio Ducking Mode ====[SelectSynthesizerDuckingMode]
-Key: NVDA+shift+d
-
-On Windows 8 and above, this option allows you to choose if NVDA should lower the volume of other applications while NVDA is speaking, or all the time while NVDA is running.
-- No Ducking: NVDA will never lower the volume of other audio.
-- Duck when outputting speech and sounds: NVDA will only lower the volume of other audio when NVDA is speaking or playing sounds. This may not work for all synthesizers.
-- Always duck: NVDA will keep the volume of other audio lower the whole time NVDA is running.
--
-
-This option is only available if NVDA has been installed.
-It is not possible to support audio ducking for portable and temporary copies of NVDA.
-
 +++ Synth settings ring +++[SynthSettingsRing]
 If you wish to quickly change speech settings without going to the Speech category of the NVDA settings dialog, there are some NVDA key commands that allow you to move through the most common speech settings from anywhere while running NVDA:
 %kc:beginInclude
@@ -1785,6 +1772,37 @@ You may consult the documentation for your braille display in the section [Suppo
 Please note: If you connect multiple Braille Displays to your machine at the same time which use the same driver (E.g. connecting two Seika displays),
 it is currently impossible to tell NVDA which display to use.
 Therefore it is recommended to only connect one Braille Display of a given type / manufacturer to your machine at a time.
+
++++ Audio +++[AudioSettings]
+
+%kc:setting
+==== Audio Ducking Mode ====[SelectSynthesizerDuckingMode]
+Key: ``NVDA+shift+d``
+
+On Windows 8 and above, this option allows you to choose if NVDA should lower the volume of other applications while NVDA is speaking, or all the time while NVDA is running.
+- No Ducking: NVDA will never lower the volume of other audio.
+- Duck when outputting speech and sounds: NVDA will only lower the volume of other audio when NVDA is speaking or playing sounds. This may not work for all synthesizers.
+- Always duck: NVDA will keep the volume of other audio lower the whole time NVDA is running.
+-
+
+This option is only available if NVDA has been installed.
+It is not possible to support audio ducking for portable and temporary copies of NVDA.
+
+==== Volume of NVDA sounds follows voice volume ====[SoundVolumeFollowsVoice]
+: Default
+  Disabled
+: Options
+  Disabled, Enabled
+:
+
+When this option is enabled, the volume of NVDA sounds and beeps will follow the volume setting of the voice you are using.
+If you decrease the volume of the voice, the volume of sounds will decrease.
+Similarly, if you increase the volume of the voice, the volume of sounds will increase.
+
+==== Volume of NVDA sounds ====[SoundVolume]
+This slider allows you to set the volume of NVDA sounds and beeps.
+This setting only takes effect when "Volume of NVDA sounds follows voice volume" is disabled.
+
 
 +++ Vision +++[VisionSettings]
 The Vision category in the NVDA Settings dialog allows you to enable, disable and configure [visual aids #Vision].
@@ -2415,22 +2433,10 @@ With several historically popular GUI APIs, the text may be rendered with a tran
 This option enables audio output via the Windows Audio Session API (WASAPI).
 WASAPI is a more modern audio framework which may improve the responsiveness, performance and stability of NVDA audio output, including both speech and sounds.
 After changing this option, you will need to restart NVDA for the change to take effect.
-
-==== Volume of NVDA sounds follows voice volume ====[SoundVolumeFollowsVoice]
-: Default
-  Disabled
-: Options
-  Disabled, Enabled
-:
-
-When this option is enabled, the volume of NVDA sounds and beeps will follow the volume setting of the voice you are using.
-If you decrease the volume of the voice, the volume of sounds will decrease.
-Similarly, if you increase the volume of the voice, the volume of sounds will increase.
-This option only takes effect when "Use WASAPI for audio output" is enabled.
-
-==== Volume of NVDA sounds ====[SoundVolume]
-This slider allows you to set the volume of NVDA sounds and beeps.
-This setting only takes effect when "Use WASAPI for audio output" is enabled and "Volume of NVDA sounds follows voice volume" is disabled.
+Disabling WASAPI will disable the following options:
+- [Volume of NVDA sounds follows voice volume #SoundVolumeFollowsVoice]
+- [Volume of NVDA sounds #SoundVolume]
+-
 
 ==== Debug logging categories ====[AdvancedSettingsDebugLoggingCategories]
 The checkboxes in this list allow you to enable specific categories of debug messages in NVDA's log.

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -1554,9 +1554,6 @@ For a list of the Synthesizers that NVDA supports, please see the [Supported Spe
 One special item that will always appear in this list is "No speech", which allows you to use NVDA with no speech output whatsoever.
 This may be useful for someone who wishes to only use NVDA with braille, or perhaps to sighted developers who only wish to use the Speech Viewer.
 
-==== Output device ====[SelectSynthesizerOutputDevice]
-This option allows you to choose the audio device that NVDA should instruct the selected synthesizer to speak through.
-
 +++ Synth settings ring +++[SynthSettingsRing]
 If you wish to quickly change speech settings without going to the Speech category of the NVDA settings dialog, there are some NVDA key commands that allow you to move through the most common speech settings from anywhere while running NVDA:
 %kc:beginInclude
@@ -1774,6 +1771,10 @@ it is currently impossible to tell NVDA which display to use.
 Therefore it is recommended to only connect one Braille Display of a given type / manufacturer to your machine at a time.
 
 +++ Audio +++[AudioSettings]
+The Audio category in the NVDA Settings dialog contains options that let you change several aspects of audio output.
+
+==== Output device ====[SelectSynthesizerOutputDevice]
+This option allows you to choose the audio device that NVDA should instruct the selected synthesizer to speak through.
 
 %kc:setting
 ==== Audio Ducking Mode ====[SelectSynthesizerDuckingMode]


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Fix #8711

### Summary of the issue:
WASAPI is now enabled by default, so the new features for setting the volume of NVDA sounds should be moved out of the advanced setting panel.

### Description of user facing changes
A new audio settings panel is created for:
- Volume of NVDA sounds
- Volume of NVDA sounds follows voice volume
- Audio ducking was moved to this panel
- Audio output device was moved to this panel

### Description of development approach
Move settings, update user guide

### Testing strategy:
Test change the various settings.
Ensure the settings are toggled as expected when WASAPI is toggled.

### Known issues with pull request:
None

### Change log entries:
Refer to diff

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
