### PR TITLE
Use UIA for syslistview32 controls backed by Windows Forms

### DIFF
--- a/source/UIAHandler/__init__.py
+++ b/source/UIAHandler/__init__.py
@@ -1167,6 +1167,12 @@ class UIAHandler(COMObject):
 					if isDebug:
 						log.debug("Windows console treated as non-UIA")
 					return False
+			elif windowClass == "SysListView32":
+				# #15283: SysListView3 controls in Windows Forms have a native UIA implementation and no native MSAA implementation.
+				# We need to rely on UIA for these controls, as otherwise parent/child navigation is broken.
+				# For other instances however, even when the controls advertises a native UIA implementation,
+				# the implementation is likely to be incomplete and MSAA is prefered.
+				return utils._isFrameworkIdWinForm(hwnd)
 			if isDebug:
 				log.debug("Treating as UIA")
 		else:

--- a/source/UIAHandler/__init__.py
+++ b/source/UIAHandler/__init__.py
@@ -86,9 +86,6 @@ goodUIAWindowClassNames = (
 badUIAWindowClassNames = (
 	# UIA events of candidate window interfere with MSAA events.
 	"Microsoft.IME.CandidateWindow.View",
-	# Known issue with "Reliability Monitor" in explorer.exe #15541.
-	# Task manager and mmc.exe are also affected, but have isBadUIAWindow workarounds.
-	"SysListView32",
 	"SysTreeView32",
 	"WuDuiListView",
 	"ComboBox",

--- a/source/UIAHandler/__init__.py
+++ b/source/UIAHandler/__init__.py
@@ -1168,7 +1168,7 @@ class UIAHandler(COMObject):
 						log.debug("Windows console treated as non-UIA")
 					return False
 			elif windowClass == "SysListView32":
-				# #15283: SysListView3 controls in Windows Forms have a native UIA implementation
+				# #15283: SysListView32 controls in Windows Forms have a native UIA implementation
 				# and lack a MSAA implementation.
 				# We need to rely on UIA for these controls, as otherwise parent/child navigation is broken.
 				# For other instances however, even when the control advertises a native UIA implementation,

--- a/source/UIAHandler/__init__.py
+++ b/source/UIAHandler/__init__.py
@@ -1061,7 +1061,8 @@ class UIAHandler(COMObject):
 				log.debug("Window is from NVDA's process. Treating as non-UIA")
 			return False
 		import NVDAObjects.window
-		windowClass=NVDAObjects.window.Window.normalizeWindowClassName(winUser.getClassName(hwnd))
+		rawWindowClass = winUser.getClassName(hwnd)
+		windowClass = NVDAObjects.window.Window.normalizeWindowClassName(rawWindowClass)
 		# For certain window classes, we always want to use UIA.
 		if windowClass in goodUIAWindowClassNames:
 			if isDebug:
@@ -1173,7 +1174,12 @@ class UIAHandler(COMObject):
 				# We need to rely on UIA for these controls, as otherwise parent/child navigation is broken.
 				# For other instances however, even when the control advertises a native UIA implementation,
 				# the implementation is likely to be incomplete and MSAA should be prefered.
-				return utils._isFrameworkIdWinForm(hwnd)
+				if isDebug:
+					log.debug(f"Checking framework of {rawWindowClass} window ")
+				if not utils._isFrameworkIdWinForm(hwnd):
+					if isDebug:
+						log.debug("SysListView32 treated as non-UIA")
+					return False
 			if isDebug:
 				log.debug("Treating as UIA")
 		else:

--- a/source/UIAHandler/__init__.py
+++ b/source/UIAHandler/__init__.py
@@ -1168,10 +1168,11 @@ class UIAHandler(COMObject):
 						log.debug("Windows console treated as non-UIA")
 					return False
 			elif windowClass == "SysListView32":
-				# #15283: SysListView3 controls in Windows Forms have a native UIA implementation and no native MSAA implementation.
+				# #15283: SysListView3 controls in Windows Forms have a native UIA implementation
+				# and lack a MSAA implementation.
 				# We need to rely on UIA for these controls, as otherwise parent/child navigation is broken.
-				# For other instances however, even when the controls advertises a native UIA implementation,
-				# the implementation is likely to be incomplete and MSAA is prefered.
+				# For other instances however, even when the control advertises a native UIA implementation,
+				# the implementation is likely to be incomplete and MSAA should be prefered.
 				return utils._isFrameworkIdWinForm(hwnd)
 			if isDebug:
 				log.debug("Treating as UIA")

--- a/source/UIAHandler/utils.py
+++ b/source/UIAHandler/utils.py
@@ -368,3 +368,18 @@ def _shouldSelectivelyRegister() -> bool:
 def _shouldUseWindowsTerminalNotifications() -> bool:
 	"Determines whether to use notifications for new text reporting in Windows Terminal."
 	return config.conf["terminals"]["wtStrategy"] == WindowsTerminalStrategyFlag.NOTIFICATIONS
+
+
+def _isFrameworkIdWinForm(hwnd: int) -> bool:
+	"""
+	Returns whether this window belongs to an elemnt that originates from the Windows Forms framework (WinForm).
+	This is used to determine whether a native UIA implementation should be used for SysListView32 controls.
+	"""
+	try:
+		UIAElement = UIAHandler.handler.clientObject.ElementFromHandleBuildCache(
+			hwnd, UIAHandler.handler.baseCacheRequest
+		)
+		return UIAElement.cachedFrameworkID == "WinForm"
+	except COMError:
+		log.exception(f"Couldn't get FrameworkId for window {hwnd}")
+		return False

--- a/source/UIAHandler/utils.py
+++ b/source/UIAHandler/utils.py
@@ -372,7 +372,7 @@ def _shouldUseWindowsTerminalNotifications() -> bool:
 
 def _isFrameworkIdWinForm(hwnd: int) -> bool:
 	"""
-	Returns whether this window belongs to an elemnt that originates from the Windows Forms framework (WinForm).
+	Returns whether this window belongs to an element that originates from the Windows Forms framework (WinForm).
 	This is used to determine whether a native UIA implementation should be used for SysListView32 controls.
 	"""
 	try:

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -256,7 +256,6 @@ There's also been bug fixes for the Add-on Store, Microsoft Office, Microsoft Ed
   - Fixed bug where add-ons cannot be installed if a previous download failed or was cancelled. (#15469)
   - Fixed issues with handling incompatible add-ons when upgrading NVDA. (#15414, #15412, #15437)
   -
-- Fixed support for System List view (``SysListView32``) controls in Windows Forms applications. (#15283)
 - NVDA once again announces calculation results in the Windows 32bit calculator on Server, LTSC and LTSB versions of Windows. (#15230)
 - NVDA no longer ignores focus changes when a nested window (grand child window) gets focus. (#15432)
 - Fixed a potential cause of crashing during NVDA startup. (#15517)

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -56,6 +56,7 @@ It is also updated with UIA enabled, when typing text and braille is tethered to
 - More objects which contain useful text are detected, and text content is displayed in braille. (#15605)
 - NVDA no longer freezes briefly when multiple sounds are played in rapid succession. (#15757)
 - NVDA will not fail to start anymore when the configuration file is corrupted, but it will restore the configuration to default as it did in the past. (#15690, @CyrilleB79)
+- Fixed support for System List view (``SysListView32``) controls in Windows Forms applications. (#15283, @LeonarddeR)
 -
 
 == Changes for Developers ==

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -256,6 +256,7 @@ There's also been bug fixes for the Add-on Store, Microsoft Office, Microsoft Ed
   - Fixed bug where add-ons cannot be installed if a previous download failed or was cancelled. (#15469)
   - Fixed issues with handling incompatible add-ons when upgrading NVDA. (#15414, #15412, #15437)
   -
+- Fixed support for System List view (``SysListView32``) controls in Windows Forms applications. (#15283)
 - NVDA once again announces calculation results in the Windows 32bit calculator on Server, LTSC and LTSB versions of Windows. (#15230)
 - NVDA no longer ignores focus changes when a nested window (grand child window) gets focus. (#15432)
 - Fixed a potential cause of crashing during NVDA startup. (#15517)


### PR DESCRIPTION
### Link to issue number:
Fixes #15283 

### Summary of the issue:
In Windows Forms applications, errors occur in list view controls.

### Description of user facing changes
Win forms project in #15283 now works as expected for the most part.

### Description of development approach
Rather than the previous approach where we removed the listing of SysListView32 from the list of bad UIA class names, this adds a specific utility function to checks for a Framework Id of WinForm. If that's the case, we use UIA for SysListView32, as it seems these implementations are mature enough.

### Testing strategy:
Tested with the win forms project in #15283 

### Known issues with pull request:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
