### PR TITLE
Touch handler: remove Windows 8 checks from code and documentation

### DIFF
--- a/source/touchHandler.py
+++ b/source/touchHandler.py
@@ -10,6 +10,7 @@ In order to use touch features, NVDA must be installed on a touchscreen computer
 
 import threading
 from ctypes import *
+from ctypes import windll
 from ctypes.wintypes import *
 import re
 import gui

--- a/source/touchHandler.py
+++ b/source/touchHandler.py
@@ -1,7 +1,7 @@
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-# Copyright (C) 2012-2021 NV Access Limited, Joseph Lee, Babbage B.V.
+# Copyright (C) 2012-2023 NV Access Limited, Joseph Lee, Babbage B.V.
 
 """handles touchscreen interaction (Windows 8 and later).
 Used to provide input gestures for touchscreens, touch modes and other support facilities.

--- a/source/touchHandler.py
+++ b/source/touchHandler.py
@@ -3,9 +3,9 @@
 # See the file COPYING for more details.
 # Copyright (C) 2012-2023 NV Access Limited, Joseph Lee, Babbage B.V.
 
-"""handles touchscreen interaction (Windows 8 and later).
+"""handles touchscreen interaction.
 Used to provide input gestures for touchscreens, touch modes and other support facilities.
-In order to use touch features, NVDA must be installed on a touchscreen computer running Windows 8 and later.
+In order to use touch features, NVDA must be installed on a touchscreen computer.
 """
 
 import threading

--- a/source/touchHandler.py
+++ b/source/touchHandler.py
@@ -306,10 +306,6 @@ def touchSupported(debugLog: bool = False):
 		if debugLog:
 			log.debugWarning("Touch only supported on installed copies")
 		return False
-	if winVersion.getWinVer() < winVersion.WIN8:
-		if debugLog:
-			log.debugWarning("Touch only supported on Windows 8 and higher")
-		return False
 	maxTouches=windll.user32.GetSystemMetrics(SM_MAXIMUMTOUCHES)
 	if maxTouches<=0:
 		if debugLog:

--- a/source/touchHandler.py
+++ b/source/touchHandler.py
@@ -298,7 +298,7 @@ class TouchHandler(threading.Thread):
 handler=None
 
 
-def touchSupported(debugLog: bool = False):
+def touchSupported(debugLog: bool = False) -> bool:
 	"""Returns if the system and current NVDA session supports touchscreen interaction.
 	@param debugLog: Whether to log additional details about touch support to the NVDA log.
 	"""
@@ -306,8 +306,8 @@ def touchSupported(debugLog: bool = False):
 		if debugLog:
 			log.debugWarning("Touch only supported on installed copies")
 		return False
-	maxTouches=windll.user32.GetSystemMetrics(SM_MAXIMUMTOUCHES)
-	if maxTouches<=0:
+	maxTouches = windll.user32.GetSystemMetrics(SM_MAXIMUMTOUCHES)
+	if maxTouches <= 0:
 		if debugLog:
 			log.debugWarning("No touch devices found")
 		return False

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -356,7 +356,7 @@ Portable and temporary copies of NVDA have the following restrictions:
 - The inability to interact with applications running with administrative privileges, unless of course NVDA itself has been run also with these privileges (not recommended).
 - The inability to read User Account Control (UAC) screens when trying to start an application with administrative privileges.
 - The inability to support input from a touchscreen.
-- Windows 8 and later: the inability to provide features such as browse mode and speaking of typed characters in Windows Store apps.
+- The inability to provide features such as browse mode and speaking of typed characters in Windows Store apps.
 - Windows 8 and later: audio ducking is not supported.
 -
 

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -355,7 +355,7 @@ Portable and temporary copies of NVDA have the following restrictions:
 - The inability to automatically start during and/or after log-on.
 - The inability to interact with applications running with administrative privileges, unless of course NVDA itself has been run also with these privileges (not recommended).
 - The inability to read User Account Control (UAC) screens when trying to start an application with administrative privileges.
-- Windows 8 and later: the inability to support input from a touchscreen.
+- The inability to support input from a touchscreen.
 - Windows 8 and later: the inability to provide features such as browse mode and speaking of typed characters in Windows Store apps.
 - Windows 8 and later: audio ducking is not supported.
 -
@@ -419,7 +419,7 @@ Although most laptops do not have a physical numpad, some laptops can emulate on
 If your laptop cannot do this or does not allow you to turn Num Lock off, you may want to switch to the Laptop layout instead.
 
 ++ NVDA Touch Gestures ++[NVDATouchGestures]
-If you are running NVDA on a device with a touchscreen and running Windows 8 or higher, you can also control NVDA directly via touch commands.
+If you are running NVDA on a device with a touchscreen, you can also control NVDA directly via touch commands.
 While NVDA is running, unless touch interaction support is disabled, all touch input will go directly to NVDA.
 Therefore, actions that can be performed normally without NVDA will not work.
 %kc:beginInclude
@@ -1985,7 +1985,7 @@ This option is unchecked by default.
 If you check this option and you have the "Enable mouse tracking" option enabled, NVDA will not announce what is under the mouse if the mouse is moved by another application.
 
 +++ Touch Interaction +++[TouchInteraction]
-This settings category, only available on computers running Windows 8 and later with touch capabilities, allows you to configure how NVDA interacts with touchscreens.
+This settings category, only available on computers with touch capabilities, allows you to configure how NVDA interacts with touchscreens.
 This category contains the following options:
 
 ==== Enable touch interaction support ====[TouchSupportEnable]

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -357,7 +357,7 @@ Portable and temporary copies of NVDA have the following restrictions:
 - The inability to read User Account Control (UAC) screens when trying to start an application with administrative privileges.
 - The inability to support input from a touchscreen.
 - The inability to provide features such as browse mode and speaking of typed characters in Windows Store apps.
-- Windows 8 and later: audio ducking is not supported.
+- Audio ducking is not supported.
 -
 
 


### PR DESCRIPTION

### Link to issue number:
Closes #15635 

### Summary of the issue:
Touch handler's touchSupported function and the user guide continues to check (or document requirement) for Windows 8 when minimum OS is Windows 8.1.

### Description of user facing changes
Edited the user guide and context help to point out that touch support requires a touch-capable hardware and that NVDA must be installed, removing wording on Windows 8 requirement.

### Description of development approach
Edit touchHandler.touchSupported function to remove check for Windows 8 as Windows 8.1 is the minimum OS required, as wel as edited parts of the user guide dealing with touch support.

### Testing strategy:
Requires specialized manual testing: context help does point to the edited user guide on touch capable hardware.

### Known issues with pull request:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

### Additional context:
The code used to obtain and check maximum touches value could be a good candidate for assignment expressions (walrus operator) in the future for readability.
