### PR TITLE
Update SCons to version 4.5.2

### DIFF
--- a/nvdaHelper/archBuild_sconscript
+++ b/nvdaHelper/archBuild_sconscript
@@ -55,8 +55,7 @@ def COMProxyDllBuilder(env,target,source,proxyClsid):
 		target=target,
 		source=source,
 		LIBS=['rpcrt4','oleaut32','ole32'],
-		CPPDEFINES=[
-			env['CPPDEFINES'],
+		CPPDEFINES=list(env['CPPDEFINES']) + [
 			'WIN32',
 			('PROXY_CLSID_IS',clsidStringToCLSIDDefine(proxyClsid)),
 		],
@@ -130,7 +129,7 @@ else:
 	env.Append(LINKFLAGS=['/LTCG'])
 
 if 'debugCRT' not in debug:
-	env.Append(CPPDEFINES=['NDEBUG'])
+	env.Append(CPPDEFINES='NDEBUG')
 
 if 'RTC' in debug:
 	env.Append(CCFLAGS=['/RTCsu'])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # NVDA's build system is SCons
-SCons==4.3.0
+SCons==4.5.2
 
 # NVDA's runtime dependencies
 comtypes==1.2.0

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -27,7 +27,7 @@ Please refer to [the developer guide https://www.nvaccess.org/files/nvda/documen
 Add-ons will need to be re-tested and have their manifest updated.
 - Updated Comtypes to version 1.2.0. (#15513)
 - Updated fast_diff_match_patch to version 2.0.1. (#15514)
-- Updated SCons to version 4.5.2.
+- Updated SCons to version 4.5.2. (#15529)
 - Added extension point: ``treeInterceptorHandler.post_browseModeStateChange``. (#14969)
 -
 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -27,6 +27,7 @@ Please refer to [the developer guide https://www.nvaccess.org/files/nvda/documen
 Add-ons will need to be re-tested and have their manifest updated.
 - Updated Comtypes to version 1.2.0. (#15513)
 - Updated fast_diff_match_patch to version 2.0.1. (#15514)
+- Updated SCons to version 4.5.2.
 - Added extension point: ``treeInterceptorHandler.post_browseModeStateChange``. (#14969)
 -
 


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
As part of the investment to update all NVDA dependencies, SCons needs an update to the most recent version.

### Description of user facing changes
Updates Scons to 4.5.2

### Description of development approach
Updates requirements. As CPPDEFINES is now saved as a deque internally, I needed to convert the deque to a list before expanding it for one of the libraries.

### Testing strategy:
Tested that NVDA builds and that a launcher can still be created.

### Known issues with pull request:
None known

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
