### PR TITLE
Python console small improvements

### DIFF
--- a/source/appModules/nvda.py
+++ b/source/appModules/nvda.py
@@ -20,6 +20,7 @@ import textInfos
 import braille
 import config
 from logHandler import log
+import ui
 
 if typing.TYPE_CHECKING:
 	import inputCore
@@ -73,6 +74,8 @@ class NvdaPythonConsoleUIOutputClear(ScriptableObject):
 	def script_clearOutput(self, gesture: "inputCore.InputGesture"):
 		from pythonConsole import consoleUI
 		consoleUI.clear()
+		# Translators: Description of a message spoken when clearing the Python Console output pane
+		ui.message(_("Output pane cleared"))
 
 
 class NvdaPythonConsoleUIOutputCtrl(ScriptableObject):

--- a/source/pythonConsole.py
+++ b/source/pythonConsole.py
@@ -318,8 +318,6 @@ class ConsoleUI(
 		if not (0 <= newIndex < len(self.inputHistory)):
 			# No more lines in this direction.
 			return False
-		# Update the content of the history at the current position.
-		self.inputHistory[self.inputHistoryPos] = self.inputCtrl.GetValue()
 		self.inputHistoryPos = newIndex
 		self.inputCtrl.ChangeValue(self.inputHistory[newIndex])
 		self.inputCtrl.SetInsertionPointEnd()

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -56,6 +56,7 @@ It is also updated with UIA enabled, when typing text and braille is tethered to
 - More objects which contain useful text are detected, and text content is displayed in braille. (#15605)
 - NVDA no longer freezes briefly when multiple sounds are played in rapid succession. (#15757)
 - NVDA will not fail to start anymore when the configuration file is corrupted, but it will restore the configuration to default as it did in the past. (#15690, @CyrilleB79)
+- It is not possible anymore to overwrite NVDA's Python console history. (#15792, @CyrilleB79)
 -
 
 == Changes for Developers ==


### PR DESCRIPTION
### Link to issue number:
Closes #15792
Closes #15793
### Summary of the issue:
1. When going back in the Python console history, modifying a line modifies the history. As a consequence, some previous commands cannot be found anymore in the console history.
2. The clear command control+L in the console does not provide any feedback
### Description of user facing changes
1. When going back in the console history, editing a line will not change the item in the history anymore
2. Clearing the console output with control+L will now report a confirmation message.

### Description of development approach
1. Remove the line of code that was updating an item in the history. It seemed to be done on purpose, but it seems not appropriate. Maybe it was intended for the last line? I may restore it for the last (empty) line if NV Access wants.
2. Trivial
### Testing strategy:
Manual test
### Known issues with pull request:
None
### Code Review Checklist:


- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
