### PR TITLE
Add add-on store conventions for manifest to developer guide

### DIFF
--- a/projectDocs/dev/developerGuide/developerGuide.t2t
+++ b/projectDocs/dev/developerGuide/developerGuide.t2t
@@ -782,13 +782,15 @@ Although it is highly suggested that manifests contain all fields, the fields ma
 Otherwise, the add-on will not install.
 
 - name (string, required): A short unique name for the add-on.
-This is used to differentiate add-ons internally and is not shown to the user.
-The recommended convention is lowerCamelCase.
-Special characters should be avoided.
+  - The recommended convention is lowerCamelCase.
+  - This is used to differentiate add-ons internally, and is also used as the name of the add-on's directory in the user configuration directory.
+  - Special characters should be avoided as the add-on name will be used as a folder name.
+  Expected characters are alphanumeric, space, underscore and hyphen.
+  -
 - summary (string, required): The name of the add-on as shown to the user.
 - version (string, required): The version of this add-on; e.g. 2.0.1.
 When uploading to the Add-on Store certain requirements apply:
-  - Using ``<major>.<minor>.<patch>`` format.
+  - Using ``<major>.<minor>`` or ``<major>.<minor>.<patch>`` format.
   - For a user to be able to update to this add-on, the version must be greater than the last version uploaded.
   - Add-on versions are expected to be unique for the addon name and channel, meaning that a beta, stable and dev version of the same add-on cannot share a version number.
   This is so there can be a unique ordering of newest to oldest.
@@ -797,19 +799,26 @@ When uploading to the Add-on Store certain requirements apply:
 - author (string, required): The author of this add-on, preferably in the form Full Name <email address>; e.g. Michael Curran <mick@example.com>.
 - description (string): A sentence or two describing what the add-on does.
 - url (string): A URL where this add-on, further info and upgrades can be found.
