### PR TITLE
show result of report current focus, navigator object, and selection in braille

### DIFF
--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -20,7 +20,6 @@ from annotation import (
 )
 
 import audioDucking
-
 import touchHandler
 import keyboardHandler
 import mouseHandler
@@ -260,7 +259,7 @@ class GlobalCommands(ScriptableObject):
 			"Announces the current selection in edit controls and documents. "
 			"Pressing twice spells this information. "
 			"Pressing three times spells it using character descriptions. "
-			"Pressing four times shows it in a browseable message."
+			"Pressing four times shows it in a browsable message. "
 		),
 		category=SCRCAT_SYSTEMCARET,
 		gestures=("kb(desktop):NVDA+shift+upArrow", "kb(laptop):NVDA+shift+s"),

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -2507,9 +2507,7 @@ class GlobalCommands(ScriptableObject):
 		if repeatCount == 0:
 			speechList = speech.getObjectSpeech(focusObject, reason=controlTypes.OutputReason.QUERY)
 			speech.speech.speak(speechList)
-			brailleList = speechList.copy()
 			text = ' '.join(s for s in speechList if isinstance(s, str))
-
 			braille.handler.message(text)
 		else:
 			speech.speakSpelling(focusObject.name, useCharacterDescriptions=repeatCount > 1)

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -20,7 +20,7 @@ from annotation import (
 )
 
 import audioDucking
-import copy
+
 import touchHandler
 import keyboardHandler
 import mouseHandler
@@ -275,9 +275,11 @@ class GlobalCommands(ScriptableObject):
 		except (RuntimeError, NotImplementedError):
 			info=None
 		if not info or info.isCollapsed:
+			# Translators: The message reported when there is no selection
 			ui.message(_("No selection"))
 		else:
 			scriptCount = scriptHandler.getLastScriptRepeatCount()
+			# Translators: The message reported after selected text
 			selectMessage = speech.speech._getSelectionMessageSpeech(_('%s selected'), info.text)[0]
 			if scriptCount == 0:
 				speech.speakTextSelected(info.text)
@@ -2504,10 +2506,11 @@ class GlobalCommands(ScriptableObject):
 		if repeatCount == 0:
 			speechList = speech.getObjectSpeech(focusObject, reason=controlTypes.OutputReason.QUERY)
 			speech.speech.speak(speechList)
-			for i in copy.copy(speechList):
+			brailleList = speechList.copy()
+			for i in speechList:
 				if not isinstance(i, str):
-					speechList.remove(i)
-			text = ' '.join(speechList)
+					brailleList.remove(i)
+			text = ' '.join(brailleList)
 			braille.handler.message(text)
 		else:
 			speech.speakSpelling(focusObject.name, useCharacterDescriptions=repeatCount > 1)

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -1166,10 +1166,11 @@ class GlobalCommands(ScriptableObject):
 		else:
 			speechList = speech.getObjectSpeech(curObject, reason=controlTypes.OutputReason.QUERY)
 			speech.speech.speak(speechList)
-			for i in copy.copy(speechList):
+			brailleList = speechList.copy()
+			for i in speechList:
 				if not isinstance(i, str):
-					speechList.remove(i)
-			text = ' '.join(speechList)
+					brailleList.remove(i)
+			text = ' '.join(brailleList)
 
 			braille.handler.message(text)
 

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -2508,10 +2508,8 @@ class GlobalCommands(ScriptableObject):
 			speechList = speech.getObjectSpeech(focusObject, reason=controlTypes.OutputReason.QUERY)
 			speech.speech.speak(speechList)
 			brailleList = speechList.copy()
-			for i in speechList:
-				if not isinstance(i, str):
-					brailleList.remove(i)
-			text = ' '.join(brailleList)
+			text = ' '.join(s for s in speechList if isinstance(s, str))
+
 			braille.handler.message(text)
 		else:
 			speech.speakSpelling(focusObject.name, useCharacterDescriptions=repeatCount > 1)

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -20,6 +20,7 @@ from annotation import (
 )
 
 import audioDucking
+import copy
 import touchHandler
 import keyboardHandler
 import mouseHandler

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -278,7 +278,7 @@ class GlobalCommands(ScriptableObject):
 			ui.message(_("No selection"))
 		else:
 			scriptCount = scriptHandler.getLastScriptRepeatCount()
