### PR TITLE
Remove add-on modules imported in install tasks to avoid conflicts between add-ons

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,9 @@ Pillow==10.0.1 -C "zlib=disable" -C "jpeg=disable"
 #NVDA_DMP requires diff-match-patch
 fast_diff_match_patch==2.0.1
 
+# typing_extensions are required for specifying default value for `TypeVar`, which is not yet possible with any released version of Python (see PEP 696)
+typing-extensions == 4.9.0 
+
 # Packaging NVDA
 git+https://github.com/py2exe/py2exe@4e7b2b2c60face592e67cb1bc935172a20fa371d#egg=py2exe
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ Pillow==10.0.1 -C "zlib=disable" -C "jpeg=disable"
 fast_diff_match_patch==2.0.1
 
 # typing_extensions are required for specifying default value for `TypeVar`, which is not yet possible with any released version of Python (see PEP 696)
-typing-extensions == 4.9.0 
+typing-extensions==4.9.0 
 
 # Packaging NVDA
 git+https://github.com/py2exe/py2exe@4e7b2b2c60face592e67cb1bc935172a20fa371d#egg=py2exe

--- a/source/addonStore/install.py
+++ b/source/addonStore/install.py
@@ -76,7 +76,7 @@ def installAddon(addonPath: PathLike) -> None:
 	@note See also L{gui.addonGui.installAddon}
 	@raise DisplayableError on failure
 	"""
-	from addonHandler import AddonError, installAddonBundle
+	import addonHandler
 	from gui.message import DisplayableError
 
 	addonPath = cast(str, addonPath)
@@ -84,10 +84,10 @@ def installAddon(addonPath: PathLike) -> None:
 	prevAddon = _getPreviouslyInstalledAddonById(bundle)
 
 	try:
-		systemUtils.ExecAndPump(installAddonBundle, bundle)
+		addonObj = systemUtils.ExecAndPump[addonHandler.Addon](addonHandler.installAddonBundle, bundle).funcRes
 		if prevAddon:
 			prevAddon.requestRemove()
-	except AddonError:  # Handle other exceptions as they are known
+	except addonHandler.AddonError:  # Handle other exceptions as they are known
 		log.error("Error installing addon bundle from %s" % addonPath, exc_info=True)
 		raise DisplayableError(
 			displayMessage=pgettext(
@@ -97,3 +97,6 @@ def installAddon(addonPath: PathLike) -> None:
 				"Failed to install add-on from %s"
 			) % addonPath
 		)
+	finally:
+		if addonObj is not None:
+			addonObj._cleanupAddonImports()

--- a/source/gui/addonGui.py
+++ b/source/gui/addonGui.py
@@ -219,7 +219,7 @@ def installAddon(parentWindow: wx.Window, addonPath: str) -> bool:  # noqa: C901
 	try:
 		# Use context manager to ensure that `done` and `Destroy` are called on the progress dialog afterwards
 		with doneAndDestroy(progressDialog):
-			systemUtils.ExecAndPump(addonHandler.installAddonBundle, bundle)
+			addonObj = systemUtils.ExecAndPump[addonHandler.Addon](addonHandler.installAddonBundle, bundle).funcRes
 			if prevAddon:
 				from addonStore.dataManager import addonDataManager
 				assert addonDataManager
@@ -236,6 +236,9 @@ def installAddon(parentWindow: wx.Window, addonPath: str) -> bool:  # noqa: C901
 			_("Error"),
 			wx.OK | wx.ICON_ERROR
 		)
+	finally:
+		if addonObj is not None:
+			addonObj._cleanupAddonImports()
 	return False
 
 

--- a/source/systemUtils.py
+++ b/source/systemUtils.py
@@ -225,7 +225,7 @@ class ExecAndPump(threading.Thread, Generic[_execAndPumpResT]):
 		self.func = func
 		self.args = args
 		self.kwargs = kwargs
-		# Intentionally uses older syntacs with `Optional`, instead of `_execAndPumpResT | None`,
+		# Intentionally uses older syntax with `Optional`, instead of `_execAndPumpResT | None`,
 		# as latter is not yet supported for unions potentially containing two instances of `None`
 		# (see CPython issue 107271).
 		self.funcRes: Optional[_execAndPumpResT] = None

--- a/source/systemUtils.py
+++ b/source/systemUtils.py
@@ -18,8 +18,16 @@ from ctypes import (
 	windll,
 )
 from typing import (
-	Any,
+	Generic,
+	Optional,
 )
+from typing_extensions import (
+	# Uses `TypeVar` from `typing_extensions`, to be able to specify default type.
+	# This should be changed to use version from `typing`
+	# when updating to version of Python supporting PEP 696.
+	TypeVar,
+)
+
 import winKernel
 import winreg
 import shellapi
@@ -205,15 +213,22 @@ def _isSystemClockSecondsVisible() -> bool:
 		return False
 
 
-class ExecAndPump(threading.Thread):
+_execAndPumpResT = TypeVar("_execAndPumpResT", default=None)
+
+
+class ExecAndPump(threading.Thread, Generic[_execAndPumpResT]):
 	"""Executes the given function with given args and kwargs in a background thread,
 	while blocking and pumping in the current thread.
 	"""
 
-	def __init__(self, func: Callable[..., Any], *args, **kwargs) -> None:
+	def __init__(self, func: Callable[..., _execAndPumpResT], *args, **kwargs) -> None:
 		self.func = func
 		self.args = args
 		self.kwargs = kwargs
+		# Intentionally uses older syntacs with `Optional`, instead of `_execAndPumpResT | None`,
+		# as latter is not yet supported for unions potentially containing two instances of `None`
+		# (see CPython issue 107271).
+		self.funcRes: Optional[_execAndPumpResT] = None
 		fname = repr(func)
 		super().__init__(
 			name=f"{self.__class__.__module__}.{self.__class__.__qualname__}({fname})"
@@ -233,7 +248,7 @@ class ExecAndPump(threading.Thread):
 
 	def run(self):
 		try:
-			self.func(*self.args, **self.kwargs)
+			self.funcRes = self.func(*self.args, **self.kwargs)
 		except Exception as e:
 			self.threadExc = e
 			log.debugWarning("task had errors", exc_info=True)


### PR DESCRIPTION
### Link to issue number:
Fixes regression from PR #14481.
Discovered due to intermittent failures  occurring when installing add-ons, when working on #15852 and #15937

### Summary of the issue:
When installing and uninstalling add-ons bundling install tasks, installation either fails or behaves unexpectedly in the following scenarios:
### 1:
- User installs an add-on
- User removes it and restarts NVDA
- User tries to install the same add-on

In this scenario when installing the install tasks included in the version of add-on which was just removed are used, which is unexpected. Note that this worked well before #14481, not sure why `pkgutil.ImpImporter` behaves better (I haven't investigated, as it is deprecated).

### 2:
- User installs an add-on, which imports its sub module in install tasks using `loadModule` and also imports a sub module in the same way inside global plugin / app module during normal operation
- User upgrades the add-on to a different version

In this scenario after upgrade the add-on module from the uninstalled version is used during normal operation of  NVDA. 

### 3:
- User installs an add-on which imports one of its modules in install tasks by manipulating `sys.path`, for real life examples see Instant Translate and Mouse Wheel Scrolling
- User uninstalls this add-on, restarts NVDA, and tries to install the new version

In this scenario installation fails since the imported module from the old version is used. A slight variation of this scenario is to try to install both Instant Translate and Mouse Wheel Scrolling the add-on installed last would fail to be installed, since they both bundle module named `donate_dialog` but with different functions
### Description of user facing changes
Add-ons are successfully installed in all scenarios described above.
### Description of development approach
All these problems exist because when importing modules in Python if module with the same name exists in `sys.modules` it is just used without importing it again. To ensure modules are always re-imported when needed, the following has been done:
1. When importing modules we no longer use add-on name to create a name space package in which the module would be imported, the last segment of the add-on path is used instead. This ensures that the package for add-on which is installed would just be its name, and for add-on which is pending install it would end with the pending install suffix. This fixes issue 1.
2. `loadModule` memorizes all modules it imported for a given add-on. After installation / removal is done they're removed from `sys.modules`. This fixes issue 2.
3. To remove cached modules imported with the standard `import` command, we store names of all modules imported before installation / removal, perform it, create list of newly imported modules and remove all newly added modules which belong to the add-on from the cache. This fixes issue 3.

### Testing strategy:
Executed scenarios from above. Inspected `sys.modules` afterwards to make sure no add-on modules remained after add-on removal, and that after installation install tasks are also not present in the modules cache.
### Known issues with pull request:
I've  decided not to add a change log entry since issues fixed by this PR occur pretty rarely (I have encountered them only because I have been installing / removing the same add-ons over and over without restarting NVDA when working on another PRs) and describing what exactly has been fixed in a concise way seems difficult here.
### Code Review Checklist:


- [X] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [X] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [X] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [X] API is compatible with existing add-ons.
- [X] Security precautions taken.
