### PR TITLE
Make list of speech modes in the NVDA+s cycling script configurable.

### DIFF
--- a/source/config/__init__.py
+++ b/source/config/__init__.py
@@ -635,7 +635,12 @@ class ConfigManager(object):
 		return self.rootSection.dict()
 
 	def listProfiles(self):
-		for name in os.listdir(WritePaths.profilesDir):
+		try:
+			profileFiles = os.listdir(WritePaths.profilesDir)
+		except FileNotFoundError:
+			log.debugWarning("Profiles directory does not exist.")
+			profileFiles = []
+		for name in profileFiles:
 			name, ext = os.path.splitext(name)
 			if ext == ".ini":
 				yield name

--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -1,7 +1,7 @@
 # A part of NonVisual Desktop Access (NVDA)
 # Copyright (C) 2006-2023 NV Access Limited, Babbage B.V., Davy Kager, Bill Dengler, Julien Cochuyt,
 # Joseph Lee, Dawid Pieper, mltony, Bram Duvigneau, Cyrille Bougot, Rob Meredith,
-# Burman's Computer and Education Ltd., Leonard de Ruijter
+# Burman's Computer and Education Ltd., Leonard de Ruijter, Łukasz Golonka
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -40,6 +40,7 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 	autoLanguageSwitching = boolean(default=true)
 	autoDialectSwitching = boolean(default=false)
 	delayedCharacterDescriptions = boolean(default=false)
+	excludedSpeechModes = int_list(default=list())
 
 	[[__many__]]
 		capPitchChange = integer(default=30,min=-100,max=100)

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -2035,6 +2035,10 @@ class GlobalCommands(ScriptableObject):
 		currModeIndex = modesList.index(curMode)
 		excludedModesIndexes = config.conf["speech"]["excludedSpeechModes"]
 		possibleIndexes = [i for i in range(len(modesList)) if i not in excludedModesIndexes]
