### PR TITLE
bdDetect: swap KEY_* constants with enum

### DIFF
--- a/source/bdDetect.py
+++ b/source/bdDetect.py
@@ -15,10 +15,10 @@ For drivers in add-ons, this must be done in a global plugin.
 import itertools
 import threading
 from concurrent.futures import ThreadPoolExecutor, Future
+from enum import StrEnum
 from typing import (
 	Any,
 	Callable,
-	DefaultDict,
 	Dict,
 	Generator,
 	Iterable,
@@ -33,6 +33,7 @@ from typing import (
 	Union,
 )
 import hwPortUtils
+import NVDAState
 import braille
 import winUser
 import config
@@ -42,6 +43,7 @@ import re
 from winAPI import messageWindow
 import extensionPoints
 from logHandler import log
+from collections import defaultdict
 
 
 HID_USAGE_PAGE_BRAILLE = 0x41
@@ -51,10 +53,39 @@ DBT_DEVNODES_CHANGED = 7
 USB_ID_REGEX = re.compile(r"^VID_[0-9A-F]{4}&PID_[0-9A-F]{4}$", re.U)
 
 
+class DeviceType(StrEnum):
+	HID = "hid"
+	"""HID devices"""
+	SERIAL = "serial"
+	"""Serial devices (COM ports)"""
+	CUSTOM = "custom"
+	"""Devices with a manufacturer specific driver"""
+	BLUETOOTH = "bluetooth"
+	"""Bluetooth devices"""
+
+
+def __getattr__(attrName: str) -> Any:
+	"""Module level `__getattr__` used to preserve backward compatibility."""
+	_deprecatedConstantsMap = {
+		"KEY_HID": DeviceType.HID,
+		"KEY_SERIAL": DeviceType.SERIAL,
+		"KEY_BLUETOOTH": DeviceType.BLUETOOTH,
+		"KEY_CUSTOM": DeviceType.CUSTOM,
+	}
+	if attrName in _deprecatedConstantsMap and NVDAState._allowDeprecatedAPI():
+		replacementSymbol = _deprecatedConstantsMap[attrName]
+		log.warning(
+			f"{attrName} is deprecated. "
+			f"Use bdDetect.DeviceType.{replacementSymbol.name} instead. "
+		)
+		return replacementSymbol
+	raise AttributeError(f"module {repr(__name__)} has no attribute {repr(attrName)}")
+
+
 class DeviceMatch(NamedTuple):
 	"""Represents a detected device.
 	"""
-	type: str
+	type: DeviceType
 	"""The type of the device."""
 	id: str
 	"""The identifier of the device."""
@@ -65,7 +96,7 @@ class DeviceMatch(NamedTuple):
 
 
 MatchFuncT = Callable[[DeviceMatch], bool]
-DriverDictT = DefaultDict[str, Union[Set[str], MatchFuncT]]
+DriverDictT = defaultdict[DeviceType, set[str] | MatchFuncT]
 
 _driverDevices = OrderedDict[str, DriverDictT]()
 
@@ -84,21 +115,6 @@ Handlers are called with these keyword arguments:
 """
 
 
-# Device type constants
-#: Key constant for HID devices
-KEY_HID = "hid"
-#: Key for serial devices (COM ports)
-KEY_SERIAL = "serial"
-#: Key for devices with a manufacturer specific driver
-KEY_CUSTOM = "custom"
-#: Key for bluetooth devices
-KEY_BLUETOOTH = "bluetooth"
-
-# Constants for USB and bluetooth detection to be used by the background thread scanner.
-DETECT_USB = 1
-DETECT_BLUETOOTH = 2
-
-
 def _isDebug():
 	return config.conf["debugLog"]["hwIo"]
 
@@ -114,11 +130,11 @@ def getDriversForConnectedUsbDevices(
 	@return: Generator of pairs of drivers and device information.
 	"""
 	usbCustomDeviceMatches = (
-		DeviceMatch(KEY_CUSTOM, port["usbID"], port["devicePath"], port)
+		DeviceMatch(DeviceType.CUSTOM, port["usbID"], port["devicePath"], port)
 		for port in deviceInfoFetcher.usbDevices
 	)
 	usbComDeviceMatches = (
-		DeviceMatch(KEY_SERIAL, port["usbID"], port["port"], port)
+		DeviceMatch(DeviceType.SERIAL, port["usbID"], port["port"], port)
 		for port in deviceInfoFetcher.comPorts
 		if "usbID" in port
 	)
@@ -128,7 +144,7 @@ def getDriversForConnectedUsbDevices(
 	# The corollary is that clients of this method don't have to process all devices (and create all
 	# device matches), if one is found early the iteration can stop.
 	usbHidDeviceMatches, usbHidDeviceMatchesForCustom = itertools.tee((
-		DeviceMatch(KEY_HID, port["usbID"], port["devicePath"], port)
+		DeviceMatch(DeviceType.HID, port["usbID"], port["devicePath"], port)
 		for port in deviceInfoFetcher.hidDevices
 		if port["provider"] == "usb"
 	))
@@ -159,7 +175,7 @@ def _getStandardHidDriverName() -> str:
 
 
 def _isHIDBrailleMatch(match: DeviceMatch) -> bool:
-	return match.type == KEY_HID and match.deviceInfo.get('HIDUsagePage') == HID_USAGE_PAGE_BRAILLE
+	return match.type == DeviceType.HID and match.deviceInfo.get('HIDUsagePage') == HID_USAGE_PAGE_BRAILLE
 
 
 def getDriversForPossibleBluetoothDevices(
@@ -173,7 +189,7 @@ def getDriversForPossibleBluetoothDevices(
 	@return: Generator of pairs of drivers and port information.
 	"""
 	btSerialMatchesForCustom = (
-		DeviceMatch(KEY_SERIAL, port["bluetoothName"], port["port"], port)
+		DeviceMatch(DeviceType.SERIAL, port["bluetoothName"], port["port"], port)
 		for port in deviceInfoFetcher.comPorts
 		if "bluetoothName" in port
 	)
@@ -183,7 +199,7 @@ def getDriversForPossibleBluetoothDevices(
 	# The corollary is that clients of this method don't have to process all devices (and create all
 	# device matches), if one is found early the iteration can stop.
 	btHidDevMatchesForHid, btHidDevMatchesForCustom = itertools.tee((
-		DeviceMatch(KEY_HID, port["hardwareID"], port["devicePath"], port)
+		DeviceMatch(DeviceType.HID, port["hardwareID"], port["devicePath"], port)
 		for port in deviceInfoFetcher.hidDevices
 		if port["provider"] == "bluetooth"
 	))
@@ -191,7 +207,7 @@ def getDriversForPossibleBluetoothDevices(
 		for driver, devs in _driverDevices.items():
 			if limitToDevices and driver not in limitToDevices:
 				continue
-			matchFunc = devs[KEY_BLUETOOTH]
+			matchFunc = devs[DeviceType.BLUETOOTH]
 			if not callable(matchFunc):
 				continue
 			if matchFunc(match):
@@ -423,15 +439,15 @@ def getConnectedUsbDevicesForDriver(driver: str) -> Iterator[DeviceMatch]:
 	"""
 	usbDevs = itertools.chain(
 		(
-			DeviceMatch(KEY_CUSTOM, port["usbID"], port["devicePath"], port)
+			DeviceMatch(DeviceType.CUSTOM, port["usbID"], port["devicePath"], port)
 			for port in deviceInfoFetcher.usbDevices
 		),
 		(
-			DeviceMatch(KEY_HID, port["usbID"], port["devicePath"], port)
+			DeviceMatch(DeviceType.HID, port["usbID"], port["devicePath"], port)
 			for port in deviceInfoFetcher.hidDevices if port["provider"] == "usb"
 		),
 		(
-			DeviceMatch(KEY_SERIAL, port["usbID"], port["port"], port)
+			DeviceMatch(DeviceType.SERIAL, port["usbID"], port["port"], port)
 			for port in deviceInfoFetcher.comPorts if "usbID" in port
 		)
 	)
@@ -455,17 +471,17 @@ def getPossibleBluetoothDevicesForDriver(driver: str) -> Iterator[DeviceMatch]:
 	if driver == _getStandardHidDriverName():
 		matchFunc = _isHIDBrailleMatch
 	else:
-		matchFunc = _driverDevices[driver][KEY_BLUETOOTH]
+		matchFunc = _driverDevices[driver][DeviceType.BLUETOOTH]
 		if not callable(matchFunc):
 			return
 	btDevs = itertools.chain(
 		(
-			DeviceMatch(KEY_SERIAL, port["bluetoothName"], port["port"], port)
+			DeviceMatch(DeviceType.SERIAL, port["bluetoothName"], port["port"], port)
 			for port in deviceInfoFetcher.comPorts
 			if "bluetoothName" in port
 		),
 		(
-			DeviceMatch(KEY_HID, port["hardwareID"], port["devicePath"], port)
+			DeviceMatch(DeviceType.HID, port["hardwareID"], port["devicePath"], port)
 			for port in deviceInfoFetcher.hidDevices if port["provider"] == "bluetooth"
 		),
 	)
@@ -569,12 +585,12 @@ class DriverRegistrar:
 			ret = _driverDevices[self._driver] = DriverDictT(set)
 			return ret
 
-	def addUsbDevices(self, type: str, ids: Set[str]):
+	def addUsbDevices(self, type: DeviceType, ids: Set[str]):
 		"""Associate USB devices with the driver on this instance.
-		@param type: The type of the driver, either C{KEY_HID}, C{KEY_SERIAL} or C{KEY_CUSTOM}.
-		@param ids: A set of USB IDs in the form C{"VID_xxxx&PID_XXXX"}.
+		:param type: The type of the driver.
+		:param ids: A set of USB IDs in the form C{"VID_xxxx&PID_XXXX"}.
 			Note that alphabetical characters in hexadecimal numbers should be uppercase.
-		@raise ValueError: When one of the provided IDs is malformed.
+		:raise ValueError: When one of the provided IDs is malformed.
 		"""
 		malformedIds = [id for id in ids if not isinstance(id, str) or not USB_ID_REGEX.match(id)]
 		if malformedIds:
@@ -593,7 +609,7 @@ class DriverRegistrar:
 			and returns a C{bool} indicating whether it matched.
 		"""
 		devs = self._getDriverDict()
-		devs[KEY_BLUETOOTH] = matchFunc
+		devs[DeviceType.BLUETOOTH] = matchFunc
 
 	def addDeviceScanner(
 			self,

--- a/source/bdDetect.py
+++ b/source/bdDetect.py
@@ -66,6 +66,12 @@ class DeviceType(StrEnum):
 
 def __getattr__(attrName: str) -> Any:
 	"""Module level `__getattr__` used to preserve backward compatibility."""
+	if attrName == "DETECT_USB" and NVDAState._allowDeprecatedAPI():
+		log.warning(f"{attrName} is deprecated.")
+		return 1
+	if attrName == "DETECT_BLUETOOTH" and NVDAState._allowDeprecatedAPI():
+		log.warning(f"{attrName} is deprecated.")
+		return 2
 	_deprecatedConstantsMap = {
 		"KEY_HID": DeviceType.HID,
 		"KEY_SERIAL": DeviceType.SERIAL,

--- a/source/braille.py
+++ b/source/braille.py
@@ -3003,9 +3003,9 @@ class BrailleDisplayDriver(driverHandler.Driver):
 					pass
 				else:
 					if "bluetoothName" in portInfo:
-						yield bdDetect.DeviceMatch(bdDetect.KEY_SERIAL, portInfo["bluetoothName"], portInfo["port"], portInfo)
+						yield bdDetect.DeviceMatch(bdDetect.DeviceType.SERIAL, portInfo["bluetoothName"], portInfo["port"], portInfo)
 					else:
-						yield bdDetect.DeviceMatch(bdDetect.KEY_SERIAL, portInfo["friendlyName"], portInfo["port"], portInfo)
+						yield bdDetect.DeviceMatch(bdDetect.DeviceType.SERIAL, portInfo["friendlyName"], portInfo["port"], portInfo)
 			else:
 				for match in cls._getAutoPorts(usb=isUsb, bluetooth=isBluetooth):
 					yield match

--- a/source/braille.py
+++ b/source/braille.py
@@ -3002,10 +3002,12 @@ class BrailleDisplayDriver(driverHandler.Driver):
 				except StopIteration:
 					pass
 				else:
-					if "bluetoothName" in portInfo:
-						yield bdDetect.DeviceMatch(bdDetect.DeviceType.SERIAL, portInfo["bluetoothName"], portInfo["port"], portInfo)
-					else:
-						yield bdDetect.DeviceMatch(bdDetect.DeviceType.SERIAL, portInfo["friendlyName"], portInfo["port"], portInfo)
+					yield bdDetect.DeviceMatch(
+						bdDetect.DeviceType.SERIAL,
+						portInfo["bluetoothName" if "bluetoothName" in portInfo else "friendlyName"],
+						portInfo["port"],
+						portInfo
+					)
 			else:
 				for match in cls._getAutoPorts(usb=isUsb, bluetooth=isBluetooth):
 					yield match

--- a/source/brailleDisplayDrivers/albatross/driver.py
+++ b/source/brailleDisplayDrivers/albatross/driver.py
@@ -12,7 +12,7 @@ import serial
 import time
 
 from collections import deque
-from bdDetect import KEY_SERIAL, DriverRegistrar
+from bdDetect import DeviceType, DriverRegistrar
 from logHandler import log
 from serial.win32 import (
 	PURGE_RXABORT,
@@ -84,7 +84,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 
 	@classmethod
 	def registerAutomaticDetection(cls, driverRegistrar: DriverRegistrar):
-		driverRegistrar.addUsbDevices(KEY_SERIAL, {
+		driverRegistrar.addUsbDevices(DeviceType.SERIAL, {
 			"VID_0403&PID_6001",  # Caiku Albatross 46/80
 		})
 

--- a/source/brailleDisplayDrivers/alva.py
+++ b/source/brailleDisplayDrivers/alva.py
@@ -116,7 +116,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver, ScriptableObject):
 
 	@classmethod
 	def registerAutomaticDetection(cls, driverRegistrar: bdDetect.DriverRegistrar):
-		driverRegistrar.addUsbDevices(bdDetect.KEY_HID, {
+		driverRegistrar.addUsbDevices(bdDetect.DeviceType.HID, {
 			"VID_0798&PID_0640",  # BC640
 			"VID_0798&PID_0680",  # BC680
 			"VID_0798&PID_0699",  # USB protocol converter
@@ -170,7 +170,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver, ScriptableObject):
 		self._deviceId = None
 
 		for portType, portId, port, portInfo in self._getTryPorts(port):
-			self.isHid = portType == bdDetect.KEY_HID
+			self.isHid = portType == bdDetect.DeviceType.HID
 			# Try talking to the display.
 			try:
 				if self.isHid:

--- a/source/brailleDisplayDrivers/baum.py
+++ b/source/brailleDisplayDrivers/baum.py
@@ -66,7 +66,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 
 	@classmethod
 	def registerAutomaticDetection(cls, driverRegistrar: bdDetect.DriverRegistrar):
-		driverRegistrar.addUsbDevices(bdDetect.KEY_HID, {
+		driverRegistrar.addUsbDevices(bdDetect.DeviceType.HID, {
 			"VID_0904&PID_3001",  # RefreshaBraille 18
 			"VID_0904&PID_6101",  # VarioUltra 20
 			"VID_0904&PID_6103",  # VarioUltra 32
@@ -90,7 +90,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 			"VID_0904&PID_6301",  # Vario 4
 		})
 
-		driverRegistrar.addUsbDevices(bdDetect.KEY_SERIAL, {
+		driverRegistrar.addUsbDevices(bdDetect.DeviceType.SERIAL, {
 			"VID_0403&PID_FE70",  # Vario 40
 			"VID_0403&PID_FE71",  # PocketVario
 			"VID_0403&PID_FE72",  # SuperVario/Brailliant 40
@@ -136,7 +136,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 		for portType, portId, port, portInfo in self._getTryPorts(port):
 			# At this point, a port bound to this display has been found.
 			# Try talking to the display.
-			self.isHid = portType == bdDetect.KEY_HID
+			self.isHid = portType == bdDetect.DeviceType.HID
 			try:
 				if self.isHid:
 					self._dev = hwIo.Hid(port, onReceive=self._onReceive)

--- a/source/brailleDisplayDrivers/brailleNote.py
+++ b/source/brailleDisplayDrivers/brailleNote.py
@@ -129,7 +129,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 
 	@classmethod
 	def registerAutomaticDetection(cls, driverRegistrar: bdDetect.DriverRegistrar):
-		driverRegistrar.addUsbDevices(bdDetect.KEY_SERIAL, {
+		driverRegistrar.addUsbDevices(bdDetect.DeviceType.SERIAL, {
 			"VID_1C71&PID_C004",  # Apex
 		})
 		driverRegistrar.addBluetoothDevices(lambda m: (

--- a/source/brailleDisplayDrivers/brailliantB.py
+++ b/source/brailleDisplayDrivers/brailliantB.py
@@ -87,7 +87,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 
 	@classmethod
 	def registerAutomaticDetection(cls, driverRegistrar: bdDetect.DriverRegistrar):
-		driverRegistrar.addUsbDevices(bdDetect.KEY_HID, {
+		driverRegistrar.addUsbDevices(bdDetect.DeviceType.HID, {
 			"VID_1C71&PID_C111",  # Mantis Q 40
 			"VID_1C71&PID_C101",  # Chameleon 20
 			"VID_1C71&PID_C121",  # Humanware BrailleOne 20 HID
@@ -99,13 +99,13 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 			"VID_1C71&PID_C00A",  # BrailleNote Touch
 			"VID_1C71&PID_C00E",  # BrailleNote Touch v2
 		})
-		driverRegistrar.addUsbDevices(bdDetect.KEY_SERIAL, {
+		driverRegistrar.addUsbDevices(bdDetect.DeviceType.SERIAL, {
 			"VID_1C71&PID_C005",  # Brailliant BI 32, 40 and 80
 			"VID_1C71&PID_C021",  # Brailliant BI 14
 		})
 		driverRegistrar.addBluetoothDevices(
 			lambda m: (
-				m.type == bdDetect.KEY_SERIAL
+				m.type == bdDetect.DeviceType.SERIAL
 				and (
 					m.id.startswith("Brailliant B")
 					or m.id == "Brailliant 80"
@@ -113,7 +113,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 				)
 			)
 			or (
-				m.type == bdDetect.KEY_HID
+				m.type == bdDetect.DeviceType.HID
 				and m.deviceInfo.get("manufacturer") == "Humanware"
 				and m.deviceInfo.get("product") in (
 					"Brailliant HID",
@@ -137,7 +137,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 		self.numCells = 0
 
 		for portType, portId, port, portInfo in self._getTryPorts(port):
-			self.isHid = portType == bdDetect.KEY_HID
+			self.isHid = portType == bdDetect.DeviceType.HID
 			# Try talking to the display.
 			try:
 				if self.isHid:

--- a/source/brailleDisplayDrivers/eurobraille/driver.py
+++ b/source/brailleDisplayDrivers/eurobraille/driver.py
@@ -46,7 +46,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver, ScriptableObject):
 
 	@classmethod
 	def registerAutomaticDetection(cls, driverRegistrar: bdDetect.DriverRegistrar):
-		driverRegistrar.addUsbDevices(bdDetect.KEY_HID, {
+		driverRegistrar.addUsbDevices(bdDetect.DeviceType.HID, {
 			"VID_C251&PID_1122",  # Esys (version < 3.0, no SD card
 			"VID_C251&PID_1123",  # Esys (version >= 3.0, with HID keyboard, no SD card
 			"VID_C251&PID_1124",  # Esys (version < 3.0, with SD card
@@ -65,7 +65,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver, ScriptableObject):
 			"VID_C251&PID_1131",  # Reserved
 			"VID_C251&PID_1132",  # Reserved
 		})
-		driverRegistrar.addUsbDevices(bdDetect.KEY_SERIAL, {
+		driverRegistrar.addUsbDevices(bdDetect.DeviceType.SERIAL, {
 			"VID_28AC&PID_0012",  # b.note
 			"VID_28AC&PID_0013",  # b.note 2
 			"VID_28AC&PID_0020",  # b.book internal
@@ -93,7 +93,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver, ScriptableObject):
 		for portType, portId, port, portInfo in self._getTryPorts(port):
 			# At this point, a port bound to this display has been found.
 			# Try talking to the display.
-			self.isHid = portType == bdDetect.KEY_HID
+			self.isHid = portType == bdDetect.DeviceType.HID
 			try:
 				if self.isHid:
 					self._dev = hwIo.Hid(

--- a/source/brailleDisplayDrivers/freedomScientific.py
+++ b/source/brailleDisplayDrivers/freedomScientific.py
@@ -179,7 +179,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver, ScriptableObject):
 
 	@classmethod
 	def registerAutomaticDetection(cls, driverRegistrar: bdDetect.DriverRegistrar):
-		driverRegistrar.addUsbDevices(bdDetect.KEY_CUSTOM, {
+		driverRegistrar.addUsbDevices(bdDetect.DeviceType.CUSTOM, {
 			"VID_0F4E&PID_0100",  # Focus 1
 			"VID_0F4E&PID_0111",  # PAC Mate
 			"VID_0F4E&PID_0112",  # Focus 2
@@ -218,7 +218,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver, ScriptableObject):
 		self.gestureMap.add("br(freedomScientific):rightWizWheelDown", *action[2])
 		super(BrailleDisplayDriver, self).__init__()
 		for portType, portId, port, portInfo in self._getTryPorts(port):
-			self.isUsb = portType == bdDetect.KEY_CUSTOM
+			self.isUsb = portType == bdDetect.DeviceType.CUSTOM
 			# Try talking to the display.
 			try:
 				if self.isUsb:

--- a/source/brailleDisplayDrivers/handyTech.py
+++ b/source/brailleDisplayDrivers/handyTech.py
@@ -614,13 +614,13 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver, ScriptableObject):
 
 	@classmethod
 	def registerAutomaticDetection(cls, driverRegistrar: bdDetect.DriverRegistrar):
-		driverRegistrar.addUsbDevices(bdDetect.KEY_SERIAL, {
+		driverRegistrar.addUsbDevices(bdDetect.DeviceType.SERIAL, {
 			"VID_0403&PID_6001",  # FTDI chip
 			"VID_0921&PID_1200",  # GoHubs chip
 		})
 
 		# Newer Handy Tech displays have a native HID processor
-		driverRegistrar.addUsbDevices(bdDetect.KEY_HID, {
+		driverRegistrar.addUsbDevices(bdDetect.DeviceType.HID, {
 			"VID_1FE4&PID_0054",  # Active Braille
 			"VID_1FE4&PID_0055",  # Connect Braille
 			"VID_1FE4&PID_0061",  # Actilino
@@ -640,7 +640,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver, ScriptableObject):
 		})
 
 		# Some older HT displays use a HID converter and an internal serial interface
-		driverRegistrar.addUsbDevices(bdDetect.KEY_HID, {
+		driverRegistrar.addUsbDevices(bdDetect.DeviceType.HID, {
 			"VID_1FE4&PID_0003",  # USB-HID adapter
 			"VID_1FE4&PID_0074",  # Braille Star 40
 			"VID_1FE4&PID_0044",  # Easy Braille
@@ -684,7 +684,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver, ScriptableObject):
 		for portType, portId, port, portInfo in self._getTryPorts(port):
 			# At this point, a port bound to this display has been found.
 			# Try talking to the display.
-			self.isHid = portType == bdDetect.KEY_HID
+			self.isHid = portType == bdDetect.DeviceType.HID
 			self.isHidSerial = portId in USB_IDS_HID_CONVERTER
 			self.port = port
 			try:

--- a/source/brailleDisplayDrivers/hidBrailleStandard.py
+++ b/source/brailleDisplayDrivers/hidBrailleStandard.py
@@ -93,7 +93,7 @@ class HidBrailleDriver(braille.BrailleDisplayDriver):
 		self.numCells = 0
 
 		for portType, portId, port, portInfo in self._getTryPorts(port):
-			if portType != bdDetect.KEY_HID:
+			if portType != bdDetect.DeviceType.HID:
 				continue
 			# Try talking to the display.
 			try:

--- a/source/brailleDisplayDrivers/hims.py
+++ b/source/brailleDisplayDrivers/hims.py
@@ -215,7 +215,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 
 		for match in self._getTryPorts(port):
 			portType, portId, port, portInfo = match
-			self.isBulk = portType==bdDetect.DeviceType.CUSTOM
+			self.isBulk = portType == bdDetect.DeviceType.CUSTOM
 			# Try talking to the display.
 			try:
 				if self.isBulk:
@@ -265,7 +265,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 
 	def _sendIdentificationRequests(self, match: bdDetect.DeviceMatch):
 		log.debug("Considering sending identification requests for device %s"%str(match))
-		if match.type==bdDetect.DeviceType.CUSTOM: # USB Bulk
+		if match.type == bdDetect.DeviceType.CUSTOM:  # USB Bulk
 			matchedModelsMap = [
 				modelTuple for modelTuple in modelMap if(
 					modelTuple[1].usbId == match.id

--- a/source/brailleDisplayDrivers/hims.py
+++ b/source/brailleDisplayDrivers/hims.py
@@ -188,13 +188,13 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 	@classmethod
 	def registerAutomaticDetection(cls, driverRegistrar: bdDetect.DriverRegistrar):
 		# Bulk devices
-		driverRegistrar.addUsbDevices(bdDetect.KEY_CUSTOM, {
+		driverRegistrar.addUsbDevices(bdDetect.DeviceType.CUSTOM, {
 			"VID_045E&PID_930A",  # Braille Sense & Smart Beetle
 			"VID_045E&PID_930B",  # Braille EDGE 40
 		})
 
 		# Sync Braille, serial device
-		driverRegistrar.addUsbDevices(bdDetect.KEY_SERIAL, {
+		driverRegistrar.addUsbDevices(bdDetect.DeviceType.SERIAL, {
 			"VID_0403&PID_6001",
 		})
 
@@ -215,7 +215,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 
 		for match in self._getTryPorts(port):
 			portType, portId, port, portInfo = match
-			self.isBulk = portType==bdDetect.KEY_CUSTOM
+			self.isBulk = portType==bdDetect.DeviceType.CUSTOM
 			# Try talking to the display.
 			try:
 				if self.isBulk:
@@ -265,7 +265,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 
 	def _sendIdentificationRequests(self, match: bdDetect.DeviceMatch):
 		log.debug("Considering sending identification requests for device %s"%str(match))
-		if match.type==bdDetect.KEY_CUSTOM: # USB Bulk
+		if match.type==bdDetect.DeviceType.CUSTOM: # USB Bulk
 			matchedModelsMap = [
 				modelTuple for modelTuple in modelMap if(
 					modelTuple[1].usbId == match.id

--- a/source/brailleDisplayDrivers/nattiqbraille.py
+++ b/source/brailleDisplayDrivers/nattiqbraille.py
@@ -38,7 +38,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 
 	@classmethod
 	def registerAutomaticDetection(cls, driverRegistrar: bdDetect.DriverRegistrar):
-		driverRegistrar.addUsbDevices(bdDetect.KEY_SERIAL, {
+		driverRegistrar.addUsbDevices(bdDetect.DeviceType.SERIAL, {
 			"VID_2341&PID_8036",  # Atmel-based USB Serial for Nattiq nBraille
 		})
 

--- a/source/brailleDisplayDrivers/seikantk.py
+++ b/source/brailleDisplayDrivers/seikantk.py
@@ -16,7 +16,7 @@ from typing import Dict, List, Optional, Set
 import serial
 
 import braille
-from bdDetect import KEY_HID, DeviceMatch, DriverRegistrar
+from bdDetect import DeviceType, DeviceMatch, DriverRegistrar
 import brailleInput
 import inputCore
 import bdDetect
@@ -107,7 +107,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 
 	@classmethod
 	def registerAutomaticDetection(cls, driverRegistrar: DriverRegistrar):
-		driverRegistrar.addUsbDevices(KEY_HID, {
+		driverRegistrar.addUsbDevices(DeviceType.HID, {
 			vidpid,  # Seika Notetaker
 		})
 
@@ -133,8 +133,8 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 		log.debug(f"Seika Notetaker braille driver: ({port!r})")
 		dev: typing.Optional[typing.Union[hwIo.Hid, hwIo.Serial]] = None
 		for match in self._getTryPorts(port):
-			self.isHid = match.type == bdDetect.KEY_HID
-			self.isSerial = match.type == bdDetect.KEY_SERIAL
+			self.isHid = match.type == bdDetect.DeviceType.HID
+			self.isSerial = match.type == bdDetect.DeviceType.SERIAL
 			try:
 				if self.isHid:
 					log.info(f"Trying Seika notetaker on USB-HID")

--- a/source/brailleDisplayDrivers/superBrl.py
+++ b/source/brailleDisplayDrivers/superBrl.py
@@ -32,7 +32,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 
 	@classmethod
 	def registerAutomaticDetection(cls, driverRegistrar: bdDetect.DriverRegistrar):
-		driverRegistrar.addUsbDevices(bdDetect.KEY_SERIAL, {
+		driverRegistrar.addUsbDevices(bdDetect.DeviceType.SERIAL, {
 			"VID_10C4&PID_EA60",  # SuperBraille 3.2
 		})
 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -169,8 +169,9 @@ Code which imports from one of them, should instead import from the replacement 
   - ``winVersion.WIN7_SP1``
   - ``winVersion.WIN8``
   -
-- The ``bdDetect.KEY_*`` constants have been deprecated. Use ``bdDetect.DeviceType.*`` instead. (#15772, @LeonarddeR).
-- The ``bdDetect.DETECT_USB`` and ``bdDetect.DETECT_BLUETOOTH`` constants have been deprecated wit no public replacement. (#15772, @LeonarddeR).
+- The ``bdDetect.KEY_*`` constants have been deprecated.
+Use ``bdDetect.DeviceType.*`` instead. (#15772, @LeonarddeR).
+- The ``bdDetect.DETECT_USB`` and ``bdDetect.DETECT_BLUETOOTH`` constants have been deprecated with no public replacement. (#15772, @LeonarddeR).
 -
 
 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -169,6 +169,8 @@ Code which imports from one of them, should instead import from the replacement 
   - ``winVersion.WIN7_SP1``
   - ``winVersion.WIN8``
   -
+- The ``bdDetect.KEY_*`` constants have been deprecated. Use ``bdDetect.DeviceType.*`` instead. (#15772, @LeonarddeR).
+- The ``bdDetect.DETECT_USB`` and ``bdDetect.DETECT_BLUETOOTH`` constants have been deprecated wit no public replacement. (#15772, @LeonarddeR).
 -
 
 


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
bdDetect is using old style string constants to distinguish device types.

### Description of user facing changes
None.

### Description of development approach
Replace with enum.

### Testing strategy:
Test whether random braille display is still detected appropriately.

### Known issues with pull request:
None known

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
