### PR TITLE
Remove defunct pywin32 license

### DIFF
--- a/copying.txt
+++ b/copying.txt
@@ -1915,42 +1915,6 @@ the HTML Library software distribution is included in the file
 docs/license.html_lib.
 ```
 
-= Python Windows Extensions License =
-This applies to Python Windows extensions, available from http://sourceforge.net/projects/pywin32/
-
-```
-Unless stated in the specfic source file, this work is
-Copyright (c) 1994-2008, Mark Hammond 
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without 
-modification, are permitted provided that the following conditions 
-are met:
-
-Redistributions of source code must retain the above copyright notice, 
-this list of conditions and the following disclaimer.
-
-Redistributions in binary form must reproduce the above copyright 
-notice, this list of conditions and the following disclaimer in 
-the documentation and/or other materials provided with the distribution.
-
-Neither name of Mark Hammond nor the name of contributors may be used 
-to endorse or promote products derived from this software without 
-specific prior written permission. 
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS
-IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
-TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE REGENTS OR
-CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
-PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
-PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
-```
-
 = wxWindows Library License version 3.1 =
 This applies to wxPython, available from http://www.wxpython.org/
 


### PR DESCRIPTION
By performing `pip freeze` in the NVDA virtual environment, it appears we no longer use or depend on the library [pywin32](https://pypi.org/project/pywin32/)  - #9639

Pywin32 also has changed licence to the Python Software Foundation licence which is also included in our license file.

Therefore, we should remove this custom license from our licence.