### PR TITLE
Adding command gesture categories for appmodules

### DIFF
--- a/source/NVDAObjects/IAccessible/winword.py
+++ b/source/NVDAObjects/IAccessible/winword.py
@@ -218,6 +218,7 @@ class WordDocument(IAccessible, EditableTextWithoutAutoSelectDetection, winWordW
 		gesture="kb:NVDA+shift+c",
 		# Translators: The label of a shortcut of NVDA.
 		description=_(
+			"Set column header"
 			"Pressing once will set this cell as the first column header for any cells lower and "
 			"to the right of it within this table. "
 			"Pressing twice will forget the current column header for this cell."

--- a/source/NVDAObjects/IAccessible/winword.py
+++ b/source/NVDAObjects/IAccessible/winword.py
@@ -217,9 +217,11 @@ class WordDocument(IAccessible, EditableTextWithoutAutoSelectDetection, winWordW
 	@script(
 		gesture="kb:NVDA+shift+c",
 		# Translators: The label of a shortcut of NVDA.
-		description=_("""Pressing once will set this cell as the first column header for any cells lower and 
-to the right of it within this table. 
-Pressing twice will forget the current column header for this cell."""),
+		description=_(
+			"Pressing once will set this cell as the first column header for any cells lower and "
+			"to the right of it within this table. "
+			"Pressing twice will forget the current column header for this cell."
+		),
 		category=SCRCAT_SYSTEMCARET
 	)
 	def script_setColumnHeader(self,gesture):
@@ -248,9 +250,11 @@ Pressing twice will forget the current column header for this cell."""),
 	@script(
 		gesture="kb:NVDA+shift+r",
 		# Translators: The label of a shortcut of NVDA.
-		description=_("""Pressing once will set this cell as the first row header for any cells lower and 
-to the right of it within this table. 
-Pressing twice will forget the current row header for this cell."""),
+		description=_(
+			"Pressing once will set this cell as the first row header for any cells lower and "
+			"to the right of it within this table. "
+			"Pressing twice will forget the current row header for this cell."
+		),
 		category=SCRCAT_SYSTEMCARET
 	)
 	def script_setRowHeader(self,gesture):

--- a/source/NVDAObjects/IAccessible/winword.py
+++ b/source/NVDAObjects/IAccessible/winword.py
@@ -251,6 +251,7 @@ class WordDocument(IAccessible, EditableTextWithoutAutoSelectDetection, winWordW
 		gesture="kb:NVDA+shift+r",
 		# Translators: The label of a shortcut of NVDA.
 		description=_(
+			"Set row header."
 			"Pressing once will set this cell as the first row header for any cells lower and "
 			"to the right of it within this table. "
 			"Pressing twice will forget the current row header for this cell."

--- a/source/NVDAObjects/IAccessible/winword.py
+++ b/source/NVDAObjects/IAccessible/winword.py
@@ -217,7 +217,9 @@ class WordDocument(IAccessible, EditableTextWithoutAutoSelectDetection, winWordW
 	@script(
 		gesture="kb:NVDA+shift+c",
 		# Translators: The label of a shortcut of NVDA.
-		description=_("Pressing once will set this cell as the first column header for any cells lower and to the right of it within this table. Pressing twice will forget the current column header for this cell."),
+		description=_("""Pressing once will set this cell as the first column header for any cells lower and 
+to the right of it within this table. 
+Pressing twice will forget the current column header for this cell."""),
 		category=SCRCAT_SYSTEMCARET
 	)
 	def script_setColumnHeader(self,gesture):
@@ -246,8 +248,9 @@ class WordDocument(IAccessible, EditableTextWithoutAutoSelectDetection, winWordW
 	@script(
 		gesture="kb:NVDA+shift+r",
 		# Translators: The label of a shortcut of NVDA.
-		description=_("""Pressing once will set this cell as the first row header for any cells lower and to the right of it within this table. 
-		Pressing twice will forget the current row header for this cell."""),
+		description=_("""Pressing once will set this cell as the first row header for any cells lower and 
+to the right of it within this table. 
+Pressing twice will forget the current row header for this cell."""),
 		category=SCRCAT_SYSTEMCARET
 	)
 	def script_setRowHeader(self,gesture):

--- a/source/NVDAObjects/IAccessible/winword.py
+++ b/source/NVDAObjects/IAccessible/winword.py
@@ -27,6 +27,7 @@ import NVDAObjects.window.winword as winWordWindowModule
 from speech import sayAll
 import inputCore
 
+SCRCAT_SYSTEMCARET = _("System caret")
 
 class WordDocument(IAccessible, EditableTextWithoutAutoSelectDetection, winWordWindowModule.WordDocument):
 
@@ -212,6 +213,11 @@ class WordDocument(IAccessible, EditableTextWithoutAutoSelectDetection, winWordW
 			if text:
 				return text
 
+	@script(
+			gesture="kb:NVDA+shift+c",
+			description=_("Pressing once will set this cell as the first column header for any cells lower and to the right of it within this table. Pressing twice will forget the current column header for this cell."),
+			category=SCRCAT_SYSTEMCARET
+	)
 	def script_setColumnHeader(self,gesture):
 		scriptCount=scriptHandler.getLastScriptRepeatCount()
 		try:
@@ -234,8 +240,12 @@ class WordDocument(IAccessible, EditableTextWithoutAutoSelectDetection, winWordW
 			else:
 				# Translators: a message reported in the SetColumnHeader script for Microsoft Word.
 				ui.message(_("Cannot find row {rowNumber} column {columnNumber}  in column headers").format(rowNumber=cell.rowIndex,columnNumber=cell.columnIndex))
-	script_setColumnHeader.__doc__=_("Pressing once will set this cell as the first column header for any cells lower and to the right of it within this table. Pressing twice will forget the current column header for this cell.")
 
+	@script(
+			gesture="kb:NVDA+shift+r",
+			description=_("Pressing once will set this cell as the first row header for any cells lower and to the right of it within this table. Pressing twice will forget the current row header for this cell."),
+			category=SCRCAT_SYSTEMCARET
+	)
 	def script_setRowHeader(self,gesture):
 		scriptCount=scriptHandler.getLastScriptRepeatCount()
 		try:
@@ -258,14 +268,25 @@ class WordDocument(IAccessible, EditableTextWithoutAutoSelectDetection, winWordW
 			else:
 				# Translators: a message reported in the SetRowHeader script for Microsoft Word.
 				ui.message(_("Cannot find row {rowNumber} column {columnNumber}  in row headers").format(rowNumber=cell.rowIndex,columnNumber=cell.columnIndex))
-	script_setRowHeader.__doc__=_("Pressing once will set this cell as the first row header for any cells lower and to the right of it within this table. Pressing twice will forget the current row header for this cell.")
 
+	@script(
+			gesture="kb:NVDA+shift+h",
+			category=SCRCAT_SYSTEMCARET
+	)
 	def script_reportCurrentHeaders(self,gesture):
 		cell=self.WinwordSelectionObject.cells[1]
 		rowText=self.fetchAssociatedHeaderCellText(cell,False)
 		columnText=self.fetchAssociatedHeaderCellText(cell,True)
 		ui.message("Row %s, column %s"%(rowText or "empty",columnText or "empty"))
 
+	@script(
+		gestures=(
+			"kb:alt+home",
+			"kb:alt+end",
+			"kb:alt+pageUp",
+			"kb:alt+pageDown"
+		)
+	)
 	def script_caret_moveByCell(self, gesture: inputCore.InputGesture) -> None:
 		info = self.makeTextInfo(textInfos.POSITION_SELECTION)
 		inTable = info._rangeObj.tables.count > 0
@@ -301,6 +322,7 @@ class WordDocument(IAccessible, EditableTextWithoutAutoSelectDetection, winWordW
 		# Translators: a description for a script
 		description=_("Reports the text of the comment where the system caret is located."),
 		gesture="kb:NVDA+alt+c",
+		category=SCRCAT_SYSTEMCARET,
 		speakOnDemand=True,
 	)
 	def script_reportCurrentComment(self,gesture):
@@ -375,33 +397,51 @@ class WordDocument(IAccessible, EditableTextWithoutAutoSelectDetection, winWordW
 		newInfo.updateCaret()
 		return True
 
+	@script(
+			gesture="kb:control+alt+downArrow"
+	)
 	def script_nextRow(self,gesture):
 		self._moveInTable(row=True,forward=True)
 
+	@script(
+			gesture="kb:control+alt+upArrow"
+	)
 	def script_previousRow(self,gesture):
 		self._moveInTable(row=True,forward=False)
 
+	@script(
+			gesture="kb:control+alt+rightArrow"
+	)
 	def script_nextColumn(self,gesture):
 		self._moveInTable(row=False,forward=True)
 
+	@script(
+			gesture="kb:control+alt+leftArrow"
+	)
 	def script_previousColumn(self,gesture):
 		self._moveInTable(row=False,forward=False)
 
+	@script(
+			gesture="kb:control+downArrow",
+			resumeSayAllMode=sayAll.CURSOR.CARET
+	)
 	def script_nextParagraph(self,gesture):
 		info=self.makeTextInfo(textInfos.POSITION_CARET)
 		# #4375: can't use self.move here as it may check document.chracters.count which can take for ever on large documents.
 		info._rangeObj.move(winWordWindowModule.wdParagraph, 1)
 		info.updateCaret()
 		self._caretScriptPostMovedHelper(textInfos.UNIT_PARAGRAPH,gesture,None)
-	script_nextParagraph.resumeSayAllMode = sayAll.CURSOR.CARET
 
+	@script(
+			gesture="kb:control+upArrow",
+			resumeSayAllMode=sayAll.CURSOR.CARET
+	)
 	def script_previousParagraph(self,gesture):
 		info=self.makeTextInfo(textInfos.POSITION_CARET)
 		# #4375: keeping symmetrical with nextParagraph script.
 		info._rangeObj.move(winWordWindowModule.wdParagraph, -1)
 		info.updateCaret()
 		self._caretScriptPostMovedHelper(textInfos.UNIT_PARAGRAPH,gesture,None)
-	script_previousParagraph.resumeSayAllMode = sayAll.CURSOR.CARET
 
 	@script(
 		gestures=(
@@ -434,23 +474,6 @@ class WordDocument(IAccessible, EditableTextWithoutAutoSelectDetection, winWordW
 		self.WinwordApplicationObject.ActiveDocument.Range(rangeStart, rangeStart).Select()
 		import api
 		eventHandler.executeEvent("gainFocus", api.getDesktopObject().objectWithFocus())
-
-	__gestures={
-		"kb:NVDA+shift+c":"setColumnHeader",
-		"kb:NVDA+shift+r":"setRowHeader",
-		"kb:NVDA+shift+h":"reportCurrentHeaders",
-		"kb:control+alt+upArrow": "previousRow",
-		"kb:control+alt+downArrow": "nextRow",
-		"kb:control+alt+leftArrow": "previousColumn",
-		"kb:control+alt+rightArrow": "nextColumn",
-		"kb:control+downArrow":"nextParagraph",
-		"kb:control+upArrow":"previousParagraph",
-		"kb:alt+home":"caret_moveByCell",
-		"kb:alt+end":"caret_moveByCell",
-		"kb:alt+pageUp":"caret_moveByCell",
-		"kb:alt+pageDown":"caret_moveByCell",
-	}
-
 
 class SpellCheckErrorField(IAccessible, winWordWindowModule.WordDocument_WwN):
 

--- a/source/NVDAObjects/IAccessible/winword.py
+++ b/source/NVDAObjects/IAccessible/winword.py
@@ -214,9 +214,9 @@ class WordDocument(IAccessible, EditableTextWithoutAutoSelectDetection, winWordW
 				return text
 
 	@script(
-			gesture="kb:NVDA+shift+c",
-			description=_("Pressing once will set this cell as the first column header for any cells lower and to the right of it within this table. Pressing twice will forget the current column header for this cell."),
-			category=SCRCAT_SYSTEMCARET
+		gesture="kb:NVDA+shift+c",
+		description=_("Pressing once will set this cell as the first column header for any cells lower and to the right of it within this table. Pressing twice will forget the current column header for this cell."),
+		category=SCRCAT_SYSTEMCARET
 	)
 	def script_setColumnHeader(self,gesture):
 		scriptCount=scriptHandler.getLastScriptRepeatCount()
@@ -242,9 +242,9 @@ class WordDocument(IAccessible, EditableTextWithoutAutoSelectDetection, winWordW
 				ui.message(_("Cannot find row {rowNumber} column {columnNumber}  in column headers").format(rowNumber=cell.rowIndex,columnNumber=cell.columnIndex))
 
 	@script(
-			gesture="kb:NVDA+shift+r",
-			description=_("Pressing once will set this cell as the first row header for any cells lower and to the right of it within this table. Pressing twice will forget the current row header for this cell."),
-			category=SCRCAT_SYSTEMCARET
+		gesture="kb:NVDA+shift+r",
+		description=_("Pressing once will set this cell as the first row header for any cells lower and to the right of it within this table. Pressing twice will forget the current row header for this cell."),
+		category=SCRCAT_SYSTEMCARET
 	)
 	def script_setRowHeader(self,gesture):
 		scriptCount=scriptHandler.getLastScriptRepeatCount()
@@ -270,8 +270,8 @@ class WordDocument(IAccessible, EditableTextWithoutAutoSelectDetection, winWordW
 				ui.message(_("Cannot find row {rowNumber} column {columnNumber}  in row headers").format(rowNumber=cell.rowIndex,columnNumber=cell.columnIndex))
 
 	@script(
-			gesture="kb:NVDA+shift+h",
-			category=SCRCAT_SYSTEMCARET
+		gesture="kb:NVDA+shift+h",
+		category=SCRCAT_SYSTEMCARET
 	)
 	def script_reportCurrentHeaders(self,gesture):
 		cell=self.WinwordSelectionObject.cells[1]
@@ -398,32 +398,32 @@ class WordDocument(IAccessible, EditableTextWithoutAutoSelectDetection, winWordW
 		return True
 
 	@script(
-			gesture="kb:control+alt+downArrow"
+		gesture="kb:control+alt+downArrow"
 	)
 	def script_nextRow(self,gesture):
 		self._moveInTable(row=True,forward=True)
 
 	@script(
-			gesture="kb:control+alt+upArrow"
+		gesture="kb:control+alt+upArrow"
 	)
 	def script_previousRow(self,gesture):
 		self._moveInTable(row=True,forward=False)
 
 	@script(
-			gesture="kb:control+alt+rightArrow"
+		gesture="kb:control+alt+rightArrow"
 	)
 	def script_nextColumn(self,gesture):
 		self._moveInTable(row=False,forward=True)
 
 	@script(
-			gesture="kb:control+alt+leftArrow"
+		gesture="kb:control+alt+leftArrow"
 	)
 	def script_previousColumn(self,gesture):
 		self._moveInTable(row=False,forward=False)
 
 	@script(
-			gesture="kb:control+downArrow",
-			resumeSayAllMode=sayAll.CURSOR.CARET
+		gesture="kb:control+downArrow",
+		resumeSayAllMode=sayAll.CURSOR.CARET
 	)
 	def script_nextParagraph(self,gesture):
 		info=self.makeTextInfo(textInfos.POSITION_CARET)
@@ -433,8 +433,8 @@ class WordDocument(IAccessible, EditableTextWithoutAutoSelectDetection, winWordW
 		self._caretScriptPostMovedHelper(textInfos.UNIT_PARAGRAPH,gesture,None)
 
 	@script(
-			gesture="kb:control+upArrow",
-			resumeSayAllMode=sayAll.CURSOR.CARET
+		gesture="kb:control+upArrow",
+		resumeSayAllMode=sayAll.CURSOR.CARET
 	)
 	def script_previousParagraph(self,gesture):
 		info=self.makeTextInfo(textInfos.POSITION_CARET)

--- a/source/NVDAObjects/IAccessible/winword.py
+++ b/source/NVDAObjects/IAccessible/winword.py
@@ -246,7 +246,8 @@ class WordDocument(IAccessible, EditableTextWithoutAutoSelectDetection, winWordW
 	@script(
 		gesture="kb:NVDA+shift+r",
 		# Translators: The label of a shortcut of NVDA.
-		description=_("Pressing once will set this cell as the first row header for any cells lower and to the right of it within this table. Pressing twice will forget the current row header for this cell."),
+		description=_("""Pressing once will set this cell as the first row header for any cells lower and to the right of it within this table. 
+		Pressing twice will forget the current row header for this cell."""),
 		category=SCRCAT_SYSTEMCARET
 	)
 	def script_setRowHeader(self,gesture):

--- a/source/NVDAObjects/IAccessible/winword.py
+++ b/source/NVDAObjects/IAccessible/winword.py
@@ -27,6 +27,7 @@ import NVDAObjects.window.winword as winWordWindowModule
 from speech import sayAll
 import inputCore
 
+# Translators: The name of a category of NVDA commands.
 SCRCAT_SYSTEMCARET = _("System caret")
 
 class WordDocument(IAccessible, EditableTextWithoutAutoSelectDetection, winWordWindowModule.WordDocument):
@@ -215,6 +216,7 @@ class WordDocument(IAccessible, EditableTextWithoutAutoSelectDetection, winWordW
 
 	@script(
 		gesture="kb:NVDA+shift+c",
+		# Translators: The label of a shortcut of NVDA.
 		description=_("Pressing once will set this cell as the first column header for any cells lower and to the right of it within this table. Pressing twice will forget the current column header for this cell."),
 		category=SCRCAT_SYSTEMCARET
 	)
@@ -243,6 +245,7 @@ class WordDocument(IAccessible, EditableTextWithoutAutoSelectDetection, winWordW
 
 	@script(
 		gesture="kb:NVDA+shift+r",
+		# Translators: The label of a shortcut of NVDA.
 		description=_("Pressing once will set this cell as the first row header for any cells lower and to the right of it within this table. Pressing twice will forget the current row header for this cell."),
 		category=SCRCAT_SYSTEMCARET
 	)

--- a/source/NVDAObjects/IAccessible/winword.py
+++ b/source/NVDAObjects/IAccessible/winword.py
@@ -26,9 +26,7 @@ from ..behaviors import EditableTextWithoutAutoSelectDetection
 import NVDAObjects.window.winword as winWordWindowModule
 from speech import sayAll
 import inputCore
-
-# Translators: The name of a category of NVDA commands.
-SCRCAT_SYSTEMCARET = _("System caret")
+from globalCommands import SCRCAT_SYSTEMCARET
 
 class WordDocument(IAccessible, EditableTextWithoutAutoSelectDetection, winWordWindowModule.WordDocument):
 
@@ -217,12 +215,7 @@ class WordDocument(IAccessible, EditableTextWithoutAutoSelectDetection, winWordW
 	@script(
 		gesture="kb:NVDA+shift+c",
 		# Translators: The label of a shortcut of NVDA.
-		description=_(
-			"Set column header"
-			"Pressing once will set this cell as the first column header for any cells lower and "
-			"to the right of it within this table. "
-			"Pressing twice will forget the current column header for this cell."
-		),
+		description=_("Set column header"),
 		category=SCRCAT_SYSTEMCARET
 	)
 	def script_setColumnHeader(self,gesture):
@@ -251,12 +244,7 @@ class WordDocument(IAccessible, EditableTextWithoutAutoSelectDetection, winWordW
 	@script(
 		gesture="kb:NVDA+shift+r",
 		# Translators: The label of a shortcut of NVDA.
-		description=_(
-			"Set row header."
-			"Pressing once will set this cell as the first row header for any cells lower and "
-			"to the right of it within this table. "
-			"Pressing twice will forget the current row header for this cell."
-		),
+		description=_("Set row header."),
 		category=SCRCAT_SYSTEMCARET
 	)
 	def script_setRowHeader(self,gesture):
@@ -284,7 +272,6 @@ class WordDocument(IAccessible, EditableTextWithoutAutoSelectDetection, winWordW
 
 	@script(
 		gesture="kb:NVDA+shift+h",
-		category=SCRCAT_SYSTEMCARET
 	)
 	def script_reportCurrentHeaders(self,gesture):
 		cell=self.WinwordSelectionObject.cells[1]

--- a/source/NVDAObjects/UIA/wordDocument.py
+++ b/source/NVDAObjects/UIA/wordDocument.py
@@ -41,6 +41,7 @@ import eventHandler
 
 """Support for Microsoft Word via UI Automation."""
 
+# Translators: The name of a category of NVDA commands.
 SCRCAT_SYSTEMCARET = _("System caret")
 
 class UIACustomAttributeID(enum.IntEnum):

--- a/source/NVDAObjects/UIA/wordDocument.py
+++ b/source/NVDAObjects/UIA/wordDocument.py
@@ -37,12 +37,9 @@ from NVDAObjects.window.winword import (
 from NVDAObjects import NVDAObject
 from scriptHandler import script
 import eventHandler
-
+from globalCommands import SCRCAT_SYSTEMCARET
 
 """Support for Microsoft Word via UI Automation."""
-
-# Translators: The name of a category of NVDA commands.
-SCRCAT_SYSTEMCARET = _("System caret")
 
 class UIACustomAttributeID(enum.IntEnum):
 	LINE_NUMBER = 0

--- a/source/NVDAObjects/UIA/wordDocument.py
+++ b/source/NVDAObjects/UIA/wordDocument.py
@@ -41,6 +41,7 @@ import eventHandler
 
 """Support for Microsoft Word via UI Automation."""
 
+SCRCAT_SYSTEMCARET = _("System caret")
 
 class UIACustomAttributeID(enum.IntEnum):
 	LINE_NUMBER = 0
@@ -601,6 +602,7 @@ class WordDocument(UIADocumentWithTableNavigation,WordDocumentNode,WordDocumentB
 		gesture="kb:NVDA+alt+c",
 		# Translators: a description for a script that reports the comment at the caret.
 		description=_("Reports the text of the comment where the system caret is located."),
+		category=SCRCAT_SYSTEMCARET,
 		speakOnDemand=True,
 	)
 	def script_reportCurrentComment(self,gesture):

--- a/source/NVDAObjects/window/excel.py
+++ b/source/NVDAObjects/window/excel.py
@@ -52,9 +52,7 @@ import ctypes
 import vision
 from utils.displayString import DisplayStringIntEnum
 import NVDAState
-
-# Translators: The name of a category of NVDA commands.
-SCRCAT_SYSTEMCARET = _("System caret")
+from globalCommands import SCRCAT_SYSTEMCARET
 
 excel2010VersionMajor=14
 

--- a/source/NVDAObjects/window/excel.py
+++ b/source/NVDAObjects/window/excel.py
@@ -12,7 +12,6 @@ from typing import (
 	Dict,
 	Optional,
 )
-from unicodedata import category
 
 from comtypes import COMError, BSTR
 import comtypes.automation
@@ -54,6 +53,7 @@ import vision
 from utils.displayString import DisplayStringIntEnum
 import NVDAState
 
+# Translators: The name of a category of NVDA commands.
 SCRCAT_EXCEL = _("Excel")
 
 excel2010VersionMajor=14

--- a/source/NVDAObjects/window/excel.py
+++ b/source/NVDAObjects/window/excel.py
@@ -1437,10 +1437,7 @@ class ExcelCell(ExcelBase):
 		return self.parent.fetchAssociatedHeaderCellText(self,columnHeader=False)
 
 	@script(
-		# Translators: the description  for a script for Excel
-		description=_("opens a dropdown item at the current cell"),
 		gesture="kb:alt+downArrow",
-		category=SCRCAT_SYSTEMCARET
 	)
 	def script_openDropdown(self,gesture):
 		gesture.send()

--- a/source/NVDAObjects/window/excel.py
+++ b/source/NVDAObjects/window/excel.py
@@ -12,6 +12,7 @@ from typing import (
 	Dict,
 	Optional,
 )
+from unicodedata import category
 
 from comtypes import COMError, BSTR
 import comtypes.automation
@@ -52,6 +53,8 @@ import ctypes
 import vision
 from utils.displayString import DisplayStringIntEnum
 import NVDAState
+
+SCRCAT_EXCEL = _("Excel")
 
 excel2010VersionMajor=14
 
@@ -1438,7 +1441,8 @@ class ExcelCell(ExcelBase):
 	@script(
 		# Translators: the description  for a script for Excel
 		description=_("opens a dropdown item at the current cell"),
-		gesture="kb:alt+downArrow")
+		gesture="kb:alt+downArrow",
+		category=SCRCAT_EXCEL)
 	def script_openDropdown(self,gesture):
 		gesture.send()
 		d=None
@@ -1464,7 +1468,8 @@ class ExcelCell(ExcelBase):
 	@script(
 		# Translators: the description  for a script for Excel
 		description=_("Sets the current cell as start of column header"),
-		gesture="kb:NVDA+shift+c")
+		gesture="kb:NVDA+shift+c",
+		category=SCRCAT_EXCEL)
 	def script_setColumnHeader(self,gesture):
 		scriptCount=scriptHandler.getLastScriptRepeatCount()
 		if scriptCount==0:
@@ -1486,7 +1491,8 @@ class ExcelCell(ExcelBase):
 	@script(
 		# Translators: the description  for a script for Excel
 		description=_("sets the current cell as start of row header"),
-		gesture="kb:NVDA+shift+r")
+		gesture="kb:NVDA+shift+r",
+		category=SCRCAT_EXCEL)
 	def script_setRowHeader(self,gesture):
 		scriptCount=scriptHandler.getLastScriptRepeatCount()
 		if scriptCount==0:
@@ -1672,6 +1678,7 @@ class ExcelCell(ExcelBase):
 		# Translators: the description  for a script for Excel
 		description=_("Reports the note on the current cell"),
 		gesture="kb:NVDA+alt+c",
+		category=SCRCAT_EXCEL,
 		speakOnDemand=True,
 	)
 	def script_reportComment(self,gesture):
@@ -1686,7 +1693,8 @@ class ExcelCell(ExcelBase):
 	@script(
 		# Translators: the description  for a script for Excel
 		description=_("Opens the note editing dialog"),
-		gesture="kb:shift+f2")
+		gesture="kb:shift+f2",
+		category=SCRCAT_EXCEL)
 	def script_editComment(self,gesture):
 		commentObj=self.excelCellObject.comment
 		d = EditCommentDialog(

--- a/source/NVDAObjects/window/excel.py
+++ b/source/NVDAObjects/window/excel.py
@@ -1486,7 +1486,6 @@ class ExcelCell(ExcelBase):
 			else:
 				# Translators: a message reported in the SetColumnHeader script for Excel.
 				ui.message(_("Cannot find {address}    in column headers").format(address=self.cellCoordsText))
-	script_setColumnHeader.__doc__=_("Pressing once will set this cell as the first column header for any cells lower and to the right of it within this region. Pressing twice will forget the current column header for this cell.")
 
 	@script(
 		# Translators: the description  for a script for Excel
@@ -1510,7 +1509,6 @@ class ExcelCell(ExcelBase):
 			else:
 				# Translators: a message reported in the SetRowHeader script for Excel.
 				ui.message(_("Cannot find {address}    in row headers").format(address=self.cellCoordsText))
-	script_setRowHeader.__doc__=_("Pressing once will set this cell as the first row header for any cells lower and to the right of it within this region. Pressing twice will forget the current row header for this cell.")
 
 	@classmethod
 	def kwargsFromSuper(cls,kwargs,relation=None):

--- a/source/NVDAObjects/window/excel.py
+++ b/source/NVDAObjects/window/excel.py
@@ -1442,7 +1442,8 @@ class ExcelCell(ExcelBase):
 		# Translators: the description  for a script for Excel
 		description=_("opens a dropdown item at the current cell"),
 		gesture="kb:alt+downArrow",
-		category=SCRCAT_EXCEL)
+		category=SCRCAT_EXCEL
+	)
 	def script_openDropdown(self,gesture):
 		gesture.send()
 		d=None
@@ -1469,7 +1470,8 @@ class ExcelCell(ExcelBase):
 		# Translators: the description  for a script for Excel
 		description=_("Sets the current cell as start of column header"),
 		gesture="kb:NVDA+shift+c",
-		category=SCRCAT_EXCEL)
+		category=SCRCAT_EXCEL
+	)
 	def script_setColumnHeader(self,gesture):
 		scriptCount=scriptHandler.getLastScriptRepeatCount()
 		if scriptCount==0:
@@ -1492,7 +1494,8 @@ class ExcelCell(ExcelBase):
 		# Translators: the description  for a script for Excel
 		description=_("sets the current cell as start of row header"),
 		gesture="kb:NVDA+shift+r",
-		category=SCRCAT_EXCEL)
+		category=SCRCAT_EXCEL
+	)
 	def script_setRowHeader(self,gesture):
 		scriptCount=scriptHandler.getLastScriptRepeatCount()
 		if scriptCount==0:
@@ -1694,7 +1697,8 @@ class ExcelCell(ExcelBase):
 		# Translators: the description  for a script for Excel
 		description=_("Opens the note editing dialog"),
 		gesture="kb:shift+f2",
-		category=SCRCAT_EXCEL)
+		category=SCRCAT_EXCEL
+	)
 	def script_editComment(self,gesture):
 		commentObj=self.excelCellObject.comment
 		d = EditCommentDialog(

--- a/source/NVDAObjects/window/excel.py
+++ b/source/NVDAObjects/window/excel.py
@@ -54,7 +54,7 @@ from utils.displayString import DisplayStringIntEnum
 import NVDAState
 
 # Translators: The name of a category of NVDA commands.
-SCRCAT_EXCEL = _("Excel")
+SCRCAT_SYSTEMCARET = _("System caret")
 
 excel2010VersionMajor=14
 
@@ -1442,7 +1442,7 @@ class ExcelCell(ExcelBase):
 		# Translators: the description  for a script for Excel
 		description=_("opens a dropdown item at the current cell"),
 		gesture="kb:alt+downArrow",
-		category=SCRCAT_EXCEL
+		category=SCRCAT_SYSTEMCARET
 	)
 	def script_openDropdown(self,gesture):
 		gesture.send()
@@ -1470,7 +1470,7 @@ class ExcelCell(ExcelBase):
 		# Translators: the description  for a script for Excel
 		description=_("Sets the current cell as start of column header"),
 		gesture="kb:NVDA+shift+c",
-		category=SCRCAT_EXCEL
+		category=SCRCAT_SYSTEMCARET
 	)
 	def script_setColumnHeader(self,gesture):
 		scriptCount=scriptHandler.getLastScriptRepeatCount()
@@ -1494,7 +1494,7 @@ class ExcelCell(ExcelBase):
 		# Translators: the description  for a script for Excel
 		description=_("sets the current cell as start of row header"),
 		gesture="kb:NVDA+shift+r",
-		category=SCRCAT_EXCEL
+		category=SCRCAT_SYSTEMCARET
 	)
 	def script_setRowHeader(self,gesture):
 		scriptCount=scriptHandler.getLastScriptRepeatCount()
@@ -1681,7 +1681,7 @@ class ExcelCell(ExcelBase):
 		# Translators: the description  for a script for Excel
 		description=_("Reports the note on the current cell"),
 		gesture="kb:NVDA+alt+c",
-		category=SCRCAT_EXCEL,
+		category=SCRCAT_SYSTEMCARET,
 		speakOnDemand=True,
 	)
 	def script_reportComment(self,gesture):
@@ -1697,7 +1697,7 @@ class ExcelCell(ExcelBase):
 		# Translators: the description  for a script for Excel
 		description=_("Opens the note editing dialog"),
 		gesture="kb:shift+f2",
-		category=SCRCAT_EXCEL
+		category=SCRCAT_SYSTEMCARET
 	)
 	def script_editComment(self,gesture):
 		commentObj=self.excelCellObject.comment

--- a/source/appModules/eclipse.py
+++ b/source/appModules/eclipse.py
@@ -15,6 +15,8 @@ from speech import sayAll
 import keyboardHandler
 from scriptHandler import script
 
+category_title = "Eclipse"
+
 class EclipseTextArea(EditableTextWithSuggestions, IAccessible):
 
 	def event_suggestionsClosed(self):
@@ -52,7 +54,8 @@ class EclipseTextArea(EditableTextWithSuggestions, IAccessible):
 	@script(
 		# Translators: Input help mode message for the 'read documentation script
 		description = _("Tries to read documentation for the selected autocompletion item."),
-		gesture = "kb:nvda+d"
+		gesture = "kb:nvda+d",
+		category=category_title
 	)
 	def script_readDocumentation(self, gesture):
 		rootDocumentationWindow = None

--- a/source/appModules/eclipse.py
+++ b/source/appModules/eclipse.py
@@ -16,7 +16,7 @@ import keyboardHandler
 from scriptHandler import script
 
 # Translators: The name of a category of NVDA commands.
-categorySCRCAT_ECLIPSE = _("Eclipse")
+SCRCAT_ECLIPSE = _("Eclipse")
 
 class EclipseTextArea(EditableTextWithSuggestions, IAccessible):
 
@@ -54,9 +54,9 @@ class EclipseTextArea(EditableTextWithSuggestions, IAccessible):
 
 	@script(
 		# Translators: Input help mode message for the 'read documentation script
-		description = _("Tries to read documentation for the selected autocompletion item."),
-		gesture = "kb:nvda+d",
-		category = categorySCRCAT_ECLIPSE
+		description=_("Tries to read documentation for the selected autocompletion item."),
+		gesture="kb:nvda+d",
+		category=SCRCAT_ECLIPSE
 	)
 	def script_readDocumentation(self, gesture):
 		rootDocumentationWindow = None

--- a/source/appModules/eclipse.py
+++ b/source/appModules/eclipse.py
@@ -15,7 +15,8 @@ from speech import sayAll
 import keyboardHandler
 from scriptHandler import script
 
-category_title = "Eclipse"
+# Translators: The name of a category of NVDA commands.
+categorySCRCAT_ECLIPSE = _("Eclipse")
 
 class EclipseTextArea(EditableTextWithSuggestions, IAccessible):
 
@@ -55,7 +56,7 @@ class EclipseTextArea(EditableTextWithSuggestions, IAccessible):
 		# Translators: Input help mode message for the 'read documentation script
 		description = _("Tries to read documentation for the selected autocompletion item."),
 		gesture = "kb:nvda+d",
-		category=category_title
+		category = categorySCRCAT_ECLIPSE
 	)
 	def script_readDocumentation(self, gesture):
 		rootDocumentationWindow = None

--- a/source/appModules/miranda32.py
+++ b/source/appModules/miranda32.py
@@ -22,7 +22,8 @@ import oleacc
 from keyboardHandler import KeyboardInputGesture
 import watchdog
 
-category_title = "Miranda32"
+# Translators: The name of a category of NVDA commands.
+categorySCRCAT_MIRANDA = _("Miranda")
 
 #contact list window messages
 CLM_FIRST=0x1000    #this is the same as LVM_FIRST
@@ -115,7 +116,7 @@ class AppModule(appModuleHandler.AppModule):
 		# Translators: The description of an NVDA command to view one of the recent messages.
 		description=_("Displays one of the recent messages"),
 		gestures=[f"kb:NVDA+control+{n}" for n in range(1, MessageHistoryLength + 1)],
-		category=category_title,
+		category=categorySCRCAT_MIRANDA,
 		speakOnDemand=True,
 	)
 	def script_readMessage(self,gesture):

--- a/source/appModules/miranda32.py
+++ b/source/appModules/miranda32.py
@@ -22,6 +22,8 @@ import oleacc
 from keyboardHandler import KeyboardInputGesture
 import watchdog
 
+category_title = "Miranda32"
+
 #contact list window messages
 CLM_FIRST=0x1000    #this is the same as LVM_FIRST
 CLM_LAST=0x1100
@@ -113,6 +115,7 @@ class AppModule(appModuleHandler.AppModule):
 		# Translators: The description of an NVDA command to view one of the recent messages.
 		description=_("Displays one of the recent messages"),
 		gestures=[f"kb:NVDA+control+{n}" for n in range(1, MessageHistoryLength + 1)],
+		category=category_title,
 		speakOnDemand=True,
 	)
 	def script_readMessage(self,gesture):

--- a/source/appModules/miranda32.py
+++ b/source/appModules/miranda32.py
@@ -23,7 +23,7 @@ from keyboardHandler import KeyboardInputGesture
 import watchdog
 
 # Translators: The name of a category of NVDA commands.
-categorySCRCAT_MIRANDA = _("Miranda")
+SCRCAT_MIRANDA = _("Miranda")
 
 #contact list window messages
 CLM_FIRST=0x1000    #this is the same as LVM_FIRST
@@ -116,7 +116,7 @@ class AppModule(appModuleHandler.AppModule):
 		# Translators: The description of an NVDA command to view one of the recent messages.
 		description=_("Displays one of the recent messages"),
 		gestures=[f"kb:NVDA+control+{n}" for n in range(1, MessageHistoryLength + 1)],
-		category=categorySCRCAT_MIRANDA,
+		category=SCRCAT_MIRANDA,
 		speakOnDemand=True,
 	)
 	def script_readMessage(self,gesture):

--- a/source/appModules/miranda32.py
+++ b/source/appModules/miranda32.py
@@ -23,7 +23,7 @@ from keyboardHandler import KeyboardInputGesture
 import watchdog
 
 # Translators: The name of a category of NVDA commands.
-SCRCAT_MIRANDA = _("Miranda")
+SCRCAT_MIRANDA = _("Miranda NG")
 
 #contact list window messages
 CLM_FIRST=0x1000    #this is the same as LVM_FIRST

--- a/source/appModules/poedit.py
+++ b/source/appModules/poedit.py
@@ -23,6 +23,7 @@ from scriptHandler import getLastScriptRepeatCount, script
 LEFT_TO_RIGHT_EMBEDDING = "\u202a"
 """Character often found in translator comments."""
 
+category_title = "Poedit"
 
 class _WindowControlIdOffset(IntEnum):
 	"""Window control ID's are not static, however, the order of ids stays the same.
@@ -146,6 +147,7 @@ class AppModule(appModuleHandler.AppModule):
 			"Reports any notes for translators. If pressed twice, presents the notes in browse mode",
 		),
 		gesture="kb:control+shift+a",
+		category=category_title,
 		speakOnDemand=True,
 	)
 	def script_reportAutoCommentsWindow(self, gesture):
@@ -172,6 +174,7 @@ class AppModule(appModuleHandler.AppModule):
 			"If pressed twice, presents the comment in browse mode",
 		),
 		gesture="kb:control+shift+c",
