### PR TITLE
UIA handler: work directly with UIA interfaces introduced in Windows 8 and later

### DIFF
--- a/source/UIAHandler/__init__.py
+++ b/source/UIAHandler/__init__.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2008-2022 NV Access Limited, Joseph Lee, Babbage B.V., Leonard de Ruijter, Bill Dengler
+# Copyright (C) 2008-2023 NV Access Limited, Joseph Lee, Babbage B.V., Leonard de Ruijter, Bill Dengler
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 

--- a/source/UIAHandler/__init__.py
+++ b/source/UIAHandler/__init__.py
@@ -450,12 +450,7 @@ class UIAHandler(COMObject):
 	def MTAThreadFunc(self):
 		try:
 			oledll.ole32.CoInitializeEx(None,comtypes.COINIT_MULTITHREADED) 
-			isUIA8=False
-			try:
-				self.clientObject=CoCreateInstance(CUIAutomation8._reg_clsid_,interface=IUIAutomation,clsctx=CLSCTX_INPROC_SERVER)
-				isUIA8=True
-			except (COMError,WindowsError,NameError):
-				self.clientObject=CoCreateInstance(CUIAutomation._reg_clsid_,interface=IUIAutomation,clsctx=CLSCTX_INPROC_SERVER)
+			self.clientObject=CoCreateInstance(CUIAutomation8._reg_clsid_,interface=IUIAutomation,clsctx=CLSCTX_INPROC_SERVER)
 			# #7345: Instruct UIA to never map MSAA winEvents to UIA propertyChange events.
 			# These events are not needed by NVDA, and they can cause the UI Automation client library to become unresponsive if an application firing winEvents has a slow message pump. 
 			pfm=self.clientObject.proxyFactoryMapping

--- a/source/UIAHandler/__init__.py
+++ b/source/UIAHandler/__init__.py
@@ -479,20 +479,19 @@ class UIAHandler(COMObject):
 					# Therefore remove the entry and re-insert it.
 					pfm.removeEntry(index)
 					pfm.insertEntry(index,e)
-			if isUIA8:
-				# #8009: use appropriate interface based on highest supported interface.
-				# #8338: made easier by traversing interfaces supported on Windows 8 and later in reverse.
-				for interface in reversed(CUIAutomation8._com_interfaces_):
-					try:
-						self.clientObject=self.clientObject.QueryInterface(interface)
-						break
-					except COMError:
-						pass
-				# Windows 10 RS5 provides new performance features for UI Automation including event coalescing and connection recovery. 
-				# Enable all of these where available.
-				if isinstance(self.clientObject,IUIAutomation6):
-					self.clientObject.CoalesceEvents=CoalesceEventsOptions_Enabled
-					self.clientObject.ConnectionRecoveryBehavior=ConnectionRecoveryBehaviorOptions_Enabled
+			# #8009: use appropriate interface based on highest supported interface.
+			# #8338: made easier by traversing interfaces supported on Windows 8 and later in reverse.
+			for interface in reversed(CUIAutomation8._com_interfaces_):
+				try:
+					self.clientObject=self.clientObject.QueryInterface(interface)
+					break
+				except COMError:
+					pass
+			# Windows 10 RS5 provides new performance features for UI Automation including event coalescing and connection recovery. 
+			# Enable all of these where available.
+			if isinstance(self.clientObject,IUIAutomation6):
+				self.clientObject.CoalesceEvents=CoalesceEventsOptions_Enabled
+				self.clientObject.ConnectionRecoveryBehavior=ConnectionRecoveryBehaviorOptions_Enabled
 			log.info("UIAutomation: %s"%self.clientObject.__class__.__mro__[1].__name__)
 			self.windowTreeWalker=self.clientObject.createTreeWalker(self.clientObject.CreateNotCondition(self.clientObject.CreatePropertyCondition(UIA_NativeWindowHandlePropertyId,0)))
 			self.windowCacheRequest=self.clientObject.CreateCacheRequest()

--- a/source/UIAHandler/__init__.py
+++ b/source/UIAHandler/__init__.py
@@ -481,17 +481,18 @@ class UIAHandler(COMObject):
 					pfm.insertEntry(index,e)
 			# #8009: use appropriate interface based on highest supported interface.
 			# #8338: made easier by traversing interfaces supported on Windows 8 and later in reverse.
