### PR TITLE
winVersion: Deprecate Windows 7/8 constants

### DIFF
--- a/source/winVersion.py
+++ b/source/winVersion.py
@@ -143,9 +143,6 @@ class WinVersion(object):
 
 
 # Windows releases to WinVersion instances for easing comparisons.
-WIN7 = WinVersion(major=6, minor=1, build=7600)
-WIN7_SP1 = WinVersion(major=6, minor=1, build=7601, servicePack="1")
-WIN8 = WinVersion(major=6, minor=2, build=9200)
 WIN81 = WinVersion(major=6, minor=3, build=9600)
 WIN10 = WIN10_1507 = WinVersion(major=10, minor=0, build=10240)
 WIN10_1511 = WinVersion(major=10, minor=0, build=10586)
@@ -222,6 +219,7 @@ if NVDAState._allowDeprecatedAPI():
 			stack_info=True
 		)
 		return True
+
 
 def __getattr__(attrName: str) -> Any:
 	"""Module level `__getattr__` used to preserve backward compatibility."""

--- a/source/winVersion.py
+++ b/source/winVersion.py
@@ -10,7 +10,7 @@ making sure NVDA can run on a minimum supported version of Windows.
 When working on this file, consider moving to winAPI.
 """
 
-from typing import Optional, Dict
+from typing import Optional, Dict, Any
 import sys
 import os
 import functools
@@ -226,3 +226,16 @@ if NVDAState._allowDeprecatedAPI():
 			stack_info=True
 		)
 		return True
+
+def __getattr__(attrName: str) -> Any:
+	"""Module level `__getattr__` used to preserve backward compatibility."""
+	if attrName == "WIN7" and NVDAState._allowDeprecatedAPI():
+		log.warning("WIN7 is deprecated.")
+		return WinVersion(major=6, minor=1, build=7600)
+	if attrName == "WIN7_SP1" and NVDAState._allowDeprecatedAPI():
+		log.warning("WIN7_SP1 is deprecated.")
+		return WinVersion(major=6, minor=1, build=7601, servicePack="1")
+	if attrName == "WIN8" and NVDAState._allowDeprecatedAPI():
+		log.warning("WIN8 is deprecated.")
+		return WinVersion(major=6, minor=2, build=9200)
+	raise AttributeError(f"module {repr(__name__)} has no attribute {repr(attrName)}")

--- a/source/winVersion.py
+++ b/source/winVersion.py
@@ -100,8 +100,8 @@ class WinVersion(object):
 	def _getWindowsReleaseName(self) -> str:
 		"""Returns the public release name for a given Windows release based on major, minor, and build.
 		This is useful if release names are not defined when constructing this class.
-		For example, 6.1 will return 'Windows 7'.
-		For Windows 10, feature update release name will be included.
+		For example, 6.3 will return 'Windows 8.1'.
+		For Windows 10 and later, feature update release name will be included.
 		On server systems, unless noted otherwise, client release names will be returned.
 		For example, 'Windows 10 1809' will be returned on Server 2019 systems.
 		"""

--- a/source/winVersion.py
+++ b/source/winVersion.py
@@ -105,11 +105,7 @@ class WinVersion(object):
 		On server systems, unless noted otherwise, client release names will be returned.
 		For example, 'Windows 10 1809' will be returned on Server 2019 systems.
 		"""
-		if (self.major, self.minor) == (6, 1):
-			return "Windows 7"
-		elif (self.major, self.minor) == (6, 2):
-			return "Windows 8"
-		elif (self.major, self.minor) == (6, 3):
+		if (self.major, self.minor) == (6, 3):
 			return "Windows 8.1"
 		elif self.major == 10:
 			# From Version 1511 (build 10586), release Id/display version comes from Windows Registry.
@@ -231,11 +227,11 @@ def __getattr__(attrName: str) -> Any:
 	"""Module level `__getattr__` used to preserve backward compatibility."""
 	if attrName == "WIN7" and NVDAState._allowDeprecatedAPI():
 		log.warning("WIN7 is deprecated.")
-		return WinVersion(major=6, minor=1, build=7600)
+		return WinVersion(major=6, minor=1, build=7600, releaseName="Windows 7")
 	if attrName == "WIN7_SP1" and NVDAState._allowDeprecatedAPI():
 		log.warning("WIN7_SP1 is deprecated.")
-		return WinVersion(major=6, minor=1, build=7601, servicePack="1")
+		return WinVersion(major=6, minor=1, build=7601, releaseName="Windows 7", servicePack="1")
 	if attrName == "WIN8" and NVDAState._allowDeprecatedAPI():
 		log.warning("WIN8 is deprecated.")
-		return WinVersion(major=6, minor=2, build=9200)
+		return WinVersion(major=6, minor=2, build=9200, releaseName="Windows 8")
 	raise AttributeError(f"module {repr(__name__)} has no attribute {repr(attrName)}")

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -122,6 +122,7 @@ Code which imports from one of them, should instead import from the replacement 
   - ``winVersion.WIN7``
   - ``winVersion.WIN7_SP1``
   - ``winVersion.WIN8``
+  -
 -
 
 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -118,6 +118,10 @@ Code which imports from one of them, should instead import from the replacement 
 - Using ``watchdog.getFormattedStacksForAllThreads`` is deprecated - please use ``logHandler.getFormattedStacksForAllThreads`` instead. (#15616, @lukaszgo1)
 - ``easeOfAccess.canConfigTerminateOnDesktopSwitch`` has been deprecated, as it became obsolete since Windows 7 is no longer supported. (#15644, @LeonarddeR)
 - ``winVersion.isFullScreenMagnificationAvailable`` has been deprecated - use ``visionEnhancementProviders.screenCurtain.ScreenCurtainProvider.canStart`` instead. (#15664, @josephsl)
+- The following Windows release constants has been deprecated from winVersion module (#15647, @josephsl):
+  - winVersion.WIN7
+  - winVersion.WIN7_SP1
+  - winVersion.WIN8
 -
 
 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -119,9 +119,9 @@ Code which imports from one of them, should instead import from the replacement 
 - ``easeOfAccess.canConfigTerminateOnDesktopSwitch`` has been deprecated, as it became obsolete since Windows 7 is no longer supported. (#15644, @LeonarddeR)
 - ``winVersion.isFullScreenMagnificationAvailable`` has been deprecated - use ``visionEnhancementProviders.screenCurtain.ScreenCurtainProvider.canStart`` instead. (#15664, @josephsl)
 - The following Windows release constants has been deprecated from winVersion module (#15647, @josephsl):
-  - winVersion.WIN7
-  - winVersion.WIN7_SP1
-  - winVersion.WIN8
+  - ``winVersion.WIN7``
+  - ``winVersion.WIN7_SP1``
+  - ``winVersion.WIN8``
 -
 
 


### PR DESCRIPTION

### Link to issue number:
Closes #15647 

### Summary of the issue:
Deprecate Windows 7/8 constants and change release name fetcher process.

### Description of user facing changes
None

### Description of development approach
Edit winVersion module:

* Deprecate winVersion.WIN7/WIN7_SP1/WIN8 constants, replaced with getattr deprecation method.
* Remove 6.1/6.2 checks from release name fetcher - only deal with Windows 8.1 and later.
* For deprecated constants, provide release name field in getattr function.

### Testing strategy:
Manual testing and code coverage: the deprecated constants are removed from NVDA Core (try using Grep or similar tools) and documented in what's new document.

### Known issues with pull request:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
