### PR TITLE
Fixes the announcement of cell formatting commands in Excel

### DIFF
--- a/source/NVDAObjects/window/excel.py
+++ b/source/NVDAObjects/window/excel.py
@@ -1098,7 +1098,7 @@ class ExcelWorksheet(ExcelBase):
 			ui.message(msgOff)
 
 	@script(
-		gestures=["kb:control+b", "kb:control+shift+2"],
+		gestures=["kb:control+b", "kb:control+2"],
 		canPropagate=True,
 	)
 	def script_toggleBold(self, gesture):
@@ -1112,7 +1112,7 @@ class ExcelWorksheet(ExcelBase):
 		)
 
 	@script(
-		gestures=["kb:control+i", "kb:control+shift+3"],
+		gestures=["kb:control+i", "kb:control+3"],
 		canPropagate=True,
 	)
 	def script_toggleItalic(self, gesture):
@@ -1126,7 +1126,7 @@ class ExcelWorksheet(ExcelBase):
 		)
 
 	@script(
-		gestures=["kb:control+u", "kb:control+shift+4"],
+		gestures=["kb:control+u", "kb:control+4"],
 		canPropagate=True,
 	)
 	def script_toggleUnderline(self, gesture):
@@ -1140,7 +1140,7 @@ class ExcelWorksheet(ExcelBase):
 		)
 
 	@script(
-		gesture="kb:control+shift+5",
+		gesture="kb:control+5",
 		canPropagate=True,
 	)
 	def script_toggleStrikethrough(self, gesture):

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -67,6 +67,7 @@ There's also been bug fixes for the Add-on Store, Microsoft Office, Microsoft Ed
 - Microsoft Office:
   - Fixed crash in Microsoft Word when Document formatting options "report headings" and "report comments and notes" were not enabled. (#15019)
   - In Word and Excel, text alignment will be correctly reported in more situations. (#15206, #15220)
+  - Fixes the announcement of some cell formatting shortcuts in Excel. (#15527)
   -
 - Microsoft Edge:
   - NVDA will no longer jump back to the last browse mode position when opening the context menu in Microsoft Edge. (#15309)


### PR DESCRIPTION
### Link to issue number:
Fixes #15506
Fix-up of #14923

### Summary of the issue:
When peforming tests for #14923, I have wrongly assumed that Excel cell formatting shortcuts were control+shift+2/3/4/5. This assumption was based on my tests with Excel's interface changed to English on my system. However, it seems that the keyboard layout when Excel is started has also an impact on the shortcuts containing digits (see discussion in #14923).
The actual shortcuts are control+2/3/4/5, as described in Microsoft documentation and as confirmed starting Excel with English GUI and English keyboard layout.

### Description of user facing changes
On English systems (and probably many others), Excel cell formatting shortcuts control+2/3/4/5 will have their effect reported correctly. shift+control+2/3/4/5 will not report inappropriately formatting information on English systems.

### Description of development approach
Modified the gesture definition.

### Testing strategy:
Same as #14923 but taking care to have an English keyboard layout when starting Excel.
### Known issues with pull request:
* Translators will have to modify their locale `gestures.ini` if the shortcuts differ in their language. That may be the case if the local keyboard layout uses shift to write digits.
* Translators will also have to check any mapping done after #14923 to see if it is still relevant or not.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
