### PR TITLE
Detach disabling "talk" speech mode warning dialog

### DIFF
--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -1695,11 +1695,9 @@ class VoiceSettingsPanel(AutoSettingsMixin, SettingsPanel):
 			if gui.messageBox(
 				_(
 					# Translators: Warning shown when 'talk' speech mode is disabled in settings.
-					(
-						"You did not choose Talk as one of your speech mode options. "
-						"Please note that this may result in no speech output at all. "
-						"Are you sure you want to continue?"
-					)
+					"You did not choose Talk as one of your speech mode options. "
+					"Please note that this may result in no speech output at all. "
+					"Are you sure you want to continue?"
 				),
 				# Translators: Title of the warning message.
 				_("Warning"),

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -1649,7 +1649,7 @@ class VoiceSettingsPanel(AutoSettingsMixin, SettingsPanel):
 		self.speechModesList.Checked = [
 			mIndex for mIndex in range(len(self._allSpeechModes)) if mIndex not in excludedModes
 		]
-		self.speechModesList.Bind(wx.EVT_CHECKLISTBOX, self.onSpeechModesListChange)
+		self.speechModesList.Bind(wx.EVT_CHECKLISTBOX, self._onSpeechModesListChange)
 		self.speechModesList.Select(0)
 
 	def _appendDelayedCharacterDescriptions(self, settingsSizerHelper: guiHelper.BoxSizerHelper) -> None:

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -4,7 +4,7 @@
 # Derek Riemer, Babbage B.V., Davy Kager, Ethan Holliger, Bill Dengler, Thomas Stivers,
 # Julien Cochuyt, Peter Vágner, Cyrille Bougot, Mesar Hameed, Łukasz Golonka, Aaron Cannon,
 # Adriani90, André-Abush Clause, Dawid Pieper, Heiko Folkerts, Takuya Nishimoto, Thomas Stivers,
-# jakubl7545, mltony, Rob Meredith, Burman's Computer and Education Ltd.
+# jakubl7545, mltony, Rob Meredith, Burman's Computer and Education Ltd, hwf1324.
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 import logging

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -1687,7 +1687,7 @@ class VoiceSettingsPanel(AutoSettingsMixin, SettingsPanel):
 			mIndex for mIndex in range(len(self._allSpeechModes)) if mIndex not in self.speechModesList.CheckedItems
 		]
 
-	def onSpeechModesListChange(self, evt):
+	def _onSpeechModesListChange(self, evt: wx.CommandEvent):
 		if (
 			evt.GetInt() == self._allSpeechModes.index(speech.SpeechMode.talk)
 			and not self.speechModesList.IsChecked(evt.GetInt())


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:

Related #15894

### Summary of the issue:

Disable the "talk" speech mode warning dialog box can be completely separated for judgment, as the status of this option does not need to be guaranteed when determining the settings

### Description of user facing changes

When "talk" is deselected, a warning dialog box pops up. If "no" is chosen, then "talk" is set back to the selected state

### Description of development approach

Move the "talk" speech mode warning dialog to the method bound to the `wx.EVT_CHECKLISTBOX` event.

### Testing strategy:

1. Open the speech settings panel
2. Deselect the "talk" speech mode in loop speech mode

### Known issues with pull request:

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
