### PR TITLE
Windows 11 emoji panel: replace regular editable text with NVDAObjects.UIA.XamlEditableText

### DIFF
--- a/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
+++ b/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
@@ -19,8 +19,8 @@ import ui
 import config
 import winVersion
 import controlTypes
-from NVDAObjects.UIA import UIA
-from NVDAObjects.behaviors import CandidateItem as CandidateItemBehavior, EditableTextWithAutoSelectDetection
+from NVDAObjects.UIA import UIA, XamlEditableText
+from NVDAObjects.behaviors import CandidateItem as CandidateItemBehavior
 
 
 class ImeCandidateUI(UIA):
@@ -335,4 +335,4 @@ class AppModule(appModuleHandler.AppModule):
 			# However this means NVDA's own edit field scripts will override emoji panel commands.
 			# Therefore remove text field movement commands so emoji panel commands can be used directly.
 			elif obj.UIAAutomationId == "Windows.Shell.InputApp.FloatingSuggestionUI.DelegationTextBox":
-				clsList.remove(EditableTextWithAutoSelectDetection)
+				clsList.remove(XamlEditableText)


### PR DESCRIPTION

### Link to issue number:
Closes #15836 

### Summary of the issue:
Windows 11 emoji panel items are not annonced when using arrow keys to navigate the emoji panel.

### Description of user facing changes
Emoji panel items are once again announced when using the arrow keys to navigate Windows 11 emoji panel.

### Description of development approach
In modern keyboard/emoji panel app modue, replace regular editable text with NVDAObjects.UIA.XamlEditableText when detecting and removing edit field commands form emoji search field.

### Testing strategy:
Manual test: make sure emoji panel items are announced when using arrow keys after opening Windows 11 emoji panel.

### Known issues with pull request:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
