### PR TITLE
Move the column Status in the Add-on Store GUI

### DIFF
--- a/source/gui/_addonStoreGui/viewModels/addonList.py
+++ b/source/gui/_addonStoreGui/viewModels/addonList.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2022-2023 NV Access Limited
+# Copyright (C) 2022-2023 NV Access Limited, Cyrille Bougot
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -57,6 +57,12 @@ class AddonListField(_AddonListFieldData, Enum):
 		pgettext("addonStore", "Name"),
 		150,
 	)
+	status = (
+		# Translators: The name of the column that contains the status of the addon.
+		# e.g. available, downloading installing
+		pgettext("addonStore", "Status"),
+		150
+	)
 	currentAddonVersionName = (
 		# Translators: The name of the column that contains the installed addon's version string.
 		pgettext("addonStore", "Installed version"),
@@ -85,12 +91,6 @@ class AddonListField(_AddonListFieldData, Enum):
 		pgettext("addonStore", "Author"),
 		100,
 		frozenset({_StatusFilterKey.AVAILABLE, _StatusFilterKey.UPDATE})
-	)
-	status = (
-		# Translators: The name of the column that contains the status of the addon.
-		# e.g. available, downloading installing
-		pgettext("addonStore", "Status"),
-		150
 	)
 
 


### PR DESCRIPTION
### Link to issue number:
Fixes #15069
### Summary of the issue:
In the Add-on Store GUI the Status column is the last one. However, the status information is much more important for users than Author. Users wanting to hear the status information when an add-on is selected in the GUI need to wait for the whole line to be read or to use additional object navigation commands. This is less efficient.

### Description of user facing changes
The column "Status" is now located just after the add-on's name.

As discussed in #15069, both version numbers and status are important informations in the Updatable add-on tab. However, it's important to keep a quite similar order between tabs to allow a smoother UX.

### Description of development approach
In `AddonListField` enum, moved the `status` item in second position.
### Testing strategy:
Checked the order of the columns in the four tabs of the Add-on Store
### Known issues with pull request:
None

### Change log
Not needed IMO for small GUI changes.
### Code Review Checklist:


- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
