### PR TITLE
No longer focus controls in settings dialog when they're invalid

### DIFF
--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -1698,7 +1698,6 @@ class VoiceSettingsPanel(AutoSettingsMixin, SettingsPanel):
 				wx.OK | wx.ICON_ERROR,
 				self,
 			)
-			self.speechModesList.SetFocus()
 			return False
 		if self._allSpeechModes.index(speech.SpeechMode.talk) not in enabledSpeechModes:
 			if gui.messageBox(
@@ -1715,7 +1714,6 @@ class VoiceSettingsPanel(AutoSettingsMixin, SettingsPanel):
 				wx.YES | wx.NO | wx.ICON_WARNING,
 				self,
 			) == wx.NO:
-				self.speechModesList.SetFocus()
 				return False
 		return super().isValid()
 
@@ -1832,7 +1830,6 @@ class KeyboardSettingsPanel(SettingsPanel):
 				_("At least one key must be used as the NVDA key."),
 				# Translators: The title of the message box
 				_("Error"), wx.OK|wx.ICON_ERROR,self)
-			self.modifierList.SetFocus()
 			return False
 		return super().isValid()
 


### PR DESCRIPTION
### Link to issue number:
Related to  #15894

### Summary of the issue:
PR #15873 changed the validation for settings, so that when given control is invalid focus is moved to it. Unfortunately this works only when user didn't switch to a different panel. If they did the correct control was announced in speech, but the old panel is shown on screen.
### Description of user facing changes
Invalid controls are no longer focused. This is still an improvement compared to 2023.3, where if one control was invalid the entire settings dialog was closed, thereby discarding all changes performed by the user.
### Description of development approach
Removes calls to `SetFocus` from the validation code.
### Testing strategy:
Ensured that validation errors are still shown for both NVDA modifier list and list of speech modes. Ensured that after dismissing the validation error settings dialog stays open, but focus remains where it was before applying settings.
### Known issues with pull request:
We should consider improving our validation so that the panel containing invalid control is shown, or, ideally, so that when validation is triggered when leaving the control. Both of these require more work, and are not related to #15873.
### Code Review Checklist:


- [X] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [X] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [X] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [X] API is compatible with existing add-ons.
- [X] Security precautions taken.
