### PR TITLE
NVDA source: remove Windows 7 constant mentions

### DIFF
--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -460,9 +460,6 @@ class UIATextInfo(textInfos.TextInfo):
 			# sometimes rangeFromChild can return a NULL range
 			if not self._rangeObj: raise LookupError
 		elif isinstance(position,locationHelper.Point):
-			if winVersion.getWinVer() <= winVersion.WIN7_SP1:
-				# #9435: RangeFromPoint causes a freeze in UIA client library in the Windows 7 start menu!
-				raise NotImplementedError("RangeFromPoint not supported on Windows 7")
 			self._rangeObj: IUIAutomationTextRangeT = self.obj.UIATextPattern.RangeFromPoint(position.toPOINT())
 		elif isinstance(position, UIAHandler.IUIAutomationTextRange):
 			position = typing.cast(IUIAutomationTextRangeT, position)

--- a/source/appModules/explorer.py
+++ b/source/appModules/explorer.py
@@ -382,7 +382,7 @@ class AppModule(appModuleHandler.AppModule):
 		return statusBar
 
 	@staticmethod
-	def _getStatusBarTextPostWin7(obj) -> str:
+	def _getStatusBarText(obj) -> str:
 		# The expected status bar, as of Windows 10 20H2 at least, contains:
 		#  - A grouping with a single static text child presenting the total number of elements
 		#  - Optionally, a grouping with a single static text child presenting the number of
@@ -426,10 +426,8 @@ class AppModule(appModuleHandler.AppModule):
 		return ", ".join(parts)
 
 	def getStatusBarText(self, obj) -> str:
-		if (
-			isinstance(obj, UIA) or obj.UIAElement.cachedClassname == "StatusBarModuleInner"
-		):  # Windows 8 or later
-			return self._getStatusBarTextPostWin7(obj)
+		if isinstance(obj, UIA) or obj.UIAElement.cachedClassName == "StatusBarModuleInner":
+			return self._getStatusBarText(obj)
 		else:
 			# This is not the file explorer status bar. Resort to standard behavior.
 			raise NotImplementedError

--- a/source/appModules/explorer.py
+++ b/source/appModules/explorer.py
@@ -75,11 +75,8 @@ class SysListView32EmittingDuplicateFocusEvents(IAccessible):
 		focus = eventHandler.lastQueuedFocusObject
 		if (
 			type(focus) != type(self)
-			or (
-				self.event_windowHandle, self.event_objectID, self.event_childID
-			) != (
-				focus.event_windowHandle, focus.event_objectID, focus.event_childID
-			)
+			or (self.event_windowHandle, self.event_objectID, self.event_childID)
+			!= (focus.event_windowHandle, focus.event_objectID, focus.event_childID)
 		):
 			return True
 		return False

--- a/source/appModules/explorer.py
+++ b/source/appModules/explorer.py
@@ -237,15 +237,10 @@ class ReadOnlyEditBox(Edit):
 
 
 class MetadataEditField(RichEdit50):
-	""" Used for metadata edit fields in Windows Explorer in Windows 7.
-	By default these fields would use ITextDocumentTextInfo ,
-	but to avoid Windows Explorer crashes we need to use EditTextInfo here. """
+
 	@classmethod
 	def _get_TextInfo(cls):
-		if winVersion.getWinVer() <= winVersion.WIN7_SP1:
-			cls.TextInfo = EditTextInfo
-		else:
-			cls.TextInfo = super().TextInfo
+		cls.TextInfo = super().TextInfo
 		return cls.TextInfo
 
 

--- a/source/appModules/explorer.py
+++ b/source/appModules/explorer.py
@@ -382,14 +382,6 @@ class AppModule(appModuleHandler.AppModule):
 		return statusBar
 
 	@staticmethod
-	def _getStatusBarTextWin7(obj) -> str:
-		"""For status bar in Windows 7 Windows Explorer we're interested only in the name of the first child
-		the rest are either empty or contain garbage."""
-		if obj.firstChild and obj.firstChild.name:
-			return obj.firstChild.name
-		raise NotImplementedError
-
-	@staticmethod
 	def _getStatusBarTextPostWin7(obj) -> str:
 		# The expected status bar, as of Windows 10 20H2 at least, contains:
 		#  - A grouping with a single static text child presenting the total number of elements

