### PR TITLE
Add spelling for double presses of some NVDA commands

### DIFF
--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -255,7 +255,7 @@ class GlobalCommands(ScriptableObject):
 		description=_(
 			# Translators: Input help mode message for report current selection command.
 			"Announces the current selection in edit controls and documents. "
-			"If there is no selection it says so."
+			"Pressing twice spells this information."
 		),
 		category=SCRCAT_SYSTEMCARET,
 		gestures=("kb(desktop):NVDA+shift+upArrow", "kb(laptop):NVDA+shift+s")
@@ -272,7 +272,13 @@ class GlobalCommands(ScriptableObject):
 		if not info or info.isCollapsed:
 			speech.speakMessage(_("No selection"))
 		else:
-			speech.speakTextSelected(info.text)
+			scriptCount = scriptHandler.getLastScriptRepeatCount()
+			if scriptCount == 0:
+				speech.speakTextSelected(info.text)
+			elif len(info.text) < speech.speech.MAX_LENGTH_FOR_SELECTION_REPORTING:
+				speech.speakSpelling(info.text)
+			else:
+				speech.speakTextSelected(info.text)
 
 	@script(
 		# Translators: Input help mode message for report date and time command.
@@ -3374,8 +3380,11 @@ class GlobalCommands(ScriptableObject):
 		ui.message(msg)
 
 	@script(
-		# Translators: Input help mode message for report clipboard text command.
-		description=_("Reports the text on the Windows clipboard"),
+		description=_(
+			# Translators: Input help mode message for report clipboard text command.
+			"Reports the text on the Windows clipboard. "
+			"Pressing twice spells this information."
+		),
 		category=SCRCAT_SYSTEM,
 		gesture="kb:NVDA+c"
 	)
@@ -3389,7 +3398,11 @@ class GlobalCommands(ScriptableObject):
 			ui.message(_("There is no text on the clipboard"))
 			return
 		if len(text) < 1024: 
-			ui.message(text)
+			repeatCount = scriptHandler.getLastScriptRepeatCount()
+			if repeatCount == 0:
+				ui.message(text)
+			elif repeatCount == 1:
+				speech.speakSpelling(text)
 		else:
 			# Translators: If the number of characters on the clipboard is greater than about 1000, it reports this message and gives number of characters on the clipboard.
 			# Example output: The clipboard contains a large portion of text. It is 2300 characters long.

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -255,7 +255,8 @@ class GlobalCommands(ScriptableObject):
 		description=_(
 			# Translators: Input help mode message for report current selection command.
 			"Announces the current selection in edit controls and documents. "
-			"Pressing twice spells this information."
+			"Pressing twice spells this information. "
+			"Pressing three times spells it using character descriptions."
 		),
 		category=SCRCAT_SYSTEMCARET,
 		gestures=("kb(desktop):NVDA+shift+upArrow", "kb(laptop):NVDA+shift+s")
@@ -276,7 +277,7 @@ class GlobalCommands(ScriptableObject):
 			if scriptCount == 0:
 				speech.speakTextSelected(info.text)
 			elif len(info.text) < speech.speech.MAX_LENGTH_FOR_SELECTION_REPORTING:
-				speech.speakSpelling(info.text)
+				speech.speakSpelling(info.text, useCharacterDescriptions=scriptCount > 1)
 			else:
 				speech.speakTextSelected(info.text)
 
@@ -2437,8 +2438,12 @@ class GlobalCommands(ScriptableObject):
 		return
 
 	@script(
-		# Translators: Input help mode message for report current focus command.
-		description=_("Reports the object with focus. If pressed twice, spells the information"),
+		description=_(
+			# Translators: Input help mode message for report current focus command.
+			"Reports the object with focus. "
+			"If pressed twice, spells the information. "
+			"Pressing three times spells it using character descriptions."
+		),
 		category=SCRCAT_FOCUS,
 		gesture="kb:NVDA+tab"
 	)
@@ -2458,10 +2463,11 @@ class GlobalCommands(ScriptableObject):
 			ui.message(gui.blockAction.Context.WINDOWS_LOCKED.translatedMessage)
 			return
 
-		if scriptHandler.getLastScriptRepeatCount() == 0:
+		repeatCount = scriptHandler.getLastScriptRepeatCount()
+		if repeatCount == 0:
 			speech.speakObject(focusObject, reason=controlTypes.OutputReason.QUERY)
 		else:
-			speech.speakSpelling(focusObject.name)
+			speech.speakSpelling(focusObject.name, useCharacterDescriptions=repeatCount > 1)
 
 	@staticmethod
 	def _getStatusBarText(setReviewCursor: bool = False) -> Optional[str]:
@@ -3383,7 +3389,8 @@ class GlobalCommands(ScriptableObject):
 		description=_(
 			# Translators: Input help mode message for report clipboard text command.
 			"Reports the text on the Windows clipboard. "
-			"Pressing twice spells this information."
+			"Pressing twice spells this information. "
+			"Pressing three times spells it using character descriptions."
 		),
 		category=SCRCAT_SYSTEM,
 		gesture="kb:NVDA+c"
@@ -3401,8 +3408,8 @@ class GlobalCommands(ScriptableObject):
 			repeatCount = scriptHandler.getLastScriptRepeatCount()
 			if repeatCount == 0:
 				ui.message(text)
-			elif repeatCount == 1:
-				speech.speakSpelling(text)
+			else:
+				speech.speakSpelling(text, useCharacterDescriptions=repeatCount > 1)
 		else:
 			# Translators: If the number of characters on the clipboard is greater than about 1000, it reports this message and gives number of characters on the clipboard.
 			# Example output: The clipboard contains a large portion of text. It is 2300 characters long.

--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -1016,16 +1016,20 @@ def speakSelectionMessage(
 		speak(seq, symbolLevel=None, priority=priority)
 
 
+MAX_LENGTH_FOR_SELECTION_REPORTING = 512
+
+
 def _getSelectionMessageSpeech(
 		message: str,
 		text: str,
 ) -> SpeechSequence:
-	if len(text) < 512:
+	if len(text) < MAX_LENGTH_FOR_SELECTION_REPORTING:
 		return _getSpeakMessageSpeech(message % text)
 	# Translators: This is spoken when the user has selected a large portion of text.
 	# Example output "1000 characters"
 	numCharactersText = _("%d characters") % len(text)
 	return _getSpeakMessageSpeech(message % numCharactersText)
+
 
 # C901 'speakSelectionChange' is too complex
 # Note: when working on speakSelectionChange, look for opportunities to simplify

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -12,7 +12,8 @@ What's New in NVDA
 
 
 == Changes ==
-- The following commands will now support two and three presses to spell the reported information: report selection, report clipboard text and report focused object. (#15449)
+- The following commands now support two and three presses to spell the reported information and spell with character descriptions: report selection, report clipboard text and report focused object. (#15449)
+-
 
 == Bug Fixes ==
 - Reporting of object shortcut keys has been improved. (#10807)

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -12,7 +12,7 @@ What's New in NVDA
 
 
 == Changes ==
-
+- A second press on the commands to report the clipboard or the selection will now spell the reported information. (#15449)
 
 == Bug Fixes ==
 - Reporting of object shortcut keys has been improved. (#10807)

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -12,7 +12,7 @@ What's New in NVDA
 
 
 == Changes ==
-- A second press on the commands to report the clipboard or the selection will now spell the reported information. (#15449)
+- The following commands will now support two and three presses to spell the reported information: report selection, report clipboard text and report focused object. (#15449)
 
 == Bug Fixes ==
 - Reporting of object shortcut keys has been improved. (#10807)

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -213,8 +213,8 @@ The actual commands will not execute while in input help mode.
 || Name | Desktop key | Laptop key | Description |
 | Say all | ``NVDA+downArrow`` | ``NVDA+a`` | Starts reading from the current position, moving it along as it goes |
 | Read current line | ``NVDA+upArrow`` | ``NVDA+l`` | Reads the line. Pressing twice spells the line. Pressing three times spells the line using character descriptions (Alpha, Bravo, Charlie, etc) |
-| Read selection | ``NVDA+shift+upArrow`` | ``NVDA+shift+s`` | Reads any selected text |
-| Read clipboard text | ``NVDA+c`` | ``NVDA+c`` | Reads any text on the clipboard |
+| Read selection | ``NVDA+shift+upArrow`` | ``NVDA+shift+s`` | Reads any selected text. Pressing twice will spell the information |
+| Read clipboard text | ``NVDA+c`` | ``NVDA+c`` | Reads any text on the clipboard. Pressing twice will spell the information |
 
 +++ Reporting location and other information +++[ReportingLocation]
 || Name | Desktop key | Laptop key | Description |

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -213,13 +213,13 @@ The actual commands will not execute while in input help mode.
 || Name | Desktop key | Laptop key | Description |
 | Say all | ``NVDA+downArrow`` | ``NVDA+a`` | Starts reading from the current position, moving it along as it goes |
 | Read current line | ``NVDA+upArrow`` | ``NVDA+l`` | Reads the line. Pressing twice spells the line. Pressing three times spells the line using character descriptions (Alpha, Bravo, Charlie, etc) |
-| Read selection | ``NVDA+shift+upArrow`` | ``NVDA+shift+s`` | Reads any selected text. Pressing twice will spell the information |
-| Read clipboard text | ``NVDA+c`` | ``NVDA+c`` | Reads any text on the clipboard. Pressing twice will spell the information |
+| Read selection | ``NVDA+shift+upArrow`` | ``NVDA+shift+s`` | Reads any selected text. Pressing twice will spell the information. Pressing three times will spell it using character description |
+| Read clipboard text | ``NVDA+c`` | ``NVDA+c`` | Reads any text on the clipboard. Pressing twice will spell the information. Pressing three times will spell it using character description |
 
 +++ Reporting location and other information +++[ReportingLocation]
 || Name | Desktop key | Laptop key | Description |
 | Window title | ``NVDA+t`` | ``NVDA+t`` | Reports the title of the currently active window. Pressing twice will spell the information. Pressing three times will copy it to the clipboard |
-| Report focus | ``NVDA+tab`` | ``NVDA+tab`` | Reports the current control which has focus.  Pressing twice will spell the information |
+| Report focus | ``NVDA+tab`` | ``NVDA+tab`` | Reports the current control which has focus.  Pressing twice will spell the information. Pressing three times will spell it using character description |
 | Read window | ``NVDA+b`` | ``NVDA+b`` | Reads the entire current window (useful for dialogs) |
 | Read status bar | ``NVDA+end`` | ``NVDA+shift+end`` | Reports the Status Bar if NVDA finds one. Pressing twice will spell the information. Pressing three times will copy it to the clipboard |
 | Read time | ``NVDA+f12`` | ``NVDA+f12`` | Pressing once reports the current time, pressing twice reports the date. The time and date are reported in the format specified in Windows settings for the system tray clock. |


### PR DESCRIPTION
### Link to issue number:
Closes #15449
### Summary of the issue:
Various NVDA commands which report information spells it on second press. This was not the case for the two following commands:
- Report current selection
- Report clipboard text

Moreover, the command to report focus (NVDA+Tab) support spelling the information on second press, but not the triple press version spelling it using character description.

### Description of user facing changes
When pressing two times NVDA+C or NVDA+shift+upArrow, the reported information will be spelt. A third press spells the information using character description. As for other similar scripts, if the selection or the clipboard text contains too many characters, the information is not spelt and the number of characters is reported instead.

Similarly, the command to report focus (NVDA+Tab) has also been extended to support spelling the information using character description on third press.

### Description of development approach
Same logic as other similar scripts.
### Testing strategy:
Manual test:

Tested report selection script with 1, 2 or more presses for:
* Nothing selected
* Few characters selected, e.g. one word
* Many characters selected (more than 2000)

Tested report clipboard script with 1, 2 or more presses and in the following cases:
* The clipboard does not contain text ; file copied from Windows Explorer
* The clipboard contains a text with few characters, e.g. one word
* The clipboard contains a lot of text, e.g. a page of more than 2000 characters.

Tested NVDA+Tab with 1, 2 or 3 presses

### Known issues with pull request:
None
### Code Review Checklist:


- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
