### PR TITLE
UX fixes for WASAPI GUI and doc

### DIFF
--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -2652,7 +2652,7 @@ class AudioPanel(SettingsPanel):
 
 	def _onSoundVolChange(self, event: wx.Event) -> None:
 		"""Called when the sound volume follow checkbox is checked or unchecked."""
-		wasapi = bool(config.conf["audio"]["WASAPI"])
+		wasapi = nvwave.usingWasapiWavePlayer()
 		self.soundVolFollowCheckBox.Enable(wasapi)
 		self.soundVolSlider.Enable(
 			wasapi

--- a/source/nvwave.py
+++ b/source/nvwave.py
@@ -1070,3 +1070,7 @@ def initialize():
 		func.restype = HRESULT
 		func.errcheck = _wasPlay_errcheck
 	NVDAHelper.localLib.wasPlay_startup()
+
+
+def usingWasapiWavePlayer() -> bool:
+	return issubclass(WavePlayer, WasapiWavePlayer)

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -1799,11 +1799,12 @@ It is not possible to support audio ducking for portable and temporary copies of
 When this option is enabled, the volume of NVDA sounds and beeps will follow the volume setting of the voice you are using.
 If you decrease the volume of the voice, the volume of sounds will decrease.
 Similarly, if you increase the volume of the voice, the volume of sounds will increase.
+This option is not available if you have started NVDA with [WASAPI disabled for audio output #WASAPI] in Advanced Settings.
 
 ==== Volume of NVDA sounds ====[SoundVolume]
 This slider allows you to set the volume of NVDA sounds and beeps.
 This setting only takes effect when "Volume of NVDA sounds follows voice volume" is disabled.
-
+This option is not available if you have started NVDA with [WASAPI disabled for audio output #WASAPI] in Advanced Settings.
 
 +++ Vision +++[VisionSettings]
 The Vision category in the NVDA Settings dialog allows you to enable, disable and configure [visual aids #Vision].


### PR DESCRIPTION
    ### Link to issue number:
Follow-up of #15472.

### Summary of the issue:
If NVDA is started with WASAPI disabled in config and if you enable WASAPI, the new audio options to control NVDA sounds along with voice and volume of NVDA sound are available. That's confusing because modifying them will not have any effect until NVDA is restarted.

### Description of user facing changes
Enabling or disabling audio options linked to WASAPI will be done looking at current state of WASAPI usage rather than looking at the state configured for next restart.

Also added an indication in the User Guide that these options can be unavailable so that the user does not look for them when they are greyed out.

### Description of development approach
Rather than checking the config, check the player currently used to determine if the WASAPI related options need to be disabled or not.

Cc @jcsteh to confirm this check.

### Testing strategy:
* Manual test: disable and reenable WASAPI option in adv settings. Check audio options after having changed WASAPI option and after restart of NVDA.
* Check User Guide generated by appVeyor.
### Known issues with pull request:
None

### Note
No change log needed.
Note: With the new process requiring change log to be integrated in the modifications rather than in the PR's description, we should pay attention to missing change log: has it been forgotten or is its omission intended (small fix, fix of unreleased code, etc.)
### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
