### PR TITLE
Once again show description of role and states in the dev info.

### DIFF
--- a/source/NVDAObjects/__init__.py
+++ b/source/NVDAObjects/__init__.py
@@ -1427,8 +1427,7 @@ This code is executed if a gain focus event is received by this object.
 		except Exception as e:
 			ret = "exception: %s" % e
 		info.append("name: %s" % ret)
-		ret = self.role
-		info.append("role: %s" % ret)
+		info.append(f"role: {self.role.name}")
 		info.append(f"processID: {self.processID}")
 		try:
 			ret = repr(self.roleText)
@@ -1436,7 +1435,7 @@ This code is executed if a gain focus event is received by this object.
 			ret = f"exception: {e}"
 		info.append(f"roleText: {ret}")
 		try:
-			ret = ", ".join(str(state) for state in self.states)
+			ret = ", ".join(state.name for state in self.states)
 		except Exception as e:
 			ret = "exception: %s" % e
 		info.append("states: %s" % ret)


### PR DESCRIPTION
### Link to issue number:
Fixes #15703

### Summary of the issue:
In Alphas of NVDA compiled with Python 3.11 role and states in the developer info were shown as integer values of the underlying enum members, and not as, more readable, member names. This is due to a change in Python 3.11, which adds a new base class for `IntEnum` and `IntFlag` which converts the members to string in the same way their underlying type (in this particular case integers) are formatted. Since we convert both role and states implicitly (using `%s`) to string in the developer info the member description is replaced with the meaningless integer value there.
### Description of user facing changes
Role and states are once again displayed as names in the developer info.
### Description of development approach
When logging these properties we are logging their names directly, rather than converting enum members to string.
### Testing strategy:
Ensured that in the developer info both role and states are once again shown as strings.
### Known issues with pull request:
I haven't inspected all usages of `enum.IntEnum` and `enum.IntFlag` - it is possible some of these may also need similar fix in the future. To do this it would be necessary to look at each enun and check if it members are converted into a string anywhere in our code, so quite a bit of work.
### Code Review Checklist:

- [X] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [X] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [X] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [X] API is compatible with existing add-ons.
- [X] Security precautions taken.
