### PR TITLE
Start 2024.2

### DIFF
--- a/source/buildVersion.py
+++ b/source/buildVersion.py
@@ -66,7 +66,7 @@ def formatVersionForGUI(year, major, minor):
 # Version information for NVDA
 name = "NVDA"
 version_year = 2024
-version_major = 1
+version_major = 2
 version_minor = 0
 version_build = 0  # Should not be set manually. Set in 'sconscript' provided by 'appVeyor.yml'
 version=_formatDevVersionString()

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -4,6 +4,23 @@ What's New in NVDA
 %!includeconf: ../changes.t2tconf
 %!includeconf: ./locale.t2tconf
 
+= 2024.2 =
+
+== New Features ==
+
+
+== Changes ==
+
+
+== Bug Fixes ==
+
+
+== Changes for Developers ==
+Please refer to [the developer guide https://www.nvaccess.org/files/nvda/documentation/developerGuide.html#API] for information on NVDA's API deprecation and removal process.
+
+=== Deprecations ===
+
+
 = 2024.1 =
 
 A new "on-demand" speech mode has been added.


### PR DESCRIPTION
Start the dev cycle for the 20XY.Z release.
This won't be a compatibility breaking release.

Complete:
- [x] New section in the change log.
- [x] Update NVDA version in `master`
- [x] Update [`nvdaAPIVersions.json` to include the next version](https://github.com/nvaccess/addon-datastore-transform)
  - Re-run the last "Transform NVDA addons to views" on [addon-datastore](https://github.com/nvaccess/addon-datastore/actions) to regenerate projections (views) for the add-on datastore API.

On merge:
- [x] Update auto milestone ID