### PR TITLE
Sapi4: Only send prosody commands when there is prosody in the sequence

### DIFF
--- a/source/synthDrivers/sapi4.py
+++ b/source/synthDrivers/sapi4.py
@@ -134,11 +134,15 @@ class SynthDriver(SynthDriver):
 		# #15500: Some SAPI4 voices reset all prosody when they receive any prosody command,
 		# whereas other voices never undo prosody changes when a sequence is interrupted.
 		# Add all default values to the start and end of the sequence,
-		# but avoid duplicating the first command, if any.
-		prosodyToAdd = [
-			c() for c in self.supportedCommands
+		# but avoid duplicating the first command, if any,
+		# And only add the defaults when there is a prosody command in the sequence.
+		supportedProsody = [
+			c for c in self.supportedCommands
 			if issubclass(c, BaseProsodyCommand)
 		]
+		prosodyToAdd = []
+		if any(type(i) in supportedProsody for i in unprocessedSequence):
+			prosodyToAdd.extend(c() for c in supportedProsody)
 		speechSequence = [c for c in prosodyToAdd if not isinstance(unprocessedSequence[0], type(c))]
 		speechSequence.extend(unprocessedSequence)
 		# To be sure, add all default values to the end of the sequence.


### PR DESCRIPTION
### Link to issue number:
Fixes #15580 
Follow up of #15502 

### Summary of the issue:
In #15502, I fixed some regressions regarding capital pitch changes introduced in #15271. This meant that we'd add prosody commands to every speech sequence to support a specific version of IBM TTS that seemed to need that. However, it introduced a regression in that it was no longer possible to change speech parameters using the gui.

### Description of user facing changes
It is again possible to change SAPI4 parameters using the GUI.

### Description of development approach
Only add blank prosody commands when there is any prosody in the sequence. IF not, don't do anything.

### Additional context
A prosody command in SAPI4 (like pitch) behaves as the pitch would really be changed with PitchSet. In other words, when you'd fetch the pitch from the synth driver during a long sequence that contains a PitchCommand, the driver would return the Pitch as reflected by the PitchCommand. This meant that, when we'd set the pitch using the GUI, the pitch would also be affected by the PitchCommand added to the speech sequence. This caused conflicts. Thus, we should only add prosody commands when necessary.

### Testing strategy:
Tested str from #15580 and #15500

### Known issues with pull request:
None nkown

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
