### PR TITLE
Windows 11 emoji panel: remove both XAML editable text and editable text selection detection behavior

### DIFF
--- a/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
+++ b/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
@@ -20,7 +20,7 @@ import config
 import winVersion
 import controlTypes
 from NVDAObjects.UIA import UIA, XamlEditableText
-from NVDAObjects.behaviors import CandidateItem as CandidateItemBehavior
+from NVDAObjects.behaviors import CandidateItem as CandidateItemBehavior, EditableTextWithAutoSelectDetection
 
 
 class ImeCandidateUI(UIA):
@@ -335,4 +335,5 @@ class AppModule(appModuleHandler.AppModule):
 			# However this means NVDA's own edit field scripts will override emoji panel commands.
 			# Therefore remove text field movement commands so emoji panel commands can be used directly.
 			elif obj.UIAAutomationId == "Windows.Shell.InputApp.FloatingSuggestionUI.DelegationTextBox":
+				clsList.remove(EditableTextWithAutoSelectDetection)
 				clsList.remove(XamlEditableText)


### PR DESCRIPTION
Hi,

Follow-up to #15837:

### Link to issue number:
Addresses initial flaw found in #15837 

### Summary of the issue:
Turns out both XAML editable text and editable text auto-select detection behavior must be removed to let emoji panel items be announced when using arrow keys.

### Description of user facing changes
Windows 11 emoji panel items can be reported when using arrow keys.

### Description of development approach
Both XAML editable text and editable text with auto-select detection behavior must be removed when handling Windows 11 emoji panel text field to allow arrow keys to work when reviewing emoji panel entries. I'm sure there is a more elegant solution.

### Testing strategy:
Manual testing: make sure emoji panel items are announced when using arrow keys.

### Known issues with pull request:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