+		category=category_title,
 		speakOnDemand=True,
 	)
 	def script_reportCommentsWindow(self, gesture):
@@ -197,6 +200,7 @@ class AppModule(appModuleHandler.AppModule):
 			"Reports the old source text, if any. If pressed twice, presents the text in browse mode",
 		),
 		gesture="kb:control+shift+o",
+		category=category_title,
 		speakOnDemand=True,
 	)
 	def script_reportOldSourceText(self, gesture):
@@ -220,6 +224,7 @@ class AppModule(appModuleHandler.AppModule):
 			"Reports a translation warning, if any. If pressed twice, presents the warning in browse mode",
 		),
 		gesture="kb:control+shift+w",
+		category=category_title,
 		speakOnDemand=True,
 	)
 	def script_reportTranslationWarning(self, gesture):

--- a/source/appModules/poedit.py
+++ b/source/appModules/poedit.py
@@ -23,7 +23,8 @@ from scriptHandler import getLastScriptRepeatCount, script
 LEFT_TO_RIGHT_EMBEDDING = "\u202a"
 """Character often found in translator comments."""
 
-category_title = "Poedit"
+# Translators: The name of a category of NVDA commands.
+categorySCRCAT_POEDIT = _("Poedit")
 
 class _WindowControlIdOffset(IntEnum):
 	"""Window control ID's are not static, however, the order of ids stays the same.
@@ -147,7 +148,7 @@ class AppModule(appModuleHandler.AppModule):
 			"Reports any notes for translators. If pressed twice, presents the notes in browse mode",
 		),
 		gesture="kb:control+shift+a",
-		category=category_title,
+		category=categorySCRCAT_POEDIT,
 		speakOnDemand=True,
 	)
 	def script_reportAutoCommentsWindow(self, gesture):
@@ -174,7 +175,7 @@ class AppModule(appModuleHandler.AppModule):
 			"If pressed twice, presents the comment in browse mode",
 		),
 		gesture="kb:control+shift+c",
-		category=category_title,
+		category=categorySCRCAT_POEDIT,
 		speakOnDemand=True,
 	)
 	def script_reportCommentsWindow(self, gesture):
@@ -200,7 +201,7 @@ class AppModule(appModuleHandler.AppModule):
 			"Reports the old source text, if any. If pressed twice, presents the text in browse mode",
 		),
 		gesture="kb:control+shift+o",
-		category=category_title,
+		category=categorySCRCAT_POEDIT,
 		speakOnDemand=True,
 	)
 	def script_reportOldSourceText(self, gesture):
@@ -224,7 +225,7 @@ class AppModule(appModuleHandler.AppModule):
 			"Reports a translation warning, if any. If pressed twice, presents the warning in browse mode",
 		),
 		gesture="kb:control+shift+w",
-		category=category_title,
+		category=categorySCRCAT_POEDIT,
 		speakOnDemand=True,
 	)
 	def script_reportTranslationWarning(self, gesture):

--- a/source/appModules/poedit.py
+++ b/source/appModules/poedit.py
@@ -24,7 +24,7 @@ LEFT_TO_RIGHT_EMBEDDING = "\u202a"
 """Character often found in translator comments."""
 
 # Translators: The name of a category of NVDA commands.
-categorySCRCAT_POEDIT = _("Poedit")
+SCRCAT_POEDIT = _("Poedit")
 
 class _WindowControlIdOffset(IntEnum):
 	"""Window control ID's are not static, however, the order of ids stays the same.
