### PR TITLE
Move getFormattedStacksForAllThreads from watchdog to logHandler, to fix build of developer documentation.

### DIFF
--- a/source/hwIo/ioThread.py
+++ b/source/hwIo/ioThread.py
@@ -11,11 +11,9 @@ import winKernel
 import typing
 from logHandler import log
 from serial.win32 import OVERLAPPED, LPOVERLAPPED
-from contextlib import contextmanager
 from extensionPoints.util import AnnotatableWeakref, BoundMethodWeakref
 from inspect import ismethod
-from buildVersion import version_year
-from watchdog import getFormattedStacksForAllThreads
+from logHandler import getFormattedStacksForAllThreads
 
 
 LPOVERLAPPED_COMPLETION_ROUTINE = ctypes.WINFUNCTYPE(

--- a/source/watchdog.py
+++ b/source/watchdog.py
@@ -5,10 +5,12 @@
 
 import sys
 import os
-import traceback
 import time
 from time import perf_counter as _timer
 import threading
+from typing import (
+	Any,
+)
 import inspect
 from ctypes import windll, oledll
 import ctypes.wintypes
@@ -17,10 +19,25 @@ import comtypes
 import winUser
 import winKernel
 from logHandler import log
+import logHandler
 import globalVars
 import core
 import exceptions
 import NVDAHelper
+import NVDAState
+
+
+def __getattr__(attrName: str) -> Any:
+	"""Module level `__getattr__` used to preserve backward compatibility."""
+	if attrName == "getFormattedStacksForAllThreads" and NVDAState._allowDeprecatedAPI():
+		log.warning(
+			"Importing getFormattedStacksForAllThreads from here is deprecated. "
+			"getFormattedStacksForAllThreads should be imported from logHandler instead.",
+			stack_info=True,
+		)
+		return logHandler.getFormattedStacksForAllThreads
+	raise AttributeError(f"module {repr(__name__)} has no attribute {repr(attrName)}")
+
 
 MIN_CORE_ALIVE_TIMEOUT = 0.5
 """The minimum time (seconds) to wait for the core to be alive.
@@ -51,23 +68,6 @@ _watcherThread=None
 _cancelCallEvent = None
 
 
-def getFormattedStacksForAllThreads():
-	"""
-	Generates a string containing a call stack for every Python thread in this process, suitable for logging.
-	"""
-	# First collect the names of all threads that have actually been started by Python itself.
-	threadNamesByID = {x.ident: x.name for x in threading.enumerate()}
-	stacks = []
-	# If a Python function is entered by a thread that was not started by Python itself,
-	# It will have a frame, but won't be tracked by Python's threading module and therefore will have no name.
-	for ident, frame in sys._current_frames().items():
-		# The strings in the formatted stack all end with \n, so no join separator is necessary.
-		stack = "".join(traceback.format_stack(frame))
-		name = threadNamesByID.get(ident, "Unknown")
-		stacks.append(f"Python stack for thread {ident} ({name}):\n{stack}")
-	return "\n".join(stacks)
-
-
 def alive():
 	"""Inform the watchdog that the core is alive.
 	"""
@@ -92,6 +92,7 @@ def alive():
 			-int(SECOND_TO_100_NANOSECOND * MIN_CORE_ALIVE_TIMEOUT)
 		)),
 		0, None, None, False)
+
 
 def asleep():
 	"""Inform the watchdog that the core is going to sleep.
@@ -162,7 +163,7 @@ def _watcher():
 def waitForFreezeRecovery(waitedSince: float):
 	log.info(f"Starting freeze recovery after {_timer() - waitedSince} seconds.")
 	if log.isEnabledFor(log.DEBUGWARNING):
-		stacks = getFormattedStacksForAllThreads()
+		stacks = logHandler.getFormattedStacksForAllThreads()
 		log.debugWarning(
 			f"Listing stacks for Python threads:\n{stacks}"
 		)
@@ -183,7 +184,7 @@ def waitForFreezeRecovery(waitedSince: float):
 			# Core is completely frozen.
 			# Collect formatted stacks for all Python threads.
 			log.error(f"Core frozen in stack! ({curTime - waitedSince} seconds)")
-			stacks = getFormattedStacksForAllThreads()
+			stacks = logHandler.getFormattedStacksForAllThreads()
 			log.info(f"Listing stacks for Python threads:\n{stacks}")
 		_recoverAttempt()
 		time.sleep(RECOVER_ATTEMPT_INTERVAL)
@@ -255,7 +256,7 @@ def _crashHandler(exceptionInfo):
 		log.critical("NVDA crashed! Minidump written to %s" % dumpPath)
 
 	# Log Python stacks for every thread.
-	stacks = getFormattedStacksForAllThreads()
+	stacks = logHandler.getFormattedStacksForAllThreads()
 	log.info(f"Listing stacks for Python threads:\n{stacks}")
 
 	log.info("Restarting due to crash")

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -61,6 +61,9 @@ That method receives a ``DriverRegistrar`` object on which the ``addUsbDevices``
 
 === Deprecations ===
 
+- Using ``watchdog.getFormattedStacksForAllThreads`` is deprecated - please use ``logHandler.getFormattedStacksForAllThreads`` instead. (#15616, @lukaszgo1)
+-
+
 
 = 2023.3 =
 This release includes improvements to performance, responsiveness and stability of audio output.


### PR DESCRIPTION
### Link to issue number:
None, related to #12971 problem caused by PR #14899
### Summary of the issue:
When trying to build developer documentation with Sphinx, many modules failed to be parsed with one of the following errors:
```
WARNING: autodoc: failed to import module 'IAccessibleHandler'; the following exception was raised:
cannot import name 'getFormattedStacksForAllThreads' from 'watchdog' (D:\my_repos\nvda\source\watchdog.py)
```

```
WARNING: autodoc: failed to import module 'NVDAObjects'; the following exception was raised:
Traceback (most recent call last):
  File "D:\my_repos\nvda\.venv\lib\site-packages\sphinx\ext\autodoc\importer.py", line 58, in import_module
    return importlib.import_module(modname)
  File "C:\Python37\lib\importlib\__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1006, in _gcd_import
  File "<frozen importlib._bootstrap>", line 983, in _find_and_load
  File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 728, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "D:\my_repos\nvda\source\NVDAObjects\__init__.py", line 23, in <module>
    import review
  File "D:\my_repos\nvda\source\review.py", line 11, in <module>
    import api
  File "D:\my_repos\nvda\source\api.py", line 21, in <module>
    from NVDAObjects.window import Window
  File "D:\my_repos\nvda\source\NVDAObjects\window\__init__.py", line 16, in <module>
    import displayModel
  File "D:\my_repos\nvda\source\displayModel.py", line 17, in <module>
    import mouseHandler
  File "D:\my_repos\nvda\source\mouseHandler.py", line 10, in <module>
    import gui
  File "D:\my_repos\nvda\source\gui\__init__.py", line 37, in <module>
    from .speechDict import (
  File "D:\my_repos\nvda\source\gui\speechDict.py", line 20, in <module>
    from .settingsDialogs import SettingsDialog
  File "D:\my_repos\nvda\source\gui\settingsDialogs.py", line 66, in <module>
    import updateCheck
  File "D:\my_repos\nvda\source\updateCheck.py", line 345, in <module>
    gui.contextHelp.ContextHelpMixin,AttributeError: module 'gui' has no attribute 'contextHelp'
```

I've tracked this down to PR #14899, which imported stuff from `watchdog` in the `hwIo` package.
### Description of user facing changes
None - this only moves code used internally for logging.
### Description of development approach
`getFormattedStacksForAllThreads` is moved from `watchdog` to the `logHandler`, which avoids these warnings. Appropriate backwards compatibility is added to `watchdog`, to make sure add-on authors are warned to use the moved function from `logHandler` in the future.
### Testing strategy:
Ensured that for affected modules developer documentation can once again be created.
### Known issues with pull request:
- If someone has better suggestions as to where `getFormattedStacksForAllThreads` should be placed I'd be happy to hear them
- While this PR makes developer documentation buildable once again, it only covers the underlying issue. There is a circular import somewhere in NVDA's code base which should be found and fixed separately
### Code Review Checklist:


- [X] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [X] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [X] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [X] API is compatible with existing add-ons.
- [X] Security precautions taken.
