### PR TITLE
Wait for sent keys to be picked up by the keyboard hook.

### DIFF
--- a/source/keyboardHandler.py
+++ b/source/keyboardHandler.py
@@ -35,6 +35,7 @@ import core
 import NVDAState
 from contextlib import contextmanager
 import threading
+import winKernel
 
 if typing.TYPE_CHECKING:
 	from NVDAObjects import NVDAObject  # noqa: F401
@@ -42,6 +43,8 @@ if typing.TYPE_CHECKING:
 
 _watchdogObserver: typing.Optional["WatchdogObserver"] = None
 ignoreInjected=False
+_lastInjectedKeyUp: typing.Tuple[int, int] = None
+_injectionDoneEvent: int = None
 
 # Fake vk codes.
 # These constants should be assigned to the name that NVDA will use for the key.
@@ -285,11 +288,15 @@ def internal_keyUpEvent(vkCode,scanCode,extended,injected):
 	"""
 	try:
 		global lastNVDAModifier, lastNVDAModifierReleaseTime, bypassNVDAModifier, passKeyThroughCount, lastPassThroughKeyDown, currentModifiers
-		# Injected keys should be ignored in some cases.
-		if injected and (ignoreInjected or not config.conf['keyboard']['handleInjectedKeys']):
-			return True
-
 		keyCode = (vkCode, extended)
+		# Injected keys should be ignored in some cases.
+		if injected:
+			if not config.conf['keyboard']['handleInjectedKeys']:
+				return True
+			if ignoreInjected:
+				if keyCode == _lastInjectedKeyUp:
+					winKernel.kernel32.SetEvent(_injectionDoneEvent)
+				return True
 
 		if passKeyThroughCount >= 1:
 			if lastPassThroughKeyDown == keyCode:
@@ -567,7 +574,11 @@ class KeyboardInputGesture(inputCore.InputGesture):
 		# Now actually execute the script.
 		super().executeScript(script)
 
+	#: The maximum amount of time (in ms) to wait for keys injected by NVDA to be
+	#: received by NVDA.
+	_INJECTION_WAIT_TIMEOUT: int = 10
 	def send(self):
+		global _lastInjectedKeyUp, _injectionDoneEvent
 		keys = []
 		for vk, ext in self.generalizedModifiers:
 			if vk == VK_WIN:
@@ -582,6 +593,11 @@ class KeyboardInputGesture(inputCore.InputGesture):
 		keys.append((self.vkCode, self.scanCode, self.isExtended))
 
 		with ignoreInjection():
+			handleInjectedKeys = config.conf['keyboard']['handleInjectedKeys']
+			if handleInjectedKeys:
+				_lastInjectedKeyUp = (keys[0][0], keys[0][2])
+				if not _injectionDoneEvent:
+					_injectionDoneEvent = winKernel.createEvent()
 			if winUser.getKeyState(self.vkCode) & 32768:
 				# This key is already down, so send a key up for it first.
 				winUser.keybd_event(self.vkCode, self.scanCode, self.isExtended + 2, 0)
@@ -592,6 +608,11 @@ class KeyboardInputGesture(inputCore.InputGesture):
 			# Send key up events for the keys in reverse order.
 			for vk, scan, ext in reversed(keys):
 				winUser.keybd_event(vk, scan, ext + 2, 0)
+			if handleInjectedKeys:
+				# Wait for the keys to be received by NVDA. We don't do this if
+				# handleInjectedKeys is disabled because we just ignore all injected keys
+				# in that case.
+				winKernel.waitForSingleObject(_injectionDoneEvent, self._INJECTION_WAIT_TIMEOUT)
 
 	@classmethod
 	def fromName(cls, name):

--- a/source/keyboardHandler.py
+++ b/source/keyboardHandler.py
@@ -43,8 +43,8 @@ if typing.TYPE_CHECKING:
 
 _watchdogObserver: typing.Optional["WatchdogObserver"] = None
 ignoreInjected=False
-_lastInjectedKeyUp: typing.Tuple[int, int] = None
-_injectionDoneEvent: int = None
+_lastInjectedKeyUp: tuple[int, int] | None = None
+_injectionDoneEvent: int | None = None
 
 # Fake vk codes.
 # These constants should be assigned to the name that NVDA will use for the key.
@@ -577,6 +577,7 @@ class KeyboardInputGesture(inputCore.InputGesture):
 	#: The maximum amount of time (in ms) to wait for keys injected by NVDA to be
 	#: received by NVDA.
 	_INJECTION_WAIT_TIMEOUT: int = 10
+
 	def send(self):
 		global _lastInjectedKeyUp, _injectionDoneEvent
 		keys = []

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -13,7 +13,7 @@ What's New in NVDA
 
 
 == Bug Fixes ==
-- Backspace now works correctly when using Nudi6.1 with NVDA's "Handle keys from other applications" setting enabled. (#15822, @jcsteh)
+- Backspace now works correctly when using Nudi 6.1 with NVDA's "Handle keys from other applications" setting enabled. (#15822, @jcsteh)
 -
 
 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -13,6 +13,8 @@ What's New in NVDA
 
 
 == Bug Fixes ==
+- Backspace now works correctly when using Nudi6.1 with NVDA's "Handle keys from other applications" setting enabled. (#15822, @jcsteh)
+-
 
 
 == Changes for Developers ==


### PR DESCRIPTION
### Link to issue number:
Fixes #15822.

### Summary of the issue:
With "Handle keys from other applications" enabled, NVDA interferes with certain software which intercepts and re-transmits keyboard commands such as Nudi6.1. For example, this makes it impossible to use backspace while this software is running.

### Description of user facing changes
Backspace now works correctly when using Nudi6.1 with NVDA's "Handle keys from other applications" setting enabled.

### Description of development approach
Before #14708, we delayed slightly when sending keys, which would mean that any keys sent by an app which captured a key sent by NVDA would be ignored during that period. After #14708, we only ignore any keys received while NVDA is sending keys, but that doesn't include any keys captured and sent afterward by, for example, Nudi6.1. This could result in a loop where NVDA kept receiving the key it sent (re-transmitted by the other app) and sending it again.

To fix this, we now explicitly wait for the key sent by NVDA (e.g. backspace) to be received by the keyboard hook before we stop ignoring keys and thus return from KeyboardInputGesture.send(). This means that if another application intercepts this key and re-transmits it, we will wait for that re-transmission and ignore it. We use a kernel event so that the notification from the keyboard hook can be handled as quickly as possible without being dependent on the system timer resolution.

There is a chance that a key will be intercepted and never re-sent. To deal with this, we wait for a maximum timeout of 10 ms. This means that in the best case scenario, nothing intercepts a key sent by NVDA and we return almost immediately. In the worst case scenario, we wait between 10 and 30 ms (depending on the system timer resolution), which is no worse than the situation before #14708.

### Testing strategy:
I don't have Nudi6.1, but the reporter confirmed this fix works in https://github.com/nvaccess/nvda/issues/15822#issuecomment-1845190338.

### Known issues with pull request:
None.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
