### PR TITLE
Report keyboard shortcut when entering a list

### DIFF
--- a/source/gui/installerGui.py
+++ b/source/gui/installerGui.py
@@ -359,7 +359,7 @@ class PortableCreaterDialog(
 
 		# Translators: The label of a grouping containing controls to select the destination directory
 		# in the Create Portable NVDA dialog.
-		directoryGroupText = _("Portable &directory:")
+		directoryGroupText = _("Portable directory:")
 		groupSizer = wx.StaticBoxSizer(wx.VERTICAL, self, label=directoryGroupText)
 		groupHelper = sHelper.addItem(guiHelper.BoxSizerHelper(self, sizer=groupSizer))
 		groupBox = groupSizer.GetStaticBox()

--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -774,6 +774,9 @@ def _objectSpeech_calculateAllowedProps(reason, shouldReportTextContent, objRole
 	}
 	if reason in (OutputReason.FOCUSENTERED, OutputReason.MOUSE):
 		allowProperties["value"] = False
+		# #15826: For containers, there are cases where the shortcut key can be defined but not working (e.g.
+		# GROUPING). The safest strategy is then to remove the shortcut keys of containers except in the known
+		# cases where it is working and useful. The only such known case is the one of LIST.
 		if not objRole == controlTypes.Role.LIST:
 			allowProperties["keyboardShortcut"] = False
 		allowProperties["positionInfo_level"] = False

--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -745,7 +745,11 @@ def getObjectSpeech(
 	return sequence
 
 
-def _objectSpeech_calculateAllowedProps(reason, shouldReportTextContent, objRole):
+def _objectSpeech_calculateAllowedProps(
+		reason: OutputReason,
+		shouldReportTextContent: bool,
+		objRole: controlTypes.Role,
+):
 	allowProperties = {
 		'name': True,
 		'role': True,

--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -749,7 +749,7 @@ def _objectSpeech_calculateAllowedProps(
 		reason: OutputReason,
 		shouldReportTextContent: bool,
 		objRole: controlTypes.Role,
-):
+) -> dict[str, bool]:
 	allowProperties = {
 		'name': True,
 		'role': True,

--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -699,7 +699,7 @@ def getObjectSpeech(
 		or not obj._hasNavigableText
 	)
 
-	allowProperties = _objectSpeech_calculateAllowedProps(reason, shouldReportTextContent)
+	allowProperties = _objectSpeech_calculateAllowedProps(reason, shouldReportTextContent, obj.role)
 
 	if reason == OutputReason.FOCUSENTERED:
 		# Aside from excluding some properties, focus entered should be spoken like focus.
@@ -745,7 +745,7 @@ def getObjectSpeech(
 	return sequence
 
 
-def _objectSpeech_calculateAllowedProps(reason, shouldReportTextContent):
+def _objectSpeech_calculateAllowedProps(reason, shouldReportTextContent, objRole):
 	allowProperties = {
 		'name': True,
 		'role': True,
@@ -774,7 +774,8 @@ def _objectSpeech_calculateAllowedProps(reason, shouldReportTextContent):
 	}
 	if reason in (OutputReason.FOCUSENTERED, OutputReason.MOUSE):
 		allowProperties["value"] = False
-		allowProperties["keyboardShortcut"] = False
+		if not objRole == controlTypes.Role.LIST:
+			allowProperties["keyboardShortcut"] = False
 		allowProperties["positionInfo_level"] = False
 	if reason == OutputReason.MOUSE:
 		# Name is often part of the text content when mouse tracking.

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -36,7 +36,7 @@ Users of Poedit 1 are encouraged to update to Poedit 3 if they want to rely on e
 -
 
 == Bug Fixes ==
-- Reporting of object shortcut keys has been improved. (#10807, @CyrilleB79)
+- Reporting of object shortcut keys has been improved. (#10807, #15816, @CyrilleB79)
 - The SAPI4 synthesizer now properly supports volume, rate and pitch changes embedded in speech. (#15271, @LeonarddeR)
 - Multi line state is now correctly reported in applications using Java Access Bridge. (#14609)
 - In LibreOffice, words deleted using the ``control+backspace`` keyboard shortcut are now also properly announced when the deleted word is followed by whitespace (like spaces and tabs). (#15436, @michaelweghorn)


### PR DESCRIPTION
### Link to issue number:
Closes #15816

### Summary of the issue:
When the focus enters in a list, the list's keyboard shortcut is not reported. It's because a list item takes the focus, whereas the shortcut key is on the whole list; logically, individual list items have no shortcut. We usually do not report shortcut keys when entering container objects. However, in the case of list, it would be useful so that people know that the list has a shortcut key.

### Description of user facing changes
Reports shortcut when the focus enters a list.
### Description of development approach
When speaking an object for `FOCUS_ENTERED` reason, if the object is a list, we do not discard keyboard shortcut anymore.

While at it, removed the accelerator of path selection in the "Create portable NVDA" dialog, since I have realized during the investigation for this PR that it was not working. A better solution would be to have a working key accelerator for this field but I do not know how to do this.

### Testing strategy:
Manually tested the lists in https://github.com/nvaccess/nvda/issues/15816#issuecomment-1825970242.

### Known issues with pull request:
None
### Code Review Checklist:


- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
