### PR TITLE
Determine add-on status based on tab of add-on store

### DIFF
--- a/source/addonStore/models/status.py
+++ b/source/addonStore/models/status.py
@@ -45,6 +45,7 @@ class EnabledStatus(DisplayStringEnum):
 
 
 @enum.unique
+# TODO refactor rename from AvailableAddonStatus to AddonStatus
 class AvailableAddonStatus(DisplayStringEnum):
 	""" Values to represent the status of add-ons within the NVDA add-on store.
 	Although related, these are independent of the states in L{addonHandler}
@@ -53,6 +54,7 @@ class AvailableAddonStatus(DisplayStringEnum):
 	PENDING_REMOVE = enum.auto()
 	AVAILABLE = enum.auto()
 	UPDATE = enum.auto()
+	UPDATE_INCOMPATIBLE = enum.auto()
 	REPLACE_SIDE_LOAD = enum.auto()
 	"""
 	Used when an addon in the store matches an installed add-on ID.
@@ -85,6 +87,8 @@ class AvailableAddonStatus(DisplayStringEnum):
 			self.AVAILABLE: pgettext("addonStore", "Available"),
 			# Translators: Status for addons shown in the add-on store dialog
 			self.UPDATE: pgettext("addonStore", "Update Available"),
+			# Translators: Status for addons shown in the add-on store dialog
+			self.UPDATE_INCOMPATIBLE: pgettext("addonStore", "Update Available (incompatible)"),
 			# Translators: Status for addons shown in the add-on store dialog
 			self.REPLACE_SIDE_LOAD: pgettext("addonStore", "Migrate to add-on store"),
 			# Translators: Status for addons shown in the add-on store dialog
@@ -147,136 +151,6 @@ class AddonStateCategory(str, enum.Enum):
 	"""Add-ons in this state are incompatible but their compatibility would be overridden on the next restart."""
 
 
