### PR TITLE
Fix SAPI4 prosody regressions

### DIFF
--- a/source/synthDrivers/sapi4.py
+++ b/source/synthDrivers/sapi4.py
@@ -45,7 +45,9 @@ from speech.commands import (
 	PitchCommand,
 	RateCommand,
 	VolumeCommand,
+	BaseProsodyCommand
 )
+from speech.types import SpeechSequence
 
 
 class SynthDriverBufSink(COMObject):
@@ -124,35 +126,43 @@ class SynthDriver(SynthDriver):
 	def terminate(self):
 		self._bufSink._allowDelete = True
 
-	def speak(self,speechSequence):
+	def speak(self, speechSequence: SpeechSequence):
 		textList=[]
 		charMode=False
-		item=None
-		oldPitch = self.pitch
-		oldVolume = self.volume
-		oldRate = self.rate
-
+		unprocessedSequence = speechSequence
+		# #15500: Some SAPI4 voices reset all prosody when they receive any prosody command,
+		# whereas other voices never undo prosody changes when a sequence is interrupted.
+		# Add all default values to the start and end of the sequence,
+		# but avoid duplicating the first command, if any.
+		prosodyToAdd = [
+			c() for c in self.supportedCommands
+			if issubclass(c, BaseProsodyCommand)
+		]
+		speechSequence = [c for c in prosodyToAdd if not isinstance(unprocessedSequence[0], type(c))]
+		speechSequence.extend(unprocessedSequence)
+		# To be sure, add all default values to the end of the sequence.
+		# This might cause multiple cases of prosody resets, but better safe than sorry.
+		speechSequence.extend(prosodyToAdd)
+		lastHandledIndexInSequence = 0
 		for item in speechSequence:
 			if isinstance(item,str):
 				textList.append(item.replace('\\','\\\\'))
 			elif isinstance(item, IndexCommand):
 				textList.append("\\mrk=%d\\"%item.index)
+				lastHandledIndexInSequence = item.index
 			elif isinstance(item, CharacterModeCommand):
 				textList.append("\\RmS=1\\" if item.state else "\\RmS=0\\")
 				charMode=item.state
 			elif isinstance(item, BreakCommand):
 				textList.append(f"\\Pau={item.time}\\")
 			elif isinstance(item, PitchCommand):
-				val = oldPitch + item.offset
-				val = self._percentToParam(val, self._minPitch, self._maxPitch)
+				val = self._percentToParam(item.newValue, self._minPitch, self._maxPitch)
 				textList.append(f"\\Pit={val}\\")
 			elif isinstance(item, RateCommand):
-				val = oldRate + item.offset
-				val = self._percentToParam(val, self._minRate, self._maxRate)
+				val = self._percentToParam(item.newValue, self._minRate, self._maxRate)
 				textList.append(f"\\Spd={val}\\")
 			elif isinstance(item, VolumeCommand):
-				val = oldVolume + item.offset
-				val = self._percentToParam(val, self._minVolume, self._maxVolume)
+				val = self._percentToParam(item.newValue, self._minVolume, self._maxVolume)
 				# If you specify a value greater than 65535, the engine assumes that you want to set the
 				# left and right channels separately and converts the value to a double word,
 				# using the low word for the left channel and the high word for the right channel.
@@ -162,9 +172,9 @@ class SynthDriver(SynthDriver):
 				log.debugWarning("Unsupported speech command: %s"%item)
 			else:
 				log.error("Unknown speech: %s"%item)
-		if isinstance(item, IndexCommand):
-			# This is the index denoting the end of the speech sequence.
-			self._finalIndex=item.index
+		# lastHandledIndexInSequence is the index denoting the end of the speech sequence.
+		# store it on the driver to support the synthDoneSpeaking notification.
+		self._finalIndex = lastHandledIndexInSequence
 		if charMode:
 			# Some synths stay in character mode if we don't explicitly disable it.
 			textList.append("\\RmS=0\\")


### PR DESCRIPTION
CC @cary-rowen 

### Link to issue number:
Fixes #15500 
Follow up of #15271

### Summary of the issue:
Some SAPI4 synthesizers reset all their prosody values to their defaults when they come across prosody in a sequence.

### Description of user facing changes
Capital pitch changes no longer cause some SAPI4 voices to reset their rate and volume.

### Description of development approach
When a sequence contains any prosody command, for the other prosody commands supported by the synth, we add commands to set them to the currently configured value.

### Testing strategy:
Tested str from #15500.
Tested a sequence with a prosody command in the middle of a sequence, ensure that the prosody change is reflected in the speech.

### Known issues with pull request:
None known 
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
