### PR TITLE
playWaveFile: Don't create a new WavePlayer until after we have waited on the previous thread.

### DIFF
--- a/source/nvwave.py
+++ b/source/nvwave.py
@@ -696,6 +696,23 @@ def playWaveFile(
 			"Playing wave file canceled by handler registered to decide_playWaveFile extension point"
 		)
 		return
+
+	def play():
+		global fileWavePlayer
+		try:
+			fileWavePlayer.feed(f.readframes(f.getnframes()))
+			fileWavePlayer.idle()
+		except Exception:
+			log.exception("Error playing wave file")
+		# #11169: Files might not be played that often. Leaving the device open
+		# until the next file is played really shouldn't be a problem regardless of
+		# how long we wait, but closing the device seems to hang occasionally.
+		# There's no benefit to keeping it open - we're going to create a new
+		# player for the next file anyway - so just destroy it now.
+		fileWavePlayer = None
+
+	if asynchronous and fileWavePlayerThread is not None:
+		fileWavePlayerThread.join()
 	fileWavePlayer = WavePlayer(
 		channels=f.getnchannels(),
 		samplesPerSec=f.getframerate(),
@@ -704,21 +721,7 @@ def playWaveFile(
 		wantDucking=False,
 		purpose=AudioPurpose.SOUNDS
 	)
-
-	def play():
-		global fileWavePlayer
-		fileWavePlayer.feed(f.readframes(f.getnframes()))
-		fileWavePlayer.idle()
-		# #11169: Files might not be played that often. Leaving the device open
-		# until the next file is played really shouldn't be a problem regardless of
-		# how long we wait, but closing the device seems to hang occasionally.
-		# There's no benefit to keeping it open - we're going to create a new
-		# player for the next file anyway - so just destroy it now.
-		fileWavePlayer = None
-
 	if asynchronous:
-		if fileWavePlayerThread is not None:
-			fileWavePlayerThread.join()
 		fileWavePlayerThread = threading.Thread(
 			name=f"{__name__}.playWaveFile({os.path.basename(fileName)})",
 			target=play

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -38,6 +38,7 @@ This makes the announcement of spelling errors work when announcing a line in Wr
 - In Microsoft Word with UIA disabled braille is updated when ``control+v``, ``control+x``, ``control+y``, ``control+z``, ``alt+backspace``, ``backspace`` or ``control+backspace`` is pressed.
 It is also updated with UIA enabled, when typing text and braille is tethered to review and review follows caret. (#3276)
 - Multi line braille displays will no longer crash the BRLTTY driver and are treated as one continuous display. (#15386)
+- NVDA no longer sometimes freezes briefly when multiple sounds are played in rapid succession. (#15311)
 -
 
 == Changes for Developers ==


### PR DESCRIPTION
### Link to issue number:
Fixes #15311.

### Summary of the issue:
When multiple wave files are played asynchronously in rapid succession without any delay between the calls, NVDA can freeze briefly and throw exceptions such as "AttributeError: 'NoneType' object has no attribute 'feed'".

### Description of user facing changes
NVDA no longer sometimes freezes briefly when multiple sounds are played in rapid succession.

### Description of development approach
Previously, playWaveFile reassigned fileWavePlayer before waiting for the previous thread to complete. If the previous thread was still cleaning up, it might set fileWavePlayer to None after this new assignment. This meant that fileWavePlayer would be None when the new thread tried to run.

Instead, fileWavePlayer is now reassigned after waiting for the previous thread to complete.

In addition, the inner play() function now catches and logs exceptions that occur while trying to play. This would have made this problem a little easier to debug and should make related problems easier to debug in future.

### Testing strategy:
Ran this Python console snippet:
`import nvwave; nvwave.playWaveFile("waves/browseMode.wav"); nvwave.playWaveFile("waves/browseMode.wav"); nvwave.playWaveFile("waves/browseMode.wav")`
Before this change, it usually freezes and throws exceptions. After this change, it does not.

### Known issues with pull request:
None.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
