### PR TITLE
No longer remove failed add-ons installs and warn when add-on installs, removals and updates cannot complete

### DIFF
--- a/source/addonHandler/__init__.py
+++ b/source/addonHandler/__init__.py
@@ -19,7 +19,6 @@ from six import string_types
 from typing import (
 	Callable,
 	Dict,
-	List,
 	Optional,
 	Set,
 	TYPE_CHECKING,
@@ -314,8 +313,8 @@ def terminate():
 	pass
 
 
-def _getDefaultAddonPaths() -> List[str]:
-	""" Returns paths where addons can be found.
+def _getDefaultAddonPaths() -> list[str]:
+	r""" Returns paths where addons can be found.
 	For now, only <userConfig>\addons is supported.
 	"""
 	addon_paths = []
@@ -515,13 +514,18 @@ class Addon(AddonBase):
 				_report_manifest_errors(self.manifest)
 				raise AddonError("Manifest file has errors.")
 
-	def completeInstall(self) -> str:
+	def completeInstall(self) -> Optional[str]:
+		if not os.path.exists(self.pendingInstallPath):
+			log.error(f"Pending install path {self.pendingInstallPath} does not exist")
+			return None
+
 		try:
 			os.rename(self.pendingInstallPath, self.installPath)
 			state[AddonStateCategory.PENDING_INSTALL].discard(self.name)
 			return self.installPath
 		except OSError:
 			log.error(f"Failed to complete addon installation for {self.name}", exc_info=True)
+			return None
 
 	def requestRemove(self):
 		"""Marks this addon for removal on NVDA restart."""

--- a/source/addonHandler/__init__.py
+++ b/source/addonHandler/__init__.py
@@ -5,7 +5,6 @@
 # See the file COPYING for more details.
 
 from abc import abstractmethod, ABC
-import glob
 import sys
 import os.path
 import gettext
@@ -20,6 +19,7 @@ from six import string_types
 from typing import (
 	Callable,
 	Dict,
+	List,
 	Optional,
 	Set,
 	TYPE_CHECKING,
@@ -203,25 +203,6 @@ class AddonsState(collections.UserDict[AddonStateCategory, CaseInsensitiveSet[st
 				log.debug(f"Discarding {disabledAddonName} from disabled add-ons as it has been uninstalled.")
 				self[AddonStateCategory.DISABLED].discard(disabledAddonName)
 
-	def _cleanupInstalledAddons(self) -> None:
-		# There should be no pending installs after add-ons have been loaded during initialization.
-		for path in _getDefaultAddonPaths():
-			pendingInstallPaths = glob.glob(f"{path}/*.{ADDON_PENDINGINSTALL_SUFFIX}")
-			for pendingInstallPath in pendingInstallPaths:
-				if os.path.exists(pendingInstallPath):
-					try:
-						log.error(f"Removing failed install of {pendingInstallPath}")
-						shutil.rmtree(pendingInstallPath, ignore_errors=True)
-					except OSError:
-						log.error(f"Failed to remove {pendingInstallPath}", exc_info=True)
-
-		if self[AddonStateCategory.PENDING_INSTALL]:
-			log.error(
-				f"Discarding {self[AddonStateCategory.PENDING_INSTALL]} from pending install add-ons "
-				"as their install failed."
-			)
-			self[AddonStateCategory.PENDING_INSTALL].clear()
-
 	def _cleanupCompatibleAddonsFromDowngrade(self) -> None:
 		from addonStore.dataManager import addonDataManager
 		installedAddons = addonDataManager._installedAddonsCache.installedAddons
@@ -306,7 +287,6 @@ def initialize():
 	getAvailableAddons(refresh=True, isFirstLoad=True)
 	state.cleanupRemovedDisabledAddons()
 	state._cleanupCompatibleAddonsFromDowngrade()
-	state._cleanupInstalledAddons()
 	if NVDAState.shouldWriteToDisk():
 		state.save()
 	initializeModulePackagePaths()
@@ -323,8 +303,8 @@ def terminate():
 	pass
 
 
-def _getDefaultAddonPaths() -> list[str]:
-	r""" Returns paths where addons can be found.
+def _getDefaultAddonPaths() -> List[str]:
+	""" Returns paths where addons can be found.
 	For now, only <userConfig>\addons is supported.
 	"""
 	addon_paths = []
@@ -517,25 +497,13 @@ class Addon(AddonBase):
 				_report_manifest_errors(self.manifest)
 				raise AddonError("Manifest file has errors.")
 
-	def completeInstall(self) -> Optional[str]:
-		if not os.path.exists(self.pendingInstallPath):
-			log.error(f"Pending install path {self.pendingInstallPath} does not exist")
-			return None
-
+	def completeInstall(self) -> str:
 		try:
 			os.rename(self.pendingInstallPath, self.installPath)
 			state[AddonStateCategory.PENDING_INSTALL].discard(self.name)
 			return self.installPath
 		except OSError:
 			log.error(f"Failed to complete addon installation for {self.name}", exc_info=True)
-
-		# Remove pending install folder
-		try:
-			log.error(f"Removing failed install of {self.pendingInstallPath}")
-			shutil.rmtree(self.pendingInstallPath, ignore_errors=True)
-			state[AddonStateCategory.PENDING_INSTALL].discard(self.name)
-		except OSError:
-			log.error(f"Failed to remove {self.pendingInstallPath}", exc_info=True)
 
 	def requestRemove(self):
 		"""Marks this addon for removal on NVDA restart."""

--- a/source/core.py
+++ b/source/core.py
@@ -69,7 +69,7 @@ _hasShutdownBeenTriggered = False
 _shuttingDownFlagLock = threading.Lock()
 
 
-def _showAddonsWarnings() -> None:
+def _showAddonsErrors() -> None:
 	addonFailureMessages: list[str] = []
 	failedUpdates = addonHandler._failedPendingInstalls.intersection(addonHandler._failedPendingRemovals)
 	failedInstalls = addonHandler._failedPendingInstalls - failedUpdates
@@ -78,8 +78,8 @@ def _showAddonsWarnings() -> None:
 		addonFailureMessages.append(
 			ngettext(
 				# Translators: Shown when one or more add-ons failed to update.
-				"The following add-on failed to update: {}",
-				"The following add-ons failed to update: {}",
+				"The following add-on failed to update: {}.",
+				"The following add-ons failed to update: {}.",
 				len(failedUpdates)
 			).format(", ".join(failedUpdates))
 		)
@@ -87,8 +87,8 @@ def _showAddonsWarnings() -> None:
 		addonFailureMessages.append(
 			ngettext(
 				# Translators: Shown when one or more add-ons failed to be uninstalled.
-				"The following add-on failed to uninstall: {}",
-				"The following add-ons failed to uninstall: {}",
+				"The following add-on failed to uninstall: {}.",
+				"The following add-ons failed to uninstall: {}.",
 				len(failedRemovals)
 			).format(", ".join(failedRemovals))
 		)
@@ -96,8 +96,8 @@ def _showAddonsWarnings() -> None:
 		addonFailureMessages.append(
 			ngettext(
 				# Translators: Shown when one or more add-ons failed to be installed.
-				"The following add-on failed to be installed: {}",
-				"The following add-ons failed to be installed: {}",
+				"The following add-on failed to be installed: {}.",
+				"The following add-ons failed to be installed: {}.",
 				len(failedInstalls)
 			).format(", ".join(failedInstalls))
 		)
@@ -111,7 +111,7 @@ def _showAddonsWarnings() -> None:
 				"Some operations on add-ons failed. See the log file for more details.\n{}"
 			).format("\n".join(addonFailureMessages)),
 			# Translators: Title of message shown when requested action on add-ons failed.
