### PR TITLE
Minor fixes in preparation for python 3.11

### DIFF
--- a/source/NVDAHelper.py
+++ b/source/NVDAHelper.py
@@ -599,7 +599,6 @@ def initialize() -> None:
 		raise RuntimeError("Error initializing NVDAHelperRemote")
 	#Manually start the in-process manager thread for this NVDA main thread now, as a slow system can cause this action to confuse WX
 	_remoteLib.initInprocManagerThreadIfNeeded()
-	versionedLibARM64Path
 	arch = winVersion.getWinVer().processorArchitecture
 	if arch == 'AMD64':
 		_remoteLoaderAMD64 = _RemoteLoader(versionedLibAMD64Path)

--- a/source/_addonStore/dataManager.py
+++ b/source/_addonStore/dataManager.py
@@ -186,7 +186,7 @@ class _DataManager:
 
 	def getLatestCompatibleAddons(
 			self,
-			onDisplayableError: Optional[DisplayableError.OnDisplayableErrorT] = None,
+			onDisplayableError: Optional["DisplayableError.OnDisplayableErrorT"] = None,
 	) -> "AddonGUICollectionT":
 		cacheHash = self._getCacheHash()
 		shouldRefreshData = (
@@ -225,7 +225,7 @@ class _DataManager:
 
 	def getLatestAddons(
 			self,
-			onDisplayableError: Optional[DisplayableError.OnDisplayableErrorT] = None,
+			onDisplayableError: Optional["DisplayableError.OnDisplayableErrorT"] = None,
 	) -> "AddonGUICollectionT":
 		cacheHash = self._getCacheHash()
 		shouldRefreshData = (

--- a/source/_addonStore/models/addon.py
+++ b/source/_addonStore/models/addon.py
@@ -182,7 +182,7 @@ class _AddonManifestModel(_AddonGUIModel):
 	homepage: Optional[str]
 	minNVDAVersion: MajorMinorPatch
 	lastTestedVersion: MajorMinorPatch
-	manifest: AddonManifest
+	manifest: "AddonManifest"
 	legacy: bool = False
 	"""
 	Legacy add-ons contain invalid metadata
@@ -216,7 +216,7 @@ class AddonManifestModel(_AddonManifestModel):
 	homepage: Optional[str]
 	minNVDAVersion: MajorMinorPatch
 	lastTestedVersion: MajorMinorPatch
-	manifest: AddonManifest
+	manifest: "AddonManifest"
 	legacy: bool = False
 	"""
 	Legacy add-ons contain invalid metadata

--- a/source/garbageHandler.py
+++ b/source/garbageHandler.py
@@ -44,7 +44,7 @@ def initialize():
 def _collectionCallback(action, info):
 	global _collectionThreadID, _reportCountDuringCollection
 	if action == "start":
-		_collectionThreadID = threading.currentThread().ident
+		_collectionThreadID = threading.current_thread().ident
 		_reportCountDuringCollection = 0
 	elif action == "stop":
 		_collectionThreadID = 0
@@ -60,7 +60,7 @@ def notifyObjectDeletion(obj):
 	if it is due to Python's cyclic garbage collector.
 	"""
 	global _reportCountDuringCollection
-	if _collectionThreadID != threading.currentThread().ident:
+	if _collectionThreadID != threading.current_thread().ident:
 		return
 	_reportCountDuringCollection += 1
 	if _reportCountDuringCollection == 1:

--- a/source/globalVars.py
+++ b/source/globalVars.py
@@ -131,6 +131,11 @@ appPid: int = 0
 """The process ID of NVDA itself.
 """
 
+appDir: str
+"""
+The directory where NVDA is installed or running from.
+Set by nvda_slave.pyw and nvda.pyw.
+"""
 
 # TODO: encapsulate in synthDriverHandler
 settingsRing = None

--- a/source/gui/_addonStoreGui/controls/addonList.py
+++ b/source/gui/_addonStoreGui/controls/addonList.py
@@ -64,8 +64,8 @@ class AddonVirtualList(
 
 	def _refreshColumns(self):
 		self.ClearAll()
-		for colIndex, col in enumerate(self._addonsListVM.presentedFields):
-			self.InsertColumn(colIndex, col.displayString, width=self.scaleSize(col.width))
+		for col in self._addonsListVM.presentedFields:
+			self.AppendColumn(col.displayString, width=self.scaleSize(col.width))
 		self.Layout()
 
 	def _getListSelectionPosition(self) -> Optional[wx.Position]:

--- a/source/gui/_addonStoreGui/viewModels/addonList.py
+++ b/source/gui/_addonStoreGui/viewModels/addonList.py
@@ -132,7 +132,7 @@ class AddonListItemVM(Generic[_AddonModelT]):
 
 
 class AddonDetailsVM:
-	def __init__(self, listVM: AddonListVM):
+	def __init__(self, listVM: "AddonListVM"):
 		self._listVM = listVM
 		self._listItem: Optional[AddonListItemVM] = listVM.getSelection()
 		self.updated = extensionPoints.Action()  # triggered by setting L{self._listItem}

--- a/source/gui/addonGui.py
+++ b/source/gui/addonGui.py
@@ -185,13 +185,13 @@ class AddonsDialog(
 			proportion=1,
 		)
 		# Translators: The label for a column in add-ons list used to identify add-on package name (example: package is OCR).
-		self.addonsList.InsertColumn(0, _("Package"), width=self.scaleSize(150))
+		self.addonsList.AppendColumn(_("Package"), width=self.scaleSize(150))
 		# Translators: The label for a column in add-ons list used to identify add-on's running status (example: status is running).
-		self.addonsList.InsertColumn(1, _("Status"), width=self.scaleSize(50))
+		self.addonsList.AppendColumn(_("Status"), width=self.scaleSize(50))
 		# Translators: The label for a column in add-ons list used to identify add-on's version (example: version is 0.3).
-		self.addonsList.InsertColumn(2, _("Version"), width=self.scaleSize(50))
+		self.addonsList.AppendColumn(_("Version"), width=self.scaleSize(50))
 		# Translators: The label for a column in add-ons list used to identify add-on's author (example: author is NV Access).
-		self.addonsList.InsertColumn(3, _("Author"), width=self.scaleSize(300))
+		self.addonsList.AppendColumn(_("Author"), width=self.scaleSize(300))
 		self.addonsList.Bind(wx.EVT_LIST_ITEM_FOCUSED, self.onListItemSelected)
 
 		# this is the group of buttons that affects the currently selected addon
@@ -710,11 +710,11 @@ class IncompatibleAddonsDialog(
 		)
 
 		# Translators: The label for a column in add-ons list used to identify add-on package name (example: package is OCR).
-		self.addonsList.InsertColumn(1, _("Package"), width=self.scaleSize(150))
+		self.addonsList.AppendColumn(_("Package"), width=self.scaleSize(150))
 		# Translators: The label for a column in add-ons list used to identify add-on's running status (example: status is running).
-		self.addonsList.InsertColumn(2, _("Version"), width=self.scaleSize(150))
+		self.addonsList.AppendColumn(_("Version"), width=self.scaleSize(150))
 		# Translators: The label for a column in add-ons list used to provide some explanation about incompatibility
-		self.addonsList.InsertColumn(3, _("Incompatible reason"), width=self.scaleSize(180))
+		self.addonsList.AppendColumn(_("Incompatible reason"), width=self.scaleSize(180))
 
 		buttonSizer = guiHelper.ButtonHelper(wx.HORIZONTAL)
 		# Translators: The label for a button in Add-ons Manager dialog to show information about the selected add-on.

--- a/source/gui/dpiScalingHelper.py
+++ b/source/gui/dpiScalingHelper.py
@@ -1,6 +1,6 @@
 # -*- coding: UTF-8 -*-
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2018-2022 NV Access Limited
+# Copyright (C) 2018-2023 NV Access Limited
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 from typing import Optional, Any, Callable, Tuple, Union
@@ -8,17 +8,17 @@ from typing import Optional, Any, Callable, Tuple, Union
 
 _FloatInt = Union[int, float]
 _Size = Union[Tuple[_FloatInt, _FloatInt], _FloatInt]
-_ScaledSize = Union[Tuple[float, float], float]
+_ScaledSize = Union[Tuple[int, int], int]
 
 
 def scaleSize(scaleFactor: float, size: _Size) -> _ScaledSize:
 	"""Helper method to scale a size using the logical DPI
 	@param size: The size (x, y) as a tuple or a single numerical type to scale
-	@returns: The scaled size, as a float or tuple of floats.
+	@returns: The scaled size, as a tuple or a single numerical type.
 	"""
 	if isinstance(size, tuple):
-		return (scaleFactor * size[0], scaleFactor * size[1])
-	return scaleFactor * size
+		return (int(scaleFactor * size[0]), int(scaleFactor * size[1]))
+	return int(scaleFactor * size)
 
 
 def getScaleFactor(windowHandle: int) -> float:

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -4453,14 +4453,14 @@ class SpeechSymbolsDialog(SettingsDialog):
 		)
 
 		# Translators: The label for a column in symbols list used to identify a symbol.
-		self.symbolsList.InsertColumn(0, _("Symbol"), width=self.scaleSize(150))
+		self.symbolsList.AppendColumn(_("Symbol"), width=self.scaleSize(150))
 		# Translators: The label for a column in symbols list used to identify a replacement.
-		self.symbolsList.InsertColumn(1, _("Replacement"))
+		self.symbolsList.AppendColumn(_("Replacement"))
 		# Translators: The label for a column in symbols list used to identify a symbol's speech level (either none, some, most, all or character).
-		self.symbolsList.InsertColumn(2, _("Level"))
+		self.symbolsList.AppendColumn(_("Level"))
 		# Translators: The label for a column in symbols list which specifies when the actual symbol will be sent to the synthesizer (preserved).
 		# See the "Punctuation/Symbol Pronunciation" section of the User Guide for details.
-		self.symbolsList.InsertColumn(3, _("Preserve"))
+		self.symbolsList.AppendColumn(_("Preserve"))
 		self.symbolsList.Bind(wx.EVT_LIST_ITEM_FOCUSED, self.onListItemFocused)
 
 		# Translators: The label for the group of controls in symbol pronunciation dialog to change the pronunciation of a symbol.

--- a/source/gui/speechDict.py
+++ b/source/gui/speechDict.py
@@ -177,19 +177,19 @@ class DictionaryDialog(
 			wx.ListCtrl, style=wx.LC_REPORT | wx.LC_SINGLE_SEL
 		)
 		# Translators: The label for a column in dictionary entries list used to identify comments for the entry.
-		self.dictList.InsertColumn(0, _("Comment"), width=150)
+		self.dictList.AppendColumn(_("Comment"), width=150)
 		# Translators: The label for a column in dictionary entries list used to identify pattern
 		# (original word or a pattern).
-		self.dictList.InsertColumn(1, _("Pattern"), width=150)
+		self.dictList.AppendColumn(_("Pattern"), width=150)
 		# Translators: The label for a column in dictionary entries list and in a list of symbols
 		# from symbol pronunciation dialog used to identify replacement for a pattern or a symbol
-		self.dictList.InsertColumn(2, _("Replacement"), width=150)
+		self.dictList.AppendColumn(_("Replacement"), width=150)
 		# Translators: The label for a column in dictionary entries list used to identify
 		# whether the entry is case sensitive or not.
-		self.dictList.InsertColumn(3, _("case"), width=50)
+		self.dictList.AppendColumn(_("case"), width=50)
 		# Translators: The label for a column in dictionary entries list used to identify
 		# whether the entry is a regular expression, matches whole words, or matches anywhere.
-		self.dictList.InsertColumn(4, _("Type"), width=50)
+		self.dictList.AppendColumn(_("Type"), width=50)
 		self.offOn = (_("off"), _("on"))
 		for entry in self.tempSpeechDict:
 			self.dictList.Append((

--- a/source/monkeyPatches/enumPatches.py
+++ b/source/monkeyPatches/enumPatches.py
@@ -46,15 +46,15 @@ def _replacement__new__(cls, value):
 	if isinstance(result, cls):
 		return result
 
-	with ValueError(
+	ve_exc = ValueError(
 		"%r is not a valid %s" % (value, cls.__name__)
-	) as ve_exc:
-		if result is None:
-			raise ve_exc
+	)
+	if result is None:
+		raise ve_exc
 
-		te_exc = TypeError(
-			'error in %s._missing_: returned %r instead of None or a valid member'
-			% (cls.__name__, result)
-		)
-		te_exc.__context__ = ve_exc
-		raise te_exc
+	te_exc = TypeError(
+		'error in %s._missing_: returned %r instead of None or a valid member'
+		% (cls.__name__, result)
+	)
+	te_exc.__context__ = ve_exc
+	raise te_exc

--- a/source/watchdog.py
+++ b/source/watchdog.py
@@ -396,7 +396,11 @@ def cancellableExecute(func, *args, ccPumpMessages=True, **kwargs):
 	@raise CallCancelled: If the call was cancelled.
 	"""
 	global cancellableCallThread
-	if not isRunning or _suspended or not isinstance(threading.currentThread(), threading._MainThread):
+	if (
+		not isRunning
+		or _suspended
+		or threading.current_thread() is not threading.main_thread()
+	):
 		# Watchdog is not running or this is a background thread,
 		# so just execute the call.
 		return func(*args, **kwargs)


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
In preparation for #12064 

### Summary of the issue:
- Certain types which are imported for type checking only are not correctly encapsulated by strings.
- `threading.currentThread()` is deprecated in favour of  `threading.current_thread()` 
- `with Exception() as ex:` syntax is no longer valid in 3.11
- in wxPython 4.2.0, integers are expected for scaling sizes
- in wxPython 4.2.0, using `AppendColumn` is preferred with our current syntax of adding width

### Description of user facing changes
None

### Description of development approach
Makes various backwards compatible fixes that become compatibility issues when upgrading to python 3.11

### Testing strategy:
Test running NVDA with changes, tested in an experimental 3.11 branch as well

### Known issues with pull request:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
