### PR TITLE
Ensure the mouse does not play audio coordinates in sleep mode

### DIFF
--- a/source/mouseHandler.py
+++ b/source/mouseHandler.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2016-2022 NV Access Limited
+# Copyright (C) 2016-2023 NV Access Limited
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -201,19 +201,18 @@ def getTotalWidthAndHeightAndMinimumPosition(displays):
 	return (totalWidth, totalHeight, wx.Point(smallestX, smallestY))
 
 def executeMouseMoveEvent(x,y):
-	global currentMouseWindow
 	desktopObject=api.getDesktopObject()
 	displays = [ wx.Display(i).GetGeometry() for i in range(wx.Display.GetCount()) ]
 	x, y = getMouseRestrictedToScreens(x, y, displays)
 	screenWidth, screenHeight, minPos = getTotalWidthAndHeightAndMinimumPosition(displays)
+	oldMouseObject = api.getMouseObject()
+	mouseObject = desktopObject.objectFromPoint(x, y)
 
-	if config.conf["mouse"]["audioCoordinatesOnMouseMove"]:
+	if config.conf["mouse"]["audioCoordinatesOnMouseMove"] and not oldMouseObject.appModule.sleepMode:
 		playAudioCoordinates(x, y, screenWidth, screenHeight, minPos,
 			config.conf['mouse']['audioCoordinates_detectBrightness'],
 			config.conf['mouse']['audioCoordinates_blurFactor'])
 
-	oldMouseObject=api.getMouseObject()
-	mouseObject=desktopObject.objectFromPoint(x, y)
 	while mouseObject and mouseObject.beTransparentToMouse:
 		mouseObject=mouseObject.parent
 	if not mouseObject:

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -14,6 +14,7 @@ What's New in NVDA
 
 == Bug Fixes ==
 - Backspace now works correctly when using Nudi 6.1 with NVDA's "Handle keys from other applications" setting enabled. (#15822, @jcsteh)
+- Fix the error of playing audio coordinates while the application is in sleep mode when the play mouse audio coordinates feature is enabled. (#8059, hwf1324)
 -
 
 
@@ -147,7 +148,6 @@ Users of Poedit 1 are encouraged to update to Poedit 3 if they want to rely on e
   -
 - NVDA is again able to track the focus in applications running within Windows Defender Application Guard (WDAG). (#15164)
 - The speech text is no longer updated when the mouse moves in the Speech Viewer. (#15952, @hwf1324)
-- Fix the error of playing audio coordinates while the application is in sleep mode when the play mouse audio coordinates feature is enabled. (#8059, hwf1324)
 -
 
 == Changes for Developers ==

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -147,7 +147,7 @@ Users of Poedit 1 are encouraged to update to Poedit 3 if they want to rely on e
   - This new behavior can be disabled using the new "Use enhanced event processing" setting in NVDA's advanced settings.
   -
 - NVDA is again able to track the focus in applications running within Windows Defender Application Guard (WDAG). (#15164)
-- The speech text is no longer updated when the mouse moves in the Speech Viewer. (#15952, @hwf1324)
+- The speech text is no longer updated when the mouse moves in the Speech Viewer. (#15953, @hwf1324)
 -
 
 == Changes for Developers ==

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -127,7 +127,8 @@ Users of Poedit 1 are encouraged to update to Poedit 3 if they want to rely on e
   - This new behavior can be disabled using the new "Use enhanced event processing" setting in NVDA's advanced settings.
   -
 - NVDA is again able to track the focus in applications running within Windows Defender Application Guard (WDAG). (#15164)
-- The speech text is no longer updated when the mouse moves in the Speech Viewer. (#15953, @hwf1324)
+- The speech text is no longer updated when the mouse moves in the Speech Viewer. (#15952, @hwf1324)
+- Fix the error of playing audio coordinates while the application is in sleep mode when the play mouse audio coordinates feature is enabled. (#8059, hwf1324)
 -
 
 == Changes for Developers ==

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -14,7 +14,7 @@ What's New in NVDA
 
 == Bug Fixes ==
 - Backspace now works correctly when using Nudi 6.1 with NVDA's "Handle keys from other applications" setting enabled. (#15822, @jcsteh)
-- Fix the error of playing audio coordinates while the application is in sleep mode when the play mouse audio coordinates feature is enabled. (#8059, hwf1324)
+- Fixed a bug where audio coordinates would be played while the application is in sleep mode when "Play audio coordinates when mouse moves" is enabled. (#8059, hwf1324)
 -
 
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:

Fixes #8059

### Summary of the issue:

This issue seems to be because in the core pump, mouse movement events are being handled, but when executing the mouse movement event, there is no check for whether it is in sleep mode. And the function to play audio coordinates is executed accordingly.

### Description of user facing changes

The audio coordinates are no longer played when the mouse moves over an application in sleep mode.

### Description of development approach

Simultaneously determine whether to report audio coordinates and whether to be in sleep mode.

### Testing strategy:

1. Open mouse settings, and check Play audio coordinates when mouse moves, then hit okay.
2. Open sleep mode on an application

Do not play audio coordinates when moving the mouse on this application

### Known issues with pull request:

I was considering the possibility of failure in the logic of updating the mouse object.

So to be on the safe side I chose to use the old mouse object for the judgment.

Although this will delay the response of a mouse object, I think it is acceptable for this PR.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
