### PR TITLE
Re-enable chrome tests

### DIFF
--- a/appveyor/scripts/tests/systemTests.ps1
+++ b/appveyor/scripts/tests/systemTests.ps1
@@ -9,8 +9,7 @@ if ($env:VERBOSE_SYSTEM_TEST_LOGGING) {
 
 # This tag is used to exclude system tests.
 # If provided to runsystemtests, RF would give an error.
-# Chrome system tests are currently broken due to experiemental changes happening to control+F6 behaviour
-$SKIP_SYS_TESTS = "excluded_from_build chrome"
+$SKIP_SYS_TESTS = "excluded_from_build"
 $tagsForTest = "installer NVDA"  # include the tests tagged with installer, or NVDA
 if ($env:INCLUDE_SYSTEM_TEST_TAGS) {
 	if ($env:INCLUDE_SYSTEM_TEST_TAGS -eq $SKIP_SYS_TESTS) {


### PR DESCRIPTION
Undo #15524 

Chrome tests appear to be working in more cases.
Additionally, #15524 was not implemented correctly and chrome tests are still enabled