### PR TITLE
Replace deprecated threading methods

### DIFF
--- a/source/UIAHandler/__init__.py
+++ b/source/UIAHandler/__init__.py
@@ -698,7 +698,7 @@ class UIAHandler(COMObject):
 				f"handleAutomationEvent called with event {self.getUIAEventIDDebugString(eventID)} "
 				f"for element {self.getUIAElementDebugString(sender)}"
 			)
-		if not self.MTAThreadInitEvent.isSet():
+		if not self.MTAThreadInitEvent.is_set():
 			# UIAHandler hasn't finished initialising yet, so just ignore this event.
 			if _isDebug():
 				log.debug("HandleAutomationEvent: event received while not fully initialized")
@@ -799,7 +799,7 @@ class UIAHandler(COMObject):
 	def IUIAutomationFocusChangedEventHandler_HandleFocusChangedEvent(self,sender):
 		if _isDebug():
 			log.debug(f"handleFocusChangedEvent called with element {self.getUIAElementDebugString(sender)}")
-		if not self.MTAThreadInitEvent.isSet():
+		if not self.MTAThreadInitEvent.is_set():
 			# UIAHandler hasn't finished initialising yet, so just ignore this event.
 			if _isDebug():
 				log.debug("HandleFocusChangedEvent: event received while not fully initialized")
@@ -888,7 +888,7 @@ class UIAHandler(COMObject):
 		# #3867: For now manually force this VARIANT type to empty to get around a nasty double free in comtypes/ctypes.
 		# We also don't use the value in this callback.
 		newValue.vt=VT_EMPTY
-		if not self.MTAThreadInitEvent.isSet():
+		if not self.MTAThreadInitEvent.is_set():
 			# UIAHandler hasn't finished initialising yet, so just ignore this event.
 			if _isDebug():
 				log.debug("HandlePropertyChangedEvent: event received while not fully initialized")
@@ -978,7 +978,7 @@ class UIAHandler(COMObject):
 				f"activityID {activityId}, "
 				f"for element {self.getUIAElementDebugString(sender)}"
 			)
-		if not self.MTAThreadInitEvent.isSet():
+		if not self.MTAThreadInitEvent.is_set():
 			# UIAHandler hasn't finished initialising yet, so just ignore this event.
 			if _isDebug():
 				log.debug("HandleNotificationEvent: event received while not fully initialized")
@@ -1023,7 +1023,7 @@ class UIAHandler(COMObject):
 			log.debug(
 				f"HandleActiveTextPositionChangedEvent called for element {self.getUIAElementDebugString(sender)}"
 			)
-		if not self.MTAThreadInitEvent.isSet():
+		if not self.MTAThreadInitEvent.is_set():
 			# UIAHandler hasn't finished initialising yet, so just ignore this event.
 			if _isDebug():
 				log.debug("HandleActiveTextPositionchangedEvent: event received while not fully initialized")

--- a/source/brailleDisplayDrivers/albatross/_threading.py
+++ b/source/brailleDisplayDrivers/albatross/_threading.py
@@ -62,7 +62,7 @@ class ReadThread(Thread):
 	def run(self):
 		data = dwEvtMask = DWORD()
 		log.debug(f"{self.name} started")
-		while not self._event.isSet():
+		while not self._event.is_set():
 			# Try to reconnect if port is not open
 			if not self._dev.is_open:
 				# But if port is not present, just wait and continue
@@ -87,7 +87,7 @@ class ReadThread(Thread):
 			try:
 				if not SetCommMask(self._dev._port_handle, EV_RXCHAR):
 					# Exiting
-					if self._event.isSet():
+					if self._event.is_set():
 						break
 					self._disableFunction()
 					log.debug("SetCommMask failed")
@@ -98,7 +98,7 @@ class ReadThread(Thread):
 					byref(self._dev._overlapped_read)
 				)
 				if not result and GetLastError() != ERROR_IO_PENDING:
-					if self._event.isSet():
+					if self._event.is_set():
 						break
 					self._disableFunction()
 					log.debug("WaitCommEvent failed")
@@ -113,7 +113,7 @@ class ReadThread(Thread):
 					log.debug(f"Calling function {self._readFunction.__name__} for read")
 					self._readFunction()
 				else:
-					if self._event.isSet():
+					if self._event.is_set():
 						break
 					log.debug(f"GetOverLappedResult failed {ctypes.WinError()}")
 					self._disableFunction()
@@ -121,7 +121,7 @@ class ReadThread(Thread):
 			# but writing to display fails during it - or vice versa - AttributeError
 			# or TypeError might raise.
 			except (OSError, AttributeError, TypeError):
-				if self._event.isSet():
+				if self._event.is_set():
 					break
 				else:
 					self._disableFunction()

--- a/source/synthDrivers/_espeak.py
+++ b/source/synthDrivers/_espeak.py
@@ -193,7 +193,7 @@ def callback(wav,numsamples,event):
 class BgThread(threading.Thread):
 	def __init__(self):
 		super().__init__(name=f"{self.__class__.__module__}.{self.__class__.__qualname__}")
-		self.setDaemon(True)
+		self.daemon = True
 
 	def run(self):
 		global isSpeaking


### PR DESCRIPTION
### Link to issue number:
None
### Summary of the issue:
Running Python 3.11 build, there are deprecation `DEBUGWARNING`'s related to `threading` package.

From Python 3.10 [What's new](https://docs.python.org/3.11/whatsnew/3.10.html?highlight=input):
> The following threading methods are now deprecated:
> * threading.currentThread => threading.current_thread()
> * threading.activeCount => threading.active_count()
> * threading.Condition.notifyAll => threading.Condition.notify_all()
> * threading.Event.isSet => threading.Event.is_set()
> * threading.Thread.setName => threading.Thread.name
> * threading.thread.getName => threading.Thread.name
> * threading.Thread.isDaemon => threading.Thread.daemon
> * threading.Thread.setDaemon => threading.Thread.daemon

Among these only `threading.Event.isSet` and `threading.Thread.setDaemon` are used in NVDA's codebase.


### Description of user facing changes
No more such deprecation warning in the log.

### Description of development approach
Replace the deprecated methods by their replacing method or attribute.

Since all these replacement method or attribute are available in Python 3.7, this PR is opened against master and can be merged before Python 3.11 switch, in preparation.

### Testing strategy:
* Rebase this branch on Python 3.11 branch and check that these deprecation DEBUGWARNING's are not present anymore.
* I have no Albatross braill display to test. It can then be tested in alpha. Or maybe @burmancomp can check on the build of this PR that the display still works as expected?
### Known issues with pull request:
None
### Change log entry
I guess such syntax change do not need a specific entry. In any case, there will be an entry for Python 3.11 transition.

### Code Review Checklist:


- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
