### PR TITLE
Indicate that setting column/row headers in Word tables does not work for UIA

### DIFF
--- a/source/NVDAObjects/UIA/wordDocument.py
+++ b/source/NVDAObjects/UIA/wordDocument.py
@@ -607,3 +607,22 @@ class WordDocument(UIADocumentWithTableNavigation,WordDocumentNode,WordDocumentB
 			# Translators: a message when there is no comment to report in Microsoft Word
 			ui.message(_("No comments"))
 		return
+
+	@script(gesture="kb:NVDA+shift+c")
+	def script_setColumnHeader(self,gesture):
+		ui.message(_(
+			# Translators: The message reported in Microsoft Word for document types not supporting setting custom headers.
+			"Command not supported in this type of document. "
+			"The tables have their first row cells automatically set as column headers."
+		))
+
+	@script(gesture="kb:NVDA+shift+r")
+	def script_setRowHeader(self,gesture):
+		ui.message(_(
+			# Translators: The message reported in Microsoft Word for document types not supporting setting custom headers.
+			"Command not supported in this type of document. "
+			"The tables have their first column cells automatically set as row headers."
+		))
+
+
+

--- a/source/NVDAObjects/UIA/wordDocument.py
+++ b/source/NVDAObjects/UIA/wordDocument.py
@@ -609,20 +609,19 @@ class WordDocument(UIADocumentWithTableNavigation,WordDocumentNode,WordDocumentB
 		return
 
 	@script(gesture="kb:NVDA+shift+c")
-	def script_setColumnHeader(self,gesture):
+	def script_setColumnHeader(self, gesture):
 		ui.message(_(
-			# Translators: The message reported in Microsoft Word for document types not supporting setting custom headers.
+			# Translators: The message reported in Microsoft Word for document types not supporting setting custom
+			# headers.
 			"Command not supported in this type of document. "
 			"The tables have their first row cells automatically set as column headers."
 		))
 
 	@script(gesture="kb:NVDA+shift+r")
-	def script_setRowHeader(self,gesture):
+	def script_setRowHeader(self, gesture):
 		ui.message(_(
-			# Translators: The message reported in Microsoft Word for document types not supporting setting custom headers.
+			# Translators: The message reported in Microsoft Word for document types not supporting setting custom
+			# headers.
 			"Command not supported in this type of document. "
 			"The tables have their first column cells automatically set as row headers."
 		))
-
-
-

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -1140,7 +1140,7 @@ NVDA provides its own extra features  for some applications to make certain task
 NVDA is able to automatically announce appropriate row and column headers when navigating around tables in Microsoft Word.
 This requires that the Report Table row / column headers option in NVDA's Document Formatting settings, found in the [NVDA Settings #NVDASettings] dialog, be turned on.
 
-If you use [UIA to access Word documents #MSWordUIA], that is, by default, in recent versions of Word and Windows, the cells of the first row will automatically be considered as column headers; similarly, the cells of the first column will automatically be considered as row headers; 
+If you use [UIA to access Word documents #MSWordUIA], which is default in recent versions of Word and Windows, the cells of the first row will automatically be considered as column headers; similarly, the cells of the first column will automatically be considered as row headers.
 
 On the contrary, if you do not use [UIA to access Word documents #MSWordUIA], you will have to indicate to NVDA which row or column contains the headers in any given table.
 After moving to the first cell in the column or row containing the headers, use one of the following commands:

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -1138,8 +1138,11 @@ NVDA provides its own extra features  for some applications to make certain task
 
 +++ Automatic Column and Row Header Reading +++[WordAutomaticColumnAndRowHeaderReading]
 NVDA is able to automatically announce appropriate row and column headers when navigating around tables in Microsoft Word.
-This firstly requires that the Report Table row / column headers option in NVDA's Document Formatting settings, found in the [NVDA Settings #NVDASettings] dialog, be turned on.
-Secondly, NVDA needs to know which row or column contains the headers in any given table.
+This requires that the Report Table row / column headers option in NVDA's Document Formatting settings, found in the [NVDA Settings #NVDASettings] dialog, be turned on.
+
+If you use [UIA to access Word documents #MSWordUIA], that is, by default, in recent versions of Word and Windows, the cells of the first row will automatically be considered as column headers; similarly, the cells of the first column will automatically be considered as row headers; 
+
+On the contrary, if you do not use [UIA to access Word documents #MSWordUIA], you will have to indicate to NVDA which row or column contains the headers in any given table.
 After moving to the first cell in the column or row containing the headers, use one of the following commands:
 %kc:beginInclude
 || Name | Key | Description |


### PR DESCRIPTION
### Link to issue number:
Fixes #13006

### Summary of the issue:
UIA has become the default in Word for people with recent versions of Word and running Windows 11. When they try to set the column/row headers in tables with NVDA+shift+C/R, the command does not work and they are confused.
The first row and the first column are however automatically treated as headers.

### Description of user facing changes
Following the discussion in #13006, ^more specifically https://github.com/nvaccess/nvda/issues/13006#issuecomment-175684609, and considering that:
* the headers are usually in the first row or column in of the tables,
* Some work is needed on Microsoft's side to make our traditional headers work with UIA,
it has been decided to accept and document this limitation of being able to have headers only on the first row/column.

Thus the User Guide has been updated.

Also, in Word documents when using UIA, NVDA+shift+C/R now report an information so that user know that these commands are not supported nor needed anymore.

Notes:
When this fix is released in a stable release, we can evaluate if this information is enough for people or if they keep on asking the old way to manage column/row headers; we can then consider reopening #13006 (or opening a new similar issue) if needed.


### Description of development approach
Two script added in the class for Word UI§A documents. These script have no description since they do not need to be discovered nor remapped in the Input gesture dialog. They're just here to give information to people trying to use the old way to handle row/column headers.

### Testing strategy:
* Check that the error message is reported in UIA Word Document
* Check that the headers script still works normally in IAccessible Word documents
* Check the UG
### Known issues with pull request:
A similar issue exists for Excel. However, since UIA is still experimental in Excel, there is no point in adding confusion in the Excel paragraph of the User Guide.
Thus, the similar issue is not documented for Excel.

### Change log entry
Not needed.
### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
