### PR TITLE
WASAPI: Recover after the device is reconfigured or leaves exclusive mode.

### DIFF
--- a/nvdaHelper/local/wasapi.cpp
+++ b/nvdaHelper/local/wasapi.cpp
@@ -351,8 +351,10 @@ HRESULT WasapiPlayer::feed(unsigned char* data, unsigned int size,
 				}
 			}
 			hr = client->GetCurrentPadding(&paddingFrames);
-			if (hr == AUDCLNT_E_DEVICE_INVALIDATED ||
-					hr == AUDCLNT_E_NOT_INITIALIZED) {
+			if (
+				hr == AUDCLNT_E_DEVICE_INVALIDATED
+				|| hr == AUDCLNT_E_NOT_INITIALIZED
+			) {
 				// Either the device we're using has just been invalidated, or it was
 				// invalidated previously and we failed to reopen. Try reopening, which
 				// might fall back to the default device if appropriate.
@@ -527,8 +529,10 @@ HRESULT WasapiPlayer::stop() {
 	// If the device has been invalidated, it has already stopped. Just ignore
 	// this and behave as if we were successful to avoid a cascade of breakage.
 	// feed() will attempt to reopen the device next time it is called.
-	if (hr != AUDCLNT_E_DEVICE_INVALIDATED &&
-			hr != AUDCLNT_E_NOT_INITIALIZED) {
+	if (
+		hr != AUDCLNT_E_DEVICE_INVALIDATED
+		&& hr != AUDCLNT_E_NOT_INITIALIZED
+	) {
 		if (FAILED(hr)) {
 			return hr;
 		}

--- a/nvdaHelper/local/wasapi.cpp
+++ b/nvdaHelper/local/wasapi.cpp
@@ -315,7 +315,7 @@ HRESULT WasapiPlayer::feed(unsigned char* data, unsigned int size,
 
 	// Returns false if we should abort, in which case we should return hr.
 	auto reopenUsingNewDev = [&] {
-		HRESULT hr = open(true);
+		hr = open(true);
 		if (FAILED(hr)) {
 			return false;
 		}
@@ -351,9 +351,11 @@ HRESULT WasapiPlayer::feed(unsigned char* data, unsigned int size,
 				}
 			}
 			hr = client->GetCurrentPadding(&paddingFrames);
-			if (hr == AUDCLNT_E_DEVICE_INVALIDATED) {
-				// If we're using a specific device, it's just been invalidated. Fall back
-				// to the default device.
+			if (hr == AUDCLNT_E_DEVICE_INVALIDATED ||
+					hr == AUDCLNT_E_NOT_INITIALIZED) {
+				// Either the device we're using has just been invalidated, or it was
+				// invalidated previously and we failed to reopen. Try reopening, which
+				// might fall back to the default device if appropriate.
 				if (!reopenUsingNewDev()) {
 					return false;
 				}
@@ -522,12 +524,18 @@ bool WasapiPlayer::didPreferredDeviceBecomeAvailable() {
 HRESULT WasapiPlayer::stop() {
 	playState = PlayState::stopping;
 	HRESULT hr = client->Stop();
-	if (FAILED(hr)) {
-		return hr;
-	}
-	hr = client->Reset();
-	if (FAILED(hr)) {
-		return hr;
+	// If the device has been invalidated, it has already stopped. Just ignore
+	// this and behave as if we were successful to avoid a cascade of breakage.
+	// feed() will attempt to reopen the device next time it is called.
+	if (hr != AUDCLNT_E_DEVICE_INVALIDATED &&
+			hr != AUDCLNT_E_NOT_INITIALIZED) {
+		if (FAILED(hr)) {
+			return hr;
+		}
+		hr = client->Reset();
+		if (FAILED(hr)) {
+			return hr;
+		}
 	}
 	// If there is a feed/sync call waiting, wake it up so it can immediately
 	// return to the caller.

--- a/source/nvwave.py
+++ b/source/nvwave.py
@@ -1055,6 +1055,7 @@ def initialize():
 	NVDAHelper.localLib.wasPlay_create.restype = c_void_p
 	for func in (
 		NVDAHelper.localLib.wasPlay_startup,
+		NVDAHelper.localLib.wasPlay_open,
 		NVDAHelper.localLib.wasPlay_feed,
 		NVDAHelper.localLib.wasPlay_stop,
 		NVDAHelper.localLib.wasPlay_sync,

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -51,13 +51,14 @@ It is also updated with UIA enabled, when typing text and braille is tethered to
 - NVDA no longer sometimes freezes briefly when multiple sounds are played in rapid succession. (#15311)
 - NVDA will announce dialog content for more Windows 10 and 11 dialogs. (#15729, @josephsl)
 - NVDA will no longer fail to read a newly loaded page in Microsoft Edge when using UI Automation. (#15736)
-- When using say all or commands which spell text, pauses between sentences or characters no longer gradually decrease over time. (#15739)
-- NVDA no longer sometimes freezes when speaking a large amount of text. (#15752)
+- When using say all or commands which spell text, pauses between sentences or characters no longer gradually decrease over time. (#15739, @jcsteh)
+- NVDA no longer sometimes freezes when speaking a large amount of text. (#15752, @jcsteh)
 - More objects which contain useful text are detected, and text content is displayed in braille. (#15605)
-- NVDA no longer freezes briefly when multiple sounds are played in rapid succession. (#15757)
+- NVDA no longer freezes briefly when multiple sounds are played in rapid succession. (#15757, @jcsteh)
 - NVDA will not fail to start anymore when the configuration file is corrupted, but it will restore the configuration to default as it did in the past. (#15690, @CyrilleB79)
-- If the audio output device is set to something other than the default and that device becomes available again after being unavailable, NVDA will now switch back to the configured device instead of continuing to use the default device. (#15759)
+- If the audio output device is set to something other than the default and that device becomes available again after being unavailable, NVDA will now switch back to the configured device instead of continuing to use the default device. (#15759, @jcsteh)
 - It is not possible anymore to overwrite NVDA's Python console history. (#15792, @CyrilleB79)
+- NVDA now resumes audio if the configuration of the output device changes or another application releases exclusive control of the device. (#15758, #15775, @jcsteh)
 -
 
 == Changes for Developers ==


### PR DESCRIPTION
### Link to issue number:
Fixes #15758. Fixes #15775.

### Summary of the issue:
When another application takes exclusive control of NVDA's audio output device, NVDA can no longer speak. There's nothing we can do about this and it's reasonable that we log errors in this case. However, previously, when the other application released exclusive control of the device, NVDA would still fail to speak. Similar behaviour has been observed when the sampling rate is changed with certain audio drivers.

### Description of user facing changes
NVDA now resumes audio if the configuration of the output device changes or another application releases exclusive control of the device.

### Description of development approach
1. In WasapiPlayer::feed, as well as attempting reopen for AUDCLNT_E_DEVICE_INVALIDATED, reopen also for AUDCLNT_E_NOT_INITIALIZED. This handles the case that we tried to reopen previously due to an invalidated device and failed.
2. In WasapiPlayer::stop, if either of these error codes is returned by WASAPI, just ignore them. The device is clearly stopped anyway. Previously, these errors got propagated to Python, which broke SpeechManager and stopped speech from being attempted at all. That in turn meant that feed was never called and thus reopen was never attempted.
3. In WasapiPlayer::feed's reopenUsingNewDev, the hr result code was being accidentally shadowed and thus never returned to the caller. This meant that reopen failures were never raised as exceptions and thus never logged. This has now been fixed.
4. Previously, due to an oversight, we weren't setting the ctypes restype for wasPlay_open. This meant that errors from this function were silently ignored. This is really a bit of drive-by cleanup and isn't necessary to fix this bug, but should make debugging easier if we hit problems here in future.

### Testing strategy:
1. Configured REAPER to use WASAPI exclusive mode.
2. Confirmed that NVDA couldn't speak.
3. Exited REAPER.
4. Confirmed that NVDA could speak again. Before this change, it just logged lots of exceptions until restarted.

I can't reproduce the device reconfiguration problem myself, so I can't test it. However, @kirill-jjj, who reported #15758, has tested it and confirmed that it works as per https://github.com/nvaccess/nvda/pull/15783#issuecomment-1811059003.

### Known issues with pull request:
None.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
