### PR TITLE
Fix installer bug where install fails if registry entries exist but NVDA is not installed

### DIFF
--- a/source/config/__init__.py
+++ b/source/config/__init__.py
@@ -177,7 +177,7 @@ def isInstalledCopy() -> bool:
 	winreg.CloseKey(k)
 	try:
 		return os.stat(instDir) == os.stat(globalVars.appDir)
-	except WindowsError:
+	except (WindowsError, FileNotFoundError):
 		log.error(
 			"Failed to access the installed NVDA directory,"
 			"or, a portable copy failed to access the current NVDA app directory",


### PR DESCRIPTION

<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
None
### Summary of the issue:
A user reported the installer failing to start with the following traceback:
```py
INFO - __main__ (17:42:54.836) - MainThread (11512):
Starting NVDA version 2023.3
CRITICAL - __main__ (17:42:55.691) - MainThread (11512):
core failure
Traceback (most recent call last):
  File "config\__init__.pyc", line 179, in isInstalledCopy
FileNotFoundError: [WinError 2] The system cannot find the file specified: 'C:\\Program Files (x86)\\NVDA'
```

It is expected that this is caused when the registry contains keys suggesting NVDA is installed, but the install directory does not exist.

### Description of user facing changes
Installer should be more resilient

### Description of development approach
Catch `FileNotFoundError` when checking if NVDA is installed.

### Testing strategy:
None - however the cause of this issue was confirmed with the user

### Known issues with pull request:
None
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