-			_("Add-on failures"),
+			_("Error"),
 			wx.ICON_ERROR | wx.OK
 		)
 
@@ -185,7 +185,7 @@ def doStartupDialogs():
 						pass
 			# Ask the user if usage stats can be collected.
 			gui.runScriptModalDialog(gui.startupDialogs.AskAllowUsageStatsDialog(None), onResult)
-	_showAddonsWarnings()
+	_showAddonsErrors()
 
 
 @dataclass

--- a/source/core.py
+++ b/source/core.py
@@ -70,6 +70,8 @@ _shuttingDownFlagLock = threading.Lock()
 
 
 def doStartupDialogs():
+	import wx
+
 	import config
 	import gui
 
@@ -88,7 +90,6 @@ def doStartupDialogs():
 		if not isParamKnown:
 			unknownCLIParams.append(param)
 	if unknownCLIParams:
-		import wx
 		gui.messageBox(
 			# Translators: Shown when NVDA has been started with unknown command line parameters.
 			_("The following command line parameters are unknown to NVDA: {params}").format(
@@ -100,7 +101,6 @@ def doStartupDialogs():
 			wx.OK | wx.ICON_ERROR
 		)
 	if config.conf.baseConfigError:
-		import wx
 		gui.messageBox(
 			# Translators: A message informing the user that there are errors in the configuration file.
 			_("Your configuration file contains errors. "
@@ -118,7 +118,6 @@ def doStartupDialogs():
 		gui.mainFrame.onToggleSpeechViewerCommand(evt=None)
 	import inputCore
 	if inputCore.manager.userGestureMap.lastUpdateContainedError:
-		import wx
 		gui.messageBox(_("Your gesture map file contains errors.\n"
 				"More details about the errors can be found in the log file."),
 			_("gesture map File Error"), wx.OK|wx.ICON_EXCLAMATION)
@@ -130,7 +129,6 @@ def doStartupDialogs():
 		if updateCheck and not config.conf['update']['askedAllowUsageStats']:
 			# a callback to save config after the usage stats question dialog has been answered.
 			def onResult(ID):
-				import wx
 				if ID in (wx.ID_YES,wx.ID_NO):
 					try:
 						config.conf.save()
@@ -138,6 +136,36 @@ def doStartupDialogs():
 						pass
 			# Ask the user if usage stats can be collected.
 			gui.runScriptModalDialog(gui.startupDialogs.AskAllowUsageStatsDialog(None), onResult)
+	addonFailureMessages: list[str] = []
+	failedUpdates = addonHandler._failedPendingInstalls.intersection(addonHandler._failedPendingRemovals)
+	failedInstalls = addonHandler._failedPendingInstalls - failedUpdates
+	failedRemovals = addonHandler._failedPendingRemovals - failedUpdates
+	if failedUpdates:
+		addonFailureMessages.append(
+			# Translators: Shown when one or more add-ons failed to update.
+			_("Following add-ons failed to update: {}").format(", ".join(failedUpdates))
+		)
+	if failedRemovals:
+		addonFailureMessages.append(
+			# Translators: Shown when one or more add-ons failed to be uninstalled.
+			_("Following add-ons failed to uninstall: {}").format(", ".join(failedRemovals))
+		)
+	if failedInstalls:
+		addonFailureMessages.append(
+			# Translators: Shown when one or more add-ons failed to be installed.
+			_("Following add-ons failed to be installed: {}").format(", ".join(failedInstalls))
+		)
+
+	if addonFailureMessages:
+		gui.messageBox(
+			_(
+				# Translators: Shown when one or more actions on add-ons failed.
+				"Some operations on add-ons failed. See the log file for more details.\n{}"
+			).format("\n".join(addonFailureMessages)),
+			# Translators: Title of message shown when requested action on add-ons failed.
+			_("Add-on failures"),
+			wx.ICON_ERROR | wx.OK
+		)
 
 
 @dataclass


### PR DESCRIPTION
### Link to issue number:
Reverts #15921
Closes #12823
Addresses the most likely cause of #15719
Hopefully fixes #15927

### Summary of the issue:
PR #15921 started removing all add-ons which failed to be installed without showing warnings to the user. Users generally expect NVDA to attempt installation / removal of add-ons on the next restart if they failed, to have a warning when one of these operations didn't succeed and not to be able to install add-on which is not fully removed from Add-ons Store.
### Description of user facing changes
When one or more add-ons fails to be updated, uninstalled or installed, NVDA shows an appropriate warning on startup. Installation / removal is attempted on the next restart. When add-on is pending remove it is shown in the Add-ons Store along with the 'pending remove' status. All add-ons which are no longer present on disk are removed from the list of pending installs to hopefully improve #15719.
### Description of development approach
NVDA stores add-ons whose installation / removal failed in a list. All these add-ons are not loaded ,but shown in the Add-ons Store. These lists are used to determine what warnings should be shown to the user. List of pending installs is cleaned-up from add-ons which are no longer present on disk, excluding these which failed to be installed, as their install is going to be attempted on the next restart.
### Testing strategy:
- Installed an add-on from Add-ons Store, opened its folder to make sure it cannot be uninstalled, tried to uninstall it and verified that after the restart there is a warning, code from the add-on is not loaded and  that it is shown in the store with an 'pending remove' status
- Keeping folder of the installed add-on open tried to update it, verified that expected warnings are shown and that add-on' status in the store  is 'pending installation'
- Performed the above steps with an incompatible add-on, verified that when its folder is closed and therefore it can be installed, the fact that user overridden its compatibility is not lost
- Added a non existent add-on to the pending install list, restarted NVDA and make sure that it was removed from the list and an appropriate message was logged
### Known issues with pull request:
None known
### Code Review Checklist:

- [X] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [X] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [X] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [X] API is compatible with existing add-ons.
- [X] Security precautions taken.
