### PR TITLE
Drop win7 support in crft

### DIFF
--- a/source/COMRegistrationFixes/__init__.py
+++ b/source/COMRegistrationFixes/__init__.py
@@ -131,12 +131,3 @@ def fixCOMRegistrations() -> None:
 	if is64bit:
 		register64bitServer(os.path.join(SYSTEM32, "oleaut32.dll"))
 		register64bitServer(os.path.join(SYSTEM32, "actxprxy.dll"))
-	# IServiceProvider on windows 7 can become unregistered 
-	if OSMajorMinor == (6, 1):  # Windows 7
-		# There was no "Program Files (x86)" in Windows 7 32-bit, so we cover both cases
-		register32bitServer(os.path.join(
-			PROGRAM_FILES_X86 if is64bit else PROGRAM_FILES,
-			"Internet Explorer", "ieproxy.dll"
-		))
-		if is64bit:
-			register64bitServer(os.path.join(PROGRAM_FILES, "Internet Explorer", "ieproxy.dll"))

--- a/source/COMRegistrationFixes/__init__.py
+++ b/source/COMRegistrationFixes/__init__.py
@@ -29,8 +29,8 @@ PROGRAM_FILES_X86 = os.path.join(SYSTEM_DRIVE, "Program Files (x86)")
 def register32bitServer(fileName: str) -> None:
 	"""Registers the COM proxy dll with the given file name, using the 32-bit version of regsvr32.
 	Note: this function is valid while NVDA remains a 32-bit app. Re-evaluate if we move to 64-bit.
-	@param fileName: the path to the dll
-	@type fileName: str
+
+	:param fileName: The path to the DLL
 	"""
 	# Points to the 32-bit version, on Windows 32-bit or 64-bit.
 	regsvr32 = os.path.join(SYSTEM32, "regsvr32.exe")
@@ -49,8 +49,8 @@ def register32bitServer(fileName: str) -> None:
 def register64bitServer(fileName: str) -> None:
 	"""Registers the COM proxy dll with the given file name, using the 64-bit version of regsvr64.
 	Note: this function is valid while NVDA remains a 32-bit app. Re-evaluate if we move to 64-bit.
-	@param fileName: the path to the dll
-	@type fileName: str
+
+	:param fileName: The path to the DLL
 	"""
 	# SysWOW64 provides a virtual directory to allow 32-bit programs to reach 64-bit executables.
 	regsvr32 = os.path.join(SYSNATIVE, "regsvr32.exe")
@@ -69,8 +69,7 @@ def register64bitServer(fileName: str) -> None:
 def apply32bitRegistryPatch(fileName: str) -> None:
 	"""Applies the registry patch with the given file name, using 32-bit regExe.
 	Note: this function is valid while NVDA remains a 32-bit app. Re-evaluate if we move to 64-bit.
-	@param fileName: the path to the .reg file
-	@type fileName: str
+	:param fileName: The path to the .reg file
 	"""
 	if not os.path.isfile(fileName):
 		raise FileNotFoundError(f"Cannot apply 32-bit registry patch: {fileName} not found.")
@@ -91,8 +90,8 @@ def apply32bitRegistryPatch(fileName: str) -> None:
 def apply64bitRegistryPatch(fileName: str) -> None:
 	"""Applies the registry patch with the given file name, using 64-bit regExe.
 	Note: this function is valid while NVDA remains a 32-bit app. Re-evaluate if we move to 64-bit.
-	@param fileName: the path to the .reg file
-	@type fileName: str
+
+	:param fileName: The path to the .reg file
 	"""
 	if not os.path.isfile(fileName):
 		raise FileNotFoundError(f"Cannot apply 64-bit registry patch: {fileName} not found.")


### PR DESCRIPTION
### Link to issue number:

None

### Summary of the issue:

The COM Registration Fixing Tool, contained a (re)registration for `ieproxy.dll`, applicable in Windows 7 contexts only.

### Description of user facing changes

None, since this version will not run on Win 7.

### Description of development approach

Removed code from `COMRegistrationFixes.fixCOMRegistrations()` which detected Windows 7, and performed an architecture-specific (re)registration of `ieproxy.dll`.

Additionally, modernized a few docstrings in that module.

No changelog mention, since covered under general removal of Win 7 support notice.

### Testing strategy:

Ran the CRFT twice on Win 11, with no unexpected results, and expected logging.

### Known issues with pull request:

None

### Code Review Checklist:

- [X] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [X] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [X] API is compatible with existing add-ons.
- [X] Security precautions taken.
