### PR TITLE
Add-on store: Clean up failed installs

### DIFF
--- a/source/addonHandler/__init__.py
+++ b/source/addonHandler/__init__.py
@@ -216,7 +216,10 @@ class AddonsState(collections.UserDict[AddonStateCategory, CaseInsensitiveSet[st
 						log.error(f"Failed to remove {pendingInstallPath}", exc_info=True)
 
 		if self[AddonStateCategory.PENDING_INSTALL]:
-			log.error(f"Discarding {self[AddonStateCategory.PENDING_INSTALL]} from pending install add-ons as their install failed.")
+			log.error(
+				f"Discarding {self[AddonStateCategory.PENDING_INSTALL]} from pending install add-ons "
+				"as their install failed."
+			)
 			self[AddonStateCategory.PENDING_INSTALL].clear()
 
 	def _cleanupCompatibleAddonsFromDowngrade(self) -> None:

--- a/source/addonHandler/__init__.py
+++ b/source/addonHandler/__init__.py
@@ -5,6 +5,7 @@
 # See the file COPYING for more details.
 
 from abc import abstractmethod, ABC
+import glob
 import sys
 import os.path
 import gettext
@@ -19,7 +20,6 @@ from six import string_types
 from typing import (
 	Callable,
 	Dict,
-	List,
 	Optional,
 	Set,
 	TYPE_CHECKING,
@@ -203,6 +203,22 @@ class AddonsState(collections.UserDict[AddonStateCategory, CaseInsensitiveSet[st
 				log.debug(f"Discarding {disabledAddonName} from disabled add-ons as it has been uninstalled.")
 				self[AddonStateCategory.DISABLED].discard(disabledAddonName)
 
+	def _cleanupInstalledAddons(self) -> None:
+		# There should be no pending installs after add-ons have been loaded during initialization.
+		for path in _getDefaultAddonPaths():
+			pendingInstallPaths = glob.glob(f"{path}/*.{ADDON_PENDINGINSTALL_SUFFIX}")
+			for pendingInstallPath in pendingInstallPaths:
+				if os.path.exists(pendingInstallPath):
+					try:
+						log.error(f"Removing failed install of {pendingInstallPath}")
+						shutil.rmtree(pendingInstallPath, ignore_errors=True)
+					except OSError:
+						log.error(f"Failed to remove {pendingInstallPath}", exc_info=True)
+
+		if self[AddonStateCategory.PENDING_INSTALL]:
+			log.error(f"Discarding {self[AddonStateCategory.PENDING_INSTALL]} from pending install add-ons as their install failed.")
+			self[AddonStateCategory.PENDING_INSTALL].clear()
+
 	def _cleanupCompatibleAddonsFromDowngrade(self) -> None:
 		from addonStore.dataManager import addonDataManager
 		installedAddons = addonDataManager._installedAddonsCache.installedAddons
@@ -287,6 +303,7 @@ def initialize():
 	getAvailableAddons(refresh=True, isFirstLoad=True)
 	state.cleanupRemovedDisabledAddons()
 	state._cleanupCompatibleAddonsFromDowngrade()
+	state._cleanupInstalledAddons()
 	if NVDAState.shouldWriteToDisk():
 		state.save()
 	initializeModulePackagePaths()
@@ -303,8 +320,8 @@ def terminate():
 	pass
 
 
-def _getDefaultAddonPaths() -> List[str]:
-	""" Returns paths where addons can be found.
+def _getDefaultAddonPaths() -> list[str]:
+	r""" Returns paths where addons can be found.
 	For now, only <userConfig>\addons is supported.
 	"""
 	addon_paths = []
@@ -497,13 +514,25 @@ class Addon(AddonBase):
 				_report_manifest_errors(self.manifest)
 				raise AddonError("Manifest file has errors.")
 
-	def completeInstall(self) -> str:
+	def completeInstall(self) -> Optional[str]:
+		if not os.path.exists(self.pendingInstallPath):
+			log.error(f"Pending install path {self.pendingInstallPath} does not exist")
+			return None
+
 		try:
 			os.rename(self.pendingInstallPath, self.installPath)
 			state[AddonStateCategory.PENDING_INSTALL].discard(self.name)
 			return self.installPath
 		except OSError:
 			log.error(f"Failed to complete addon installation for {self.name}", exc_info=True)
+
+		# Remove pending install folder
+		try:
+			log.error(f"Removing failed install of {self.pendingInstallPath}")
+			shutil.rmtree(self.pendingInstallPath, ignore_errors=True)
+			state[AddonStateCategory.PENDING_INSTALL].discard(self.name)
+		except OSError:
+			log.error(f"Failed to remove {self.pendingInstallPath}", exc_info=True)
 
 	def requestRemove(self):
 		"""Marks this addon for removal on NVDA restart."""


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Fixes #15719

### Summary of the issue:
If an add-ons install failed, it might never be cleaned up, causing NVDA to be constantly expecting there are add-ons pending install.
This causes a warning dialog that NVDA must be restarted when closing the add-on store.

### Description of user facing changes
Pending installs that fail are removed and cleaned up, ensuring it is easy to attempt a future install.
The warning dialog no longer fires as NVDA cleans up failed installs.

### Description of development approach
Clear the pending install set and delete pending install add-on folders after loading add-ons.
When loading add-ons, all installs should complete, and there should be no new pending installs from the user.

If an install fails, also attempt to clean up the files immediately after.

### Testing strategy:
Tested in source code by forcing an add-on to be in the pending install set, and preventing the "pendingInstall" folder of an add-on be renamed/moved.

### Known issues with pull request:
None
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
