### PR TITLE
bdDetect: Enrich USB serial data with info about USB device

### DIFF
--- a/source/bdDetect.py
+++ b/source/bdDetect.py
@@ -119,8 +119,7 @@ def getDriversForConnectedUsbDevices(
 	)
 	usbComDeviceMatches = (
 		DeviceMatch(KEY_SERIAL, port["usbID"], port["port"], port)
-		for port in deviceInfoFetcher.comPorts
-		if "usbID" in port
+		for port in deviceInfoFetcher.usbComPorts
 	)
 	# Tee is used to ensure that the DeviceMatches aren't created multiple times.
 	# The processing of these HID device matches, looking for a custom driver, means that all
@@ -237,23 +236,28 @@ class _DeviceInfoFetcher(AutoPropertyObject):
 	comPorts: list[dict[str, str]]
 
 	def _get_comPorts(self) -> list[dict[str, str]]:
-		comPorts = list(hwPortUtils.listComPorts(onlyAvailable=True))
-		for port in comPorts:
-			if (usbId := port.get("usbID")) is None:
-				continue
-			if (usbDict := next(
-				(d for d in self.usbDevices if d.get("usbID") == usbId),
-				None
-			)) is not None:
-				port.update(usbDict)
-		return comPorts
-
+		return list(hwPortUtils.listComPorts(onlyAvailable=True))
 
 	#: Type info for auto property: _get_usbDevices
 	usbDevices: List[Dict]
 
 	def _get_usbDevices(self) -> List[Dict]:
 		return list(hwPortUtils.listUsbDevices(onlyAvailable=True))
+
+	#: Type info for auto property: _get_usbComPorts
+	usbComPorts: list[dict[str, str]]
+
+	def _get_usbComPorts(self) -> list[dict[str, str]]:
+		comPorts = []
+		for port in self.comPorts:
+			if (usbId := port.get("usbID")) is None:
+				continue
+			if (usbDict := next(
+				(d for d in self.usbDevices if d.get("usbID") == usbId),
+				None
+			)) is not None:
+				comPorts.append(port | usbDict)
+		return comPorts
 
 	#: Type info for auto property: _get_hidDevices
 	hidDevices: List[Dict]
@@ -442,7 +446,7 @@ def getConnectedUsbDevicesForDriver(driver: str) -> Iterator[DeviceMatch]:
 		),
 		(
 			DeviceMatch(KEY_SERIAL, port["usbID"], port["port"], port)
-			for port in deviceInfoFetcher.comPorts if "usbID" in port
+			for port in deviceInfoFetcher.usbComPorts
 		)
 	)
 	for match in usbDevs:

--- a/source/bdDetect.py
+++ b/source/bdDetect.py
@@ -234,10 +234,20 @@ class _DeviceInfoFetcher(AutoPropertyObject):
 			self._btDevsCache = cache.copy() if cache else None
 
 	#: Type info for auto property: _get_comPorts
-	comPorts: List[Dict]
+	comPorts: list[dict[str, str]]
 
-	def _get_comPorts(self) -> List[Dict]:
-		return list(hwPortUtils.listComPorts(onlyAvailable=True))
+	def _get_comPorts(self) -> list[dict[str, str]]:
+		comPorts = list(hwPortUtils.listComPorts(onlyAvailable=True))
+		for port in comPorts:
+			if (usbId := port.get("usbID")) is None:
+				continue
+			if (usbDict := next(
+				(d for d in self.usbDevices if d.get("usbID") == usbId),
+				None
+			)) is not None:
+				port.update(usbDict)
+		return comPorts
+
 
 	#: Type info for auto property: _get_usbDevices
 	usbDevices: List[Dict]

--- a/source/hwPortUtils.py
+++ b/source/hwPortUtils.py
@@ -419,9 +419,7 @@ def listUsbDevices(onlyAvailable=True) -> typing.Iterator[dict]:
 			None,
 			0
 		):
-			# Ignore ERROR_INSUFFICIENT_BUFFER
-			if ctypes.GetLastError() != ERROR_INSUFFICIENT_BUFFER:
-				raise ctypes.WinError()
+			log.debugWarning(f"Couldn't get DEVPKEY_Device_BusReportedDeviceDesc for {entry!r}: {ctypes.WinError()}")
 		else:
 			entry["busReportedDeviceDescription"] = buf.value
 

