### PR TITLE
Honor useSpellingFunctionality parameter when reporting shortcuts

### DIFF
--- a/source/mathPres/mathPlayer.py
+++ b/source/mathPres/mathPlayer.py
@@ -2,7 +2,7 @@
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-# Copyright (C) 2014-2022 NV Access Limited
+# Copyright (C) 2014-2023 NV Access Limited, Cyrille Bougot
 
 """Support for math presentation using MathPlayer 4.
 """
@@ -20,6 +20,7 @@ from synthDriverHandler import getSynth
 from keyboardHandler import KeyboardInputGesture
 import braille
 import mathPres
+import config
 
 from speech.commands import (
 	PitchCommand,
@@ -68,7 +69,10 @@ def _processMpSpeech(text, language):
 		if m.lastgroup == "break":
 			out.append(BreakCommand(time=int(m.group("break")) * breakMulti))
 		elif m.lastgroup == "char":
-			out.extend((CharacterModeCommand(True), m.group("char"), CharacterModeCommand(False)))
+			if config.conf["speech"][synth.name]["useSpellingFunctionality"]:
+				out.extend((CharacterModeCommand(True), m.group("char"), CharacterModeCommand(False)))
+			else:
+				out.append(m.group("char"))
 		elif m.lastgroup == "comma":
 			out.append(BreakCommand(time=100))
 		elif m.lastgroup in PROSODY_COMMANDS:

--- a/source/speech/shortcutKeys.py
+++ b/source/speech/shortcutKeys.py
@@ -11,6 +11,8 @@ import re
 
 import characterProcessing
 from logHandler import log
+from synthDriverHandler import getSynth
+import config
 
 from .commands import CharacterModeCommand
 from .types import SpeechSequence
@@ -91,6 +93,9 @@ def _getKeySpeech(key: str) -> SpeechSequence:
 	keySymbol = characterProcessing.processSpeechSymbol(locale, key)
 	if keySymbol != key:
 		return [keySymbol]
+	synth = getSynth()
+	if not config.conf["speech"][synth.name]["useSpellingFunctionality"]:
+		return [key]
 	return [
 		CharacterModeCommand(True),
 		key,

--- a/source/speech/shortcutKeys.py
+++ b/source/speech/shortcutKeys.py
@@ -81,6 +81,10 @@ def _getKeyboardShortcutSpeech(keyboardShortcut: str) -> SpeechSequence:
 	return seq
 
 
+def shouldUseSpellingFunctionality() -> bool:
+	synth = getSynth()
+	return config.conf["speech"][synth.name]["useSpellingFunctionality"]
+
 def _getKeySpeech(key: str) -> SpeechSequence:
 	"""Gets the speech sequence for a string describing a key.
 	@param key: the key string.
@@ -93,8 +97,7 @@ def _getKeySpeech(key: str) -> SpeechSequence:
 	keySymbol = characterProcessing.processSpeechSymbol(locale, key)
 	if keySymbol != key:
 		return [keySymbol]
-	synth = getSynth()
-	if not config.conf["speech"][synth.name]["useSpellingFunctionality"]:
+	if not shouldUseSpellingFunctionality():
 		return [key]
 	return [
 		CharacterModeCommand(True),

--- a/source/speech/shortcutKeys.py
+++ b/source/speech/shortcutKeys.py
@@ -85,6 +85,7 @@ def shouldUseSpellingFunctionality() -> bool:
 	synth = getSynth()
 	return config.conf["speech"][synth.name]["useSpellingFunctionality"]
 
+
 def _getKeySpeech(key: str) -> SpeechSequence:
 	"""Gets the speech sequence for a string describing a key.
 	@param key: the key string.

--- a/tests/unit/test_speechShortcutKeys.py
+++ b/tests/unit/test_speechShortcutKeys.py
@@ -37,11 +37,9 @@ class Test_getKeyboardShortcutSpeech(unittest.TestCase):
 	def test_simpleLetterKeyWithSpellingFunctionalityDisabled(self):
 		"""A shortcut consisting in only one letter in the case where "Use spelling functionality" is disabled
 		(see #15566).
-		."""
+		"""
 
-		expected = repr([
-			'A',
-		])
+		expected = repr(['A',])
 		output = _getKeyboardShortcutSpeech(
 			keyboardShortcut='A',
 		)

--- a/tests/unit/test_speechShortcutKeys.py
+++ b/tests/unit/test_speechShortcutKeys.py
@@ -12,10 +12,21 @@ from speech.shortcutKeys import (
 	_getKeyboardShortcutSpeech,
 	getKeyboardShortcutsSpeech,
 )
+import speech.shortcutKeys
 from speech.commands import CharacterModeCommand
 
 
+original_shouldUseSpellingFunctionality = speech.shortcutKeys.shouldUseSpellingFunctionality
+
 class Test_getKeyboardShortcutSpeech(unittest.TestCase):
+
+	@classmethod
+	def setUpClass(cls):
+		speech.shortcutKeys.shouldUseSpellingFunctionality = lambda: True
+
+	@classmethod
+	def tearDownClass(cls):
+		speech.shortcutKeys.shouldUseSpellingFunctionality = original_shouldUseSpellingFunctionality
 
 	def test_simpleLetterKey(self):
 		"""A shortcut consisting in only one letter."""
@@ -135,6 +146,14 @@ class Test_getKeyboardShortcutSpeech(unittest.TestCase):
 
 
 class Test_getKeyboardShortcutsSpeech(unittest.TestCase):
+
+	@classmethod
+	def setUpClass(cls):
+		speech.shortcutKeys.shouldUseSpellingFunctionality = lambda: True
+
+	@classmethod
+	def tearDownClass(cls):
+		speech.shortcutKeys.shouldUseSpellingFunctionality = original_shouldUseSpellingFunctionality
 
 	def test_twoShortcutKeys(self):
 		"""A shortcut key indication indicating two shortcut keys (a sequential one and a simultaneous one)

--- a/tests/unit/test_speechShortcutKeys.py
+++ b/tests/unit/test_speechShortcutKeys.py
@@ -7,6 +7,7 @@
 """
 
 import unittest
+from unittest.mock import patch
 
 from speech.shortcutKeys import (
 	_getKeyboardShortcutSpeech,
@@ -20,14 +21,7 @@ original_shouldUseSpellingFunctionality = speech.shortcutKeys.shouldUseSpellingF
 
 class Test_getKeyboardShortcutSpeech(unittest.TestCase):
 
-	@classmethod
-	def setUpClass(cls):
-		speech.shortcutKeys.shouldUseSpellingFunctionality = lambda: True
-
-	@classmethod
-	def tearDownClass(cls):
-		speech.shortcutKeys.shouldUseSpellingFunctionality = original_shouldUseSpellingFunctionality
-
+	@patch('speech.shortcutKeys.shouldUseSpellingFunctionality', lambda: True)
 	def test_simpleLetterKey(self):
 		"""A shortcut consisting in only one letter."""
 
@@ -41,6 +35,21 @@ class Test_getKeyboardShortcutSpeech(unittest.TestCase):
 		)
 		self.assertEqual(repr(output), expected)
 
+	@patch('speech.shortcutKeys.shouldUseSpellingFunctionality', lambda: False)
+	def test_simpleLetterKeyWithSpellingFunctionalityDisabled(self):
+		"""A shortcut consisting in only one letter in the case where "Use spelling functionality" is disabled
+		(see #15566).
+		."""
+
+		expected = repr([
+			'A',
+		])
+		output = _getKeyboardShortcutSpeech(
+			keyboardShortcut='A',
+		)
+		self.assertEqual(repr(output), expected)
+
+	
 	def test_simpleSymbolKey(self):
 		"""A shortcut consisting in only one symbol present in symbols.dic."""
 
@@ -63,6 +72,7 @@ class Test_getKeyboardShortcutSpeech(unittest.TestCase):
 		)
 		self.assertEqual(repr(output), expected)
 
+	@patch('speech.shortcutKeys.shouldUseSpellingFunctionality', lambda: True)
 	def test_modifiersAndLetterKey(self):
 		"""A shortcut consisting in modifiers and a letter key."""
 
@@ -121,6 +131,7 @@ class Test_getKeyboardShortcutSpeech(unittest.TestCase):
 		)
 		self.assertEqual(repr(output), expected)
 
+	@patch('speech.shortcutKeys.shouldUseSpellingFunctionality', lambda: True)
 	def test_sequentialShortcutCombiningSpacesAndCommas(self):
 		"""A sequential shortcut found in ribbons (e.g. Word)."""
 
@@ -147,14 +158,7 @@ class Test_getKeyboardShortcutSpeech(unittest.TestCase):
 
 class Test_getKeyboardShortcutsSpeech(unittest.TestCase):
 
-	@classmethod
-	def setUpClass(cls):
-		speech.shortcutKeys.shouldUseSpellingFunctionality = lambda: True
-
-	@classmethod
-	def tearDownClass(cls):
-		speech.shortcutKeys.shouldUseSpellingFunctionality = original_shouldUseSpellingFunctionality
-
+	@patch('speech.shortcutKeys.shouldUseSpellingFunctionality', lambda: True)
 	def test_twoShortcutKeys(self):
 		"""A shortcut key indication indicating two shortcut keys (a sequential one and a simultaneous one)
 		as found in ribbons (e.g. Word).

--- a/tests/unit/test_speechShortcutKeys.py
+++ b/tests/unit/test_speechShortcutKeys.py
@@ -39,7 +39,7 @@ class Test_getKeyboardShortcutSpeech(unittest.TestCase):
 		(see #15566).
 		"""
 
-		expected = repr(['A',])
+		expected = repr(['A', ])
 		output = _getKeyboardShortcutSpeech(
 			keyboardShortcut='A',
 		)

--- a/tests/unit/test_speechShortcutKeys.py
+++ b/tests/unit/test_speechShortcutKeys.py
@@ -13,11 +13,9 @@ from speech.shortcutKeys import (
 	_getKeyboardShortcutSpeech,
 	getKeyboardShortcutsSpeech,
 )
-import speech.shortcutKeys
+import speech.shortcutKeys  # noqa F401 - Used by unittest.mock.patch
 from speech.commands import CharacterModeCommand
 
-
-original_shouldUseSpellingFunctionality = speech.shortcutKeys.shouldUseSpellingFunctionality
 
 class Test_getKeyboardShortcutSpeech(unittest.TestCase):
 


### PR DESCRIPTION

### Link to issue number:
Closes #15566
Fix-up of #14900 / #15373.
### Summary of the issue:
In #14900 / #15373., spelling mode was used (`CharacterModeCommand`) no matter the state of the "Use spelling functionality" option.

The use spelling functionality exists because some old SAPI synth do not support spelling mode correctly. For them, this option needs to be honored.

### Description of user facing changes
Use spelling functionality option will now be honored when reporting shortcuts.
### Description of development approach
See logic in the code.
If use spelling functionality option is disabled, the key is just reported as is.

### Testing strategy:
Manual check:
* Checked that reporting shortcuts is still OK
* Checked in the log that `CharacterModeCommand` is used only when the "Use spelling functionality" option is enabled.
### Known issues with pull request:
None

### Change log

None: unreleased issue.

### Code Review Checklist:


- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
