### PR TITLE
Fix logic error making it impossible to uninstall multiple add-ons

### DIFF
--- a/source/gui/addonStoreGui/viewModels/store.py
+++ b/source/gui/addonStoreGui/viewModels/store.py
@@ -282,7 +282,7 @@ class AddonStoreVM:
 		shouldRemove = True
 		shouldRememberChoice = False
 		for aVM in listItemVMs:
-			if aVM.canUseRemoveAction():
+			if not aVM.canUseRemoveAction():
 				log.debug(f"Skipping {aVM.Id} ({aVM.status}) as it is not relevant for remove action")
 			else:
 				if shouldRememberChoice:


### PR DESCRIPTION
This should go into beta, as it fixes a bug introduced in 2024.1 development cycle. For the same reason I do not include a change log entry,as it is unnecessary. cc @CyrilleB79 
### Link to issue number:
None
### Summary of the issue:
When trying to uninstall multiple add-ons nothing was happening, and according to the log none of the selected add-ons was relevant for remove action.
### Description of user facing changes
It is now possible to uninstall multiple add-ons in the Add-ons Store.
### Description of development approach
The condition which was checking if the given add-on can be removed is inverted, so that the removal is possible when add-on can indeed be removed.
### Testing strategy:
Selected two add-ons in the store, executed 'remove' from the context menu, made sure the removal process works.
### Known issues with pull request:
None known
### Code Review Checklist:


- [X] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [X] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [X] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [X] API is compatible with existing add-ons.
- [X] Security precautions taken.
