### PR TITLE
Disable speech and braille viewer in secure mode

### DIFF
--- a/source/brailleViewer/__init__.py
+++ b/source/brailleViewer/__init__.py
@@ -2,7 +2,7 @@
 # Copyright (C) 2014-2023 NV Access Limited, Leonard de Ruijter
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-from typing import Optional, List
+from typing import Optional
 
 import gui
 import extensionPoints
@@ -91,6 +91,7 @@ def _getDisplaySize(numCells: int):
 	return numCells if numCells > 0 else DEFAULT_NUM_CELLS
 
 
+@gui.blockAction.when(gui.blockAction.Context.SECURE_MODE)
 def createBrailleViewerTool():
 	if not gui.mainFrame:
 		raise RuntimeError("Can not initialise the BrailleViewerGui: gui.mainFrame not yet initialised")

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -3191,7 +3191,8 @@ class GlobalCommands(ScriptableObject):
 		),
 		category=SCRCAT_TOOLS
 	)
-	def script_toggleSpeechViewer(self,gesture):
+	@gui.blockAction.when(gui.blockAction.Context.SECURE_MODE)
+	def script_toggleSpeechViewer(self, gesture: inputCore.InputGesture):
 		if gui.speechViewer.isActive:
 			# Translators: The message announced when disabling speech viewer.
 			state = _("speech viewer disabled")
@@ -3212,7 +3213,8 @@ class GlobalCommands(ScriptableObject):
 		),
 		category=SCRCAT_TOOLS
 	)
-	def script_toggleBrailleViewer(self, gesture):
+	@gui.blockAction.when(gui.blockAction.Context.SECURE_MODE)
+	def script_toggleBrailleViewer(self, gesture: inputCore.InputGesture):
 		import brailleViewer
 		if brailleViewer.isBrailleViewerActive():
 			# Translators: The message announced when disabling braille viewer.

--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -352,6 +352,7 @@ class MainFrame(wx.Frame):
 		if self.sysTrayIcon and self.sysTrayIcon.menu_tools_toggleSpeechViewer:
 			self.sysTrayIcon.menu_tools_toggleSpeechViewer.Check(isEnabled)
 
+	@blockAction.when(blockAction.Context.SECURE_MODE)
 	def onToggleSpeechViewerCommand(self, evt):
 		if not speechViewer.isActive:
 			speechViewer.activate()
@@ -363,6 +364,7 @@ class MainFrame(wx.Frame):
 		if self.sysTrayIcon and self.sysTrayIcon.menu_tools_toggleBrailleViewer:
 			self.sysTrayIcon.menu_tools_toggleBrailleViewer.Check(created)
 
+	@blockAction.when(blockAction.Context.SECURE_MODE)
 	def onToggleBrailleViewerCommand(self, evt):
 		import brailleViewer
 		if brailleViewer.isBrailleViewerActive():
@@ -500,21 +502,23 @@ class SysTrayIcon(wx.adv.TaskBarIcon):
 			# Translators: The label for the menu item to open NVDA Log Viewer.
 			item = menu_tools.Append(wx.ID_ANY, _("View &log"))
 			self.Bind(wx.EVT_MENU, frame.onViewLogCommand, item)
-		# Translators: The label for the menu item to toggle Speech Viewer.
-		item = self.menu_tools_toggleSpeechViewer = menu_tools.AppendCheckItem(wx.ID_ANY, _("&Speech viewer"))
-		item.Check(speechViewer.isActive)
-		self.Bind(wx.EVT_MENU, frame.onToggleSpeechViewerCommand, item)
 
-		self.menu_tools_toggleBrailleViewer: wx.MenuItem = menu_tools.AppendCheckItem(
-			wx.ID_ANY,
-			# Translators: The label for the menu item to toggle Braille Viewer.
-			_("&Braille viewer")
-		)
-		item = self.menu_tools_toggleBrailleViewer
-		self.Bind(wx.EVT_MENU, frame.onToggleBrailleViewerCommand, item)
-		import brailleViewer
-		self.menu_tools_toggleBrailleViewer.Check(brailleViewer.isBrailleViewerActive())
-		brailleViewer.postBrailleViewerToolToggledAction.register(frame.onBrailleViewerChangedState)
+			# Translators: The label for the menu item to toggle Speech Viewer.
+			item = self.menu_tools_toggleSpeechViewer = menu_tools.AppendCheckItem(wx.ID_ANY, _("&Speech viewer"))
+			item.Check(speechViewer.isActive)
+			self.Bind(wx.EVT_MENU, frame.onToggleSpeechViewerCommand, item)
+
+			self.menu_tools_toggleBrailleViewer: wx.MenuItem = menu_tools.AppendCheckItem(
+				wx.ID_ANY,
+				# Translators: The label for the menu item to toggle Braille Viewer.
+				_("&Braille viewer")
+			)
+
+			item = self.menu_tools_toggleBrailleViewer
+			self.Bind(wx.EVT_MENU, frame.onToggleBrailleViewerCommand, item)
+			import brailleViewer
+			self.menu_tools_toggleBrailleViewer.Check(brailleViewer.isBrailleViewerActive())
+			brailleViewer.postBrailleViewerToolToggledAction.register(frame.onBrailleViewerChangedState)
 
 		if not config.isAppX and NVDAState.shouldWriteToDisk():
 			# Translators: The label of a menu item to open the Add-on store

