### PR TITLE
Always rebuild it when building dist

### DIFF
--- a/sconstruct
+++ b/sconstruct
@@ -409,6 +409,7 @@ if certFile:
 
 dist = env.NVDADist("dist", [sourceDir,userDocsDir], uiAccess=bool(certFile))
 env.Depends(dist,uninstaller)
+AlwaysBuild(dist)
 # Dir node targets don't get cleaned, so cleaning of the dist nodes has to be explicitly specified.
 env.Clean(dist, dist)
 # Clean the intermediate build directory.

--- a/sconstruct
+++ b/sconstruct
@@ -409,6 +409,7 @@ if certFile:
 
 dist = env.NVDADist("dist", [sourceDir,userDocsDir], uiAccess=bool(certFile))
 env.Depends(dist,uninstaller)
+# dist will always be considered obsolete
 AlwaysBuild(dist)
 # Dir node targets don't get cleaned, so cleaning of the dist nodes has to be explicitly specified.
 env.Clean(dist, dist)

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -167,6 +167,7 @@ Setting ``numCells`` is still supported for single line braille displays and ``n
   - Scripts that perform an action (e.g. move the cursor, change a parameter) should not speak in the "on-demand" mode.
   -
 - Fixed bug where deleting git-tracked files during `scons -c` resulted in missing UIA COM interfaces on rebuild. (#7070, #10833, @hwf1324)
+- Fix a bug where some code changes were not detected when building `dist` that prevented a new build from being triggered. Now always rebuilds every time `dist` is built. (#13372, @hwf1324)
 -
 
 === API Breaking Changes ===

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -169,7 +169,8 @@ Setting ``numCells`` is still supported for single line braille displays and ``n
   - Scripts that perform an action (e.g. move the cursor, change a parameter) should not speak in the "on-demand" mode.
   -
 - Fixed bug where deleting git-tracked files during `scons -c` resulted in missing UIA COM interfaces on rebuild. (#7070, #10833, @hwf1324)
-- Fix a bug where some code changes were not detected when building `dist` that prevented a new build from being triggered. Now always rebuilds every time `dist` is built. (#13372, @hwf1324)
+- Fix a bug where some code changes were not detected when building `dist`, that prevented a new build from being triggered.
+Now `dist` always rebuilds. (#13372, @hwf1324)
 -
 
 === API Breaking Changes ===


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:

Fixes #13372

### Summary of the issue:

When rebuilding `dist`, some code changes were not detected. SCons does not trigger a new build.

### Description of user facing changes

None

### Description of development approach

`dist` will always be considered obsolete.

### Testing strategy:

Test steps from #13372:

> The following steps use `scons launcher` command but all the same applies to `scons dist` as well.
> 
> 1. Get a fresh copy of NVDA:
> 
> ```
> > git clone --recursive https://github.com/nvaccess/nvda.git
> > ...
> > cd nvda
> ```
> 
> 2. Build launcher:
> 
> ```
> > scons launcher
> ... many lines of actual building process omitted
> scons: done building targets.
> ```
> 
> 3. Check that launcher was built successfully:
> 
> ```
> > output\nvda_snapshot_source-master-6310b86.exe
> ```
> 
> 4. Adding the following lines in core.py in def main right before `app.MainLoop()`:
> 
> ```
> import tones
> tones.beep(1000, 1000)
> ```
> 
> 5. Running NVDA from source to make sure beep can be heard:
> 
> ```
> > runnvda.bat
> ```
> 
> 6. Rebuild launcher:
> 
> ```
> > scons launcher
> ...
> scons: `launcher' is up to date.
> scons: done building targets.
> ```

### Known issues with pull request:

It will always rebuild when building `dist`.

After running NVDA in the `dist` folder, encountered a Windows error during the rebuild. Speculating that py2exe is unable to replace the occupied file.
This issue, although not caused by this PR, should still be mentioned. See details in #15884.

There is no method found to only replace the modified files when rebuilding py2exe

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
