### PR TITLE
addonHandler: install ngettext function when calling initTranslation

### DIFF
--- a/source/addonHandler/__init__.py
+++ b/source/addonHandler/__init__.py
@@ -752,22 +752,21 @@ def getCodeAddon(obj=None, frameDist=1):
 	raise AddonError("Code does not belong to an addon")
 
 
-_TRANSLATION_FUNCTIONS = ["_", "ngettext", "pgettext", "npgettext"]
-
-
 def initTranslation():
 	addon = getCodeAddon(frameDist=2)
 	translations = addon.getTranslationsInstance()
+	_TRANSLATION_FUNCTIONS = {
+		translations.gettext: "_",
+		translations.ngettext: "ngettext",
+		translations.pgettext: "pgettext",
+		translations.npgettext: "npgettext"
+	}
 	# Point _ to the translation object in the globals namespace of the caller frame
 	try:
 		callerFrame = inspect.currentframe().f_back
 		module = inspect.getmodule(callerFrame)
-		[
-			setattr(
-				module, func, getattr(translations, "gettext" if func == "_" else func)
-			)
-			for func in _TRANSLATION_FUNCTIONS
-		]
+		for funcName, installAs in _TRANSLATION_FUNCTIONS.items():
+			setattr(module, installAs, funcName)
 	finally:
 		del callerFrame # Avoid reference problems with frames (per python docs)
 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -43,7 +43,7 @@ Please refer to [the developer guide https://www.nvaccess.org/files/nvda/documen
 - Note: this is an Add-on API compatibility breaking release.
 Add-ons will need to be re-tested and have their manifest updated.
 - Added extension point: ``treeInterceptorHandler.post_browseModeStateChange``. (#14969, @nvdaes)
-- It is now possible to use plural forms in addon's translations. (#15661, @beqabeqa473)
+- It is now possible to use plural forms in an add-on's translations. (#15661, @beqabeqa473)
 -
 
 === API Breaking Changes ===

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -43,6 +43,7 @@ Please refer to [the developer guide https://www.nvaccess.org/files/nvda/documen
 - Note: this is an Add-on API compatibility breaking release.
 Add-ons will need to be re-tested and have their manifest updated.
 - Added extension point: ``treeInterceptorHandler.post_browseModeStateChange``. (#14969, @nvdaes)
+- It is now possible to use plural forms in addon's translations. (#15661, @beqabeqa473)
 -
 
 === API Breaking Changes ===


### PR DESCRIPTION
### Link to issue number:
None
### Summary of the issue:
Currently, it is not possible to use gettext plural forms in addons.
### Description of user facing changes
Nothing
### Description of development approach
Refactored installing of translation functions.
Now they are defined in list just above initTranslation function, and set in the caller module itself instead of adding these functions in frame_globals.
### Testing strategy:
Tested and confirmed, that plural forms are now working in addons.
### Known issues with pull request:
None
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [ ] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [ ] API is compatible with existing add-ons.
- [ ] Security precautions taken.
