### PR TITLE
Fix up changes entry under incorrect release

### DIFF
--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -16,6 +16,7 @@ What's New in NVDA
 
 == Bug Fixes ==
 - Reporting of object shortcut keys has been improved. (#10807)
+- The SAPI4 synthesizer now properly supports volume, rate and pitch changes embedded in speech. (#15271)
 -
 
 == Changes for Developers ==
@@ -23,6 +24,7 @@ Please refer to [the developer guide https://www.nvaccess.org/files/nvda/documen
 
 - Note: this is an Add-on API compatibility breaking release.
 Add-ons will need to be re-tested and have their manifest updated.
+- Added extension point: ``treeInterceptorHandler.post_browseModeStateChange``. (#14969)
 -
 
 === API Breaking Changes ===
@@ -123,7 +125,6 @@ There's also been bug fixes for the Add-on Store, Microsoft Office, Microsoft Ed
 - Fixed support for System List view (``SysListView32``) controls in Windows Forms applications. (#15283)
 - NVDA once again announces calculation results in the Windows 32bit calculator on Server, LTSC and LTSB versions of Windows. (#15230)
 - NVDA no longer ignores focus changes when a nested window (grand child window) gets focus. (#15432)
-- The SAPI4 synthesizer now properly supports volume, rate and pitch changes embedded in speech. (#15271)
 -
 
 == Changes for Developers ==
@@ -135,7 +136,6 @@ They should also be thread safe, making it possible to call them from background
 - Added official support to register custom braille display drivers in the automatic braille display detection process.
 Consult the ``braille.BrailleDisplayDriver`` class documentation for more details.
 Most notably, the ``supportsAutomaticDetection`` attribute must be set to ``True`` and the ``registerAutomaticDetection`` ``classmethod`` must be implemented.  (#15196)
-- Added extension point: ``treeInterceptorHandler.post_browseModeStateChange``. (#14969)
 -
 
 === Deprecations ===


### PR DESCRIPTION
Fixup of #15271 #15450

Change log entries were mistakenly placed under 2023.3 instead of 2024.1