### PR TITLE
Add an action to review add-ons in the store

### DIFF
--- a/source/_addonStore/models/addon.py
+++ b/source/_addonStore/models/addon.py
@@ -121,6 +121,7 @@ class _AddonStoreModel(_AddonGUIModel):
 	URL: str
 	sha256: str
 	addonVersionNumber: MajorMinorPatch
+	reviewUrl: Optional[str]
 
 	@property
 	def tempDownloadPath(self) -> str:
@@ -236,6 +237,7 @@ class InstalledAddonStoreModel(_AddonManifestModel, _AddonStoreModel):
 	addonVersionNumber: MajorMinorPatch
 	minNVDAVersion: MajorMinorPatch
 	lastTestedVersion: MajorMinorPatch
+	reviewUrl: Optional[str]
 	legacy: bool = False
 	"""
 	Legacy add-ons contain invalid metadata
@@ -269,6 +271,7 @@ class AddonStoreModel(_AddonStoreModel):
 	addonVersionNumber: MajorMinorPatch
 	minNVDAVersion: MajorMinorPatch
 	lastTestedVersion: MajorMinorPatch
+	reviewUrl: Optional[str]
 	legacy: bool = False
 	"""
 	Legacy add-ons contain invalid metadata
@@ -300,6 +303,7 @@ def _createInstalledStoreModelFromData(addon: Dict[str, Any]) -> InstalledAddonS
 		sha256=addon["sha256"],
 		minNVDAVersion=MajorMinorPatch(**addon["minNVDAVersion"]),
 		lastTestedVersion=MajorMinorPatch(**addon["lastTestedVersion"]),
+		reviewUrl=addon.get("reviewUrl"),
 		legacy=addon.get("legacy", False),
 	)
 
@@ -321,6 +325,7 @@ def _createStoreModelFromData(addon: Dict[str, Any]) -> AddonStoreModel:
 		sha256=addon["sha256"],
 		minNVDAVersion=MajorMinorPatch(**addon["minNVDAVersion"]),
 		lastTestedVersion=MajorMinorPatch(**addon["lastTestedVersion"]),
+		reviewUrl=addon.get("reviewUrl"),
 		legacy=addon.get("legacy", False),
 	)
 

--- a/source/_addonStore/models/addon.py
+++ b/source/_addonStore/models/addon.py
@@ -121,7 +121,7 @@ class _AddonStoreModel(_AddonGUIModel):
 	URL: str
 	sha256: str
 	addonVersionNumber: MajorMinorPatch
-	reviewUrl: Optional[str]
+	reviewURL: Optional[str]
 
 	@property
 	def tempDownloadPath(self) -> str:
@@ -237,7 +237,7 @@ class InstalledAddonStoreModel(_AddonManifestModel, _AddonStoreModel):
 	addonVersionNumber: MajorMinorPatch
 	minNVDAVersion: MajorMinorPatch
 	lastTestedVersion: MajorMinorPatch
-	reviewUrl: Optional[str]
+	reviewURL: Optional[str]
 	legacy: bool = False
 	"""
 	Legacy add-ons contain invalid metadata
@@ -271,7 +271,7 @@ class AddonStoreModel(_AddonStoreModel):
 	addonVersionNumber: MajorMinorPatch
 	minNVDAVersion: MajorMinorPatch
 	lastTestedVersion: MajorMinorPatch
-	reviewUrl: Optional[str]
+	reviewURL: Optional[str]
 	legacy: bool = False
 	"""
 	Legacy add-ons contain invalid metadata
@@ -303,7 +303,7 @@ def _createInstalledStoreModelFromData(addon: Dict[str, Any]) -> InstalledAddonS
 		sha256=addon["sha256"],
 		minNVDAVersion=MajorMinorPatch(**addon["minNVDAVersion"]),
 		lastTestedVersion=MajorMinorPatch(**addon["lastTestedVersion"]),
-		reviewUrl=addon.get("reviewUrl"),
+		reviewURL=addon.get("reviewUrl"),
 		legacy=addon.get("legacy", False),
 	)
 
@@ -325,7 +325,7 @@ def _createStoreModelFromData(addon: Dict[str, Any]) -> AddonStoreModel:
 		sha256=addon["sha256"],
 		minNVDAVersion=MajorMinorPatch(**addon["minNVDAVersion"]),
 		lastTestedVersion=MajorMinorPatch(**addon["lastTestedVersion"]),
-		reviewUrl=addon.get("reviewUrl"),
+		reviewURL=addon.get("reviewUrl"),
 		legacy=addon.get("legacy", False),
 	)
 