@@ -148,7 +148,7 @@ class AppModule(appModuleHandler.AppModule):
 			"Reports any notes for translators. If pressed twice, presents the notes in browse mode",
 		),
 		gesture="kb:control+shift+a",
-		category=categorySCRCAT_POEDIT,
+		category=SCRCAT_POEDIT,
 		speakOnDemand=True,
 	)
 	def script_reportAutoCommentsWindow(self, gesture):
@@ -175,7 +175,7 @@ class AppModule(appModuleHandler.AppModule):
 			"If pressed twice, presents the comment in browse mode",
 		),
 		gesture="kb:control+shift+c",
-		category=categorySCRCAT_POEDIT,
+		category=SCRCAT_POEDIT,
 		speakOnDemand=True,
 	)
 	def script_reportCommentsWindow(self, gesture):
@@ -201,7 +201,7 @@ class AppModule(appModuleHandler.AppModule):
 			"Reports the old source text, if any. If pressed twice, presents the text in browse mode",
 		),
 		gesture="kb:control+shift+o",
-		category=categorySCRCAT_POEDIT,
+		category=SCRCAT_POEDIT,
 		speakOnDemand=True,
 	)
 	def script_reportOldSourceText(self, gesture):
@@ -225,7 +225,7 @@ class AppModule(appModuleHandler.AppModule):
 			"Reports a translation warning, if any. If pressed twice, presents the warning in browse mode",
 		),
 		gesture="kb:control+shift+w",
