### PR TITLE
Move private message dialogs into addonStoreGui

### DIFF
--- a/source/gui/addonStoreGui/controls/messageDialogs.py
+++ b/source/gui/addonStoreGui/controls/messageDialogs.py
@@ -16,7 +16,7 @@ from addonStore.models.addon import (
 	_AddonManifestModel,
 )
 import config
-from gui.addonGui import ErrorAddonInstallDialog
+from gui.addonGui import ConfirmAddonInstallDialog, ErrorAddonInstallDialog
 from gui.contextHelp import ContextHelpMixin
 from gui.guiHelper import (
 	BoxSizerHelper,
@@ -166,6 +166,54 @@ def _shouldEnableWhenAddonTooOldDialog(
 		showAddonInfoFunction=lambda: _showAddonInfo(addon)
 	))
 	return res == wx.YES
+
+
+def _showAddonRequiresNVDAUpdateDialog(
+		parent: wx.Window,
+		addon: _AddonGUIModel
+) -> None:
+	incompatibleMessage = _(
+		# Translators: The message displayed when installing an add-on package is prohibited,
+		# because it requires a later version of NVDA than is currently installed.
+		"Installation of {summary} {version} has been blocked. The minimum NVDA version required for "
+		"this add-on is {minimumNVDAVersion}, your current NVDA version is {NVDAVersion}"
+		).format(
+	summary=addon.displayName,
+	version=addon.addonVersionName,
+	minimumNVDAVersion=addonAPIVersion.formatForGUI(addon.minimumNVDAVersion),
+	NVDAVersion=addonAPIVersion.formatForGUI(addonAPIVersion.CURRENT)
+	)
+	displayDialogAsModal(ErrorAddonInstallDialog(
+		parent=parent,
+		# Translators: The title of a dialog presented when an error occurs.
+		title=_("Add-on not compatible"),
+		message=incompatibleMessage,
+		showAddonInfoFunction=lambda: _showAddonInfo(addon)
+	))
+
+
+def _showConfirmAddonInstallDialog(
+		parent: wx.Window,
+		addon: _AddonGUIModel
+) -> int:
+	confirmInstallMessage = _(
+		# Translators: A message asking the user if they really wish to install an addon.
+		"Are you sure you want to install this add-on?\n"
+		"Only install add-ons from trusted sources.\n"
+		"Addon: {summary} {version}"
+		).format(
+	summary=addon.displayName,
+	version=addon.addonVersionName,
+	)
+
+	return displayDialogAsModal(ConfirmAddonInstallDialog(
+		parent=parent,
+		# Translators: Title for message asking if the user really wishes to install an Addon.
+		title=_("Add-on Installation"),
+		message=confirmInstallMessage,
+		showAddonInfoFunction=lambda: _showAddonInfo(addon)
+	))
+
 
 
 def _showAddonInfo(addon: _AddonGUIModel) -> None:


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Summary of the issue:
Some dialogs could be moved to tidy up the add-on store work.
These are part of the private API so moving them doesn't affect add-on authors.
Remaining changes to integrate relevant code in `addonHandler` and `addonGui` to `addonStore` and `addonStoreGui` would require deprecations or API breaking changes.

### Description of development approach
2 dialogs moved to tidy up add-on store work.

### Testing strategy:
Smoke test installing an add-on

### Known issues with pull request:
None
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
