### PR TITLE
Update to flake8 4.0.1.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ sphinx==7.2.6
 sphinx_rtd_theme==1.3.0
 
 # Requirements for automated linting
-flake8 ~= 3.7.7
+flake8 ~= 4.0.1
 flake8-tabs == 2.1.0
 
 # Requirements for system tests

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -51,6 +51,7 @@ Please open a GitHub issue if your Add-on has an issue with updating to the new 
   - configobj to 5.1.0dev commit e2ba4457. (#15544)
   - Comtypes to 1.2.0. (#15513, @codeofdusk)
   - fast_diff_match_patch to 2.0.1. (#15514, @codeofdusk)
+  - Flake8 to 4.0.1. (#15636, @lukaszgo1)
   - py2exe to 0.13.0.1dev commit 4e7b2b2c60face592e67cb1bc935172a20fa371d. (#15544) 
   - robotframework to 6.1.1. (#15544)
   - SCons to 4.5.2. (#15529)


### PR DESCRIPTION
### Link to issue number:
Discussion in #15299
Unblocks PR #15546

### Summary of the issue:
The version of Flake8 we're using is extremely old. While it worked well up to now, it does not support some newer syntactic construct in recent versions of Python (in particular walrus operator). Unfortunately we cannot update to the latest release, since it does not support flake8-tabs, nor linting a diff (the latter can be achieved using external tools).
### Description of user facing changes
None
### Description of development approach
Flake8 is updated to the version 4.0.1. This is the last version which supports flake8-tabs, and it also recognizes various newer language constructs in Python, by the simple fact that it was released almost 2.5 years after the version we're using currently.
### Testing strategy:
Ensured that code from PR #15546 can be linted correctly.
### Known issues with pull request:
While this version of Flake8 is way more recent than what we we're using up to now, it predates Python 3.11. It means that some constructs (`case` statements) would not be recognized. Possible solutions are discussed in  #15299.
### Code Review Checklist:


- [X] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [X] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [X] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [X] API is compatible with existing add-ons.
- [X] Security precautions taken.