-			selectMessage = ' '.join(speech.speech.getPreselectedTextSpeech(info.text))
+			selectMessage = speech.speech._getSelectionMessageSpeech(_('%s selected'), info.text)[0]
 			if scriptCount == 0:
 				speech.speakTextSelected(info.text)
 				braille.handler.message(selectMessage)

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -259,7 +259,8 @@ class GlobalCommands(ScriptableObject):
 			# Translators: Input help mode message for report current selection command.
 			"Announces the current selection in edit controls and documents. "
 			"Pressing twice spells this information. "
-			"Pressing three times spells it using character descriptions."
+			"Pressing three times spells it using character descriptions. "
+			"Pressing four times shows it in a browseable message."
 		),
 		category=SCRCAT_SYSTEMCARET,
 		gestures=("kb(desktop):NVDA+shift+upArrow", "kb(laptop):NVDA+shift+s"),
@@ -284,6 +285,10 @@ class GlobalCommands(ScriptableObject):
 			if scriptCount == 0:
 				speech.speakTextSelected(info.text)
 				braille.handler.message(selectMessage)
+
+			elif scriptCount == 3:
+				ui.browseableMessage(info.text)
+				return
 
 			elif len(info.text) < speech.speech.MAX_LENGTH_FOR_SELECTION_REPORTING:
 				speech.speakSpelling(info.text, useCharacterDescriptions=scriptCount > 1)

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -1168,11 +1168,7 @@ class GlobalCommands(ScriptableObject):
 		else:
 			speechList = speech.getObjectSpeech(curObject, reason=controlTypes.OutputReason.QUERY)
 			speech.speech.speak(speechList)
-			brailleList = speechList.copy()
-			for i in speechList:
-				if not isinstance(i, str):
-					brailleList.remove(i)
-			text = ' '.join(brailleList)
+			text = ' '.join(s for s in speechList if isinstance(s, str))
 
 			braille.handler.message(text)
 

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -1165,11 +1165,12 @@ class GlobalCommands(ScriptableObject):
 					api.copyToClip(text, notify=True)
 		else:
 			speechList = speech.getObjectSpeech(curObject, reason=controlTypes.OutputReason.QUERY)
+			speech.speech.speak(speechList)
 			for i in copy.copy(speechList):
 				if not isinstance(i, str):
 					speechList.remove(i)
 			text = ' '.join(speechList)
-			speech.speech.speak(speechList)
+
 			braille.handler.message(text)
 
 
@@ -2501,11 +2502,11 @@ class GlobalCommands(ScriptableObject):
 		repeatCount = scriptHandler.getLastScriptRepeatCount()
 		if repeatCount == 0:
 			speechList = speech.getObjectSpeech(focusObject, reason=controlTypes.OutputReason.QUERY)
+			speech.speech.speak(speechList)
 			for i in copy.copy(speechList):
 				if not isinstance(i, str):
 					speechList.remove(i)
 			text = ' '.join(speechList)
