### PR TITLE
Revert creation of Doc Menu, move back to Help menu

### DIFF
--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -655,7 +655,8 @@ class SysTrayIcon(wx.adv.TaskBarIcon):
 			self.Bind(wx.EVT_MENU, frame.onSaveConfigurationCommand, item)
 
 	def _appendHelpSubMenu(self, frame: MainFrame) -> None:
-		self.helpMenu = self.helpMenu = wx.Menu()
+		self.helpMenu = wx.Menu()
+
 		if not globalVars.appArgs.secure:
 			# Translators: The label of a menu item to open NVDA user guide.
 			item = self.helpMenu.Append(wx.ID_ANY, _("&User Guide"))

--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -548,8 +548,6 @@ class SysTrayIcon(wx.adv.TaskBarIcon):
 		# Translators: The label for the Tools submenu in NVDA menu.
 		self.menu.AppendSubMenu(menu_tools, _("&Tools"))
 
-		self._appendDocsSubMenu()
-
 		self._appendHelpSubMenu(frame)
 
 		self._appendConfigManagementSection(frame)
@@ -656,66 +654,65 @@ class SysTrayIcon(wx.adv.TaskBarIcon):
 			)
 			self.Bind(wx.EVT_MENU, frame.onSaveConfigurationCommand, item)
 
-	def _appendDocsSubMenu(self) -> None:
+	def _appendHelpSubMenu(self, frame: MainFrame) -> None:
+		self.helpMenu = self.helpMenu = wx.Menu()
 		if not globalVars.appArgs.secure:
-			self.docsMenu = wx.Menu()
 			# Translators: The label of a menu item to open NVDA user guide.
-			item = self.docsMenu.Append(wx.ID_ANY, _("&User Guide"))
+			item = self.helpMenu.Append(wx.ID_ANY, _("&User Guide"))
 			self.Bind(wx.EVT_MENU, lambda evt: os.startfile(getDocFilePath("userGuide.html")), item)
 			# Translators: The label of a menu item to open the Commands Quick Reference document.
-			item = self.docsMenu.Append(wx.ID_ANY, _("Commands &Quick Reference"))
+			item = self.helpMenu.Append(wx.ID_ANY, _("Commands &Quick Reference"))
 			self.Bind(wx.EVT_MENU, lambda evt: os.startfile(getDocFilePath("keyCommands.html")), item)
 			# Translators: The label for the menu item to open What's New document.
-			item = self.docsMenu.Append(wx.ID_ANY, _("What's &new"))
+			item = self.helpMenu.Append(wx.ID_ANY, _("What's &new"))
 			self.Bind(wx.EVT_MENU, lambda evt: os.startfile(getDocFilePath("changes.html")), item)
+
+			self.helpMenu.AppendSeparator()
+
+			# Translators: The label for the menu item to view the NVDA website
+			item = self.helpMenu.Append(wx.ID_ANY, _("NV Access &web site"))
+			self.Bind(wx.EVT_MENU, lambda evt: os.startfile(versionInfo.url), item)
+			# Translators: The label for the menu item to view the NVDA website's get help section
+			item = self.helpMenu.Append(wx.ID_ANY, _("&Help, training and support"))
+			self.Bind(wx.EVT_MENU, lambda evt: os.startfile(f"{versionInfo.url}/get-help/"), item)
+			# Translators: The label for the menu item to view the NVDA website's get help section
+			item = self.helpMenu.Append(wx.ID_ANY, _("NV Access &shop"))
+			self.Bind(wx.EVT_MENU, lambda evt: os.startfile(f"{versionInfo.url}/shop/"), item)
+
+			self.helpMenu.AppendSeparator()
+
 			# Translators: The label for the menu item to view NVDA License document.
-			item = self.docsMenu.Append(wx.ID_ANY, _("L&icense"))
+			item = self.helpMenu.Append(wx.ID_ANY, _("L&icense"))
 			self.Bind(
 				wx.EVT_MENU,
 				lambda evt: systemUtils._displayTextFileWorkaround(getDocFilePath("copying.txt", False)),
 				item
 			)
 			# Translators: The label for the menu item to view NVDA Contributors list document.
