### PR TITLE
Do not offer External channel in tabs where it is not relevant

### DIFF
--- a/source/gui/_addonStoreGui/controls/storeDialog.py
+++ b/source/gui/_addonStoreGui/controls/storeDialog.py
@@ -158,7 +158,6 @@ class AddonStoreDialog(SettingsDialog):
 			wxCtrlClass=wx.Choice,
 			choices=list(c.displayString for c in _channelFilters),
 		))
-		gv.dbg = self.channelFilterCtrl
 		self.channelFilterCtrl.Bind(wx.EVT_CHOICE, self.onChannelFilterChange, self.channelFilterCtrl)
 		self.bindHelpEvent("AddonStoreFilterChannel", self.channelFilterCtrl)
 
@@ -310,7 +309,6 @@ class AddonStoreDialog(SettingsDialog):
 			_StatusFilterKey.UPDATE,
 		}:
 			self._storeVM._filterChannelKey = Channel.STABLE
-			#zzz self.channelFilterCtrl.zzz
 			self.enabledFilterCtrl.Hide()
 			self.enabledFilterCtrl.Disable()
 			self.includeIncompatibleCtrl.Enable()

--- a/source/gui/_addonStoreGui/controls/storeDialog.py
+++ b/source/gui/_addonStoreGui/controls/storeDialog.py
@@ -158,6 +158,7 @@ class AddonStoreDialog(SettingsDialog):
 			wxCtrlClass=wx.Choice,
 			choices=list(c.displayString for c in _channelFilters),
 		))
+		gv.dbg = self.channelFilterCtrl
 		self.channelFilterCtrl.Bind(wx.EVT_CHOICE, self.onChannelFilterChange, self.channelFilterCtrl)
 		self.bindHelpEvent("AddonStoreFilterChannel", self.channelFilterCtrl)
 
@@ -300,16 +301,22 @@ class AddonStoreDialog(SettingsDialog):
 		self.SetTitle(self._titleText)
 
 	def _toggleFilterControls(self):
+		self.channelFilterCtrl.Clear()
+		for c in _channelFilters:
+			if c != Channel.EXTERNAL:
+				self.channelFilterCtrl.Append(c.displayString)
 		if self._storeVM._filteredStatusKey in {
 			_StatusFilterKey.AVAILABLE,
 			_StatusFilterKey.UPDATE,
 		}:
 			self._storeVM._filterChannelKey = Channel.STABLE
+			#zzz self.channelFilterCtrl.zzz
 			self.enabledFilterCtrl.Hide()
 			self.enabledFilterCtrl.Disable()
 			self.includeIncompatibleCtrl.Enable()
 			self.includeIncompatibleCtrl.Show()
 		else:
+			self.channelFilterCtrl.Append(Channel.EXTERNAL.displayString)
 			self._storeVM._filterChannelKey = Channel.ALL
 			self.enabledFilterCtrl.Show()
 			self.enabledFilterCtrl.Enable()


### PR DESCRIPTION

### Link to issue number:
Closes #15039
### Summary of the issue:
External appears in channel filter list even in tabs where it is not relevant, i.e. in Available add-ons and Updatable add-ons.
### Description of user facing changes
Remove these External channel from the channel filter list in these tabs.
### Description of development approach
See code.
### Testing strategy:
Manual testing.
### Known issues with pull request:
None

### Change log
None for such a small fix.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
