### PR TITLE
Add @codeofdusk attributions for Python 3.11 upgrade

### DIFF
--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -45,8 +45,8 @@ Please open a GitHub issue if your Add-on has an issue with updating to the new 
 - NVDA is now built with Python 3.11. (#12064)
 - Updated pip dependencies:
   - configobj to 5.1.0dev commit e2ba4457. (#15544)
-  - Comtypes to 1.2.0. (#15513)
-  - fast_diff_match_patch to 2.0.1. (#15514)
+  - Comtypes to 1.2.0. (#15513, @codeofdusk)
+  - fast_diff_match_patch to 2.0.1. (#15514, @codeofdusk)
   - py2exe to 0.13.0.1dev commit 4e7b2b2c60face592e67cb1bc935172a20fa371d. (#15544) 
   - robotframework to 6.1.1. (#15544)
   - SCons to 4.5.2. (#15529)


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Fix-up of #15513 #15514 . 

### Description of how this pull request fixes the issue:
Add @codeofdusk attributions for Python 3.11 upgrade 

### Testing strategy:
N/A

### Known issues with pull request:
None known

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
