### PR TITLE
Update what's new for PR #15512

### DIFF
--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -15,7 +15,8 @@ What's New in NVDA
 == Changes ==
 - NVDA no longer supports Windows 7 and Windows 8.
 Windows 8.1 is the minimum Windows version supported. (#15544)
-- The audio output device and ducking mode options have been removed from the "Select Synthesizer" dialog. They can be found in the audio settings panel which can be opened with ``NVDA+control+u``. (#15512)
+- The audio output device and ducking mode options have been removed from the "Select Synthesizer" dialog.
+They can be found in the audio settings panel which can be opened with ``NVDA+control+u``. (#15512)
 - Component updates:
   - Updated LibLouis braille translator to 3.27.0. (#15435, @codeofdusk)
     - Added new Thai and Romanian Braille tables.

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -15,6 +15,7 @@ What's New in NVDA
 == Changes ==
 - NVDA no longer supports Windows 7 and Windows 8.
 Windows 8.1 is the minimum Windows version supported. (#15544)
+- The audio output device and ducking mode options have been removed from the "Select Synthesizer" dialog. They can be found in the audio settings panel which can be opened with ``NVDA+control+u``. (#15512)
 - Component updates:
   - Updated LibLouis braille translator to 3.27.0. (#15435, @codeofdusk)
     - Added new Thai and Romanian Braille tables.


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
None

### Summary of the issue:
#15512 wasn't mentioned in the changelog for 2024.1.

### Description of how this pull request fixes the issue:
Update what's new accordingly.

### Testing strategy:
N/A

### Known issues with pull request:
None known

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
