### PR TITLE
Add an "on-demand" speech mode

### DIFF
--- a/projectDocs/dev/developerGuide/developerGuide.t2t
+++ b/projectDocs/dev/developerGuide/developerGuide.t2t
@@ -532,6 +532,8 @@ The following keyword arguments can be used when applying the script decorator:
 - resumeSayAllMode: The say all mode that should be resumed when active before executing this script.
   The constants for say all mode can be found in the CURSOR enum in speech.sayAll.
   If resumeSayAllMode is not specified, say all does not resume after this script.
+- speakOnDemand: A boolean indicating whether this script should produce speech when called while speech mode is "on demand".
+  This option defaults to False.
 -
 
 Though the script decorator makes the script definition process a lot easier, there are more ways of binding gestures and setting script properties.

--- a/projectDocs/dev/developerGuide/developerGuide.t2t
+++ b/projectDocs/dev/developerGuide/developerGuide.t2t
@@ -532,7 +532,7 @@ The following keyword arguments can be used when applying the script decorator:
 - resumeSayAllMode: The say all mode that should be resumed when active before executing this script.
   The constants for say all mode can be found in the CURSOR enum in speech.sayAll.
   If resumeSayAllMode is not specified, say all does not resume after this script.
-- speakOnDemand: A boolean indicating whether this script should produce speech when called while speech mode is "on demand".
+- speakOnDemand: A boolean indicating whether this script should produce speech when called while speech mode is "on-demand".
   This option defaults to False.
 -
 

--- a/source/NVDAObjects/IAccessible/winword.py
+++ b/source/NVDAObjects/IAccessible/winword.py
@@ -275,6 +275,12 @@ class WordDocument(IAccessible, EditableTextWithoutAutoSelectDetection, winWordW
 			speech.speakTextInfo(info, reason=controlTypes.OutputReason.FOCUS)
 			braille.handler.handleCaretMove(self)
 
+	@script(
+		# Translators: a description for a script
+		description=_("Reports the text of the comment where the System caret is located."),
+		gesture="kb:NVDA+alt+c",
+		speakOnDemand=True,
+	)
 	def script_reportCurrentComment(self,gesture):
 		info=self.makeTextInfo(textInfos.POSITION_CARET)
 		info.expand(textInfos.UNIT_CHARACTER)
@@ -294,8 +300,6 @@ class WordDocument(IAccessible, EditableTextWithoutAutoSelectDetection, winWordW
 						return
 		# Translators: a message when there is no comment to report in Microsoft Word
 		ui.message(_("No comments"))
-	# Translators: a description for a script
-	script_reportCurrentComment.__doc__=_("Reports the text of the comment where the System caret is located.")
 
 	def _moveInTable(self,row=True,forward=True):
 		info=self.makeTextInfo(textInfos.POSITION_CARET)
@@ -423,7 +427,6 @@ class WordDocument(IAccessible, EditableTextWithoutAutoSelectDetection, winWordW
 		"kb:alt+end":"caret_moveByCell",
 		"kb:alt+pageUp":"caret_moveByCell",
 		"kb:alt+pageDown":"caret_moveByCell",
-		"kb:NVDA+alt+c":"reportCurrentComment",
 	}
 
 

--- a/source/NVDAObjects/IAccessible/winword.py
+++ b/source/NVDAObjects/IAccessible/winword.py
@@ -277,7 +277,7 @@ class WordDocument(IAccessible, EditableTextWithoutAutoSelectDetection, winWordW
 
 	@script(
 		# Translators: a description for a script
-		description=_("Reports the text of the comment where the System caret is located."),
+		description=_("Reports the text of the comment where the system caret is located."),
 		gesture="kb:NVDA+alt+c",
 		speakOnDemand=True,
 	)

--- a/source/NVDAObjects/UIA/wordDocument.py
+++ b/source/NVDAObjects/UIA/wordDocument.py
@@ -600,7 +600,8 @@ class WordDocument(UIADocumentWithTableNavigation,WordDocumentNode,WordDocumentB
 	@script(
 		gesture="kb:NVDA+alt+c",
 		# Translators: a description for a script that reports the comment at the caret.
-		description=_("Reports the text of the comment where the System caret is located.")
+		description=_("Reports the text of the comment where the System caret is located."),
+		speakOnDemand=True,
 	)
 	def script_reportCurrentComment(self,gesture):
 		caretInfo=self.makeTextInfo(textInfos.POSITION_CARET)

--- a/source/NVDAObjects/UIA/wordDocument.py
+++ b/source/NVDAObjects/UIA/wordDocument.py
@@ -600,7 +600,7 @@ class WordDocument(UIADocumentWithTableNavigation,WordDocumentNode,WordDocumentB
 	@script(
 		gesture="kb:NVDA+alt+c",
 		# Translators: a description for a script that reports the comment at the caret.
-		description=_("Reports the text of the comment where the System caret is located."),
+		description=_("Reports the text of the comment where the system caret is located."),
 		speakOnDemand=True,
 	)
 	def script_reportCurrentComment(self,gesture):

--- a/source/NVDAObjects/window/excel.py
+++ b/source/NVDAObjects/window/excel.py
@@ -1671,7 +1671,9 @@ class ExcelCell(ExcelBase):
 	@script(
 		# Translators: the description  for a script for Excel
 		description=_("Reports the note on the current cell"),
-		gesture="kb:NVDA+alt+c")
+		gesture="kb:NVDA+alt+c",
+		speakOnDemand=True,
+	)
 	def script_reportComment(self,gesture):
 		commentObj=self.excelCellObject.comment
 		text=commentObj.text() if commentObj else None

--- a/source/appModules/foobar2000.py
+++ b/source/appModules/foobar2000.py
@@ -1,6 +1,6 @@
 # A part of NonVisual Desktop Access (NVDA)
 # Copyright (C) 2009-2023 NV Access Limited, Aleksey Sadovoy, James Teh, Joseph Lee, Tuukka Ojala,
-# Bram Duvigneau
+# Bram Duvigneau, Cyrille Bougot
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -19,6 +19,7 @@ from datetime import timedelta
 from logHandler import log
 import ui
 from utils.localisation import TimeOutputFormat
+from scriptHandler import script
 
 if TYPE_CHECKING:
 	from inputCore import InputGesture  # noqa: F401
@@ -146,6 +147,13 @@ class AppModule(appModuleHandler.AppModule):
 			ui.message(_("No track playing"))
 		return elapsedAndTotalTime
 
+	@script(
+		# Translators: The description of an NVDA command for reading the remaining time of the currently playing
+		# track in Foobar 2000.
+		description=_("Reports the remaining time of the currently playing track, if any"),
+		gesture="kb:control+shift+r",
+		speakOnDemand=True,
+	)
 	def script_reportRemainingTime(self, gesture: "InputGesture"):
 		elapsedTime, totalTime = self.getElapsedAndTotalIfPlaying()
 		parsedElapsedTime = None
@@ -163,9 +171,13 @@ class AppModule(appModuleHandler.AppModule):
 			# Translators: Reported if the remaining time can not be calculated in Foobar2000
 			ui.message(_("Remaining time not available"))
 
-	# Translators: The description of an NVDA command for reading the remaining time of the currently playing track in Foobar 2000.
-	script_reportRemainingTime.__doc__ = _("Reports the remaining time of the currently playing track, if any")
-
+	@script(
+		# Translators: The description of an NVDA command for reading the elapsed time of the currently playing
+		# track in Foobar 2000.
+		description=_("Reports the elapsed time of the currently playing track, if any"),
+		gesture="kb:control+shift+e",
+		speakOnDemand=True,
+	)
 	def script_reportElapsedTime(self, gesture: "InputGesture"):
 		elapsedTime = self.getElapsedAndTotalIfPlaying().elapsed
 		if elapsedTime:
@@ -177,9 +189,13 @@ class AppModule(appModuleHandler.AppModule):
 			# Translators: Reported if the elapsed time is not available in Foobar2000
 			ui.message(_("Elapsed time not available"))
 
-	# Translators: The description of an NVDA command for reading the elapsed time of the currently playing track in Foobar 2000.
-	script_reportElapsedTime.__doc__ = _("Reports the elapsed time of the currently playing track, if any")
-
+	@script(
+		# Translators: The description of an NVDA command for reading the length of the currently playing track in
+		# Foobar 2000.
+		description=_("Reports the length of the currently playing track, if any"),
+		gesture="kb:control+shift+t",
+		speakOnDemand=True,
+	)
 	def script_reportTotalTime(self, gesture: "InputGesture"):
 		totalTime = self.getElapsedAndTotalIfPlaying().total
 		if totalTime:
@@ -190,12 +206,3 @@ class AppModule(appModuleHandler.AppModule):
 		else:
 			# Translators: Reported if the total time is not available in Foobar2000
 			ui.message(_("Total time not available"))
-
-	# Translators: The description of an NVDA command for reading the length of the currently playing track in Foobar 2000.
-	script_reportTotalTime.__doc__ = _("Reports the length of the currently playing track, if any")
-
-	__gestures = {
-		"kb:control+shift+r": "reportRemainingTime",
-		"kb:control+shift+e": "reportElapsedTime",
-		"kb:control+shift+t": "reportTotalTime",
-	}

--- a/source/appModules/miranda32.py
+++ b/source/appModules/miranda32.py
@@ -112,6 +112,7 @@ class AppModule(appModuleHandler.AppModule):
 	@script(
 		# Translators: The description of an NVDA command to view one of the recent messages.
 		description=_("Displays one of the recent messages"),
+		gestures=[f"kb:NVDA+control+{n}" for n in range(1, MessageHistoryLength + 1)],
 		speakOnDemand=True,
 	)
 	def script_readMessage(self,gesture):
@@ -121,11 +122,6 @@ class AppModule(appModuleHandler.AppModule):
 		else:
 			# Translators: This is presented to inform the user that no instant message has been received.
 			ui.message(_("No message yet"))
-
-	def __init__(self, *args, **kwargs):
-		super(AppModule, self).__init__(*args, **kwargs)
-		for n in range(1, self.MessageHistoryLength + 1):
-			self.bindGesture("kb:NVDA+control+%s" % n, "readMessage")
 
 class mirandaIMContactList(IAccessible):
 

--- a/source/appModules/miranda32.py
+++ b/source/appModules/miranda32.py
@@ -1,9 +1,8 @@
-# -*- coding: UTF-8 -*-
-#appModules/miranda32.py
-#A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2006-2019 NV Access Limited, Aleksey Sadovoy, Peter Vágner, Joseph Lee, Bill Dengler
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2006-2023 NV Access Limited, Aleksey Sadovoy, Peter Vágner, Joseph Lee, Bill Dengler,
+# Cyrille Bougot
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
 
 import ui
 import config
@@ -16,7 +15,7 @@ import appModuleHandler
 import speech
 import braille
 import controlTypes
-from scriptHandler import isScriptWaiting
+from scriptHandler import isScriptWaiting, script
 import api
 import mouseHandler
 import oleacc
@@ -110,6 +109,11 @@ class AppModule(appModuleHandler.AppModule):
 		elif (obj.windowControlID in ANSILOGS) and (obj.windowClassName=="RichEdit20A"):
 			obj._isWindowUnicode=False
 
+	@script(
+		# Translators: The description of an NVDA command to view one of the recent messages.
+		description=_("Displays one of the recent messages"),
+		speakOnDemand=True,
+	)
 	def script_readMessage(self,gesture):
 		num=int(gesture.mainKeyName[-1])
 		if len(self.lastMessages)>num-1:
@@ -117,8 +121,6 @@ class AppModule(appModuleHandler.AppModule):
 		else:
 			# Translators: This is presented to inform the user that no instant message has been received.
 			ui.message(_("No message yet"))
-	# Translators: The description of an NVDA command to view one of the recent messages.
-	script_readMessage.__doc__=_("Displays one of the recent messages")
 
 	def __init__(self, *args, **kwargs):
 		super(AppModule, self).__init__(*args, **kwargs)

--- a/source/appModules/poedit.py
+++ b/source/appModules/poedit.py
@@ -1,7 +1,7 @@
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-# Copyright (C) 2012-2023 Mesar Hameed, NV Access Limited, Leonard de Ruijter, Rui Fontes
+# Copyright (C) 2012-2023 Mesar Hameed, NV Access Limited, Leonard de Ruijter, Rui Fontes, Cyrille Bougot
 
 """App module for Poedit 3.4+.
 """
@@ -146,6 +146,7 @@ class AppModule(appModuleHandler.AppModule):
 			"Reports any notes for translators. If pressed twice, presents the notes in browse mode",
 		),
 		gesture="kb:control+shift+a",
+		speakOnDemand=True,
 	)
 	def script_reportAutoCommentsWindow(self, gesture):
 		self._reportControlScriptHelper(
@@ -171,6 +172,7 @@ class AppModule(appModuleHandler.AppModule):
 			"If pressed twice, presents the comment in browse mode",
 		),
 		gesture="kb:control+shift+c",
+		speakOnDemand=True,
 	)
 	def script_reportCommentsWindow(self, gesture):
 		self._reportControlScriptHelper(
@@ -195,6 +197,7 @@ class AppModule(appModuleHandler.AppModule):
 			"Reports the old source text, if any. If pressed twice, presents the text in browse mode",
 		),
 		gesture="kb:control+shift+o",
+		speakOnDemand=True,
 	)
 	def script_reportOldSourceText(self, gesture):
 		self._reportControlScriptHelper(
@@ -217,6 +220,7 @@ class AppModule(appModuleHandler.AppModule):
 			"Reports a translation warning, if any. If pressed twice, presents the warning in browse mode",
 		),
 		gesture="kb:control+shift+w",
