### PR TITLE
soffice: Make status bar announcement work for dialogs, LO >= 24.2

### DIFF
--- a/source/appModules/soffice.py
+++ b/source/appModules/soffice.py
@@ -388,7 +388,13 @@ class AppModule(appModuleHandler.AppModule):
 		(up to the given depth) has the corresponding role."""
 		if obj.role == controlTypes.Role.STATUSBAR:
 			return obj
-		if max_depth < 1 or obj.role not in {controlTypes.Role.ROOTPANE, controlTypes.Role.WINDOW}:
+		if max_depth < 1 or obj.role not in {
+			controlTypes.Role.DIALOG,
+			controlTypes.Role.FRAME,
+			controlTypes.Role.OPTIONPANE,
+			controlTypes.Role.ROOTPANE,
+			controlTypes.Role.WINDOW
+		}:
 			return None
 		for child in obj.children:
 			status_bar = self.searchStatusBar(child, max_depth - 1)
@@ -402,9 +408,10 @@ class AppModule(appModuleHandler.AppModule):
 	def getStatusBarText(self, obj: NVDAObject) -> str:
 		text = ""
 		for child in obj.children:
-			textObj = child.IAccessibleTextObject
-			if textObj:
-				if text:
-					text += " "
-				text += textObj.textAtOffset(0, IA2.IA2_TEXT_BOUNDARY_ALL)[2]
+			if hasattr(child, 'IAccessibleTextObject'):
+				textObj = child.IAccessibleTextObject
+				if textObj:
+					if text:
+						text += " "
+					text += textObj.textAtOffset(0, IA2.IA2_TEXT_BOUNDARY_ALL)[2]
 		return text

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -26,7 +26,7 @@ This option now announces additional relevant information about an object when t
 - The SAPI4 synthesizer now properly supports volume, rate and pitch changes embedded in speech. (#15271)
 - Multi line state is now correctly reported in applications using Java Access Bridge. (#14609)
 - In LibreOffice, words deleted using the ``control+backspace`` keyboard shortcut are now also properly announced when the deleted word is followed by whitespace (like spaces and tabs). (#15436)
-- In LibreOffice, announcement of the status bar using the ``NVDA+end`` keyboard shortcut now also works for dialogs and the upcoming LibreOffice version 24.2. (#15591)
+- In LibreOffice, announcement of the status bar using the ``NVDA+end`` keyboard shortcut now also works for dialogs in LibreOffice version 24.2 and newer. (#15591)
 -
 
 == Changes for Developers ==

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -26,6 +26,7 @@ This option now announces additional relevant information about an object when t
 - The SAPI4 synthesizer now properly supports volume, rate and pitch changes embedded in speech. (#15271)
 - Multi line state is now correctly reported in applications using Java Access Bridge. (#14609)
 - In LibreOffice, words deleted using the ``control+backspace`` keyboard shortcut are now also properly announced when the deleted word is followed by whitespace (like spaces and tabs). (#15436)
+- In LibreOffice, announcement of the status bar using the ``NVDA+end`` keyboard shortcut now also works for dialogs and the upcoming LibreOffice version 24.2. (#15591)
 -
 
 == Changes for Developers ==


### PR DESCRIPTION
 ### Link to issue number:

Fixes #15591

 ### Summary of the issue:

Commit 62536a97cd29019c7055c927746da72435d12b95
("soffice: Implement methods for status bar announcement (#14933)") added support for status bar announcement in LibreOffice by searching for it in the a11y tree. For performance reasons, only objects of specific roles are considered when traversing the tree. The DIALOG and OPTIONPANE roles, needed to find the status bar in Writer's "Edit Contour" dialog were not taken into account yet, so the status bar was not found and could therefore not be announced when pressing NVDA+End.

In addition, the status bar object in dialogs like that one did not have the proper role in LibreOffice yet.

 ### Description of user facing changes

Status bar announcement for LibreOffice using the NVDA+End keyboard shortcut now also works for dialogs and with the upcoming LibreOffice version 24.2.

 ### Description of development approach

LibreOffice is adapted to expose the proper role for the status bar in dialogs like the one mentioned above:
https://gerrit.libreoffice.org/c/core/+/157659

The DIALOG and OPTIONPANE roles are now also considered by NVDA when traversing the a11y tree to find the status bar.

In addition, the FRAME role is also taken into account, which is needed to support finding the status bar in the default application window with LibreOffice >= 24.2, see commit message of this LibreOffice change for more details: https://gerrit.libreoffice.org/c/core/+/157658

Add a check whether the statusbar children have the 'IAccessibleTextObject' member before accessing it.

 ### Testing strategy:

1) Start LibreOffice Writer (current development version including
   https://gerrit.libreoffice.org/c/core/+/157659 )
2) insert a Formula: "Insert" -> "OLE Object" -> "Formula Object", type any formula, e.g. "1+1=2" 3) click outside of the formula then click the formula object again to focus it 4) in Writer's menu, select "Format" -> "Wrap" -> "Edit Contour" 5) Once the dialog shows up, press NVDA+End to announce the status bar

 ### Known issues with pull request:

Requires https://gerrit.libreoffice.org/c/core/+/157659 on LibreOffice side in addition for the announcement to actually work.

 ### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.