### PR TITLE
forcibly add ctypes.util in builds

### DIFF
--- a/source/setup.py
+++ b/source/setup.py
@@ -219,10 +219,9 @@ freeze(
 		],
 		"includes": [
 			"nvdaBuiltin",
-			# #3368: bisect was implicitly included with Python 2.7.3, but isn't with 2.7.5.
-			"bisect",
 			# robotremoteserver (for system tests) depends on xmlrpc.server
 			"xmlrpc.server",
+			"ctypes.util",
 		],
 	},
 	data_files=[


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
None

### Summary of the issue:
Code in 2024.1 removed `ctypes.util` from being implicitly included in the exe compiled version of NVDA.
Add-on authors have requested that `ctypes.util` remain available in NVDA.

### Description of user facing changes
`ctypes.util` can be imported in the NVDA python console
### Description of development approach
Force `ctypes.util` to be included in `setup.py`
Remove `bisect`  from that same list, as it is now implicitly included regardless. https://github.com/nvaccess/nvda/issues/3368

### Testing strategy:
- Test that `ctypes.util` can be imported in the NVDA python console
- Test that `bisect` can still be imported in the NVDA python console
### Known issues with pull request:

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
