### PR TITLE
Remove incorrect change log item

### DIFF
--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -87,7 +87,6 @@ There's also been bug fixes for the Add-on Store, Microsoft Office, Microsoft Ed
   -
 - NVDA once again announces calculation results in the Windows 32bit calculator on Server, LTSC and LTSB versions of Windows. (#15230)
 - NVDA no longer ignores focus changes when a nested window (grand child window) gets focus. (#15432)
-- Fixed performance issues with Task Manager and some Windows versions. (#6245)
 - Fixed a potential cause of crashing during NVDA startup. (#15517)
 -
 


### PR DESCRIPTION
### Link to issue number:

Related to #6245 and #15519


### Summary of the issue:

Change log contains an incorrect item
`Fixed performance issues with Task Manager and some Windows versions. (#6245)`

Indeed #6245. It had been erroneously closed as duplicate of #15519 before being reopened again. Indeed, #15519 is about tagging the task list as bad UIA window, whereas #6245 was already an issue before trying to consider the task list as good UIA window.
### Description of user facing changes
Remove the incorrect log entry
### Description of development approach
N/A
### Testing strategy:
N/A
### Known issues with pull request:
None

### Note

We always need to be very careful when reopening a closed issue with a milestone or when reverting PRs/

### Code Review Checklist:


- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