--- a/source/hwPortUtils.py
+++ b/source/hwPortUtils.py
@@ -159,7 +159,7 @@ def _isDebug():
 	return config.conf["debugLog"]["hwIo"]
 
 
-def _getBluetotohPortInfo(regKey: int, hwID: str):
+def _getBluetoohPortInfo(regKey: int, hwID: str) -> dict:
 	info = {}
 	try:
 		port = info["port"] = winreg.QueryValueEx(regKey, "PortName")[0]

--- a/source/hwPortUtils.py
+++ b/source/hwPortUtils.py
@@ -116,6 +116,7 @@ DIGCF_PRESENT = 2
 DIGCF_DEVICEINTERFACE = 16
 INVALID_HANDLE_VALUE = 0
 ERROR_INSUFFICIENT_BUFFER = 122
+SPDRP_DEVICEDESC = 0
 SPDRP_HARDWAREID = 1
 SPDRP_FRIENDLYNAME = 12
 SPDRP_LOCATION_INFORMATION = 13
@@ -403,7 +404,21 @@ def listUsbDevices(onlyAvailable=True) -> typing.Iterator[dict]:
 			})
 			if _isDebug():
 				log.debug("%r" % usbId)
-			yield entry
+
+		# Devie description
+		if not SetupDiGetDeviceRegistryProperty(
+			g_hdi,
+			ctypes.byref(devinfo),
+			SPDRP_DEVICEDESC,
+			None,
+			ctypes.byref(buf), ctypes.sizeof(buf) - 1,
+			None
+		):
+			log.debugWarning(f"Couldn't get SPDRP_DEVICEDESC for {entry!r}: {ctypes.WinError()}")
+		else:
+			entry["deviceDescription"] = buf.value
+
+		yield entry
 	if _isDebug():
 		log.debug("Finished listing USB devices")
 

--- a/source/hwPortUtils.py
+++ b/source/hwPortUtils.py
@@ -451,7 +451,7 @@ def listUsbDevices(onlyAvailable: bool = True) -> typing.Iterator[dict]:
 				"devicePath": idd.DevicePath
 			})
 			if _isDebug():
-				log.debug("%r" % usbId)
+				log.debug(f"USB Id: {usbId!r}")
 
 		# Bus reported device description
 		propRegDataType = DWORD()

--- a/source/hwPortUtils.py
+++ b/source/hwPortUtils.py
@@ -311,7 +311,7 @@ def getWidcommBluetoothPortInfo(port):
 
 def _listDevices(
 		deviceClass: GUID,
-		onlyAvailable=True
+		onlyAvailable: bool = True
 ) -> typing.Iterator[tuple[HDEVINFO, ctypes.Structure, SP_DEVINFO_DATA, ctypes.c_wchar * 1024]]:
 	"""Internal helper function to list devices on the system for a specific device class.
 	@param deviceClass: The device class GUID.
@@ -377,7 +377,7 @@ def _listDevices(
 		SetupDiDestroyDeviceInfoList(g_hdi)
 
 
-def listUsbDevices(onlyAvailable=True) -> typing.Iterator[dict]:
+def listUsbDevices(onlyAvailable: bool = True) -> typing.Iterator[dict]:
 	"""List USB devices on the system.
 	:param onlyAvailable: Only return devices that are currently available.
 	:return: Generates dicts including keys of usbID (VID and PID), devicePath and hardwareID.
@@ -495,10 +495,9 @@ def _getHidInfo(hwId, path):
 _hidGuid = None
 
 
