### PR TITLE
Add-on store: emit a namechange event when a list item is updated

### DIFF
--- a/source/gui/addonStoreGui/controls/addonList.py
+++ b/source/gui/addonStoreGui/controls/addonList.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2022-2023 NV Access Limited
+# Copyright (C) 2022-2023 NV Access Limited, Leonard de Ruijter
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -116,6 +116,8 @@ class AddonVirtualList(
 	def _itemDataUpdated(self, index: int):
 		log.debug(f"index: {index}")
 		self.RefreshItem(index)
+		# Emit a namechange event for the list item in order for NVDA to report the updated state.
+		wx.Accessible.NotifyEvent(wx.ACC_EVENT_OBJECT_NAMECHANGE, self, wx.OBJID_CLIENT, index + 1)
 
 	def OnItemSelected(self, evt: wx.ListEvent):
 		newIndex = evt.GetIndex()

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -73,6 +73,7 @@ It is also updated with UIA enabled, when typing text and braille is tethered to
 - Contracted braille input works properly again. (#15773, @aaclause)
 - NVDA is again able to track the focus in applications running within Windows Defender Application Guard (WDAG). (#15164)
 - Braille is now updated when moving the navigator object between table cells in more situations (#15755, @Emil-18)
+- When the status of an add-on is changed in the add-on store list while the add-on has focus, e.g. when changing  the status from "downloading" to "downloaded", the updated state is now announced correctly. (#15859, @LeonarddeR)
 -
 
 == Changes for Developers ==

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -73,7 +73,7 @@ It is also updated with UIA enabled, when typing text and braille is tethered to
 - Contracted braille input works properly again. (#15773, @aaclause)
 - NVDA is again able to track the focus in applications running within Windows Defender Application Guard (WDAG). (#15164)
 - Braille is now updated when moving the navigator object between table cells in more situations (#15755, @Emil-18)
-- When the status of an add-on is changed in the add-on store list while the add-on has focus, e.g. when changing  the status from "downloading" to "downloaded", the updated state is now announced correctly. (#15859, @LeonarddeR)
+- When the status of an add-on is changed in the add-on store list while it has focus, e.g. a change from "downloading" to "downloaded", the updated item is now announced correctly. (#15859, @LeonarddeR)
 -
 
 == Changes for Developers ==


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
When installing an add-on, the state of the add-on is updated in the list, but state changes aren't pronounced by NVDA.

### Description of user facing changes
Re-announce the list item after an item update.

### Description of development approach
Send a namechange event to the selected list item

### Testing strategy:
Tested installing an add-on, ensured that the status update from `downloading` to `downloaded, pending install` and that this was announced correctly.

### Known issues with pull request:
The whole list item is announced instead of only the changed column. Note that the announcement is triggered by a MSAA name change event. Of course it is technically possible to announce changed columns only, but that would require much more custom code.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
