### PR TITLE
Documentation for 2024.1

### DIFF
--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -37,9 +37,9 @@ Windows 8.1 is the minimum Windows version supported.
   - A new action has been added to open a dedicated webpage to see or provide feedback about the selected add-on. (#15576, @nvdaes)
   -
 - Added support for Bluetooth Low Energy HID Braille displays. (#15470)
-- A new Native Selection mode (toggled by ``NVDA+shift+f10``) is now available in NVDA's browse mode for Mozilla Firefox. (#15830)
+- A new Native Selection mode (toggled by ``NVDA+shift+f10``) is now available in NVDA's browse mode for Mozilla Firefox.
 When turned on, selecting text in browse mode will also manipulate Firefox's own native selection.
-Copying text with ``control+c`` will pass straight through to Firefox, thus copying the rich content, rather than NVDA's plain text representation.
+Copying text with ``control+c`` will pass straight through to Firefox, thus copying the rich content, rather than NVDA's plain text representation. (#15830)
 - A new "on-demand" speech mode has been added.
 When speech is on-demand, NVDA does not speak automatically (e.g. when moving the cursor) but still speaks when calling commands whose goal is explicitly to report something (e.g. report window title). (#481, @CyrilleB79)
 - In the Speech category of NVDA's settings, it is now possible to exclude unwanted speech modes from the Cycle speech modes command (``NVDA+s``). (#15806, @lukaszgo1)

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -68,7 +68,7 @@ Windows 8.1 is the minimum Windows version supported. (#15544)
   - NVDA will again no longer report unlabelled groupings such as in recent versions of Microsoft Office 365 menus. (#15638)
   -
 - The audio output device and ducking mode options have been removed from the "Select Synthesizer" dialog.
-They can be found in the audio settings panel which can be opened with ``NVDA+control+u``. (#15512)
+They can be found in the audio settings panel which can be opened with ``NVDA+control+u``. (#15512, @codeofdusk)
 - The option "Report role when mouse enters object" in NVDA's mouse settings category has been renamed to "Report object when mouse enters it".
 This option now announces additional relevant information about an object when the mouse enters it, such as states (checked/pressed) or cell coordinates in a table. (#15420, @LeonarddeR)
 - New items have been added to the Help menu for the NV Access "Get Help" page and Shop. (#14631)
@@ -200,7 +200,7 @@ Please open a GitHub issue if your Add-on has an issue with updating to the new 
   - Flake8 to 4.0.1. (#15636, @lukaszgo1)
   - py2exe to 0.13.0.1dev commit ``4e7b2b2c60face592e67cb1bc935172a20fa371d``. (#15544) 
   - robotframework to 6.1.1. (#15544)
-  - SCons to 4.5.2. (#15529)
+  - SCons to 4.5.2. (#15529, @LeonarddeR)
   - sphinx to 7.2.6. (#15544)
   - wxPython to 4.2.1. (#12551)
   -

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -8,6 +8,12 @@ What's New in NVDA
 
 A new "on-demand" speech mode has been added.
 When speech is on-demand, NVDA does not speak automatically (e.g. when moving the cursor) but still speaks when calling commands whose goal is explicitly to report something (e.g. report window title).
+In the Speech category of NVDA's settings, it is now possible to exclude unwanted speech modes from the Cycle speech modes command (``NVDA+s``).
+
+A new Native Selection mode (toggled by ``NVDA+shift+f10``) is now available in NVDA's browse mode for Mozilla Firefox.
+When turned on, selecting text in browse mode will also manipulate Firefox's own native selection.
+Copying text with ``control+c`` will pass straight through to Firefox, thus copying the rich content, rather than NVDA's plain text representation.
+
 The Add-on Store now supports bulk actions (e.g. installing, enabling add-ons) by selecting multiple add-ons
 There is a new action to open a reviews webpage for the selected add-on.
 
@@ -15,7 +21,9 @@ The audio output device and ducking mode options have been removed from the "Sel
 They can be found in the audio settings panel which can be opened with ``NVDA+control+u``.
 
 eSpeak-NG, LibLouis braille translator, and Unicode CLDR have been updated.
-New Thai and Romanian braille tables are available.
+New Thai, Filipino and Romanian braille tables are available.
+
+There are many bug fixes, particularly for the Add-on Store, braille, Libre Office, Microsoft Office and audio.
 
 == Important notes == 
 - This release breaks compatibility with existing add-ons.
@@ -43,7 +51,7 @@ When speech is on-demand, NVDA does not speak automatically (e.g. when moving th
 - NVDA no longer supports Windows 7 and Windows 8.
 Windows 8.1 is the minimum Windows version supported. (#15544)
 - Component updates:
-  - Updated LibLouis braille translator to 3.28.0. (#15435, #15876, @codeofdusk)
+  - Updated LibLouis braille translator to [3.28.0 https://github.com/liblouis/liblouis/releases/tag/v3.28.0]. (#15435, #15876, @codeofdusk)
     - Added new Thai, Romanian, and Filipino Braille tables.
     -
   - eSpeak NG has been updated to 1.52-dev commit ``530bf0abf``. (#15036)
@@ -53,7 +61,7 @@ Windows 8.1 is the minimum Windows version supported. (#15544)
 - Key Commands:
   - The following commands now support two and three presses to spell the reported information and spell with character descriptions: report selection, report clipboard text and report focused object. (#15449, @CyrilleB79)
   - The command to toggle the screen curtain now has a default gesture: ``NVDA+control+escape``. (#10560, @CyrilleB79)
-  - When pressed four times, the report selection command now shows the selection in a browsable message (#15858, @Emil-18)
+  - When pressed four times, the report selection command now shows the selection in a browsable message. (#15858, @Emil-18)
   - 
 - Microsoft Office:
   - When requesting formatting information on Excel cells, borders and background will only be reported if there is such formatting. (#15560, @CyrilleB79)
@@ -128,39 +136,39 @@ Add-ons will need to be re-tested and have their manifest updated.
 - Building NVDA now requires Visual Studio 2022.
 Please refer to the [NVDA docs https://github.com/nvaccess/nvda/blob/release-2024.1/projectDocs/dev/createDevEnvironment.md] for the specific list of Visual Studio components. (#14313)
 - Added the following extension points:
- - ``treeInterceptorHandler.post_browseModeStateChange``. (#14969, @nvdaes)
- - ``speech.speechCanceled``. (#15700, @LeonarddeR)
- -
+  - ``treeInterceptorHandler.post_browseModeStateChange``. (#14969, @nvdaes)
+  - ``speech.speechCanceled``. (#15700, @LeonarddeR)
+  -
 - It is now possible to use plural forms in an add-on's translations. (#15661, @beqabeqa473)
 - Included python3.dll in the binary distribution for use by add-ons with external libraries utilizing the [stable ABI https://docs.python.org/3.11/c-api/stable.html]. (#15674, @mzanm)
 - The ``BrailleDisplayDriver`` base class now has ``numRows`` and ``numCols`` properties to provide information about multi line braille displays.
 Setting ``numCells`` is still supported for single line braille displays and ``numCells`` will return the total number of cells for multi line braille displays. (#15386)
 - Updated BrlAPI for BRLTTY to version 0.8.5, and its corresponding python module to a Python 3.11 compatible build. (#15652, @LeonarddeR)
-- Added the ``speech.speakSsml`` function, which allows you to write NVDA speech sequences using [SSML https://www.w3.org/TR/speech-synthesis11/].  (#15699, @LeonarddeR)
- - The following tags are currently supported and translated to appropriate NVDA speech commands:
-  - ``Prosody`` (``pitch``, ``rate`` and ``volume``). Only multiplication (e.g. ``200%`` are supported.
-  - ``say-as`` with the ``interpret`` attribute set to ``characters``
-  - ``voice`` with the ``xml:lang`` set to an XML language
-  - ``break`` with the ``time`` attribute set to a value in milliseconds, e.g. ``200ms``
-  - ``mark`` with the ``name`` attribute set to a mark name, e.g. ``mark1``, requires providing a callback
-  -
- - Example: ``speech.speakSsml('<speak><prosody pitch="200%">hello</prosody><break time="500ms" /><prosody rate="50%">John</prosody></speak>')``
- - The SSML parsing capabilities are backed by the ``SsmlParser`` class in the ``speechXml`` module.
- -
-- Changes to the NVDA Controller Client library:
- - The file names of the library no longer contain a suffix denoting the architecture, i.e. ``nvdaControllerClient32/64.dll`` are now called ``nvdaControllerClient.dll``. (#15718, #15717, @LeonarddeR)
- - Added an example to demonstrate using nvdaControllerClient.dll from Rust. (#15771, @LeonarddeR)
- - Added the following functions to the controller client: (#15734, #11028, #5638, @LeonarddeR)
-  - ``nvdaController_getProcessId``: To get the process id (PID) of the current instance of NVDA the controller client is using.
-  - ``nvdaController_speakSsml``: To instruct NVDA to speak according to the given SSML. This function also supports:
-    - Providing the symbol level.
-    - Providing the priority of speech to be spoken.
-    - Speaking both synchronously (blocking) and asynchronously (instant return).
+- Added the ``speech.speakSsml`` function, which allows you to write NVDA speech sequences using [SSML https://www.w3.org/TR/speech-synthesis11/]. (#15699, @LeonarddeR)
+  - The following tags are currently supported and translated to appropriate NVDA speech commands:
+    - ``Prosody`` (``pitch``, ``rate`` and ``volume``). Only multiplication (e.g. ``200%`` are supported.
+    - ``say-as`` with the ``interpret`` attribute set to ``characters``
+    - ``voice`` with the ``xml:lang`` set to an XML language
+    - ``break`` with the ``time`` attribute set to a value in milliseconds, e.g. ``200ms``
+    - ``mark`` with the ``name`` attribute set to a mark name, e.g. ``mark1``, requires providing a callback
     -
-  - ``nvdaController_setOnSsmlMarkReachedCallback``: To register a callback of type ``onSsmlMarkReachedFuncType`` that is called in synchronous mode for every ``<mark />`` tag encountered in the SSML sequence provided to ``nvdaController_speakSsml``.
+  - Example: ``speech.speakSsml('<speak><prosody pitch="200%">hello</prosody><break time="500ms" /><prosody rate="50%">John</prosody></speak>')``
+  - The SSML parsing capabilities are backed by the ``SsmlParser`` class in the ``speechXml`` module.
   -
- - Note: the new functions in the controller client only support NVDA 2024.1 and above.
- -
+- Changes to the NVDA Controller Client library:
+  - The file names of the library no longer contain a suffix denoting the architecture, i.e. ``nvdaControllerClient32/64.dll`` are now called ``nvdaControllerClient.dll``. (#15718, #15717, @LeonarddeR)
+  - Added an example to demonstrate using nvdaControllerClient.dll from Rust. (#15771, @LeonarddeR)
+  - Added the following functions to the controller client: (#15734, #11028, #5638, @LeonarddeR)
+    - ``nvdaController_getProcessId``: To get the process id (PID) of the current instance of NVDA the controller client is using.
+    - ``nvdaController_speakSsml``: To instruct NVDA to speak according to the given SSML. This function also supports:
+      - Providing the symbol level.
+      - Providing the priority of speech to be spoken.
+      - Speaking both synchronously (blocking) and asynchronously (instant return).
+      -
+    - ``nvdaController_setOnSsmlMarkReachedCallback``: To register a callback of type ``onSsmlMarkReachedFuncType`` that is called in synchronous mode for every ``<mark />`` tag encountered in the SSML sequence provided to ``nvdaController_speakSsml``.
+    -
+  - Note: the new functions in the controller client only support NVDA 2024.1 and above.
+  -
 - Updated ``include`` dependencies:
   - detours to ``4b8c659f549b0ab21cf649377c7a84eb708f5e68``. (#15695)
   - ia2 to ``3d8c7f0b833453f761ded6b12d8be431507bfe0b``. (#15695)
@@ -175,9 +183,9 @@ Setting ``numCells`` is still supported for single line braille displays and ``n
   - Scripts that provide information (e.g. say window title, report time/date) should speak in the "on-demand" mode.
   - Scripts that perform an action (e.g. move the cursor, change a parameter) should not speak in the "on-demand" mode.
   -
-- Fixed bug where deleting git-tracked files during `scons -c` resulted in missing UIA COM interfaces on rebuild. (#7070, #10833, @hwf1324)
-- Fix a bug where some code changes were not detected when building `dist`, that prevented a new build from being triggered.
-Now `dist` always rebuilds. (#13372, @hwf1324)
+- Fixed bug where deleting git-tracked files during ``scons -c`` resulted in missing UIA COM interfaces on rebuild. (#7070, #10833, @hwf1324)
+- Fix a bug where some code changes were not detected when building ``dist``, that prevented a new build from being triggered.
+Now ``dist`` always rebuilds. (#13372, @hwf1324)
 -
 
 === API Breaking Changes ===
@@ -214,20 +222,20 @@ That method receives a ``DriverRegistrar`` object on which the ``addUsbDevices``
 - ``languageHandler.makeNpgettext`` and ``languageHandler.makePgettext`` have been removed.
 ``npgettext`` and ``pgettext`` are supported natively now. (#15546)
 - The app module for [Poedit https://poedit.net] has been changed significantly. The ``fetchObject`` function has been removed. (#15313, #7303, @LeonarddeR)
-- The following redundant types and constants have been removed from ``hwPortUtils``:  (#15764, @LeonarddeR)
- - ``PCWSTR``
- - ``HWND`` (replaced by ``ctypes.wintypes.HWND``)
- - ``ULONG_PTR``
- - ``ULONGLONG``
- - ``NULL``
- - ``GUID`` (replaced by ``comtypes.GUID``)
- -
+- The following redundant types and constants have been removed from ``hwPortUtils``: (#15764, @LeonarddeR)
+  - ``PCWSTR``
+  - ``HWND`` (replaced by ``ctypes.wintypes.HWND``)
+  - ``ULONG_PTR``
+  - ``ULONGLONG``
+  - ``NULL``
+  - ``GUID`` (replaced by ``comtypes.GUID``)
+  -
 - ``gui.addonGui.AddonsDialog`` has been removed. (#15834)
 - ``touchHandler.TouchInputGesture.multiFingerActionLabel`` has been removed with no replacement. (#15864, @CyrilleB79)
 - ``NVDAObjects.IAccessible.winword.WordDocument.script_reportCurrentHeaders`` has been removed with no replacement. (#15904, @CyrilleB79)
 % Insert new list items here as the alias appModule table should be kept at the bottom of this list
 - The following app modules are removed.
-Code which imports from one of them, should instead import from the replacement module.  (#15618, @lukaszgo1)
+Code which imports from one of them, should instead import from the replacement module. (#15618, @lukaszgo1)
 -
 
 || Removed module name | Replacement module |

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -3588,7 +3588,7 @@ The following Braille displays are supported:
 These displays do not support NVDA's automatic background braille display detection functionality.
 There is an option in the display's USB driver which can cause an issue with loading the display.
 Please try the following:
-+ Please make sure that you have installed the [latest driver](https://www.papenmeier-rehatechnik.de/en/service/downloadcenter/software/articles/software-braille-devices.html).
++ Please make sure that you have installed the [latest driver https://www.papenmeier-rehatechnik.de/en/service/downloadcenter/software/articles/software-braille-devices.html].
 + Open the Windows Device Manager.
 + Scroll down the list to "USB Controllers" or "USB Devices".
 + Select "Papenmeier Braillex USB Device".


### PR DESCRIPTION
**Must be a squash merge**

Changes from this PR to the previous release:
- Files to check: `user_docs/en/userGuide.t2t`, `user_docs/en/changes.t2t` `developerGuide.t2t`
- [Compare this branch to the previous release](https://github.com/nvaccess/nvda/compare/release-2023.3...documentationFor2024.1?expand=1)
- Comparison command:
`git diff release-2023.3...documentationFor2024.1  -- "**/en/*.t2t" "**/developerGuide.t2t"`

Common mistakes to check for:
- Issue/PR reference in changes file is incorrect
- Incorrect spelling.
- Lists not terminated with a final `-` on a new line, matching indentation
- List items not indented by a multiple of 2 spaces (regex `^ (  )*-`)
- Single grave marks \` instead of double grave marks \`\` (regex ``` [^`]`[^`] ```)
- Shortcuts added without code markdown, use two 'grave' characters (e.g. ` ``NVDA+d`` `)
- Double spaces (regex `[^ ]  `)
- Inconsistent use of single vs double quote. (regex `' `)