### PR TITLE
Suppress garbageHandler log warnings

### DIFF
--- a/projectDocs/design/unreachableObjects.md
+++ b/projectDocs/design/unreachableObjects.md
@@ -5,14 +5,22 @@ Cyclic references are typically a symptom of bad design, and can cause major pro
 For instance, cyclic references involving COM objects may cause a deadlock if the garbage collector happens to break the cycle and release the COM object in the wrong thread.
 
 ## How to know about a cyclic reference?
-The log may contain errors like the following.
+The log may contain messages like the following.
+
+```py
+DEBUGWARNING - garbageHandler._collectionCallback (10:45:23.172) - MainThread (21820):
+Found at least 1 unreachable objects in run
 ```
-WARNING - garbageHandler.notifyObjectDeletion (10:45:23.171) - MainThread (21820):
+
+With `garbageHandler` logging enabled in advanced preferences, a more detailed log can be created:
+
+```py
+DEBUGWARNING - garbageHandler.notifyObjectDeletion (10:45:23.171) - MainThread (21820):
 Garbage collector has found one or more unreachable objects. See further warnings for specific objects.
 ...
-WARNING - garbageHandler.notifyObjectDeletion (10:45:23.171) - MainThread (21820):
+DEBUGWARNING - garbageHandler.notifyObjectDeletion (10:45:23.171) - MainThread (21820):
 Deleting unreachable object <eventHandler._EventExecuter object at 0x1AC15350>
-ERROR - garbageHandler._collectionCallback (10:45:23.172) - MainThread (21820):
+DEBUGWARNING - garbageHandler._collectionCallback (10:45:23.172) - MainThread (21820):
 Found at least 1 unreachable objects in run
 ```
 

--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -294,6 +294,7 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 	nvwave = boolean(default=false)
 	annotations = boolean(default=false)
 	events = boolean(default=false)
+	garbageHandler = boolean(default=false)
 
 [uwpOcr]
 	language = string(default="")

--- a/source/garbageHandler.py
+++ b/source/garbageHandler.py
@@ -53,7 +53,7 @@ def _collectionCallback(action, info):
 		if _reportCountDuringCollection > 0:
 			log.debugWarning(f"Found at least {_reportCountDuringCollection} unreachable objects in run")
 	else:
-		log.debugWarning(f"Unknown action: {action}")
+		log.error(f"Unknown action: {action}")
 
 
 def notifyObjectDeletion(obj):

--- a/source/garbageHandler.py
+++ b/source/garbageHandler.py
@@ -1,13 +1,15 @@
 # -*- coding: UTF-8 -*-
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2020 NV Access Limited
+# Copyright (C) 2020-2023 NV Access Limited
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
 
-import sys
 import gc
+import sys
 import threading
+
+import config
 from logHandler import log
 
 """ Watches Python's cyclic garbage collector and reports questionable collections. """
@@ -49,9 +51,9 @@ def _collectionCallback(action, info):
 	elif action == "stop":
 		_collectionThreadID = 0
 		if _reportCountDuringCollection > 0:
-			log.error(f"Found at least {_reportCountDuringCollection} unreachable objects in run")
+			log.debugWarning(f"Found at least {_reportCountDuringCollection} unreachable objects in run")
 	else:
-		log.error(f"Unknown action: {action}")
+		log.debugWarning(f"Unknown action: {action}")
 
 
 def notifyObjectDeletion(obj):
@@ -63,12 +65,13 @@ def notifyObjectDeletion(obj):
 	if _collectionThreadID != threading.current_thread().ident:
 		return
 	_reportCountDuringCollection += 1
-	if _reportCountDuringCollection == 1:
-		log.warning(
-			"Garbage collector has found one or more unreachable objects. See further warnings for specific objects.",
-			stack_info=True
-		)
-	log.warning(f"Deleting unreachable object {obj}")
+	if config.conf["debugLog"]["garbageHandler"]:
+		if _reportCountDuringCollection == 1:
+			log.debugWarning(
+				"Garbage collector has found one or more unreachable objects. See further warnings for specific objects.",
+				stack_info=True
+			)
+		log.debugWarning(f"Deleting unreachable object {obj}")
 
 
 

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -3164,7 +3164,7 @@ class AdvancedPanelControls(
 		debugLogGroup = guiHelper.BoxSizerHelper(self, sizer=debugLogSizer)
 		sHelper.addItem(debugLogGroup)
 
-		self.logCategories=[
+		self.logCategories = [
 			"hwIo",
 			"MSAA",
 			"UIA",
@@ -3179,6 +3179,7 @@ class AdvancedPanelControls(
 			"nvwave",
 			"annotations",
 			"events",
+			"garbageHandler",
 		]
 		# Translators: This is the label for a list in the
 		#  Advanced settings panel


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Fixes #15634

### Summary of the issue:
The information provided by garbageHandler is very noisy, and not indicative of a high priority fatal error.

### Description of user facing changes
Less noisy logs, and less frequent error bells on dev builds of NVDA.

### Description of development approach
Instead of logging every object on deletion, only log the number of objects deleted at "warning" level.
Logging every object can be enabled by enabling debug logging for garbageHandler.

### Testing strategy:
Manual testing
### Known issues with pull request:

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
