### PR TITLE
Require change log entries to be include in the pull request

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,12 +19,6 @@ See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
 
 ### Known issues with pull request:
 
-### Change log entries:
-New features
-Changes
-Bug fixes
-For Developers
-
 ### Code Review Checklist:
 
 <!--
@@ -38,22 +32,20 @@ A detailed explanation of this checklist is available here:
 https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
 -->
 
-- [ ] Pull Request description:
-  - description is up to date
-  - change log entries
+- [ ] Documentation:
+  - Change log entry
+  - User Documentation
+  - Developer / Technical Documentation
+  - Context sensitive help for GUI changes
 - [ ] Testing:
   - Unit tests
   - System (end to end) tests
   - Manual testing
-- [ ] API is compatible with existing add-ons.
-- [ ] Documentation:
-  - User Documentation
-  - Developer / Technical Documentation
-  - Context sensitive help for GUI changes
 - [ ] UX of all users considered:
   - Speech 
   - Braille
   - Low Vision
   - Different web browsers
   - Localization in other languages / culture than English
+- [ ] API is compatible with existing add-ons.
 - [ ] Security precautions taken.

--- a/projectDocs/dev/contributing.md
+++ b/projectDocs/dev/contributing.md
@@ -35,6 +35,7 @@ If you are new to the project, or looking for some way to help take a look at:
 	- If possible for your PR, please consider creating a set of unit or system tests to test your changes.
 	- The lint check ensures your changes comply with our code style expectations. Use `runlint nvaccess/master` (`runlint.bat`)
 	- Run `scons checkPot` to ensure translatable strings have comments for the translators
+1. [Create a change log entry](#change-log-entry)
 1. [Create a Pull Request (PR)](./githubPullRequestTemplateExplanationAndExamples.md)
 	- When you think a contribution is ready, or you would like feedback, open a draft pull request.
 	When you would like a review, mark the PR as "ready for review".
@@ -54,6 +55,34 @@ If you are new to the project, or looking for some way to help take a look at:
 1. Feedback from alpha users
 	- After a PR is merged, watch for feedback from alpha users / testers.
 	You may have to follow up to address bugs or missed use-cases.
+
+#### Change log entry
+An entry intended to explain changes in NVDA to end users.
+Your proposed entry should be added to the [`changes.t2t` file](../../user_docs/en/changes.t2t) which is converted to HTML.
+Change log entries are not required for changes with no/minor user impact or no developer impact.
+
+Because the `changes.t2t` file is prone to conflicts, NV Access will resolve any merge conflicts with the change log entry before merging.
+
+These descriptions should be in the format: `"{Description of change}. (#{issue number})"`.
+Multiple issue numbers can be included, separated by comma.
+If there is no issue number, you can use the PR number.
+
+For instance:
+```t2t
+New features
+- Added a command to announce useful thing. (#WXYZ, #ABCD)
+
+Changes
+- Old command, now also uses new useful command. (#WXYZ)
+```
+
+You may add descriptions for multiple sections.
+The sections are:
+ 
+* New features
+* Changes
+* Bug fixes
+* Changes for developers
 
 ## Code Style
 Please ensure you follow [our coding standards document](./codingStandards.md).

--- a/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
+++ b/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
@@ -76,41 +76,7 @@ Example:
 
 ### Known issues with pull request:
 Are there any known issues or downsides of this approach.
-For instance: _Will not work with python 3_
-
-### Change log entries:
-An entry intended to explain changes in NVDA to end users.
-Your proposed entry will be added to the `changes.t2t` file which is converted to html and used as a
-what's changed / change log document.
-See 
-[`user_docs/en/changes.t2t`](https://github.com/nvaccess/nvda/blob/master/user_docs/en/changes.t2t)
-
-Because the `changes.t2t` file is prone to conflicts, we ask contributors not to edit the file directly, but instead add the entry to the bottom of the PR description.
-A lead developer will update file when merging the pull request.
-
-For instance:
-```
-*New features*
-`Added a command to announce useful thing. (#WXYZ, #ABCD)`
-
-*Changes*
-`Old command, now also uses new useful command. (#WXYZ)`
-```
-
-These descriptions should be in the format: `"{Description of change}. (#{issue number})"`
-
-You may suggest descriptions for multiple sections.
-The usual sections are:
- 
-* New features
-* Changes
-* Bug fixes
-
-Multiple issue numbers can be included, separated by comma.
-If there is no issue number, you can use the PR number.
-
-For examples see the
-[changes.t2t file](https://github.com/nvaccess/nvda/blob/master/user_docs/en/changes.t2t)
+For instance: _Will not work with UIA enabled in advanced settings_
 
 ## Code Review Checklist
 
@@ -131,16 +97,6 @@ If the reviewer reaches the same conclusion as the author, no further work is ne
 Most items in the checklist have a section in the PR template where you can add your thoughts, doing
 so may preempt questions from the reviewer ensuring you are on the same page, and speed up the
 review process.
-
-### Pull Request description:
-- description is up to date.
-  Authors must keep the PR description up to date.
-  - Even if changes to the approach are described in the comments for the PR.
-  - Future developers need a concise explanation of a change.
-  After each modification, check that the PR description is still accurate.
-- change log entries
-  Has an appropriate change log entry been supplied?
-  As a reviewer, please review it.
 
 ### Testing:
 Discuss under "testing strategy" heading:
@@ -165,6 +121,8 @@ Discuss under "testing strategy" heading:
 - See [Deprecations](./deprecations.md) for more information.
 
 ### Documentation
+- Change log entries
+  [Ensure there is a change log entry if required](./contributing.md#change-log-entry).
 - User Documentation
   Does the user documentation need updating?
 - Context sensitive help for GUI changes.


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Summary of the issue:
Change log entries from contributors are currently requested to be included in the PR description rather than code changes.
This is because entries are prone to merge conflicts, however GitHub allows you to handle these through the web UX.
Alternatively, NV Access can always resolve these via git locally.

Change log entries in the PR description are harder to review, as you cannot make suggestions using GitHub's PR review UX.
This also adds unnecessary work for NV Access, to checkout PRs and copy paste the changes.

### Description of user facing changes
contributors are encouraged to add changes directly to the changes file rather than the PR description