-def _getDownloadableStatus(model: "_AddonGUIModel") -> Optional[AvailableAddonStatus]:
-	from ..dataManager import addonDataManager
-	assert addonDataManager is not None
-
-	if model.name in (d.model.name for d in addonDataManager._downloadsPendingCompletion):
-		return AvailableAddonStatus.DOWNLOADING
-
-	if model.name in (d.model.name for d, _ in addonDataManager._downloadsPendingInstall):
-		return AvailableAddonStatus.DOWNLOAD_SUCCESS
-
-	if model._addonHandlerModel is None:
-		# add-on is not installed
-		if model.isPendingInstall:
-			return AvailableAddonStatus.DOWNLOAD_SUCCESS
-
-		if not model.isCompatible:
-			# Installed incompatible add-ons have a status of disabled or running
-			return AvailableAddonStatus.INCOMPATIBLE
-
-		# Any compatible add-on which is not installed should be listed as available
-		return AvailableAddonStatus.AVAILABLE
-
-	return None
-
-
-def _getUpdateStatus(model: "_AddonGUIModel") -> Optional[AvailableAddonStatus]:
-	from .addon import AddonStoreModel
-	from ..dataManager import addonDataManager
-	assert addonDataManager is not None
-
-	if not isinstance(model, AddonStoreModel):
-		# If the listed add-on is installed from a side-load
-		# and not available on the add-on store
-		# the type will not be AddonStoreModel
-		return None
-
-	addonStoreInstalledData = addonDataManager._getCachedInstalledAddonData(model.addonId)
-	if addonStoreInstalledData is not None:
-		if model.addonVersionNumber > addonStoreInstalledData.addonVersionNumber:
-			return AvailableAddonStatus.UPDATE
-	else:
-		# Parsing from a side-loaded add-on
-		try:
-			manifestAddonVersion = MajorMinorPatch._parseVersionFromVersionStr(model._addonHandlerModel.version)
-		except ValueError:
-			# Parsing failed to get a numeric version.
-			# Ideally a numeric version would be compared,
-			# however the manifest only has a version string.
-			# Ensure the user is aware that it may be a downgrade or reinstall.
-			# Encourage users to re-install or upgrade the add-on from the add-on store.
-			return AvailableAddonStatus.REPLACE_SIDE_LOAD
-
-		if model.addonVersionNumber > manifestAddonVersion:
-			return AvailableAddonStatus.UPDATE
-
-	return None
-
-
-def getStatus(model: "_AddonGUIModel") -> AvailableAddonStatus:
-	from addonHandler import state as addonHandlerState
-
-	downloadableStatus = _getDownloadableStatus(model)
-	if downloadableStatus:
-		# Is this available in the add-on store and not installed?
-		return downloadableStatus
-	else:
-		# Add-on is currently installed or pending restart
-		addonHandlerModel = model._addonHandlerModel
-		assert addonHandlerModel
-
-	for storeState, handlerStateCategories in _addonStoreStateToAddonHandlerState.items():
-		# Match special addonHandler states early for installed add-ons.
-		# Includes enabled, pending enabled, disabled, e.t.c.
-		if all(
-			model.addonId in addonHandlerState[stateCategory]
-			for stateCategory in handlerStateCategories
-		):
-			# Return the add-on store state if the add-on
-			# is in all of the addonHandlerStates
-			# required to match to an add-on store state.
-			# Most states are a 1-to-1 match,
-			# however incompatible add-ons match to two states:
-			# one to flag if that its incompatible,
-			# and another for enabled/disabled.
-			return storeState
-
-	updateStatus = _getUpdateStatus(model)
-	if updateStatus:
-		# Can add-on be updated?
-		return updateStatus
-
-	if addonHandlerModel.isRunning:
-		return AvailableAddonStatus.RUNNING
-	
-	if addonHandlerModel.isEnabled:
-		return AvailableAddonStatus.ENABLED
-
-	log.error(f"Add-on in unknown state: {model.addonId}")
-	return AvailableAddonStatus.UNKNOWN
-
-
-_addonStoreStateToAddonHandlerState: OrderedDict[
-	AvailableAddonStatus,
-	Set[AddonStateCategory]
-	] = OrderedDict({
-	# Pending states must be first as the pending state may be altering another state.
-	AvailableAddonStatus.PENDING_INCOMPATIBLE_DISABLED: {
-		AddonStateCategory.BLOCKED,
-		AddonStateCategory.PENDING_DISABLE,
-	},
-	AvailableAddonStatus.PENDING_INCOMPATIBLE_ENABLED: {
-		AddonStateCategory.PENDING_OVERRIDE_COMPATIBILITY,
-		AddonStateCategory.PENDING_ENABLE,
-	},
-	# If an add-on is being updated,
-	# it will be in both pending remove and pending install
-	AvailableAddonStatus.INSTALLED: {
-		AddonStateCategory.PENDING_INSTALL,
-		AddonStateCategory.PENDING_REMOVE,
-	},
-	AvailableAddonStatus.PENDING_REMOVE: {AddonStateCategory.PENDING_REMOVE},
-	AvailableAddonStatus.PENDING_ENABLE: {AddonStateCategory.PENDING_ENABLE},
-	AvailableAddonStatus.PENDING_DISABLE: {AddonStateCategory.PENDING_DISABLE},
-	AvailableAddonStatus.INCOMPATIBLE_DISABLED: {AddonStateCategory.BLOCKED},
-	AvailableAddonStatus.INCOMPATIBLE_ENABLED: {AddonStateCategory.OVERRIDE_COMPATIBILITY},
-	AvailableAddonStatus.DISABLED: {AddonStateCategory.DISABLED},
-	AvailableAddonStatus.INSTALLED: {AddonStateCategory.PENDING_INSTALL},
-})
-
-
 class _StatusFilterKey(DisplayStringEnum):
 	"""Keys for filtering by status in the NVDA add-on store."""
 	INSTALLED = enum.auto()
@@ -334,6 +208,157 @@ class _StatusFilterKey(DisplayStringEnum):
 			raise e
 
 