-def listHidDevices(onlyAvailable=True) -> typing.Iterator[dict]:
+def listHidDevices(onlyAvailable: bool = True) -> typing.Iterator[dict]:
 	"""List HID devices on the system.
 	@param onlyAvailable: Only return devices that are currently available.
-	@type onlyAvailable: bool
 	@return: Generates dicts including keys such as hardwareID,
 		usbID (in the form "VID_xxxx&PID_xxxx")
 		and devicePath.

--- a/source/hwPortUtils.py
+++ b/source/hwPortUtils.py
@@ -159,7 +159,7 @@ def _isDebug():
 	return config.conf["debugLog"]["hwIo"]
 
 
-def _getBluetoohPortInfo(regKey: int, hwID: str) -> dict:
+def _getBluetoothPortInfo(regKey: int, hwID: str) -> dict:
 	info = {}
 	try:
 		port = info["port"] = winreg.QueryValueEx(regKey, "PortName")[0]
@@ -238,7 +238,7 @@ def listComPorts(onlyAvailable: bool = True) -> typing.Iterator[dict]:
 			winreg.KEY_READ
 		)
 		try:
-			portInfo = _getBluetotohPortInfo(regKey, hwID)
+			portInfo = _getBluetoothPortInfo(regKey, hwID)
 			if not portInfo:
 				continue
 			else:

--- a/source/hwPortUtils.py
+++ b/source/hwPortUtils.py
@@ -175,7 +175,7 @@ def listComPorts(onlyAvailable: bool = True) -> typing.Iterator[dict]:  # noqa: 
 					addr = winreg.QueryValueEx(
 						regKey,
 						"Bluetooth_UniqueID"
-					)[0].split("#",1)[1].split("_", 1)[0]
+					)[0].split("#", 1)[1].split("_", 1)[0]
 					addr = int(addr, 16)
 					entry["bluetoothAddress"] = addr
 					if addr:
@@ -207,9 +207,9 @@ def listComPorts(onlyAvailable: bool = True) -> typing.Iterator[dict]:  # noqa: 
 					pass
 			elif "USB" in hwID or "FTDIBUS" in hwID:
 				usbIDStart = hwID.find("VID_")
-				if usbIDStart==-1:
+				if usbIDStart == -1:
 					continue
-				entry['usbID'] = hwID[usbIDStart:usbIDStart+17] # VID_xxxx&PID_xxxx
+				entry['usbID'] = hwID[usbIDStart:usbIDStart + 17]  # VID_xxxx&PID_xxxx
 		finally:
 			ctypes.windll.advapi32.RegCloseKey(regKey)
 
@@ -396,7 +396,7 @@ def listUsbDevices(onlyAvailable=True) -> typing.Iterator[dict]:
 				raise ctypes.WinError()
 		else:
 			# The string is of the form "usb\VID_xxxx&PID_xxxx&..."
-			usbId = buf.value[4:21] # VID_xxxx&PID_xxxx
+			usbId = buf.value[4:21]  # VID_xxxx&PID_xxxx
 			entry.update({
 				"hardwareID": buf.value,
 				"usbID": usbId,
@@ -503,7 +503,7 @@ def listHidDevices(onlyAvailable=True) -> typing.Iterator[dict]:
 		_hidGuid = GUID()
 		ctypes.windll.hid.HidD_GetHidGuid(ctypes.byref(_hidGuid))
 
-	for g_hdi, idd, devinfo, buf in _listDevices(_hidGuid , onlyAvailable):
+	for g_hdi, idd, devinfo, buf in _listDevices(_hidGuid, onlyAvailable):
 		# hardware ID
 		if not SetupDiGetDeviceRegistryProperty(
 			g_hdi,

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -91,8 +91,8 @@ Setting ``numCells`` is still supported for single line braille displays and ``n
   - w3c-aria-practices to ``9a5e55ccbeb0f1bf92b6127c9865da8426d1c864``. (#15695)
   - wil to ``5e9be7b2d2fe3834a7107f430f7d4c0631f69833``. (#15695)
   -
-- Device info yielded by ``hwPortUtils.listUsbDevices`` now contain a description of the USB device (key ``deviceDescription``). (#15764, @LeonarddeR)
-- For USB serial devices, ``bdDetect.getConnectedUsbDevicesForDriver`` and ``bdDetect.getDriversForConnectedUsbDevices`` now yield device matches containing a ``deviceInfo`` dictionary enriched with data about the USB device. (#15764, @LeonarddeR)
+- Device info yielded by ``hwPortUtils.listUsbDevices`` now contain the bus reported description of the USB device (key ``busReportedDeviceDescription``). (#15764, @LeonarddeR)
+- For USB serial devices, ``bdDetect.getConnectedUsbDevicesForDriver`` and ``bdDetect.getDriversForConnectedUsbDevices`` now yield device matches containing a ``deviceInfo`` dictionary enriched with data about the USB device, such as ``busReportedDeviceDescription``. (#15764, @LeonarddeR)
 -
 
 === API Breaking Changes ===
@@ -129,6 +129,14 @@ That method receives a ``DriverRegistrar`` object on which the ``addUsbDevices``
 - ``languageHandler.makeNpgettext`` and ``languageHandler.makePgettext`` have been removed.
 ``npgettext`` and ``pgettext`` are supported natively now. (#15546)
 - The app module for [Poedit https://poedit.net] has been changed significantly. The ``fetchObject`` function has been removed. (#15313, #7303, @LeonarddeR)
+- The following redundant types and constants have been removed from ``hwPortUtils``:  (#15764, @LeonarddeR)
+ - ``PCWSTR``
+ - ``HWND`` (Replaced by ``ctypes.wintypes.HWND``)
+ - ``ULONG_PTR``
+ - ``ULONGLONG``
+ - ``NULL``
+ - ``GUID`` (Replaced by ``comtypes.GUID``)
+ -
 % Insert new list items here as the alias appModule table should be kept at the bottom of this list
 - The following app modules are removed.
 Code which imports from one of them, should instead import from the replacement module.  (#15618, @lukaszgo1)

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -131,11 +131,11 @@ That method receives a ``DriverRegistrar`` object on which the ``addUsbDevices``
 - The app module for [Poedit https://poedit.net] has been changed significantly. The ``fetchObject`` function has been removed. (#15313, #7303, @LeonarddeR)
 - The following redundant types and constants have been removed from ``hwPortUtils``:  (#15764, @LeonarddeR)
  - ``PCWSTR``
- - ``HWND`` (Replaced by ``ctypes.wintypes.HWND``)
+ - ``HWND`` (replaced by ``ctypes.wintypes.HWND``)
  - ``ULONG_PTR``
  - ``ULONGLONG``
  - ``NULL``
- - ``GUID`` (Replaced by ``comtypes.GUID``)
+ - ``GUID`` (replaced by ``comtypes.GUID``)
  -
 % Insert new list items here as the alias appModule table should be kept at the bottom of this list
 - The following app modules are removed.

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -91,6 +91,8 @@ Setting ``numCells`` is still supported for single line braille displays and ``n
   - w3c-aria-practices to ``9a5e55ccbeb0f1bf92b6127c9865da8426d1c864``. (#15695)
   - wil to ``5e9be7b2d2fe3834a7107f430f7d4c0631f69833``. (#15695)
   -
+- Device info yielded by ``hwPortUtils.listUsbDevices`` now contain a description of the USB device (key ``deviceDescription``). (#15764, @LeonarddeR)
+- For USB serial devices, ``bdDetect.getConnectedUsbDevicesForDriver`` and ``bdDetect.getDriversForConnectedUsbDevices`` now yield device matches containing a ``deviceInfo`` dictionary enriched with data about the USB device. (#15764, @LeonarddeR)
 -
 
 === API Breaking Changes ===


### PR DESCRIPTION
### Link to issue number:
Blocks #15693

### Summary of the issue:
Many braille displays use a serial converter from FTDI with VID 0x403" and PID 0x6001. Given the weird nature of Albatross devices not being able to identify themselves on request, the Albatross driver is currently a disturbing factor in automatic detection.

### Description of user facing changes
None.

### Description of development approach
1. This pr enriches information for serial ports in bdDetect. The _DeviceInfoFetcher class now has an extra autoprop usbComPorts that bundles com port info with USB metadata. If all works as expected, the Albatross driver will be able to limit itself to Albatross devices only after this pr by using the `busReportedDeviceDescription` dictionary entry.
2. Removed duplicated code from hwPortUtils

### Testing strategy:
Testing with Albatross from @burmancomp would be appreciated.
It can be tested using `bdDetect.getConnectedUsbDevicesForDriver("albatross")`. This should yield device matches with details about the underlying USB device.

### Known issues with pull request:
None known

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [ ] API is compatible with existing add-ons.
- [x] Security precautions taken.
