### PR TITLE
Update release process: .1 beta release

### DIFF
--- a/projectDocs/community/releaseProcess.md
+++ b/projectDocs/community/releaseProcess.md
@@ -15,7 +15,9 @@ The production of a release consists of the following:
     - The add-on API for the release is unstable.
     Add-ons targeting this release should use "dev" channel.
 1. [Beta phase](#beta-phase) (~4 weeks)
-    - Beta1 is released 1 week after the most recent final release
+    - Beta1 is released 1 week after the most recent final release.
+    There is an exception for `20XX.1` releases.
+    The first `20XX.1` beta release will occur when all planned API breaking changes have been made.
     - A new beta is released weekly as required
     - Translations should be relatively stable.
     Translators may wish to start working on the release, however further changes to translation strings will occur.


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
None

### Summary of the issue:
The current release process suggests that a beta release will always occur 1 week after the last stable release.
This is not the case for `.1` releases, where the `.1` release will not occur until all planned API breaking changes have occurred.

### Description of user facing changes
Clear up release process