-			item = self.docsMenu.Append(wx.ID_ANY, _("C&ontributors"))
+			item = self.helpMenu.Append(wx.ID_ANY, _("C&ontributors"))
 			self.Bind(
 				wx.EVT_MENU,
 				lambda evt: systemUtils._displayTextFileWorkaround(getDocFilePath("contributors.txt", False)),
 				item
 			)
 
-			# Translators: The label for the documentation submenu in NVDA menu.
-			self.menu.AppendSubMenu(self.docsMenu, _("Docu&mentation"))
-
-	def _appendHelpSubMenu(self, frame: MainFrame) -> None:
-		menu_help = self.helpMenu = wx.Menu()
-		if not globalVars.appArgs.secure:
-			# Translators: The label for the menu item to view the NVDA website
-			item = menu_help.Append(wx.ID_ANY, _("NV Access &web site"))
-			self.Bind(wx.EVT_MENU, lambda evt: os.startfile(versionInfo.url), item)
-			# Translators: The label for the menu item to view the NVDA website's get help section
-			item = menu_help.Append(wx.ID_ANY, _("&Help, training and support"))
-			self.Bind(wx.EVT_MENU, lambda evt: os.startfile(f"{versionInfo.url}/get-help/"), item)
-			# Translators: The label for the menu item to view the NVDA website's get help section
-			item = menu_help.Append(wx.ID_ANY, _("NV Access &shop"))
-			self.Bind(wx.EVT_MENU, lambda evt: os.startfile(f"{versionInfo.url}/shop/"), item)
-
-			menu_help.AppendSeparator()
+			self.helpMenu.AppendSeparator()
 
 			# Translators: The label for the menu item to open NVDA Welcome Dialog.
-			item = menu_help.Append(wx.ID_ANY, _("We&lcome dialog..."))
+			item = self.helpMenu.Append(wx.ID_ANY, _("We&lcome dialog..."))
 			self.Bind(wx.EVT_MENU, lambda evt: WelcomeDialog.run(), item)
 
 			if updateCheck:
 				# Translators: The label of a menu item to manually check for an updated version of NVDA.
-				item = menu_help.Append(wx.ID_ANY, _("&Check for update..."))
+				item = self.helpMenu.Append(wx.ID_ANY, _("&Check for update..."))
 				self.Bind(wx.EVT_MENU, frame.onCheckForUpdateCommand, item)
 
 		# Translators: The label for the menu item to open About dialog to get information about NVDA.
-		item = menu_help.Append(wx.ID_ABOUT, _("&About..."), _("About NVDA"))
+		item = self.helpMenu.Append(wx.ID_ABOUT, _("&About..."), _("About NVDA"))
 		self.Bind(wx.EVT_MENU, frame.onAboutCommand, item)
 
 		# Translators: The label for the Help submenu in NVDA menu.
-		self.menu.AppendSubMenu(menu_help, _("&Help"))
+		self.menu.AppendSubMenu(self.helpMenu, _("&Help"))
 
 	def _appendPendingUpdateSection(self, frame: MainFrame) -> None:
 		if not globalVars.appArgs.secure and updateCheck:


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Fixes #15749
Partially reverts #15688

### Summary of the issue:
There has been significant negative feedback to the creation of the documentation menu.
Instead items should be return to the help menu.
Given that there is now 11 items in the Help menu, more separators should be added.

### Description of user facing changes

The new help menu structure is:

- User Guide
- Key commands
- Changes
- **[separator]**
- NV Access website
- NV Access Get Help page
- NV Access Shop page
- **[separator]**
- License
- Contributors
- **[separator]**
- Welcome dialog
- Check for update
- About dialog

### Description of development approach
Move items back, remove internal variable `menu_help` which duplicated `self.helpMenu`

### Testing strategy:
Tested viewing and using the help menu

### Known issues with pull request:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
