### PR TITLE
Strip accelerator keys from certain menu items

### DIFF
--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -535,11 +535,11 @@ class SysTrayIcon(wx.adv.TaskBarIcon):
 				item = menu_tools.Append(wx.ID_ANY, _("&Install NVDA..."))
 				self.Bind(wx.EVT_MENU, frame.onInstallCommand, item)
 			# Translators: The label for the menu item to run the COM registration fix tool 
-			item = menu_tools.Append(wx.ID_ANY, _("&Run COM Registration Fixing tool..."))
+			item = menu_tools.Append(wx.ID_ANY, _("Run COM Registration Fixing tool..."))
 			self.Bind(wx.EVT_MENU, frame.onRunCOMRegistrationFixesCommand, item)
 		if not config.isAppX:
 			# Translators: The label for the menu item to reload plugins.
-			item = menu_tools.Append(wx.ID_ANY, _("R&eload plugins"))
+			item = menu_tools.Append(wx.ID_ANY, _("Reload plugins"))
 			self.Bind(wx.EVT_MENU, frame.onReloadPluginsCommand, item)
 		# Translators: The label for the Tools submenu in NVDA menu.
 		self.menu.AppendSubMenu(menu_tools, _("&Tools"))


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Fixes #15588
Replaces #15589
Follow-up of https://github.com/nvaccess/nvda/pull/15364

### Summary of the issue:
Among changes made in https://github.com/nvaccess/nvda/pull/15364, the accelerator key for the item "Reload plugins" in "Tools" menu has be modified to "E".
Users of NVDA remote add-on have complained that it conflicts with this add-on's accelerator key, that is being used for many years.

Usually, NVDA defines the shortcut keys and the add-ons should adapt to it. Given the popularity of NVDA Remote and it's age in the community though, NV Access may accept this case as a valid exception to this rule.

### Description of user facing changes
Strip accelerator keys from "reload plugins" and "run com registration fixing tool".

### Description of development approach
When removing the accelerator key for reload plugins, "r" becomes the implicit key. This conflicts with explicit key for the COM reg tool, so both should be removed in the mean time.

### Testing strategy:
N/A
### Known issues with pull request:
None
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