-		category=categorySCRCAT_POEDIT,
+		category=SCRCAT_POEDIT,
 		speakOnDemand=True,
 	)
 	def script_reportTranslationWarning(self, gesture):

--- a/source/appModules/powerpnt.py
+++ b/source/appModules/powerpnt.py
@@ -41,7 +41,8 @@ import scriptHandler
 from locationHelper import RectLTRB
 from NVDAObjects.window._msOfficeChart import OfficeChart
 
-category_title = "Powerpoint"
+# Translators: The name of a category of NVDA commands.
+categorySCRCAT_POWERPOINT = _("PowerPoint")
 
 # Window classes where PowerPoint's object model should be used 
 # These also all request to have their (incomplete) UI Automation implementations  disabled. [MS Office 2013]
@@ -1244,7 +1245,7 @@ class SlideShowWindow(PaneClassDC):
 		self.treeInterceptor.reportNewSlide()
 
 class AppModule(appModuleHandler.AppModule):
-	scriptCategory = category_title
+	scriptCategory = categorySCRCAT_POWERPOINT
 	
 	hasTriedPpAppSwitch=False
 	_ppApplicationWindow=None

--- a/source/appModules/powerpnt.py
+++ b/source/appModules/powerpnt.py
@@ -41,6 +41,8 @@ import scriptHandler
 from locationHelper import RectLTRB
 from NVDAObjects.window._msOfficeChart import OfficeChart
 