-			speech.speech.speak(speechList)
 			braille.handler.message(text)
 		else:
 			speech.speakSpelling(focusObject.name, useCharacterDescriptions=repeatCount > 1)

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -48,7 +48,8 @@ Windows 8.1 is the minimum Windows version supported. (#15544)
 - Key Commands:
   - The following commands now support two and three presses to spell the reported information and spell with character descriptions: report selection, report clipboard text and report focused object. (#15449, @CyrilleB79)
   - The command to toggle the screen curtain now has a default gesture: ``NVDA+control+escape``. (#10560, @CyrilleB79)
-  -
+  - When pressed four times, the report selection command now shows the selection in a browseable message(@Emil-18)
+  - 
 - Microsoft Office:
   - When requesting formatting information on Excel cells, borders and background will only be reported if there is such formatting. (#15560, @CyrilleB79)
   - NVDA will again no longer report unlabelled groupings such as in recent versions of Microsoft Office 365 menus. (#15638)

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -73,6 +73,7 @@ It is also updated with UIA enabled, when typing text and braille is tethered to
 - Contracted braille input works properly again. (#15773, @aaclause)
 - NVDA is again able to track the focus in applications running within Windows Defender Application Guard (WDAG). (#15164)
 - Braille is now updated when moving the navigator object between table cells in more situations (#15755, @Emil-18)
+- Report focus, report navigator object, and report selection scripts are now reported in braille as well as speech (#15844, @Emil-18)
 -
 
 == Changes for Developers ==

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -82,7 +82,7 @@ Users of Poedit 1 are encouraged to update to Poedit 3 if they want to rely on e
   - More objects which contain useful text are detected, and text content is displayed in braille. (#15605)
   - Contracted braille input works properly again. (#15773, @aaclause)
   - Braille is now updated when moving the navigator object between table cells in more situations (#15755, @Emil-18)
-  - The result of report current focus, current navigator object, and current selection commands is now shown in brraille. (#15844, @Emil-18)
+  - The result of reporting current focus, current navigator object, and current selection commands is now shown in braille. (#15844, @Emil-18)
   -
 - LibreOffice:
   - Words deleted using the ``control+backspace`` keyboard shortcut are now also properly announced when the deleted word is followed by whitespace (like spaces and tabs). (#15436, @michaelweghorn)

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -6,10 +6,29 @@ What's New in NVDA
 
 = 2024.1 =
 
+A new "on-demand" speech mode has been added.
+When speech is on-demand, NVDA does not speak automatically (e.g. when moving the cursor) but still speaks when calling commands whose goal is explicitly to report something (e.g. report window title).
+The Add-on Store now supports bulk actions (e.g. installing, enabling add-ons) by selecting multiple add-ons
+There is a new action to open a reviews webpage for the selected add-on.
+
+The audio output device and ducking mode options have been removed from the "Select Synthesizer" dialog.
+They can be found in the audio settings panel which can be opened with ``NVDA+control+u``.
+
+eSpeak-NG, LibLouis braille translator, and Unicode CLDR have been updated.
+New Thai and Romanian braille tables are available.
+
+== Important notes == 
+- This release breaks compatibility with existing add-ons.
+- Windows 7, and Windows 8 are no longer supported.
+Windows 8.1 is the minimum Windows version supported.
+-
+
 == New Features ==
+- Add-on Store:
+  - The Add-on Store now supports bulk actions (e.g. installing, enabling add-ons) by selecting multiple add-ons. (#15350, #15623, @CyrilleB79)
+  - A new action has been added to open a dedicated webpage to see or provide feedback about the selected add-on. (#15576, @nvdaes)
+  -
 - Added support for Bluetooth Low Energy HID Braille displays. (#15470)
-- The Add-on Store now supports bulk actions (e.g. installing, enabling add-ons) by selecting multiple add-ons. (#15350, #15623, @CyrilleB79)
-- From the add-on store, it's possible to open a dedicated webpage to see or provide feedback about the selected add-on. (#15576, @nvdaes)
 - A new "on-demand" speech mode has been added.
 When speech is on-demand, NVDA does not speak automatically (e.g. when moving the cursor) but still speaks when calling commands whose goal is explicitly to report something (e.g. report window title). (#481, @CyrilleB79)
 -
@@ -26,12 +45,18 @@ Windows 8.1 is the minimum Windows version supported. (#15544)
   - CLDR emoji and symbol annotations has been updated to version 44.0. (#15712, @OzancanKaratas)
   - Updated Java Access Bridge to 17.0.9+8Zulu (17.46.19). (#15744)
   -
-- The following commands now support two and three presses to spell the reported information and spell with character descriptions: report selection, report clipboard text and report focused object. (#15449, @CyrilleB79)
+- Key Commands:
+  - The following commands now support two and three presses to spell the reported information and spell with character descriptions: report selection, report clipboard text and report focused object. (#15449, @CyrilleB79)
+  - The command to toggle the screen curtain now has a default gesture: ``NVDA+control+escape``. (#10560, @CyrilleB79)
+  -
+- Microsoft Office:
+  - When requesting formatting information on Excel cells, borders and background will only be reported if there is such formatting. (#15560, @CyrilleB79)
+  - NVDA will again no longer report unlabelled groupings such as in recent versions of Microsoft Office 365 menus. (#15638)
+  -
+- The audio output device and ducking mode options have been removed from the "Select Synthesizer" dialog.
+They can be found in the audio settings panel which can be opened with ``NVDA+control+u``. (#15512)
 - The option "Report role when mouse enters object" in NVDA's mouse settings category has been renamed to "Report object when mouse enters it".
 This option now announces additional relevant information about an object when the mouse enters it, such as states (checked/pressed) or cell coordinates in a table. (#15420, @LeonarddeR)
-- When requesting formatting information on Excel cells, borders and background will only be reported if there is such formatting. (#15560, @CyrilleB79)
-- The command to toggle the screen curtain now has a default gesture: ``NVDA+control+escape``. (#10560, @CyrilleB79)
-- NVDA will again no longer report unlabelled groupings such as in recent versions of Microsoft Office 365 menus. (#15638)
 - New items have beeen added to the Help menu for the NV Access "Get Help" page and Shop. (#14631)
 - NVDA's support for [Poedit https://poedit.net] is overhauled for Poedit version 3 and above.
 Users of Poedit 1 are encouraged to update to Poedit 3 if they want to rely on enhanced accessibility in Poedit, such as shortcuts to read translator notes and comments. (#15313, #7303, @LeonarddeR)
@@ -40,40 +65,49 @@ Users of Poedit 1 are encouraged to update to Poedit 3 if they want to rely on e
 -
 
 == Bug Fixes ==
+- Add-on Store:
+  - When the status of an add-on is changed while it has focus, e.g. a change from "downloading" to "downloaded", the updated item is now announced correctly. (#15859, @LeonarddeR)
+  - When installing add-ons install prompts are no longer overlapped by the restart dialog. (#15613, @lukaszgo1)
+  - When reinstalling an incompatible add-on it is no longer forcefully disabled. (#15584, @lukaszgo1)
+  -
+- Audio:
+  - NVDA no longer freezes briefly when multiple sounds are played in rapid succession. (#15311, #15757, @jcsteh)
+  - If the audio output device is set to something other than the default and that device becomes available again after being unavailable, NVDA will now switch back to the configured device instead of continuing to use the default device. (#15759, @jcsteh)
+  - NVDA now resumes audio if the configuration of the output device changes or another application releases exclusive control of the device. (#15758, #15775, @jcsteh)
+  -
+- Braille:
+  - Multi line braille displays will no longer crash the BRLTTY driver and are treated as one continuous display. (#15386)
+  - More objects which contain useful text are detected, and text content is displayed in braille. (#15605)
+  - Contracted braille input works properly again. (#15773, @aaclause)
+  - Braille is now updated when moving the navigator object between table cells in more situations (#15755, @Emil-18)
+  -
+- LibreOffice:
+  - Words deleted using the ``control+backspace`` keyboard shortcut are now also properly announced when the deleted word is followed by whitespace (like spaces and tabs). (#15436, @michaelweghorn)
+  - Announcement of the status bar using the ``NVDA+end`` keyboard shortcut now also works for dialogs in LibreOffice version 24.2 and newer. (#15591, @michaelweghorn)
+  - All expected text attributes are now supported in LibreOffice versions 24.2 and above.
+  This makes the announcement of spelling errors work when announcing a line in Writer. (#15648, @michaelweghorn)
+  -
+- Microsoft Office:
+  - In Excel with UIA disabled, braille is updated, and the active cell content is spoken, when ``control+y``, ``control+z`` or ``alt+backspace`` is pressed. (#15547)
+  - In Word with UIA disabled braille is updated when ``control+v``, ``control+x``, ``control+y``, ``control+z``, ``alt+backspace``, ``backspace`` or ``control+backspace`` is pressed.
+  It is also updated with UIA enabled, when typing text and braille is tethered to review and review follows caret. (#3276)
+  - In Word, the landing cell will now be correctly reported when using the native Word commands for table navigation ``alt+home``, ``alt+end``, ``alt+pageUp`` and ``alt+pageDown``. (#15805, @CyrilleB79)
+  -
 - Reporting of object shortcut keys has been improved. (#10807, #15816, @CyrilleB79)
 - The SAPI4 synthesizer now properly supports volume, rate and pitch changes embedded in speech. (#15271, @LeonarddeR)
 - Multi line state is now correctly reported in applications using Java Access Bridge. (#14609)
-- In LibreOffice, words deleted using the ``control+backspace`` keyboard shortcut are now also properly announced when the deleted word is followed by whitespace (like spaces and tabs). (#15436, @michaelweghorn)
-- In LibreOffice, announcement of the status bar using the ``NVDA+end`` keyboard shortcut now also works for dialogs in LibreOffice version 24.2 and newer. (#15591, @michaelweghorn)
-- In LibreOffice, text attributes according to the [IAccessible2 text attributes specification https://wiki.linuxfoundation.org/accessibility/iaccessible2/textattributes] are supported, which is required to support announcement of text attributes in LibreOffice versions 24.2 and above.
-This makes the announcement of spelling errors work when announcing a line in Writer. (#15648, @michaelweghorn)
-- In Microsoft Excel with UIA disabled, braille is updated, and the active cell content is spoken, when ``control+y``, ``control+z`` or ``alt+backspace`` is pressed. (15547)
-- In Microsoft Word with UIA disabled braille is updated when ``control+v``, ``control+x``, ``control+y``, ``control+z``, ``alt+backspace``, ``backspace`` or ``control+backspace`` is pressed.
-It is also updated with UIA enabled, when typing text and braille is tethered to review and review follows caret. (#3276)
-- Multi line braille displays will no longer crash the BRLTTY driver and are treated as one continuous display. (#15386)
-- NVDA no longer sometimes freezes briefly when multiple sounds are played in rapid succession. (#15311)
 - NVDA will announce dialog content for more Windows 10 and 11 dialogs. (#15729, @josephsl)
 - NVDA will no longer fail to read a newly loaded page in Microsoft Edge when using UI Automation. (#15736)
 - When using say all or commands which spell text, pauses between sentences or characters no longer gradually decrease over time. (#15739, @jcsteh)
 - NVDA no longer sometimes freezes when speaking a large amount of text. (#15752, @jcsteh)
-- More objects which contain useful text are detected, and text content is displayed in braille. (#15605)
-- When reinstalling an incompatible add-on it is no longer forcefully disabled. (#15584, @lukaszgo1)
-- When installing add-ons in the Add-on Store, install prompts are no longer overlapped by the restart dialog. (#15613, @lukaszgo1)
 - When accessing Microsoft Edge using UI Automation, NVDA is able to activate more controls in browse mode. (#14612)
-- NVDA no longer freezes briefly when multiple sounds are played in rapid succession. (#15757, @jcsteh)
 - NVDA will not fail to start anymore when the configuration file is corrupted, but it will restore the configuration to default as it did in the past. (#15690, @CyrilleB79)
 - Fixed support for System List view (``SysListView32``) controls in Windows Forms applications. (#15283, @LeonarddeR)
-- If the audio output device is set to something other than the default and that device becomes available again after being unavailable, NVDA will now switch back to the configured device instead of continuing to use the default device. (#15759, @jcsteh)
 - It is not possible anymore to overwrite NVDA's Python console history. (#15792, @CyrilleB79)
-- In Word, the landing cell will now be correctly reported when using the native Word commands for table navigation ``alt+home``, ``alt+end``, ``alt+pageUp`` and ``alt+pageDown``. (#15805, @CyrilleB79)
-- NVDA now resumes audio if the configuration of the output device changes or another application releases exclusive control of the device. (#15758, #15775, @jcsteh)
 - NVDA should remain responsive when being flooded with many UI Automation events, e.g. large amounts of text in a terminal. (#14888)
  - This new behavior can be disabled using the new Use enhanced event processing setting in NVDA's advanced settings.
  -
-- Contracted braille input works properly again. (#15773, @aaclause)
 - NVDA is again able to track the focus in applications running within Windows Defender Application Guard (WDAG). (#15164)
-- Braille is now updated when moving the navigator object between table cells in more situations (#15755, @Emil-18)
-- Report focus, report navigator object, and report selection scripts are now reported in braille as well as speech (#15844, @Emil-18)
 -
 
 == Changes for Developers ==
@@ -105,6 +139,7 @@ Setting ``numCells`` is still supported for single line braille displays and ``n
  -
 - Changes to the NVDA Controller Client library:
  - The file names of the library no longer contain a suffix denoting the architecture, i.e. ``nvdaControllerClient32/64.dll`` are now called ``nvdaControllerClient.dll``. (#15718, #15717, @LeonarddeR)
+ - Added an example to demonstrate using nvdaControllerClient.dll from Rust. (#15771, @LeonarddeR)
  - Added the following functions to the controller client: (#15734, #11028, #5638, @LeonarddeR)
   - ``nvdaController_getProcessId``: To get the process id (PID) of the current instance of NVDA the controller client is using.
   - ``nvdaController_speakSsml``: To instruct NVDA to speak according to the given SSML. This function also supports:
@@ -156,7 +191,7 @@ Please open a GitHub issue if your Add-on has an issue with updating to the new 
 Instead, when NVDA is running on the user profile, track the existence of the secure desktop with the extension point: ``winAPI.secureDesktop.post_secureDesktopStateChange``. (#14488)
 - ``braille.BrailleHandler.handlePendingCaretUpdate`` has been removed with no public replacement. (#15163, @LeonarddeR)
 - ``bdDetect.addUsbDevices and bdDetect.addBluetoothDevices`` have been removed.
-Braille display drivers should implement the ``registerAutomaticDetection`` ``classmethod`` instead.
+Braille display drivers should implement the ``registerAutomaticDetection`` class method instead.
 That method receives a ``DriverRegistrar`` object on which the ``addUsbDevices`` and ``addBluetoothDevices`` methods can be used. (#15200, @LeonarddeR)
 - The default implementation of the check method on ``BrailleDisplayDriver`` now requires both the ``threadSafe`` and ``supportsAutomaticDetection`` attributes to be set to ``True``. (#15200, @LeonarddeR)
 - Passing lambda functions to ``hwIo.ioThread.IoThread.queueAsApc`` is no longer possible, as functions should be weakly referenceable. (#14627, @LeonarddeR)

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -80,6 +80,7 @@ Users of Poedit 1 are encouraged to update to Poedit 3 if they want to rely on e
   - More objects which contain useful text are detected, and text content is displayed in braille. (#15605)
   - Contracted braille input works properly again. (#15773, @aaclause)
   - Braille is now updated when moving the navigator object between table cells in more situations (#15755, @Emil-18)
+  - The result of report current focus, current navigator object, and current selection commands is now shown in brraille. (#15844, @Emil-18)
   -
 - LibreOffice:
   - Words deleted using the ``control+backspace`` keyboard shortcut are now also properly announced when the deleted word is followed by whitespace (like spaces and tabs). (#15436, @michaelweghorn)

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -48,7 +48,7 @@ Windows 8.1 is the minimum Windows version supported. (#15544)
 - Key Commands:
   - The following commands now support two and three presses to spell the reported information and spell with character descriptions: report selection, report clipboard text and report focused object. (#15449, @CyrilleB79)
   - The command to toggle the screen curtain now has a default gesture: ``NVDA+control+escape``. (#10560, @CyrilleB79)
-  - When pressed four times, the report selection command now shows the selection in a browseable message(@Emil-18)
+  - When pressed four times, the report selection command now shows the selection in a browsable message (#15858, @Emil-18)
   - 
 - Microsoft Office:
   - When requesting formatting information on Excel cells, borders and background will only be reported if there is such formatting. (#15560, @CyrilleB79)


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
fixes #15844
### Summary of the issue:
The report current focus and navigator object commands reports more information then NVDA normaly does by navigating to an object. Because of this, A user that only uses braille is unable to get this information. They are also unable to see acuratly what is selected if the selection is grater then one line, because when tethered to review, the selection information for text is lost, and when tethered to focus, the text is un selected when moving up or down a line.
### Description of user facing changes
A user that only uses braille will be able to get the information described above
### Description of development approach
I changed both the report focus and navigator object scripts, so that instead of calling speakObject, they call getObjectSpeech and saves its return value.
It then uses speech.speech.speak to speak this information
I then go over the list and remove every item that isn't a string, and then joins it with ' '.join
I then show this string in braille
In the reportCurrentSelection script, I get the information spoken using the _getSelectionMessageSpeech function, then show it in braille
### Testing strategy:
I tested the report current focus and navigator scripts. Both worked as expected. I tested the report selection script in a situation where it was no selection, in a situation where the selection was small enough to be reported by NVDA, and in a situation where it was large enough that NVDA reported the number of characters selected. It worked in all those cases
### Known issues with pull request:
None so far
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