+		speakOnDemand=True,
 	)
 	def script_reportTranslationWarning(self, gesture):
 		self._reportControlScriptHelper(

--- a/source/appModules/vipmud.py
+++ b/source/appModules/vipmud.py
@@ -21,14 +21,11 @@ class AppModule(appModuleHandler.AppModule):
 	def chooseNVDAObjectOverlayClasses(self, obj, clsList):
 		if controlTypes.State.READONLY in obj.states:
 			clsList.insert(0, MudText)
-	def __init__(self, *args, **kwargs):
-		super(AppModule, self).__init__(*args, **kwargs)
-		for n in range(1, self.historyLength +1):
-			self.bindGesture("kb:control+%s" % n, "readMessage")
 
 	@script(
 		# Translators: The description of an NVDA command to view one of the recent messages.
 		description=_("Displays one of the recent messages"),
+		gestures=[f"kb:control+{n}" for n in range(1, historyLength + 1)],
 		speakOnDemand=True,
 	)
 	def script_readMessage(self,gesture):

--- a/source/appModules/vipmud.py
+++ b/source/appModules/vipmud.py
@@ -1,13 +1,13 @@
-#appModules/vipmud.py
-#A part of NonVisual Desktop Access (NVDA)
-#Copyright (C) 2011 Willem Venter and Rynhardt Kruger
-#This file is covered by the GNU General Public License.
-#See the file COPYING for more details.
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2011-2023 Willem Venter and Rynhardt Kruger, Cyrille Bougot
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
 
 from NVDAObjects.window import edit
 import ui
 import appModuleHandler
 import controlTypes
+from scriptHandler import script
 
 """
 App module for VIP Mud
@@ -25,13 +25,18 @@ class AppModule(appModuleHandler.AppModule):
 		super(AppModule, self).__init__(*args, **kwargs)
 		for n in range(1, self.historyLength +1):
 			self.bindGesture("kb:control+%s" % n, "readMessage")
+
+	@script(
+		# Translators: The description of an NVDA command to view one of the recent messages.
+		description=_("Displays one of the recent messages"),
+		speakOnDemand=True,
+	)
 	def script_readMessage(self,gesture):
 		num=int(gesture.mainKeyName[-1])
 		try:
 			ui.message(self.msgs[num-1])
 		except IndexError:
 			ui.message(_("No message yet"))
-	script_readMessage.__doc__=_("Displays one of the recent messages")
 
 
 class MudText(edit.Edit):

--- a/source/documentBase.py
+++ b/source/documentBase.py
@@ -512,6 +512,8 @@ class DocumentWithTableNavigation(TextContainerObject,ScriptableObject):
 		# Translators: the description for the sayAll row command
 		"Reads the row horizontally from the current cell rightwards to the last cell in the row."
 	)
+	script_sayAllRow.speakOnDemand = True
+	
 
 	def script_sayAllColumn(self, gesture):
 		self._tableSayAll(_Movement.NEXT, _Axis.ROW)
@@ -519,6 +521,7 @@ class DocumentWithTableNavigation(TextContainerObject,ScriptableObject):
 		# Translators: the description for the sayAll row command
 		"Reads the column vertically from the current cell downwards to the last cell in the column."
 	)
+	script_sayAllColumn.speakOnDemand = True
 
 	def script_speakRow(self, gesture):
 		self._tableSayAll(_Movement.FIRST, _Axis.COLUMN, updateCaret=False)
@@ -527,6 +530,7 @@ class DocumentWithTableNavigation(TextContainerObject,ScriptableObject):
 		"Reads the current row horizontally from left to right "
 		"without moving the system caret."
 	)
+	script_speakRow.speakOnDemand = True
 
 	def script_speakColumn(self, gesture):
 		self._tableSayAll(_Movement.FIRST, _Axis.ROW, updateCaret=False)
@@ -535,6 +539,7 @@ class DocumentWithTableNavigation(TextContainerObject,ScriptableObject):
 		"Reads the current column vertically from top to bottom "
 		"without moving the system caret."
 	)
+	script_speakColumn.speakOnDemand = True
 
 	def script_toggleIncludeLayoutTables(self,gesture):
 		# documentBase is a core module and should not depend on UI, so it is imported at run-time. (#12404)

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -185,7 +185,8 @@ class GlobalCommands(ScriptableObject):
 			"Pressing three times will spell the line using character descriptions."
 		),
 		category=SCRCAT_SYSTEMCARET,
-		gestures=("kb(desktop):NVDA+upArrow", "kb(laptop):NVDA+l")
+		gestures=("kb(desktop):NVDA+upArrow", "kb(laptop):NVDA+l"),
+		speakOnDemand=True,
 	)
 	def script_reportCurrentLine(self,gesture):
 		obj=api.getFocusObject()
@@ -259,7 +260,8 @@ class GlobalCommands(ScriptableObject):
 			"Pressing three times spells it using character descriptions."
 		),
 		category=SCRCAT_SYSTEMCARET,
-		gestures=("kb(desktop):NVDA+shift+upArrow", "kb(laptop):NVDA+shift+s")
+		gestures=("kb(desktop):NVDA+shift+upArrow", "kb(laptop):NVDA+shift+s"),
+		speakOnDemand=True,
 	)
 	def script_reportCurrentSelection(self,gesture):
 		obj=api.getFocusObject()
@@ -285,7 +287,8 @@ class GlobalCommands(ScriptableObject):
 		# Translators: Input help mode message for report date and time command.
 		description=_("If pressed once, reports the current time. If pressed twice, reports the current date"),
 		category=SCRCAT_SYSTEM,
-		gesture="kb:NVDA+f12"
+		gesture="kb:NVDA+f12",
+		speakOnDemand=True,
 	)
 	def script_dateTime(self,gesture):
 		if scriptHandler.getLastScriptRepeatCount()==0:
@@ -1108,7 +1111,8 @@ class GlobalCommands(ScriptableObject):
 			"and pressing three times Copies name and value of this object to the clipboard"
 		),
 		category=SCRCAT_OBJECTNAVIGATION,
-		gestures=("kb:NVDA+numpad5", "kb(laptop):NVDA+shift+o")
+		gestures=("kb:NVDA+numpad5", "kb(laptop):NVDA+shift+o"),
+		speakOnDemand=True,
 	)
 	def script_navigatorObject_current(self, gesture: inputCore.InputGesture):
 		curObject=api.getNavigatorObject()
@@ -1173,6 +1177,7 @@ class GlobalCommands(ScriptableObject):
 			"or location of the navigator object if there is no text under review cursor."
 		),
 		category=SCRCAT_OBJECTNAVIGATION,
+		speakOnDemand=True,
 	)
 	def script_reportReviewCursorLocation(self, gesture):
 		self._reportLocationText((api.getReviewPosition(), api.getNavigatorObject()))
@@ -1183,6 +1188,7 @@ class GlobalCommands(ScriptableObject):
 			"Reports information about the location of the current navigator object."
 		),
 		category=SCRCAT_OBJECTNAVIGATION,
+		speakOnDemand=True,
 	)
 	def script_reportCurrentNavigatorObjectLocation(self, gesture):
 		self._reportLocationText((api.getNavigatorObject(),))
@@ -1195,6 +1201,7 @@ class GlobalCommands(ScriptableObject):
 			"or location of the currently focused object if there is no caret."
 		),
 		category=SCRCAT_SYSTEMCARET,
+		speakOnDemand=True,
 	)
 	def script_reportCaretLocation(self, gesture):
 		self._reportLocationText(
@@ -1208,6 +1215,7 @@ class GlobalCommands(ScriptableObject):
 			"Reports information about the location of the currently focused object."
 		),
 		category=SCRCAT_FOCUS,
+		speakOnDemand=True,
 	)
 	def script_reportFocusObjectLocation(self, gesture):
 		self._reportLocationText((api.getFocusObject(),))
@@ -1219,7 +1227,8 @@ class GlobalCommands(ScriptableObject):
 			"Pressing twice may provide further detail."
 		),
 		category=SCRCAT_OBJECTNAVIGATION,
-		gestures=("kb:NVDA+shift+numpadDelete", "kb(laptop):NVDA+shift+delete")
+		gestures=("kb:NVDA+shift+numpadDelete", "kb(laptop):NVDA+shift+delete"),
+		speakOnDemand=True,
 	)
 	def script_navigatorObject_currentDimensions(self, gesture):
 		if scriptHandler.getLastScriptRepeatCount() == 0:
@@ -1236,7 +1245,8 @@ class GlobalCommands(ScriptableObject):
 			"Pressing twice may provide further detail."
 		),
 		category=SCRCAT_SYSTEMCARET,
-		gestures=("kb:NVDA+numpadDelete", "kb(laptop):NVDA+delete")
+		gestures=("kb:NVDA+numpadDelete", "kb(laptop):NVDA+delete"),
+		speakOnDemand=True,
 	)
 	def script_caretPos_currentDimensions(self, gesture):
 		if scriptHandler.getLastScriptRepeatCount() == 0:
@@ -1554,7 +1564,8 @@ class GlobalCommands(ScriptableObject):
 			"Pressing three times will spell the line using character descriptions."
 		),
 		category=SCRCAT_TEXTREVIEW,
-		gestures=("kb:numpad8", "kb(laptop):NVDA+shift+.")
+		gestures=("kb:numpad8", "kb(laptop):NVDA+shift+."),
+		speakOnDemand=True,
 	)
 	def script_review_currentLine(self, gesture: inputCore.InputGesture):
 		info=api.getReviewPosition().copy()
@@ -1741,7 +1752,8 @@ class GlobalCommands(ScriptableObject):
 			"Pressing three times spells the word using character descriptions"
 		),
 		category=SCRCAT_TEXTREVIEW,
-		gestures=("kb:numpad5", "kb(laptop):NVDA+control+.", "ts(text):hoverUp")
+		gestures=("kb:numpad5", "kb(laptop):NVDA+control+.", "ts(text):hoverUp"),
+		speakOnDemand=True,
 	)
 	def script_review_currentWord(self, gesture: inputCore.InputGesture):
 		info=api.getReviewPosition().copy()
@@ -1871,7 +1883,8 @@ class GlobalCommands(ScriptableObject):
 			"Pressing three times reports the numeric value of the character in decimal and hexadecimal"
 		),
 		category=SCRCAT_TEXTREVIEW,
-		gestures=("kb:numpad2", "kb(laptop):NVDA+.")
+		gestures=("kb:numpad2", "kb(laptop):NVDA+."),
+		speakOnDemand=True,
 	)
 	def script_review_currentCharacter(self, gesture: inputCore.InputGesture):
 		info=api.getReviewPosition().copy()
@@ -1982,7 +1995,8 @@ class GlobalCommands(ScriptableObject):
 	@script(
 		# Translators: Input help mode message for Review Current Symbol command.
 		description=_("Reports the symbol where the review cursor is positioned. Pressed twice, shows the symbol and the text used to speak it in browse mode"),
-		category=SCRCAT_TEXTREVIEW
+		category=SCRCAT_TEXTREVIEW,
+		speakOnDemand=True,
 	)
 	def script_review_currentSymbol(self,gesture):
 		info=api.getReviewPosition().copy()
@@ -2265,7 +2279,8 @@ class GlobalCommands(ScriptableObject):
 	@script(
 		# Translators: Input help mode message for report formatting command.
 		description=_("Reports formatting info for the current review cursor position."),
-		category=SCRCAT_TEXTREVIEW
+		category=SCRCAT_TEXTREVIEW,
+		speakOnDemand=True,
 	)
 	def script_reportFormattingAtReview(self, gesture):
 		self._reportFormattingHelper(api.getReviewPosition(), False)
@@ -2285,7 +2300,8 @@ class GlobalCommands(ScriptableObject):
 			" If pressed twice, presents the information in browse mode"
 		),
 		category=SCRCAT_TEXTREVIEW,
-		gesture="kb:NVDA+shift+f"
+		gesture="kb:NVDA+shift+f",
+		speakOnDemand=True,
 	)
 	def script_reportFormatting(self, gesture):
 		repeats = scriptHandler.getLastScriptRepeatCount()
@@ -2297,7 +2313,8 @@ class GlobalCommands(ScriptableObject):
 	@script(
 		# Translators: Input help mode message for report formatting at caret command.
 		description=_("Reports formatting info for the text under the caret."),
-		category=SCRCAT_SYSTEMCARET
+		category=SCRCAT_SYSTEMCARET,
+		speakOnDemand=True,
 	)
 	def script_reportFormattingAtCaret(self, gesture):
 		self._reportFormattingHelper(self._getTIAtCaret(True), False)
@@ -2317,7 +2334,8 @@ class GlobalCommands(ScriptableObject):
 			" If pressed twice, presents the information in browse mode"
 		),
 		category=SCRCAT_SYSTEMCARET,
-		gesture="kb:NVDA+f"
+		gesture="kb:NVDA+f",
+		speakOnDemand=True,
 	)
 	def script_reportOrShowFormattingAtCaret(self, gesture):
 		repeats = scriptHandler.getLastScriptRepeatCount()
@@ -2381,6 +2399,7 @@ class GlobalCommands(ScriptableObject):
 			"Report summary of any annotation details at the system caret."
 		),
 		category=SCRCAT_SYSTEMCARET,
+		speakOnDemand=True,
 	)
 	def script_reportDetailsSummary(self, gesture: inputCore.InputGesture):
 		"""Report the annotation details summary for the single character under the caret or the object with
@@ -2448,7 +2467,8 @@ class GlobalCommands(ScriptableObject):
 			"Pressing three times spells it using character descriptions."
 		),
 		category=SCRCAT_FOCUS,
