### PR TITLE
Revert "NVDAObject.presentationType: groupings with position information but no name and no description should still be treated as content I.e. announced in focus ancestry. (#14878)"

### DIFF
--- a/source/NVDAObjects/__init__.py
+++ b/source/NVDAObjects/__init__.py
@@ -919,16 +919,13 @@ class NVDAObject(documentBase.TextContainerObject, baseObject.ScriptableObject, 
 				controlTypes.Role.PANEL,
 				controlTypes.Role.PROPERTYPAGE,
 				controlTypes.Role.TEXTFRAME,
+				controlTypes.Role.GROUPING,
 				controlTypes.Role.OPTIONPANE,
 				controlTypes.Role.INTERNALFRAME,
 				controlTypes.Role.FORM,
 				controlTypes.Role.TABLEBODY,
 				controlTypes.Role.REGION,
 			):
-				return self.presType_layout
-			# Groupings should only be considered layout (I.e. filtered out)
-			# if they also don't have any position information as well as no name or description.
-			if role == controlTypes.Role.GROUPING and not self.name and not self.description and not self.positionInfo:
 				return self.presType_layout
 			if role == controlTypes.Role.TABLE and not config.conf["documentFormatting"]["reportTables"]:
 				return self.presType_layout

--- a/source/NVDAObjects/__init__.py
+++ b/source/NVDAObjects/__init__.py
@@ -913,6 +913,12 @@ class NVDAObject(documentBase.TextContainerObject, baseObject.ScriptableObject, 
 			return self.presType_layout
 		name = self.name
 		description = self.description
+		# #15324: Some builds of Microsoft Office expose a space character as the name of unlabeled groupings.
+		# trying to force NVDA to announce them.
+		if name and name.isspace():
+			name = None
+		if description and description.isspace():
+			description = None
 		if not name and not description:
 			if role in (
 				controlTypes.Role.WINDOW,

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -23,7 +23,7 @@ Windows 8.1 is the minimum Windows version supported. (#15544)
 This option now announces additional relevant information about an object when the mouse enters it, such as states (checked/pressed) or cell coordinates in a table. (#15420, @LeonarddeR)
 - When requesting formatting information on Excel cells, borders and background will only be reported if there is such formatting. (#15560, @CyrilleB79)
 - The command to toggle the screen curtain now has a default gesture: ``NVDA+control+escape``. (#10560, @CyrilleB79)
-- NVDA will again  no longer report unlabeled groupings such as in recent versions of Microsoft Office 365 menus. (#15638)
+- NVDA will again no longer report unlabelled groupings such as in recent versions of Microsoft Office 365 menus. (#15638)
 -
 
 == Bug Fixes ==

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -23,7 +23,7 @@ Windows 8.1 is the minimum Windows version supported. (#15544)
 This option now announces additional relevant information about an object when the mouse enters it, such as states (checked/pressed) or cell coordinates in a table. (#15420, @LeonarddeR)
 - When requesting formatting information on Excel cells, borders and background will only be reported if there is such formatting. (#15560, @CyrilleB79)
 - The command to toggle the screen curtain now has a default gesture: ``NVDA+control+escape``. (#10560, @CyrilleB79)
-- NVDA will again  no longer report unlabeled groupings such as in recent versions of Microsoft Office 365 menus. (#14878)
+- NVDA will again  no longer report unlabeled groupings such as in recent versions of Microsoft Office 365 menus. (#15638)
 -
 
 == Bug Fixes ==

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -23,6 +23,7 @@ Windows 8.1 is the minimum Windows version supported. (#15544)
 This option now announces additional relevant information about an object when the mouse enters it, such as states (checked/pressed) or cell coordinates in a table. (#15420, @LeonarddeR)
 - When requesting formatting information on Excel cells, borders and background will only be reported if there is such formatting. (#15560, @CyrilleB79)
 - The command to toggle the screen curtain now has a default gesture: ``NVDA+control+escape``. (#10560, @CyrilleB79)
+- NVDA will again  no longer report unlabeled groupings such as in recent versions of Microsoft Office 365 menus. (#14878)
 -
 
 == Bug Fixes ==
@@ -287,7 +288,6 @@ eSpeak-NG, LibLouis braille translator, and Unicode CLDR have been updated.
 - Script for reporting the destination of a link now reports from the caret / focus position rather than the navigator object. (#14659)
 - Portable copy creation no longer requires that a drive letter be entered as part of the absolute path. (#14680)
 - If Windows is configured to display seconds in the system tray clock, using ``NVDA+f12`` to report the time now honors that setting. (#14742)
-- NVDA will now report unlabeled groupings that have useful position information, such as in recent versions of Microsoft Office 365 menus. (#14878)
 -
 
 


### PR DESCRIPTION
This reverts commit bcc7f25470b45731911197c063cf9923b7efb2ec.

<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Reverts pr #14878
Closes #15324

### Summary of the issue:
Traditionally, NvDA has only ever announced groupings in the focus ancestry if they have a name or description. 
Recently Microsoft had been placing unlabeled groupings within context menus in Office and other places, to denote visual spacing. Microsoft had also recently been exposing position info (x of y) on these groupings. 
In order to take advantage of this new info, through suggestion from Microsoft, in pr #14878 NVDA started announcing these unalabeled groupings, if they had position info. the advantage being that the blind user would then have a much better idea of how these context menu items were grouped, and just how many were in each section.
However, it is very clear based on user feedback, that there are way too many small groupings for the extra speech to outway missing info. There are many groupings in these context menus with only 1 or 2 items, greatly slowing down a user's navigation.
 

### Description of user facing changes
NVDA will again no longer report unlabeled gorupings in the focus ancestory.

### Description of development approach
Reverts pr #14878.
this pr also tightens up the detection of labels for groupings and similar controls to ignore names and descriptions that only contain whitespace. This is necessary as in some builds of Office, Microsoft also started exposing a space character on the name of unlabeled groupings in order to force screen readers to announce the unlabeled groupings.
 
### Testing strategy:
Moved up and down the context menu in Microsoft Word, ensuring that unlabeled groupings are no longer reported.
Tabbed through the windows settings app to ensure that labeled groupings are still announced.

### Known issues with pull request:
Issue #15324 suggested a new setting for Object Presentation settings which would allow configuring if NVDA announced all groupings / labeled groupings / no groupings. But it primary motivation was to remove the announcement of unlabeled groupings. Thus, reverting pr #14878 seems a more straight forward solution for now. And later one we could consider re-introducing something optional - though I personally am not convinced there is much of a need. The community has been quite vocal about this.
remains a problem in the future, NVDA may also need to specifically filter out 

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
