### PR TITLE
Add SSML parser and speakSsml function

### DIFF
--- a/source/speech/__init__.py
+++ b/source/speech/__init__.py
@@ -1,8 +1,8 @@
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-# Copyright (C) 2006-2021 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Babbage B.V., Bill Dengler,
-# Julien Cochuyt
+# Copyright (C) 2006-2023 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Babbage B.V., Bill Dengler,
+# Julien Cochuyt, Leonard de Ruijter
 
 from .speech import (
 	_extendSpeechSequence_addMathForTextInfo,
@@ -47,6 +47,7 @@ from .speech import (
 	setSpeechMode,
 	speak,
 	speakMessage,
+	speakSsml,
 	speakObject,
 	speakObjectProperties,
 	speakPreselectedText,
@@ -62,7 +63,6 @@ from .speech import (
 	spellTextInfo,
 	splitTextIndentation,
 )
-
 from .priorities import Spri
 
 from .types import (
@@ -124,6 +124,7 @@ __all__ = [
 	"RE_INDENTATION_SPLIT",
 	"setSpeechMode",
 	"speak",
+	"speakSsml",
 	"speakMessage",
 	"speakObject",
 	"speakObjectProperties",

--- a/source/speech/commands.py
+++ b/source/speech/commands.py
@@ -2,7 +2,7 @@
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-# Copyright (C) 2006-2020 NV Access Limited
+# Copyright (C) 2006-2023 NV Access Limited, Leonard de Ruijter
 
 """
 Commands that can be embedded in a speech sequence for changing synth parameters, playing sounds or running
@@ -109,6 +109,14 @@ class IndexCommand(SynthCommand):
 	def __repr__(self):
 		return "IndexCommand(%r)" % self.index
 
+	def __eq__(self, __o: object) -> bool:
+		if __o is self:
+			return True
+		if type(self) is not type(__o):
+			return super().__eq__(__o)
+		return self.index == __o.index
+
+
 class SynthParamCommand(SynthCommand):
 	"""A synth command which changes a parameter for subsequent speech.
 	"""
@@ -133,6 +141,14 @@ class CharacterModeCommand(SynthParamCommand):
 	def __repr__(self):
 		return "CharacterModeCommand(%r)" % self.state
 
+	def __eq__(self, __o: object) -> bool:
+		if __o is self:
+			return True
+		if type(self) is not type(__o):
+			return super().__eq__(__o)
+		return self.state == __o.state
+
+
 class LangChangeCommand(SynthParamCommand):
 	"""A command to switch the language within speech."""
 
@@ -155,6 +171,7 @@ class LangChangeCommand(SynthParamCommand):
 			return self.lang == __o.lang
 		return super().__eq__(__o)
 
+
 class BreakCommand(SynthCommand):
 	"""Insert a break between words.
 	"""
@@ -168,6 +185,14 @@ class BreakCommand(SynthCommand):
 
 	def __repr__(self):
 		return f"BreakCommand(time={self.time})"
+
+	def __eq__(self, __o: object) -> bool:
+		if __o is self:
+			return True
+		if type(self) is not type(__o):
+			return super().__eq__(__o)
+		return self.time == __o.time
+
 
 class EndUtteranceCommand(SpeechCommand):
 	"""End the current utterance at this point in the speech.
@@ -264,6 +289,21 @@ class BaseProsodyCommand(SynthParamCommand):
 		return "{type}({param})".format(
 			type=type(self).__name__, param=param)
 
+	def __eq__(self, __o: object) -> bool:
+		if __o is self:
+			return True
+		if type(self) is not type(__o):
+			return super().__eq__(__o)
+		return self._offset == __o._offset and self._multiplier == __o._multiplier
+
+	def __ne__(self, __o) -> bool:
+		if __o is self:
+			return False
+		if type(self) is not type(__o):
+			return super().__ne__(__o)
+		return self._offset != __o._offset or self._multiplier != __o._multiplier
+
+
 class PitchCommand(BaseProsodyCommand):
 	"""Change the pitch of the voice.
 	"""
@@ -302,6 +342,14 @@ class PhonemeCommand(SynthCommand):
 		if self.text:
 			out += ", text=%r" % self.text
 		return out + ")"
+
+	def __eq__(self, __o: object) -> bool:
+		if __o is self:
+			return True
+		if type(self) is not type(__o):
+			return super().__eq__(__o)
+		return self.ipa == __o.ipa and self.text == __o.text
+
 
 class BaseCallbackCommand(SpeechCommand, metaclass=ABCMeta):
 	"""Base class for commands which cause a function to be called when speech reaches them.

--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -204,7 +204,7 @@ def _getSpeakSsmlSpeech(
 ) -> SpeechSequence:
 	"""Gets the speech sequence for given SSML.
 	:param ssml: The SSML data to speak
-	:param markCallback: An optional callback called for every mark command in the SSSML.
+	:param markCallback: An optional callback called for every mark command in the SSML.
 	:param _prefixSpeechCommand: A SpeechCommand to append before the sequence.
 	"""
 	if ssml is None:
@@ -227,7 +227,7 @@ def speakSsml(
 ) -> None:
 	"""Speaks a given speech sequence provided as ssml.
 	:param ssml: The SSML data to speak.
-	:param markCallback: An optional callback called for every mark command in the SSSML.
+	:param markCallback: An optional callback called for every mark command in the SSML.
 	:param symbolLevel: The symbol verbosity level.
 	:param _prefixSpeechCommand: A SpeechCommand to append before the sequence.
 	:param priority: The speech priority.

--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -194,6 +194,42 @@ def speakMessage(
 		speak(seq, symbolLevel=None, priority=priority)
 
 
+def _getSpeakSsmlSpeech(
+		ssml: str,
+		_prefixSpeechCommand: Optional[SpeechCommand] = None,
+) -> SpeechSequence:
+	"""Gets the speech sequence for given SSML.
+	@param ssml: The SSML data to speak
+	@param _prefixSpeechCommand: A SpeechCommand to append before the sequence.
+	"""
+	if ssml is None:
+		return []
+	from speechXml import SsmlParser
+	parser = SsmlParser()
+	sequence = parser.convertFromXml(ssml)
+	if sequence:
+		if _prefixSpeechCommand is not None:
+			sequence.insert(0, _prefixSpeechCommand)
+	return sequence
+
+
+def speakSsml(
+		ssml: str,
+		symbolLevel: Optional[int] = None,
+		_prefixSpeechCommand: Optional[SpeechCommand] = None,
+		priority: Optional[Spri] = None
+) -> None:
+	"""Speaks a given speech sequence provided as ssml.
+	@param ssml: The SSML data to speak.
+	@param symbolLevel: The symbol verbosity level.
+	@param _prefixSpeechCommand: A SpeechCommand to append before the sequence.
+	@param priority: The speech priority.
+	"""
+	seq = _getSpeakSsmlSpeech(ssml, _prefixSpeechCommand)
+	if seq:
+		speak(seq, symbolLevel=symbolLevel, priority=priority)
+
+
 def getCurrentLanguage() -> str:
 	synth = getSynth()
 	language=None

--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -72,6 +72,7 @@ from utils.security import objectBelowLockScreenAndWindowsIsLocked
 
 if typing.TYPE_CHECKING:
 	import NVDAObjects
+	from speechXml import MarkCallbackT
 
 _speechState: Optional['SpeechState'] = None
 _curWordChars: List[str] = []
@@ -198,11 +199,13 @@ def speakMessage(
 
 def _getSpeakSsmlSpeech(
 		ssml: str,
-		_prefixSpeechCommand: Optional[SpeechCommand] = None,
+		markCallback: "MarkCallbackT | None" = None,
+		_prefixSpeechCommand: SpeechCommand | None = None,
 ) -> SpeechSequence:
 	"""Gets the speech sequence for given SSML.
-	@param ssml: The SSML data to speak
-	@param _prefixSpeechCommand: A SpeechCommand to append before the sequence.
+	:param ssml: The SSML data to speak
+	:param markCallback: An optional callback called for every mark command in the SSSML.
+	:param _prefixSpeechCommand: A SpeechCommand to append before the sequence.
 	"""
 	if ssml is None:
 		return []
@@ -217,17 +220,19 @@ def _getSpeakSsmlSpeech(
 
 def speakSsml(
 		ssml: str,
+		markCallback: "MarkCallbackT | None" = None,
 		symbolLevel: Optional[int] = None,
-		_prefixSpeechCommand: Optional[SpeechCommand] = None,
-		priority: Optional[Spri] = None
+		_prefixSpeechCommand: SpeechCommand | None = None,
+		priority: Spri | None = None
 ) -> None:
 	"""Speaks a given speech sequence provided as ssml.
-	@param ssml: The SSML data to speak.
-	@param symbolLevel: The symbol verbosity level.
-	@param _prefixSpeechCommand: A SpeechCommand to append before the sequence.
-	@param priority: The speech priority.
+	:param ssml: The SSML data to speak.
+	:param markCallback: An optional callback called for every mark command in the SSSML.
+	:param symbolLevel: The symbol verbosity level.
+	:param _prefixSpeechCommand: A SpeechCommand to append before the sequence.
+	:param priority: The speech priority.
 	"""
-	seq = _getSpeakSsmlSpeech(ssml, _prefixSpeechCommand)
+	seq = _getSpeakSsmlSpeech(ssml, markCallback, _prefixSpeechCommand)
 	if seq:
 		speak(seq, symbolLevel=symbolLevel, priority=priority)
 

--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -210,7 +210,7 @@ def _getSpeakSsmlSpeech(
 	if ssml is None:
 		return []
 	from speechXml import SsmlParser
-	parser = SsmlParser()
+	parser = SsmlParser(markCallback)
 	sequence = parser.convertFromXml(ssml)
 	if sequence:
 		if _prefixSpeechCommand is not None:

--- a/source/speech/types.py
+++ b/source/speech/types.py
@@ -10,7 +10,6 @@ Kept here so they can be re-used without having to worry about circular imports.
 from collections.abc import Sequence
 from typing import (
 	Union,
-	List,
 	Iterable, Any, Optional, Generator,
 )
 

--- a/source/speech/types.py
+++ b/source/speech/types.py
@@ -19,7 +19,7 @@ from logHandler import log
 from .commands import SpeechCommand
 
 SequenceItemT = Union[SpeechCommand, str]
-SpeechSequence = List[SequenceItemT]
+SpeechSequence = list[SequenceItemT]
 SpeechIterable = Iterable[SequenceItemT]
 
 _IndexT = int  # Type for indexes.

--- a/source/speechXml.py
+++ b/source/speechXml.py
@@ -1,21 +1,32 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2016-2022 NV Access Limited
+# Copyright (C) 2016-2023 NV Access Limited, Leonard de Ruijter
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
-"""Utilities for converting NVDA speech sequences to XML.
+"""Utilities for converting NVDA speech sequences to XML and vice versa.
 Several synthesizers accept XML, either SSML or their own schemas.
 L{SpeechXmlConverter} is the base class for conversion to XML.
 You can subclass this to support specific XML schemas.
 L{SsmlConverter} is an implementation for conversion to SSML.
 """
 
-from collections import namedtuple, OrderedDict
 import re
-import speech
+from collections import OrderedDict, namedtuple
+from collections.abc import Callable, Generator
+from xml.parsers import expat
+
 import textUtils
-from speech.commands import LangChangeCommand, SpeechCommand
 from logHandler import log
+from speech.commands import (
+	BreakCommand,
+	CharacterModeCommand,
+	LangChangeCommand,
+	PitchCommand,
+	RateCommand,
+	SpeechCommand,
+	VolumeCommand,
+)
+from speech.types import SpeechSequence
 
 XML_ESCAPES = {
 	0x3C: u"&lt;", # <
@@ -47,6 +58,8 @@ def _buildInvalidXmlRegexp():
 			trailing=trailingSurrogate))
 
 RE_INVALID_XML_CHARS = _buildInvalidXmlRegexp()
+RE_TIME_MS = re.compile(r"^(?P<time>\d+)ms$", re.IGNORECASE)
+RE_PERCENTAGE = re.compile(r"^(?P<percentage>\d+(\.\d+)?)%$")
 REPLACEMENT_CHAR = textUtils.REPLACEMENT_CHAR
 
 
@@ -54,6 +67,13 @@ def toXmlLang(nvdaLang: str) -> str:
 	"""Convert an NVDA language to an XML language.
 	"""
 	return nvdaLang.replace("_", "-")
+
+
+def toNvdaLang(xmlLang: str) -> str:
+	"""Convert an XML language to an NVDA language.
+	"""
+	return xmlLang.replace("-", "_")
+
 
 #: An XMLBalancer command to enclose the entire output in a tag.
 #: This must be the first command.
@@ -79,7 +99,8 @@ def _escapeXml(text):
 	text = RE_INVALID_XML_CHARS.sub(REPLACEMENT_CHAR, text)
 	return text
 
-class XmlBalancer(object):
+
+class XmlBalancer:
 	"""Generates balanced XML given a set of commands.
 	NVDA speech sequences are linear, but XML is hierarchical, which makes conversion challenging.
 	For example, a speech sequence might change the pitch, then change the volume, then reset the pitch to default.
@@ -185,7 +206,8 @@ class XmlBalancer(object):
 			self._closeTag(tag)
 		return u"".join(self._out)
 
-class SpeechXmlConverter(object):
+
+class SpeechXmlConverter:
 	"""Base class for conversion of NVDA speech sequences to XML.
 	This class converts an NVDA speech sequence into XmlBalancer commands
 	which can then be passed to L{XmlBalancer} to produce correct XML.
@@ -231,6 +253,7 @@ class SpeechXmlConverter(object):
 		bal = XmlBalancer()
 		balCommands = self.generateBalancerCommands(speechSequence)
 		return bal.generateXml(balCommands)
+
 
 class SsmlConverter(SpeechXmlConverter):
 	"""Converts an NVDA speech sequence to SSML.
@@ -280,3 +303,109 @@ class SsmlConverter(SpeechXmlConverter):
 
 	def convertPhonemeCommand(self, command):
 		return StandAloneTagCommand("phoneme", {"alphabet": "ipa", "ph": command.ipa}, command.text)
+
+
+class SpeechXmlParser:
+	"""Base class for parsing of NVDA speech sequences from XML.
+	This class converts XML to an NVDA speech sequence.
+
+	Callers can call L{convertFromXml} with XML to generate a speech sequence.
+
+	Subclasses implement specific XML schemas by implementing generators which convert each XML tag supported.
+	The method for a tag should be named with the prefix "parse" followed by the tag.
+	For example, the handler for <volume /> should be named C{parseVolume}.
+	These generators receive an optional dictionary containing the attributes and values.
+	When the tags value is None, it is a closing tag.
+	They should yield an appropriate SPeechCommand instance.
+	"""
+
+	_speechSequence: SpeechSequence
+
+	def _elementHandler(self, tagName: str, attrs: dict | None = None):
+		processedTagName = "".join(tagName.title().split("-"))
+		funcName = f"parse{processedTagName}"
+		if (func := getattr(self, funcName, None)) is None:
+			log.debugWarning(f"Unsupported tag: {tagName}")
+			return
+		for command in func(attrs):
+			# If the last command in the sequence is of the same type, we can remove it.
+			if self._speechSequence and type(self._speechSequence[-1]) is type(command):
+				self._speechSequence.pop()
+			# Look up the previous command of the same class, if any.
+			# If the last instance of this command in the sequence is equal to this command, we don't have to add it.
+			prevCommand = next((c for c in reversed(self._speechSequence) if type(c) is type(command)), None)
+			if prevCommand != command:
+				self._speechSequence.append(command)
+
+	def convertFromXml(self, xml):
+		"""Convert XML to a speech sequence.
+		"""
+		self._speechSequence = SpeechSequence()
+		parser = expat.ParserCreate('utf-8')
+		parser.StartElementHandler = parser.EndElementHandler = self._elementHandler
+		parser.CharacterDataHandler = self._speechSequence.append
+		try:
+			parser.Parse(xml)
+		except Exception e:
+			raise ValueError(f"XML: {xml}") from e
+		return self._speechSequence
+
+
+ParseGeneratorT = Generator[SpeechCommand, None, None]
+ParseFuncT = Callable[[dict[str, str]], ParseGeneratorT]
+
+
+class SsmlParser(SpeechXmlParser):
+	"""Parses SSML into an NVDA speech sequence.
+	"""
+
+	def parseSayAs(self, attrs: dict[str, str]) -> ParseGeneratorT:
+		state = attrs is not None and attrs.get("interpret-as") == "characters"
+		yield CharacterModeCommand(state)
+
+	def parseVoice(self, attrs: dict[str, str]) -> ParseGeneratorT:
+		if attrs is None:
+			return None
+		if (xmlLang := attrs.get("xml:lang")) is None:
+			return None
+		yield LangChangeCommand(toNvdaLang(xmlLang))
+
+	def parseBreak(self, attrs: dict[str, str]) -> ParseGeneratorT:
+		if attrs is None or "time" not in attrs:
+			return None
+		if (time := RE_TIME_MS.match(attrs["time"])) is None:
+			log.debugWarning(f"Unknown attributes for break tag: {attrs}")
+			return None
+		yield BreakCommand(int(time.group("time")))
+
+	_cachedProsodyAttrs: list[dict]
+
+	def parseProsody(self, attrs: dict[str, str]) -> ParseGeneratorT:
+		if isOpenTag := attrs is not None:
+			self._cachedProsodyAttrs.append(attrs)
+		else:  # attrs is None
+			# Pop the attrs from the cache so we can add commands to reset them.
+			attrs = self._cachedProsodyAttrs.pop()
+		for attr, val in attrs.items():
+			if (percentage := RE_PERCENTAGE.match(val)) is None:
+				log.debugWarning(f"Attribute {attr!r} for prosody tag has unparseable value: {val!r}")
+				continue
+			multiplier = float(percentage.group("percentage")) / 100 if isOpenTag else 1
+			match attr:
+				case "pitch":
+					yield PitchCommand(multiplier=multiplier)
+				case "volume":
+					yield VolumeCommand(multiplier=multiplier)
+				case "rate":
+					yield RateCommand(multiplier=multiplier)
+				case _:
+					log.debugWarning(f"Unknown prosody attribute: {attr!r}")
+					continue
+
+	def parseSpeak(self, attrs: dict[str, str]):
+		return
+		yield
+
+	def convertFromXml(self, xml):
+		self._cachedProsodyAttrs = []
+		return super().convertFromXml(xml)

--- a/source/speechXml.py
+++ b/source/speechXml.py
@@ -364,7 +364,7 @@ class SsmlParser(SpeechXmlParser):
 	def __init__(self, markCallback: MarkCallbackT | None = None):
 		"""Constructor.
 
-		:param markCallback: An optional callback called for every mark command in the SSSML.
+		:param markCallback: An optional callback called for every mark command in the SSML.
 			The mark command in the SSML will be translated to a CallbackCommand instance.
 		"""
 		self._markCallback = markCallback

--- a/source/winAPI/constants.py
+++ b/source/winAPI/constants.py
@@ -15,6 +15,9 @@ class HResult(enum.IntEnum):
 
 class SystemErrorCodes(enum.IntEnum):
 	# https://docs.microsoft.com/en-us/windows/win32/debug/system-error-codes--0-499-
+	SUCCESS = 0x0
 	ACCESS_DENIED = 0x5
+	INVALID_DATA = 0xD
+	NOT_READY = 0x15
 	INVALID_PARAMETER = 0x57
 	MOD_NOT_FOUND = 0x7E

--- a/tests/unit/test_speechXml.py
+++ b/tests/unit/test_speechXml.py
@@ -259,6 +259,7 @@ class TestSsmlConverter(unittest.TestCase):
 			'</voice></prosody></speak>'
 		)
 
+
 class TestSsmlParser(unittest.TestCase):
 
 	def test_parse(self):

--- a/tests/unit/test_speechXml.py
+++ b/tests/unit/test_speechXml.py
@@ -2,7 +2,7 @@
 #A part of NonVisual Desktop Access (NVDA)
 #This file is covered by the GNU General Public License.
 #See the file COPYING for more details.
-#Copyright (C) 2017 NV Access Limited
+#Copyright (C) 2017-2023 NV Access Limited, Leonard de Ruijter
 
 """Unit tests for the speechXml module.
 """

--- a/tests/unit/test_speechXml.py
+++ b/tests/unit/test_speechXml.py
@@ -258,3 +258,30 @@ class TestSsmlConverter(unittest.TestCase):
 			'<phoneme alphabet="ipa" ph="phIpa">phText</phoneme>'
 			'</voice></prosody></speak>'
 		)
+
+class TestSsmlParser(unittest.TestCase):
+
+	def test_parse(self):
+		"""Test parsing a speech sequence from SSML."""
+		parser = speechXml.SsmlParser()
+		expectedSequence = [
+			"t1",
+			PitchCommand(multiplier=2),
+			VolumeCommand(multiplier=2),
+			"t2",
+			PitchCommand(),
+			LangChangeCommand("de_DE"),
+			CharacterModeCommand(True),
+			"c",
+			CharacterModeCommand(False),
+			VolumeCommand(),
+		]
+		xml = (
+			'<speak version="1.0" xmlns="http://www.w3.org/2001/10/synthesis" xml:lang="en-US">'
+			't1'
+			'<prosody pitch="200%" volume="200%">t2</prosody>'
+			'<prosody volume="200%"><voice xml:lang="de-DE">'
+			'<say-as interpret-as="characters">c</say-as>'
+			'</voice></prosody></speak>'
+		)
+		self.assertEqual(expectedSequence, parser.convertFromXml(xml))

--- a/tests/unit/test_speechXml.py
+++ b/tests/unit/test_speechXml.py
@@ -1,8 +1,7 @@
-#tests/unit/test_speechXml.py
-#A part of NonVisual Desktop Access (NVDA)
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
-#Copyright (C) 2017-2023 NV Access Limited, Leonard de Ruijter
+# A part of NonVisual Desktop Access (NVDA)
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+# Copyright (C) 2017-2023 NV Access Limited, Leonard de Ruijter
 
 """Unit tests for the speechXml module.
 """

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -53,14 +53,16 @@ Add-ons will need to be re-tested and have their manifest updated.
 - The ``BrailleDisplayDriver`` base class now has ``numRows`` and ``numCols`` properties to provide information about multi line braille displays.
 Setting ``numCells`` is still supported for single line braille displays and ``numCells`` will return the total number of cells for multi line braille displays. (#15386)
 - Updated BrlAPI for BRLTTY to version 0.8.5, and its corresponding python module to a Python 3.11 compatible build. (#15652, @LeonarddeR)
-- Added the ``speech.speakSsml`` function, which allows you to write NVDA speech sequences using [SSML https://www.w3.org/TR/speech-synthesis11/].
-The following tags are currently supported and translated to appropriate NVDA speech commands:
- - ``Prosody`` (``pitch``, ``rate`` and ``volume``). Only multiplication (e.g. ``200%`` are supported.
- - ``say-as`` with the ``interpret`` attribute set to ``characters``
- - ``voice`` with the ``xml:lang`` set to an XML language
- - ``break`` with the ``time`` attribute set to a value in milliseconds, e.g. ``200ms``
+- Added the ``speech.speakSsml`` function, which allows you to write NVDA speech sequences using [SSML https://www.w3.org/TR/speech-synthesis11/].  (#15699, @LeonarddeR)
+ - The following tags are currently supported and translated to appropriate NVDA speech commands:
+  - ``Prosody`` (``pitch``, ``rate`` and ``volume``). Only multiplication (e.g. ``200%`` are supported.
+  - ``say-as`` with the ``interpret`` attribute set to ``characters``
+  - ``voice`` with the ``xml:lang`` set to an XML language
+  - ``break`` with the ``time`` attribute set to a value in milliseconds, e.g. ``200ms``
+  -
+ - Example: ``speech.speakSsml('<speak><prosody pitch="200%">hello</prosody><break time="500ms" /><prosody rate="50%">John</prosody></speak>')``
+ - The SSML parsing capabilities are backed by the ``SsmlParser`` class in the ``speechXml`` module.
  -
-- Added basic SSML parsing capabilities in the ``speechXml`` module. Consult the ``SsmlParser`` class for more details.
 -
 
 === API Breaking Changes ===

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -62,6 +62,7 @@ Setting ``numCells`` is still supported for single line braille displays and ``n
   - ``say-as`` with the ``interpret`` attribute set to ``characters``
   - ``voice`` with the ``xml:lang`` set to an XML language
   - ``break`` with the ``time`` attribute set to a value in milliseconds, e.g. ``200ms``
+  - ``mark`` with the ``name`` attribute set to a mark name, e.g. ``mark1``, requires providing a callback
   -
  - Example: ``speech.speakSsml('<speak><prosody pitch="200%">hello</prosody><break time="500ms" /><prosody rate="50%">John</prosody></speak>')``
  - The SSML parsing capabilities are backed by the ``SsmlParser`` class in the ``speechXml`` module.

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -53,6 +53,14 @@ Add-ons will need to be re-tested and have their manifest updated.
 - The ``BrailleDisplayDriver`` base class now has ``numRows`` and ``numCols`` properties to provide information about multi line braille displays.
 Setting ``numCells`` is still supported for single line braille displays and ``numCells`` will return the total number of cells for multi line braille displays. (#15386)
 - Updated BrlAPI for BRLTTY to version 0.8.5, and its corresponding python module to a Python 3.11 compatible build. (#15652, @LeonarddeR)
+- Added the ``speech.speakSsml`` function, which allows you to write NVDA speech sequences using [SSML https://www.w3.org/TR/speech-synthesis11/].
+The following tags are currently supported and translated to appropriate NVDA speech commands:
+ - ``Prosody`` (``pitch``, ``rate`` and ``volume``). Only multiplication (e.g. ``200%`` are supported.
+ - ``say-as`` with the ``interpret`` attribute set to ``characters``
+ - ``voice`` with the ``xml:lang`` set to an XML language
+ - ``break`` with the ``time`` attribute set to a value in milliseconds, e.g. ``200ms``
+ -
+- Added basic SSML parsing capabilities in the ``speechXml`` module. Consult the ``SsmlParser`` class for more details.
 -
 
 === API Breaking Changes ===


### PR DESCRIPTION
### Link to issue number:
Preparations for #12945

### Summary of the issue:
1. The way you can output speech using the nvda controller is pretty limited. It is not possible to control prosody parameters, for example. Also you can't easily insert pauses in speech.
2. Construction of speech sequences can be pretty complex. It would if we'd have some standardized way of providing speech attributes in text.

### Description of user facing changes
None for normal users, only developers.

### Description of development approach
Documented in changelog entries. Basically:
- Added an SSML Parser to generate speech sequences
- Added speech.speakSsml to generate speech output using SSML.

Support in the NVDA Controller Client will be added in a follow up.

### Testing strategy:
Unit tests

### Known issues with pull request:
None known

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
