### PR TITLE
Restore old IA2 install/uninstall approach

### DIFF
--- a/nvdaHelper/remote/IA2Support.h
+++ b/nvdaHelper/remote/IA2Support.h
@@ -28,10 +28,13 @@ struct IA2InstallData {
 	HANDLE uiThreadUninstalledEvent;
 };
 
-std::pair<std::map<DWORD, IA2InstallData>::iterator, bool> installIA2SupportForThread(DWORD threadID);
-bool uninstallIA2SupportForThread(DWORD threadID);
+bool installIA2Support();
+bool uninstallIA2Support();
 
 //Private functions
+
+std::pair<std::map<DWORD, IA2InstallData>::iterator, bool> installIA2SupportForThread(DWORD threadID);
+bool uninstallIA2SupportForThread(DWORD threadID);
 void IA2Support_inProcess_initialize();
 void IA2Support_inProcess_terminate();
 

--- a/nvdaHelper/remote/IA2Support.h
+++ b/nvdaHelper/remote/IA2Support.h
@@ -28,8 +28,8 @@ struct IA2InstallData {
 	HANDLE uiThreadUninstalledEvent;
 };
 
-std::pair<std::map<DWORD, IA2InstallData>::iterator, bool> installIA2Support(DWORD threadID);
-bool uninstallIA2Support(DWORD threadID);
+std::pair<std::map<DWORD, IA2InstallData>::iterator, bool> installIA2SupportForThread(DWORD threadID);
+bool uninstallIA2SupportForThread(DWORD threadID);
 
 //Private functions
 void IA2Support_inProcess_initialize();

--- a/nvdaHelper/remote/nvdaHelperRemote.def
+++ b/nvdaHelper/remote/nvdaHelperRemote.def
@@ -2,6 +2,8 @@ EXPORTS
 	injection_initialize
 	injection_terminate
 	initInprocManagerThreadIfNeeded
+	installIA2Support
+	uninstallIA2Support
 	registerWinEventHook
 	unregisterWinEventHook
 	registerWindowsHook

--- a/source/NVDAHelper.py
+++ b/source/NVDAHelper.py
@@ -597,6 +597,8 @@ def initialize() -> None:
 	_remoteLib=CDLL("nvdaHelperRemote",handle=h)
 	if _remoteLib.injection_initialize() == 0:
 		raise RuntimeError("Error initializing NVDAHelperRemote")
+	if not _remoteLib.installIA2Support():
+		log.error("Error installing IA2 support")
 	#Manually start the in-process manager thread for this NVDA main thread now, as a slow system can cause this action to confuse WX
 	_remoteLib.initInprocManagerThreadIfNeeded()
 	versionedLibARM64Path
@@ -615,6 +617,8 @@ def terminate():
 	global _remoteLib, _remoteLoaderAMD64, _remoteLoaderARM64
 	global localLib, generateBeep, VBuf_getTextInRange
 	if not config.isAppX:
+		if not _remoteLib.uninstallIA2Support():
+			log.debugWarning("Error uninstalling IA2 support")
 		if _remoteLib.injection_terminate() == 0:
 			raise RuntimeError("Error terminating NVDAHelperRemote")
 		_remoteLib=None


### PR DESCRIPTION
### Link to issue number:
Replaces #15517 

### Summary of the issue:
It was pointed out by @michaelDCurran  in https://github.com/nvaccess/nvda/pull/15517#issuecomment-1734739993 that proxy registration in NVDA's main thread is essential.

### Description of user facing changes
Probably nothing noticeable.

### Description of development approach
Rename installIA2Support and uninstallIA2Support to installIA2SupportForThread and uninstallIA2SupportForTrhead, respectively. Introduce new installIA2Support and uninstallIA2Support wrappers that install/uninstall for the current thread. Also restored installation/uninstallation in NVDAHelper.py

### Testing strategy:
Tested that installing and uninstalling works as no errors are generated.

### Known issues with pull request:
None known

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