--- a/source/gui/_addonStoreGui/controls/details.py
+++ b/source/gui/_addonStoreGui/controls/details.py
@@ -314,6 +314,13 @@ class AddonDetails(
 						details.sourceURL
 					)
 
+					if details.reviewUrl is not None:
+						self._appendDetailsLabelValue(
+							# Translators: Label for an extra detail field for the selected add-on. In the add-on store dialog.
+							pgettext("addonStore", "Review URL:"),
+							details.reviewUrl
+						)
+
 				self.contentsPanel.Show()
 
 		self.Layout()

--- a/source/gui/_addonStoreGui/controls/details.py
+++ b/source/gui/_addonStoreGui/controls/details.py
@@ -314,11 +314,11 @@ class AddonDetails(
 						details.sourceURL
 					)
 
-					if details.reviewUrl is not None:
+					if details.reviewURL is not None:
 						self._appendDetailsLabelValue(
 							# Translators: Label for an extra detail field for the selected add-on. In the add-on store dialog.
 							pgettext("addonStore", "Review URL:"),
-							details.reviewUrl
+							details.reviewURL
 						)
 
 				self.contentsPanel.Show()

--- a/source/gui/_addonStoreGui/controls/details.py
+++ b/source/gui/_addonStoreGui/controls/details.py
@@ -317,7 +317,7 @@ class AddonDetails(
 					if details.reviewURL is not None:
 						self._appendDetailsLabelValue(
 							# Translators: Label for an extra detail field for the selected add-on. In the add-on store dialog.
-							pgettext("addonStore", "Review URL:"),
+							pgettext("addonStore", "Reviews URL:"),
 							details.reviewURL
 						)
 

--- a/source/gui/_addonStoreGui/viewModels/store.py
+++ b/source/gui/_addonStoreGui/viewModels/store.py
@@ -241,6 +241,21 @@ class AddonStoreVM:
 				validCheck=lambda aVM: isinstance(aVM.model, _AddonStoreModel),
 				actionTarget=selectedListItem
 			),
+			AddonActionVM(
+				# Translators: Label for an action that opens the webpage to see and provide feedback for the selected add-on
+				displayName=pgettext("addonStore", "&review"),
+				actionHandler=lambda aVM: startfile(
+					cast(
+						str,
+						cast(_AddonStoreModel, aVM.model).reviewUrl
+					)
+				),
+				validCheck=lambda aVM: (
+					isinstance(aVM.model, _AddonStoreModel)
+					and aVM.model.reviewUrl is not None
+				),
+				actionTarget=selectedListItem
+			),
 		]
 
 	def helpAddon(self, listItemVM: AddonListItemVM) -> None:

--- a/source/gui/_addonStoreGui/viewModels/store.py
+++ b/source/gui/_addonStoreGui/viewModels/store.py
@@ -247,12 +247,12 @@ class AddonStoreVM:
 				actionHandler=lambda aVM: startfile(
 					cast(
 						str,
-						cast(_AddonStoreModel, aVM.model).reviewUrl
+						cast(_AddonStoreModel, aVM.model).reviewURL
 					)
 				),
 				validCheck=lambda aVM: (
 					isinstance(aVM.model, _AddonStoreModel)
-					and aVM.model.reviewUrl is not None
+					and aVM.model.reviewURL is not None
 				),
 				actionTarget=selectedListItem
 			),

