### PR TITLE
WasapiWavePlayer: Don't explicitly remove the instance from the instances map in the destructor.

### DIFF
--- a/source/nvwave.py
+++ b/source/nvwave.py
@@ -840,7 +840,11 @@ class WasapiWavePlayer(garbageHandler.TrackedObject):
 			return
 		if self._player:
 			NVDAHelper.localLib.wasPlay_destroy(self._player)
-			del self._instances[self._player]
+			# Because _instances is a WeakValueDictionary, it will remove the
+			# reference to this instance by itself. We don't need to do it explicitly
+			# here. Furthermore, doing it explicitly might cause an exception because
+			# a weakref callback can run before __del__ in some cases, which would mean
+			# it has already been removed from _instances.
 			self._player = None
 
 	def open(self):

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -51,6 +51,7 @@ It is also updated with UIA enabled, when typing text and braille is tethered to
 - NVDA will announce dialog content for more Windows 10 and 11 dialogs. (#15729, @josephsl)
 - NVDA will no longer fail to read a newly loaded page in Microsoft Edge when using UI Automation. (#15736)
 - When using say all or commands which spell text, pauses between sentences or characters no longer gradually decrease over time. (#15739)
+- NVDA no longer sometimes freezes when speaking a large amount of text. (#15752)
 -
 
 == Changes for Developers ==


### PR DESCRIPTION
### Link to issue number:
Fixes #15752.

### Summary of the issue:
Some users sometimes see errors like this in their logs, accompanied by long freezes:

```
ERROR - stderr (15:18:17.518) - MainThread (29504):
Exception ignored in:
ERROR - stderr (15:18:17.529) - MainThread (29504):
<function WasapiWavePlayer.__del__ at 0x0467A6B8>
ERROR - stderr (15:18:17.950) - MainThread (29504):
Traceback (most recent call last):
ERROR - stderr (15:18:18.392) - MainThread (29504):
  File "nvwave.pyc", line 843, in __del__
ERROR - stderr (15:18:18.830) - MainThread (29504):
  File "weakref.pyc", line 145, in __delitem__
ERROR - stderr (15:18:18.843) - MainThread (29504):
KeyError
ERROR - stderr (15:18:18.855) - MainThread (29504):
:
ERROR - stderr (15:18:19.283) - MainThread (29504):
80057872
```

### Description of user facing changes
NVDA no longer sometimes freezes when speaking a large amount of text.

### Description of development approach
Previously, WasapiWavePlayer's `__del__` method removed itself from the `_instances` map. However, a WeakValueDictionary actually removes the reference itself when the object dies. A weakref callback can run before `__del__` in some cases, which would mean that the item was already removed, resulting in this KeyError.

To fix this, we just don't explicitly remove the item and rely entirely on WeakValueDictionary to do this.

### Testing strategy:
I can't reproduce this, but @beqabeqa473 confirmed that this change seems to fix the issue.

### Known issues with pull request:
None.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