+def _getDownloadableStatus(model: "_AddonGUIModel") -> Optional[AvailableAddonStatus]:
+	from ..dataManager import addonDataManager
+	assert addonDataManager is not None
+
+	if model.name in (d.model.name for d in addonDataManager._downloadsPendingCompletion):
+		return AvailableAddonStatus.DOWNLOADING
+
+	if model.name in (d.model.name for d, _ in addonDataManager._downloadsPendingInstall):
+		return AvailableAddonStatus.DOWNLOAD_SUCCESS
+
+	if model._addonHandlerModel is None:
+		# add-on is not installed
+		if model.isPendingInstall:
+			return AvailableAddonStatus.DOWNLOAD_SUCCESS
+
+		if not model.isCompatible:
+			# Installed incompatible add-ons have a status of disabled or running
+			return AvailableAddonStatus.INCOMPATIBLE
+
+		# Any compatible add-on which is not installed should be listed as available
+		return AvailableAddonStatus.AVAILABLE
+
+	return None
+
+
+def _getUpdateStatus(model: "_AddonGUIModel") -> Optional[AvailableAddonStatus]:
+	from .addon import AddonStoreModel
+	from ..dataManager import addonDataManager
+	assert addonDataManager is not None
+
+	if not isinstance(model, AddonStoreModel):
+		# If the listed add-on is installed from a side-load
+		# and not available on the add-on store
+		# the type will not be AddonStoreModel
+		return None
+
+	addonStoreInstalledData = addonDataManager._getCachedInstalledAddonData(model.addonId)
+	if addonStoreInstalledData is not None:
+		if model.addonVersionNumber > addonStoreInstalledData.addonVersionNumber:
+			if not model.isCompatible:
+				return AvailableAddonStatus.UPDATE_INCOMPATIBLE
+			return AvailableAddonStatus.UPDATE
+	else:
+		# Parsing from a side-loaded add-on
+		try:
+			manifestAddonVersion = MajorMinorPatch._parseVersionFromVersionStr(model._addonHandlerModel.version)
+		except ValueError:
+			# Parsing failed to get a numeric version.
+			# Ideally a numeric version would be compared,
+			# however the manifest only has a version string.
+			# Ensure the user is aware that it may be a downgrade or reinstall.
+			# Encourage users to re-install or upgrade the add-on from the add-on store.
+			return AvailableAddonStatus.REPLACE_SIDE_LOAD
+
+		if model.addonVersionNumber > manifestAddonVersion:
+			if not model.isCompatible:
+				return AvailableAddonStatus.UPDATE_INCOMPATIBLE
+			return AvailableAddonStatus.UPDATE
+
+	return None
+
+
+def _getInstalledStatus(model: "_AddonGUIModel") -> Optional[AvailableAddonStatus]:
+	from addonHandler import state as addonHandlerState
+	from ..dataManager import addonDataManager
+	assert addonDataManager is not None
+	assert model._addonHandlerModel is not None
+
+	for storeState, handlerStateCategories in _addonStoreStateToAddonHandlerState.items():
+		# Match special addonHandler states early for installed add-ons.
+		# Includes enabled, pending enabled, disabled, e.t.c.
+		if all(
+			model.addonId in addonHandlerState[stateCategory]
+			for stateCategory in handlerStateCategories
+		):
+			# Return the add-on store state if the add-on
+			# is in all of the addonHandlerStates
+			# required to match to an add-on store state.
+			# Most states are a 1-to-1 match,
+			# however incompatible add-ons match to two states:
+			# one to flag if that its incompatible,
+			# and another for enabled/disabled.
+			return storeState
+
+	if model._addonHandlerModel.isRunning:
+		return AvailableAddonStatus.RUNNING
+	
+	if model._addonHandlerModel.isEnabled:
+		return AvailableAddonStatus.ENABLED
+
+	return None
+
+
+def getStatus(model: "_AddonGUIModel", context: _StatusFilterKey) -> AvailableAddonStatus:
+	"""Get status for an add-on in the context of the current tab in the add-on store.
+	e.g. "update available" from the update tab, and "installed (incompatible)" from the installed tab.
+
+	:param model: Add-on to determine the status of.
+	:param context: Add-on Store tab context we are checking the status for.
+	:return: Status of add-on for the context of the current tab.
+	"""
+
+	if context in (_StatusFilterKey.AVAILABLE, _StatusFilterKey.UPDATE):
+		downloadableStatus = _getDownloadableStatus(model)
+		if downloadableStatus:
+			# Is this available in the add-on store and not installed?
+			return downloadableStatus
+
+		updateStatus = _getUpdateStatus(model)
+		if updateStatus:
+			# Can add-on be updated?
+			return updateStatus
+
+	# This add-on should be installed if we aren't fetching for the available add-ons tab
+	installedStatus = _getInstalledStatus(model)
+	if installedStatus:
+		return installedStatus
+
+	log.error(f"Add-on in unknown state: {model.addonId} {context}")
+	return AvailableAddonStatus.UNKNOWN
+
+
+_addonStoreStateToAddonHandlerState: OrderedDict[
+	AvailableAddonStatus,
+	Set[AddonStateCategory]
+	] = OrderedDict({
+	# Pending states must be first as the pending state may be altering another state.
+	AvailableAddonStatus.PENDING_INCOMPATIBLE_DISABLED: {
+		AddonStateCategory.BLOCKED,
+		AddonStateCategory.PENDING_DISABLE,
+	},
+	AvailableAddonStatus.PENDING_INCOMPATIBLE_ENABLED: {
+		AddonStateCategory.PENDING_OVERRIDE_COMPATIBILITY,
+		AddonStateCategory.PENDING_ENABLE,
+	},
+	# If an add-on is being updated,
+	# it will be in both pending remove and pending install
+	AvailableAddonStatus.INSTALLED: {
+		AddonStateCategory.PENDING_INSTALL,
+		AddonStateCategory.PENDING_REMOVE,
+	},
+	AvailableAddonStatus.PENDING_REMOVE: {AddonStateCategory.PENDING_REMOVE},
+	AvailableAddonStatus.PENDING_ENABLE: {AddonStateCategory.PENDING_ENABLE},
+	AvailableAddonStatus.PENDING_DISABLE: {AddonStateCategory.PENDING_DISABLE},
+	AvailableAddonStatus.INCOMPATIBLE_DISABLED: {AddonStateCategory.BLOCKED},
+	AvailableAddonStatus.INCOMPATIBLE_ENABLED: {AddonStateCategory.OVERRIDE_COMPATIBILITY},
+	AvailableAddonStatus.DISABLED: {AddonStateCategory.DISABLED},
+	AvailableAddonStatus.INSTALLED: {AddonStateCategory.PENDING_INSTALL},
+})
+
+
 _installedAddonStatuses: Set[AvailableAddonStatus] = {
 	AvailableAddonStatus.UPDATE,
 	AvailableAddonStatus.REPLACE_SIDE_LOAD,
@@ -355,12 +380,14 @@ _statusFilters: OrderedDict[_StatusFilterKey, Set[AvailableAddonStatus]] = Order
 	_StatusFilterKey.INSTALLED: _installedAddonStatuses,
 	_StatusFilterKey.UPDATE: {
 		AvailableAddonStatus.UPDATE,
+		AvailableAddonStatus.UPDATE_INCOMPATIBLE,
 		AvailableAddonStatus.REPLACE_SIDE_LOAD,
 	},
 	_StatusFilterKey.AVAILABLE: _installedAddonStatuses.union({
 		AvailableAddonStatus.INCOMPATIBLE,
 		AvailableAddonStatus.AVAILABLE,
 		AvailableAddonStatus.UPDATE,
+		AvailableAddonStatus.UPDATE_INCOMPATIBLE,
 		AvailableAddonStatus.REPLACE_SIDE_LOAD,
 		AvailableAddonStatus.DOWNLOAD_FAILED,
 		AvailableAddonStatus.DOWNLOAD_SUCCESS,

--- a/source/gui/addonStoreGui/controls/actions.py
+++ b/source/gui/addonStoreGui/controls/actions.py
@@ -199,7 +199,11 @@ class AddonListValidator:
 		hasUpdatable = False
 		hasInstallable = False
 		for aVM in self.addonsList:
-			if aVM.canUseUpdateAction() or aVM.canUseReplaceAction() or aVM.canUseUpdateOverrideIncompatibilityAction():
+			if (
+				aVM.canUseUpdateAction()
+				or aVM.canUseReplaceAction()
+				or aVM.canUseUpdateOverrideIncompatibilityAction()
+			):
 				hasUpdatable = True
 			if aVM.canUseInstallAction() or aVM.canUseInstallOverrideIncompatibilityAction():
 				hasInstallable = True

--- a/source/gui/addonStoreGui/controls/actions.py
+++ b/source/gui/addonStoreGui/controls/actions.py
@@ -199,7 +199,7 @@ class AddonListValidator:
 		hasUpdatable = False
 		hasInstallable = False
 		for aVM in self.addonsList:
-			if aVM.canUseUpdateAction() or aVM.canUseReplaceAction():
+			if aVM.canUseUpdateAction() or aVM.canUseReplaceAction() or aVM.canUseUpdateOverrideIncompatibilityAction():
 				hasUpdatable = True
 			if aVM.canUseInstallAction() or aVM.canUseInstallOverrideIncompatibilityAction():
 				hasInstallable = True

--- a/source/gui/addonStoreGui/viewModels/addonList.py
+++ b/source/gui/addonStoreGui/viewModels/addonList.py
@@ -133,6 +133,9 @@ class AddonListItemVM(Generic[_AddonModelT]):
 	def canUseUpdateAction(self) -> bool:
 		return self.status == AvailableAddonStatus.UPDATE
 
+	def canUseUpdateOverrideIncompatibilityAction(self) -> bool:
+		return self.status == AvailableAddonStatus.UPDATE_INCOMPATIBLE and self.model.canOverrideCompatibility
+
 	def canUseReplaceAction(self) -> bool:
 		return self.status == AvailableAddonStatus.REPLACE_SIDE_LOAD
 

--- a/source/gui/addonStoreGui/viewModels/store.py
+++ b/source/gui/addonStoreGui/viewModels/store.py
@@ -133,6 +133,13 @@ class AddonStoreVM:
 				actionTarget=selectedListItem
 			),
 			AddonActionVM(
+				# Translators: Label for an action that installs the selected addon
+				displayName=pgettext("addonStore", "&Update (override incompatibility)"),
+				actionHandler=self.installOverrideIncompatibilityForAddon,
+				validCheck=lambda aVM: aVM.canUseUpdateOverrideIncompatibilityAction(),
+				actionTarget=selectedListItem
+			),
+			AddonActionVM(
 				# Translators: Label for an action that replaces the selected addon with
 				# an add-on store version.
 				displayName=pgettext("addonStore", "Re&place"),
@@ -268,7 +275,7 @@ class AddonStoreVM:
 			assert listItemVM.model._addonHandlerModel is not None
 			listItemVM.model._addonHandlerModel.requestRemove()
 			self.refresh()
-			listItemVM.status = getStatus(listItemVM.model)
+			listItemVM.status = getStatus(listItemVM.model, self._filteredStatusKey)
 		return shouldRemove, shouldRememberChoice
 
 	def removeAddons(self, listItemVMs: Iterable[AddonListItemVM[_AddonStoreModel]]) -> None:
@@ -344,7 +351,7 @@ class AddonStoreVM:
 			# ensure calling on the main thread.
 			core.callLater(delay=0, callable=self.onDisplayableError.notify, displayableError=displayableError)
 
-		listItemVM.status = getStatus(listItemVM.model)
+		listItemVM.status = getStatus(listItemVM.model, self._filteredStatusKey)
 		self.refresh()
 
 	def enableOverrideIncompatibilityForAddon(
@@ -635,7 +642,7 @@ class AddonStoreVM:
 			raise NotImplementedError(f"Unhandled status filter key {self._filteredStatusKey}")
 
 		addonsWithStatus = (
-			(model, getStatus(model))
+			(model, getStatus(model, self._filteredStatusKey))
 			for channel in addons
 			for model in addons[channel].values()
 		)

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -69,6 +69,7 @@ Users of Poedit 1 are encouraged to update to Poedit 3 if they want to rely on e
   - When the status of an add-on is changed while it has focus, e.g. a change from "downloading" to "downloaded", the updated item is now announced correctly. (#15859, @LeonarddeR)
   - When installing add-ons install prompts are no longer overlapped by the restart dialog. (#15613, @lukaszgo1)
   - When reinstalling an incompatible add-on it is no longer forcefully disabled. (#15584, @lukaszgo1)
+  - Disabled and incompatible add-ons can now be updated. (#15568, #15029)
   -
 - Audio:
   - NVDA no longer freezes briefly when multiple sounds are played in rapid succession. (#15311, #15757, @jcsteh)


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Fixes #15029
Fixes #15568

### Summary of the issue:
Disabled add-ons were not listed in the updatable add-ons tab.
Add-ons with overridden compatibility were also not listed in the updatable add-ons tab.
Disabled incompatible add-ons should trigger the dialog to override when attempting to update.

Add-on statuses were the same for each tab of the add-on store, this limited determining actions for the add-on.

### Description of user facing changes
Add-on status is now contextual. to the add-on store tab Updatable/downloadable information is only shown on the updatable and available add-ons tab. Installed add-ons tabs now only show statuses relevant to installed add-ons. This means "update available" and "downloaded, pending install" will not be listed in the installed add-ons tab.

Disabled and incompatible add-ons can now be updated.
### Description of development approach
Created a new status and action for incompatible add-ons with an incompatible update available.

Ensure available and updatable statuses are checked before statuses for installed add-ons.
Ensure available and updatable statuses are only checked for their relevant tabs.
This means disabled and incompatible add-ons  return updatable status before checking their disabled/compatibility state.

### Testing strategy:
Manual testing with various states across various add-ons.
Particular cases:
- Updating "clip contents" in disabled/enabled state from incompatible version 27.1 to incompatible version 29.0.0 to compatible version 29.0.1

### Known issues with pull request:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
