### PR TITLE
Allow the add-on store to be launched on Python 3.11

### DIFF
--- a/source/gui/dpiScalingHelper.py
+++ b/source/gui/dpiScalingHelper.py
@@ -17,8 +17,8 @@ def scaleSize(scaleFactor: float, size: _Size) -> _ScaledSize:
 	@returns: The scaled size, as a tuple or a single numerical type.
 	"""
 	if isinstance(size, tuple):
-		return (int(scaleFactor * size[0]), int(scaleFactor * size[1]))
-	return int(scaleFactor * size)
+		return (round(scaleFactor * size[0]), round(scaleFactor * size[1]))
+	return round(scaleFactor * size)
 
 
 def getScaleFactor(windowHandle: int) -> int:

--- a/source/gui/dpiScalingHelper.py
+++ b/source/gui/dpiScalingHelper.py
@@ -21,7 +21,7 @@ def scaleSize(scaleFactor: float, size: _Size) -> _ScaledSize:
 	return int(scaleFactor * size)
 
 
-def getScaleFactor(windowHandle: int) -> float:
+def getScaleFactor(windowHandle: int) -> int:
 	"""Helper method to get the window scale factor. The window needs to be constructed first, in
 	order to get the window handle, this likely means calling the wx.window __init__ method prior
 	to calling self.GetHandle()"""
@@ -47,7 +47,7 @@ class DpiScalingHelperMixinWithoutInit:
 		of wx.Window or this mixin
 	"""
 	GetHandle: Callable[[], Any]  # Should be provided by wx.Window
-	_scaleFactor: Optional[float] = None
+	_scaleFactor: Optional[int] = None
 
 	def scaleSize(self, size: _Size) -> _ScaledSize:
 		if self._scaleFactor is None:

--- a/source/windowUtils.py
+++ b/source/windowUtils.py
@@ -99,6 +99,7 @@ def physicalToLogicalPoint(window, x, y):
 	_physicalToLogicalPoint(window, ctypes.byref(point))
 	return point.x, point.y
 
+
 DEFAULT_DPI_LEVEL = 96
 # The constant (defined in winGdi.h) to get the number of logical pixels per inch on the x axis
 # via the GetDeviceCaps function.

--- a/source/windowUtils.py
+++ b/source/windowUtils.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2013 NV Access Limited
+# Copyright (C) 2013-2023 NV Access Limited, Bill Dengler
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -105,7 +105,7 @@ DEFAULT_DPI_LEVEL = 96.0
 LOGPIXELSX = 88
 
 
-def getWindowScalingFactor(window: int) -> float:
+def getWindowScalingFactor(window: int) -> int:
 	"""Gets the logical scaling factor used for the given window handle. This is based off the Dpi reported by windows
 	for the given window handle / divided by the "base" DPI level of 96. Typically this is a result of using the scaling
 	percentage in the windows display settings. 100% is typically 96 DPI, 150% is typically 144 DPI.
@@ -127,11 +127,11 @@ def getWindowScalingFactor(window: int) -> float:
 	# a value of zero is certainly an error.
 	if winDpi <= 0:
 		log.debugWarning("Failed to get the DPI for the window, assuming a "
-		                 "DPI of {} and using a scaling of 1.0. The hWnd value "
+		                 "DPI of {} and using a scaling of 1. The hWnd value "
 		                 "used was: {}".format(DEFAULT_DPI_LEVEL, window))
-		return 1.0
+		return 1
 
-	return winDpi / DEFAULT_DPI_LEVEL
+	return round(winDpi / DEFAULT_DPI_LEVEL)
 
 
 

--- a/source/windowUtils.py
+++ b/source/windowUtils.py
@@ -99,7 +99,7 @@ def physicalToLogicalPoint(window, x, y):
 	_physicalToLogicalPoint(window, ctypes.byref(point))
 	return point.x, point.y
 
-DEFAULT_DPI_LEVEL = 96.0
+DEFAULT_DPI_LEVEL = 96
 # The constant (defined in winGdi.h) to get the number of logical pixels per inch on the x axis
 # via the GetDeviceCaps function.
 LOGPIXELSX = 88


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
None

### Summary of the issue:
When the add-on store is launched, the following error is generated:

```python traceback
Traceback (most recent call last):
  File "gui\blockAction.pyc", line 72, in funcWrapper
  File "gui\__init__.pyc", line 400, in onAddonStoreCommand
  File "gui\blockAction.pyc", line 72, in funcWrapper
  File "gui\__init__.pyc", line 216, in popupSettingsDialog
  File "gui\_addonStoreGui\controls\storeDialog.pyc", line 56, in __init__
  File "gui\_addonStoreGui\controls\messageDialogs.pyc", line 236, in __init__
TypeError: StaticText.Wrap(): argument 1 has unexpected type 'float'
```

### Description of how this pull request fixes the issue:
In wxpython 4.2, `Wrap` expects an `int`. Round the scale factor.

### Testing strategy:
Verified that the add-on store opens. Someone sighted should verify visual scaling.

### Known issues with pull request:
None known

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
