### PR TITLE
Remove architecture suffix from nvdaControllerClient.dll

### DIFF
--- a/extras/controllerClient/x86/example_csharp.cs
+++ b/extras/controllerClient/x86/example_csharp.cs
@@ -1,4 +1,4 @@
-﻿// Copyright(C) 2017-2019 NV Access Limited, Arnold Loubriat
+﻿// Copyright(C) 2017-2023 NV Access Limited, Arnold Loubriat, Leonard de Ruijter
 // This file is covered by the GNU Lesser General Public License, version 2.1.
 // See the file license.txt for more details.
 

--- a/extras/controllerClient/x86/example_csharp.cs
+++ b/extras/controllerClient/x86/example_csharp.cs
@@ -13,16 +13,16 @@ namespace NVAccess
 	/// </summary>
 	static class NVDA
 	{
-		[DllImport("nvdaControllerClient32.dll", CharSet = CharSet.Unicode)]
+		[DllImport("nvdaControllerClient.dll", CharSet = CharSet.Unicode)]
 		private static extern int nvdaController_brailleMessage(string message);
 
-		[DllImport("nvdaControllerClient32.dll")]
+		[DllImport("nvdaControllerClient.dll")]
 		private static extern int nvdaController_cancelSpeech();
 
-		[DllImport("nvdaControllerClient32.dll", CharSet = CharSet.Unicode)]
+		[DllImport("nvdaControllerClient.dll", CharSet = CharSet.Unicode)]
 		private static extern int nvdaController_speakText(string text);
 
-		[DllImport("nvdaControllerClient32.dll")]
+		[DllImport("nvdaControllerClient.dll")]
 		private static extern int nvdaController_testIfRunning();
 
 		/// <summary>

--- a/extras/controllerClient/x86/example_python.py
+++ b/extras/controllerClient/x86/example_python.py
@@ -1,3 +1,8 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2006-2023 NV Access Limited, Łukasz Golonka, Leonard de Ruijter
+# This file is covered by the GNU Lesser General Public License, version 2.1.
+# See the file license.txt for more details.
+
 import ctypes
 import time
 

--- a/extras/controllerClient/x86/example_python.py
+++ b/extras/controllerClient/x86/example_python.py
@@ -2,7 +2,7 @@ import time
 import ctypes
 
 #Load the NVDA client library
-clientLib=ctypes.windll.LoadLibrary('./nvdaControllerClient32.dll')
+clientLib=ctypes.windll.LoadLibrary('./nvdaControllerClient.dll')
 
 #Test if NVDA is running, and if its not show a message
 res=clientLib.nvdaController_testIfRunning()

--- a/extras/controllerClient/x86/example_python.py
+++ b/extras/controllerClient/x86/example_python.py
@@ -1,20 +1,20 @@
-import time
 import ctypes
+import time
 
-#Load the NVDA client library
-clientLib=ctypes.windll.LoadLibrary('./nvdaControllerClient.dll')
+# Load the NVDA client library
+clientLib = ctypes.windll.LoadLibrary("./nvdaControllerClient.dll")
 
-#Test if NVDA is running, and if its not show a message
-res=clientLib.nvdaController_testIfRunning()
-if res!=0:
-	errorMessage=str(ctypes.WinError(res))
-	ctypes.windll.user32.MessageBoxW(0,u"Error: %s"%errorMessage,u"Error communicating with NVDA",0)
+# Test if NVDA is running, and if its not show a message
+res = clientLib.nvdaController_testIfRunning()
+if res != 0:
+	errorMessage = str(ctypes.WinError(res))
+	ctypes.windll.user32.MessageBoxW(0, "Error: %s" % errorMessage, "Error communicating with NVDA", 0)
 
-#Speak and braille some messages
+# Speak and braille some messages
 for count in range(4):
-	clientLib.nvdaController_speakText(u"This is a test client for NVDA")
-	clientLib.nvdaController_brailleMessage(u"Time: %g seconds"%(0.75*count))
+	clientLib.nvdaController_speakText("This is a test client for NVDA")
+	clientLib.nvdaController_brailleMessage("Time: %g seconds" % (0.75 * count))
 	time.sleep(0.625)
 	clientLib.nvdaController_cancelSpeech()
-clientLib.nvdaController_speakText(u"This is a test client for NVDA!")
-clientLib.nvdaController_brailleMessage(u"Test completed!")
+clientLib.nvdaController_speakText("This is a test client for NVDA!")
+clientLib.nvdaController_brailleMessage("Test completed!")

--- a/nvdaHelper/client/sconscript
+++ b/nvdaHelper/client/sconscript
@@ -28,7 +28,7 @@ controllerRPCHeader,controllerRPCClientSource=env.MSRPCStubs(
 	MSRPCStubs_prefix="nvdaController_",
 )
 
-clientLibName="nvdaControllerClient%s"%('64' if env['TARGET_ARCH']=='x86_64' else '32')
+clientLibName = "nvdaControllerClient"
 
 clientLib=env.SharedLibrary(
 	target=clientLibName,
@@ -44,11 +44,5 @@ clientLib=env.SharedLibrary(
 		"rpcrt4",
 	],
 )
-
-#if 'install' in COMMAND_LINE_TARGETS:
-#	installDir=env.Install('#../../extras/controllerClient/',clientLib)
-#	env.Default(installDir)
-
-#env.Default(clientLib)
 
 Return(['clientLib','controllerRPCHeader'])

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -56,6 +56,7 @@ Add-ons will need to be re-tested and have their manifest updated.
 - The ``BrailleDisplayDriver`` base class now has ``numRows`` and ``numCols`` properties to provide information about multi line braille displays.
 Setting ``numCells`` is still supported for single line braille displays and ``numCells`` will return the total number of cells for multi line braille displays. (#15386)
 - Updated BrlAPI for BRLTTY to version 0.8.5, and its corresponding python module to a Python 3.11 compatible build. (#15652, @LeonarddeR)
+- The file names of the NVDA Controller Library no longer contain a suffix denoting the architecture, i.e. ``nvdaControllerClient32/64.dll`` are now called ``nvdaControllerClient.dll``. (#15718, #15717, @LeonarddeR)
 -
 
 === API Breaking Changes ===


### PR DESCRIPTION
### Link to issue number:
Fixes #15717 

### Summary of the issue:
The controller client library for ARM64 is called nvdaControllerClient32.dll

### Description of user facing changes
None, devs only change

### Description of development approach
Remove the 32/64 suffix from nvdaControllerClient32/64.dll. This change also has the benefit that python/c# samples run without change for X64 versions of the dll.

### Testing strategy:
Only file name changes.

### Known issues with pull request:
None known
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
