### PR TITLE
Add speech.speechCanceled extension point

### DIFF
--- a/projectDocs/dev/developerGuide/developerGuide.t2t
+++ b/projectDocs/dev/developerGuide/developerGuide.t2t
@@ -1012,6 +1012,10 @@ For examples of how to define and use new extension points, please see the code 
 || Type | Extension Point | Description |
 | ``Decider`` | ``decide_playWaveFile`` | Notifies when a wave file is about to be played, allowing other code to decide if it should be. |
 
+++ speech ++[speechExtPts]
+|| Type | Extension Point | Description |
+| ``Action`` | ``speechCanceled`` | Triggered when speech is canceled. |
+
 ++ synthDriverHandler ++[synthDriverHandlerExtPts]
 || Type | Extension Point | Description |
 | ``Action`` | ``synthIndexReached`` | Notifies when a synthesizer reaches an index during speech. |

--- a/source/speech/__init__.py
+++ b/source/speech/__init__.py
@@ -62,7 +62,7 @@ from .speech import (
 	spellTextInfo,
 	splitTextIndentation,
 )
-
+from .extensions import speechCanceled
 from .priorities import Spri
 
 from .types import (
@@ -139,6 +139,7 @@ __all__ = [
 	"SpeechMode",
 	"spellTextInfo",
 	"splitTextIndentation",
+	"speechCanceled",
 ]
 
 import synthDriverHandler

--- a/source/speech/extensions.py
+++ b/source/speech/extensions.py
@@ -1,0 +1,16 @@
+# A part of NonVisual Desktop Access (NVDA)
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+# Copyright (C) 2023 NV Access Limited, Leonard de Ruijter
+
+"""
+Extension points for speech.
+"""
+
+from extensionPoints import Action
+
+speechCanceled = Action()
+"""
+Notifies when speech is canceled.
+Handlers are called without arguments.
+"""

--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -25,6 +25,7 @@ import speechDictHandler
 import characterProcessing
 import languageHandler
 from . import manager
+from .extensions import speechCanceled
 from .commands import (
 	# Commands that are used in this file.
 	BreakCommand,
@@ -156,6 +157,7 @@ def cancelSpeech():
 	elif _speechState.speechMode == SpeechMode.beeps:
 		return
 	_manager.cancel()
+	speechCanceled.notify()
 	_speechState.beenCanceled = True
 	_speechState.isPaused = False
 

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -79,6 +79,10 @@ appModuleHandler.initialize()
 import vision  # noqa: E402
 vision.initialize()
 
+import speech  # noqa: E402
+
+speech.initialize()
+
 import braille
 # Disable auto detection of braille displays when unit testing.
 config.conf['braille']['display'] = "noBraille"

--- a/tests/unit/test_speech.py
+++ b/tests/unit/test_speech.py
@@ -5,22 +5,27 @@
 
 """Unit tests for the speech module.
 """
-import unittest
 import gettext
 import typing
+import unittest
+
 import config
 from speech import (
-	_getSpellingSpeechAddCharMode,
 	_getSpellingCharAddCapNotification,
+	_getSpellingSpeechAddCharMode,
 	_getSpellingSpeechWithoutCharMode,
+	cancelSpeech,
+	speechCanceled,
 )
 from speech.commands import (
-	EndUtteranceCommand,
-	CharacterModeCommand,
-	PitchCommand,
 	BeepCommand,
-	LangChangeCommand
+	CharacterModeCommand,
+	EndUtteranceCommand,
+	LangChangeCommand,
+	PitchCommand,
 )
+
+from .extensionPointTestHelpers import actionTester
 
 
 class Test_getSpellingSpeechAddCharMode(unittest.TestCase):
@@ -347,3 +352,12 @@ class Test_getSpellingSpeechWithoutCharMode(unittest.TestCase):
 			beepForCapitals=False,
 		)
 		self.assertEqual(repr(list(output)), expected)
+
+class SPeechExtensionPoints(unittest.TestLoader):
+
+	def test_speechCanceledExtensionPoint(self):
+		with actionTester(
+			self,
+			speechCanceled,
+		):
+			cancelSpeech()

--- a/tests/unit/test_speech.py
+++ b/tests/unit/test_speech.py
@@ -353,6 +353,7 @@ class Test_getSpellingSpeechWithoutCharMode(unittest.TestCase):
 		)
 		self.assertEqual(repr(list(output)), expected)
 
+
 class SPeechExtensionPoints(unittest.TestLoader):
 
 	def test_speechCanceledExtensionPoint(self):

--- a/tests/unit/test_speech.py
+++ b/tests/unit/test_speech.py
@@ -354,7 +354,7 @@ class Test_getSpellingSpeechWithoutCharMode(unittest.TestCase):
 		self.assertEqual(repr(list(output)), expected)
 
 
-class SPeechExtensionPoints(unittest.TestLoader):
+class SpeechExtensionPoints(unittest.TestCase):
 
 	def test_speechCanceledExtensionPoint(self):
 		with actionTester(

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -49,7 +49,7 @@ Please refer to [the developer guide https://www.nvaccess.org/files/nvda/documen
 Add-ons will need to be re-tested and have their manifest updated.
 - Added the following extension points:
  - ``treeInterceptorHandler.post_browseModeStateChange``. (#14969, @nvdaes)
- - ``speech.speechCanceled``. (#, @LeonarddeR)
+ - ``speech.speechCanceled``. (#15700, @LeonarddeR)
  -
 - It is now possible to use plural forms in an add-on's translations. (#15661, @beqabeqa473)
 - Included python3.dll in the binary distribution for use by add-ons with external libraries utilizing the [stable ABI https://docs.python.org/3.11/c-api/stable.html]. (#15674, @mzanm)

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -47,7 +47,10 @@ Please refer to [the developer guide https://www.nvaccess.org/files/nvda/documen
 
 - Note: this is an Add-on API compatibility breaking release.
 Add-ons will need to be re-tested and have their manifest updated.
-- Added extension point: ``treeInterceptorHandler.post_browseModeStateChange``. (#14969, @nvdaes)
+- Added the following extension points:
+ - ``treeInterceptorHandler.post_browseModeStateChange``. (#14969, @nvdaes)
+ - ``speech.speechCanceled``. (#, @LeonarddeR)
+ -
 - It is now possible to use plural forms in an add-on's translations. (#15661, @beqabeqa473)
 - Included python3.dll in the binary distribution for use by add-ons with external libraries utilizing the [stable ABI https://docs.python.org/3.11/c-api/stable.html]. (#15674, @mzanm)
 - The ``BrailleDisplayDriver`` base class now has ``numRows`` and ``numCols`` properties to provide information about multi line braille displays.


### PR DESCRIPTION
### Link to issue number:
Part of #14520 

### Summary of the issue:
There is no way for add-ons to be notified about speech cancellation.

### Description of user facing changes
None, developer oriented.

### Description of development approach
Added the speech.speechCanceled extension point.

### Testing strategy:
Unit test.

### Known issues with pull request:
None known

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
