### PR TITLE
Edge with UIA: catch COMError when checking if an object is contained in a dead document when loading a new page

### DIFF
--- a/source/UIAHandler/browseMode.py
+++ b/source/UIAHandler/browseMode.py
@@ -21,6 +21,7 @@ import treeInterceptorHandler
 import cursorManager
 import textInfos
 import browseMode
+from logHandler import log
 from NVDAObjects.UIA import UIA
 
 class UIADocumentWithTableNavigation(documentBase.DocumentWithTableNavigation):
@@ -519,7 +520,15 @@ class UIABrowseModeDocument(UIADocumentWithTableNavigation,browseMode.BrowseMode
 			return False
 		# Ensure that this object is a descendant of the document or is the document itself. 
 		runtimeID=VARIANT()
-		self.rootNVDAObject.UIAElement._IUIAutomationElement__com_GetCurrentPropertyValue(UIAHandler.UIA_RuntimeIdPropertyId,byref(runtimeID))
+		try:
+			self.rootNVDAObject.UIAElement._IUIAutomationElement__com_GetCurrentPropertyValue(
+				UIAHandler.UIA_RuntimeIdPropertyId, byref(runtimeID)
+			)
+		except COMError:
+			log.debugWarning(
+				"Could not get runtimeID of document. Most likely document is dead."
+			)
+			return False
 		UIACondition=UIAHandler.handler.clientObject.createPropertyCondition(UIAHandler.UIA_RuntimeIdPropertyId,runtimeID)
 		UIAWalker=UIAHandler.handler.clientObject.createTreeWalker(UIACondition)
 		try:

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -46,6 +46,7 @@ It is also updated with UIA enabled, when typing text and braille is tethered to
 - Multi line braille displays will no longer crash the BRLTTY driver and are treated as one continuous display. (#15386)
 - NVDA no longer sometimes freezes briefly when multiple sounds are played in rapid succession. (#15311)
 - NVDA will announce dialog content for more Windows 10 and 11 dialogs. (#15729, @josephsl)
+- NVDA will no longer fail to read a newly loaded page in Microsoft Edge when using UI Automation. (#15736)
 -
 
 == Changes for Developers ==


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
None.

### Summary of the issue:
When NVDA is set to use UI Automation for Chromium-based browsers, and loading a new page in Microsoft Edge, NVDA fails to detect the newly loaded page, and a traceback is logged:
```
ERROR - api.setFocusObject (09:12:32.825) - MainThread (17268):
Error updating tree interceptor
Traceback (most recent call last):
  File "api.pyc", line 158, in setFocusObject
  File "treeInterceptorHandler.pyc", line 40, in update
  File "NVDAObjects\__init__.pyc", line 430, in _get_treeInterceptor
  File "treeInterceptorHandler.pyc", line 32, in getTreeInterceptor
  File "UIAHandler\browseMode.pyc", line 522, in __contains__
  File "monkeyPatches\comtypesMonkeyPatches.pyc", line 32, in __call__
_ctypes.COMError: (-2147220991, 'An event was unable to invoke any of the subscribers', (None, None, None, 0, None))
```
Specifically, fetching the runtime ID from the root element of the dead document fails.

### Description of user facing changes
NVDA no longer fails to read a newly loaded page in Microsoft Edge when accessing it using UI Automation.

### Description of development approach
Catch COMError and return False (conveying that the given object is not within the dead document).

### Testing strategy:
* Set NVDA to use UI Automation to access Chromium-based browsers.
In Microsoft Edge, go to https://www.nvaccess.org/
* Tab to the Download link and press etner.
* Once the new page is loaded, confirm that the arrow keys can be used to move through NVDA's browse mode for the new document, and that a traceback is not logged.

### Known issues with pull request:
None known.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
