### PR TITLE
Add docs note for reporting translation issues

### DIFF
--- a/projectDocs/dev/contributing.md
+++ b/projectDocs/dev/contributing.md
@@ -19,6 +19,7 @@ If you are new to the project, or looking for some way to help take a look at:
   - e.g. a fix for a typo/obvious coding error or a simple synthesizer/braille display driver
   - This should be fairly rare.
 - If in doubt, use an issue first. Use this issue to discuss the alternatives you have considered in regards to implementation, design, and user experience. Then give people time to offer feedback.
+- Issues with translations should be reported to the [NVDA Translators list](https://groups.io/g/nvda-translations).
 
 
 ### Overview of contribution process:

--- a/projectDocs/issues/readme.md
+++ b/projectDocs/issues/readme.md
@@ -7,6 +7,8 @@ If you don't have a clear idea of the issue, and you are unable to fill out the 
 
 Do not report security issues via GitHub, instead follow our [security policy](../../security.md).
 
+Issues with translations should be reported to the [NVDA Translators list](https://groups.io/g/nvda-translations).
+
 If you are reporting an issue with an application or website, please consider reporting the issue to the authors of the application/website first.
 
 If you are a developer reporting an issue with your application/website, please include a minimal reproducible sample and details of the specification not being handled correctly.


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Fixes #15627

### Summary of the issue:
Sometimes, people want to report or even fix translation or localization issues in NVDA's GitHub. 

However, translation is not performed through NVDA GitHub's repo but through SVN repo.

Translation issues are usually reported through various local communities (e.g. user mailing lists) or on the translator's mailing list. This seems to work quite well, at least in the French community.

### Description of development approach
Add docs note for reporting translation issues
