### PR TITLE
playWaveFile: Repeatedly call stop until we're certain the previous file playback has been stopped.

### DIFF
--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -53,6 +53,7 @@ It is also updated with UIA enabled, when typing text and braille is tethered to
 - When using say all or commands which spell text, pauses between sentences or characters no longer gradually decrease over time. (#15739)
 - NVDA no longer sometimes freezes when speaking a large amount of text. (#15752)
 - More objects which contain useful text are detected, and text content is displayed in braille. (#15605)
+- NVDA no longer freezes briefly when multiple sounds are played in rapid succession. (#15757)
 -
 
 == Changes for Developers ==


### PR DESCRIPTION
### Link to issue number:
Fixes #15757.

### Summary of the issue:
Asynchronously playing multiple files in quick succession can block while one of the files plays. However, async playback should never block.

### Description of user facing changes
NVDA no longer sometimes freezes briefly when multiple sounds are played in rapid succession.

### Description of development approach
There are several race conditions where the background thread might feed audio after we call stop in the main thread. Some of these are difficult to fix with locks because they involve switches between Python and blocking native code. We now just keep calling stop until we know that the backgroundd thread is done, which means it was successfully stopped. We know when the background thread is done because it sets fileWavePlayer to None.

### Testing strategy:
Ran the following Python console snippet:

`import nvwave; nvwave.playWaveFile("waves/start.wav"); nvwave.playWaveFile("waves/start.wav")`

Before this change, the first call often blocked, resulting in two sounds playing. After the change, it doesn't block and only the final sound plays.

### Known issues with pull request:
Strictly speaking, this code "spins" calling stop(). Spinning is generally bad. In practice, this should only call stop() a few times at most, since the background thread should clean up as soon as it is stopped.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
