### PR TITLE
Default gesture for the screen curtain

### DIFF
--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -4174,7 +4174,8 @@ class GlobalCommands(ScriptableObject):
 			"Pressed once, screen curtain is enabled until you restart NVDA. "
 			"Pressed twice, screen curtain is enabled until you disable it"
 		),
-		category=SCRCAT_VISION
+		category=SCRCAT_VISION,
+		gesture="kb:NVDA+control+escape",
 	)
 	def script_toggleScreenCurtain(self, gesture):
 		scriptCount = scriptHandler.getLastScriptRepeatCount()

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -19,7 +19,7 @@ What's New in NVDA
 - The following commands now support two and three presses to spell the reported information and spell with character descriptions: report selection, report clipboard text and report focused object. (#15449)
 - The option "Report role when mouse enters object" in NVDA's mouse settings category has been renamed to "Report object when mouse enters it".
 This option now announces additional relevant information about an object when the mouse enters it, such as states (checked/pressed) or cell coordinates in a table. (#15420)
-- The command to toggle the screen curtain has now a default gesture: ``NVDA+control+escape``. (#10560)
+- The command to toggle the screen curtain now has a default gesture: ``NVDA+control+escape``. (#10560)
 -
 
 == Bug Fixes ==

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -19,6 +19,7 @@ What's New in NVDA
 - The following commands now support two and three presses to spell the reported information and spell with character descriptions: report selection, report clipboard text and report focused object. (#15449)
 - The option "Report role when mouse enters object" in NVDA's mouse settings category has been renamed to "Report object when mouse enters it".
 This option now announces additional relevant information about an object when the mouse enters it, such as states (checked/pressed) or cell coordinates in a table. (#15420)
+- The command to toggle the screen curtain has now a default gesture: ``NVDA+control+escape``. (#10560)
 -
 
 == Bug Fixes ==

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -1088,7 +1088,12 @@ As a blind or vision impaired user, it is often not possible or necessary to see
 Furthermore, it might be hard to ensure that there isn't someone looking over your shoulder.
 For this situation, NVDA contains a feature called "Screen Curtain" which can be enabled to make the screen black.
 
-You can enable the Screen Curtain in the [vision category #VisionSettings] of the [NVDA Settings #NVDASettings] dialog.
+You can enable the Screen Curtain in the [vision category #VisionSettings] of the [NVDA Settings #NVDASettings] dialog. zzz
+
+%kc:beginInclude
+|| Name | Key | Description |
+| Toggles the state of the screen curtain | NVDA+control+escape | Enable to make the screen black or disable to show the contents of the screen. Pressed once, screen curtain is enabled until you restart NVDA. Pressed twice, screen curtain is enabled until you disable it. |
+%kc:endInclude
 
 When the Screen Curtain is active some tasks directly based on what appears on the screen such as performing [OCR #Win10Ocr] or taking a screenshot cannot be achieved.
 
@@ -1858,8 +1863,6 @@ Select "No" if you no longer wish to enable the Screen Curtain.
 If you are sure, you can choose the Yes button to enable the screen curtain.
 If you no longer want to see this warning message every time, you can change this behaviour in the dialog that displays the message.
 You can always restore the warning by checking the "Always show a warning when loading Screen Curtain" check box next to the "Make screen black" check box.
-
-To toggle the Screen Curtain from anywhere, please assign a custom gesture using the [Input Gestures dialog #InputGestures].
 
 By default, sounds are played when the Screen Curtain is toggled.
 When you want to change this behaviour, you can uncheck the "Play sound when toggling Screen Curtain" check box.

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -1088,11 +1088,11 @@ As a blind or vision impaired user, it is often not possible or necessary to see
 Furthermore, it might be hard to ensure that there isn't someone looking over your shoulder.
 For this situation, NVDA contains a feature called "Screen Curtain" which can be enabled to make the screen black.
 
-You can enable the Screen Curtain in the [vision category #VisionSettings] of the [NVDA Settings #NVDASettings] dialog. zzz
+You can enable the Screen Curtain in the [vision category #VisionSettings] of the [NVDA Settings #NVDASettings] dialog.
 
 %kc:beginInclude
 || Name | Key | Description |
-| Toggles the state of the screen curtain | NVDA+control+escape | Enable to make the screen black or disable to show the contents of the screen. Pressed once, screen curtain is enabled until you restart NVDA. Pressed twice, screen curtain is enabled until you disable it. |
+| Toggles the state of the screen curtain | ``NVDA+control+escape`` | Enable to make the screen black or disable to show the contents of the screen. Pressed once, screen curtain is enabled until you restart NVDA. Pressed twice, screen curtain is enabled until you disable it. |
 %kc:endInclude
 
 When the Screen Curtain is active some tasks directly based on what appears on the screen such as performing [OCR #Win10Ocr] or taking a screenshot cannot be achieved.


### PR DESCRIPTION
### Link to issue number:
Closes #10560
### Summary of the issue:
The screen curtain is missing a default gesture (working out of the box). Users want to have a default gesture in order not to have to define one themselves.

### Description of user facing changes
`NVDA+control+escape`  is defined as default gesture.

The gesture has been discussed in #10560:
* The main key is quite easy to find on a keyboard; e.g. PrintScreen is much harder because it's not always at the same place or sometimes behind Fn key.
* Usage of punctuation key for main key should be avoided because it differs from a local keyboard layout to another. Even if it may be translated by translators, the issue remains for people switching their keyboard layout. Punctuation keys are better suited for personal gestures.
* shortcut using 3 keys and not two due to the probable unfrequency of use with respect to other gestures/commands
* with this gesture, there is no risk to activate the screen curtain by accident.

### Description of development approach
Added in script's decorator and updated the documentation.

### Testing strategy:
Tested this gesture in NVDA started with a blank config folder.
### Known issues with pull request:
None
### Code Review Checklist:


- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