--- a/source/gui/_addonStoreGui/viewModels/store.py
+++ b/source/gui/_addonStoreGui/viewModels/store.py
@@ -242,8 +242,8 @@ class AddonStoreVM:
 				actionTarget=selectedListItem
 			),
 			AddonActionVM(
-				# Translators: Label for an action that opens the webpage to see and provide feedback for the selected add-on
-				displayName=pgettext("addonStore", "&review"),
+				# Translators: Label for an action that opens the webpage to see and send feedback for the selected add-on
+				displayName=pgettext("addonStore", "See or provide &feedback"),
 				actionHandler=lambda aVM: startfile(
 					cast(
 						str,

--- a/source/gui/_addonStoreGui/viewModels/store.py
+++ b/source/gui/_addonStoreGui/viewModels/store.py
@@ -243,7 +243,7 @@ class AddonStoreVM:
 			),
 			AddonActionVM(
 				# Translators: Label for an action that opens the webpage to see and send feedback for the selected add-on
-				displayName=pgettext("addonStore", "See or provide &feedback"),
+				displayName=pgettext("addonStore", "Read or provide &feedback"),
 				actionHandler=lambda aVM: startfile(
 					cast(
 						str,

--- a/source/gui/_addonStoreGui/viewModels/store.py
+++ b/source/gui/_addonStoreGui/viewModels/store.py
@@ -243,7 +243,7 @@ class AddonStoreVM:
 			),
 			AddonActionVM(
 				# Translators: Label for an action that opens the webpage to see and send feedback for the selected add-on
-				displayName=pgettext("addonStore", "Re&views"),
+				displayName=pgettext("addonStore", "Community re&views"),
 				actionHandler=lambda aVM: startfile(
 					cast(
 						str,

--- a/source/gui/_addonStoreGui/viewModels/store.py
+++ b/source/gui/_addonStoreGui/viewModels/store.py
@@ -243,7 +243,7 @@ class AddonStoreVM:
 			),
 			AddonActionVM(
 				# Translators: Label for an action that opens the webpage to see and send feedback for the selected add-on
-				displayName=pgettext("addonStore", "Read or provide &feedback"),
+				displayName=pgettext("addonStore", "Re&views"),
 				actionHandler=lambda aVM: startfile(
 					cast(
 						str,

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -9,6 +9,7 @@ What's New in NVDA
 == New Features ==
 - Added support for Bluetooth Low Energy HID Braille displays. (#15470)
 - The Add-on Store now supports installing add-ons in bulk by selecting multiple add-ons. (#15350)
+- From the add-on store, it's possible to open a dedicated webpage to see or provide feedback about the selected add-on. (#15576, @nvdaes)
 -
 
 

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2842,7 +2842,7 @@ Just like when you install or remove add-ons, you need to restart NVDA in order 
 
 +++ Reviewing add-ons and reading reviews +++[AddonStoreReviews]
 Before installing an add-on, you may want to read opinions and reactions by others.
-Also, you may want to provide feedback about add-ons to help other users.
+Also, it is helpful to other users, if you  take time to provide feedback about add-ons you have tried.
 To see or share your feedback about add-ons, select an add-on and use the See or provide feedback option in the actions menu.
 This will open a dedicated webpage at GitHub Discussions, where you will be able to see or share your reactions for the add-on, or even for specific versions.
 Please, keep account that this doesn't replace direct communication with add-on developers. Instead, the purpose of this feature is to provide a mechanism to share feedback from the store to help users to decide if an add-on can be useful for them.

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2844,7 +2844,7 @@ Just like when you install or remove add-ons, you need to restart NVDA in order 
 Before installing an add-on, you may want to read opinions and reactions by others.
 Also, it is helpful to other users, if you  take time to provide feedback about add-ons you have tried.
 To see or share your feedback about add-ons, select an add-on and use the See or provide feedback option in the actions menu.
-This will open a dedicated webpage at GitHub Discussions, where you will be able to see or share your reactions for the add-on, or even for specific versions.
+This will open a dedicated webpage at GitHub Discussions, where you will be able to read and write reviews for the add-on, or even comment on specific versions.
 Please, keep account that this doesn't replace direct communication with add-on developers. Instead, the purpose of this feature is to provide a mechanism to share feedback from the store to help users to decide if an add-on can be useful for them.
 
 ++ Incompatible Add-ons ++[incompatibleAddonsManager]

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2840,7 +2840,7 @@ If the add-on was previously "disabled", the status will show "enabled after res
 If the add-on was previously "enabled", the status will show "disabled after restart".
 Just like when you install or remove add-ons, you need to restart NVDA in order for changes to take effect.
 
-+++ Reviewing and consulting feedback for add-ons +++[AddonStoreReviews]
++++ Reviewing add-ons and reading reviews +++[AddonStoreReviews]
 Before installing an add-on, you may want to see opinions and reactions by others.
 Also, you may want to provide feedback about add-ons to help other users.
 To see or share your feedback about add-ons, select an add-on and use the See or provide feedback option in the actions menu.

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2841,7 +2841,7 @@ If the add-on was previously "enabled", the status will show "disabled after res
 Just like when you install or remove add-ons, you need to restart NVDA in order for changes to take effect.
 
 +++ Reviewing add-ons and reading reviews +++[AddonStoreReviews]
-Before installing an add-on, you may want to see opinions and reactions by others.
+Before installing an add-on, you may want to read opinions and reactions by others.
 Also, you may want to provide feedback about add-ons to help other users.
 To see or share your feedback about add-ons, select an add-on and use the See or provide feedback option in the actions menu.
 This will open a dedicated webpage at GitHub Discussions, where you will be able to see or share your reactions for the add-on, or even for specific versions.

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2840,6 +2840,13 @@ If the add-on was previously "disabled", the status will show "enabled after res
 If the add-on was previously "enabled", the status will show "disabled after restart".
 Just like when you install or remove add-ons, you need to restart NVDA in order for changes to take effect.
 
++++ Reviewing and consulting feedback for add-ons +++[AddonStoreReviews]
+Before installing an add-on, you may want to see opinions and reactions by others.
+Also, you may want to provide feedback about add-ons to help other users.
+To see or share your feedback about add-ons, select an add-on and use the See or provide feedback option in the actions menu.
+This will open a dedicated webpage at GitHub Discussions, where you will be able to see or share your reactions for the add-on, or even for specific versions.
+Please, keep account that this doesn't replace direct communication with add-on developers. Instead, the purpose of this feature is to provide a mechanism to share feedback from the store to help users to decide if an add-on can be useful for them.
+
 ++ Incompatible Add-ons ++[incompatibleAddonsManager]
 Some older add-ons may no longer be compatible with the version of NVDA that you have.
 If you are using an older version of NVDA, some newer add-ons may not be compatible either.

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2845,7 +2845,8 @@ Before installing an add-on, you may want to read opinions and reactions by othe
 Also, it is helpful to other users, if you  take time to provide feedback about add-ons you have tried.
 To see or share your feedback about add-ons, select an add-on and use the See or provide feedback option in the actions menu.
 This will open a dedicated webpage at GitHub Discussions, where you will be able to read and write reviews for the add-on, or even comment on specific versions.
-Please, keep account that this doesn't replace direct communication with add-on developers. Instead, the purpose of this feature is to provide a mechanism to share feedback from the store to help users to decide if an add-on can be useful for them.
+Please be aware that this doesn't replace direct communication with add-on developers.
+Instead, the purpose of this feature is to provide a mechanism to share feedback from the store to help users decide if an add-on may be useful for them.
 
 ++ Incompatible Add-ons ++[incompatibleAddonsManager]
 Some older add-ons may no longer be compatible with the version of NVDA that you have.

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2841,12 +2841,12 @@ If the add-on was previously "enabled", the status will show "disabled after res
 Just like when you install or remove add-ons, you need to restart NVDA in order for changes to take effect.
 
 +++ Reviewing add-ons and reading reviews +++[AddonStoreReviews]
-Before installing an add-on, you may want to read opinions and reactions by others.
-Also, it is helpful to other users, if you  take time to provide feedback about add-ons you have tried.
-To see or share your feedback about add-ons, select an add-on and use the See or provide feedback option in the actions menu.
-This will open a dedicated webpage at GitHub Discussions, where you will be able to read and write reviews for the add-on, or even comment on specific versions.
+Before installing an add-on, you may want to read reviews by others.
+Also, it may be helpful to other users to provide feedback about add-ons you have tried.
+To read reviews for an add-on, select an add-on and use the "Community reviews" action.
+This links to a GitHub Discussion webpage, where you will be able to read and write reviews for the add-on, or even comment on specific versions.
 Please be aware that this doesn't replace direct communication with add-on developers.
-Instead, the purpose of this feature is to provide a mechanism to share feedback from the store to help users decide if an add-on may be useful for them.
+Instead, the purpose of this feature is to share feedback to help users decide if an add-on may be useful for them.
 
 ++ Incompatible Add-ons ++[incompatibleAddonsManager]
 Some older add-ons may no longer be compatible with the version of NVDA that you have.


### PR DESCRIPTION
- Addan action to review add-ons in the store
- Fix linter error and add changelog

<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Closes #15576
### Summary of the issue:
The add-on store doesn't have a mechanism to see and provide feedback for add-ons.
### Description of user facing changes
- Now, it's possible to open a webpage to provide or see feedback for add-ons from an action added to the add-on store.
- The review URL is shown in the details panel for add-ons including a reviewUrl in metadata.
### Description of development approach
An action has been added to provide feedback for add-ons, in a similar way to the approach followed for the license URL. Also, this has been added to the details panel.
### Testing strategy:
- Tested manually in English to ensure that "f" shortcut doesn't produce conflicts with other shortcuts in the actions menu.
- Ensure that the action is available for Alzaker add-on, which includes a reviewUrl in metadata. Also, ensure that the review URL is shown in the details panel.
### Known issues with pull request:
None
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
