### PR TITLE
Update eSpeak to 530bf0abf

### DIFF
--- a/include/espeak.md
+++ b/include/espeak.md
@@ -40,7 +40,7 @@ Modifications will need to be made in [`nvdaHelper/espeak`](../nvdaHelper/espeak
       - [`nvdaHelper/espeak/config.h`](../nvdaHelper/espeak/config.h) must exist (despite being empty) since a "config.h" is included within eSpeak.
       - Compare to eSpeak source config: [`include/espeak/src/windows/config.h`](./espeak/src/windows/config.h).
       - Diff `src/windows/config.h` with the previous commit.
-   1. Update NVDA [`readme.md`](../readme.md) with eSpeak version and commit.
+   1. Update NVDA [documentation](../projectDocs/dev/createDevEnvironment.md#git-submodules) and [changelog](../user_docs/en/changes.t2t) with eSpeak version and commit.
    1. Build NVDA: `scons source`
       - Expected warnings from eSpeak compilation:
          - On the first build after changes, all languages may show this warning.

--- a/nvdaHelper/espeak/sconscript
+++ b/nvdaHelper/espeak/sconscript
@@ -93,7 +93,7 @@ env.Append(
 		# Ignore all warnings as the code is not ours.
 		'/W0',
 		# Preprocessor definitions. Migrated from 'nvdaHelper/espeak/config.h'
-		'/DPACKAGE_VERSION=\\"1.52-dev\\"',  # See 'include/espeak/src/windows/config.h'
+		'/DPACKAGE_VERSION=\\"1.52-dev 530bf0ab\\"',  # See 'include/espeak/src/windows/config.h'
 		'/DHAVE_STDINT_H=1',
 		'/D__WIN32__#1',
 		'/DLIBESPEAK_NG_EXPORT',

--- a/projectDocs/dev/createDevEnvironment.md
+++ b/projectDocs/dev/createDevEnvironment.md
@@ -66,7 +66,7 @@ If you aren't sure, run `git submodule update` after every git pull, merge or ch
 
 For reference, the following run time dependencies are included in Git submodules:
 
-* [eSpeak NG](https://github.com/espeak-ng/espeak-ng), version 1.52-dev commit `ed9a7bcf`
+* [eSpeak NG](https://github.com/espeak-ng/espeak-ng), version 1.52-dev commit `530bf0abf4174dc9ca28dbacc11bd5e9ae6152cd`
 * [Sonic](https://github.com/waywardgeek/sonic), commit `8694c596378c24e340c09ff2cd47c065494233f1`
 * [IAccessible2](https://wiki.linuxfoundation.org/accessibility/iaccessible2/start), commit `3d8c7f0b833453f761ded6b12d8be431507bfe0b`
 * [liblouis](http://www.liblouis.io/), version 3.27.0

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -20,6 +20,7 @@ Windows 8.1 is the minimum Windows version supported. (#15544)
   - Updated LibLouis braille translator to 3.27.0. (#15435, @codeofdusk)
     - Added new Thai and Romanian Braille tables.
     -
+  - eSpeak NG has been updated to 1.52-dev commit ``530bf0abf``. (#15036)
   - CLDR emoji and symbol annotations has been updated to version 44.0. (#15712, @OzancanKaratas)
   - Updated Java Access Bridge to 17.0.9+8Zulu (17.46.19). (#15744)
   -


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Closes #15181 

### Summary of the issue:
Janitorial update

### Description of user facing changes
Added commit to build version that is logged when espeak is initialized. this is because espeak has abandoned regular versioning, so the commit is more important than the version in the log.

### Description of development approach
Followed steps in espeak.md

### Testing strategy:
Tested using steps in espeak.md, smoke testing a compiled version of eSpeak in NVDA source.

### Known issues with pull request:

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
