### PR TITLE
Fix hovering on cell in braille viewer

### DIFF
--- a/source/brailleViewer/brailleViewerGui.py
+++ b/source/brailleViewer/brailleViewerGui.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2014-2022 NV Access Limited, Accessolutions, Julien Cochuyt
+# Copyright (C) 2014-2023 NV Access Limited, Accessolutions, Julien Cochuyt, Cyrille Bougot
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 import enum
@@ -95,11 +95,11 @@ class CharCellBackgroundColorAnimation:
 		# [0..1] proportion accumulatedElapsedTime is through totalTime
 		normalisedElapsed = min(1.0, max(0.0, (0.001 + accumulatedElapsedTime) / self._durationSeconds))
 		colourTransitionValue = self._startValue + normalisedElapsed * (1 - self._startValue)
-		currentColorTuple = _linearInterpolate(
+		currentColorTuple = tuple(int(c) for c in _linearInterpolate(
 			colourTransitionValue,
 			self._originColor.Get(includeAlpha=False),
 			self._destColor.Get(includeAlpha=False)
-		)
+		))
 		currentStyle = createBackgroundColorTextAttr(wx.Colour(*currentColorTuple))
 		index = self._textCellIndex
 		length = len(self._textCtrl.GetValue())


### PR DESCRIPTION
### Link to issue number:
Closes #15895

### Summary of the issue:
Activation of routing cursor in the braille viewer by hovering the mouse on the cell does not work anymore in last alpha. This is due to wxPython upgrade, since `int` types is now expected for some functions when `float` was tolerated before. More specifically, `wx.Colour` now expects 3 integers.
### Description of user facing changes
Mouse hovering to activate the routing cursor of a cell in the braille viewer works again.
### Description of development approach
Convert the 3 numeric values passed to `wx.Colour` to integers.
### Testing strategy:
Tested that hovering a cell with the mouse activates the routing cursor.
### Known issues with pull request:
None


### Change log
Not needed, unreleased regression appeared with wxPython upgrade.
### Code Review Checklist:


- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
