### PR TITLE
NVDAObjects.UIA: fallback to known dialog class names if encountering a dialog despite UIA saying no

### DIFF
--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -1156,7 +1156,10 @@ class UIA(Window):
 		try:
 			isDialog = self._getUIACacheablePropertyValue(UIAHandler.UIA_IsDialogPropertyId)
 		except COMError:
-			# We can fallback to a known set of dialog classes for window elements.
+			# #15729: prepare to fallback if encountering a dialog when UIA says it is not.
+			isDialog = False
+		# We can fallback to a known set of dialog classes for window elements.
+		if not isDialog:
 			isDialog = (self.UIAIsWindowElement and UIAClassName in UIAHandler.UIADialogClassNames)
 		if isDialog:
 			clsList.append(Dialog)

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -43,6 +43,7 @@ This makes the announcement of spelling errors work when announcing a line in Wr
 It is also updated with UIA enabled, when typing text and braille is tethered to review and review follows caret. (#3276)
 - Multi line braille displays will no longer crash the BRLTTY driver and are treated as one continuous display. (#15386)
 - NVDA no longer sometimes freezes briefly when multiple sounds are played in rapid succession. (#15311)
+- NVDA will announce dialog content for more Windows 10 and 11 dialogs. (#15729, @josephsl)
 -
 
 == Changes for Developers ==


### PR DESCRIPTION

### Link to issue number:
Closes #15729 

### Summary of the issue:
NVDA does not announce dialog content for dialogs which UIA says no.

### Description of user facing changes
NVDA will announce dialog content for more dialogs in Windows 10 and 11.

### Description of development approach
Changed dialog detection in NVDAObjects.UIA by falling back to known class names if isDialog property says False.

### Testing strategy:
Manual testing: type "shutdown /S /T 600" from PowerShell or Command Prompt with admin privileges and making sure NVDA announces dialog content.

### Known issues with pull request:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
