### PR TITLE
Use safer method of clearing display buffer

### DIFF
--- a/source/braille.py
+++ b/source/braille.py
@@ -1512,8 +1512,7 @@ class BrailleBuffer(baseObject.AutoPropertyObject):
 		#: @type: int
 		self.cursorPos = None
 		#: The translated braille representation of the entire buffer.
-		#: @type: [int, ...]
-		self.brailleCells = []
+		self.brailleCells: list[int] = []
 		#: The position in L{brailleCells} where the display window starts (inclusive).
 		#: @type: int
 		self.windowStartPos = 0
@@ -1769,7 +1768,11 @@ class BrailleBuffer(baseObject.AutoPropertyObject):
 	def _get_windowRawText(self):
 		return self.bufferPositionsToRawText(self.windowStartPos,self.windowEndPos)
 
-	def _get_windowBrailleCells(self):
+	#: Typing information for auto-property: _get_next
+	windowBrailleCells: list[int]
+	"""The braille cells for the current window."""
+
+	def _get_windowBrailleCells(self) -> list[int]:
 		return self.brailleCells[self.windowStartPos:self.windowEndPos]
 
 	def routeTo(self, windowPos):
@@ -2053,7 +2056,7 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 		self._keyCountForLastMessage=0
 		self._cursorPos = None
 		self._cursorBlinkUp = True
-		self._cells = []
+		self._cells: list[int] = []
 		self._cursorBlinkTimer = None
 		config.post_configProfileSwitch.register(self.handlePostConfigProfileSwitch)
 		if config.conf["braille"]["tetherTo"] == TetherTo.AUTO.value:
@@ -2284,7 +2287,7 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 			# Make sure we start the blink timer from the main thread to avoid wx assertions
 			wx.CallAfter(self._cursorBlinkTimer.Start,blinkRate)
 
-	def _writeCells(self, cells: List[int]):
+	def _writeCells(self, cells: list[int]):
 		handlerCellCount = self.displaySize
 		pre_writeCells.notify(cells=cells, rawText=self._rawText, currentCellCount=handlerCellCount)
 		displayCellCount = self.display.numCells

--- a/source/brailleDisplayDrivers/eurobraille/driver.py
+++ b/source/brailleDisplayDrivers/eurobraille/driver.py
@@ -93,7 +93,10 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver, ScriptableObject):
 		for portType, portId, port, portInfo in self._getTryPorts(port):
 			# At this point, a port bound to this display has been found.
 			# Try talking to the display.
-			self.isHid = portType == bdDetect.DeviceType.HID
+			# Braille display drivers must be thread-safe to use HID, as it utilises a background thread.
+			# eurobraille drivers appear not to be thread-safe.
+			# self.isHid = portType == bdDetect.DeviceType.HID
+			self.isHid = False
 			try:
 				if self.isHid:
 					self._dev = hwIo.Hid(

--- a/source/brailleDisplayDrivers/eurobraille/driver.py
+++ b/source/brailleDisplayDrivers/eurobraille/driver.py
@@ -94,7 +94,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver, ScriptableObject):
 			# At this point, a port bound to this display has been found.
 			# Try talking to the display.
 			# Braille display drivers must be thread-safe to use HID, as it utilises a background thread.
-			# eurobraille drivers appear not to be thread-safe.
+			# eurobraille drivers appear not to be thread-safe. (#14872)
 			# self.isHid = portType == bdDetect.DeviceType.HID
 			self.isHid = False
 			try:

--- a/source/hwIo/hid.py
+++ b/source/hwIo/hid.py
@@ -318,7 +318,7 @@ class Hid(IoBase):
 			raise ctypes.WinError()
 
 	def close(self):
-		super(Hid, self).close()
+		super().close()
 		winKernel.closeHandle(self._file)
 		self._file = None
 		hidDll.HidD_FreePreparsedData(self._pd)


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Fixes #14872

### Summary of the issue:
When resetting a config, the braille display is terminated and restarted.
When terminating a braille display, the display content is attempted to be clearer.
If a braille device attempts to refresh content during a config reset, there is a thread collision when writing to the display at the same time.

### Description of user facing changes
No freeze when resetting config with a braille display active

### Description of development approach
Clear the buffer rather than writing to the display directly

### Testing strategy:
Manual testing is required:
- braille devices should still clear their content when terminating NVDA and resetting config
- the freeze/crash should not occur when resetting config

### Known issues with pull request:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [ ] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [ ] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [ ] API is compatible with existing add-ons.
- [ ] Security precautions taken.
