### PR TITLE
Modify mnemonic for Reload plugin item to avoid conflict with NVDA remote

### DIFF
--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -539,7 +539,7 @@ class SysTrayIcon(wx.adv.TaskBarIcon):
 			self.Bind(wx.EVT_MENU, frame.onRunCOMRegistrationFixesCommand, item)
 		if not config.isAppX:
 			# Translators: The label for the menu item to reload plugins.
-			item = menu_tools.Append(wx.ID_ANY, _("R&eload plugins"))
+			item = menu_tools.Append(wx.ID_ANY, _("Reload plu&gins"))
 			self.Bind(wx.EVT_MENU, frame.onReloadPluginsCommand, item)
 		# Translators: The label for the Tools submenu in NVDA menu.
 		self.menu.AppendSubMenu(menu_tools, _("&Tools"))


### PR DESCRIPTION
### Link to issue number:
Fixes #15588
Follow-up of #15364
### Summary of the issue:
Among changes made in #15364, the accelerator key for the item "Reload plugins" in "Tools" menu has be modified to "E".
Users of NVDA remote add-on have complained that it conflicts with this add-on's accelerator key, that is being used for many years.

Usually, NVDA defines the shortcut keys and the add-ons should adapt to it. Given the popularity of NVDA Remote and it's age in the community though, NV Access may accept this case as a valid exception to this rule.

### Description of user facing changes
The following letters are already used in the Tools menu: l, s, b, a, p, c, i, r. Thus among the letters of "Reload plugins", the following letters are remaining: o, d, u, g, n.

There is no possibility to use the first letter of a wor, so "G" becomes the new accelerator key for "Reload plugins" item.

### Description of development approach
Modify the string

### Testing strategy:
Manual test from source.
### Known issues with pull request:
Conflicts with add-ons should usually be handled by add-on authors to adapt to NVDA changes. This PR is an exception given the popularity and the age of NVDA remote. But it is not meant to become the norm.
### Code Review Checklist:


- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