--- a/source/speechViewer.py
+++ b/source/speechViewer.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2006-2022 NV Access Limited, Thomas Stivers, Accessolutions, Julien Cochuyt
+# Copyright (C) 2006-2023 NV Access Limited, Thomas Stivers, Accessolutions, Julien Cochuyt
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -12,6 +12,7 @@ import gui
 import config
 from logHandler import log
 from speech import SpeechSequence
+from gui import blockAction
 import gui.contextHelp
 from utils.security import isLockScreenModeActive, post_sessionLockStateChanged
 
@@ -155,9 +156,10 @@ _guiFrame: Optional[SpeechViewerFrame] = None
 isActive: bool = False
 
 
+@blockAction.when(blockAction.Context.SECURE_MODE)
 def activate():
 	"""
-		Function to call to trigger the speech viewer window to open.
+	Function to call to trigger the speech viewer window to open.
 	"""
 	_setActive(True, SpeechViewerFrame(_cleanup))
 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -24,7 +24,7 @@ This option now announces additional relevant information about an object when t
 - When requesting formatting information on Excel cells, borders and background will only be reported if there is such formatting. (#15560, @CyrilleB79)
 - The command to toggle the screen curtain now has a default gesture: ``NVDA+control+escape``. (#10560, @CyrilleB79)
 - NVDA will again no longer report unlabelled groupings such as in recent versions of Microsoft Office 365 menus. (#15638)
-- Log viewer and speech viewer are now disabled in secure mode. (#15680)
+- Braille viewer and speech viewer are now disabled in secure mode. (#15680)
 -
 
 == Bug Fixes ==

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -24,7 +24,7 @@ This option now announces additional relevant information about an object when t
 - When requesting formatting information on Excel cells, borders and background will only be reported if there is such formatting. (#15560, @CyrilleB79)
 - The command to toggle the screen curtain now has a default gesture: ``NVDA+control+escape``. (#10560, @CyrilleB79)
 - NVDA will again no longer report unlabelled groupings such as in recent versions of Microsoft Office 365 menus. (#15638)
-- Log viewer and speech viewer are now disabled in secure mode. (#)
+- Log viewer and speech viewer are now disabled in secure mode. (#15680)
 -
 
 == Bug Fixes ==

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -24,6 +24,7 @@ This option now announces additional relevant information about an object when t
 - When requesting formatting information on Excel cells, borders and background will only be reported if there is such formatting. (#15560, @CyrilleB79)
 - The command to toggle the screen curtain now has a default gesture: ``NVDA+control+escape``. (#10560, @CyrilleB79)
 - NVDA will again no longer report unlabelled groupings such as in recent versions of Microsoft Office 365 menus. (#15638)
+- Log viewer and speech viewer are now disabled in secure mode. (#)
 -
 
 == Bug Fixes ==

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -4120,6 +4120,7 @@ Secure mode disables:
 - The [Add-on Store #AddonsManager]
 - The [NVDA Python console #PythonConsole]
 - The [Log Viewer #LogViewer] and logging
+- The [Braille Viewer #BrailleViewer] and [Speech Viewer #SpeechViewer]
 - Opening external documents from the NVDA menu, such as the user guide or contributors file.
 -
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
None

### Summary of the issue:

Speech and braille viewer are not required and may cause secure information to be retained in testing environments, where secure mode is often used.

### Description of user facing changes
Disable speech and braille viewer in secure mode

### Description of development approach
Disable speech and braille viewer in secure mode

### Testing strategy:
Test trying to open speech and braille viewer when starting NVDA with `--secure`

### Known issues with pull request:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
