### PR TITLE
Disable "Ignore blank lines" checkbox when report indent is off

### DIFF
--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -2363,6 +2363,10 @@ class DocumentFormattingPanel(SettingsPanel):
 		ignoreBlankLinesText = _("Ignore &blank lines for line indentation reporting")
 		ignoreBlankLinesCheckBox = wx.CheckBox(pageAndSpaceBox, label=ignoreBlankLinesText)
 		self.ignoreBlankLinesRLICheckbox = pageAndSpaceGroup.addItem(ignoreBlankLinesCheckBox)
+		self.bindHelpEvent(
+			"DocumentFormattingSettingsLineIndentation",
+			self.ignoreBlankLinesRLICheckbox
+		)
 		self.ignoreBlankLinesRLICheckbox.SetValue(config.conf["documentFormatting"]["ignoreBlankLinesForRLI"])
 		self.ignoreBlankLinesRLICheckbox.Enable(reportLineIndentation != 0)
 

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -2501,7 +2501,7 @@ class DocumentFormattingPanel(SettingsPanel):
 		self.detectFormatAfterCursorCheckBox.SetValue(config.conf["documentFormatting"]["detectFormatAfterCursor"])
 		sHelper.addItem(self.detectFormatAfterCursorCheckBox)
 
-	def onLineIndentationChange(self, evt):
+	def onLineIndentationChange(self, evt: wx.CommandEvent) -> None:
 		self.ignoreBlankLinesRLICheckbox.Enable(evt.GetSelection() != 0)
 
 	def onSave(self):

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -2354,7 +2354,7 @@ class DocumentFormattingPanel(SettingsPanel):
 			"DocumentFormattingSettingsLineIndentation",
 			self.lineIndentationCombo
 		)
-		self.lineIndentationCombo.Bind(wx.EVT_CHOICE, self.onLineIndentationChange)
+		self.lineIndentationCombo.Bind(wx.EVT_CHOICE, self._onLineIndentationChange)
 		reportLineIndentation = config.conf['documentFormatting']['reportLineIndentation']
 		self.lineIndentationCombo.SetSelection(reportLineIndentation)
 
@@ -2501,7 +2501,7 @@ class DocumentFormattingPanel(SettingsPanel):
 		self.detectFormatAfterCursorCheckBox.SetValue(config.conf["documentFormatting"]["detectFormatAfterCursor"])
 		sHelper.addItem(self.detectFormatAfterCursorCheckBox)
 
-	def onLineIndentationChange(self, evt: wx.CommandEvent) -> None:
+	def _onLineIndentationChange(self, evt: wx.CommandEvent) -> None:
 		self.ignoreBlankLinesRLICheckbox.Enable(evt.GetSelection() != 0)
 
 	def onSave(self):

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -2354,7 +2354,9 @@ class DocumentFormattingPanel(SettingsPanel):
 			"DocumentFormattingSettingsLineIndentation",
 			self.lineIndentationCombo
 		)
-		self.lineIndentationCombo.SetSelection(config.conf['documentFormatting']['reportLineIndentation'])
+		self.lineIndentationCombo.Bind(wx.EVT_CHOICE, self.onLineIndentationChange)
+		reportLineIndentation = config.conf['documentFormatting']['reportLineIndentation']
+		self.lineIndentationCombo.SetSelection(reportLineIndentation)
 
 		# Translators: This is the label of a checkbox in the document formatting settings panel
 		# If this option is selected, NVDA will ignore blank lines for line indentation reporting
@@ -2362,6 +2364,7 @@ class DocumentFormattingPanel(SettingsPanel):
 		ignoreBlankLinesCheckBox = wx.CheckBox(pageAndSpaceBox, label=ignoreBlankLinesText)
 		self.ignoreBlankLinesRLICheckbox = pageAndSpaceGroup.addItem(ignoreBlankLinesCheckBox)
 		self.ignoreBlankLinesRLICheckbox.SetValue(config.conf["documentFormatting"]["ignoreBlankLinesForRLI"])
+		self.ignoreBlankLinesRLICheckbox.Enable(reportLineIndentation != 0)
 
 		# Translators: This message is presented in the document formatting settings panel
 		# If this option is selected, NVDA will report paragraph indentation if available.
@@ -2493,6 +2496,9 @@ class DocumentFormattingPanel(SettingsPanel):
 		)
 		self.detectFormatAfterCursorCheckBox.SetValue(config.conf["documentFormatting"]["detectFormatAfterCursor"])
 		sHelper.addItem(self.detectFormatAfterCursorCheckBox)
+
+	def onLineIndentationChange(self, evt):
+		self.ignoreBlankLinesRLICheckbox.Enable(evt.GetSelection() != 0)
 
 	def onSave(self):
 		config.conf["documentFormatting"]["detectFormatAfterCursor"]=self.detectFormatAfterCursorCheckBox.IsChecked()


### PR DESCRIPTION
### Link to issue number:
Follow-up of #15057
### Summary of the issue:
In the GUI, the recent trend is to disable (grey out) the options that are not applicable due to the values of other options.
New option "Ignore blank lines for line indentation reporting" has no sense when report indentation is OFF. Thus it should be greyed out when report indent is off.

This is especially needed to reduce the number of tab presses when navigating in the Doc formatting settings dialog which contains a lot of items.

### Description of user facing changes
Option "Ignore blank lines for lineis greyed out when report indent is off and enabled when other indent reporting types are configured.

While at it, in this PR, I have also changed the context help target for "Ignore blank lines" option. Before it was jumping by default to "Document formatting settings" paragraph; now it jumps to "Line indentation reporting" paragraph, which contains more precise information on this topic.

### Description of development approach
See code.
### Testing strategy:
Manual tests:

1. For each value of indent reporting:
* Check that "Ignore blank lines..." is greyed out or not when opening doc formatting settings
* Check that "Ignore blank lines..." is greyed out or not when changing the indent report mode in the combobox

2. Check with appVeyor build the context help target.

### Known issues with pull request:
* In doc formatting settings, one may think that similar handling should be applied to table related options. But it should not instead. Because when using table nav commands, we can have coordinates reported even if tables are not reported (as a container)
* I have not checked all the settings (and that's not suitable for a PR against beta); but there are other options in settings that may be greyed out depending on the value of another option. If there is a need for it, a new PR will be submitted.

### Change log
Not needed: small change + applies to unreleased feature.

### Code Review Checklist:


- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