--- a/source/appModules/explorer.py
+++ b/source/appModules/explorer.py
@@ -434,8 +434,6 @@ class AppModule(appModuleHandler.AppModule):
 		return ", ".join(parts)
 
 	def getStatusBarText(self, obj) -> str:
-		if obj.windowClassName == "msctls_statusbar32":  # Windows 7
-			return self._getStatusBarTextWin7(obj)
 		if (
 			isinstance(obj, UIA) or obj.UIAElement.cachedClassname == "StatusBarModuleInner"
 		):  # Windows 8 or later

--- a/source/appModules/explorer.py
+++ b/source/appModules/explorer.py
@@ -251,22 +251,9 @@ class MetadataEditField(RichEdit50):
 
 class WorkerW(IAccessible):
 	def event_gainFocus(self):
-		# #6671: Normally we do not allow WorkerW thread to send gain focus event,
+		# #6671: do not allow WorkerW thread to send gain focus event,
 		# as it causes 'pane" to be announced when minimizing windows or moving to desktop.
-		# However when closing Windows 7 Start Menu in some  cases
-		# focus lands  on it instead of the focused desktop item.
-		# Simply ignore the event if running on anything other than Win 7.
-		if winVersion.getWinVer() > winVersion.WIN7_SP1:
-			return
-		if eventHandler.isPendingEvents("gainFocus"):
-			return
-		if self.simpleFirstChild:
-			# If focus is not going to be moved autotically
-			# we need to forcefully move it to the focused desktop item.
-			# As we are interested in the first focusable object below the pane use simpleFirstChild.
-			self.simpleFirstChild.setFocus()
-			return
-		super().event_gainFocus()
+		return
 
 
 class AppModule(appModuleHandler.AppModule):

--- a/source/appModules/explorer.py
+++ b/source/appModules/explorer.py
@@ -31,17 +31,17 @@ from winAPI.types import HWNDValT
 
 # Suppress incorrect Win 10 Task switching window focus
 class MultitaskingViewFrameWindow(UIA):
-	shouldAllowUIAFocusEvent=False
+	shouldAllowUIAFocusEvent = False
 
 
 # Suppress focus ancestry for task switching list items if alt is held down (alt+tab)
 class MultitaskingViewFrameListItem(UIA):
 
 	def _get_container(self):
-		if winUser.getAsyncKeyState(winUser.VK_MENU)&32768:
+		if winUser.getAsyncKeyState(winUser.VK_MENU) & 32768:
 			return api.getDesktopObject()
 		else:
-			return super(MultitaskingViewFrameListItem,self).container
+			return super(MultitaskingViewFrameListItem, self).container
 
 
 # Support for Win8 start screen search suggestions.
@@ -54,9 +54,10 @@ class SuggestionListItem(UIA):
 			super().event_UIA_elementSelected()
 
 
-# Windows 8 hack: Class to disable incorrect focus on windows 8 search box (containing the already correctly focused edit field)
+# Windows 8 hack: Class to disable incorrect focus on windows 8 search box
+# (containing the already correctly focused edit field)
 class SearchBoxClient(IAccessible):
-	shouldAllowIAccessibleFocusEvent=False
+	shouldAllowIAccessibleFocusEvent = False
 
 
 # Class for menu items  for Windows Places and Frequently used Programs (in start menu)
@@ -72,9 +73,17 @@ class SysListView32EmittingDuplicateFocusEvents(IAccessible):
 		if not res:
 			return False
 		focus = eventHandler.lastQueuedFocusObject
-		if type(focus)!=type(self) or (self.event_windowHandle,self.event_objectID,self.event_childID)!=(focus.event_windowHandle,focus.event_objectID,focus.event_childID):
+		if (
+			type(focus) != type(self)
+			or (
+				self.event_windowHandle, self.event_objectID, self.event_childID
+			) != (
+				focus.event_windowHandle, focus.event_objectID, focus.event_childID
+			)
+		):
 			return True
 		return False
