### PR TITLE
Make add-on store base end point part of the public API

### DIFF
--- a/source/addonStore/network.py
+++ b/source/addonStore/network.py
@@ -40,7 +40,7 @@ if TYPE_CHECKING:
 	from gui.addonStoreGui.viewModels.addonList import AddonListItemVM
 
 
-_BASE_URL = "https://nvaccess.org/addonStore"
+BASE_URL = "https://nvaccess.org/addonStore"
 _LATEST_API_VER = "latest"
 """
 A string value used in the add-on store to fetch the latest version of all add-ons,
@@ -54,11 +54,11 @@ def _getCurrentApiVersionForURL() -> str:
 
 
 def _getAddonStoreURL(channel: Channel, lang: str, nvdaApiVersion: str) -> str:
-	return f"{_BASE_URL}/{lang}/{channel.value}/{nvdaApiVersion}.json"
+	return f"{BASE_URL}/{lang}/{channel.value}/{nvdaApiVersion}.json"
 
 
 def _getCacheHashURL() -> str:
-	return f"{_BASE_URL}/cacheHash.json"
+	return f"{BASE_URL}/cacheHash.json"
 
 
 class AddonFileDownloader:


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Relates to #14974 

### Summary of the issue:
Add-on authors wish to have a stable API so that they can change the base URL of the add-on store.
This allows add-ons to use a mirror for the add-on store.

### Description of user facing changes
None

### Description of development approach
Change BASE_URL for the add-on store to be public

### Testing strategy:
Confirm with add-on authors that changes are sufficient

### Known issues with pull request:
None
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
