### PR TITLE
Remove a demo script

### DIFF
--- a/source/NVDAObjects/IAccessible/winword.py
+++ b/source/NVDAObjects/IAccessible/winword.py
@@ -271,15 +271,6 @@ class WordDocument(IAccessible, EditableTextWithoutAutoSelectDetection, winWordW
 				ui.message(_("Cannot find row {rowNumber} column {columnNumber}  in row headers").format(rowNumber=cell.rowIndex,columnNumber=cell.columnIndex))
 
 	@script(
-		gesture="kb:NVDA+shift+h",
-	)
-	def script_reportCurrentHeaders(self,gesture):
-		cell=self.WinwordSelectionObject.cells[1]
-		rowText=self.fetchAssociatedHeaderCellText(cell,False)
-		columnText=self.fetchAssociatedHeaderCellText(cell,True)
-		ui.message("Row %s, column %s"%(rowText or "empty",columnText or "empty"))
-
-	@script(
 		gestures=(
 			"kb:alt+home",
 			"kb:alt+end",

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -221,6 +221,7 @@ That method receives a ``DriverRegistrar`` object on which the ``addUsbDevices``
  -
 - ``gui.addonGui.AddonsDialog`` has been removed. (#15834)
 - ``touchHandler.TouchInputGesture.multiFingerActionLabel`` has been removed with no replacement. (#15864, @CyrilleB79)
+- ``NVDAObjects.IAccessible.winword.WordDocument.script_reportCurrentHeaders`` has been removed with no replacement. (#15904, @CyrilleB79)
 % Insert new list items here as the alias appModule table should be kept at the bottom of this list
 - The following app modules are removed.
 Code which imports from one of them, should instead import from the replacement module.  (#15618, @lukaszgo1)


### PR DESCRIPTION
@seanbudd, feel free to merge or to close without merging, depending on your answer to https://github.com/nvaccess/nvda/issues/11465#issuecomment-1849790581.

### Link to issue number:
Closes #11465

### Summary of the issue:

`NVDAObjects\IAccessible\winword.py` contains a script that is not documented (no input help, not mentioned in user Guide). It has been introduced in commit 465dce8 when #3110 has been implemented as a demo script to test the new headers reading capability.

This script cause an error in the log when called outside of a table.

### Description of user facing changes
No more error when pressing `NVDA+shift+H` in Word document.

### Description of development approach
Just removed the script.

### Testing strategy:
Tested that NVDA+shift+H does not produce any error in Word document.
### Known issues with pull request:
This script is probably used by nobody since it is undocumented: it does not appear in input help, nor in input gesture dialog, nor in User Guide. Anyway, we cannot exclude 100% that someone uses this undocumented and unadvertised feature.
If it is the case, let's hope that this person will make a feedback to explain their need.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

### For information
Cc @michaelDCurran, in case you have something to say since you were the one who had introduced this script.