+		# Sort speech modes to present next modes in the list before the ones at the beginning of the list.
+		# Use a key function which places modes whose index is higher than the currently used at the beginning.
+		# Note that since Python's sorting is stable
+		# relative ordering of elements for which key function returns the same value is preserved.
 		# Sorting uses `<=` since when sorting booleans they are threated as integers,
 		# so `False` (0) comes before `True` (1).
 		newModeIndex = sorted(possibleIndexes, key=lambda i: i <= currModeIndex)[0]

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -2023,7 +2023,7 @@ class GlobalCommands(ScriptableObject):
 	@script(
 		description=_(
 			# Translators: Input help mode message for cycle speech mode command.
-			"Cycles between the speech modes of off, beep, talk and on-demand."
+			"Cycles between enabled speech modes."
 		),
 		category=SCRCAT_SPEECH,
 		gesture="kb:NVDA+s"
@@ -2031,21 +2031,18 @@ class GlobalCommands(ScriptableObject):
 	def script_speechMode(self, gesture: inputCore.InputGesture) -> None:
 		curMode = speech.getState().speechMode
 		speech.setSpeechMode(speech.SpeechMode.talk)
-		newMode = (curMode + 1) % len(speech.SpeechMode)
-		if newMode == speech.SpeechMode.off:
-			# Translators: A speech mode which disables speech output.
-			name=_("Speech mode off")
-		elif newMode == speech.SpeechMode.beeps:
-			# Translators: A speech mode which will cause NVDA to beep instead of speaking.
-			name=_("Speech mode beeps")
-		elif newMode == speech.SpeechMode.talk:
-			# Translators: The normal speech mode; i.e. NVDA will talk as normal.
-			name=_("Speech mode talk")
-		elif newMode == speech.SpeechMode.onDemand:
-			# Translators: The on-demand speech mode; i.e. NVDA will talk only on commands asking to report something.
-			name = _("Speech mode on-demand")
+		modesList = list(speech.SpeechMode)
+		currModeIndex = modesList.index(curMode)
+		excludedModesIndexes = config.conf["speech"]["excludedSpeechModes"]
+		possibleIndexes = [i for i in range(len(modesList)) if i not in excludedModesIndexes]
+		# Sorting uses `<=`  since when sorting booleans they are threated as integers,
+		# so `False` (0) comes before `True` (1).
+		newModeIndex = sorted(possibleIndexes, key=lambda i: i <= currModeIndex)[0]
+		newMode = modesList[newModeIndex]
 		speech.cancelSpeech()
-		ui.message(name)
+		# Translators: Announced when user switches to another speech mode.
+		# 'mode' is replaced with the translated name of the new mode.
+		ui.message(_("Speech mode {mode}").format(mode=newMode.displayString))
 		speech.setSpeechMode(newMode)
 
 	@script(

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -2023,7 +2023,7 @@ class GlobalCommands(ScriptableObject):
 	@script(
 		description=_(
 			# Translators: Input help mode message for cycle speech mode command.
-			"Cycles between enabled speech modes."
+			"Cycles between speech modes."
 		),
 		category=SCRCAT_SPEECH,
 		gesture="kb:NVDA+s"

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -2039,8 +2039,8 @@ class GlobalCommands(ScriptableObject):
 		# Use a key function which places modes whose index is higher than the currently used at the beginning.
 		# Note that since Python's sorting is stable
 		# relative ordering of elements for which key function returns the same value is preserved.
-		# Sorting uses `<=` since when sorting booleans they are threated as integers,
-		# so `False` (0) comes before `True` (1).
+		# Sorting uses `<=` since when sorting booleans they are handled as integers,
+		# so `False` (0) sorts before `True` (1).
 		newModeIndex = sorted(possibleIndexes, key=lambda i: i <= currModeIndex)[0]
 		newMode = modesList[newModeIndex]
 		speech.cancelSpeech()

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -2035,7 +2035,7 @@ class GlobalCommands(ScriptableObject):
 		currModeIndex = modesList.index(curMode)
 		excludedModesIndexes = config.conf["speech"]["excludedSpeechModes"]
 		possibleIndexes = [i for i in range(len(modesList)) if i not in excludedModesIndexes]
-		# Sorting uses `<=`  since when sorting booleans they are threated as integers,
+		# Sorting uses `<=` since when sorting booleans they are threated as integers,
 		# so `False` (0) comes before `True` (1).
 		newModeIndex = sorted(possibleIndexes, key=lambda i: i <= currModeIndex)[0]
 		newMode = modesList[newModeIndex]

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -1688,7 +1688,6 @@ class VoiceSettingsPanel(AutoSettingsMixin, SettingsPanel):
 
 	def isValid(self) -> bool:
 		enabledSpeechModes = self.speechModesList.CheckedItems
-		speechModesListRequiresChange = False
 		if len(enabledSpeechModes) < 2:
 			log.debugWarning("Too few speech modes enabled.")
 			gui.messageBox(
@@ -1699,7 +1698,8 @@ class VoiceSettingsPanel(AutoSettingsMixin, SettingsPanel):
 				wx.OK | wx.ICON_ERROR,
 				self,
 			)
-			speechModesListRequiresChange = True
+			self.speechModesList.SetFocus()
+			return False
 		if not any(
 			self._allSpeechModes[i].producesSpeech for i in enabledSpeechModes
 		):
@@ -1717,10 +1717,8 @@ class VoiceSettingsPanel(AutoSettingsMixin, SettingsPanel):
 				wx.YES | wx.NO | wx.ICON_WARNING,
 				self,
 			) == wx.NO:
-				speechModesListRequiresChange = True
-		if speechModesListRequiresChange:
-			self.speechModesList.SetFocus()
-			return False
+				self.speechModesList.SetFocus()
+				return False
 		return super().isValid()
 
 

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -1700,14 +1700,12 @@ class VoiceSettingsPanel(AutoSettingsMixin, SettingsPanel):
 			)
 			self.speechModesList.SetFocus()
 			return False
-		if not any(
-			self._allSpeechModes[i].producesSpeech for i in enabledSpeechModes
-		):
+		if self._allSpeechModes.index(speech.SpeechMode.talk) not in enabledSpeechModes:
 			if gui.messageBox(
 				_(
-					# Translators: Warning shown when all modes producing speech are disabled in settings.
+					# Translators: Warning shown when 'talk' speech mode is disabled in settings.
 					(
-						"You did not choose either Talk or On-Demand as one of your speech mode options. "
+						"You did not choose Talk as one of your speech mode options. "
 						"Please note that this may result in no speech output at all. "
 						"Are you sure you want to continue?"
 					)

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -1631,7 +1631,7 @@ class VoiceSettingsPanel(AutoSettingsMixin, SettingsPanel):
 		self._appendSpeechModesList(settingsSizerHelper)
 
 	def _appendSpeechModesList(self, settingsSizerHelper: guiHelper.BoxSizerHelper) -> None:
-		self._allSpeechModes = [mode for mode in speech.SpeechMode]
+		self._allSpeechModes = list(speech.SpeechMode)
 		self.speechModesList: nvdaControls.CustomCheckListBox = settingsSizerHelper.addLabeledControl(
 			# Translators: Label of the list where user can enable or disable speech modes.
 			_("Switch between the following speech &modes:"),

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -1688,6 +1688,7 @@ class VoiceSettingsPanel(AutoSettingsMixin, SettingsPanel):
 
 	def isValid(self) -> bool:
 		enabledSpeechModes = self.speechModesList.CheckedItems
+		speechModesListRequiresChange = False
 		if len(enabledSpeechModes) < 2:
 			log.debugWarning("Too few speech modes enabled.")
 			gui.messageBox(
@@ -1698,6 +1699,26 @@ class VoiceSettingsPanel(AutoSettingsMixin, SettingsPanel):
 				wx.OK | wx.ICON_ERROR,
 				self,
 			)
+			speechModesListRequiresChange = True
+		if not any(
+			self._allSpeechModes[i].producesSpeech for i in enabledSpeechModes
+		):
+			if gui.messageBox(
+				_(
+					# Translators: Warning shown when all modes producing speech are disabled in settings.
+					(
+						"You did not choose either Talk or On-Demand as one of your speech mode options. "
+						"Please note that this may result in no speech output at all. "
+						"Are you sure you want to continue?"
+					)
+				),
+				# Translators: Title of the warning message.
+				_("Warning"),
+				wx.YES | wx.NO | wx.ICON_WARNING,
+				self,
+			) == wx.NO:
+				speechModesListRequiresChange = True
+		if speechModesListRequiresChange:
 			self.speechModesList.SetFocus()
 			return False
 		return super().isValid()

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -1685,7 +1685,7 @@ class VoiceSettingsPanel(AutoSettingsMixin, SettingsPanel):
 		if len(enabledSpeechModes) < 2:
 			log.debugWarning("Too few speech modes enabled.")
 			gui.messageBox(
-				# translators: Message shown when not enough speech modes are enabled.
+				# Translators: Message shown when not enough speech modes are enabled.
 				_("At least two speech modes have to be checked."),
 				# Translators: The title of the message box
 				_("Error"),
@@ -1698,7 +1698,7 @@ class VoiceSettingsPanel(AutoSettingsMixin, SettingsPanel):
 		):
 			log.debugWarning("None of the speech modes producing speech are enabled. This configuration is invalid.")
 			gui.messageBox(
-				# translators: Message shown when none of required speech modes are enabled.
+				# Translators: Message shown when none of required speech modes are enabled.
 				_("One of speech mode talk or on-demand has to be enabled."),
 				# Translators: The title of the message box
 				_("Error"),

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -1634,7 +1634,7 @@ class VoiceSettingsPanel(AutoSettingsMixin, SettingsPanel):
 		self._allSpeechModes = list(speech.SpeechMode)
 		self.speechModesList: nvdaControls.CustomCheckListBox = settingsSizerHelper.addLabeledControl(
 			# Translators: Label of the list where user can enable or disable speech modes.
-			_("Switch between the following speech &modes:"),
+			_("&Modes available in the Cycle speech mode command:"),
 			nvdaControls.CustomCheckListBox,
 			choices=[mode.displayString for mode in self._allSpeechModes]
 		)

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -1639,7 +1639,7 @@ class VoiceSettingsPanel(AutoSettingsMixin, SettingsPanel):
 	def _appendSpeechModesList(self, settingsSizerHelper: guiHelper.BoxSizerHelper) -> None:
 		self._allSpeechModes = list(speech.SpeechMode)
 		self.speechModesList: nvdaControls.CustomCheckListBox = settingsSizerHelper.addLabeledControl(
-			# Translators: Label of the list where user can enable or disable speech modes.
+			# Translators: Label of the list where user can select speech modes that will be available.
 			_("&Modes available in the Cycle speech mode command:"),
 			nvdaControls.CustomCheckListBox,
 			choices=[mode.displayString for mode in self._allSpeechModes]
@@ -1836,7 +1836,7 @@ class KeyboardSettingsPanel(SettingsPanel):
 				_("Error"), wx.OK|wx.ICON_ERROR,self)
 			self.modifierList.SetFocus()
 			return False
-		return super(KeyboardSettingsPanel, self).isValid()
+		return super().isValid()
 
 	def onSave(self):
 		layout=self.kbdNames[self.kbdList.GetSelection()]

--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -2,7 +2,7 @@
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 # Copyright (C) 2006-2023 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Babbage B.V., Bill Dengler,
-# Julien Cochuyt, Derek Riemer, Cyrille Bougot, Leonard de Ruijter
+# Julien Cochuyt, Derek Riemer, Cyrille Bougot, Leonard de Ruijter, Łukasz Golonka
 
 """High-level functions to speak information.
 """ 
@@ -55,6 +55,7 @@ from typing import (
 	Generator,
 	Union,
 	Tuple,
+	Self,
 )
 from logHandler import log
 import config
@@ -65,10 +66,10 @@ from config.configFlags import (
 )
 import aria
 from .priorities import Spri
-from enum import IntEnum
 from dataclasses import dataclass
 from copy import copy
 from utils.security import objectBelowLockScreenAndWindowsIsLocked
+from utils.displayString import DisplayStringIntEnum
 
 if typing.TYPE_CHECKING:
 	import NVDAObjects
@@ -78,11 +79,30 @@ _speechState: Optional['SpeechState'] = None
 _curWordChars: List[str] = []
 
 
-class SpeechMode(IntEnum):
+class SpeechMode(DisplayStringIntEnum):
 	off = 0
 	beeps = 1
 	talk = 2
 	onDemand = 3
+
+	@property
+	def _displayStringLabels(self) -> dict[Self, str]:
+		return {
+			# Translators: Name of the speech mode which disables speech output.
+			self.off: pgettext("speechModes", "off"),
+			# Translators: Name of the speech mode which will cause NVDA to beep instead of speaking.
+			self.beeps: pgettext("speechModes", "beeps"),
+			# Translators: Name of the speech mode, which, when enabled, causes NVDA to talk as normal.
+			self.talk: pgettext("speechModes", "talk"),
+			# Translators: Name of the on-demand speech mode;
+			# i.e. NVDA will talk only on commands asking to report something.
+			self.onDemand: pgettext("speechModes", "on-demand"),
+		}
+
+	@property
+	def producesSpeech(self) -> bool:
+		"""Is any speech produced when this mode is enabled?"""
+		return self in (SpeechMode.talk, SpeechMode.onDemand)
 
 
 @dataclass

--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -94,15 +94,10 @@ class SpeechMode(DisplayStringIntEnum):
 			self.beeps: pgettext("speechModes", "beeps"),
 			# Translators: Name of the speech mode which causes NVDA to speak normally.
 			self.talk: pgettext("speechModes", "talk"),
-			# Translators: Name of the on-demand speech mode;
-			# i.e. NVDA will talk only on commands asking to report something.
+			# Translators: Name of the on-demand speech mode,
+			# in which NVDA only speaks in response to commands that report content.
 			self.onDemand: pgettext("speechModes", "on-demand"),
 		}
-
-	@property
-	def producesSpeech(self) -> bool:
-		"""Is any speech produced when this mode is enabled?"""
-		return self in (SpeechMode.talk, SpeechMode.onDemand)
 
 
 @dataclass

--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -99,11 +99,6 @@ class SpeechMode(DisplayStringIntEnum):
 			self.onDemand: pgettext("speechModes", "on-demand"),
 		}
 
-	@property
-	def producesSpeech(self) -> bool:
-		"""Is any speech produced when this mode is enabled?"""
-		return self in (SpeechMode.talk, SpeechMode.onDemand)
-
 
 @dataclass
 class SpeechState:

--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -99,6 +99,11 @@ class SpeechMode(DisplayStringIntEnum):
 			self.onDemand: pgettext("speechModes", "on-demand"),
 		}
 
+	@property
+	def producesSpeech(self) -> bool:
+		"""Is any speech produced when this mode is enabled?"""
+		return self in (SpeechMode.talk, SpeechMode.onDemand)
+
 
 @dataclass
 class SpeechState:

--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -92,7 +92,7 @@ class SpeechMode(DisplayStringIntEnum):
 			self.off: pgettext("speechModes", "off"),
 			# Translators: Name of the speech mode which will cause NVDA to beep instead of speaking.
 			self.beeps: pgettext("speechModes", "beeps"),
-			# Translators: Name of the speech mode, which, when enabled, causes NVDA to talk as normal.
+			# Translators: Name of the speech mode which causes NVDA to speak normally.
 			self.talk: pgettext("speechModes", "talk"),
 			# Translators: Name of the on-demand speech mode;
 			# i.e. NVDA will talk only on commands asking to report something.

--- a/source/utils/displayString.py
+++ b/source/utils/displayString.py
@@ -11,7 +11,9 @@ from enum import (
 	IntEnum,
 	IntFlag,
 )
-from typing import Dict
+from typing import (
+	Self,
+)
 
 from logHandler import log
 
@@ -44,11 +46,10 @@ class _DisplayStringEnumMixin(ABC):
 	```
 	"""
 	@abstractproperty
-	def _displayStringLabels(self) -> Dict[Enum, str]:
+	def _displayStringLabels(self) -> dict[Self, str]:
 		"""
 		Specify a dictionary which takes members of the Enum and returns the translated display string.
 		"""
-		pass
 
 	@property
 	def displayString(self) -> str:

--- a/tests/unit/test_globalCommands.py
+++ b/tests/unit/test_globalCommands.py
@@ -1,0 +1,121 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2023 NV Access Limited, Łukasz Golonka
+# This file may be used under the terms of the GNU General Public License, version 2 or later.
+# For more details see: https://www.gnu.org/licenses/gpl-2.0.html
+
+"""Set of unit tests veryfying behavior of scripts defined in ``globalCommands``."""
+
+import unittest
+
+import config
+import globalCommands
+import inputCore
+import speech
+
+
+class _FakeInputGesture(inputCore.InputGesture):
+
+	"""An input gesture which does nothing, but can be passed to scripts."""
+
+	def _get_identifiers(self):
+		"""Implemented just to satisfy base class requirements, where this is defined as abstract."""
+		raise RuntimeError("Should not be required in tests.")
+
+
+class SpeechModeSwitching(unittest.TestCase):
+
+	"""Verifies that switching between speech modes with `NVDA+S` works.
+
+	Ideally we will also ensure that name of the new speech mode is presented to the user,
+	but we don't yet track calls to ``speech.speak``, so can't make any assertions on what has been spoken.
+	"""
+
+	@staticmethod
+	def _getCurrSpeechMode() -> speech.SpeechMode:
+		"""A convenience helper which retrieves currently set speech mode."""
+		return speech.getState().speechMode
+
+	@staticmethod
+	def _setDisabledSpeechModes(modesToExclude: tuple[speech.SpeechMode, ...]) -> None:
+		"""Disables given modes in the config."""
+		disabledModes: list[int] = []
+		for modeIndex, mode in enumerate(speech.SpeechMode):
+			if mode in modesToExclude:
+				disabledModes.append(modeIndex)
+		if len(disabledModes) > len(speech.SpeechMode) - 2:
+			raise RuntimeError("At least two modes have to be enabled.")
+		config.conf["speech"]["excludedSpeechModes"] = disabledModes
+
+	def setUp(self) -> None:
+		self._origSpeechMode = speech.getState().speechMode
+		self._defaultDisabledSpeechModes = config.conf["speech"]["excludedSpeechModes"]
+		# The new speech mode is shown in Braille, but displaying messages requires WX to be initialized.
+		# Just disable showing messages for these tests.
+		self._oldShowBraileMessagesVal = config.conf["braille"]["showMessages"]
+		config.conf["braille"]["showMessages"] = 0  # Disabled
+
+	def tearDown(self) -> None:
+		config.conf["speech"]["excludedSpeechModes"] = self._defaultDisabledSpeechModes
+		speech.setSpeechMode(self._origSpeechMode)
+		config.conf["braille"]["showMessages"] = self._oldShowBraileMessagesVal
+
+	@staticmethod
+	def _executeSpeechModeCycleScript():
+		globalCommands.commands.script_speechMode(_FakeInputGesture())
+
+	def test_cyclesThroughAllModesByDefault(self):
+		"""By default keyboard command should switch between all available speech modes."""
+		seenModes = set()
+		for __ in range(len(speech.SpeechMode)):
+			self._executeSpeechModeCycleScript()
+			seenModes.add(self._getCurrSpeechMode())
+		self.assertEqual(seenModes, set(speech.SpeechMode))
+		# Just to make sure, verify that we returned to the mode set initially.
+		self.assertEqual(self._getCurrSpeechMode(), self._origSpeechMode)
+
+	def test_nextModeIsUsed(self):
+		"""Next speech mode is picked when the currently selected is not the last one."""
+		# Verify that expected mode is set initially.
+		self.assertEqual(self._getCurrSpeechMode(), speech.SpeechMode.talk)
+		self._executeSpeechModeCycleScript()
+		self.assertEqual(self._getCurrSpeechMode(), speech.SpeechMode.onDemand)
+
+	def test_cyclingWrapsNoMoreModes(self):
+		"""When the selected speech mode is last on the list, the next press should switch to a first one."""
+		speech.setSpeechMode(speech.SpeechMode.onDemand)
+		self._executeSpeechModeCycleScript()
+		self.assertEqual(self._getCurrSpeechMode(), speech.SpeechMode.off)
+
+	def test_nextModePickedWhenEnabled(self):
+		"""When the next mode in the list is enabled, pressing the command once should switch to it."""
+		self._setDisabledSpeechModes((speech.SpeechMode.off, speech.SpeechMode.beeps))
+		self._executeSpeechModeCycleScript()
+		self.assertEqual(self._getCurrSpeechMode(), speech.SpeechMode.onDemand)
+
+	def test_nextModeDisabledMoreModesInTheList(self):
+		"""Next mode is disabled, yet there are more modes in the list, so no need to wrap to the first one."""
+		self._setDisabledSpeechModes((speech.SpeechMode.beeps,))
+		speech.setSpeechMode(speech.SpeechMode.off)
+		self._executeSpeechModeCycleScript()
+		self.assertEqual(self._getCurrSpeechMode(), speech.SpeechMode.talk)
+
+	def test_nextModeDisabledNoMoreModes(self):
+		"""When the next mode is disabled, switching wraps to the first mode."""
+		self._setDisabledSpeechModes((speech.SpeechMode.onDemand,))
+		self._executeSpeechModeCycleScript()
+		self.assertEqual(self._getCurrSpeechMode(), speech.SpeechMode.off)
+
+	def test_nextModesDisabledFirstEnabledNotAtTheBeginning(self):
+		"""Script has to wrap, mode at the beginning of the list is disabled, first enabled one is picked."""
+		self._setDisabledSpeechModes((speech.SpeechMode.off, speech.SpeechMode.onDemand))
+		self._executeSpeechModeCycleScript()
+		self.assertEqual(self._getCurrSpeechMode(), speech.SpeechMode.beeps)
+
+	def test_onlyEnabledModesAvailableForSwitching(self):
+		"""Execute script multiple times and make sure we never switched to one of the disabled modes."""
+		self._setDisabledSpeechModes((speech.SpeechMode.off, speech.SpeechMode.onDemand))
+		seenModes = set()
+		for __ in range(30):  # Chosen arbitrarily, so that script wraps multipe times.
+			self._executeSpeechModeCycleScript()
+			seenModes.add(self._getCurrSpeechMode())
+		self.assertEqual(seenModes, {speech.SpeechMode.talk, speech.SpeechMode.beeps})

--- a/tests/unit/test_globalCommands.py
+++ b/tests/unit/test_globalCommands.py
@@ -24,7 +24,7 @@ class _FakeInputGesture(inputCore.InputGesture):
 
 class SpeechModeSwitching(unittest.TestCase):
 
-	"""Verifies that switching between speech modes with `NVDA+S` works.
+	"""Verifies that switching between speech modes with `NVDA+s` works.
 
 	Ideally we will also ensure that name of the new speech mode is presented to the user,
 	but we don't yet track calls to ``speech.speak``, so can't make any assertions on what has been spoken.
@@ -115,7 +115,7 @@ class SpeechModeSwitching(unittest.TestCase):
 		"""Execute script multiple times and make sure we never switched to one of the disabled modes."""
 		self._setDisabledSpeechModes((speech.SpeechMode.off, speech.SpeechMode.onDemand))
 		seenModes = set()
-		for __ in range(30):  # Chosen arbitrarily, so that script wraps multipe times.
+		for __ in range(30):  # Chosen arbitrarily, so that script wraps multiple times.
 			self._executeSpeechModeCycleScript()
 			seenModes.add(self._getCurrSpeechMode())
 		self.assertEqual(seenModes, {speech.SpeechMode.talk, speech.SpeechMode.beeps})

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -31,8 +31,10 @@ Windows 8.1 is the minimum Windows version supported.
 - Added support for Bluetooth Low Energy HID Braille displays. (#15470)
 - A new "on-demand" speech mode has been added.
 When speech is on-demand, NVDA does not speak automatically (e.g. when moving the cursor) but still speaks when calling commands whose goal is explicitly to report something (e.g. report window title). (#481, @CyrilleB79)
+- it is now possible to exclude unwanted speech modes when cycling between them using ``NVDA+s`` from the Speech category in NVDA's settings. (#15806, @lukaszgo1)
+  - If you are currently using the NoBeepsSpeechMode add-on consider uninstalling it ,and disabling "beeps" and "on-demand" modes in the settings.
+  -
 -
-
 
 == Changes ==
 - NVDA no longer supports Windows 7 and Windows 8.

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -31,7 +31,7 @@ Windows 8.1 is the minimum Windows version supported.
 - Added support for Bluetooth Low Energy HID Braille displays. (#15470)
 - A new "on-demand" speech mode has been added.
 When speech is on-demand, NVDA does not speak automatically (e.g. when moving the cursor) but still speaks when calling commands whose goal is explicitly to report something (e.g. report window title). (#481, @CyrilleB79)
-- In the NVDA's settings Speech category, it is now possible to exclude unwanted speech modes when cycling between them using ``NVDA+s`` . (#15806, @lukaszgo1)
+- In the Speech category of NVDA's settings, it is now possible to exclude unwanted speech modes from the Cycle speech modes command (``NVDA+s``). (#15806, @lukaszgo1)
   - If you are currently using the NoBeepsSpeechMode add-on consider uninstalling it ,and disabling "beeps" and "on-demand" modes in the settings.
   -
 -

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -31,7 +31,7 @@ Windows 8.1 is the minimum Windows version supported.
 - Added support for Bluetooth Low Energy HID Braille displays. (#15470)
 - A new "on-demand" speech mode has been added.
 When speech is on-demand, NVDA does not speak automatically (e.g. when moving the cursor) but still speaks when calling commands whose goal is explicitly to report something (e.g. report window title). (#481, @CyrilleB79)
-- it is now possible to exclude unwanted speech modes when cycling between them using ``NVDA+s`` from the Speech category in NVDA's settings. (#15806, @lukaszgo1)
+- In the NVDA's settings Speech category, it is now possible to exclude unwanted speech modes when cycling between them using ``NVDA+s`` . (#15806, @lukaszgo1)
   - If you are currently using the NoBeepsSpeechMode add-on consider uninstalling it ,and disabling "beeps" and "on-demand" modes in the settings.
   -
 -

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -32,7 +32,7 @@ Windows 8.1 is the minimum Windows version supported.
 - A new "on-demand" speech mode has been added.
 When speech is on-demand, NVDA does not speak automatically (e.g. when moving the cursor) but still speaks when calling commands whose goal is explicitly to report something (e.g. report window title). (#481, @CyrilleB79)
 - In the Speech category of NVDA's settings, it is now possible to exclude unwanted speech modes from the Cycle speech modes command (``NVDA+s``). (#15806, @lukaszgo1)
-  - If you are currently using the NoBeepsSpeechMode add-on consider uninstalling it ,and disabling "beeps" and "on-demand" modes in the settings.
+  - If you are currently using the NoBeepsSpeechMode add-on consider uninstalling it, and disabling "beeps" and "on-demand" modes in the settings.
   -
 -
 

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -539,7 +539,7 @@ Examples include while recording audio, when using screen magnification, during 
 A gesture allows cycling through the various speech modes:
 %kc:beginInclude
 || Name | Key | Description |
-| Cycle Speech Mode | ``NVDA+s`` | Cycles speech mode between enabled speech modes. |
+| Cycle Speech Mode | ``NVDA+s`` | Cycles between speech modes. |
 %kc:endInclude
 
 If you only need to switch between a limited subset of speech modes, see [Switch between the following speech modes #SpeechModesDisabling] for a way to disable unwanted modes.
@@ -4108,7 +4108,7 @@ Please see the display's documentation for descriptions of where these keys can 
 | Route to braille cell | ``routing`` |
 | Report text formatting under braille cell | ``secondary routing`` |
 | Toggle the way context information is presented in braille | ``attribute1+attribute3`` |
-| Cycles between enabled speech modes | ``attribute2+attribute4`` |
+| Cycles between speech modes | ``attribute2+attribute4`` |
 | Switches to the previous review mode (e.g. object, document or screen) | ``f1`` |
 | Switches to the next review mode (e.g. object, document or screen) | ``f2`` |
 | Moves the navigator object to the object containing it | ``f3`` |

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -539,8 +539,10 @@ Examples include while recording audio, when using screen magnification, during 
 A gesture allows cycling through the various speech modes:
 %kc:beginInclude
 || Name | Key | Description |
-| Cycle Speech Mode | ``NVDA+s`` | Cycles speech mode between talk, on-demand, off and beeps. |
+| Cycle Speech Mode | ``NVDA+s`` | Cycles speech mode between enabled speech modes. |
 %kc:endInclude
+
+If you need to switch only between limited subset of speech modes, see [Switch between the following speech modes #SpeechModesDisabling] for a way to disable unwanted ones.
 
 + Navigating with NVDA +[NavigatingWithNVDA]
 NVDA allows you to explore and navigate the system in several ways, including both normal interaction and review.
@@ -1589,6 +1591,15 @@ For example, while reviewing a line by characters, when the letter "b" is read N
 This can be useful if it is hard to distinguish between pronunciation of symbols, or for hearing impaired users.
 
 The delayed character description will be cancelled if other text is spoken during that time, or if you press the ``control`` key.
+
+====Switch between the following speech modes: ====[SpeechModesDisabling]
+This checkable list allows to select which speech modes are included when cycling between them using ``NVDA+s``.
+Modes which are unchecked are excluded.
+By default all modes are included, also if any new mode is added to NVDA it will also be included by default.
+
+For example if you do not need to use "beeps" mode and the "on-demand" mode you should uncheck these two, and keep both "off" and "talk" checked.
+Note that it is necessary to check at least two modes, and one of "talk" or "on-demand" has to be checked, so that you are not left without any speech.
+This is validated when pressing Ok or Apply, and an appropriate error message is shown when these constraints are not meet.
 
 +++ Select Synthesizer +++[SelectSynthesizer]
 
@@ -4097,7 +4108,7 @@ Please see the display's documentation for descriptions of where these keys can 
 | Route to braille cell | ``routing`` |
 | Report text formatting under braille cell | ``secondary routing`` |
 | Toggle the way context information is presented in braille | ``attribute1+attribute3`` |
-| Cycles between the speech modes of talk, on-demand, off and beeps | ``attribute2+attribute4`` |
+| Cycles between enabled speech modes | ``attribute2+attribute4`` |
 | Switches to the previous review mode (e.g. object, document or screen) | ``f1`` |
 | Switches to the next review mode (e.g. object, document or screen) | ``f2`` |
 | Moves the navigator object to the object containing it | ``f3`` |

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -1597,7 +1597,7 @@ This checkable list allows selecting which speech modes are included when cyclin
 Modes which are unchecked are excluded.
 By default all modes are included.
 
-For example if you do not need to use "beeps" mode and the "on-demand" mode you should uncheck these two, and keep both "off" and "talk" checked.
+For example if you do not need to use "beeps" and "off" mode  mode you should uncheck these two, and keep both "talk" and "on-demand" checked.
 Note that it is necessary to check at least two modes.
 
 +++ Select Synthesizer +++[SelectSynthesizer]
@@ -1935,7 +1935,7 @@ The checkboxes in this list control what keys can be used as [NVDA modifier keys
 - The extended insert key (usually found above the arrow keys, near home and end)
 -
 
-If no key is chosen as the NVDA key it may be impossible to access certain NVDA commands, therefore you need to check at least one of the modifiers.
+If no key is chosen as the NVDA key it may be impossible to access many NVDA commands, therefore you are required to check at least one of the modifiers.
 
 %kc:setting
 ==== Speak Typed Characters ====[KeyboardSettingsSpeakTypedCharacters]

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -542,7 +542,7 @@ A gesture allows cycling through the various speech modes:
 | Cycle Speech Mode | ``NVDA+s`` | Cycles between speech modes. |
 %kc:endInclude
 
-If you only need to switch between a limited subset of speech modes, see [Switch between the following speech modes #SpeechModesDisabling] for a way to disable unwanted modes.
+If you only need to switch between a limited subset of speech modes, see [Modes available in the Cycle speech mode command #SpeechModesDisabling] for a way to disable unwanted modes.
 
 + Navigating with NVDA +[NavigatingWithNVDA]
 NVDA allows you to explore and navigate the system in several ways, including both normal interaction and review.
@@ -1592,7 +1592,7 @@ This can be useful if it is hard to distinguish between pronunciation of symbols
 
 The delayed character description will be cancelled if other text is spoken during that time, or if you press the ``control`` key.
 
-====Switch between the following speech modes: ====[SpeechModesDisabling]
+==== Modes available in the Cycle speech mode command ====[SpeechModesDisabling]
 This checkable list allows selecting which speech modes are included when cycling between them using ``NVDA+s``.
 Modes which are unchecked are excluded.
 By default all modes are included, also if any new mode is added to NVDA it will also be included by default.

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -1597,7 +1597,7 @@ This checkable list allows selecting which speech modes are included when cyclin
 Modes which are unchecked are excluded.
 By default all modes are included.
 
-For example if you do not need to use "beeps" and "off" mode  mode you should uncheck these two, and keep both "talk" and "on-demand" checked.
+For example if you do not need to use "beeps" and "off" mode you should uncheck these two, and keep both "talk" and "on-demand" checked.
 Note that it is necessary to check at least two modes.
 
 +++ Select Synthesizer +++[SelectSynthesizer]

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -542,7 +542,7 @@ A gesture allows cycling through the various speech modes:
 | Cycle Speech Mode | ``NVDA+s`` | Cycles speech mode between enabled speech modes. |
 %kc:endInclude
 
-If you need to switch only between limited subset of speech modes, see [Switch between the following speech modes #SpeechModesDisabling] for a way to disable unwanted ones.
+If you only need to switch between a limited subset of speech modes, see [Switch between the following speech modes #SpeechModesDisabling] for a way to disable unwanted modes.
 
 + Navigating with NVDA +[NavigatingWithNVDA]
 NVDA allows you to explore and navigate the system in several ways, including both normal interaction and review.
@@ -1593,13 +1593,13 @@ This can be useful if it is hard to distinguish between pronunciation of symbols
 The delayed character description will be cancelled if other text is spoken during that time, or if you press the ``control`` key.
 
 ====Switch between the following speech modes: ====[SpeechModesDisabling]
-This checkable list allows to select which speech modes are included when cycling between them using ``NVDA+s``.
+This checkable list allows selecting which speech modes are included when cycling between them using ``NVDA+s``.
 Modes which are unchecked are excluded.
 By default all modes are included, also if any new mode is added to NVDA it will also be included by default.
 
 For example if you do not need to use "beeps" mode and the "on-demand" mode you should uncheck these two, and keep both "off" and "talk" checked.
 Note that it is necessary to check at least two modes, and one of "talk" or "on-demand" has to be checked, so that you are not left without any speech.
-This is validated when pressing Ok or Apply, and an appropriate error message is shown when these constraints are not meet.
+This is validated when pressing Ok or Apply, and an appropriate error message is shown when these constraints are not met.
 
 +++ Select Synthesizer +++[SelectSynthesizer]
 

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -1595,11 +1595,10 @@ The delayed character description will be cancelled if other text is spoken duri
 ==== Modes available in the Cycle speech mode command ====[SpeechModesDisabling]
 This checkable list allows selecting which speech modes are included when cycling between them using ``NVDA+s``.
 Modes which are unchecked are excluded.
-By default all modes are included, also if any new mode is added to NVDA it will also be included by default.
+By default all modes are included.
 
 For example if you do not need to use "beeps" mode and the "on-demand" mode you should uncheck these two, and keep both "off" and "talk" checked.
-Note that it is necessary to check at least two modes, and one of "talk" or "on-demand" has to be checked, so that you are not left without any speech.
-This is validated when pressing Ok or Apply, and an appropriate error message is shown when these constraints are not met.
+Note that it is necessary to check at least two modes.
 
 +++ Select Synthesizer +++[SelectSynthesizer]
 
@@ -1936,9 +1935,7 @@ The checkboxes in this list control what keys can be used as [NVDA modifier keys
 - The extended insert key (usually found above the arrow keys, near home and end)
 -
 
-If no key is chosen as the NVDA key it may be impossible to access certain NVDA commands.
-Therefore, The NVDA settings dialog will display an error message if all keys are unselected when pressing Ok or Apply.
-After dismissing the error message, you must select at least one before being able to press Ok to dismiss the dialog properly.
+If no key is chosen as the NVDA key it may be impossible to access certain NVDA commands, therefore you need to check at least one of the modifiers.
 
 %kc:setting
 ==== Speak Typed Characters ====[KeyboardSettingsSpeakTypedCharacters]


### PR DESCRIPTION
### Link to issue number:
Closes #15806

### Summary of the issue:
NVDA allows to change the currently used speech mode by pressing `NVDA+s`. By default this gesture cycles between 'talk', 'beeps', 'on-demand' and  'no speech'. For many users having ability to switch to beeps or on demand is unnecessary, and they have no need for modes different than speech and no speech. For other beeps mode is certainly useful, but it is much more important to be able to quickly switch between speech and no speech, so beeps mode just makes the goal slower to achieve. With the introduction of fourth speech mode in #15804 it has been decided that users should be given ability to disable speech modes they do not need to use.
### Description of user facing changes
The new checkable list containing all speech modes (all are initially checked)has been added into the Speech settings panel. When switching between modes with NVDA+s only modes which are checked in the list are included. When applying settings selected modes are validated, to make sure at least two modes are checked. When the 'talk' mode  is disabled user is warned that they may be left without any speech.
### Description of development approach
Configuration spec has been expanded to store list of disabled modes - this ensures that if any new mode is added to NVDA it is enabled by default in the cycling script. Speech settings panel now contains a list of all the speech modes, only enabled one are checked. When introducing validation for the speech settings panel it has been discovered that code responsible for checking panel's validity displays a warning about it being invalid, prevents saving invalid config, yet after dismissing the warning settings dialog gets closed. Since this is not optimal validation for settings dialog has been modified, so that after warning is dismissed settings remain open, and the invalid control is focused. The cycling script has been modified to only cycle between enabled modes. Unit tests verifying its behavior, both when no modes are disabled (the default) and some are disabled, were added. To make them work it has been necessary to perform  a small modification to the method which lists configuration profiles in the `config` module, it assumed that profiles directory always exists, which is not true in unit tests. Now when the directory is missing appropriate warning is logged, and empty list is returned. User guide has been expanded to describe newly added control.
### Testing strategy:
- Executed unit tests
- Manually verified various combinations of enabled and disabled modes
- Ensured that when only one mode is checked appropriate error message is shown
- Ensured that when 'talk' is disabled user is warned, and can either continue saving settings, or return to the list of speech modes
- Verified that changes to the user guide can be compiled
### Known issues with pull request:
- Warning about 'talk' being disabled may be not optimal for users - if there is a lot of complaints about it we can always revert this part
- Since the default mode is 'talk', yet it can be disabled it there is an inconsistency about what is used when starting NVDA, and to what mode NVDA can be switched. It has been proposed to allow configuring in which speech mode NVDA should start, but this was determined to be out of scope of this work
- Currently change log recommends users to uninstall the NoBeepsSpeechMode add-on, as it is redundant, and hides the new on-demand speech mode. It should be possible to ask user if it should be uninstalled automatically, but that was also determined to be out of scope

### Code Review Checklist:

- [X] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [X] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [X] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [X] API is compatible with existing add-ons.
- [X] Security precautions taken.
