### PR TITLE
Report unavailable (disabled) objects during object navigation

### DIFF
--- a/source/NVDAObjects/IAccessible/__init__.py
+++ b/source/NVDAObjects/IAccessible/__init__.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2006-2023 NV Access Limited, Babbage B.V.
+# Copyright (C) 2006-2023 NV Access Limited, Babbage B.V., Cyrille Bougot
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -1961,7 +1961,7 @@ class WindowRoot(GenericWindow):
 
 	def _get_presentationType(self):
 		states=self.states
-		if controlTypes.State.INVISIBLE in states or controlTypes.State.UNAVAILABLE in states:
+		if controlTypes.State.INVISIBLE in states:
 			return self.presType_unavailable
 		if not self.windowHasExtraIAccessibles(self.windowHandle):
 			return self.presType_layout

--- a/source/NVDAObjects/__init__.py
+++ b/source/NVDAObjects/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: UTF-8 -*-
 # A part of NonVisual Desktop Access (NVDA)
 # Copyright (C) 2006-2023 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Patrick Zajda, Babbage B.V.,
-# Davy Kager, Leonard de Ruijter
+# Davy Kager, Leonard de Ruijter, Cyrille Bougot
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -876,7 +876,7 @@ class NVDAObject(documentBase.TextContainerObject, baseObject.ScriptableObject, 
 
 	def _get_presentationType(self):
 		states=self.states
-		if controlTypes.State.INVISIBLE in states or controlTypes.State.UNAVAILABLE in states:
+		if controlTypes.State.INVISIBLE in states:
 			return self.presType_unavailable
 		role = self.role
 		landmark = self.landmark

--- a/source/NVDAObjects/window/__init__.py
+++ b/source/NVDAObjects/window/__init__.py
@@ -1,8 +1,7 @@
-#NVDAObjects/window.py
-#A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2006-2019 NV Access Limited, Babbage B.V., Bill Dengler
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2006-2023 NV Access Limited, Babbage B.V., Bill Dengler, Cyrille Bougot
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
 
 import re
 import ctypes
@@ -30,8 +29,6 @@ except AttributeError:
 	GhostWindowFromHungWindow=None
 
 def isUsableWindow(windowHandle):
-	if not ctypes.windll.user32.IsWindowEnabled(windowHandle):
-		return False
 	if not ctypes.windll.user32.IsWindowVisible(windowHandle):
 		return False
 	if GhostWindowFromHungWindow and ctypes.windll.user32.GhostWindowFromHungWindow(windowHandle):

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -34,6 +34,7 @@ New items have beeen added to "Help" for the NV Access "Get Help" page and Shop.
 - NVDA's support for [Poedit https://poedit.net] is overhauled for Poedit version 3 and above.
 Users of Poedit 1 are encouraged to update to Poedit 3 if they want to rely on enhanced accessibility in Poedit, such as shortcuts to read translator notes and comments. (#15313, #7303, @LeonarddeR)
 - Braille viewer and speech viewer are now disabled in secure mode. (#15680)
+- During object navigation, disabled (unavailable) objects will not be ignored anymore. (#15477, @CyrilleB79)
 -
 
 == Bug Fixes ==


### PR DESCRIPTION
### Link to issue number:
Closes #15477
### Summary of the issue:
In a GUI, disabled (greyed) items are visible to sighted users. So unless there is a good reason, blind people should be able to see them too. Greyed items convey meaning in a GUI and not being able to see them causes people to miss information conveyed by the GUI.

For example in the new audio panel, if you run NVDA from source (or probably portable), the audio ducking item is greyed out (disabled). Being allowed to find the disabled item informs the user that NVDA has an audio ducking options but that this options can not be enabled.

Unfortunately, disabled controls are ignored during object navigation.

This is also inconsistant with document review mode where disabled objects are not ignored.

### Description of user facing changes
During object navigation (complete, simple or flattened), disabled object will not be ignored anymore.

### Description of development approach
* For presentation type, do not classify objects with state `UNAVAILABLE` to `presType_unavailable`.
* For windows `isUsableWindow` does not return `False` for windows that are not enabled

### Additional notes and questions for the reviewer
1. Since objects with state UNAVAILABLE are not classified to * For presentation type, do not classify objects with state `UNAVAILABLE` to `presType_unavailable` anymore, the name `presType_unavailable` may be considered confusing. I may change it if you want but this will be an API-breaking change (maybe it's not worth it); moreover, I have no idea of suitable name.
2. I do not know if there were other reasons for excluding unavailable objects from object navigation. The initial work is in commit 9a3666a07646f93e05523bbf698801716ba27abe. @michaelDCurran any idea why unavailable objects were skipped along with invisible objects?
3. In commit 62c10a382a2e21f63f87b9b092b67b939cd45cf4 (Support for the MSAA implementations of standard IME/TSF candidate lists), `source/NVDAObjects/IAccessible/mscandui.py` has been modified to discard `controlTypes.State.UNAVAILABLE`. I do not know the reason why this was done and I wonder if it is still applicable after the modifications of this PR. @michaelDCurran (again), any hint?
4. In `source/NVDAObjects/behaviors.py:`"We don't want to handle invisible or unavailable objects" (see `Dialog.getDialogText`). I have not found dialogs where this method is called to test, but I imagine that I should also remove unavailable object filtering from there?
5. Should i add an item in API breaking changes paragraph of the change log or is the change log item enough in the Change section? I am asking because changing the object hierarchy may break some add-ons that rely on identifying objects relatively to others.

### Testing strategy:
* Manual tests: As described in #15477, tested that I can navigate to unavailable objects (disabled NVDA GUI controls, disabled edit field of standard folder name in Explorer's property window). Tests were done with all 3 types of object navigation.
* Test in alpha to check that there is no excessive unwanted verbosity or any other bugs related to the change of the navigation conditions in the object hierarchy.

### Known issues with pull request:
None
### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
