### PR TITLE
WASAPI: Switch back to the preferred device if it becomes available.

### DIFF
--- a/nvdaHelper/local/nvdaHelperLocal.def
+++ b/nvdaHelper/local/nvdaHelperLocal.def
@@ -78,4 +78,3 @@ EXPORTS
 	wasPlay_resume
 	wasPlay_setChannelVolume
 	wasPlay_startup
-	wasPlay_getDevices

--- a/nvdaHelper/local/wasapi.cpp
+++ b/nvdaHelper/local/wasapi.cpp
@@ -14,6 +14,7 @@ http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 
 #include <vector>
 #include <windows.h>
+#include <atlbase.h>
 #include <atlcomcli.h>
 #include <audioclient.h>
 #include <audiopolicy.h>
@@ -72,8 +73,9 @@ class AutoHandle {
 };
 
 /**
- * Listens for default device changes. These are communicated to WasapiPlayer
- * via the getDefaultDeviceChangeCount method.
+ * Listens for default device changes and device state changes. These are
+ * communicated to WasapiPlayer via the getDefaultDeviceChangeCount and
+ * getDeviceStateChangeCount methods.
  */
 class NotificationClient: public IMMNotificationClient {
 	public:
@@ -116,6 +118,7 @@ class NotificationClient: public IMMNotificationClient {
 	}
 
 	STDMETHODIMP OnDeviceStateChanged(LPCWSTR deviceId, DWORD   newState) final {
+		++deviceStateChangeCount;
 		return S_OK;
 	}
 
@@ -133,9 +136,18 @@ class NotificationClient: public IMMNotificationClient {
 		return defaultDeviceChangeCount;
 	}
 
+	/**
+	 * A counter which increases every time a device state changes. This is
+	 * used by WasapiPlayer instances to detect such changes while playing.
+	 */
+	unsigned int getDeviceStateChangeCount() {
+		return deviceStateChangeCount;
+	}
+
 	private:
 	LONG refCount = 0;
 	unsigned int defaultDeviceChangeCount = 0;
+	unsigned int deviceStateChangeCount = 0;
 };
 
 CComPtr<NotificationClient> notificationClient;
