### PR TITLE
Use built-in pgettext and ngettext functions

### DIFF
--- a/source/languageHandler.py
+++ b/source/languageHandler.py
@@ -8,7 +8,6 @@ This module assists in NVDA going global through language services
 such as converting Windows locale ID's to friendly names and presenting available languages.
 """
 
-import builtins
 import os
 import sys
 import ctypes
@@ -362,7 +361,8 @@ def setLanguage(lang: str) -> None:
 	if trans is None:
 		trans = _createGettextTranslation("en")
 
-	trans.install(names=["pgettext", "npgettext"])
+	# #9207: Python 3.8 adds gettext.pgettext, so add it to the built-in namespace.
+	trans.install(names=["pgettext", "ngettext"])
 	setLocale(getLanguage())
 
 	global installedTranslation


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
None

### Summary of the issue:
Errors like the following appear frequently in the log and many NVDA functions are blocked:

```python traceback
Traceback (most recent call last):
  File "scriptHandler.py", line 295, in executeScript
    script(gesture)
  File "browseMode.py", line 498, in <lambda>
    script = lambda self,gesture: self._quickNavScript(gesture, itemType, "previous", prevError, readUnit)
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "browseMode.py", line 459, in _quickNavScript
    item.report(readUnit=readUnit)
  File "browseMode.py", line 210, in report
    speech.speakTextInfo(info, reason=OutputReason.QUICKNAV)
  File "speech\speech.py", line 1236, in speakTextInfo
    for seq in speechGen:
  File "speech\types.py", line 42, in __iter__
    self.returnValue = yield from self.gen
                       ^^^^^^^^^^^^^^^^^^^
  File "speech\speech.py", line 1394, in getTextInfoSpeech
    fieldSequence = info.getControlFieldSpeech(
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "textInfos\__init__.py", line 596, in getControlFieldSpeech
    sequence = speech.getControlFieldSpeech(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "speech\speech.py", line 2066, in getControlFieldSpeech
    containerContainsText = ngettext("with %s item", "with %s items", childControlCount) % childControlCount
                            ^^^^^^^^
NameError: name 'ngettext' is not defined
```

### Description of how this pull request fixes the issue:
Install the built-in `ngettext` and `pgettext` from the environment.

### Testing strategy:
Errors disappear.

### Known issues with pull request:
None known

### Change log entry:
None needed, unreleased regression

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