+category_title = "Powerpoint"
+
 # Window classes where PowerPoint's object model should be used 
 # These also all request to have their (incomplete) UI Automation implementations  disabled. [MS Office 2013]
 objectModelWindowClasses=set(["paneClassDC","mdiClass","screenClass"])
@@ -1242,7 +1244,8 @@ class SlideShowWindow(PaneClassDC):
 		self.treeInterceptor.reportNewSlide()
 
 class AppModule(appModuleHandler.AppModule):
-
+	scriptCategory = category_title
+	
 	hasTriedPpAppSwitch=False
 	_ppApplicationWindow=None
 	_ppApplication=None

--- a/source/appModules/powerpnt.py
+++ b/source/appModules/powerpnt.py
@@ -42,7 +42,7 @@ from locationHelper import RectLTRB
 from NVDAObjects.window._msOfficeChart import OfficeChart
 
 # Translators: The name of a category of NVDA commands.
-categorySCRCAT_POWERPOINT = _("PowerPoint")
+SCRCAT_POWERPOINT = _("PowerPoint")
 
 # Window classes where PowerPoint's object model should be used 
 # These also all request to have their (incomplete) UI Automation implementations  disabled. [MS Office 2013]
@@ -1245,7 +1245,7 @@ class SlideShowWindow(PaneClassDC):
 		self.treeInterceptor.reportNewSlide()
 
 class AppModule(appModuleHandler.AppModule):
