### PR TITLE
Return “Check for updates” to help menu

### DIFF
--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -707,7 +707,7 @@ class SysTrayIcon(wx.adv.TaskBarIcon):
 
 			if updateCheck:
 				# Translators: The label of a menu item to manually check for an updated version of NVDA.
-				item = self.menu.Append(wx.ID_ANY, _("&Check for update..."))
+				item = self.menu.Append(wx.ID_ANY, _("Check for &update..."))
 				self.Bind(wx.EVT_MENU, frame.onCheckForUpdateCommand, item)
 
 		# Translators: The label for the menu item to open About dialog to get information about NVDA.

--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -707,7 +707,7 @@ class SysTrayIcon(wx.adv.TaskBarIcon):
 
 			if updateCheck:
 				# Translators: The label of a menu item to manually check for an updated version of NVDA.
-				item = self.menu.Append(wx.ID_ANY, _("Check for &update..."))
+				item = menu_help.Append(wx.ID_ANY, _("&Check for update..."))
 				self.Bind(wx.EVT_MENU, frame.onCheckForUpdateCommand, item)
 
 		# Translators: The label for the menu item to open About dialog to get information about NVDA.


### PR DESCRIPTION
### Link to issue number:
Close #15740
### Summary of the issue:
#15688 moved “Check for update” to the NVDA main menu.
### Description of user facing changes
The user can again use the “Check for update” option in the Help menu.
### Description of development approach
None
### Testing strategy:
As before, open the Help menu and check for NVDA updates.
### Known issues with pull request:
None
### Code Review Checklist:
- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.