### PR TITLE
Restore accelerator key for Run COM reg tool

### DIFF
--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -535,7 +535,7 @@ class SysTrayIcon(wx.adv.TaskBarIcon):
 				item = menu_tools.Append(wx.ID_ANY, _("&Install NVDA..."))
 				self.Bind(wx.EVT_MENU, frame.onInstallCommand, item)
 			# Translators: The label for the menu item to run the COM registration fix tool 
-			item = menu_tools.Append(wx.ID_ANY, _("Run COM Registration Fixing tool..."))
+			item = menu_tools.Append(wx.ID_ANY, _("&Run COM Registration Fixing tool..."))
 			self.Bind(wx.EVT_MENU, frame.onRunCOMRegistrationFixesCommand, item)
 		if not config.isAppX:
 			# Translators: The label for the menu item to reload plugins.


### PR DESCRIPTION
### Link to issue number:
Follow-up of fix for #15588
Fix-up of #15596
Follow-up of #15364

Summary of the issue:
In #15364, accelerator keys have been modified in NVDA menu. While reviewing this PR, a specific attention has been put to avoid modifying some pre-existing written insntructions, especially to run the COM reg tool; see https://github.com/nvaccess/nvda/pull/15364#discussion_r1315648958 for details.
The previously communicated instructions to run the com reg tool were:
> Press NVDA+n, t, r 
However, unfortunately, with #15596 the instructions become:
> Press NVDA+n, t, r, Enter
### Summary of the issue:

### Description of user facing changes
Restore "R" as explicit shortcut for Run COM reg tool item.
This will mask the "Reload plugins" shortcut, for which an accelerator key has been estimated less interesting because not part of commonly and previously written instructions and because, there is already the default shortcut NVDA+control+F3. Thus "Reload plugins" has no accelerator at all.
### Description of development approach
Restored accelerator in string.
### Possible addition
If having no accelerator at all for "Reload plugins", we still can add "G" as an explicit unique accelerator for this item, restoring completely #15589.
However, if #15589 has been superseded by #15596, there should have been a reason. Unfortunately it has not been made explici. By the way, @seanbudd, could you provide an explicit reason why #15596 was considered a better choice than #15589? Thanks.
### Testing strategy:
Manual test:
* hacked the code to allow to have the com reg tool while running from source
* Checked that NVDA+N, T, R opens the tool without the need to press Enter.

### Known issues with pull request:
The translation freeze has just started. However, if this PR is just merged, we can just inform the translation mailing list that this little addition has been done.
### Code Review Checklist:



- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

Cc @XLTechie 