-	scriptCategory = categorySCRCAT_POWERPOINT
+	scriptCategory = SCRCAT_POWERPOINT
 	
 	hasTriedPpAppSwitch=False
 	_ppApplicationWindow=None

--- a/source/appModules/vipmud.py
+++ b/source/appModules/vipmud.py
@@ -15,7 +15,7 @@ This module makes NVDA read incoming text, as well as allowing the user to revie
 """
 
 # Translators: The name of a category of NVDA commands.
-categorySCRCAT_VIPMUD = _("VipMud")
+SCRCAT_VIPMUD = _("VipMud")
 
 class AppModule(appModuleHandler.AppModule):
 	lastLength=0
@@ -29,7 +29,7 @@ class AppModule(appModuleHandler.AppModule):
 		# Translators: The description of an NVDA command to view one of the recent messages.
 		description=_("Displays one of the recent messages"),
 		gestures=[f"kb:control+{n}" for n in range(1, historyLength + 1)],
-		category=categorySCRCAT_VIPMUD,
+		category=SCRCAT_VIPMUD,
 		speakOnDemand=True,
 	)
 	def script_readMessage(self,gesture):

--- a/source/appModules/vipmud.py
+++ b/source/appModules/vipmud.py
@@ -14,6 +14,8 @@ App module for VIP Mud
 This module makes NVDA read incoming text, as well as allowing the user to review the last nine messages with control 1 through 9.
 """
 
