### PR TITLE
Fix python 3.11 regression with Python console autocomplete

### DIFF
--- a/source/pythonConsole.py
+++ b/source/pythonConsole.py
@@ -63,7 +63,7 @@ consoleUI = None
 
 class Completer(rlcompleter.Completer):
 
-	def attr_matches(self, text):
+	def attr_matches(self, text: str) -> list[str]:
 		"""attr_matches implementation as used in Python 3.9.
 		In Python 3.10, attr_matches was changed in a way that filtered out property descriptors,
 		but more importantly, no longer catches exceptions when calling getattr.

--- a/source/pythonConsole.py
+++ b/source/pythonConsole.py
@@ -63,9 +63,63 @@ consoleUI = None
 
 class Completer(rlcompleter.Completer):
 
+	def attr_matches(self, text):
+		"""attr_matches implementation as used in Python 3.9.
+		In Python 3.10, attr_matches was changed in a way that filtered out property descriptors,
+		but more importantly, no longer catches exceptions when calling getattr.
+		This causes serious issues for baseObject.Getter descriptors
+		when a getter raises NotImplementedError, for example (#15872).
+		"""
+		import re
+
+		m = re.match(r"(\w+(\.\w+)*)\.(\w*)", text)
+		if not m:
+			return []
+		expr, attr = m.group(1, 3)
+		try:
+			thisobject = eval(expr, self.namespace)
+		except Exception:
+			return []
+
+		# get the content of the object, except __builtins__
+		words = set(dir(thisobject))
+		words.discard("__builtins__")
+
+		if hasattr(thisobject, "__class__"):
+			words.add("__class__")
+			words.update(rlcompleter.get_class_members(thisobject.__class__))
+		matches = []
+		n = len(attr)
+		if attr == "":
+			noprefix = "_"
+		elif attr == "_":
+			noprefix = "__"
+		else:
+			noprefix = None
+		while True:
+			for word in words:
+				if word[:n] == attr and not (noprefix and word[: n + 1] == noprefix):
+					match = f"{expr}.{word}"
+					try:
+						val = getattr(thisobject, word)
+					except Exception:
+						pass  # Include even if attribute not set
+					else:
+						match = self._callable_postfix(val, match)
+					matches.append(match)
+			if matches or not noprefix:
+				break
+			if noprefix == "_":
+				noprefix = "__"
+			else:
+				noprefix = None
+		matches.sort()
+		return matches
+
 	def _callable_postfix(self, val, word):
 		# Just because something is callable doesn't always mean we want to call it.
 		return word
+
 
 class CommandCompiler(codeop.CommandCompiler):
 	"""


### PR DESCRIPTION
### Link to issue number:
Fixes #15872

### Summary of the issue:
Since python 3.10, auto completion in the Python Console would fail when trying to complete a string that matches an AutoPropertyObject getter raising NotImplementedError. This is because starting from 3.10, the code responsible for matching no longer catches exceptions for getattr. Instead, it ensures that `property` descriptors are filtered out. In my opinion, solution from Python is far from ideal, since it doesn't deal with other descriptors, like our `baseObject.Getter`.

### Description of user facing changes
Fixes auto completion

### Description of development approach
Copied and adapted code from Python 3.9.

### Testing strategy:
Tested str from #15872

### Known issues with pull request:
We could also consider keeping the Python 3.11 code, but instead expanding it to baseObject.Getter. This would imply a change in behavior, as properties that raise exceptions would be included in the auto complete list.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