-This should start with ``https://``.
+  - Starting the URL with ``https://`` is required for submitting to the Add-on Store.
+  -
 - docFileName (string): The name of the main documentation file for this add-on; e.g. readme.html. See the [Add-on Documentation #AddonDoc] section for more details.
 - minimumNVDAVersion (string, required): The minimum required version of NVDA for this add-on to be installed or enabled.
-  - e.g "2019.1.1"
-  - Must be a three part version string I.E. Year.Major.Minor, or a two part version string of Year.Major. In the second case, Minor defaults to 0.
+  - e.g "2021.1"
+  - Must be a three part version string i.e. Year.Major.Minor, or a two part version string of Year.Major.
+  In the second case, Minor defaults to 0.
   - Defaults to "0.0.0"
   - Must be less than or equal to ``lastTestedNVDAVersion``
+  - This must match a valid API version to be submitted to the Add-on Store.
+  Valid API versions are found [on GitHub https://github.com/nvaccess/addon-datastore-transform/blob/main/nvdaAPIVersions.json].
   -
 - lastTestedNVDAVersion (string, required): The last version of NVDA this add-on has been tested with.
-  - e.g "2019.1.0"
-  - Must be a three part version string I.E. Year.Major.Minor, or a two part version string of Year.Major. In the second case, Minor defaults to 0.
+  - e.g "2022.3.3"
+  - Must be a three part version string i.e. Year.Major.Minor, or a two part version string of Year.Major.
+  In the second case, Minor defaults to 0.
   - Defaults to "0.0.0"
   - Must be greater than or equal to ``minimumNVDAVersion``
+  - This must match a valid API version to be submitted to the Add-on Store.
+  Valid API versions are found [on GitHub https://github.com/nvaccess/addon-datastore-transform/blob/main/nvdaAPIVersions.json].
   -
 -
 
@@ -829,8 +838,8 @@ description = "An example add-on showing how to create add-ons!"
 author = "Michael Curran <mick@example.com>"
 url = "https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/addons.md"
 docFileName = "readme.html"
-minimumNVDAVersion = "2018.1.0"
-lastTestedNVDAVersion = "2019.1.0"
+minimumNVDAVersion = "2021.1"
+lastTestedNVDAVersion = "2022.3.3"
 --- end ---
 ```
 

--- a/projectDocs/dev/developerGuide/developerGuide.t2t
+++ b/projectDocs/dev/developerGuide/developerGuide.t2t
@@ -781,7 +781,7 @@ This manifest file contains key = value pairs declaring info such as the add-on'
 Although it is highly suggested that manifests contain all fields, the fields marked as mandatory must be included.
 Otherwise, the add-on will not install.
 
-- name (string, required): A short unique name for the add-on.
+- name (string, required): A short, unique, name for the add-on.
   - The recommended convention is lowerCamelCase.
   - This is used to differentiate add-ons internally, and is also used as the name of the add-on's directory in the user configuration directory.
   - Special characters should be avoided as the add-on name will be used as a folder name.

--- a/projectDocs/dev/developerGuide/developerGuide.t2t
+++ b/projectDocs/dev/developerGuide/developerGuide.t2t
@@ -781,20 +781,31 @@ This manifest file contains key = value pairs declaring info such as the add-on'
 Although it is highly suggested that manifests contain all fields, the fields marked as mandatory must be included.
 Otherwise, the add-on will not install.
 
-- name (string): A short unique name for the add-on. This is used to differentiate add-ons internally and is not shown to the user. (Mandatory)
-- summary (string): The name of the add-on as shown to the user. (Mandatory)
-- version (string): The version of this add-on; e.g. 2.0. (Mandatory)
-- author (string): The author of this add-on, preferably in the form Full Name <email address>; e.g. Michael Curran <mick@kulgan.net>. (Mandatory)
+- name (string, required): A short unique name for the add-on.
+This is used to differentiate add-ons internally and is not shown to the user.
+The recommended convention is lowerCamelCase.
+Special characters should be avoided.
+- summary (string, required): The name of the add-on as shown to the user.
+- version (string, required): The version of this add-on; e.g. 2.0.1.
+When uploading to the Add-on Store certain requirements apply:
+  - Using ``<major>.<minor>.<patch>`` format.
+  - For a user to be able to update to this add-on, the version must be greater than the last version uploaded.
+  - Add-on versions are expected to be unique for the addon name and channel, meaning that a beta, stable and dev version of the same add-on cannot share a version number.
+  This is so there can be a unique ordering of newest to oldest.
+  - The suggested convention is to increment the patch version number for dev versions, increment the minor version number for beta versions, and increment the major version number for stable versions.
+  -
+- author (string, required): The author of this add-on, preferably in the form Full Name <email address>; e.g. Michael Curran <mick@example.com>.
 - description (string): A sentence or two describing what the add-on does.
 - url (string): A URL where this add-on, further info and upgrades can be found.
+This should start with ``https://``.
 - docFileName (string): The name of the main documentation file for this add-on; e.g. readme.html. See the [Add-on Documentation #AddonDoc] section for more details.
-- minimumNVDAVersion (string): The minimum required version of NVDA for this add-on to be installed or enabled.
+- minimumNVDAVersion (string, required): The minimum required version of NVDA for this add-on to be installed or enabled.
   - e.g "2019.1.1"
   - Must be a three part version string I.E. Year.Major.Minor, or a two part version string of Year.Major. In the second case, Minor defaults to 0.
   - Defaults to "0.0.0"
   - Must be less than or equal to ``lastTestedNVDAVersion``
   -
-- lastTestedNVDAVersion (string): The last version of NVDA this add-on has been tested with.
+- lastTestedNVDAVersion (string, required): The last version of NVDA this add-on has been tested with.
   - e.g "2019.1.0"
   - Must be a three part version string I.E. Year.Major.Minor, or a two part version string of Year.Major. In the second case, Minor defaults to 0.
   - Defaults to "0.0.0"
@@ -813,10 +824,10 @@ When this is not provided, or is less than the current version of NVDA (ignoring
 --- start ---
 name = "myTestAddon"
 summary = "Cool Test Add-on"
-version = "1.0"
+version = "1.0.0"
 description = "An example add-on showing how to create add-ons!"
-author = "Michael Curran <mick@kulgan.net>"
-url = "http://www.nvda-project.org/wiki/Development"
+author = "Michael Curran <mick@example.com>"
+url = "https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/addons.md"
 docFileName = "readme.html"
 minimumNVDAVersion = "2018.1.0"
 lastTestedNVDAVersion = "2019.1.0"


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
None

### Summary of the issue:
The add-on store adds additional requirements to manifest files for add-ons.
These should be explained in the developer guide.

### Description of user facing changes
- Add explanation for convention for add-on version numbers.
- Add convention for add-on ID to be lowerCamelCase.
- Add https convention for URL
