### PR TITLE
Add possibility to cycle through output devices forward and backward

### DIFF
--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -5,7 +5,7 @@
 # Copyright (C) 2006-2024 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Rui Batista, Joseph Lee,
 # Leonard de Ruijter, Derek Riemer, Babbage B.V., Davy Kager, Ethan Holliger, Łukasz Golonka, Accessolutions,
 # Julien Cochuyt, Jakub Lukowicz, Bill Dengler, Cyrille Bougot, Rob Meredith, Luke Davis,
-# Burman's Computer and Education Ltd, Beka Gozalishvili.
+# Burman's Computer and Education Ltd, Beka Gozalishvili
 
 import itertools
 from typing import (
@@ -4449,7 +4449,8 @@ class GlobalCommands(ScriptableObject):
 		"""Cycle through available output devices.
 		@param forward: boolean flag if false cycles in backward direction.
 		"""
-		deviceNames = nvwave.getFriendlyOutputDeviceNames()
+		deviceNames = nvwave.getOutputDeviceNames()
+		friendlyDeviceNames = nvwave.getFriendlyOutputDeviceNames()
 		currentIndex = 0
 		currentOutputDevice = config.conf["speech"]["outputDevice"]
 		if currentOutputDevice in deviceNames:
@@ -4457,11 +4458,12 @@ class GlobalCommands(ScriptableObject):
 		direction = 1 if forward else -1
 		newIndex = (currentIndex + direction) % len(deviceNames)
 		device = deviceNames[newIndex]
+		friendlyDevice = friendlyDeviceNames[newIndex]
 		if not nvwave.setOutputDevice(device):
 			# Translators: Error while switching to an output audio device.
-			ui.message(_("Failed to set {device} as an output audio device").format(device=device))
+			ui.message(_("Failed to set {device} as an output audio device").format(device=friendlyDevice))
 			return
-		ui.message(device)
+		ui.message(friendlyDevice)
 
 	@script(
 		description=_(
@@ -4481,7 +4483,7 @@ class GlobalCommands(ScriptableObject):
 		category=SCRCAT_SPEECH,
 	)
 	def script_switchToPreviousOutputDevice(self, gesture: inputCore.InputGesture) -> None:
-		self._cycleOutputAudioDevices(-False)
+		self._cycleOutputAudioDevices(False)
 
 
 #: The single global commands instance.

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -2661,11 +2661,7 @@ class AudioPanel(SettingsPanel):
 		# Translators: This is the label for the select output device combo in NVDA audio settings.
 		# Examples of an output device are default soundcard, usb headphones, etc.
 		deviceListLabelText = _("Audio output &device:")
-		deviceNames = nvwave.getOutputDeviceNames()
-		# #11349: On Windows 10 20H1 and 20H2, Microsoft Sound Mapper returns an empty string.
-		if deviceNames[0] in ("", "Microsoft Sound Mapper"):
-			# Translators: name for default (Microsoft Sound Mapper) audio output device.
-			deviceNames[0] = _("Microsoft Sound Mapper")
+		deviceNames = nvwave.getFriendlyOutputDeviceNames()
 		self.deviceList = sHelper.addLabeledControl(deviceListLabelText, wx.Choice, choices=deviceNames)
 		self.bindHelpEvent("SelectSynthesizerOutputDevice", self.deviceList)
 		try:
@@ -2712,15 +2708,8 @@ class AudioPanel(SettingsPanel):
 	def onSave(self):
 		if config.conf["speech"]["outputDevice"] != self.deviceList.GetStringSelection():
 			# Synthesizer must be reload if output device changes
-			config.conf["speech"]["outputDevice"] = self.deviceList.GetStringSelection()
-			currentSynth = getSynth()
-			if not setSynth(currentSynth.name):
+			if not nvwave.setOutputDevice(self.deviceList.GetStringSelection()):
 				_synthWarningDialog(currentSynth.name)
-
-			# Reinitialize the tones module to update the audio device
-			import tones
-			tones.terminate()
-			tones.initialize()
 
 		config.conf["audio"]["soundVolumeFollowsVoice"] = self.soundVolFollowCheckBox.IsChecked()
 		config.conf["audio"]["soundVolume"] = self.soundVolSlider.GetValue()

--- a/source/synthDriverHandler.py
+++ b/source/synthDriverHandler.py
@@ -1,17 +1,15 @@
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-# Copyright (C) 2006-2023 NV Access Limited, Peter Vágner, Aleksey Sadovoy,
-# Joseph Lee, Arnold Loubriat, Leonard de Ruijter
+# Copyright (C) 2006-2024 NV Access Limited, Peter Vágner, Aleksey Sadovoy,
+# Joseph Lee, Arnold Loubriat, Leonard de Ruijter, Beka Gozalishvili
 
 import pkgutil
 import importlib
 from typing import (
-	List,
 	Optional,
 	OrderedDict,
 	Set,
-	Tuple,
 )
 from locale import strxfrm
 
@@ -409,10 +407,10 @@ def _getSynthDriver(name) -> SynthDriver:
 	return importlib.import_module("synthDrivers.%s" % name, package="synthDrivers").SynthDriver
 
 
-def getSynthList() -> List[Tuple[str, str]]:
+def getSynthList() -> list[SynthDriver]:
 	from synthDrivers.silence import SynthDriver as SilenceSynthDriver
 
-	synthList: List[Tuple[str, str]] = []
+	synthList: list[SynthDriver] = []
 	# The synth that should be placed at the end of the list.
 	lastSynth = None
 	for loader, name, isPkg in pkgutil.iter_modules(synthDrivers.__path__):
@@ -426,14 +424,14 @@ def getSynthList() -> List[Tuple[str, str]]:
 		try:
 			if synth.check():
 				if synth.name == SilenceSynthDriver.name:
-					lastSynth = (synth.name, synth.description)
+					lastSynth = synth
 				else:
-					synthList.append((synth.name, synth.description))
+					synthList.append(synth)
 			else:
 				log.debugWarning("Synthesizer '%s' doesn't pass the check, excluding from list" % name)
 		except:  # noqa: E722 # Legacy bare except
 			log.error("", exc_info=True)
-	synthList.sort(key=lambda s: strxfrm(s[1]))
+	synthList.sort(key=lambda s: strxfrm(s.description))
 	if lastSynth:
 		synthList.append(lastSynth)
 	return synthList

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -22,7 +22,7 @@ What's New in NVDA
   -
 - Added support for the BrailleEdgeS2 braille device. (#16033)
 - NVDA will play silence after every speech sequence in order to prevent the start of the next speech being clipped with some audio devices such as Bluetooth headphones. (#14386, @jcsteh, @mltony)
-- Added unassigned gestures to quickly cycle through output devices forward and backward. (#8801)
+- Added unassigned gestures to quickly cycle through output devices forward and backward. (#8801, @beqabeqa473)
 -
 
 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -22,6 +22,7 @@ What's New in NVDA
   -
 - Added support for the BrailleEdgeS2 braille device. (#16033)
 - NVDA will play silence after every speech sequence in order to prevent the start of the next speech being clipped with some audio devices such as Bluetooth headphones. (#14386, @jcsteh, @mltony)
+- Added unassigned gestures to quickly cycle through output devices forward and backward. (#8801)
 -
 
 

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -1912,6 +1912,7 @@ The Audio category in the NVDA Settings dialog contains options that let you cha
 
 ==== Output device ====[SelectSynthesizerOutputDevice]
 This option allows you to choose the audio device that NVDA should instruct the selected synthesizer to speak through.
+To switch to the next or previous output device, please assign custom shortcuts from [Input Gestures dialog #InputGestures].
 
 %kc:setting
 ==== Audio Ducking Mode ====[SelectSynthesizerDuckingMode]


### PR DESCRIPTION
### Link to issue number:
Fixes #8801 
### Summary of the issue:
After introducing an additional audio panel and moving output device selection out of synthesizer selection dialog, it became harder to recover from situation where audio device is loosing and speech doesn't output anymore.
It is now possible to quickly switch to the next or previous output devices with shortcuts
### Description of user facing changes
Added two unassigned shortcuts to switch to the next and previous output device.
### Description of development approach
Added two scripts and a helper method to globalCommands.py
moved out setting output device from gui.settingDialogs to a dedicated utils.synth module to eliminate code duplication
### Testing strategy:
Tried to assign shortcuts to scripts listed above and confirmed that they switch output device forward and backward.
### Known issues with pull request:
None found
### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [ ] Security precautions taken.
