### PR TITLE
Improve logging of add-ons pending install forcing a restart

### DIFF
--- a/source/gui/addonStoreGui/controls/storeDialog.py
+++ b/source/gui/addonStoreGui/controls/storeDialog.py
@@ -31,6 +31,7 @@ from gui import (
 from gui.message import DisplayableError, displayDialogAsModal
 from gui.settingsDialogs import SettingsDialog
 from logHandler import log
+from utils.caseInsensitiveCollections import CaseInsensitiveSet
 
 from ..viewModels.store import AddonStoreVM
 from .actions import _MonoActionsContextMenu
@@ -268,6 +269,10 @@ class AddonStoreDialog(SettingsDialog):
 			addonDataManager._downloadsPendingInstall
 			or state[AddonStateCategory.PENDING_INSTALL]
 		):
+			# Create a copy and merge the sets to log the add-ons pending install
+			addonsPendingInstall = CaseInsensitiveSet(state[AddonStateCategory.PENDING_INSTALL])
+			addonsPendingInstall.union(a[0].model.name for a in addonDataManager._downloadsPendingInstall)
+			log.debug(f"Add-ons pending install, restart required: {addonsPendingInstall}")
 			return True
 
 		for addonsForChannel in self._storeVM._installedAddons.values():

--- a/source/gui/addonStoreGui/controls/storeDialog.py
+++ b/source/gui/addonStoreGui/controls/storeDialog.py
@@ -269,8 +269,8 @@ class AddonStoreDialog(SettingsDialog):
 			or state[AddonStateCategory.PENDING_INSTALL]
 		):
 			log.debug(
-				"Add-ons pending install, restart required.\n" 
-			 	f"Downloads pending install (add-on store installs): {addonDataManager._downloadsPendingInstall}.\n"
+				"Add-ons pending install, restart required.\n"
+				f"Downloads pending install (add-on store installs): {addonDataManager._downloadsPendingInstall}.\n"
 				f"Addons pending install (external installs): {state[AddonStateCategory.PENDING_INSTALL]}.\n"
 			)
 			return True

--- a/source/gui/addonStoreGui/controls/storeDialog.py
+++ b/source/gui/addonStoreGui/controls/storeDialog.py
@@ -31,7 +31,6 @@ from gui import (
 from gui.message import DisplayableError, displayDialogAsModal
 from gui.settingsDialogs import SettingsDialog
 from logHandler import log
-from utils.caseInsensitiveCollections import CaseInsensitiveSet
 
 from ..viewModels.store import AddonStoreVM
 from .actions import _MonoActionsContextMenu
@@ -269,10 +268,11 @@ class AddonStoreDialog(SettingsDialog):
 			addonDataManager._downloadsPendingInstall
 			or state[AddonStateCategory.PENDING_INSTALL]
 		):
-			# Create a copy and merge the sets to log the add-ons pending install
-			addonsPendingInstall = CaseInsensitiveSet(state[AddonStateCategory.PENDING_INSTALL])
-			addonsPendingInstall.union(a[0].model.name for a in addonDataManager._downloadsPendingInstall)
-			log.debug(f"Add-ons pending install, restart required: {addonsPendingInstall}")
+			log.debug(
+				"Add-ons pending install, restart required.\n" 
+			 	f"Downloads pending install (add-on store installs): {addonDataManager._downloadsPendingInstall}.\n"
+				f"Addons pending install (external installs): {state[AddonStateCategory.PENDING_INSTALL]}.\n"
+			)
 			return True
 
 		for addonsForChannel in self._storeVM._installedAddons.values():


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Relates to #15719

### Summary of the issue:
When triaging #15719, important information from the log is missing.
The reporter is stuck with a pending restart dialog appearing every time they close the add-on store.
For reasons other than a pending install, the first add-on found to be modified is logged.
For pending installs, all add-ons pending an install should be logged.

### Description of user facing changes
None

### Description of development approach
Log all add-ons pending install when triggering the restart dialog

### Testing strategy:
Tested by installing an external add-on and an add-on from the store, ensure these both are logged.

### Known issues with pull request:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
