### PR TITLE
Fixup of #13542: Do not call IA2 install and uninstall code from NVDA itself

### DIFF
--- a/nvdaHelper/remote/nvdaHelperRemote.def
+++ b/nvdaHelper/remote/nvdaHelperRemote.def
@@ -2,8 +2,6 @@ EXPORTS
 	injection_initialize
 	injection_terminate
 	initInprocManagerThreadIfNeeded
-	installIA2Support
-	uninstallIA2Support
 	registerWinEventHook
 	unregisterWinEventHook
 	registerWindowsHook

--- a/source/NVDAHelper.py
+++ b/source/NVDAHelper.py
@@ -597,8 +597,6 @@ def initialize() -> None:
 	_remoteLib=CDLL("nvdaHelperRemote",handle=h)
 	if _remoteLib.injection_initialize() == 0:
 		raise RuntimeError("Error initializing NVDAHelperRemote")
-	if not _remoteLib.installIA2Support():
-		log.error("Error installing IA2 support")
 	#Manually start the in-process manager thread for this NVDA main thread now, as a slow system can cause this action to confuse WX
 	_remoteLib.initInprocManagerThreadIfNeeded()
 	versionedLibARM64Path
@@ -617,8 +615,6 @@ def terminate():
 	global _remoteLib, _remoteLoaderAMD64, _remoteLoaderARM64
 	global localLib, generateBeep, VBuf_getTextInRange
 	if not config.isAppX:
-		if not _remoteLib.uninstallIA2Support():
-			log.debugWarning("Error uninstalling IA2 support")
 		if _remoteLib.injection_terminate() == 0:
 			raise RuntimeError("Error terminating NVDAHelperRemote")
 		_remoteLib=None

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -87,7 +87,7 @@ There's also been bug fixes for the Add-on Store, Microsoft Office, Microsoft Ed
 - Fixed support for System List view (``SysListView32``) controls in Windows Forms applications. (#15283)
 - NVDA once again announces calculation results in the Windows 32bit calculator on Server, LTSC and LTSB versions of Windows. (#15230)
 - NVDA no longer ignores focus changes when a nested window (grand child window) gets focus. (#15432)
-- Fixed a potential cause of crashing during NVDA startup. (15517)
+- Fixed a potential cause of crashing during NVDA startup. (#15517)
 -
 
 == Changes for Developers ==

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -87,6 +87,7 @@ There's also been bug fixes for the Add-on Store, Microsoft Office, Microsoft Ed
 - Fixed support for System List view (``SysListView32``) controls in Windows Forms applications. (#15283)
 - NVDA once again announces calculation results in the Windows 32bit calculator on Server, LTSC and LTSB versions of Windows. (#15230)
 - NVDA no longer ignores focus changes when a nested window (grand child window) gets focus. (#15432)
+- Fixed a potential cause of crashing during NVDA startup. (15517)
 -
 
 == Changes for Developers ==


### PR DESCRIPTION
This was reported by @codeofdusk as part of his work for the Py 3.11 upgrade.

### Link to issue number:
Fixup of #13542

### Summary of the issue:
In #13542, we introduced support for multi thread IA2 initialization. As part of that, the signature of the install- and uninstallIA2Support functions were changed. Somehow, it was an oversight from my end that these functions were also called from NVDAHelper.py. This causes:

1. NVDA to always log a debug warning on exit, saying that it was unable to unregister IA2 support.
2. NVDA to call installIA2Initialize without a thread Id. It is actually a miracle that the segfault we're now seeing in preliminary PY3.11 work didn't hurt us earlyer. That said, I think I've seen cases were NVDA played the startup sound and then silently crashed. I think this should be the case.

As per point 2, given the risk of NVDA calling a code path that results in undefined behavior and possible segfaults, I strongly recommend to merge this into beta.

### Description of user facing changes
No crashes during NVDA startup.

### Description of development approach
Removed the calls from NVDAHelper.py and no longer export the functions from NVDAHelper. The calls in NVDA core were actually obsolete, as IA2 support is registered by injection_initialize and injection_terminate. Note that the install and uninstall IA2 functions aren't called in de 64 bit loader of NVDAHelper, yet IA2 works as expected in X64 applications. Also, installIA2Support is no longer C friendly anyway. Note that an add-on author should never call these functions, therefore I don't consider this as an API breaking change.

### Testing strategy:
- [x] Tested that IA2 still works in X64 applications
- [x] - [ ] Tested that IA2 still works in X86 applications

### Known issues with pull request:
None known

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
