### PR TITLE
Fixes #15773 / Contracted braille input

### DIFF
--- a/source/brailleInput.py
+++ b/source/brailleInput.py
@@ -154,7 +154,7 @@ class BrailleInputHandler(AutoPropertyObject):
 				if len(newText)>1:
 					# Emulation of multiple characters at once is unsupported
 					# Clear newText, so this function returns C{False} if not at end of word
-					newText = u""
+					newText = ""
 				else:
 					self.emulateKey(newText)
 			else:
@@ -164,7 +164,7 @@ class BrailleInputHandler(AutoPropertyObject):
 			# We only need to buffer one word.
 			# Clear the previous word (anything before the cursor) from the buffer.
 			del self.bufferBraille[:pos]
-			self.bufferText = u""
+			self.bufferText = ""
 			self.cellsWithText.clear()
 			self.currentModifiers.clear()
 			self.untranslatedStart = 0
@@ -314,7 +314,8 @@ class BrailleInputHandler(AutoPropertyObject):
 		"""
 		region = braille.handler.mainBuffer.regions[-1] if braille.handler.mainBuffer.regions else None
 		if isinstance(region, braille.TextInfoRegion):
-			braille.handler._doCursorMove(region)
+			braille.handler._regionsPendingUpdate.add(region)
+			braille.handler._handlePendingUpdate()
 
 	def eraseLastCell(self):
 		# Get the index of the cell being erased.

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -62,6 +62,7 @@ It is also updated with UIA enabled, when typing text and braille is tethered to
 - It is not possible anymore to overwrite NVDA's Python console history. (#15792, @CyrilleB79)
 - In Word, the landing cell will now be correctly reported when using the native Word commands for table navigation ``alt+home``, ``alt+end``, ``alt+pageUp`` and ``alt+pageDown``. (#15805, @CyrilleB79)
 - NVDA now resumes audio if the configuration of the output device changes or another application releases exclusive control of the device. (#15758, #15775, @jcsteh)
+- Contracted braille input works properly again. (#15773, @aaclause)
 -
 
 == Changes for Developers ==


### PR DESCRIPTION
### Link to issue number:
Closes #15773
Fixup of #15163

### Summary of the issue:
Contracted braille input is broken since #15163 merge.

### Description of user facing changes
Contracted braille input works properly again.

### Description of development approach
`braille.handler._doCursorMove` no longer exists. `braille.handler._regionsPendingUpdate.add`  and `braille.handler._handlePendingUpdate` are used instead.

### Testing strategy:
Ran and tested from sources.

### Known issues with pull request:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
