### PR TITLE
Reduce verbosity when reporting Excel cell formatting

### DIFF
--- a/source/NVDAObjects/window/excel.py
+++ b/source/NVDAObjects/window/excel.py
@@ -1215,7 +1215,8 @@ class ExcelCellTextInfo(NVDAObjectTextInfo):
 				pass
 			try:
 				pattern = cellObj.Interior.Pattern
-				formatField['background-pattern'] = backgroundPatternLabels.get(pattern)
+				if pattern != xlPatternNone:
+					formatField['background-pattern'] = backgroundPatternLabels.get(pattern)
 				if pattern in (xlPatternLinearGradient, xlPatternRectangularGradient):
 					formatField['background-color']=(colors.RGB.fromCOLORREF(int(cellObj.Interior.Gradient.ColorStops(1).Color)))
 					formatField['background-color2']=(colors.RGB.fromCOLORREF(int(cellObj.Interior.Gradient.ColorStops(2).Color)))

--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -2422,7 +2422,11 @@ def getFormatFieldSpeech(  # noqa: C901
 			textList.append(_("{backgroundColor} background").format(backgroundColor=bgColorText))
 		backgroundPattern=attrs.get("background-pattern")
 		oldBackgroundPattern=attrsCache.get("background-pattern") if attrsCache is not None else None
-		if backgroundPattern and backgroundPattern!=oldBackgroundPattern:
+		if (backgroundPattern or oldBackgroundPattern is not None)and backgroundPattern != oldBackgroundPattern:
+			if not backgroundPattern:
+				# Translators: A type of background pattern in Microsoft Excel.
+				# No pattern
+				backgroundPattern = _("none")
 			textList.append(_("background pattern {pattern}").format(pattern=backgroundPattern))
 	if  formatConfig["reportLineNumber"]:
 		lineNumber=attrs.get("line-number")

--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -2368,7 +2368,7 @@ def getFormatFieldSpeech(  # noqa: C901
 	if formatConfig["reportCellBorders"] != ReportCellBorders.OFF:
 		borderStyle=attrs.get("border-style")
 		oldBorderStyle=attrsCache.get("border-style") if attrsCache is not None else None
-		if borderStyle!=oldBorderStyle:
+		if (borderStyle or oldBorderStyle is not None) and borderStyle != oldBorderStyle:
 			if borderStyle:
 				text=borderStyle
 			else:

--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -2422,7 +2422,7 @@ def getFormatFieldSpeech(  # noqa: C901
 			textList.append(_("{backgroundColor} background").format(backgroundColor=bgColorText))
 		backgroundPattern=attrs.get("background-pattern")
 		oldBackgroundPattern=attrsCache.get("background-pattern") if attrsCache is not None else None
-		if (backgroundPattern or oldBackgroundPattern is not None)and backgroundPattern != oldBackgroundPattern:
+		if (backgroundPattern or oldBackgroundPattern is not None) and backgroundPattern != oldBackgroundPattern:
 			if not backgroundPattern:
 				# Translators: A type of background pattern in Microsoft Excel.
 				# No pattern

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -19,6 +19,7 @@ What's New in NVDA
 - The following commands now support two and three presses to spell the reported information and spell with character descriptions: report selection, report clipboard text and report focused object. (#15449)
 - The option "Report role when mouse enters object" in NVDA's mouse settings category has been renamed to "Report object when mouse enters it".
 This option now announces additional relevant information about an object when the mouse enters it, such as states (checked/pressed) or cell coordinates in a table. (#15420)
+- When requesting formatting information on Excel cells, borders and background will only be reported if there is such formatting. (#15560)
 -
 
 == Bug Fixes ==


### PR DESCRIPTION
### Link to issue number:
None
### Summary of the issue:
When requesting  for cell formatting information in Excel (NVDA+F), there is over-verbose information:
* "no border lines" is often reported, since Excel files with default borders are quite common
* "background pattern none" is almost always reported since cells with other background patterns are very rare

### Description of user facing changes
When formatting information is requested with NVDA+F, we will not report anymore a lack of specific formatting for border lines or for background pattern. This formatting will still be reported during navigation if the corresponding option is enabled in document formatting settings (respectively "cell borders" and "color").

In that sense, we follow the logic used for other formatting attributes that have a negative state (lack of such formatting) such as bold/italic/etc. E.g.: "no bold" is not formatted upon NVDA+F request, but it is still reported while navigating from bold to no bold if the corresponding doc formatting option is enabled.

### Description of development approach
Do not provide info on background pattern in formatting info fields and changed the logic in `speech.py` to handle this.

For UIA, nothing is done since NVDA does not report borders or background pattern for Excel cells when UIA is enabled.

### Additional note
`_getFormatFieldAndOffsets` is private but it's probably called by `getTextWithFields`, thus changing its result.
Thus should I indicate something in API breaking changes though?

### Testing strategy:
Manual test: Tested NVDA+F and navigation with option "color" and "cell borders" enabled.
### Known issues with pull request:
None

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
