### PR TITLE
Fix reporting of native Word commands to jump to table boundaries

### DIFF
--- a/source/NVDAObjects/IAccessible/winword.py
+++ b/source/NVDAObjects/IAccessible/winword.py
@@ -285,6 +285,7 @@ class WordDocument(IAccessible, EditableTextWithoutAutoSelectDetection, winWordW
 			info = self.makeTextInfo(textInfos.POSITION_SELECTION)
 			newSelection = info.start, info.end
 			if newSelection != oldSelection:
+				elapsed = time.time() - start
 				log.debug(f"Detected new selection after {elapsed} sec")
 				break
 			elapsed = time.time() - start

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -58,6 +58,7 @@ It is also updated with UIA enabled, when typing text and braille is tethered to
 - NVDA will not fail to start anymore when the configuration file is corrupted, but it will restore the configuration to default as it did in the past. (#15690, @CyrilleB79)
 - If the audio output device is set to something other than the default and that device becomes available again after being unavailable, NVDA will now switch back to the configured device instead of continuing to use the default device. (#15759)
 - It is not possible anymore to overwrite NVDA's Python console history. (#15792, @CyrilleB79)
+- In Word, the landing cell will now be correctly reported when using the native Word commands for table navigation ``alt+home``, ``alt+end``, ``alt+pageUp`` and ``alt+pageDown``. (#15805, @CyrilleB79)
 -
 
 == Changes for Developers ==


### PR DESCRIPTION
### Link to issue number:
Closes #15805

### Summary of the issue:
In older versions of NVDA, NVDA was providing a speech feedback of the landing cell when using Word native commands for table navigation to jump to first or last cell of row or column: `alt+home`, `alt+end`, `alt+pgUp` and `alt+pgDown`. From NVDA 2023.2 onwards, this speech feedback is erroneous and reports the origin cell instead of the landing one. This is because the script for this commands was not robust and was taking advantage of existing delays in NVDA processing. in NVDA 2023.2 these delays have been reduced what uncovered this bug.


### Description of user facing changes
The landing cell will be reported correctly again when using native Word table navigation to jump to first or last cell of row or column.
### Description of development approach
Strategy inspired from #14984: send the gesture and check if the cursor location has changed before reporting its new position.  If the cursor does not move, e.g. because you call a command to jumpt to first cell while you are already on the first cell, the current cell is reported after a maximum delay set to 0.15 seconds (same value as some other polling scripts).

### Testing strategy:
Manual tests:
- tested the 4 jumps commands when the cursor moves and when it does not move (because already on the target cell)
- stress tested these commands keeping the shortcut pressed during a few seconds or calling different shortcuts in a quick sequence

### Known issues with pull request:
None
### Code Review Checklist:


- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
Cc @leonardder  if you want to have a look since you are the author of #14984.

