### PR TITLE
No longer reinit hwIo on config reset

### DIFF
--- a/source/core.py
+++ b/source/core.py
@@ -222,7 +222,6 @@ def resetConfiguration(factoryDefaults=False):
 	import vision
 	import inputCore
 	import bdDetect
-	import hwIo
 	import tones
 	log.debug("Terminating vision")
 	vision.terminate()
@@ -236,8 +235,6 @@ def resetConfiguration(factoryDefaults=False):
 	tones.terminate()
 	log.debug("Terminating background braille display detection")
 	bdDetect.terminate()
-	log.debug("Terminating background i/o")
-	hwIo.terminate()
 	log.debug("terminating addonHandler")
 	addonHandler.terminate()
 	log.debug("Reloading config")
@@ -254,9 +251,6 @@ def resetConfiguration(factoryDefaults=False):
 	from addonStore import dataManager
 	dataManager.initialize()
 	addonHandler.initialize()
-	# Hardware background i/o
-	log.debug("initializing background i/o")
-	hwIo.initialize()
 	log.debug("Initializing background braille display detection")
 	bdDetect.initialize()
 	# Tones


### PR DESCRIPTION
### Link to issue number:
Related to #15833 
Might improve #14872

### Summary of the issue:
When moving the hwIo background thread from braille to hwIo, `core.resetConfiguration` was changed to reinitialize hwIo. However since hwIo has nothing to do with config at all, there is no need to do so.

### Description of user facing changes
Might improve #14872

### Description of development approach
No longer reload hwIo.

### Testing strategy:
Ensured that reloading config still works.

### Known issues with pull request:
None known

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [ ] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