-		gesture="kb:NVDA+tab"
+		gesture="kb:NVDA+tab",
+		speakOnDemand=True,
 	)
 	def script_reportCurrentFocus(self, gesture: inputCore.InputGesture):
 		focusObject=api.getFocusObject()
@@ -2527,6 +2547,7 @@ class GlobalCommands(ScriptableObject):
 			"Reads the current application status bar."
 		),
 		category=SCRCAT_FOCUS,
+		speakOnDemand=True,
 	)
 	def script_readStatusLine(self, gesture):
 		text = self._getStatusBarText()
@@ -2544,6 +2565,7 @@ class GlobalCommands(ScriptableObject):
 			"Spells the current application status bar."
 		),
 		category=SCRCAT_FOCUS,
+		speakOnDemand=True,
 	)
 	def script_spellStatusLine(self, gesture):
 		text = self._getStatusBarText()
@@ -2597,7 +2619,8 @@ class GlobalCommands(ScriptableObject):
 			"If pressed three times, copies the status bar to the clipboard"
 		),
 		category=SCRCAT_FOCUS,
-		gestures=("kb(desktop):NVDA+end", "kb(laptop):NVDA+shift+end")
+		gestures=("kb(desktop):NVDA+end", "kb(laptop):NVDA+shift+end"),
+		speakOnDemand=True,
 	)
 	def script_reportStatusLine(self, gesture):
 		text = self._getStatusBarText()
