### PR TITLE
Esp32 microcontroller is not handled as Albatross display

### DIFF
--- a/source/brailleDisplayDrivers/albatross/constants.py
+++ b/source/brailleDisplayDrivers/albatross/constants.py
@@ -308,3 +308,11 @@ approximately 2 seconds from previous appropriate data packet.
 Otherwise it falls back to "wait for connection" state.
 This behavior is built-in feature of the firmware of device.
 """
+
+BUS_DEVICE_DESC = "Albatross Braille Display"
+"""Bus reported device description
+"""
+
+VID_AND_PID = "VID_0403&PID_6001"
+"""Vid and pid
+"""

--- a/source/brailleDisplayDrivers/albatross/driver.py
+++ b/source/brailleDisplayDrivers/albatross/driver.py
@@ -26,7 +26,6 @@ from threading import (
 	Lock,
 )
 from typing import (
-	Iterator,
 	List,
 	Optional,
 	Tuple,
@@ -61,6 +60,8 @@ from .constants import (
 	END_BYTE,
 	BOTH_BYTES,
 	KC_INTERVAL,
+	BUS_DEVICE_DESC,
+	VID_AND_PID,
 )
 from .gestures import _gestureMap
 
@@ -92,7 +93,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 	def getManualPorts(cls):
 		return braille.getSerialPorts()
 
-	def __init__(self, port="Auto"):
+	def __init__(self, port: str = "auto"):
 		super().__init__()
 		# Number of cells is received when initializing connection.
 		self.numCells = 0
@@ -158,13 +159,21 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 		except Exception:
 			log.exception("Error terminating albatross driver")
 
-	def _searchPorts(self, port: str):
+	def _searchPorts(self, originalPort: str):
 		"""Search ports where display can be connected.
-		@param port: port name as string
+		@param originalPort: original port name as string
 		@raises: RuntimeError if no display found
 		"""
 		for self._baudRate in BAUD_RATE:
-			for portType, portId, port, portInfo in self._getTryPorts(port):
+			for portType, portId, port, portInfo in self._getTryPorts(originalPort):
+				# Block port if its vid and pid are correct but bus reported
+				# device description is not "Albatross Braille Display".
+				if (
+					portId == VID_AND_PID
+					and portInfo.get("busReportedDeviceDescription") != BUS_DEVICE_DESC
+				):
+					log.debug(f"port {port} blocked; port information: {portInfo}")
+					continue
 				# For reconnection
 				self._currentPort = port
 				self._tryToConnect = True

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -97,6 +97,7 @@ Users of Poedit 1 are encouraged to update to Poedit 3 if they want to rely on e
   - Contracted braille input works properly again. (#15773, @aaclause)
   - Braille is now updated when moving the navigator object between table cells in more situations (#15755, @Emil-18)
   - The result of reporting current focus, current navigator object, and current selection commands is now shown in braille. (#15844, @Emil-18)
+  - The Albatross braille driver no longer handles a Esp32 microcontroller as an Albatross display. (#15671)
   -
 - LibreOffice:
   - Words deleted using the ``control+backspace`` keyboard shortcut are now also properly announced when the deleted word is followed by whitespace (like spaces and tabs). (#15436, @michaelweghorn)


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
fixes #15671
### Summary of the issue:
Albatross driver handled Esp32 microcontroller as Albatross display if controller send valid init packet. This is problem especially when displays are detected automatically.
### Description of user facing changes
When using usb connection, driver can check that bus reported device description is "Albatross Braille Display". Esp32 is not detected automatically as Albatross.
### Description of development approach
`_searchPorts` function blocks port if VID and PID are correct but bus reported bus reported device description is not "Albatross Braille Display", in other cases port is valid to try to connect.
### Testing strategy:
tested by @beqabeqa473
### Known issues with pull request:
none
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
