### PR TITLE
Fix announcing of multi-line state in Java Access Bridge apps

### DIFF
--- a/source/NVDAObjects/JAB/__init__.py
+++ b/source/NVDAObjects/JAB/__init__.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2006-2022 NV Access Limited, Leonard de Ruijter, Joseph Lee, Renaud Paquay, pvagner
+# Copyright (C) 2006-2023 NV Access Limited, Leonard de Ruijter, Joseph Lee, Renaud Paquay, pvagner
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -96,6 +96,7 @@ JABStatesToNVDAStates={
 	"iconified":controlTypes.State.ICONIFIED,
 	"modal":controlTypes.State.MODAL,
 	"multi_line":controlTypes.State.MULTILINE,
+	"multiple line": controlTypes.State.MULTILINE,
 	"focusable":controlTypes.State.FOCUSABLE,
 	"editable":controlTypes.State.EDITABLE,
 	"selectable": controlTypes.State.SELECTABLE,

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -21,6 +21,7 @@ This option now announces additional relevant information about an object when t
 == Bug Fixes ==
 - Reporting of object shortcut keys has been improved. (#10807)
 - The SAPI4 synthesizer now properly supports volume, rate and pitch changes embedded in speech. (#15271)
+- Multi line state is now correctly reported in applications using Java Access Bridge. (#14609)
 -
 
 == Changes for Developers ==


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:

Fixes #14609

### Summary of the issue:

NVDA doesn't report multi-line state for Java Access Bridge components that expose it.

### Description of user facing changes

NVDA will correctly report multi-line state in applications using Java Access Bridge.

### Description of development approach

Added mapping from "multiple line" JAB state to NVDA multiline state. There is already a mapping from "multi_line" JAB state to NVDA state, but the string was incorrect, so NVDA didn't announce it. JAB uses the string from the following resource file: https://github.com/openjdk/jdk/blob/516cfb135f7e5fefaf6e6f2928f6ecb88806f1ef/src/java.desktop/share/classes/com/sun/accessibility/internal/resources/accessibility_en.properties#L114. Existing "multi_line" value probably comes from the name of Java's [AccessibleState.MULTI_LINE](https://docs.oracle.com/en/java/javase/17/docs/api/java.desktop/javax/accessibility/AccessibleState.html#MULTI_LINE) const, but it doesn't seem to have ever been used as a resource value after looking at the git history. I still kept it in the mapping to ensure backwards compatibility: while unlikely, it's possible that in older Java versions the value was "multi_line".

### Testing strategy:

Manual testing with the sample app from #14609. NVDA output before and after the changes:

#### Before

> Single-line text:  edit  read only  This is a text
> tab
> filler
> Multi-line text:  edit  read only  This is the first part of a 

#### After

> Single-line text:  edit  read only  This is a text
> tab
> filler
> Multi-line text:  edit  read only  multi line  This is the first part of a 

Multi-line text is now correctly reported as "multi line". NVDA still reads only the first line, but this seems to be the same as with other read only multiline edits (e.g. NVDA Speech Viewer). Up/down arrows can still navigate the text, and the NVDA+down shortcut will read the whole text. 

### Known issues with pull request:

None.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