@@ -2619,6 +2642,7 @@ class GlobalCommands(ScriptableObject):
 		),
 		category=SCRCAT_FOCUS,
 		gestures=("kb:shift+numpad2", "kb(laptop):NVDA+control+shift+."),
+		speakOnDemand=True,
 	)
 	def script_reportFocusObjectAccelerator(self, gesture: inputCore.InputGesture) -> None:
 		obj = api.getFocusObject()
@@ -2706,7 +2730,7 @@ class GlobalCommands(ScriptableObject):
 		# Translators: Input help mode message for read foreground object command (usually the foreground window).
 		description=_("Reads all controls in the active window"),
 		category=SCRCAT_FOCUS,
-		gesture="kb:NVDA+b"
+		gesture="kb:NVDA+b",
 	)
 	def script_speakForeground(self,gesture):
 		obj=api.getForegroundObject()
@@ -2901,7 +2925,8 @@ class GlobalCommands(ScriptableObject):
 		# Translators: Input help mode message for report battery status command.
 		description=_("Reports battery status and time remaining if AC is not plugged in"),
 		category=SCRCAT_SYSTEM,
-		gesture="kb:NVDA+shift+b"
+		gesture="kb:NVDA+shift+b",
+		speakOnDemand=True,
 	)
 	def script_say_battery_status(self, gesture: inputCore.InputGesture) -> None:
 		reportCurrentBatteryStatus()
@@ -2926,7 +2951,8 @@ class GlobalCommands(ScriptableObject):
 			"Speaks the filename of the active application along with the name of the currently loaded appModule"
 		),
 		category=SCRCAT_TOOLS,
-		gesture="kb:NVDA+control+f1"
+		gesture="kb:NVDA+control+f1",
+		speakOnDemand=True,
 	)
 	def script_reportAppModuleInfo(self,gesture):
 		focus=api.getFocusObject()
@@ -3118,7 +3144,8 @@ class GlobalCommands(ScriptableObject):
 	@script(
 		# Translators: Input help mode message for the report current configuration profile command.
 		description=_("Reports the name of the current NVDA configuration profile"),
-		category=SCRCAT_CONFIG
+		category=SCRCAT_CONFIG,
+		speakOnDemand=True,
 	)
 	def script_reportActiveConfigurationProfile(self, gesture):
 		activeProfileName = config.conf.profiles[-1].name
@@ -3409,7 +3436,8 @@ class GlobalCommands(ScriptableObject):
 			"Pressing three times spells it using character descriptions."
 		),
 		category=SCRCAT_SYSTEM,
-		gesture="kb:NVDA+c"
+		gesture="kb:NVDA+c",
+		speakOnDemand=True,
 	)
 	def script_reportClipboardText(self,gesture):
 		try:
@@ -3803,7 +3831,8 @@ class GlobalCommands(ScriptableObject):
 			"If pressed twice, shows the URL in a window for easier review."
 		),
 		gesture="kb:NVDA+k",
-		category=SCRCAT_TOOLS
+		category=SCRCAT_TOOLS,
+		speakOnDemand=True,
 	)
 	def script_reportLinkDestination(
 			self, gesture: inputCore.InputGesture, forceBrowseable: bool = False

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -2161,7 +2161,8 @@ class GlobalCommands(ScriptableObject):
 			" moving the review cursor as it goes"
 		),
 		category=SCRCAT_TEXTREVIEW,
-		gestures=("kb:numpadPlus", "kb(laptop):NVDA+shift+a", "ts(text):3finger_flickDown")
+		gestures=("kb:numpadPlus", "kb(laptop):NVDA+shift+a", "ts(text):3finger_flickDown"),
+		speakOnDemand=True,
 	)
 	def script_review_sayAll(self, gesture: inputCore.InputGesture):
 		# This script is available on the lock screen via getSafeScripts
@@ -2172,7 +2173,8 @@ class GlobalCommands(ScriptableObject):
 		# Translators: Input help mode message for say all with system caret command.
 		description=_("Reads from the system caret up to the end of the text, moving the caret as it goes"),
 		category=SCRCAT_SYSTEMCARET,
-		gestures=("kb(desktop):NVDA+downArrow", "kb(laptop):NVDA+a")
+		gestures=("kb(desktop):NVDA+downArrow", "kb(laptop):NVDA+a"),
+		speakOnDemand=True,
 	)
 	def script_sayAll(self, gesture: inputCore.InputGesture):
 		sayAll.SayAllHandler.readText(sayAll.CURSOR.CARET)
@@ -2734,6 +2736,7 @@ class GlobalCommands(ScriptableObject):
 		description=_("Reads all controls in the active window"),
 		category=SCRCAT_FOCUS,
 		gesture="kb:NVDA+b",
+		speakOnDemand=True,
 	)
 	def script_speakForeground(self,gesture):
 		obj=api.getForegroundObject()

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -2026,7 +2026,8 @@ class GlobalCommands(ScriptableObject):
 			"When set to off NVDA will not speak anything. "
 			"If beeps then NVDA will simply beep each time it its supposed to speak something. "
 			"If talk then NVDA will just speak normally."
