### PR TITLE
Fix up of #15867 and other issues found during its investigation

### DIFF
--- a/source/NVDAObjects/IAccessible/winword.py
+++ b/source/NVDAObjects/IAccessible/winword.py
@@ -214,8 +214,12 @@ class WordDocument(IAccessible, EditableTextWithoutAutoSelectDetection, winWordW
 
 	@script(
 		gesture="kb:NVDA+shift+c",
-		# Translators: The label of a shortcut of NVDA.
-		description=_("Set column header"),
+		description=_(
+			# Translators: The label of a shortcut of NVDA.
+			"Set column header. Pressing once will set this cell as the first column header for any cell lower and "
+			"to the right of it within this table. Pressing twice will forget the current column header for this "
+			"cell."
+		),
 		category=SCRCAT_SYSTEMCARET
 	)
 	def script_setColumnHeader(self,gesture):
@@ -243,8 +247,11 @@ class WordDocument(IAccessible, EditableTextWithoutAutoSelectDetection, winWordW
 
 	@script(
 		gesture="kb:NVDA+shift+r",
-		# Translators: The label of a shortcut of NVDA.
-		description=_("Set row header."),
+		description=_(
+			# Translators: The label of a shortcut of NVDA.
+			"Set row header. Pressing once will set this cell as the first row header for any cell lower and to he "
+			"right of it within this table. Pressing twice will forget the current row header for this cell."
+		),
 		category=SCRCAT_SYSTEMCARET
 	)
 	def script_setRowHeader(self,gesture):

--- a/source/NVDAObjects/IAccessible/winword.py
+++ b/source/NVDAObjects/IAccessible/winword.py
@@ -249,7 +249,7 @@ class WordDocument(IAccessible, EditableTextWithoutAutoSelectDetection, winWordW
 		gesture="kb:NVDA+shift+r",
 		description=_(
 			# Translators: The label of a shortcut of NVDA.
-			"Set row header. Pressing once will set this cell as the first row header for any cell lower and to he "
+			"Set row header. Pressing once will set this cell as the first row header for any cell lower and to the "
 			"right of it within this table. Pressing twice will forget the current row header for this cell."
 		),
 		category=SCRCAT_SYSTEMCARET

--- a/source/NVDAObjects/window/excel.py
+++ b/source/NVDAObjects/window/excel.py
@@ -1492,7 +1492,8 @@ class ExcelCell(ExcelBase):
 		description=_(
 			# Translators: the description  for a script for Excel
 			"sets the current cell as start of row headers. Pressing once will set this cell as the first row header "
-			"for any cell lower and to the right of it within this region. Pressing twice will forget the current row header for this cell."
+			"for any cell lower and to the right of it within this region. Pressing twice will forget the current "
+			"row header for this cell."
 		),
 		gesture="kb:NVDA+shift+r",
 		category=SCRCAT_SYSTEMCARET

--- a/source/NVDAObjects/window/excel.py
+++ b/source/NVDAObjects/window/excel.py
@@ -1463,7 +1463,7 @@ class ExcelCell(ExcelBase):
 
 	@script(
 		description=_(
-			# Translators: the description  for a script for Excel
+			# Translators: the description for a script for Excel
 			"Sets the current cell as start of column header. Pressing once will set this cell as the first column "
 			"header for any cell lower and to the right of it within this region. Pressing twice will forget the "
 			"current column header for this cell."
@@ -1490,8 +1490,8 @@ class ExcelCell(ExcelBase):
 
 	@script(
 		description=_(
-			# Translators: the description  for a script for Excel
-			"sets the current cell as start of row headers. Pressing once will set this cell as the first row header "
+			# Translators: the description for a script for Excel
+			"Sets the current cell as start of row headers. Pressing once will set this cell as the first row header "
 			"for any cell lower and to the right of it within this region. Pressing twice will forget the current "
 			"row header for this cell."
 		),

--- a/source/NVDAObjects/window/excel.py
+++ b/source/NVDAObjects/window/excel.py
@@ -1462,8 +1462,12 @@ class ExcelCell(ExcelBase):
 		eventHandler.queueEvent("gainFocus",d)
 
 	@script(
-		# Translators: the description  for a script for Excel
-		description=_("Sets the current cell as start of column header"),
+		description=_(
+			# Translators: the description  for a script for Excel
+			"Sets the current cell as start of column header. Pressing once will set this cell as the first column "
+			"header for any cell lower and to the right of it within this region. Pressing twice will forget the "
+			"current column header for this cell."
+		),
 		gesture="kb:NVDA+shift+c",
 		category=SCRCAT_SYSTEMCARET
 	)
@@ -1485,8 +1489,11 @@ class ExcelCell(ExcelBase):
 				ui.message(_("Cannot find {address}    in column headers").format(address=self.cellCoordsText))
 
 	@script(
-		# Translators: the description  for a script for Excel
-		description=_("sets the current cell as start of row header"),
+		description=_(
+			# Translators: the description  for a script for Excel
+			"sets the current cell as start of row headers. Pressing once will set this cell as the first row header "
+			"for any cell lower and to the right of it within this region. Pressing twice will forget the current row header for this cell."
+		),
 		gesture="kb:NVDA+shift+r",
 		category=SCRCAT_SYSTEMCARET
 	)

--- a/source/appModules/eclipse.py
+++ b/source/appModules/eclipse.py
@@ -1,7 +1,7 @@
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-# Copyright (C) 2010-2022 NV Access Limited
+# Copyright (C) 2010-2023 NV Access Limited, Cyrille Bougot
 
 import controlTypes
 import appModuleHandler
@@ -63,7 +63,9 @@ class EclipseTextArea(EditableTextWithSuggestions, IAccessible):
 
 		# If there aren't any suggestion selected, there is no way to find quick documentation
 		if not self.appModule.selectedItem:
-			gesture.send()
+			# Translators: When trying to read the documentation but there is no selected autocompletion item in
+			# Eclipse
+			ui.message(_("No selection"))
 			return
 
 		# Try to locate the documentation document

--- a/source/appModules/powerpnt.py
+++ b/source/appModules/powerpnt.py
@@ -1183,8 +1183,8 @@ class SlideShowTreeInterceptor(DocumentTreeInterceptor):
 		sayAll.SayAllHandler.readText(sayAll.CURSOR.CARET)
 
 	@scriptHandler.script(
-		# Translators: The description for a script
 		description=_(
+			# Translators: The description for a script
 			"Toggles between reporting the speaker notes or the actual slide content. This does not change"
 			" what is visible on-screen, but only what the user can read with NVDA"
 		),

--- a/source/appModules/powerpnt.py
+++ b/source/appModules/powerpnt.py
@@ -1182,11 +1182,17 @@ class SlideShowTreeInterceptor(DocumentTreeInterceptor):
 		self.makeTextInfo(textInfos.POSITION_FIRST).updateCaret()
 		sayAll.SayAllHandler.readText(sayAll.CURSOR.CARET)
 
+	@scriptHandler.script(
+		# Translators: The description for a script
+		description=_(
+			"Toggles between reporting the speaker notes or the actual slide content. This does not change"
+			" what is visible on-screen, but only what the user can read with NVDA"
+		),
+		category=SCRCAT_POWERPOINT,
+	)
 	def script_toggleNotesMode(self,gesture):
 		self.rootNVDAObject.notesMode=not self.rootNVDAObject.notesMode
 		self.rootNVDAObject.handleSlideChange()
-	# Translators: The description for a script
-	script_toggleNotesMode.__doc__=_("Toggles between reporting the speaker notes or the actual slide content. This does not change what is visible on-screen, but only what the user can read with NVDA")
 
 	def script_slideChange(self,gesture):
 		gesture.send()

--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -1,6 +1,6 @@
 # A part of NonVisual Desktop Access (NVDA)
 # Copyright (C) 2007-2023 NV Access Limited, Babbage B.V., James Teh, Leonard de Ruijter,
-# Thomas Stivers, Accessolutions, Julien Cochuyt
+# Thomas Stivers, Accessolutions, Julien Cochuyt, Cyrille Bougot
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -604,8 +604,6 @@ class BrowseModeTreeInterceptor(treeInterceptorHandler.TreeInterceptor):
 			self._focusLastFocusableObject()
 			api.processPendingEvents(processEventQueue=True)
 		gesture.send()
-	# Translators: the description for the passThrough script on browseMode documents.
-	script_passThrough.__doc__ = _("Passes gesture through to the application")
 
 	def script_disablePassThrough(self, gesture):
 		if not self.passThrough or self.disableAutoPassThrough:


### PR DESCRIPTION
I have put various little changes in the same PR. Let me know if I should divide it.

### Link to issue number:

Follow-up of #15867.

### Summary of the issue:
Various issues seen in #15867 or while investigating on it (e.g. looking at usages of `gesture.send()`):
1. Script `BrowseModeTreeInterceptor.script_passThrough` in `browseMode.py` has a description. It should not since: 1. It is only dedicated to specific key which should not be remapped; 2. There should not be any input help associated to it, since this "pass through" should be transparent to users.
2. In Eclipse, when no selected auto-completion item can be found, `NVDA+D` should not pass the gesture through. Indeed `gesture.send()` should not be used since NVDA+D is not a native gesture of this IDE. An error message should be reported instead.
3. The PowerPoint script does not show up in its category, whereas it was the goal in #15867.
4. With 15867, scripts to set headers of rows or columns in Excel or Word have their description shortened and the details of its usage (e.g. 1 press, 2 presses) is not reported anymore in input help. This is not consistent with other scripts. It's better to keep more details in input help as for other scripts.

### Description of user facing changes

Fix all these points.

### Description of development approach
See code.
### Testing strategy:
Manual tests:
2. Checked that pass through script are not reported in input help, nor present in the input gesture dialog.
3. Check that PowerPoint's control+shift+S script is listed in the PowerPoint category of Input gesture dialog.
4. Check input help in Word and Excel for set column/row headers commands.

Not tested:
1. I do not have Eclipse installed; please double check the code!

### Known issues with pull request:
None
### Code Review Checklist:


- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