-			for interface in reversed(CUIAutomation8._com_interfaces_):
+			for interface in reversed(UIA.CUIAutomation8._com_interfaces_):
 				try:
-					self.clientObject=self.clientObject.QueryInterface(interface)
+					self.clientObject = self.clientObject.QueryInterface(interface)
 					break
 				except COMError:
 					pass
-			# Windows 10 RS5 provides new performance features for UI Automation including event coalescing and connection recovery. 
+			# Windows 10 RS5 provides new performance features for UI Automation
+			# including event coalescing and connection recovery.
 			# Enable all of these where available.
-			if isinstance(self.clientObject,IUIAutomation6):
-				self.clientObject.CoalesceEvents=CoalesceEventsOptions_Enabled
-				self.clientObject.ConnectionRecoveryBehavior=ConnectionRecoveryBehaviorOptions_Enabled
+			if isinstance(self.clientObject, UIA.IUIAutomation6):
+				self.clientObject.CoalesceEvents = UIA.CoalesceEventsOptions_Enabled
+				self.clientObject.ConnectionRecoveryBehavior = UIA.ConnectionRecoveryBehaviorOptions_Enabled
 			log.info(f"UIAutomation: {self.clientObject.__class__.__mro__[1].__name__}")
 			self.windowTreeWalker=self.clientObject.createTreeWalker(self.clientObject.CreateNotCondition(self.clientObject.CreatePropertyCondition(UIA_NativeWindowHandlePropertyId,0)))
 			self.windowCacheRequest=self.clientObject.CreateCacheRequest()

--- a/source/UIAHandler/__init__.py
+++ b/source/UIAHandler/__init__.py
@@ -487,7 +487,7 @@ class UIAHandler(COMObject):
 			if isinstance(self.clientObject,IUIAutomation6):
 				self.clientObject.CoalesceEvents=CoalesceEventsOptions_Enabled
 				self.clientObject.ConnectionRecoveryBehavior=ConnectionRecoveryBehaviorOptions_Enabled
-			log.info("UIAutomation: %s"%self.clientObject.__class__.__mro__[1].__name__)
+			log.info(f"UIAutomation: {self.clientObject.__class__.__mro__[1].__name__}")
 			self.windowTreeWalker=self.clientObject.createTreeWalker(self.clientObject.CreateNotCondition(self.clientObject.CreatePropertyCondition(UIA_NativeWindowHandlePropertyId,0)))
 			self.windowCacheRequest=self.clientObject.CreateCacheRequest()
 			self.windowCacheRequest.AddProperty(UIA_NativeWindowHandlePropertyId)

--- a/source/UIAHandler/__init__.py
+++ b/source/UIAHandler/__init__.py
@@ -449,8 +449,13 @@ class UIAHandler(COMObject):
 
 	def MTAThreadFunc(self):
 		try:
-			oledll.ole32.CoInitializeEx(None,comtypes.COINIT_MULTITHREADED) 
-			self.clientObject=CoCreateInstance(CUIAutomation8._reg_clsid_,interface=IUIAutomation,clsctx=CLSCTX_INPROC_SERVER)
+			oledll.ole32.CoInitializeEx(None, comtypes.COINIT_MULTITHREADED)
+			self.clientObject = CoCreateInstance(
+				UIA.CUIAutomation8._reg_clsid_,
+				# Minimum interface is IUIAutomation3 (Windows 8.1).
+				interface=UIA.CUIAutomation8._com_interfaces_[1],
+				clsctx=CLSCTX_INPROC_SERVER
+			)
 			# #7345: Instruct UIA to never map MSAA winEvents to UIA propertyChange events.
 			# These events are not needed by NVDA, and they can cause the UI Automation client library to become unresponsive if an application firing winEvents has a slow message pump. 
 			pfm=self.clientObject.proxyFactoryMapping


### PR DESCRIPTION

### Link to issue number:
None

### Summary of the issue:
NVDA checks for Windows 7/8 UIA interfaces at startup when the minimum version is Windows 8.1.

### Description of user facing changes
None

### Description of development approach
At startup, NVDA's UIA handler thread will instantiate Widnows 8 UIA interface direclty as opposed tr doing it behind a try/except block. This also removes the check for UIA8 flag when instantiating later UIA interfaces. As part of this work, UIA handler main file was linted and some functions marked as too complex (according to Flake8).

### Testing strategy:
Manual testing: making sure UIA works as expected (at least on Windows 11).

### Known issues with pull request:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