-			"If on demand then NVDA will only speak when calling commands whose goal is to speak something, but not when moving focus or cursor."
+			"If on demand then NVDA will only speak when calling commands whose goal is to speak something, but not"
+			" when performing an action such as moving the focus or the cursor."
 		),
 		category=SCRCAT_SPEECH,
 		gesture="kb:NVDA+s"

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -146,7 +146,8 @@ class GlobalCommands(ScriptableObject):
 			"will tell you what script is associated with that input, if any."
 		),
 		category=SCRCAT_INPUT,
-		gesture="kb:NVDA+1"
+		gesture="kb:NVDA+1",
+		speakOnDemand=True,
 	)
 	def script_toggleInputHelp(self,gesture):
 		inputCore.manager.isInputHelpActive = not inputCore.manager.isInputHelpActive

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -2022,13 +2022,13 @@ class GlobalCommands(ScriptableObject):
 
 	@script(
 		description=_(
-			# Translators: Input help mode message for toggle speech mode command.
-			"Toggles between the speech modes of off, beep, talk and on-demand."
+			# Translators: Input help mode message for cycle speech mode command.
+			"Cycles between the speech modes of off, beep, talk and on-demand."
 		),
 		category=SCRCAT_SPEECH,
 		gesture="kb:NVDA+s"
 	)
-	def script_speechMode(self,gesture):
+	def script_speechMode(self, gesture: inputCore.InputGesture) -> None:
 		curMode = speech.getState().speechMode
 		speech.setSpeechMode(speech.SpeechMode.talk)
 		newMode = (curMode + 1) % len(speech.SpeechMode)

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -2019,7 +2019,7 @@ class GlobalCommands(ScriptableObject):
 	def script_speechMode(self,gesture):
 		curMode = speech.getState().speechMode
 		speech.setSpeechMode(speech.SpeechMode.talk)
-		newMode=(curMode+1)%3
+		newMode = (curMode + 1) % len(speech.SpeechMode)
 		if newMode == speech.SpeechMode.off:
 			# Translators: A speech mode which disables speech output.
 			name=_("Speech mode off")
@@ -2029,6 +2029,9 @@ class GlobalCommands(ScriptableObject):
 		elif newMode == speech.SpeechMode.talk:
 			# Translators: The normal speech mode; i.e. NVDA will talk as normal.
 			name=_("Speech mode talk")
+		elif newMode == speech.SpeechMode.onDemand:
+			# Translators: The on demand speech mode; i.e. NVDA will talk only on commands asking to report something.
+			name = _("Speech mode on demand")
 		speech.cancelSpeech()
 		ui.message(name)
 		speech.setSpeechMode(newMode)
@@ -2674,7 +2677,8 @@ class GlobalCommands(ScriptableObject):
 			"If pressed three times, copies the title to the clipboard"
 		),
 		category=SCRCAT_FOCUS,
