### PR TITLE
WASAPI: Track the total number of frames buffered so far rather than the duration of audio.

### DIFF
--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -47,6 +47,7 @@ It is also updated with UIA enabled, when typing text and braille is tethered to
 - NVDA no longer sometimes freezes briefly when multiple sounds are played in rapid succession. (#15311)
 - NVDA will announce dialog content for more Windows 10 and 11 dialogs. (#15729, @josephsl)
 - NVDA will no longer fail to read a newly loaded page in Microsoft Edge when using UI Automation. (#15736)
+- When using say all or commands which spell text, pauses between sentences or characters no longer gradually decrease over time. (#15739)
 -
 
 == Changes for Developers ==


### PR DESCRIPTION
### Link to issue number:
Fixes #15739.

### Summary of the issue:
When there are several consecutive utterances of speech such as during say all or spelling, the pauses between utterances gradually decrease over time.

### Description of user facing changes
When using say all or commands which spell text, pauses between sentences or characters no longer gradually decrease over time.

### Description of development approach
Previously, the WASAPI code accumulated the total duration of ms buffered so far. To do this, we converted from the number of frames sent to ms and added that to the total ms. This conversion isn't perfect, which meant we continually accumulated conversion errors. This resulted in the callbacks gradually getting ever more inaccurate (earlier) until the stream was stopped and reset.

Instead, we now accumulate the total number of frames sent. We still convert to ms, since the current playback position is time-based. However, we only convert to ms on demand, so we don't accumulate conversion errors.

### Testing strategy:
Set synth to eSpeak, rate boost enabled, rate 40.

Spelled the following line of text:

`Another way to detect if this issue will occur is, at the noted rate values I posted above, spell a `

Before this change, the pauses between characters would get faster and faster. After this change, the pauses are consistent.

### Known issues with pull request:
None.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
