### PR TITLE
Add docstrings format to coding standards

### DIFF
--- a/projectDocs/dev/codingStandards.md
+++ b/projectDocs/dev/codingStandards.md
@@ -103,7 +103,7 @@ Refer to the [limitations to retaining backwards compatibility](./deprecations.m
 
 In summary:
 - Avoid module level global variables.
-Any module level variables should be prefixed with and underscore and be encapsulated, e.g. via getters and setters.
+Any module level variables should be prefixed with an underscore and be encapsulated, e.g. via getters and setters.
 - Avoid code which executes at import time.
 Instead use initializer functions.
 

--- a/projectDocs/dev/codingStandards.md
+++ b/projectDocs/dev/codingStandards.md
@@ -109,4 +109,7 @@ Instead use initializer functions.
 
 ### Docstrings
 
-NVDA uses [epytext](https://epydoc.sourceforge.net/manual-epytext.html) syntax for docstrings.
+Docstrings should use [Sphinx format](https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html).
+
+NVDA formerly used [epytext](https://epydoc.sourceforge.net/manual-epytext.html) syntax for docstrings, which means there is inconsistent syntax used in the NVDA code base.
+[#12971](https://github.com/nvaccess/nvda/issues/12971) exists to track converting epytext docstrings to Sphinx.

--- a/projectDocs/dev/codingStandards.md
+++ b/projectDocs/dev/codingStandards.md
@@ -106,3 +106,7 @@ In summary:
 Any module level variables should be prefixed with and underscore and be encapsulated, e.g. via getters and setters.
 - Avoid code which executes at import time.
 Instead use initializer functions.
+
+### Docstrings
+
+NVDA uses [epytext](https://epydoc.sourceforge.net/manual-epytext.html) syntax for docstrings.

--- a/projectDocs/dev/codingStandards.md
+++ b/projectDocs/dev/codingStandards.md
@@ -110,6 +110,7 @@ Instead use initializer functions.
 ### Docstrings
 
 Docstrings should use [Sphinx format](https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html).
+Providing type information in docstrings is discouraged, instead use python's type annotations.
 
 NVDA formerly used [epytext](https://epydoc.sourceforge.net/manual-epytext.html) syntax for docstrings, which means there is inconsistent syntax used in the NVDA code base.
 [#12971](https://github.com/nvaccess/nvda/issues/12971) exists to track converting epytext docstrings to Sphinx.


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Closes #15575

### Summary of the issue:
NVDA documentation does not specify the standard we use for docstrings, [epytext](https://epydoc.sourceforge.net/manual-epytext.html)

### Description of user facing changes
Add reference to docstring syntax standard to coding standards document.