-		gesture="kb:NVDA+t"
+		gesture="kb:NVDA+t",
+		speakOnDemand=True,
 	)
 	def script_title(self, gesture: inputCore.InputGesture):
 		obj=api.getForegroundObject()

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -2023,12 +2023,7 @@ class GlobalCommands(ScriptableObject):
 	@script(
 		description=_(
 			# Translators: Input help mode message for toggle speech mode command.
-			"Toggles between the speech modes of off, beep, talk and on-demand. "
-			"When set to off NVDA will not speak anything. "
-			"If beeps then NVDA will simply beep each time it its supposed to speak something. "
-			"If talk then NVDA will just speak normally."
-			"If on-demand then NVDA will only speak when calling commands whose goal is to speak something, but not"
-			" when performing an action such as moving the focus or the cursor."
+			"Toggles between the speech modes of off, beep, talk and on-demand."
 		),
 		category=SCRCAT_SPEECH,
 		gesture="kb:NVDA+s"

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -2022,10 +2022,11 @@ class GlobalCommands(ScriptableObject):
 	@script(
 		description=_(
 			# Translators: Input help mode message for toggle speech mode command.
-			"Toggles between the speech modes of off, beep and talk. "
+			"Toggles between the speech modes of off, beep, talk and speak on demand. "
 			"When set to off NVDA will not speak anything. "
 			"If beeps then NVDA will simply beep each time it its supposed to speak something. "
 			"If talk then NVDA will just speak normally."
+			"If on demand then NVDA will only speak when calling commands whose goal is to speak something, but not when moving focus or cursor."
 		),
 		category=SCRCAT_SPEECH,
 		gesture="kb:NVDA+s"

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -2023,11 +2023,11 @@ class GlobalCommands(ScriptableObject):
 	@script(
 		description=_(
 			# Translators: Input help mode message for toggle speech mode command.
-			"Toggles between the speech modes of off, beep, talk and speak on demand. "
+			"Toggles between the speech modes of off, beep, talk and on-demand. "
 			"When set to off NVDA will not speak anything. "
 			"If beeps then NVDA will simply beep each time it its supposed to speak something. "
 			"If talk then NVDA will just speak normally."
-			"If on demand then NVDA will only speak when calling commands whose goal is to speak something, but not"
+			"If on-demand then NVDA will only speak when calling commands whose goal is to speak something, but not"
 			" when performing an action such as moving the focus or the cursor."
 		),
 		category=SCRCAT_SPEECH,
@@ -2047,8 +2047,8 @@ class GlobalCommands(ScriptableObject):
 			# Translators: The normal speech mode; i.e. NVDA will talk as normal.
 			name=_("Speech mode talk")
 		elif newMode == speech.SpeechMode.onDemand:
-			# Translators: The on demand speech mode; i.e. NVDA will talk only on commands asking to report something.
-			name = _("Speech mode on demand")
+			# Translators: The on-demand speech mode; i.e. NVDA will talk only on commands asking to report something.
+			name = _("Speech mode on-demand")
 		speech.cancelSpeech()
 		ui.message(name)
 		speech.setSpeechMode(newMode)

--- a/source/scriptHandler.py
+++ b/source/scriptHandler.py
@@ -324,7 +324,7 @@ def clearLastScript():
 	_lastScriptCount = 0
 
 
-def getCurrentScript():
+def getCurrentScript() -> Optional[_ScriptFunctionT]:
 	if not _isScriptRunning:
 		return None
 	lastScriptRef = _lastScriptRef() if _lastScriptRef else None

--- a/source/scriptHandler.py
+++ b/source/scriptHandler.py
@@ -325,7 +325,6 @@ def clearLastScript():
 
 
 def getCurrentScript():
-	global _lastScriptRef
 	if not _isScriptRunning:
 		return None
 	lastScriptRef = _lastScriptRef() if _lastScriptRef else None
@@ -358,7 +357,7 @@ def script(
 	@param allowInSleepMode: Whether this script should run when NVDA is in sleep mode.
 	@param resumeSayAllMode: The say all mode that should be resumed when active before executing this script.
 	One of the C{sayAll.CURSOR_*} constants.
-	@param speakOnDemand: Either this script should speak when NVDA speech mode is "on demand"
+	@param speakOnDemand: Whether this script should speak when NVDA speech mode is "on demand"
 	"""
 	if gestures is None:
 		gestures: List[str] = []

--- a/source/scriptHandler.py
+++ b/source/scriptHandler.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2007-2022 NV Access Limited, Babbage B.V., Julien Cochuyt, Leonard de Ruijter
+# Copyright (C) 2007-2023 NV Access Limited, Babbage B.V., Julien Cochuyt, Leonard de Ruijter, Cyrille Bougot
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -324,6 +324,14 @@ def clearLastScript():
 	_lastScriptCount = 0
 
 
+def getCurrentScript():
+	global _lastScriptRef
+	if not _isScriptRunning:
+		return None
+	lastScriptRef = _lastScriptRef() if _lastScriptRef else None
+	return lastScriptRef
+
+
 def isScriptWaiting():
 	return bool(_numScriptsQueued)
 
@@ -335,7 +343,8 @@ def script(
 		canPropagate: bool = False,
 		bypassInputHelp: bool = False,
 		allowInSleepMode: bool = False,
-		resumeSayAllMode: Optional[int] = None
+		resumeSayAllMode: Optional[int] = None,
+		speakOnDemand: bool = False,
 ):
 	"""Define metadata for a script.
 	This function is to be used as a decorator to set metadata used by the scripting system and gesture editor.
@@ -349,6 +358,7 @@ def script(
 	@param allowInSleepMode: Whether this script should run when NVDA is in sleep mode.
 	@param resumeSayAllMode: The say all mode that should be resumed when active before executing this script.
 	One of the C{sayAll.CURSOR_*} constants.
+	@param speakOnDemand: Either this script should speak when NVDA speech mode is "on demand"
 	"""
 	if gestures is None:
 		gestures: List[str] = []
@@ -384,5 +394,6 @@ def script(
 		if resumeSayAllMode is not None:
 			decoratedScript.resumeSayAllMode = resumeSayAllMode
 		decoratedScript.allowInSleepMode = allowInSleepMode
+		decoratedScript.speakOnDemand = speakOnDemand
 		return decoratedScript
 	return script_decorator

--- a/source/scriptHandler.py
+++ b/source/scriptHandler.py
@@ -348,16 +348,16 @@ def script(
 	"""Define metadata for a script.
 	This function is to be used as a decorator to set metadata used by the scripting system and gesture editor.
 	It can only decorate methods which have a name starting with "script_"
-	@param description: A short translatable description of the script to be used in the gesture editor, etc.
-	@param category: The category of the script displayed in the gesture editor.
-	@param gesture: A gesture associated with this script.
-	@param gestures: A collection of gestures associated with this script
-	@param canPropagate: Whether this script should also apply when it belongs to a  focus ancestor object.
-	@param bypassInputHelp: Whether this script should run when input help is active.
-	@param allowInSleepMode: Whether this script should run when NVDA is in sleep mode.
-	@param resumeSayAllMode: The say all mode that should be resumed when active before executing this script.
+	:param description: A short translatable description of the script to be used in the gesture editor, etc.
+	:param category: The category of the script displayed in the gesture editor.
+	:param gesture: A gesture associated with this script.
+	:param gestures: A collection of gestures associated with this script
+	:param canPropagate: Whether this script should also apply when it belongs to a  focus ancestor object.
+	:param bypassInputHelp: Whether this script should run when input help is active.
+	:param allowInSleepMode: Whether this script should run when NVDA is in sleep mode.
+	:param resumeSayAllMode: The say all mode that should be resumed when active before executing this script.
 	One of the C{sayAll.CURSOR_*} constants.
-	@param speakOnDemand: Whether this script should speak when NVDA speech mode is "on demand"
+	:param speakOnDemand: Whether this script should speak when NVDA speech mode is "on demand"
 	"""
 	if gestures is None:
 		gestures: List[str] = []

--- a/source/scriptHandler.py
+++ b/source/scriptHandler.py
@@ -357,7 +357,7 @@ def script(
 	:param allowInSleepMode: Whether this script should run when NVDA is in sleep mode.
 	:param resumeSayAllMode: The say all mode that should be resumed when active before executing this script.
 	One of the C{sayAll.CURSOR_*} constants.
-	:param speakOnDemand: Whether this script should speak when NVDA speech mode is "on demand"
+	:param speakOnDemand: Whether this script should speak when NVDA speech mode is "on-demand"
 	"""
 	if gestures is None:
 		gestures: List[str] = []

--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -956,10 +956,12 @@ def speak(  # noqa: C901
 		
 		import inputCore
 		from scriptHandler import getCurrentScript
+		from .sayAll import SayAllHandler
 		script = getCurrentScript()
 		if not (
 			(script and getattr(script, 'speakOnDemand', False))
 			or inputCore.manager.isInputHelpActive
+			or SayAllHandler.isRunning()
 		):
 			return
 	_speechState.beenCanceled = False

--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -89,8 +89,7 @@ class SpeechMode(IntEnum):
 class SpeechState:
 	beenCanceled = True
 	isPaused = False
-	#: How speech should be handled; one of SpeechMode.off, SpeechMode.beeps, SpeechMode.talk. or
-	#: SpeechMode.onDemand.
+	#: How speech should be handled
 	speechMode: SpeechMode = SpeechMode.talk
 	# Length of the beep tone when speech mode is beeps
 	speechMode_beeps_ms = 15

--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -89,7 +89,8 @@ class SpeechMode(IntEnum):
 class SpeechState:
 	beenCanceled = True
 	isPaused = False
-	#: How speech should be handled; one of SpeechMode.off, SpeechMode.beeps, SpeechMode.talk. or SpeechMode.onDemand.
+	#: How speech should be handled; one of SpeechMode.off, SpeechMode.beeps, SpeechMode.talk. or
+	#: SpeechMode.onDemand.
 	speechMode: SpeechMode = SpeechMode.talk
 	# Length of the beep tone when speech mode is beeps
 	speechMode_beeps_ms = 15

--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -82,13 +82,14 @@ class SpeechMode(IntEnum):
 	off = 0
 	beeps = 1
 	talk = 2
+	onDemand = 3
 
 
 @dataclass
 class SpeechState:
 	beenCanceled = True
 	isPaused = False
-	#: How speech should be handled; one of SpeechMode.off, SpeechMode.beeps or SpeechMode.talk.
+	#: How speech should be handled; one of SpeechMode.off, SpeechMode.beeps, SpeechMode.talk. or SpeechMode.onDemand.
 	speechMode: SpeechMode = SpeechMode.talk
 	# Length of the beep tone when speech mode is beeps
 	speechMode_beeps_ms = 15
@@ -950,6 +951,11 @@ def speak(  # noqa: C901
 		return
 	if _speechState.isPaused:
 		cancelSpeech()
+	if _speechState.speechMode == SpeechMode.onDemand:
+		from scriptHandler import getCurrentScript
+		script = getCurrentScript()
+		if not (script and getattr(script, 'speakOnDemand', False)):
+			return
 	_speechState.beenCanceled = False
 	#Filter out redundant LangChangeCommand objects 
 	#And also fill in default values

--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -953,9 +953,14 @@ def speak(  # noqa: C901
 	if _speechState.isPaused:
 		cancelSpeech()
 	if _speechState.speechMode == SpeechMode.onDemand:
+		
+		import inputCore
 		from scriptHandler import getCurrentScript
 		script = getCurrentScript()
-		if not (script and getattr(script, 'speakOnDemand', False)):
+		if not (
+			(script and getattr(script, 'speakOnDemand', False))
+			or inputCore.manager.isInputHelpActive
+		):
 			return
 	_speechState.beenCanceled = False
 	#Filter out redundant LangChangeCommand objects 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -10,7 +10,8 @@ What's New in NVDA
 - Added support for Bluetooth Low Energy HID Braille displays. (#15470)
 - The Add-on Store now supports installing add-ons in bulk by selecting multiple add-ons. (#15350)
 - From the add-on store, it's possible to open a dedicated webpage to see or provide feedback about the selected add-on. (#15576, @nvdaes)
-- A new "speech on demand" mode has been added. When speech is on demand, NVDA does not speak automatically (e.g. when moving the cursor) but still speaks when calling commands whose goal is explicitly to report something (e.g. report window title). (#481, @CyrilleB79)
+- A new "on-demand" speech mode has been added.
+When speech is on-demand, NVDA does not speak automatically (e.g. when moving the cursor) but still speaks when calling commands whose goal is explicitly to report something (e.g. report window title). (#481, @CyrilleB79)
 -
 
 
@@ -101,9 +102,9 @@ Setting ``numCells`` is still supported for single line braille displays and ``n
   - wil to ``5e9be7b2d2fe3834a7107f430f7d4c0631f69833``. (#15695)
   -
 - When the configuration file ``nvda.ini`` is corrupted, a backup copy is saved before it is reinitialized. (#15779, @CyrilleB79)
-- When defining a script with the script decorator, the ``speakOnDemand`` boolean argument can be specified to control if a script should speak while in "on demand" mode. (#481, @CyrilleB79)
-  - Scripts that provide information (e.g. say window title, report time/date) should speak in the "on demand" mode.
-  - Scripts that perform an action (e.g. move the cursor, change a parameter) should not speak in the "on demand" mode.
+- When defining a script with the script decorator, the ``speakOnDemand`` boolean argument can be specified to control if a script should speak while in "on-demand" speech mode. (#481, @CyrilleB79)
+  - Scripts that provide information (e.g. say window title, report time/date) should speak in the "on-demand" mode.
+  - Scripts that perform an action (e.g. move the cursor, change a parameter) should not speak in the "on-demand" mode.
   -
 -
 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -98,6 +98,7 @@ Setting ``numCells`` is still supported for single line braille displays and ``n
 - When defining a script with the script decorator, the 'speakOnDemand' boolean argument can be specified to control if a script should speak while in "on demand" mode. (#481, @CyrilleB79)
   - Scripts that provide information (e.g. say window title, report time/date) should speak in the "on demand" mode.
   - Scripts that perform an action (e.g. move the cursor, change a parameter) should not speak in the "on demand" mode.
+  -
 -
 
 === API Breaking Changes ===

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -95,7 +95,7 @@ Setting ``numCells`` is still supported for single line braille displays and ``n
   - wil to ``5e9be7b2d2fe3834a7107f430f7d4c0631f69833``. (#15695)
   -
 - When the configuration file ``nvda.ini`` is corrupted, a backup copy is saved before it is reinitialized. (#15779, @CyrilleB79)
-- When defining a script with the script decorator, the 'speakOnDemand' boolean argument can be specified to control if a script should speak while in "on demand" mode. (#481, @CyrilleB79)
+- When defining a script with the script decorator, the ``speakOnDemand`` boolean argument can be specified to control if a script should speak while in "on demand" mode. (#481, @CyrilleB79)
   - Scripts that provide information (e.g. say window title, report time/date) should speak in the "on demand" mode.
   - Scripts that perform an action (e.g. move the cursor, change a parameter) should not speak in the "on demand" mode.
   -

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -10,6 +10,7 @@ What's New in NVDA
 - Added support for Bluetooth Low Energy HID Braille displays. (#15470)
 - The Add-on Store now supports installing add-ons in bulk by selecting multiple add-ons. (#15350)
 - From the add-on store, it's possible to open a dedicated webpage to see or provide feedback about the selected add-on. (#15576, @nvdaes)
+- A new "speech on demand" mode has been added. When speech is on demand, NVDA does not speak automatically (e.g. when moving the cursor) but still speaks when calling commands whose goal is explicitly to report something (e.g. report window title). (#481, @CyrilleB79)
 -
 
 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -95,6 +95,9 @@ Setting ``numCells`` is still supported for single line braille displays and ``n
   - wil to ``5e9be7b2d2fe3834a7107f430f7d4c0631f69833``. (#15695)
   -
 - When the configuration file ``nvda.ini`` is corrupted, a backup copy is saved before it is reinitialized. (#15779, @CyrilleB79)
+- When defining a script with the script decorator, the 'speakOnDemand' boolean argument can be specified to control if a script should speak while in "on demand" mode. (#481, @CyrilleB79)
+  - Scripts that provide information (e.g. say window title, report time/date) should speak in the "on demand" mode.
+  - Scripts that perform an action (e.g. move the cursor, change a parameter) should not speak in the "on demand" mode.
 -
 
 === API Breaking Changes ===

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -504,7 +504,7 @@ When the menu comes up, You can use the arrow keys to navigate the menu, and the
 | Stop speech | Control | control | 2-finger tap | Instantly stops speaking |
 | Pause Speech | shift | shift | none | Instantly pauses speech. Pressing it again will continue speaking where it left off (if pausing is supported by the current synthesizer) |
 | NVDA Menu | NVDA+n | NVDA+n | 2-finger double-tap | Pops up the NVDA menu to allow you to access preferences, tools, help, etc. |
-| Toggle Speech Mode | NVDA+s | NVDA+s | none | Toggles speech mode between speech, beeps and off. |
+| Toggle Speech Mode | NVDA+s | NVDA+s | none | Toggles speech mode between speech, speech on demand, beeps and off. |
 | Toggle Input Help Mode | NVDA+1 | NVDA+1 | none | Pressing any key in this mode will report the key, and the description of any NVDA command associated with it |
 | Quit NVDA | NVDA+q | NVDA+q | none | Exits NVDA |
 | Pass next key through | NVDA+f2 | NVDA+f2 | none | Tells NVDA to pass the next key press straight through to the active application - even if it is normally treated as an NVDA key command |
@@ -4048,7 +4048,7 @@ Please see the display's documentation for descriptions of where these keys can 
 | Route to braille cell | ``routing`` |
 | Report text formatting under braille cell | ``secondary routing`` |
 | Toggle the way context information is presented in braille | ``attribute1+attribute3`` |
-| Toggles between the speech modes of off, beep and talk | ``attribute2+attribute4`` |
+| Toggles between the speech modes of off, beep, speech and speech on demand | ``attribute2+attribute4`` |
 | Switches to the previous review mode (e.g. object, document or screen) | ``f1`` |
 | Switches to the next review mode (e.g. object, document or screen) | ``f2`` |
 | Moves the navigator object to the object containing it | ``f3`` |

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -520,7 +520,11 @@ When the menu comes up, You can use the arrow keys to navigate the menu, and the
 
 ++ Speech modes ++[SpeechModes]
 
-There are four speech modes available.
+The speech mode, governs how screen content, notifications, responses to commands, and other output, is spoken during operation of NVDA.
+The default mode is "talk", and provides for the kind of speech output that is usually expected when using a screen reader.
+However, under certain circumstances, or when running particular programs, you may find one of the other speech modes valuable.
+
+The four available speech modes are:
 - Talk: The Default speech mode, NVDA will speak normally in reaction to screen changes, notifications, and actions such as moving the focus, or issuing commands.
 - On-demand: NVDA will only speak when you use commands with a reporting function (e.g. report the title of the window); but it will not speak in reaction to actions such as moving the focus or the cursor.
 - Off: NVDA will not speak anything, however unlike sleep mode, it will silently react to commands.

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -504,7 +504,7 @@ When the menu comes up, You can use the arrow keys to navigate the menu, and the
 | Stop speech | Control | control | 2-finger tap | Instantly stops speaking |
 | Pause Speech | shift | shift | none | Instantly pauses speech. Pressing it again will continue speaking where it left off (if pausing is supported by the current synthesizer) |
 | NVDA Menu | NVDA+n | NVDA+n | 2-finger double-tap | Pops up the NVDA menu to allow you to access preferences, tools, help, etc. |
-| Toggle Speech Mode | NVDA+s | NVDA+s | none | Toggles speech mode between speech, speech on demand, beeps and off. |
+| Toggle Speech Mode | ``NVDA+s`` | ``NVDA+s`` | none | Toggles speech mode between speech, speech on demand, beeps and off. |
 | Toggle Input Help Mode | NVDA+1 | NVDA+1 | none | Pressing any key in this mode will report the key, and the description of any NVDA command associated with it |
 | Quit NVDA | NVDA+q | NVDA+q | none | Exits NVDA |
 | Pass next key through | NVDA+f2 | NVDA+f2 | none | Tells NVDA to pass the next key press straight through to the active application - even if it is normally treated as an NVDA key command |

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -504,7 +504,6 @@ When the menu comes up, You can use the arrow keys to navigate the menu, and the
 | Stop speech | Control | control | 2-finger tap | Instantly stops speaking |
 | Pause Speech | shift | shift | none | Instantly pauses speech. Pressing it again will continue speaking where it left off (if pausing is supported by the current synthesizer) |
 | NVDA Menu | NVDA+n | NVDA+n | 2-finger double-tap | Pops up the NVDA menu to allow you to access preferences, tools, help, etc. |
-| Toggle Speech Mode | ``NVDA+s`` | ``NVDA+s`` | none | Toggles speech mode between speech, on-demand, beeps and off. |
 | Toggle Input Help Mode | NVDA+1 | NVDA+1 | none | Pressing any key in this mode will report the key, and the description of any NVDA command associated with it |
 | Quit NVDA | NVDA+q | NVDA+q | none | Exits NVDA |
 | Pass next key through | NVDA+f2 | NVDA+f2 | none | Tells NVDA to pass the next key press straight through to the active application - even if it is normally treated as an NVDA key command |
@@ -517,6 +516,20 @@ When the menu comes up, You can use the arrow keys to navigate the menu, and the
 | Report date/time | NVDA+f12 | Pressing once reports the current time, pressing twice reports the date |
 | Report battery status | NVDA+shift+b | Reports the battery status i.e. whether AC power is in use or the current charge percentage. |
 | Report clipboard text | NVDA+c | Reports the Text on the clipboard if there is any. |
+%kc:endInclude
+
+++ Speech modes ++[SpeechModes]
+
+There are four speech modes available.
+* Talk: NVDA will just speak normally. This is the default speech mode.
+* On-demand: NVDA will only speak when calling commands whose goal is to speak an information (e.g. report the title of the window); but it will not speak in reaction to actions such as moving the focus or the cursor.
+* Off: NVDA will not speak anything. 
+* Beeps: NVDA will replace normal speech with quiet beeps.
+
+A gesture allows to cycle through the various speech modes:
+%kc:beginInclude
+|| Name | Desktop key | Laptop key | Touch | Description |
+| Toggle Speech Mode | ``NVDA+s`` | ``NVDA+s`` | none | Toggles speech mode between speech, on-demand, off and beeps. |
 %kc:endInclude
 
 + Navigating with NVDA +[NavigatingWithNVDA]

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -521,15 +521,21 @@ When the menu comes up, You can use the arrow keys to navigate the menu, and the
 ++ Speech modes ++[SpeechModes]
 
 There are four speech modes available.
-* Talk: NVDA will just speak normally. This is the default speech mode.
-* On-demand: NVDA will only speak when calling commands whose goal is to speak an information (e.g. report the title of the window); but it will not speak in reaction to actions such as moving the focus or the cursor.
-* Off: NVDA will not speak anything. 
-* Beeps: NVDA will replace normal speech with quiet beeps.
+- Talk: The Default speech mode, NVDA will speak normally in reaction to screen changes, notifications, and actions such as moving the focus, or issuing commands.
+- On-demand: NVDA will only speak when you use commands with a reporting function (e.g. report the title of the window); but it will not speak in reaction to actions such as moving the focus or the cursor.
+- Off: NVDA will not speak anything, however unlike sleep mode, it will silently react to commands.
+- Beeps: NVDA will replace normal speech with short beeps.
+-
 
-A gesture allows to cycle through the various speech modes:
+The Beeps mode may be useful when some very verbose output is scrolling in a terminal window, but you don't care what it is, only that it is continuing to scroll; or in other circumstances when the fact that there is output is more relevant than the output itself.
+
+The On-demand mode may be valuable when you don't need constant feedback about what is happening on screen or on the computer, but you periodically need to check particular things using review commands, etc.
+Examples include while recording audio, when using screen magnification, during a meeting or a call, or as an alternative to beeps mode.
+
+A gesture allows cycling through the various speech modes:
 %kc:beginInclude
-|| Name | Desktop key | Laptop key | Touch | Description |
-| Toggle Speech Mode | ``NVDA+s`` | ``NVDA+s`` | none | Toggles speech mode between speech, on-demand, off and beeps. |
+|| Name | Key | Description |
+| Cycle Speech Mode | ``NVDA+s`` | Cycles speech mode between talk, on-demand, off and beeps. |
 %kc:endInclude
 
 + Navigating with NVDA +[NavigatingWithNVDA]
@@ -4062,7 +4068,7 @@ Please see the display's documentation for descriptions of where these keys can 
 | Route to braille cell | ``routing`` |
 | Report text formatting under braille cell | ``secondary routing`` |
 | Toggle the way context information is presented in braille | ``attribute1+attribute3`` |
-| Toggles between the speech modes of off, beep, speech and on-demand | ``attribute2+attribute4`` |
+| Cycles between the speech modes of off, beeps, talk and on-demand | ``attribute2+attribute4`` |
 | Switches to the previous review mode (e.g. object, document or screen) | ``f1`` |
 | Switches to the next review mode (e.g. object, document or screen) | ``f2`` |
 | Moves the navigator object to the object containing it | ``f3`` |

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -520,12 +520,12 @@ When the menu comes up, You can use the arrow keys to navigate the menu, and the
 
 ++ Speech modes ++[SpeechModes]
 
-The speech mode, governs how screen content, notifications, responses to commands, and other output, is spoken during operation of NVDA.
-The default mode is "talk", and provides for the kind of speech output that is usually expected when using a screen reader.
+The speech mode governs how screen content, notifications, responses to commands, and other output is spoken during operation of NVDA.
+The default mode is "talk", which speaks in situations that are expected when using a screen reader.
 However, under certain circumstances, or when running particular programs, you may find one of the other speech modes valuable.
 
 The four available speech modes are:
-- Talk: The Default speech mode, NVDA will speak normally in reaction to screen changes, notifications, and actions such as moving the focus, or issuing commands.
+- Talk (Default): NVDA will speak normally in reaction to screen changes, notifications, and actions such as moving the focus, or issuing commands.
 - On-demand: NVDA will only speak when you use commands with a reporting function (e.g. report the title of the window); but it will not speak in reaction to actions such as moving the focus or the cursor.
 - Off: NVDA will not speak anything, however unlike sleep mode, it will silently react to commands.
 - Beeps: NVDA will replace normal speech with short beeps.

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -4068,7 +4068,7 @@ Please see the display's documentation for descriptions of where these keys can 
 | Route to braille cell | ``routing`` |
 | Report text formatting under braille cell | ``secondary routing`` |
 | Toggle the way context information is presented in braille | ``attribute1+attribute3`` |
-| Cycles between the speech modes of off, beeps, talk and on-demand | ``attribute2+attribute4`` |
+| Cycles between the speech modes of talk, on-demand, off and beeps | ``attribute2+attribute4`` |
 | Switches to the previous review mode (e.g. object, document or screen) | ``f1`` |
 | Switches to the next review mode (e.g. object, document or screen) | ``f2`` |
 | Moves the navigator object to the object containing it | ``f3`` |

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -504,7 +504,7 @@ When the menu comes up, You can use the arrow keys to navigate the menu, and the
 | Stop speech | Control | control | 2-finger tap | Instantly stops speaking |
 | Pause Speech | shift | shift | none | Instantly pauses speech. Pressing it again will continue speaking where it left off (if pausing is supported by the current synthesizer) |
 | NVDA Menu | NVDA+n | NVDA+n | 2-finger double-tap | Pops up the NVDA menu to allow you to access preferences, tools, help, etc. |
-| Toggle Speech Mode | ``NVDA+s`` | ``NVDA+s`` | none | Toggles speech mode between speech, speech on demand, beeps and off. |
+| Toggle Speech Mode | ``NVDA+s`` | ``NVDA+s`` | none | Toggles speech mode between speech, on-demand, beeps and off. |
 | Toggle Input Help Mode | NVDA+1 | NVDA+1 | none | Pressing any key in this mode will report the key, and the description of any NVDA command associated with it |
 | Quit NVDA | NVDA+q | NVDA+q | none | Exits NVDA |
 | Pass next key through | NVDA+f2 | NVDA+f2 | none | Tells NVDA to pass the next key press straight through to the active application - even if it is normally treated as an NVDA key command |
@@ -4049,7 +4049,7 @@ Please see the display's documentation for descriptions of where these keys can 
 | Route to braille cell | ``routing`` |
 | Report text formatting under braille cell | ``secondary routing`` |
 | Toggle the way context information is presented in braille | ``attribute1+attribute3`` |
-| Toggles between the speech modes of off, beep, speech and speech on demand | ``attribute2+attribute4`` |
+| Toggles between the speech modes of off, beep, speech and on-demand | ``attribute2+attribute4`` |
 | Switches to the previous review mode (e.g. object, document or screen) | ``f1`` |
 | Switches to the next review mode (e.g. object, document or screen) | ``f2`` |
 | Moves the navigator object to the object containing it | ``f3`` |


### PR DESCRIPTION
### Link to issue number:
Closes #481
### Summary of the issue:
In some situations, e.g. meetings or when an alternative information channel (braille, visual with magnification), the user does not want NVDA to provide speech feedback on actions such as moving the cursor or focus. But they still want to have NVDA speaking on specific request.

### Description of user facing changes
Add a new speech "on demand" mode in the NVDA+S toggle command. When speech on demand is selected, NVDA does not provide a speech feedback for actions, but still speak on explicit request.

The criterion to determine if a command should speak in "on demand" mode is:
* if the command is mainly to perform an action and the speech is only a feedback after this action, NVDA does not speak. Said otherwise, this command could have a usefulness when used blindly without any speech (or braille or visual) feedback
* if the goal command is mainly to provide information without performing any other action, NVDA speaks.

Note: although say all commands move the cursor, they are speaking in the "on demand"  mode since there is no point running them if speech is totally off.

### Description of development approach
- Added a new speech mode
- Added a new "speakOnDemand" parameter for the script decorator to indicate which script should speak in this mode.
- In `documentBase.py`, do not use script decorator as per https://github.com/nvaccess/nvda/pull/13435#discussion_r820276688

### Notes for reviewers
- Regarding UX, was it a good solution to add a fourth speech mode? There is already an add-on to remove the beep mode from the speech mode toggle command...
- For documentation, what should be the correct name to use? "speech on demand", "speak on demand", etc. Also, speak or talk? @XLTechie would you mind review documentation (change log, user guide, command description)?
- Do I need to include an API change item when extending the speech mode enum?

### Testing strategy:
Manual tests of the modified scripts to support "on demand" mode:
* All the say all scripts (caret, review, foreground window, row and column)
* Most of the other modified scripts in global commands (all those having a default shortcut)
* Word with and without UIA, Excel, poedit
* Tested miranda32 and vipmud with a fake test renaming an executable since I have not these applications.

Foobar not tested.

Tested other scripts to check that they do not speak in "on demand" mode.

### Known issues with pull request:
None
### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
