### PR TITLE
Update and move release process

### DIFF
--- a/projectDocs/community/readme.md
+++ b/projectDocs/community/readme.md
@@ -16,6 +16,7 @@ This includes information on reporting issues, triaging issues, testing, transla
 * [NVDA Developer Guide](https://www.nvaccess.org/files/nvda/documentation/developerGuide.html)
 * [Key Commands](https://www.nvaccess.org/files/nvda/documentation/keyCommands.html)
 * [Changes in the latest release](https://www.nvaccess.org/files/nvda/documentation/changes.html)
+* [Release process](./releaseProcess.md)
 
 ### Add-ons
 * [The NVDA Add-on store](https://www.nvaccess.org/files/nvda/documentation/userGuide.html#AddonsManager)

--- a/projectDocs/community/releaseProcess.md
+++ b/projectDocs/community/releaseProcess.md
@@ -1,35 +1,45 @@
 # Release Process
 
-This document provides rough guidelines for the process of developing NVDA releases. All current and potential developers and translators should read and follow this document. These guidelines may be broken under special circumstances. Any concerns should be discussed via [GitHub Discussion](https://github.com/nvaccess/nvda/discussions).
+This document provides rough guidelines for the process of developing NVDA releases.
+All current and potential developers and translators should read and follow this document.
+These guidelines may be broken under special circumstances.
+Any concerns should be discussed via [GitHub Discussion](https://github.com/nvaccess/nvda/discussions), issue or pull request.
  
 ## Release Workflow
 This is the general release workflow. Information for specific community groups is provided in later sections. The production of a release consists of the following:
-1. Development Phase
-   - Development is done in parallel to the release process for the prior version. E.G. NVDA 2020.2 is in development while NVDA 2020.1 is going through the Release Phase
-1. Release Phase
-   - Final testing, and translations work prior to release.
+1. [Alpha Phase](#alpha-phase) (~7 weeks)
+   - Development is done in parallel to the release process for the prior version.
+   - e.g. NVDA 2020.2 is in alpha while NVDA 2020.1 is going through the Release Phase
+1. [Release Phase](#release-phase) (~7 weeks)
+   - [Beta1](#beta-builds) 1 week after the most recent final release
+   - A new beta is released weekly as required
+   - Once a week passes with a stable beta, the 2 week [translation freeze begins](#translatable-string-freeze)
+   - Once the translation freeze ends, [a release candidate (RC)](#release-candidate) is created
+   - A new RC is released weekly as required
+   - Once a week passes with a stable RC, the final release is created
 
-### Development phase
-* Contributions are made according to the [For Developers](#for-developers) section 
-* Once a pull request has been reviewed and approved by at least one NVDA Collaborator and all build checks have passed, a lead developer will make a final commit to the pull request which updates `changes.t2t`, and then will squash merge the pull request into master.
-* If the merging of a pull request to `master` causes any build checks on `master` to fail, the pull request is reverted without question. This is however unlikely to be an issue as build checks on the pull request itself must have already passed.
+### Alpha phase
+* Contributions are made following the [dev contributing guide](../dev/contributing.md).
+* Once a pull request has been reviewed and approved by at least one NV Access employee and all relevant build checks have passed, NV Access will squash merge the pull request into master.
+* If the merging of a pull request to `master` causes any build checks on `master` to fail, the pull request is reverted without question.
+This is however unlikely to be an issue as build checks on the pull request itself must have already passed.
 * If a merged pull request has been identified as causing a regression, new bug, or does not work as originally reported, the pull request may be reverted at the discretion of the lead developers. Reasons in favor of not reverting the pull request may be: 
   * The pull request was submitted by an active collaborator who is likely to follow up with a suitable pull request to address the issues.
   * The bug is trivial enough to be fixed by a collaborator.
-*  Automatic 'alpha snapshots' are made available to the public for very early testing. See [For Testers](#for-testers)
+* Automatic 'alpha snapshots' are made available to the public for very early testing. See [testing guide](../testing/contributing.md).
 
 ### Release phase
 The release phase is intended to refine the release, with testing from wider audiences, and incorporated translations.
-When no blocking issues are encountered it is expected to take 5 weeks:
-- Beta builds: 2 weeks to receive any required fixes
-  - Subsequent betas may take another week or two at discretion of lead developers
+When no blocking issues are encountered it is expected to take ~6 weeks:
+- Beta builds: ~3 weeks to receive any required fixes
+  - Subsequent betas may take another week at discretion of lead developers
 - 2 weeks for translation freeze (starting 3 weeks before release) 
 - RC: 1 week.
   - When issues are encountered, subsequent RC's may take another week at the discretion of lead developers.
 
 #### Beta builds
 * A commit without any known serious issues, will be selected from the 'master' branch and merged into 'beta', this draws the line for features included in the release.
-  - This commit will have been on `master` and thus, in 'alpha builds' for at least 2 weeks and can now be considered beta quality.
+* Documentation changes will be reviewed. A release summary will be added to the change log for the beta.
 * A tagged 'beta release' will be created for wider testing. 
 * New pull requests may be now considered for squash merging straight to beta.
   - If addressing regression introduced in this release.
@@ -44,12 +54,16 @@ When no blocking issues are encountered it is expected to take 5 weeks:
   - Once a PR is reverted from `beta`, a replacement PR is very unlikely to get into the current release.
 
 ### Translatable String Freeze
-- The beta branch will enter a translatable string freeze.
-- No changes to text strings that affect translations are allowed. Minor spelling or grammatical fixes may be made to documentation files, but `gettext` strings in the code should not be changed at all.
-* Only critical bug fixes and translation updates should be committed to the beta branch at this stage. Otherwise the translation period will need to be extended by an appropriate amount of time.
+- The beta branch will enter a 2 week translatable string freeze.
+- Translators should ensure their translation is up to date a day before the translatable string freeze ends in order for it to be included in the upcoming final release.
+The lead developers will announce the deadline when the freeze begins, if in doubt check the [NVDA-Translations message board](https://groups.io/g/nvda-translations/) for the "language freeze" announcement.
+Work submitted after this time will not be included in the upcoming release.
+- No changes to text strings that affect translations are allowed during the freeze. Minor spelling or grammatical fixes may be made to documentation files, but `gettext` strings in the code should not be changed at all.
+- Only critical bug fixes and translation updates should be committed to the beta branch at this stage.
+In this case the translation period will need to be extended by an appropriate amount of time.
 
 ### Release Candidate
-* After the translatable string freeze, the "rc" branch will be created based on the beta branch.
+* After the translatable string freeze, the `rc` branch will be created based on the beta branch.
 * The first release candidate will immediately be released from the `rc` branch.
 * After this, only critical bug fixes should be committed to the `rc` branch.
 * Subsequent release candidates may be released.
@@ -64,32 +78,7 @@ When no blocking issues are encountered it is expected to take 5 weeks:
 ### Scheduled Releases
 * In the past NVDA has been released 4 times per year. This is not expected to change drastically. The exact date for each release will be determined by the lead developers.
 
-### Maintenance Release
-* Under rare circumstances, a maintenance release (e.g. 2013.1.1) may be made.
-* A maintenance release may only include fixes for crashes and major security issues.
-* Maintenance releases are made from the `rc` branch.
-
-## For Developers
-* GitHub issues should be created for most issues and discussed prior to starting work or submitting a pull request. This is to give lead developers and the community a chance to give feedback on the approach and prevent disappointment or wasted effort for contributors. However, some trivial changes might not require an issue first. See [[Contributing]] for details.
-* Work should be done in topic branches. Including for external contributors.
-  - A PR attempting to merge in the master branch of a contributors fork may not get automatic Pull Request builds.
-* Any relevant documentation should be included in the topic branch.
-* The topic branch should be submitted for inclusion using a pull request.
-* New commands, drivers, settings, dialogs, etc. must be documented in the User Guide as appropriate.
-* All Pull Requests must follow the Pull Request template provided.
-* Pull requests must be based on NVDA's master branch.
-  - A lead developer may specifically requested the pull request be made against `beta` or `rc` in the case of addressing bugs introduced in the current release cycle.
-* Submitted pull requests should not contain edits to `changes.t2t.
-  - Instead, change log entries should be placed in the pull request description, under the appropriate section in the template.
-* All pull requests submitted must have their "Allow edits from maintainers" checkbox ticked. This is the GitHub default for new pull requests.
-
-## For Translators
-* All translation should be based on the `beta` branch.
-* Translators should ensure their translation is up to date a day before the translatable string freeze ends in order for it to be included in the upcoming final release. The lead developers will announce the deadline when the freeze begins, if in doubt check the [NVDA-Translations message board](https://groups.io/g/nvda-translations/) for the "language freeze" announcement. Work submitted after this time will not be included in the upcoming release.
-
-## For Testers
-* Pre-release builds for testing (known as "snapshot builds") can be downloaded from the snapshots page at https://www.nvaccess.org/files/nvda/snapshots/.
-  - It lists 'alpha snapshots', 'beta releases', and 'release candidates'. 
-* The `alpha` builds are bleeding edge. It includes code that is being tested for possible inclusion in upcoming releases, but it may not yet be tested much (if at all) and there may be major bugs. Alpha snapshots are created directly from the `master` branch each time it changes (I.E. when a pull request is merged). Although the automated tests pass, these builds have likely had no user testing.
-* 'beta releases' are 'beta' quality. They include all features for the upcoming release that have proved stable in the alpha builds. A feature is considered stable if it has been in 'alpha builds' for at least a week.
-* 'rc releases' in most cases will be identical to the final release.
+### Patch Release
+* Under rare circumstances, a patch release (e.g. 2013.1.1) may be made.
+* A patch release may only include fixes for crashes and major security issues.
+* Patch releases are made from the `rc` branch.

--- a/projectDocs/community/releaseProcess.md
+++ b/projectDocs/community/releaseProcess.md
@@ -13,10 +13,10 @@ This is the general release workflow. Information for specific community groups 
 1. [Release Phase](#release-phase) (~7 weeks)
    - [Beta1](#beta-builds) 1 week after the most recent final release
    - A new beta is released weekly as required
-   - Once a week passes with a stable beta, the 2 week [translation freeze begins](#translatable-string-freeze)
+   - Once a beta has been stable for one week (no issues reported), the 2 week [translation freeze begins](#translatable-string-freeze)
    - Once the translation freeze ends, [a release candidate (RC)](#release-candidate) is created
    - A new RC is released weekly as required
-   - Once a week passes with a stable RC, the final release is created
+   - when an RC has been stable for one week (no issues reported), the final release is created
 
 ### Alpha phase
 * Contributions are made following the [dev contributing guide](../dev/contributing.md).
@@ -45,7 +45,7 @@ When no blocking issues are encountered it is expected to take ~6 weeks:
   - If addressing regression introduced in this release.
   - If addressing a bug in a "must have" feature for this release.
   - If addressing a critical Operating System change out of our control.
-* As appropriate new tagged beta releases will be published. 
+* As appropriate new tagged beta releases will be published once a week.
 * As necessary `beta` will be merged back into master.
   - For critical pull requests or translation merges.
 * If a merged pull request that reached beta has been identified as causing a regression, new bug, or does not work as originally reported:

--- a/projectDocs/community/releaseProcess.md
+++ b/projectDocs/community/releaseProcess.md
@@ -1,0 +1,95 @@
+# Release Process
+
+This document provides rough guidelines for the process of developing NVDA releases. All current and potential developers and translators should read and follow this document. These guidelines may be broken under special circumstances. Any concerns should be discussed via [GitHub Discussion](https://github.com/nvaccess/nvda/discussions).
+ 
+## Release Workflow
+This is the general release workflow. Information for specific community groups is provided in later sections. The production of a release consists of the following:
+1. Development Phase
+   - Development is done in parallel to the release process for the prior version. E.G. NVDA 2020.2 is in development while NVDA 2020.1 is going through the Release Phase
+1. Release Phase
+   - Final testing, and translations work prior to release.
+
+### Development phase
+* Contributions are made according to the [For Developers](#for-developers) section 
+* Once a pull request has been reviewed and approved by at least one NVDA Collaborator and all build checks have passed, a lead developer will make a final commit to the pull request which updates `changes.t2t`, and then will squash merge the pull request into master.
+* If the merging of a pull request to `master` causes any build checks on `master` to fail, the pull request is reverted without question. This is however unlikely to be an issue as build checks on the pull request itself must have already passed.
+* If a merged pull request has been identified as causing a regression, new bug, or does not work as originally reported, the pull request may be reverted at the discretion of the lead developers. Reasons in favor of not reverting the pull request may be: 
+  * The pull request was submitted by an active collaborator who is likely to follow up with a suitable pull request to address the issues.
+  * The bug is trivial enough to be fixed by a collaborator.
+*  Automatic 'alpha snapshots' are made available to the public for very early testing. See [For Testers](#for-testers)
+
+### Release phase
+The release phase is intended to refine the release, with testing from wider audiences, and incorporated translations.
+When no blocking issues are encountered it is expected to take 5 weeks:
+- Beta builds: 2 weeks to receive any required fixes
+  - Subsequent betas may take another week or two at discretion of lead developers
+- 2 weeks for translation freeze (starting 3 weeks before release) 
+- RC: 1 week.
+  - When issues are encountered, subsequent RC's may take another week at the discretion of lead developers.
+
+#### Beta builds
+* A commit without any known serious issues, will be selected from the 'master' branch and merged into 'beta', this draws the line for features included in the release.
+  - This commit will have been on `master` and thus, in 'alpha builds' for at least 2 weeks and can now be considered beta quality.
+* A tagged 'beta release' will be created for wider testing. 
+* New pull requests may be now considered for squash merging straight to beta.
+  - If addressing regression introduced in this release.
+  - If addressing a bug in a "must have" feature for this release.
+  - If addressing a critical Operating System change out of our control.
+* As appropriate new tagged beta releases will be published. 
+* As necessary `beta` will be merged back into master.
+  - For critical pull requests or translation merges.
+* If a merged pull request that reached beta has been identified as causing a regression, new bug, or does not work as originally reported:
+  - The pull request may be reverted at the discretion of the lead developers.
+  - It may be fixed by a collaborator if the bug is trivial enough.
+  - Once a PR is reverted from `beta`, a replacement PR is very unlikely to get into the current release.
+
+### Translatable String Freeze
+- The beta branch will enter a translatable string freeze.
+- No changes to text strings that affect translations are allowed. Minor spelling or grammatical fixes may be made to documentation files, but `gettext` strings in the code should not be changed at all.
+* Only critical bug fixes and translation updates should be committed to the beta branch at this stage. Otherwise the translation period will need to be extended by an appropriate amount of time.
+
+### Release Candidate
+* After the translatable string freeze, the "rc" branch will be created based on the beta branch.
+* The first release candidate will immediately be released from the `rc` branch.
+* After this, only critical bug fixes should be committed to the `rc` branch.
+* Subsequent release candidates may be released.
+* The final release can only be made if there have been no significant changes and at least 1 week since the last release candidate.
+
+### Representation on GitHub
+* For most items, an issue will be filed and discussed before a pull request is submitted.
+* If priority should be given to an issue for inclusion in a specific release, its milestone should be set to the appropriate release milestone (e.g. 2014.4).
+* Once a pull request is squash merged to the master branch, the milestone for the issue (if any) and pull request should be set to the next release milestone (e.g. 2013.2) and it should be closed as fixed.
+* Issues/pull requests for bug fixes for an rc should have their milestone set to the relevant release (e.g. 2013.2).
+
+### Scheduled Releases
+* In the past NVDA has been released 4 times per year. This is not expected to change drastically. The exact date for each release will be determined by the lead developers.
+
+### Maintenance Release
+* Under rare circumstances, a maintenance release (e.g. 2013.1.1) may be made.
+* A maintenance release may only include fixes for crashes and major security issues.
+* Maintenance releases are made from the `rc` branch.
+
+## For Developers
+* GitHub issues should be created for most issues and discussed prior to starting work or submitting a pull request. This is to give lead developers and the community a chance to give feedback on the approach and prevent disappointment or wasted effort for contributors. However, some trivial changes might not require an issue first. See [[Contributing]] for details.
+* Work should be done in topic branches. Including for external contributors.
+  - A PR attempting to merge in the master branch of a contributors fork may not get automatic Pull Request builds.
+* Any relevant documentation should be included in the topic branch.
+* The topic branch should be submitted for inclusion using a pull request.
+* New commands, drivers, settings, dialogs, etc. must be documented in the User Guide as appropriate.
+* All Pull Requests must follow the Pull Request template provided.
+* Pull requests must be based on NVDA's master branch.
+  - A lead developer may specifically requested the pull request be made against `beta` or `rc` in the case of addressing bugs introduced in the current release cycle.
+* Submitted pull requests should not contain edits to `changes.t2t.
+  - Instead, change log entries should be placed in the pull request description, under the appropriate section in the template.
+* All pull requests submitted must have their "Allow edits from maintainers" checkbox ticked. This is the GitHub default for new pull requests.
+
+## For Translators
+* All translation should be based on the `beta` branch.
+* Translators should ensure their translation is up to date a day before the translatable string freeze ends in order for it to be included in the upcoming final release. The lead developers will announce the deadline when the freeze begins, if in doubt check the [NVDA-Translations message board](https://groups.io/g/nvda-translations/) for the "language freeze" announcement. Work submitted after this time will not be included in the upcoming release.
+
+## For Testers
+* Pre-release builds for testing (known as "snapshot builds") can be downloaded from the snapshots page at https://www.nvaccess.org/files/nvda/snapshots/.
+  - It lists 'alpha snapshots', 'beta releases', and 'release candidates'. 
+* The `alpha` builds are bleeding edge. It includes code that is being tested for possible inclusion in upcoming releases, but it may not yet be tested much (if at all) and there may be major bugs. Alpha snapshots are created directly from the `master` branch each time it changes (I.E. when a pull request is merged). Although the automated tests pass, these builds have likely had no user testing.
+* 'beta releases' are 'beta' quality. They include all features for the upcoming release that have proved stable in the alpha builds. A feature is considered stable if it has been in 'alpha builds' for at least a week.
+* 'rc releases' in most cases will be identical to the final release.

--- a/projectDocs/dev/contributing.md
+++ b/projectDocs/dev/contributing.md
@@ -48,7 +48,7 @@ If you are new to the project, or looking for some way to help take a look at:
 	If you believe the failure is unrelated, feel free to ignore it unless it is raised by a reviewer.
 	- All pull requests submitted must have their "Allow edits from maintainers" checkbox ticked.
 	This is the GitHub default for new pull requests.
-	- A lead developer may specifically requested the pull request be made against `beta` or `rc` in the case of addressing bugs introduced in the current release cycle.
+	- A lead developer may specifically request the pull request be made against `beta` or `rc` in the case of addressing bugs introduced in the current release cycle.
 1. Participate in the code review process
 	- This process requires core NVDA developers to understand the intent of the change, read the code changes, asking questions or suggesting changes.
 	Please participate in this process, answering questions, and discussing the changes.

--- a/projectDocs/dev/contributing.md
+++ b/projectDocs/dev/contributing.md
@@ -24,10 +24,11 @@ If you are new to the project, or looking for some way to help take a look at:
 ### Overview of contribution process:
 1. [Setup your development environment](./createDevEnvironment.md).
 1. Ensure the issue you plan to fix is [triaged](../issues/triage.md)
-1. Create a branch for the contribution.
+1. Create a branch for the contribution, to be used for a pull request.
 	- Pull requests should be based on the latest commit in the official master branch.
 	This helps reduce the chance of merge conflicts.
-	- If you are adding a feature or changing something that will be noticeable to the user, you should update the User Guide accordingly.
+	- If you are adding a feature or changing something that will be noticeable to the user, you should update the [User Guide accordingly](./userGuideStandards.md).
+	New commands, drivers, settings, dialogs, etc. must be documented.
 1. [Build NVDA](./buildingNVDA.md) and run from source
 1. [Manually test the change](../testing/readme.md)
 1. [Run automated tests](../testing/automated.md)
@@ -45,6 +46,9 @@ If you are new to the project, or looking for some way to help take a look at:
 	If these fail, please review them.
 	Sometimes system tests fail unexpectedly.
 	If you believe the failure is unrelated, feel free to ignore it unless it is raised by a reviewer.
+	- All pull requests submitted must have their "Allow edits from maintainers" checkbox ticked.
+	This is the GitHub default for new pull requests.
+	- A lead developer may specifically requested the pull request be made against `beta` or `rc` in the case of addressing bugs introduced in the current release cycle.
 1. Participate in the code review process
 	- This process requires core NVDA developers to understand the intent of the change, read the code changes, asking questions or suggesting changes.
 	Please participate in this process, answering questions, and discussing the changes.

--- a/projectDocs/dev/readme.md
+++ b/projectDocs/dev/readme.md
@@ -11,6 +11,7 @@ This includes information on reporting issues, triaging issues, testing, transla
 * [NVDA Developer Guide](https://www.nvaccess.org/files/nvda/documentation/developerGuide.html)
 * [Technical design overview](../design/technicalDesignOverview.md)
 * [NVDA ControllerClient manual (NVDA API for external applications to directly speak or braille messages, etc.)](https://github.com/nvaccess/nvda/tree/master/extras/controllerClient)
+* [Release process](../community/releaseProcess.md)
 
 ### Communication channels
 #### NV Access

--- a/projectDocs/testing/contributing.md
+++ b/projectDocs/testing/contributing.md
@@ -1,9 +1,19 @@
+# Testing
+
+## Builds
+
+Testing alpha / beta / and release candidates (RC) help to ensure the quality of the NVDA project.
+You can find the latest builds [here](https://www.nvaccess.org/files/nvda/snapshots/).
+
+* The alpha builds are bleeding edge.
+It includes code that is being tested for possible inclusion in upcoming releases, but it may not yet be tested much (if at all) and there may be major bugs.
+Alpha snapshots are created directly from the `master` branch each time it changes (i.e. when a pull request is merged).
+Although the automated tests pass, these builds have likely had no user testing.
+* 'beta releases' are 'beta' quality. They include all features for the upcoming release that have proved stable in the alpha builds.
+* 'RC releases' in most cases will be identical to the final release.
+The latest final release will be identical to the final RC release of the release cycle.
 
 ## Manual testing
-
-Testing alpha / beta / and release candidates help to ensure the quality of the NVDA project.
-You can find the latest alpha snapshots [here](https://www.nvaccess.org/files/nvda/snapshots/).
-
 User / community testing is particularly important for languages other than English.
 
 NVDA includes [manual test plans](../../tests/manual/README.md) to guide testers in smoke testing features of NVDA.

--- a/projectDocs/testing/readme.md
+++ b/projectDocs/testing/readme.md
@@ -10,6 +10,7 @@
 * [Changes in the latest release](https://www.nvaccess.org/files/nvda/documentation/changes.html)
 * [Manual test plans](../../tests/manual/README.md)
 * [Automated tests for developers](./automated.md)
+* [Release process](../community/releaseProcess.md)
 
 ### Community communication channels
 * [NVDA Users Mailing List](https://nvda.groups.io/g/nvda)


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->


### Summary of the issue:
NV Access is intending to move most of the wiki into the repository, so changes are tracked better and easier to propose.
The release process wiki page is a prime candidate for migration.
The release process wiki is out of date, it also contains some information that is better suited to or duplicated in other documents.

### Description of user facing changes
[The release process wiki page](https://github.com/nvaccess/nvda/wiki/ReleaseProcess) is migrated to the repository.

The process is updated to include more information on the timing of the stages.
Information for testers, and developers are moved to the appropriate contributing docs.


- [x] On merge: update wiki page, index and sidebar to forward to project docs