### PR TITLE
Fix inaccurate text reporting in Visual Studio text controls

### DIFF
--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -1260,7 +1260,7 @@ class UIA(Window):
 		if self.TextInfo == UIATextInfo:
 			if self.UIAFrameworkId == 'XAML':
 				# This UIA element is being exposed by the XAML framework.
-				clsList.append(InaccurateTextChangeEventEmittingEditableText)
+				clsList.append(XamlEditableText)
 			if UIAHandler.autoSelectDetectionAvailable:
 				clsList.append(EditableTextWithAutoSelectDetection)
 			else:
@@ -2233,6 +2233,10 @@ class InaccurateTextChangeEventEmittingEditableText(EditableTextBase, UIA):
 			super()._backspaceScriptHelper(unit, gesture)
 		finally:
 			self.caretMovementDetectionUsesEvents = False
+
+
+class XamlEditableText(InaccurateTextChangeEventEmittingEditableText):
+	...
 
 
 class TreeviewItem(UIA):

--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -1260,7 +1260,7 @@ class UIA(Window):
 		if self.TextInfo == UIATextInfo:
 			if self.UIAFrameworkId == 'XAML':
 				# This UIA element is being exposed by the XAML framework.
-				clsList.append(XamlEditableText)
+				clsList.append(InaccurateTextChangeEventEmittingEditableText)
 			if UIAHandler.autoSelectDetectionAvailable:
 				clsList.append(EditableTextWithAutoSelectDetection)
 			else:
@@ -2213,17 +2213,17 @@ class UIA(Window):
 			ui.message(dropTargetEffect)
 
 
-class XamlEditableText(EditableTextBase, UIA):
-	""" a UIA element with editable text exposed by the XAML framework."""
+class InaccurateTextChangeEventEmittingEditableText(EditableTextBase, UIA):
+	""" a UIA element with editable text exposed by the XAML framework or WPF."""
 
-	# XAML fires UIA textSelectionChange events before the caret position change is reflected
+	# XAML and WPF fire UIA textSelectionChange events before the caret position change is reflected
 	# in the related UIA text pattern.
-	# This means that, apart from deleting text, NVDA cannot rely on textSelectionChange (caret) events in XAML
-	# to detect if the caret has moved, as it occurs too early.
+	# This means that, apart from deleting text, NVDA cannot rely on textSelectionChange (caret) events
+	# in XAML or WPF to detect if the caret has moved, as it occurs too early.
 	caretMovementDetectionUsesEvents = False
 
 	def _backspaceScriptHelper(self, unit: str, gesture: inputCore.InputGesture):
-		"""As UIA text range objects from XAML don't mutate with backspace,
+		"""As UIA text range objects from XAML or WPF don't mutate with backspace,
 		comparing a text range copied from before backspace with a text range fetched after backspace
 		isn't reliable, as the ranges compare equal.
 		Therefore, we must always rely on events for caret change detection in this case.
@@ -2400,16 +2400,19 @@ class ToolTip(ToolTip, UIA):
 	event_UIA_toolTipOpened=ToolTip.event_show
 
 
-#WpfTextView fires name state changes once a second, plus when IUIAutomationTextRange::GetAttributeValue is called.
-#This causes major lags when using this control with Braille in NVDA. (#2759) 
-#For now just ignore the events.
-class WpfTextView(UIA):
+class WpfTextView(InaccurateTextChangeEventEmittingEditableText):
+	"""WpfTextView fires name state changes once a second,
+	plus when IUIAutomationTextRange::GetAttributeValue is called.
+	This causes major lag when using this control with Braille in NVDA. (#2759)
+	For now just ignore the events.
+	"""
 
 	def event_nameChange(self):
 		return
 
 	def event_stateChange(self):
 		return
+
 
 class SearchField(EditableTextWithSuggestions, UIA):
 	"""An edit field that presents suggestions based on a search term.

--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -1028,8 +1028,6 @@ class UIA(Window):
 		):
 			# Bounces focus from a netUI dead placeholder menu item when no item is selected up to the menu itself.
 			clsList.append(PlaceholderNetUITWMenuItem)
-		elif UIAClassName == "WpfTextView":
-			clsList.append(WpfTextView)
 		elif (
 			UIAClassName == "ListViewItem"
 			and self.UIAElement.cachedFrameworkID == "WPF"
@@ -1261,6 +1259,8 @@ class UIA(Window):
 			if self.UIAFrameworkId == 'XAML':
 				# This UIA element is being exposed by the XAML framework.
 				clsList.append(XamlEditableText)
+			elif UIAClassName == "WpfTextView":
+				clsList.append(WpfTextView)
 			if UIAHandler.autoSelectDetectionAvailable:
 				clsList.append(EditableTextWithAutoSelectDetection)
 			else:

--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -2214,7 +2214,6 @@ class UIA(Window):
 
 
 class InaccurateTextChangeEventEmittingEditableText(EditableTextBase, UIA):
-	""" a UIA element with editable text exposed by the XAML framework or WPF."""
 
 	# XAML and WPF fire UIA textSelectionChange events before the caret position change is reflected
 	# in the related UIA text pattern.
@@ -2236,6 +2235,7 @@ class InaccurateTextChangeEventEmittingEditableText(EditableTextBase, UIA):
 
 
 class XamlEditableText(InaccurateTextChangeEventEmittingEditableText):
+	"""An UIA element with editable text exposed by the XAML framework."""
 	...
 
 


### PR DESCRIPTION
### Link to issue number:
follow up of #14888

### Summary of the issue:
During development of #14888, it was observed that XAML edit fields tend to fire text change events before the caret position is changed, resulting in wrong text reporting. After using Visual Studio, I discovered that the same issue applies to the text controls in Visual Studio, notably WPF.

### Description of user facing changes
In Visual Studio, the caret position is no longer sometimes reported inaccurately.

### Description of development approach
use a common base class for XAML and WPF editable text.

### Testing strategy:
Tested that caret reporting is again accurate in Visual Studio.

### Known issues with pull request:
None known

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
