### PR TITLE
Only show disable action for installed add-on contexts

### DIFF
--- a/source/addonStore/models/status.py
+++ b/source/addonStore/models/status.py
@@ -359,9 +359,15 @@ _addonStoreStateToAddonHandlerState: OrderedDict[
 })
 
 
-_installedAddonStatuses: Set[AvailableAddonStatus] = {
-	AvailableAddonStatus.UPDATE,
-	AvailableAddonStatus.REPLACE_SIDE_LOAD,
+_installedAddonStatuses: set[AvailableAddonStatus] = {
+	# These are technically installed,
+	# but updatable add-ons only display this status
+	# in the updatable tab context.
+	# These add-ons will show up in the installed tab
+	# with an INSTALLED status or similar.
+	# AvailableAddonStatus.UPDATE,
+	# AvailableAddonStatus.UPDATE_INCOMPATIBLE,
+	# AvailableAddonStatus.REPLACE_SIDE_LOAD,
 	AvailableAddonStatus.INSTALLED,
 	AvailableAddonStatus.PENDING_DISABLE,
 	AvailableAddonStatus.PENDING_INCOMPATIBLE_DISABLED,

--- a/source/gui/addonStoreGui/viewModels/addonList.py
+++ b/source/gui/addonStoreGui/viewModels/addonList.py
@@ -24,6 +24,7 @@ from addonStore.models.addon import (
 	_AddonManifestModel,
 )
 from addonStore.models.status import (
+	_installedAddonStatuses,
 	_StatusFilterKey,
 	AvailableAddonStatus,
 )
@@ -155,12 +156,16 @@ class AddonListItemVM(Generic[_AddonModelT]):
 		) and self.model.canOverrideCompatibility
 
 	def canUseDisableAction(self) -> bool:
-		return self.model.isInstalled and self.status not in (
-			AvailableAddonStatus.DISABLED,
-			AvailableAddonStatus.PENDING_DISABLE,
-			AvailableAddonStatus.INCOMPATIBLE_DISABLED,
-			AvailableAddonStatus.PENDING_INCOMPATIBLE_DISABLED,
-			AvailableAddonStatus.PENDING_REMOVE,
+		return (
+			self.model.isInstalled
+			and self.status in _installedAddonStatuses
+			and self.status not in (
+				AvailableAddonStatus.DISABLED,
+				AvailableAddonStatus.PENDING_DISABLE,
+				AvailableAddonStatus.INCOMPATIBLE_DISABLED,
+				AvailableAddonStatus.PENDING_INCOMPATIBLE_DISABLED,
+				AvailableAddonStatus.PENDING_REMOVE,
+			)
 		)
 
 	def __repr__(self) -> str:

--- a/source/gui/addonStoreGui/viewModels/addonList.py
+++ b/source/gui/addonStoreGui/viewModels/addonList.py
@@ -143,6 +143,7 @@ class AddonListItemVM(Generic[_AddonModelT]):
 	def canUseRemoveAction(self) -> bool:
 		return (
 			self.model.isInstalled
+			and self.status in _installedAddonStatuses
 			and self.status != AvailableAddonStatus.PENDING_REMOVE
 		)
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Fixes #15919 

### Summary of the issue:
Add-ons which are already disabled have a disabled action available in the add-on store updatable tab.
A similar problem exists for add-ons pending removal.

### Description of user facing changes
You can no longer disable or remove add-ons from the updatable add-ons tab.
This is consistent with the enable action (currently disabled from the updatable tab).

### Description of development approach
Add filtering to remove updating actions from available statuses for disabling and removing add-ons.

### Testing strategy:
Manual testing using STR in #15919
Also tested by removing an add-on, and attempting to re-remove it from the updatable add-ons tab.

### Known issues with pull request:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