+
 
 class NotificationArea(IAccessible):
 	"""The Windows notification area, a.k.a. system tray.
@@ -162,28 +171,30 @@ class ExplorerToolTip(ToolTip):
 
 class GridTileElement(UIA):
 
-	role=controlTypes.Role.TABLECELL
+	role = controlTypes.Role.TABLECELL
 
 	def _get_description(self):
-		name=self.name
-		descriptionStrings=[]
+		name = self.name
+		descriptionStrings = []
 		for child in self.children:
-			description=child.basicText
-			if not description or description==name: continue
+			description = child.basicText
+			if not description or description == name:
+				continue
 			descriptionStrings.append(description)
 		return " ".join(descriptionStrings)
 		return description
 
 
 class GridListTileElement(UIA):
-	role=controlTypes.Role.TABLECELL
-	description=None
+
+	role = controlTypes.Role.TABLECELL
+	description = None
 
 
 class GridGroup(UIA):
 	"""A group in the Windows 8 Start Menu.
 	"""
-	presentationType=UIA.presType_content
+	presentationType = UIA.presType_content
 
 	# Normally the name is the first tile which is rather redundant
 	# However some groups have custom header text which should be read instead
@@ -195,13 +206,15 @@ class GridGroup(UIA):
 
 
 class ImmersiveLauncher(UIA):
-	# When the Windows 8 start screen opens, focus correctly goes to the first tile, but then incorrectly back to the root of the window.
+	# When the Windows 8 start screen opens, focus correctly goes to the first tile,
+	# but then incorrectly back to the root of the window.
 	# Ignore focus events on this object.
-	shouldAllowUIAFocusEvent=False
+	shouldAllowUIAFocusEvent = False
 
 
 class StartButton(IAccessible):
-	"""For Windows 8.1 and 10 Start buttons to be recognized as proper buttons and to suppress selection announcement."""
+	"""For Windows 8.1 and 10 Start buttons to be recognized as proper buttons
+	and to suppress selection announcement."""
 
 	role = controlTypes.Role.BUTTON
 
@@ -211,28 +224,33 @@ class StartButton(IAccessible):
 		states = super(StartButton, self).states
 		states.discard(controlTypes.State.SELECTED)
 		return states
-		
+
+
 CHAR_LTR_MARK = u'\u200E'
 CHAR_RTL_MARK = u'\u200F'
+
+
 class UIProperty(UIA):
-	#Used for columns in Windows Explorer Details view.
-	#These can contain dates that include unwanted left-to-right and right-to-left indicator characters.
-	
+	"""Used for columns in Windows Explorer Details view.
+	These can contain dates that include unwanted left-to-right and right-to-left indicator characters.
+	"""
+
 	def _get_value(self):
 		value = super(UIProperty, self).value
 		if value is None:
 			return value
-		return value.replace(CHAR_LTR_MARK,'').replace(CHAR_RTL_MARK,'')
+		return value.replace(CHAR_LTR_MARK, '').replace(CHAR_RTL_MARK, '')
 
 
 class ReadOnlyEditBox(Edit):
-#Used for read-only edit boxes in a properties window.
-#These can contain dates that include unwanted left-to-right and right-to-left indicator characters.
+	"""Used for read-only edit boxes in a properties window.
+	These can contain dates that include unwanted left-to-right and right-to-left indicator characters.
+	"""
 
 	def _get_windowText(self):
 		windowText = super(ReadOnlyEditBox, self).windowText
 		if windowText is not None:
-			return windowText.replace(CHAR_LTR_MARK,'').replace(CHAR_RTL_MARK,'')
+			return windowText.replace(CHAR_LTR_MARK, '').replace(CHAR_RTL_MARK, '')
 		return windowText
 
 
@@ -258,9 +276,13 @@ class AppModule(appModuleHandler.AppModule):
 		windowClass = obj.windowClassName
 		role = obj.role
 
-		if windowClass in ("Search Box","UniversalSearchBand") and role==controlTypes.Role.PANE and isinstance(obj,IAccessible):
-			clsList.insert(0,SearchBoxClient)
-			return # Optimization: return early to avoid comparing class names and roles that will never match.
+		if (
+			windowClass in ("Search Box", "UniversalSearchBand")
+			and role == controlTypes.Role.PANE
+			and isinstance(obj, IAccessible)
+		):
+			clsList.insert(0, SearchBoxClient)
+			return  # Optimization: return early to avoid comparing class names and roles that will never match.
 
 		if windowClass == "ToolbarWindow32":
 			if role != controlTypes.Role.POPUPMENU:
@@ -282,12 +304,12 @@ class AppModule(appModuleHandler.AppModule):
 
 		if windowClass == "Edit" and Edit in clsList and controlTypes.State.READONLY in obj.states:
 			clsList.insert(0, ReadOnlyEditBox)
-			return # Optimization: return early to avoid comparing class names and roles that will never match.
+			return  # Optimization: return early to avoid comparing class names and roles that will never match.
 
 		if windowClass == "SysListView32" and isinstance(obj, IAccessible):
 			if(
 				role == controlTypes.Role.MENUITEM
-				or(
+				or (
 					role == controlTypes.Role.LISTITEM
 					and obj.simpleParent
 					and obj.simpleParent.simpleParent
@@ -295,14 +317,14 @@ class AppModule(appModuleHandler.AppModule):
 				)
 			):
 				clsList.insert(0, SysListView32EmittingDuplicateFocusEvents)
-			return # Optimization: return early to avoid comparing class names and roles that will never match.
+			return  # Optimization: return early to avoid comparing class names and roles that will never match.
 
 		# #5178: Start button in Windows 8.1 and 10 should not have been a list in the first place.
 		if windowClass == "Start" and role in (controlTypes.Role.LIST, controlTypes.Role.BUTTON):
 			if role == controlTypes.Role.LIST:
 				clsList.remove(List)
 			clsList.insert(0, StartButton)
-			return # Optimization: return early to avoid comparing class names and roles that will never match.
+			return  # Optimization: return early to avoid comparing class names and roles that will never match.
 
 		if windowClass == 'RICHEDIT50W' and RichEdit50 in clsList and obj.windowControlID == 256:
 			clsList.insert(0, MetadataEditField)
@@ -335,9 +357,9 @@ class AppModule(appModuleHandler.AppModule):
 			# Windows 10 task switch list
 			elif role == controlTypes.Role.LISTITEM and (
 				# RS4 and below we can match on a window class
-				windowClass == "MultitaskingViewFrame" or
+				windowClass == "MultitaskingViewFrame"
 				# RS5 and above we must look for a particular UIA automationID on the list
-				isinstance(obj.parent, UIA) and obj.parent.UIAAutomationId == "SwitchItemListControl"
+				or isinstance(obj.parent, UIA) and obj.parent.UIAAutomationId == "SwitchItemListControl"
 			):
 				clsList.insert(0, MultitaskingViewFrameListItem)
 			elif uiaClassName == "UIProperty" and role == controlTypes.Role.EDITABLETEXT:
@@ -450,14 +472,22 @@ class AppModule(appModuleHandler.AppModule):
 
 	def event_gainFocus(self, obj, nextHandler):
 		wClass = obj.windowClassName
-		if wClass == "ToolbarWindow32" and obj.role == controlTypes.Role.MENUITEM and obj.parent.role == controlTypes.Role.MENUBAR and eventHandler.isPendingEvents("gainFocus"):
-			# When exiting a menu, Explorer fires focus on the top level menu item before it returns to the previous focus.
-			# Unfortunately, this focus event always occurs in a subsequent cycle, so the event limiter doesn't eliminate it.
+		if (
+			wClass == "ToolbarWindow32"
+			and obj.role == controlTypes.Role.MENUITEM
+			and obj.parent.role == controlTypes.Role.MENUBAR
+			and eventHandler.isPendingEvents("gainFocus")
+		):
+			# When exiting a menu, Explorer fires focus on the top level menu item
+			# before it returns to the previous focus.
+			# Unfortunately, this focus event always occurs in a subsequent cycle,
+			# so the event limiter doesn't eliminate it.
 			# Therefore, if there is a pending focus event, don't bother handling this event.
 			return
 
 		if wClass in ("ForegroundStaging", "LauncherTipWnd", "ApplicationManager_DesktopShellWindow"):
-			# #5116: The Windows 10 Task View fires foreground/focus on this weird invisible window and foreground staging screen before and after it appears.
+			# #5116: The Windows 10 Task View fires foreground/focus on this weird invisible window
+			# and foreground staging screen before and after it appears.
 			# This causes NVDA to report "unknown", so ignore it.
 			# We can't do this using shouldAllowIAccessibleFocusEvent because this isn't checked for foreground.
 			# #8137: also seen when opening quick link menu (Windows+X) on Windows 8 and later.

--- a/source/appModules/explorer.py
+++ b/source/appModules/explorer.py
@@ -272,7 +272,8 @@ class WorkerW(IAccessible):
 
 class AppModule(appModuleHandler.AppModule):
 
-	def chooseNVDAObjectOverlayClasses(self, obj, clsList):
+	# C901: chooseNVDAObjectOverlayClasses is too complex
+	def chooseNVDAObjectOverlayClasses(self, obj, clsList):  # NOQA: C901
 		windowClass = obj.windowClassName
 		role = obj.role
 

--- a/source/appModules/explorer.py
+++ b/source/appModules/explorer.py
@@ -382,7 +382,7 @@ class AppModule(appModuleHandler.AppModule):
 		return statusBar
 
 	@staticmethod
-	def _getStatusBarText(obj) -> str:
+	def _getStatusBarText(obj: NVDAObject) -> str:
 		# The expected status bar, as of Windows 10 20H2 at least, contains:
 		#  - A grouping with a single static text child presenting the total number of elements
 		#  - Optionally, a grouping with a single static text child presenting the number of
@@ -404,10 +404,12 @@ class AppModule(appModuleHandler.AppModule):
 					if grandChild.role != controlTypes.Role.RADIOBUTTON
 				)
 			):
-				selected = next(iter(
-					grandChild for grandChild in child.children
-					if controlTypes.State.CHECKED in grandChild.states
-				), None)
+				selected = next(
+					iter(
+						grandChild for grandChild in child.children
+						if controlTypes.State.CHECKED in grandChild.states
+					), None
+				)
 				if selected is not None:
 					parts.append(" ".join(
 						[child.name]
@@ -425,7 +427,7 @@ class AppModule(appModuleHandler.AppModule):
 			raise NotImplementedError
 		return ", ".join(parts)
 
-	def getStatusBarText(self, obj) -> str:
+	def getStatusBarText(self, obj: NVDAObject) -> str:
 		if isinstance(obj, UIA) or obj.UIAElement.cachedClassName == "StatusBarModuleInner":
 			return self._getStatusBarText(obj)
 		else:

--- a/source/appModules/explorer.py
+++ b/source/appModules/explorer.py
@@ -464,14 +464,6 @@ class AppModule(appModuleHandler.AppModule):
 				obj.name = None
 			return
 
-		if windowClass == "DV2ControlHost" and role == controlTypes.Role.PANE:
-			# Windows 7 start menu.
-			obj.presentationType=obj.presType_content
-			obj.isPresentableFocusAncestor = True
-			# In Windows 7, the description of this pane is extremely verbose help text, so nuke it.
-			obj.description = None
-			return
-
 		# The Address bar is embedded inside a progressbar, how strange.
 		# Lets hide that
 		if windowClass=="msctls_progress32" and winUser.getClassName(winUser.getAncestor(obj.windowHandle,winUser.GA_PARENT))=="Address Band Root":

--- a/source/appModules/explorer.py
+++ b/source/appModules/explorer.py
@@ -466,8 +466,13 @@ class AppModule(appModuleHandler.AppModule):
 
 		# The Address bar is embedded inside a progressbar, how strange.
 		# Lets hide that
-		if windowClass=="msctls_progress32" and winUser.getClassName(winUser.getAncestor(obj.windowHandle,winUser.GA_PARENT))=="Address Band Root":
-			obj.presentationType=obj.presType_layout
+		if (
+			windowClass == "msctls_progress32"
+			and winUser.getClassName(
+				winUser.getAncestor(obj.windowHandle, winUser.GA_PARENT)
+			) == "Address Band Root"
+		):
+			obj.presentationType = obj.presType_layout
 			return
 
 	def event_gainFocus(self, obj, nextHandler):

--- a/source/appModules/explorer.py
+++ b/source/appModules/explorer.py
@@ -444,7 +444,7 @@ class AppModule(appModuleHandler.AppModule):
 			# This is not the file explorer status bar. Resort to standard behavior.
 			raise NotImplementedError
 
-	def event_NVDAObject_init(self, obj):
+	def event_NVDAObject_init(self, obj: NVDAObject) -> None:
 		windowClass = obj.windowClassName
 		role = obj.role
 

--- a/source/appModules/explorer.py
+++ b/source/appModules/explorer.py
@@ -478,20 +478,6 @@ class AppModule(appModuleHandler.AppModule):
 			obj.presentationType=obj.presType_layout
 			return
 
-		if windowClass == "DirectUIHWND" and role == controlTypes.Role.LIST:
-			# Is this a list containing search results in Windows 7 start menu?
-			isWin7SearchResultsList = False
-			try:
-				if obj.parent and obj.parent.parent:
-					parent = obj.parent.parent.parent
-					isWin7SearchResultsList = parent is not None and parent.windowClassName == "Desktop Search Open View"
-			except AttributeError:
-				isWin7SearchResultsList = False
-			if isWin7SearchResultsList:
-				# Namae of this list is not useful and should be  discarded.
-				obj.name = None
-				return
-
 	def event_gainFocus(self, obj, nextHandler):
 		wClass = obj.windowClassName
 		if wClass == "ToolbarWindow32" and obj.role == controlTypes.Role.MENUITEM and obj.parent.role == controlTypes.Role.MENUBAR and eventHandler.isPendingEvents("gainFocus"):

--- a/source/appModules/explorer.py
+++ b/source/appModules/explorer.py
@@ -250,6 +250,7 @@ class MetadataEditField(RichEdit50):
 
 
 class WorkerW(IAccessible):
+
 	def event_gainFocus(self):
 		# #6671: do not allow WorkerW thread to send gain focus event,
 		# as it causes 'pane" to be announced when minimizing windows or moving to desktop.

--- a/source/appModules/explorer.py
+++ b/source/appModules/explorer.py
@@ -272,7 +272,9 @@ class WorkerW(IAccessible):
 
 class AppModule(appModuleHandler.AppModule):
 
-	# C901: chooseNVDAObjectOverlayClasses is too complex
+	# C901 'chooseNVDAObjectOverlayClasses' is too complex
+	# Note: when working on chooseNVDAObjectOverlayClasses, look for opportunities to simplify
+	# and move logic out into smaller helper functions.
 	def chooseNVDAObjectOverlayClasses(self, obj, clsList):  # NOQA: C901
 		windowClass = obj.windowClassName
 		role = obj.role

--- a/source/appModules/explorer.py
+++ b/source/appModules/explorer.py
@@ -24,7 +24,7 @@ from NVDAObjects import NVDAObject
 from NVDAObjects.IAccessible import IAccessible, List
 from NVDAObjects.UIA import UIA
 from NVDAObjects.behaviors import ToolTip
-from NVDAObjects.window.edit import RichEdit50, Edit, EditTextInfo
+from NVDAObjects.window.edit import RichEdit50, Edit
 import config
 from winAPI.types import HWNDValT
 


### PR DESCRIPTION

### Link to issue number:
Closes #15651 

### Summary of the issue:
Remove Windows 7 (winVersion.WIN7_SP1) constant mentions from NVDA source code.

### Description of user facing changes
None

### Description of development approach
Mostly edited File Explorer app module and UIA objects code:

* Remove bulk of WorkerW, MetadataEditField, status bar fetcher, and Start menu/search suggestions handling on Windows 7
* Removed text range exception check from UIA objects

### Testing strategy:
Manual testing, coupled with code coverage - no regressions when using File Explorer and other UIA apps on Windows 8.1/10/11.

### Known issues with pull request:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
