### PR TITLE
Fix MSAA performance on Python 3.11

### DIFF
--- a/source/monkeyPatches/comtypesMonkeyPatches.py
+++ b/source/monkeyPatches/comtypesMonkeyPatches.py
@@ -10,7 +10,6 @@ import ctypes
 import _ctypes
 from ctypes import cast, c_void_p
 from _ctypes import _Pointer
-import importlib
 import sys
 import exceptions
 import RPCConstants

--- a/source/monkeyPatches/comtypesMonkeyPatches.py
+++ b/source/monkeyPatches/comtypesMonkeyPatches.py
@@ -187,19 +187,6 @@ def replace_check_version() -> None:
 	comtypes._check_version = _check_version
 
 
-def new_my_import(fullname):
-	import comtypes.client._generate
-	importlib.invalidate_caches()
-	return comtypes.client._generate._my_import_orig(fullname)
-
-
-def replace_my_import() -> None:
-	# Monkeypatch comtypes to clear the importlib cache when importing a new module
-	import comtypes.client._generate
-	comtypes.client._generate._my_import_orig = comtypes.client._generate._my_import
-	comtypes.client._generate._my_import = new_my_import
-
-
 def vt_R8_to_c_double() -> None:
 	# Correctly map VT_R8 to c_double.
 	# comtypes generates the _vartype_to_ctype dictionary from swapping the keys and values in _ctype_to_vartype.
@@ -233,6 +220,5 @@ def applyMonkeyPatches() -> None:
 	replace_VARIAN_value_fget()
 	replace_idispatch_getTypeInfo()
 	replace_check_version()
-	replace_my_import()
 	vt_R8_to_c_double()
 	appendComInterfacesToGenSearchPath()


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
https://github.com/nvaccess/nvda/pull/15544#issuecomment-1744208482

### Summary of the issue:
MSAA performance is extremely poor (over a second of lag on a high-end system).

### Description of how this pull request fixes the issue:
Removes the patched comtypes `replace_my_import` as suggested in https://github.com/nvaccess/nvda/pull/15544#issuecomment-1744853055.

### Testing strategy:
Followed STR, can no longer reproduce MSAA performance degradation.

### Known issues with pull request:
None known

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