@@ -150,9 +162,9 @@ class WasapiPlayer {
 
 	/**
 	 * Constructor.
-	 * Specify an empty (not null) deviceId to use the default device.
+	 * Specify an empty (not null) deviceName to use the default device.
 	 */
-	WasapiPlayer(wchar_t* deviceId, WAVEFORMATEX format,
+	WasapiPlayer(wchar_t* deviceName, WAVEFORMATEX format,
 		ChunkCompletedCallback callback);
 
 	/**
@@ -196,6 +208,9 @@ class WasapiPlayer {
 	// callback.
 	void waitUntilNeeded(UINT64 maxWait=INFINITE);
 
+	HRESULT getPreferredDevice(CComPtr<IMMDevice>& preferredDevice);
+	bool didPreferredDeviceBecomeAvailable();
+
 	enum class PlayState {
 		stopped,
 		playing,
@@ -207,7 +222,7 @@ class WasapiPlayer {
 	CComPtr<IAudioClock> clock;
 	// The maximum number of frames that will fit in the buffer.
 	UINT32 bufferFrames;
-	std::wstring deviceId;
+	std::wstring deviceName;
 	WAVEFORMATEX format;
 	ChunkCompletedCallback callback;
 	PlayState playState = PlayState::stopped;
@@ -220,11 +235,13 @@ class WasapiPlayer {
 	unsigned int nextFeedId = 0;
 	AutoHandle wakeEvent;
 	unsigned int defaultDeviceChangeCount;
+	unsigned int deviceStateChangeCount;
+	bool isUsingPreferredDevice = false;
 };
 
-WasapiPlayer::WasapiPlayer(wchar_t* deviceId, WAVEFORMATEX format,
+WasapiPlayer::WasapiPlayer(wchar_t* deviceName, WAVEFORMATEX format,
 	ChunkCompletedCallback callback)
-: deviceId(deviceId), format(format), callback(callback) {
+: deviceName(deviceName), format(format), callback(callback) {
 	wakeEvent = CreateEvent(nullptr, false, false, nullptr);
 }
 
@@ -234,16 +251,24 @@ HRESULT WasapiPlayer::open(bool force) {
 		return S_OK;
 	}
 	defaultDeviceChangeCount = notificationClient->getDefaultDeviceChangeCount();
+	deviceStateChangeCount = notificationClient->getDeviceStateChangeCount();
 	CComPtr<IMMDeviceEnumerator> enumerator;
 	HRESULT hr = enumerator.CoCreateInstance(CLSID_MMDeviceEnumerator);
 	if (FAILED(hr)) {
 		return hr;
 	}
 	CComPtr<IMMDevice> device;
-	if (deviceId.empty()) {
+	isUsingPreferredDevice = false;
+	if (deviceName.empty()) {
 		hr = enumerator->GetDefaultAudioEndpoint(eRender, eConsole, &device);
 	} else {
-		hr = enumerator->GetDevice(deviceId.c_str(), &device);
+		hr = getPreferredDevice(device);
+		if (SUCCEEDED(hr)) {
+			isUsingPreferredDevice = true;
+		} else {
+			// The preferred device wasn't found. Fall back to the default device.
+			hr = enumerator->GetDefaultAudioEndpoint(eRender, eConsole, &device);
+		}
 	}
 	if (FAILED(hr)) {
 		return hr;
@@ -315,9 +340,12 @@ HRESULT WasapiPlayer::feed(unsigned char* data, unsigned int size,
 				hr = S_OK;
 				return false;
 			}
-			if (deviceId.empty() && defaultDeviceChangeCount !=
-					notificationClient->getDefaultDeviceChangeCount()) {
-				// The default device changed.
+			if (
+				didPreferredDeviceBecomeAvailable() ||
+				// We're using the default device and the default device changed.
+				(!isUsingPreferredDevice && defaultDeviceChangeCount !=
+					notificationClient->getDefaultDeviceChangeCount())
+			) {
 				if (!reopenUsingNewDev()) {
 					return false;
 				}
@@ -326,7 +354,6 @@ HRESULT WasapiPlayer::feed(unsigned char* data, unsigned int size,
 			if (hr == AUDCLNT_E_DEVICE_INVALIDATED) {
 				// If we're using a specific device, it's just been invalidated. Fall back
 				// to the default device.
-				deviceId.clear();
 				if (!reopenUsingNewDev()) {
 					return false;
 				}
@@ -435,6 +462,63 @@ void WasapiPlayer::waitUntilNeeded(UINT64 maxWait) {
 	WaitForSingleObject(wakeEvent, (DWORD)maxWait);
 }
 
+HRESULT WasapiPlayer::getPreferredDevice(CComPtr<IMMDevice>& preferredDevice) {
+	CComPtr<IMMDeviceEnumerator> enumerator;
+	HRESULT hr = enumerator.CoCreateInstance(CLSID_MMDeviceEnumerator);
+	if (FAILED(hr)) {
+		return hr;
+	}
+	CComPtr<IMMDeviceCollection> devices;
+	hr = enumerator->EnumAudioEndpoints(eRender, DEVICE_STATE_ACTIVE, &devices);
+	if (FAILED(hr)) {
+		return hr;
+	}
+	UINT count = 0;
+	devices->GetCount(&count);
+	for (UINT d = 0; d < count; ++d) {
+		CComPtr<IMMDevice> device;
+		hr = devices->Item(d, &device);
+		if (FAILED(hr)) {
+			return hr;
+		}
+		CComPtr<IPropertyStore> props;
+		hr = device->OpenPropertyStore(STGM_READ, &props);
+		if (FAILED(hr)) {
+			return hr;
+		}
+		PROPVARIANT val;
+		hr = props->GetValue(PKEY_Device_FriendlyName, &val);
+		if (FAILED(hr)) {
+			return hr;
+		}
+		// WinMM device names are truncated to MAXPNAMELEN characters, including the
+		// null terminator.
+		constexpr size_t MAX_CHARS = MAXPNAMELEN - 1;
+		if (wcsncmp(val.pwszVal, deviceName.c_str(), MAX_CHARS) == 0) {
+			PropVariantClear(&val);
+			preferredDevice = std::move(device);
+			return S_OK;
+		}
+		PropVariantClear(&val);
+	}
+	return E_NOTFOUND;
+}
+
+bool WasapiPlayer::didPreferredDeviceBecomeAvailable() {
+	if (
+		// We're already using the preferred device.
+		isUsingPreferredDevice ||
+		// A preferred device was not specified.
+		deviceName.empty() ||
+		// A device hasn't recently changed state.
+		deviceStateChangeCount == notificationClient->getDeviceStateChangeCount()
+	) {
+		return false;
+	}
+	CComPtr<IMMDevice> device;
+	return SUCCEEDED(getPreferredDevice(device));
+}
+
 HRESULT WasapiPlayer::stop() {
 	playState = PlayState::stopping;
 	HRESULT hr = client->Stop();
@@ -516,7 +600,6 @@ HRESULT WasapiPlayer::setChannelVolume(unsigned int channel, float level) {
 	if (hr == AUDCLNT_E_DEVICE_INVALIDATED) {
 		// If we're using a specific device, it's just been invalidated. Fall back
 		// to the default device.
-		deviceId.clear();
 		hr = open(true);
 		if (FAILED(hr)) {
 			return hr;
@@ -531,13 +614,13 @@ HRESULT WasapiPlayer::setChannelVolume(unsigned int channel, float level) {
 
 /*
  * NVDA calls the functions below. Most of these just wrap calls to
- * WasapiPlayer, with the exception of wasPlay_startup and wasPlay_getDevices.
+ * WasapiPlayer, with the exception of wasPlay_startup.
  */
 
-WasapiPlayer* wasPlay_create(wchar_t* deviceId, WAVEFORMATEX format,
+WasapiPlayer* wasPlay_create(wchar_t* deviceName, WAVEFORMATEX format,
 	WasapiPlayer::ChunkCompletedCallback callback
 ) {
-	return new WasapiPlayer(deviceId, format, callback);
+	return new WasapiPlayer(deviceName, format, callback);
 }
 
 void wasPlay_destroy(WasapiPlayer* player) {
@@ -594,53 +677,4 @@ HRESULT wasPlay_startup() {
 	}
 	notificationClient = new NotificationClient();
 	return enumerator->RegisterEndpointNotificationCallback(notificationClient);
-}
-
-/**
- * Get playback device ids and friendly names.
- * devicesStr will be set to a BSTR of device ids and names separated by null
- * characters; e.g. "id1\0name1\0id2\0name2\0"
- */
-HRESULT wasPlay_getDevices(BSTR* devicesStr) {
-	CComPtr<IMMDeviceEnumerator> enumerator;
-	HRESULT hr = enumerator.CoCreateInstance(CLSID_MMDeviceEnumerator);
-	if (FAILED(hr)) {
-		return hr;
-	}
-	CComPtr<IMMDeviceCollection> devices;
-	hr = enumerator->EnumAudioEndpoints(eRender, DEVICE_STATE_ACTIVE, &devices);
-	if (FAILED(hr)) {
-		return hr;
-	}
-	UINT count = 0;
-	devices->GetCount(&count);
-	std::wostringstream s;
-	for (UINT d = 0; d < count; ++d) {
-		CComPtr<IMMDevice> device;
-		hr = devices->Item(d, &device);
-		if (FAILED(hr)) {
-			return hr;
-		}
-		wchar_t* id;
-		hr = device->GetId(&id);
-		if (FAILED(hr)) {
-			return hr;
-		}
-		s << id << L'\0';
-		CoTaskMemFree(id);
-		CComPtr<IPropertyStore> props;
-		hr = device->OpenPropertyStore(STGM_READ, &props);
-		if (FAILED(hr)) {
-			return hr;
-		}
-		PROPVARIANT val;
-		hr = props->GetValue(PKEY_Device_FriendlyName, &val);
-		if (FAILED(hr)) {
-			return hr;
-		}
-		s << val.pwszVal << L'\0';
-		PropVariantClear(&val);
-	}
-	*devicesStr = SysAllocStringLen(s.str().c_str(), (UINT)s.tellp());
-	return S_OK;
 }

--- a/source/nvwave.py
+++ b/source/nvwave.py
@@ -777,6 +777,8 @@ class WasapiWavePlayer(garbageHandler.TrackedObject):
 	_IDLE_CHECK_INTERVAL: int = 5000
 	#: Whether there is a pending stream idle check.
 	_isIdleCheckPending: bool = False
+	#: Use the default device, this is the configSpec default value.
+	DEFAULT_DEVICE_KEY = "default"
 
 	def __init__(
 			self,
@@ -818,8 +820,10 @@ class WasapiWavePlayer(garbageHandler.TrackedObject):
 			if audioDucking.isAudioDuckingSupported():
 				self._audioDucker = audioDucking.AudioDucker()
 		self._purpose = purpose
+		if self._isDefaultDevice(outputDevice):
+			outputDevice = ""
 		self._player = NVDAHelper.localLib.wasPlay_create(
-			self._deviceNameToId(outputDevice),
+			outputDevice,
 			format,
 			WasapiWavePlayer._callback
 		)
@@ -1034,33 +1038,12 @@ class WasapiWavePlayer(garbageHandler.TrackedObject):
 			# Schedule another check here in case feed isn't called for a while.
 			cls._scheduleIdleCheck()
 
-	@staticmethod
-	def _getDevices():
-		rawDevs = BSTR()
-		NVDAHelper.localLib.wasPlay_getDevices(byref(rawDevs))
-		chunkIter = iter(rawDevs.value.split("\0"))
-		while True:
-			devId = next(chunkIter)
-			if not devId:
-				break  # Final null.
-			name = next(chunkIter)
-			yield devId, name
-
-	@staticmethod
-	def _deviceNameToId(name, fallbackToDefault=True):
-		if name == WAVE_MAPPER:
-			return ""
-		for devId, devName in WasapiWavePlayer._getDevices():
-			# WinMM device names are truncated to MAXPNAMELEN characters, so we must
-			# use startswith.
-			if devName.startswith(name):
-				return devId
+	@classmethod
+	def _isDefaultDevice(cls, name):
+		if name in (WAVE_MAPPER, cls.DEFAULT_DEVICE_KEY):
+			return True
 		# Check if this is the WinMM sound mapper device, which means default.
-		if name == next(_getOutputDevices())[1]:
-			return ""
-		if fallbackToDefault:
-			return ""
-		raise LookupError
+		return name == next(_getOutputDevices())[1]
 
 
 def initialize():
@@ -1079,7 +1062,6 @@ def initialize():
 		NVDAHelper.localLib.wasPlay_pause,
 		NVDAHelper.localLib.wasPlay_resume,
 		NVDAHelper.localLib.wasPlay_setChannelVolume,
-		NVDAHelper.localLib.wasPlay_getDevices,
 	):
 		func.restype = HRESULT
 		func.errcheck = _wasPlay_errcheck

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -56,6 +56,7 @@ It is also updated with UIA enabled, when typing text and braille is tethered to
 - More objects which contain useful text are detected, and text content is displayed in braille. (#15605)
 - NVDA no longer freezes briefly when multiple sounds are played in rapid succession. (#15757)
 - NVDA will not fail to start anymore when the configuration file is corrupted, but it will restore the configuration to default as it did in the past. (#15690, @CyrilleB79)
+- If the audio output device is set to something other than the default and that device becomes available again after being unavailable, NVDA will now switch back to the configured device instead of continuing to use the default device. (#15759)
 -
 
 == Changes for Developers ==


### PR DESCRIPTION
### Link to issue number:
Fixes #15759.

### Summary of the issue:
If the audio output device is set to something other than the default and that device is (or becomes) unavailable (e.g. it is disconnected), NVDA will switch to the default device. However, when that device becomes available again (e.g. it is reconnected), NVDA continues to use the default device instead of switching back to the configured device. Worse, this can't be fixed by opening the audio preferences and pressing OK, since the Settings dialog only looks at the configuration and doesn't realise that the WASAPI code has fallen back to the default device.

### Description of user facing changes
If the audio output device is set to something other than the default and that device becomes available again after being unavailable, NVDA will now switch back to the configured device instead of continuing to use the default device. (#15759)

### Description of development approach
1. Pass the device name to the WasapiPlayer C++ code instead of the device id. This means that WasapiPlayer is created with the device name of the preferred device, even if that device is unavailable, allowing us to manage that in the C++ code.
2. Removed wasPlay_getDevices and its Python callers, since they are no longer needed.
3. Changed WasapiPlayer::open to detect whether the specified device is unavailable using an error code. If so, it falls back to the default device. We leave the preferred device name alone so we can use it later.
4. If the device is unavailable, WasapiPlayer::feed still falls back to the default device, but again does not clear the device name.
5. In NotificationClient, we now track device state change notifications in the same way we track default device changes.
6. In WasapiPlayer::feed, we now handle device state changes similar to how we handle default device changes.
7. If a device state change occurs, we scan for the preferred device by name. If it is available, we switch back to that.

### Testing strategy:
1. Configured NVDA to use a USB headset.
2. Set the Windows default device to laptop speakers.
3. Unplugged the headset.
4. Observed that NVDA switches to speakers.
5. Plugged the headset back in.
6. Observed that NVDA switches back to the headset.
7. Restarted NVDA.
9. Observed that NVDA uses the headset.
10. Exited NVDA.
11. Unplugged the headset.
12. Started NVDA.
13. Observed that NVDA uses the speakers.
14. Plugged the headset back in.
15. Observed that NVDA uses the headset.
16. Configured NVDA to use Microsoft Sound Mapper.
17. Observed that NVDA switches to the speakers.
18. Switched the Windows default device to the headset.
19. Observed that NVDA switches to the headset.

### Known issues with pull request:
None.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
