### PR TITLE
more useful text content is shown in braille

### DIFF
--- a/source/braille.py
+++ b/source/braille.py
@@ -373,15 +373,30 @@ BLUETOOTH_PORT =  ("bluetooth", _("Bluetooth"))
 
 
 def NVDAObjectHasUsefulText(obj: "NVDAObject") -> bool:
+	"""Does obj contain useful text to display in braille
+
+	:param obj: object to check
+	:type obj: NVDAObject
+	:return: True if there is useful text, False if not
+	:rtype: bool
+	"""
 	if objectBelowLockScreenAndWindowsIsLocked(obj):
 		return False
 	import displayModel
 	if issubclass(obj.TextInfo,displayModel.DisplayModelTextInfo):
 		# #1711: Flat review (using displayModel) should always be presented on the braille display
 		return True
-	else:
-		# Let the NVDAObject choose if the text should be presented
-		return obj._hasNavigableText
+	elif obj._hasNavigableText:
+		return True
+	elif controlTypes.State.READONLY in obj.states:
+		textInfoObj: textInfos.TextInfo = obj.makeTextInfo(textInfos.POSITION_ALL)
+		if (
+			textInfoObj.text != obj.name
+			and textInfoObj.text != obj.description
+			and textInfoObj != obj.TextInfo
+		):
+			return True
+	return False
 
 
 def _getDisplayDriver(moduleName: str, caseSensitive: bool = True) -> Type["BrailleDisplayDriver"]:

--- a/source/braille.py
+++ b/source/braille.py
@@ -377,9 +377,7 @@ def NVDAObjectHasUsefulText(obj: "NVDAObject") -> bool:
 	"""Does obj contain useful text to display in braille
 
 	:param obj: object to check
-	:type obj: NVDAObject
 	:return: True if there is useful text, False if not
-	:rtype: bool
 	"""
 	if objectBelowLockScreenAndWindowsIsLocked(obj):
 		return False

--- a/source/braille.py
+++ b/source/braille.py
@@ -387,7 +387,9 @@ def NVDAObjectHasUsefulText(obj: "NVDAObject") -> bool:
 	if issubclass(obj.TextInfo,displayModel.DisplayModelTextInfo):
 		# #1711: Flat review (using displayModel) should always be presented on the braille display
 		return True
-	if obj._hasNavigableText or isinstance(obj, EditableText):
+	# Late import to avoid import error
+	from NVDAObjects.behaviors import _FakeTableCell
+	if obj._hasNavigableText or isinstance(obj, EditableText) or isinstance(obj, _FakeTableCell):
 		return True
 	return False
 

--- a/source/braille.py
+++ b/source/braille.py
@@ -62,6 +62,8 @@ import brailleViewer
 from autoSettingsUtils.driverSetting import BooleanDriverSetting, NumericDriverSetting
 from utils.security import objectBelowLockScreenAndWindowsIsLocked
 import hwIo
+import NVDAObjects
+import editableText
 
 if TYPE_CHECKING:
 	from NVDAObjects import NVDAObject
@@ -388,14 +390,8 @@ def NVDAObjectHasUsefulText(obj: "NVDAObject") -> bool:
 		return True
 	elif obj._hasNavigableText:
 		return True
-	elif controlTypes.State.READONLY in obj.states:
-		textInfoObj: textInfos.TextInfo = obj.makeTextInfo(textInfos.POSITION_ALL)
-		if (
-			textInfoObj.text != obj.name
-			and textInfoObj.text != obj.description
-			and textInfoObj != obj.TextInfo
-		):
-			return True
+	elif isinstance(obj, editableText.EditableText):
+		return True
 	return False
 
 

--- a/source/braille.py
+++ b/source/braille.py
@@ -62,8 +62,7 @@ import brailleViewer
 from autoSettingsUtils.driverSetting import BooleanDriverSetting, NumericDriverSetting
 from utils.security import objectBelowLockScreenAndWindowsIsLocked
 import hwIo
-import NVDAObjects
-import editableText
+from editableText import EditableText
 
 if TYPE_CHECKING:
 	from NVDAObjects import NVDAObject
@@ -388,9 +387,7 @@ def NVDAObjectHasUsefulText(obj: "NVDAObject") -> bool:
 	if issubclass(obj.TextInfo,displayModel.DisplayModelTextInfo):
 		# #1711: Flat review (using displayModel) should always be presented on the braille display
 		return True
-	elif obj._hasNavigableText:
-		return True
-	elif isinstance(obj, editableText.EditableText):
+	if obj._hasNavigableText or isinstance(obj, EditableText):
 		return True
 	return False
 

--- a/source/braille.py
+++ b/source/braille.py
@@ -387,9 +387,7 @@ def NVDAObjectHasUsefulText(obj: "NVDAObject") -> bool:
 	if issubclass(obj.TextInfo,displayModel.DisplayModelTextInfo):
 		# #1711: Flat review (using displayModel) should always be presented on the braille display
 		return True
-	# Late import to avoid import error
-	from NVDAObjects.behaviors import _FakeTableCell
-	if obj._hasNavigableText or isinstance(obj, EditableText) or isinstance(obj, _FakeTableCell):
+	if obj._hasNavigableText or isinstance(obj, EditableText):
 		return True
 	return False
 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -51,7 +51,7 @@ It is also updated with UIA enabled, when typing text and braille is tethered to
 - NVDA will announce dialog content for more Windows 10 and 11 dialogs. (#15729, @josephsl)
 - NVDA will no longer fail to read a newly loaded page in Microsoft Edge when using UI Automation. (#15736)
 - When using say all or commands which spell text, pauses between sentences or characters no longer gradually decrease over time. (#15739)
-- More objects which contain useful text are detected, and text content is displayed in braille. (#15605, #15755)
+- More objects which contain useful text are detected, and text content is displayed in braille. (#15605)
 -
 
 == Changes for Developers ==

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -51,7 +51,7 @@ It is also updated with UIA enabled, when typing text and braille is tethered to
 - NVDA will announce dialog content for more Windows 10 and 11 dialogs. (#15729, @josephsl)
 - NVDA will no longer fail to read a newly loaded page in Microsoft Edge when using UI Automation. (#15736)
 - When using say all or commands which spell text, pauses between sentences or characters no longer gradually decrease over time. (#15739)
-- More objects which contain useful text are detected, and text content is displayed in braille. (#15605)
+- More objects which contain useful text are detected, and text content is displayed in braille. (#15605, #15755)
 -
 
 == Changes for Developers ==

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -43,6 +43,7 @@ This makes the announcement of spelling errors work when announcing a line in Wr
 It is also updated with UIA enabled, when typing text and braille is tethered to review and review follows caret. (#3276)
 - Multi line braille displays will no longer crash the BRLTTY driver and are treated as one continuous display. (#15386)
 - NVDA no longer sometimes freezes briefly when multiple sounds are played in rapid succession. (#15311)
+- More objects which contain useful text are detected, and text content is displayed in braille. (#15605)
 -
 
 == Changes for Developers ==


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
fixes #15605
### Summary of the issue:
Although object contains useful text, and it is navigable with review cursor, all these objects are not handled as navigable objects in braille.
### Description of user facing changes
Users who use merely braille can read content of more objects.
### Description of development approach
Modified `braille.NVDAObjectHasUsefulText` function.
### Testing strategy:
Tested in sasm 3.14.0 editor help document.
### Known issues with pull request:
none at this moment
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
