### PR TITLE
Honour choice when discarding the installation of an incompatible add-on

### DIFF
--- a/source/gui/addonGui.py
+++ b/source/gui/addonGui.py
@@ -150,7 +150,8 @@ def installAddon(parentWindow: wx.Window, addonPath: str) -> bool:  # noqa: C901
 		_showAddonRequiresNVDAUpdateDialog(parentWindow, bundle._addonGuiModel)
 		return False  # Exit early, addon does not have required support
 	elif bundle.canOverrideCompatibility:
-		if _shouldInstallWhenAddonTooOldDialog(parentWindow, bundle._addonGuiModel):
+		shouldInstall, rememberChoice = _shouldInstallWhenAddonTooOldDialog(parentWindow, bundle._addonGuiModel)
+		if shouldInstall:
 			# Install incompatible version
 			bundle.enableCompatibilityOverride()
 		else:


### PR DESCRIPTION
### Link to issue number:
Issue probably introduced in #15623.
### Summary of the issue:
When installing an incompatible add-on (e.g. add-on last tested with NVDA 2023.3) from Windows Explorer, we get a warning asking to confirm the installlation. If I answer No, the installation process still continues.
It's because the function to display the dialog box now returns a 2-tuple which always evals to True.

### Description of user facing changes
Answering No in the incompatibility warning dialog will now stop the installation process as expected.
### Description of development approach
Only check the first element of the tuple to know the choice made in the dialog.
### Testing strategy:
Manually tested running from source before and after this change.
### Known issues with pull request:

### Change log entry
Not needed; unreleased bug.
None
### Code Review Checklist:


- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
