### PR TITLE
Remove pre Windows 8 code from NVDAHelper

### DIFF
--- a/nvdaHelper/local/nvdaHelperLocal.cpp
+++ b/nvdaHelper/local/nvdaHelperLocal.cpp
@@ -34,21 +34,19 @@ handle_t createRemoteBindingHandle(wchar_t* uuidString) {
 		LOG_ERROR(L"RpcBindingFromStringBinding failed with status "<<rpcStatus);
 		return NULL;
 	}
-	//On Windows 8 we must allow AppContainer servers to communicate back to us
-	//Detect Windows 8 by looking for RpcServerRegisterIf3
-	HANDLE rpcrt4Handle=GetModuleHandle(L"rpcrt4.dll");
-	if(rpcrt4Handle&&GetProcAddress((HMODULE)rpcrt4Handle,"RpcServerRegisterIf3")) {
-		PSECURITY_DESCRIPTOR psd=NULL;
-		ULONG size;
-		if(!ConvertStringSecurityDescriptorToSecurityDescriptor(L"D:(A;;GA;;;wd)(A;;GA;;;AC)",SDDL_REVISION_1,&psd,&size)) {
-			LOG_ERROR(L"ConvertStringSecurityDescriptorToSecurityDescriptor failed");
-			return NULL;
-		}
-		RPC_SECURITY_QOS_V5_W securityQos={5,0,0,0,0,NULL,NULL,0,psd};
-		if((rpcStatus=RpcBindingSetAuthInfoEx(bindingHandle,NULL,RPC_C_AUTHN_LEVEL_DEFAULT,RPC_C_AUTHN_DEFAULT,NULL,0,(RPC_SECURITY_QOS*)&securityQos))!=RPC_S_OK) {
-			LOG_ERROR(L"RpcBindingSetAuthInfoEx failed with status "<<rpcStatus);
-			return NULL;
-		}
+	PSECURITY_DESCRIPTOR psd = nullptr;
+	ULONG size;
+	if (!ConvertStringSecurityDescriptorToSecurityDescriptor(L"D:(A;;GA;;;wd)(A;;GA;;;AC)", SDDL_REVISION_1, &psd, &size)) {
+		LOG_ERROR(L"ConvertStringSecurityDescriptorToSecurityDescriptor failed");
+		return NULL;
+	}
+	RPC_SECURITY_QOS_V5_W securityQos = {5, 0, 0, 0, 0, nullptr, nullptr, 0, psd};
+	if ((rpcStatus = RpcBindingSetAuthInfoEx(
+		bindingHandle, nullptr, RPC_C_AUTHN_LEVEL_DEFAULT, RPC_C_AUTHN_DEFAULT, nullptr, 0,
+		(RPC_SECURITY_QOS*)&securityQos)
+	) != RPC_S_OK) {
+		LOG_ERROR(L"RpcBindingSetAuthInfoEx failed with status " << rpcStatus);
+		return NULL;
 	}
 	return bindingHandle;
 }

