### PR TITLE
Keep a backup of a corrupted config when reinitializing it

### DIFF
--- a/source/config/__init__.py
+++ b/source/config/__init__.py
@@ -570,7 +570,7 @@ class ConfigManager(object):
 						os.unlink(backupFileName)
 					os.rename(fn, backupFileName)
 				except Exception:
-					log.error("Unable to save a copy of the corrupted configuration to {backupFileName}", exc_info=True)
+					log.error(f"Unable to save a copy of the corrupted configuration to {backupFileName}", exc_info=True)
 				self.baseConfigError = True
 				return self._initBaseConf(factoryDefaults=True)
 

--- a/source/config/__init__.py
+++ b/source/config/__init__.py
@@ -559,7 +559,18 @@ class ConfigManager(object):
 				profile = self._loadConfig(fn) # a blank config returned if fn does not exist
 				self.baseConfigError = False
 			except:
-				log.error("Error loading base configuration", exc_info=True)
+				backupFileName = fn + '.corrupted.bak'
+				log.error(
+					"Error loading base configuration; the base configuration file will be reinitialized."
+					f" A copy of your previous configuration file will be saved at {backupFileName}",
+					exc_info=True,
+				)
+				try:
+					if os.path.exists(backupFileName):
+						os.unlink(backupFileName)
+					os.rename(fn, backupFileName)
+				except Exception:
+					log.error("Unable to save a copy of the corrupted configuration to {backupFileName}", exc_info=True)
 				self.baseConfigError = True
 				return self._initBaseConf(factoryDefaults=True)
 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -93,6 +93,7 @@ Setting ``numCells`` is still supported for single line braille displays and ``n
   - w3c-aria-practices to ``9a5e55ccbeb0f1bf92b6127c9865da8426d1c864``. (#15695)
   - wil to ``5e9be7b2d2fe3834a7107f430f7d4c0631f69833``. (#15695)
   -
+- When the configuration file ``nvda.ini`` is corrupted, a backup copy is saved before it is reinitialized. (#15779, @CyrilleB79)
 -
 
 === API Breaking Changes ===


### PR DESCRIPTION
### Link to issue number:
Related to #14424 and #14412
### Summary of the issue:

In some situation, the configuration file nvda.ini may be corrupted. This can happen if the user has edited the file manually or in some cases when NVDA is downgraded. It may also happen in the case of a bug during the development phase of NVDA (alpha releases) or of add-ons.

When the configuration file is corrupted, it cannot be used. Thus NVDA deletes it and starts with a brand new config. It also warns the user with a message box indicating that the config has been reset and that more information can be found in the log. However in some case, the user may want to fix the issues in the corrupted file manually instead of re-creating all the parameters from the new config.

### Description of user facing changes
Before re-creating a new config, a backup of the old corrupted file is saved so that the user can turn back to it if they want. The logged message also indicates the presence of this file.

### Description of development approach
See above.
### Testing strategy:
Tested this PR by manually corrupting the nvda.ini file, i.e. removing a square bracket to a section name.
### Known issues with pull request:
None.
### Code Review Checklist:


- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
