### PR TITLE
Add SysListView32 to badUIAWindowClassNames

### DIFF
--- a/source/UIAHandler/__init__.py
+++ b/source/UIAHandler/__init__.py
@@ -86,6 +86,9 @@ goodUIAWindowClassNames = (
 badUIAWindowClassNames = (
 	# UIA events of candidate window interfere with MSAA events.
 	"Microsoft.IME.CandidateWindow.View",
+	# Known issue with "Reliability Monitor" in explorer.exe #15541.
+	# Task manager and mmc.exe are also affected, but have isBadUIAWindow workarounds.
+	"SysListView32",
 	"SysTreeView32",
 	"WuDuiListView",
 	"ComboBox",

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -85,7 +85,6 @@ There's also been bug fixes for the Add-on Store, Microsoft Office, Microsoft Ed
   - Fixed bug where add-ons cannot be installed if a previous download failed or was cancelled. (#15469)
   - Fixed issues with handling incompatible add-ons when upgrading NVDA. (#15414, #15412, #15437)
   -
-- Fixed support for System List view (``SysListView32``) controls in Windows Forms applications. (#15283)
 - NVDA once again announces calculation results in the Windows 32bit calculator on Server, LTSC and LTSB versions of Windows. (#15230)
 - NVDA no longer ignores focus changes when a nested window (grand child window) gets focus. (#15432)
 - Fixed performance issues with Task Manager and some Windows versions. (#6245)


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Fixes #15541 
Reverts #15295
Reopens #15283

See also #15503, #15333
### Summary of the issue:
There are several known cases where UIA is not correctly supported for SysListView32.
Reliability History is the most recently raised, with task manager and management console being raised earlier.
As this is close to a beta, it is safer to just declare SysListView32 as bad for UIA for all applications.

### Description of user facing changes
Reopens issues with SysListView32 and windows forms applications
Fixes issue with reading Reliability History, and potentially also resource monitor.

### Description of development approach
declare SysListView32 as bad for UIA for all applications.

### Testing strategy:
Confirm with beta/alpha testing
### Known issues with pull request:
None
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