+category_title = "Vipmud"
+
 class AppModule(appModuleHandler.AppModule):
 	lastLength=0
 	msgs =[]
@@ -26,6 +28,7 @@ class AppModule(appModuleHandler.AppModule):
 		# Translators: The description of an NVDA command to view one of the recent messages.
 		description=_("Displays one of the recent messages"),
 		gestures=[f"kb:control+{n}" for n in range(1, historyLength + 1)],
+		category=category_title,
 		speakOnDemand=True,
 	)
 	def script_readMessage(self,gesture):

--- a/source/appModules/vipmud.py
+++ b/source/appModules/vipmud.py
@@ -14,7 +14,8 @@ App module for VIP Mud
 This module makes NVDA read incoming text, as well as allowing the user to review the last nine messages with control 1 through 9.
 """
 
-category_title = "Vipmud"
+# Translators: The name of a category of NVDA commands.
+categorySCRCAT_VIPMUD = _("VipMud")
 
 class AppModule(appModuleHandler.AppModule):
 	lastLength=0
@@ -28,7 +29,7 @@ class AppModule(appModuleHandler.AppModule):
 		# Translators: The description of an NVDA command to view one of the recent messages.
 		description=_("Displays one of the recent messages"),
 		gestures=[f"kb:control+{n}" for n in range(1, historyLength + 1)],
-		category=category_title,
+		category=categorySCRCAT_VIPMUD,
 		speakOnDemand=True,
 	)
 	def script_readMessage(self,gesture):

--- a/tests/checkPot.py
+++ b/tests/checkPot.py
@@ -80,22 +80,6 @@ EXPECTED_MESSAGES_WITHOUT_COMMENTS = {
 	'Text frame',
 	# core.py:87
 	r'Your gesture map file contains errors.\n"More details about the errors can be found in the log file."',
-	# NVDAObjects\IAccessible\winword.py:229
-	'Pressing once will set this cell as the first column header for any cells '
-	'"lower and to the right of it within this table. Pressing twice will forget '
-	'"the current column header for this cell."',
-	# NVDAObjects\IAccessible\winword.py:257
-	'Pressing once will set this cell as the first row header for any cells lower '
-	'"and to the right of it within this table. Pressing twice will forget the '
-	'"current row header for this cell."',
-	# NVDAObjects\window\excel.py:1222
-	'Pressing once will set this cell as the first column header for any cells '
-	'"lower and to the right of it within this region. Pressing twice will forget '
-	'"the current column header for this cell."',
-	# NVDAObjects\window\excel.py:1244
-	'Pressing once will set this cell as the first row header for any cells lower '
-	'"and to the right of it within this region. Pressing twice will forget the '
-	'"current row header for this cell."',
 }
 
 def checkPot(fileName):


### PR DESCRIPTION

<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
closes https://github.com/nvaccess/nvda/issues/15815

### Summary of the issue:
Store the Poedit, PowerPoint, miranda32, vipmud, and Eclipse appModules in separate categories within the command gesture category.

### Description of user facing changes
When the user is in one of the applications (poedit, powerpoint, eclipse, vipmud, and miranda32), and if they wish to view the keyboard shortcuts offered by the appmodule, they can consult them in the command gesture category under the section named after the application rather than in various.

### Description of development approach
I have added in each appmodule a variable that contains the name of the category, and for each keyboard shortcut, I have added the name of the category associated with that command.

### Testing strategy:
I tested each application by opening the app and checking if the corresponding category appeared in NVDA's command gestures.

### Known issues with pull request:

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
