### PR TITLE
Fixed missing comma in startupDialogs.py WelcomeDialog

### DIFF
--- a/source/gui/startupDialogs.py
+++ b/source/gui/startupDialogs.py
@@ -38,7 +38,7 @@ class WelcomeDialog(
 		"By default, the numpad Insert and main Insert keys may both be used as the NVDA key.\n"
 		"You can also configure NVDA to use the CapsLock as the NVDA key.\n"
 		"Press NVDA+n at any time to activate the NVDA menu.\n"
-		"From this menu, you can configure NVDA, get help and access other NVDA functions."
+		"From this menu, you can configure NVDA, get help, and access other NVDA functions."
 	)
 	_instances: Set["WelcomeDialog"] = weakref.WeakSet()
 

--- a/source/gui/startupDialogs.py
+++ b/source/gui/startupDialogs.py
@@ -269,7 +269,7 @@ class AskAllowUsageStatsDialog(
 		wx.Dialog   # wxPython does not seem to call base class initializer, put last in MRO
 ):
 	"""A dialog asking if the user wishes to allow NVDA usage stats to be collected by NV Access."""
-
+	
 	helpId = "UsageStatsDialog"
 
 	def __init__(self, parent):

--- a/source/gui/startupDialogs.py
+++ b/source/gui/startupDialogs.py
@@ -38,7 +38,7 @@ class WelcomeDialog(
 		"By default, the numpad Insert and main Insert keys may both be used as the NVDA key.\n"
 		"You can also configure NVDA to use the CapsLock as the NVDA key.\n"
 		"Press NVDA+n at any time to activate the NVDA menu.\n"
-		"From this menu, you can configure NVDA, get help, and access other NVDA functions."
+		"From this menu, you can configure NVDA, get help and access other NVDA functions."
 	)
 	_instances: Set["WelcomeDialog"] = weakref.WeakSet()
 

--- a/source/gui/startupDialogs.py
+++ b/source/gui/startupDialogs.py
@@ -38,7 +38,7 @@ class WelcomeDialog(
 		"By default, the numpad Insert and main Insert keys may both be used as the NVDA key.\n"
 		"You can also configure NVDA to use the CapsLock as the NVDA key.\n"
 		"Press NVDA+n at any time to activate the NVDA menu.\n"
-		"From this menu, you can configure NVDA, get help and access other NVDA functions."
+		"From this menu, you can configure NVDA, get help, and access other NVDA functions."
 	)
 	_instances: Set["WelcomeDialog"] = weakref.WeakSet()
 
@@ -269,7 +269,7 @@ class AskAllowUsageStatsDialog(
 		wx.Dialog   # wxPython does not seem to call base class initializer, put last in MRO
 ):
 	"""A dialog asking if the user wishes to allow NVDA usage stats to be collected by NV Access."""
-	
+
 	helpId = "UsageStatsDialog"
 
 	def __init__(self, parent):

--- a/tests/system/robot/startupShutdownNVDA.py
+++ b/tests/system/robot/startupShutdownNVDA.py
@@ -140,7 +140,7 @@ def read_welcome_dialog():
 				"down the NVDA key while pressing other keys. By default, the numpad Insert and main Insert keys "
 				"may both be used as the NVDA key. You can also configure NVDA to use the Caps Lock as the NVDA "
 				"key. Press NVDA plus n at any time to activate the NVDA menu. From this menu, you can configure "
-				"NVDA, get help and access other NVDA functions."
+				"NVDA, get help, and access other NVDA functions."
 			),
 			"Options  grouping",
 			"Keyboard layout:  combo box  desktop  collapsed  Alt plus  k"


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
N/A for typo/grammatical error
### Summary of the issue:
Missing comma in welcome dialog
### Description of user facing changes
Added missing comma after "get help"
![image](https://github.com/nvaccess/nvda/assets/45195159/b6822d08-a5b4-469e-ad51-8a1febcf7343)

### Description of development approach
Edited message in startupDialogs.py
### Testing strategy:
Run NVDA from source and observe welcome dialog change
### Known issues with pull request:
N/A

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
