### PR TITLE
Recognize Windows version 10.0.22631 as Windows 11 2023 Update (Version 23H2)

### DIFF
--- a/appx/manifest.xml.subst
+++ b/appx/manifest.xml.subst
@@ -24,7 +24,7 @@
 		<TargetDeviceFamily 
 			Name="Windows.Desktop" 
 			MinVersion="10.0.18990.0" 
-			MaxVersionTested="10.0.22621.0" 
+			MaxVersionTested="10.0.22631.0" 
 		/>
 	</Dependencies>
 	<Capabilities>

--- a/source/winVersion.py
+++ b/source/winVersion.py
@@ -39,6 +39,7 @@ _BUILDS_TO_RELEASE_NAMES = {
 	20348: "Windows Server 2022",
 	22000: "Windows 11 21H2",
 	22621: "Windows 11 22H2",
+	22631: "Windows 11 23H2",
 }
 
 
@@ -165,6 +166,7 @@ WIN10_22H2 = WinVersion(major=10, minor=0, build=19045)
 WINSERVER_2022 = WinVersion(major=10, minor=0, build=20348)
 WIN11 = WIN11_21H2 = WinVersion(major=10, minor=0, build=22000)
 WIN11_22H2 = WinVersion(major=10, minor=0, build=22621)
+WIN11_23H2 = WinVersion(major=10, minor=0, build=22631)
 
 
 @functools.lru_cache(maxsize=1)

--- a/source/winVersion.py
+++ b/source/winVersion.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2006-2022 NV Access Limited, Bill Dengler, Joseph Lee
+# Copyright (C) 2006-2023 NV Access Limited, Bill Dengler, Joseph Lee
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 

--- a/source/winVersion.py
+++ b/source/winVersion.py
@@ -10,7 +10,7 @@ making sure NVDA can run on a minimum supported version of Windows.
 When working on this file, consider moving to winAPI.
 """
 
-from typing import Optional
+from typing import Optional, Dict
 import sys
 import os
 import functools
@@ -21,7 +21,7 @@ import platform
 # Records a mapping between Windows builds and release names.
 # These include build 10240 for Windows 10 1507 and releases with multiple release builds.
 # These are applicable to Windows 10 and later as they report the same system version (10.0).
-_BUILDS_TO_RELEASE_NAMES = {
+_BUILDS_TO_RELEASE_NAMES: Dict[int, str] = {
 	10240: "Windows 10 1507",
 	10586: "Windows 10 1511",
 	14393: "Windows 10 1607",


### PR DESCRIPTION
### Link to issue number:
Closes #15530 

### Summary of the issue:
Recognize Windows version 10.0.22631 as Windows 11 2023 Update (Version 23H2).

### Description of user facing changes
None

### Description of development approach
Edit the following files:

* source/winVersion: add Windows 11 23H2 data, including build number, release name, and WIN11_23H2 constant.
* Edit appx XML to state that last tested build is 10.0.22631.0.
* Add type hints for builds to release names dictionary.

### Testing strategy:
Tested manually - make sure that, on Windows build 10.0.22631, winVersion.getWinVer() says Windows 11 23H2, which is the release name for winVersion.WIN11_23H2.

### Known issues with pull request:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

### Additional context:
There are two Windows 11 23H2 releases: PC's and cloud (Azure) servers. This PR adds data for PC builds, not cloud servers (Azure HCI) as there is no use case for running NVDA on a cloud server unless desktop experience is used (in which case the build to add is 25398).
