### PR TITLE
IA2: Evaluate "level" object attribute

### DIFF
--- a/source/NVDAObjects/IAccessible/__init__.py
+++ b/source/NVDAObjects/IAccessible/__init__.py
@@ -1485,6 +1485,8 @@ the NVDAObject for IAccessible
 			try:
 				info={}
 				info["level"],info["similarItemsInGroup"],info["indexInGroup"]=self.IAccessibleObject.groupPosition
+				if not info["level"]:
+					info["level"] = self.IA2Attributes["level"]
 				# Object's with an IAccessibleTableCell interface should not expose indexInGroup/similarItemsInGroup as the cell's 2d info is much more useful.
 				if self._IATableCell:
 					del info['indexInGroup']

--- a/source/NVDAObjects/IAccessible/__init__.py
+++ b/source/NVDAObjects/IAccessible/__init__.py
@@ -1486,7 +1486,9 @@ the NVDAObject for IAccessible
 				info={}
 				info["level"],info["similarItemsInGroup"],info["indexInGroup"]=self.IAccessibleObject.groupPosition
 				if not info["level"]:
-					info["level"] = self.IA2Attributes["level"]
+					ia2Attrs = self.IA2Attributes
+					if "level" in ia2Attrs:
+						info["level"] = ia2Attrs["level"]
 				# Object's with an IAccessibleTableCell interface should not expose indexInGroup/similarItemsInGroup as the cell's 2d info is much more useful.
 				if self._IATableCell:
 					del info['indexInGroup']

--- a/source/appModules/soffice.py
+++ b/source/appModules/soffice.py
@@ -222,6 +222,9 @@ class SymphonyText(IAccessible, EditableText):
 	TextInfo = SymphonyTextInfo
 
 	def _get_positionInfo(self):
+		# LibreOffice versions >= 5.0 report the "level" attribute that's
+		# handled in the base class, but Apache OpenOffice doesn't,
+		# so check for the custom "heading-level" attribute first
 		level = self.IA2Attributes.get("heading-level")
 		if level:
 			return {"level": int(level)}

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -88,6 +88,7 @@ Users of Poedit 1 are encouraged to update to Poedit 3 if they want to rely on e
   - Announcement of the status bar using the ``NVDA+end`` keyboard shortcut now also works for dialogs in LibreOffice version 24.2 and newer. (#15591, @michaelweghorn)
   - All expected text attributes are now supported in LibreOffice versions 24.2 and above.
   This makes the announcement of spelling errors work when announcing a line in Writer. (#15648, @michaelweghorn)
+  - Announcement of heading levels now also works for LibreOffice versions 24.2 and newer. (#15881, @michaelweghorn)
   -
 - Microsoft Office:
   - In Excel with UIA disabled, braille is updated, and the active cell content is spoken, when ``control+y``, ``control+z`` or ``alt+backspace`` is pressed. (#15547)


### PR DESCRIPTION
 ### Link to issue number:

Fixes #15881

 ### Summary of the issue:

The "level" object attribute for IAccessible2 to specify the level of a heading is both mentioned in the [Core Accessibility API Mappings specification](https://www.w3.org/TR/core-aam-1.2/#ariaLevelHeading) and in the [IAccessible2::groupPosition documentation](https://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/interface_i_accessible2.html#a94d4d84e000ef2fa3f2abf1148779941). However, NVDA was not supporting/evaluating this object attribute in order to determine the heading level, resulting in the heading level no longer getting announced once LibreOffice only reports the "level" attribute as specified and no longer the custom "heading-level" attribute that NVDA's soffice app module relies on.

 ### Description of user facing changes

Reporting heading levels also works for LibreOffice version 24.2 and greater.

 ### Description of development approach

Add handling for the "level" IAccessible2 object attribute when determining position info for an IAccessible2 object. In the soffice app module, add a comment that the custom "heading-level" attribute is only needed for Apache OpenOffice by now, since LibreOffice has already been reporting the "level" object attribute in addition to the "heading-level" attribute since LibreOffice 5.0.

 ### Testing strategy:

Test the scenario as described in issue #15881 works as expected with this change in place:

1. start NVDA
2. start current development version of LibreOffice including the following change that drops reporting the non-standard "heading-level" object attribute: https://gerrit.libreoffice.org/c/core/+/160347
3. open the sample document [heading.odt](https://github.com/nvaccess/nvda/files/13560391/heading.odt)
4. use the cursor up/down key to move between the paragraphs/headings
5. When moving to a header, verify that NVDA announces the heading level, e.g. says "heading    level 1  Heading 1".

 ### Known issues with pull request:

none

 ### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.