--- a/nvdaHelper/local/rpcSrv.cpp
+++ b/nvdaHelper/local/rpcSrv.cpp
@@ -48,16 +48,14 @@ RPC_STATUS startServer() {
 	generateDesktopSpecificNamespace(desktopSpecificNamespace,ARRAYSIZE(desktopSpecificNamespace));
 	wstring endpointString=L"NvdaCtlr.";
 	endpointString+=desktopSpecificNamespace;
-	//On Windows 8 the new rpcServerRegisterIf3 must be used along with a security descriptor allowing appContainer access
-	HANDLE rpcrt4Handle=GetModuleHandle(L"rpcrt4.dll");
-	RpcServerRegisterIf3_functype RpcServerRegisterIf3=(RpcServerRegisterIf3_functype)GetProcAddress((HMODULE)rpcrt4Handle,"RpcServerRegisterIf3");
 	PSECURITY_DESCRIPTOR psd=NULL;
 	ULONG size;
-	if(RpcServerRegisterIf3) {
-		if(!ConvertStringSecurityDescriptorToSecurityDescriptor(L"D:(A;;GA;;;wd)(A;;GA;;;AC)",SDDL_REVISION_1,&psd,&size)||!psd) {
-			LOG_ERROR(L"ConvertStringSecurityDescriptorToSecurityDescriptor failed, GetLastError is "<<GetLastError());
-			return -1;
-		}
+	if (
+		!ConvertStringSecurityDescriptorToSecurityDescriptor(L"D:(A;;GA;;;wd)(A;;GA;;;AC)", SDDL_REVISION_1, &psd, &size)
+		|| !psd
+	) {
+		LOG_ERROR(L"ConvertStringSecurityDescriptorToSecurityDescriptor failed, GetLastError is " << GetLastError());
+		return -1;
 	}
 	status=RpcServerUseProtseqEp((RPC_WSTR)L"ncalrpc",RPC_C_PROTSEQ_MAX_REQS_DEFAULT,(RPC_WSTR)(endpointString.c_str()),psd);
 	//We can ignore the error where the endpoint is already set
@@ -66,19 +64,10 @@ RPC_STATUS startServer() {
 		return status;
 	}
 	//Register the interfaces
-	if(RpcServerRegisterIf3) { //Windows 8
-		for(int i=0;i<ARRAYSIZE(availableInterfaces);i++) {
-			if((status=RpcServerRegisterIf3(availableInterfaces[i],NULL,NULL,RPC_IF_AUTOLISTEN|RPC_IF_ALLOW_CALLBACKS_WITH_NO_AUTH,RPC_C_LISTEN_MAX_CALLS_DEFAULT,0,NULL,psd))!=RPC_S_OK) {
-				LOG_ERROR(L"RpcServerRegisterIf3 failed to register interface at index "<<i<<L", status "<<status);
-				return status;
-			}
-		}
-	} else { // Pre Windows 8
-		for(int i=0;i<ARRAYSIZE(availableInterfaces);i++) {
-			if((status=RpcServerRegisterIfEx(availableInterfaces[i],NULL,NULL,RPC_IF_AUTOLISTEN,RPC_C_LISTEN_MAX_CALLS_DEFAULT,NULL))!=RPC_S_OK) {
-				LOG_ERROR(L"RpcServerRegisterIf failed to register interface at index "<<i<<L", status "<<status);
-				return status;
-			}
+	for (int i=0; i < ARRAYSIZE(availableInterfaces); i++) {
+		if ((status =RpcServerRegisterIf3(availableInterfaces[i], nullptr, nullptr, RPC_IF_AUTOLISTEN | RPC_IF_ALLOW_CALLBACKS_WITH_NO_AUTH, RPC_C_LISTEN_MAX_CALLS_DEFAULT, 0, nullptr, psd)) != RPC_S_OK) {
+			LOG_ERROR(L"RpcServerRegisterIf3 failed to register interface at index " << i << L", status " << status);
+			return status;
 		}
 	}
 	LocalFree(psd);

--- a/nvdaHelper/remote/ime.cpp
+++ b/nvdaHelper/remote/ime.cpp
@@ -192,7 +192,7 @@ void handleReadingStringUpdate(HWND hwnd) {
 	DWORD version=0;
 	HMODULE IMEFile=NULL;
 	GetReadingString_funcType GetReadingString=NULL;
-	if (isTSFThread(true)) {
+	if (isTSFThread()) {
 		// Look up filename of active TIP
 		if(getTIPFilename(curTSFClsID, filename, MAX_PATH)) {
 			IMEFile=LoadLibrary(filename);
@@ -475,7 +475,7 @@ static LRESULT handleIMEWindowMessage(HWND hwnd, UINT message, WPARAM wParam, LP
 
 				case IMN_PRIVATE:
 					// Needed to support EasyDots IME when TSF is not available
-					if (!isTSFThread(true))
+					if (!isTSFThread())
 						handleReadingStringUpdate(hwnd);
 					break;
 			}
@@ -484,7 +484,7 @@ static LRESULT handleIMEWindowMessage(HWND hwnd, UINT message, WPARAM wParam, LP
 		case WM_IME_COMPOSITION:
 			if(!hasValidIMEContext(hwnd)) return 0;
 			curIMEWindow=hwnd;
-			if(!isTSFThread(true)) {\
+			if (!isTSFThread()) {
 				if(lParam&GCS_COMPSTR||lParam&GCS_CURSORPOS) {
 					handleComposition(hwnd, wParam, lParam);
 				}
@@ -506,7 +506,7 @@ static LRESULT handleIMEWindowMessage(HWND hwnd, UINT message, WPARAM wParam, LP
 		case WM_SETFOCUS:
 			if(!hasValidIMEContext(hwnd)) return 0;
 			handleIMEConversionModeUpdate(hwnd,false);
-			if(!isTSFThread(true)) {
+			if (!isTSFThread()) {
 				if (hwnd != GetFocus())  break;
 				handleComposition(hwnd, wParam, lParam);
 				handleCandidates(hwnd);

--- a/nvdaHelper/remote/inputLangChange.cpp
+++ b/nvdaHelper/remote/inputLangChange.cpp
@@ -21,14 +21,12 @@ http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 #include "tsf.h"
 #include "inputLangChange.h"
 
-bool isWin8=false;
-
 LPARAM lastInputLangChange=0;
 
 LRESULT CALLBACK inputLangChange_callWndProcHook(int code, WPARAM wParam, LPARAM lParam) {
 	CWPSTRUCT* pcwp=(CWPSTRUCT*)lParam;
 	if((pcwp->message==WM_INPUTLANGCHANGE)&&(pcwp->lParam!=lastInputLangChange)) {
-		if(!isTSFThread(isWin8)) {
+		if(!isTSFThread()) {
 			wchar_t buf[KL_NAMELENGTH];
 			GetKeyboardLayoutName(buf);
 			nvdaControllerInternal_inputLangChangeNotify(GetCurrentThreadId(),static_cast<unsigned long>(pcwp->lParam),buf);
@@ -39,7 +37,6 @@ LRESULT CALLBACK inputLangChange_callWndProcHook(int code, WPARAM wParam, LPARAM
 }
 
 void inputLangChange_inProcess_initialize() {
-	isWin8=IsWindows8OrGreater();
 	registerWindowsHook(WH_CALLWNDPROC,inputLangChange_callWndProcHook);
 }
 

--- a/nvdaHelper/remote/tsf.cpp
+++ b/nvdaHelper/remote/tsf.cpp
@@ -636,8 +636,8 @@ void TSF_thread_detached() {
 	sink->Release();
 }
 
-bool isTSFThread(bool checkActiveProfile) {
+bool isTSFThread() {
 	TsfSink* tsf=fetchCurrentTsfSink();
 	if(!tsf) return false; 
-	return checkActiveProfile?tsf->hasActiveProfile:true;
+	return tsf->hasActiveProfile;
 }

--- a/nvdaHelper/remote/tsf.h
+++ b/nvdaHelper/remote/tsf.h
@@ -18,7 +18,7 @@ http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 void TSF_inProcess_initialize();
 void TSF_inProcess_terminate();
 void TSF_thread_detached();
-bool isTSFThread(bool checkProfile);
+bool isTSFThread();
 extern CLSID curTSFClsID;
 
 #endif


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
There is some Windows <8 specific stuff left in NVDA Helper regarding character input and RPC registration.

### Description of user facing changes
None.

### Description of development approach
Remove code specific to older versions of Windows.

### Testing strategy:
I'm not sure how to test this properly, it might be enough to review the code and see that there was only code removed and linted slightly.

### Known issues with pull request:
None known
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
