### PR TITLE
fix regex for credit

### DIFF
--- a/user_docs/changes.t2tconf
+++ b/user_docs/changes.t2tconf
@@ -6,7 +6,7 @@
 % Make GitHub username references into links.
 % Github username may only contain alphanumeric characters or hyphens.
 % Maximum is 39 characters.
-%!PreProc: ", @([A-Za-z0-9\-]{1,39})" "[@\1 https://github.com/nvaccess/nvda/commits?author=\1]"
+%!PreProc: ", @([A-Za-z0-9\-]{1,39})" "[, @\1 https://github.com/nvaccess/nvda/commits?author=\1]"
 
 % Make links open in a new tab/window.
 %!PostProc(html): '(<A HREF=".*?")>' '\1 target="_blank">'


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Fixup of #15602 

### Summary of the issue:
Regex was incorrect in #15602, removing the comma separation between the issue number and author credit
### Description of user facing changes
Fix processing of author credit github url

