### PR TITLE
Automatically upload NVDA pot file to Crowdin when commits are made to beta.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,6 @@ branches:
  only:
   - master
   - beta
-  - crowdinUpload
   - rc
   - /try-.*/
   - /release-.*/

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,6 +9,7 @@ branches:
  only:
   - master
   - beta
+  - crowdinUpload
   - rc
   - /try-.*/
   - /release-.*/
@@ -28,6 +29,9 @@ environment:
  mozillaSymsAuthToken:
   secure: p37Fxo78fsRdmR8v8TPz978QvVaqvbjdIBzFe8ZOpX0FUprm46rkhd374QM1CqMO
  symstore: C:\Program Files (x86)\Windows Kits\10\Debuggers\x64\symstore.exe
+ crowdinProjectID: 598017
+ crowdinAuthToken:
+  secure: E3084gj4JeMZKvZIOLIhqZefuSo/tj7iYPt4yK0geOI/eQgmPvoXt37Xq0KwvXzvZiJny4AsMj1rKMTVxio8EG8KA0YsYYuy+WV1wpFRIn25zGQS+DZ/yycL75SmTWfr
 
 install:
  - ps: |

--- a/appveyor/crowdinSync.py
+++ b/appveyor/crowdinSync.py
@@ -17,7 +17,7 @@ import zipfile
 import requests
 
 
-AUTH_TOKEN = os.getenv("crowdinAuthToken")
+AUTH_TOKEN = os.getenv("crowdinAuthToken", "").strip()
 if not AUTH_TOKEN:
 	raise ValueError("crowdinAuthToken environment variable not set")
 PROJECT_ID = os.getenv("crowdinProjectID")

--- a/appveyor/crowdinSync.py
+++ b/appveyor/crowdinSync.py
@@ -20,10 +20,10 @@ if not PROJECT_ID:
 
 
 def request(
-	path: str,
-	method=requests.get,
-	headers: dict[str, str] | None = None,
-	**kwargs
+		path: str,
+		method=requests.get,
+		headers: dict[str, str] | None = None,
+		**kwargs
 ) -> requests.Response:
 	if headers is None:
 		headers = {}

--- a/appveyor/crowdinSync.py
+++ b/appveyor/crowdinSync.py
@@ -48,7 +48,7 @@ def projectRequest(path: str, **kwargs) -> requests.Response:
 
 def uploadSourceFile(crowdinFileID: int, localFilePath: str) -> None:
 	fn = os.path.basename(localFilePath)
-	print(f"Uploading {localFilePath}  to Crowdin temporary storage as {fn}")
+	print(f"Uploading {localFilePath} to Crowdin temporary storage as {fn}")
 	with open(localFilePath, "rb") as f:
 		r = request(
 			"storages", method=requests.post,

--- a/appveyor/crowdinSync.py
+++ b/appveyor/crowdinSync.py
@@ -6,13 +6,14 @@
 
 
 import argparse
-import time
-import os
 import glob
-import sys
-import zipfile
+import os
 import shutil
 import subprocess
+import sys
+import time
+import zipfile
+
 import requests
 
 

--- a/appveyor/crowdinSync.py
+++ b/appveyor/crowdinSync.py
@@ -47,10 +47,10 @@ def request(
 		raise
 	return r
 
-def projectRequest(path: str, **kwargs):
+def projectRequest(path: str, **kwargs) -> requests.Response:
 	return request(f"projects/{PROJECT_ID}/{path}", **kwargs)
 
-def uploadSourceFile(crowdinFileID: int, localFilePath: str):
+def uploadSourceFile(crowdinFileID: int, localFilePath: str) -> None:
 	fn = os.path.basename(localFilePath)
 	print(f"Uploading {localFilePath}  to Crowdin temporary storage as {fn}")
 	with open(localFilePath, "rb") as f:
@@ -63,7 +63,7 @@ def uploadSourceFile(crowdinFileID: int, localFilePath: str):
 		json={"storageId": storageID})
 	revisionId = r.json()["data"]["revisionId"]
 	print(f"Updated to revision {revisionId}") 
-	return r
+
 
 def main():
 	parser = argparse.ArgumentParser(

--- a/appveyor/crowdinSync.py
+++ b/appveyor/crowdinSync.py
@@ -1,0 +1,55 @@
+# based on file from https://github.com/jcsteh/osara
+
+import time
+import os
+import glob
+import sys
+import zipfile
+import shutil
+import subprocess
+import requests
+
+AUTH_TOKEN = os.getenv("crowdinAuthToken")
+if not AUTH_TOKEN:
+	raise ValueError("crowdinAuthToken environment variable not set")
+PROJECT_ID = int(os.getenv("crowdinProjectID"))
+if not PROJECT_ID:
+	raise ValueError("crowdinProjectID environment variable not set")
+
+
+def request(path, method=requests.get, headers={}, **kwargs):
+	headers["Authorization"] = "Bearer %s" % AUTH_TOKEN
+	r = method("https://api.crowdin.com/api/v2/%s" % path, headers=headers,
+		**kwargs)
+	# Convert errors to exceptions, but print the response before raising.
+	try:
+		r.raise_for_status()
+	except requests.exceptions.HTTPError:
+		print(r.json())
+		raise
+	return r
+
+def projectRequest(path, **kwargs):
+	return request("projects/%d/%s" % (PROJECT_ID, path), **kwargs)
+
+def uploadSourceFile(crowdinFileID, crowdinFileName, localFilePath):
+	fn = os.path.basename(localFilePath)
+	f = open(localFilePath, "rb")
+	print(f"Uploading {localFilePath}  to Crowdin temporary storage as {crowdinFileName}")
+	r = request("storages", method=requests.post,
+		headers={"Crowdin-API-FileName": crowdinFileName}, data=f)
+	storageID = r.json()["data"]["id"]
+	print(f"Updating file {crowdinFileID} on Crowdin with storage ID {storageID}")
+	r = projectRequest("files/%d" % crowdinFileID, method=requests.put,
+		json={"storageId": storageID})
+	return r
+
+if __name__ == "__main__":
+	command = sys.argv[1]
+	if command == "uploadSourceFile":
+		crowdinFileID = int(sys.argv[2])
+		crowdinFileName = sys.argv[3]
+		localFilePath = sys.argv[4]
+		uploadSourceFile(crowdinFileID, crowdinFileName, localFilePath)
+	else:
+		raise ValueError("Unknown command")

--- a/appveyor/crowdinSync.py
+++ b/appveyor/crowdinSync.py
@@ -20,7 +20,7 @@ import requests
 AUTH_TOKEN = os.getenv("crowdinAuthToken", "").strip()
 if not AUTH_TOKEN:
 	raise ValueError("crowdinAuthToken environment variable not set")
-PROJECT_ID = os.getenv("crowdinProjectID")
+PROJECT_ID = os.getenv("crowdinProjectID", "").strip()
 if not PROJECT_ID:
 	raise ValueError("crowdinProjectID environment variable not set")
 

--- a/appveyor/crowdinSync.py
+++ b/appveyor/crowdinSync.py
@@ -51,8 +51,10 @@ def uploadSourceFile(crowdinFileID: int, localFilePath: str) -> None:
 	print(f"Uploading {localFilePath} to Crowdin temporary storage as {fn}")
 	with open(localFilePath, "rb") as f:
 		r = request(
-			"storages", method=requests.post,
-			headers={"Crowdin-API-FileName": fn}, data=f
+			"storages",
+			method=requests.post,
+			headers={"Crowdin-API-FileName": fn},
+			data=f
 		)
 	storageID = r.json()["data"]["id"]
 	print(f"Updating file {crowdinFileID} on Crowdin with storage ID {storageID}")

--- a/appveyor/crowdinSync.py
+++ b/appveyor/crowdinSync.py
@@ -57,8 +57,10 @@ def uploadSourceFile(crowdinFileID: int, localFilePath: str) -> None:
 	storageID = r.json()["data"]["id"]
 	print(f"Updating file {crowdinFileID} on Crowdin with storage ID {storageID}")
 	r = projectRequest(
-		f"files/{crowdinFileID}", method=requests.put,
-		json={"storageId": storageID})
+		f"files/{crowdinFileID}",
+		method=requests.put,
+		json={"storageId": storageID}
+	)
 	revisionId = r.json()["data"]["revisionId"]
 	print(f"Updated to revision {revisionId}")
 

--- a/appveyor/crowdinSync.py
+++ b/appveyor/crowdinSync.py
@@ -6,13 +6,7 @@
 
 
 import argparse
-import glob
 import os
-import shutil
-import subprocess
-import sys
-import time
-import zipfile
 
 import requests
 
@@ -26,11 +20,11 @@ if not PROJECT_ID:
 
 
 def request(
-		path: str,
-		method=requests.get,
-		headers: dict[str, str] | None =None,
-		**kwargs
-	) -> requests.Response:
+	path: str,
+	method=requests.get,
+	headers: dict[str, str] | None = None,
+	**kwargs
+) -> requests.Response:
 	if headers is None:
 		headers = {}
 	headers["Authorization"] = f"Bearer {AUTH_TOKEN}"
@@ -47,22 +41,26 @@ def request(
 		raise
 	return r
 
+
 def projectRequest(path: str, **kwargs) -> requests.Response:
 	return request(f"projects/{PROJECT_ID}/{path}", **kwargs)
+
 
 def uploadSourceFile(crowdinFileID: int, localFilePath: str) -> None:
 	fn = os.path.basename(localFilePath)
 	print(f"Uploading {localFilePath}  to Crowdin temporary storage as {fn}")
 	with open(localFilePath, "rb") as f:
-		r = request("storages", method=requests.post,
-				headers={"Crowdin-API-FileName": fn}, data=f
+		r = request(
+			"storages", method=requests.post,
+			headers={"Crowdin-API-FileName": fn}, data=f
 		)
 	storageID = r.json()["data"]["id"]
 	print(f"Updating file {crowdinFileID} on Crowdin with storage ID {storageID}")
-	r = projectRequest(f"files/{crowdinFileID}", method=requests.put,
+	r = projectRequest(
+		f"files/{crowdinFileID}", method=requests.put,
 		json={"storageId": storageID})
 	revisionId = r.json()["data"]["revisionId"]
-	print(f"Updated to revision {revisionId}") 
+	print(f"Updated to revision {revisionId}")
 
 
 def main():

--- a/appveyor/scripts/deployScript.ps1
+++ b/appveyor/scripts/deployScript.ps1
@@ -1,6 +1,11 @@
 $ErrorActionPreference = "Stop";
 if (!$env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:versionType) {
 	# Not a try build.
+	if ($env:APPVEYOR_REPO_BRANCH -eq "beta") {
+		# Upload files to Crowdin for translation
+		py -m pip install --no-warn-script-location requests
+		py appveyor\crowdinSync.py uploadSourceFile 2 nvda.pot output\nvda.pot 2>&1
+	}
 	# Notify our server.
 	$exe = Get-ChildItem -Name output\*.exe
 	$hash = (Get-FileHash "output\$exe" -Algorithm SHA1).Hash.ToLower()

--- a/appveyor/scripts/deployScript.ps1
+++ b/appveyor/scripts/deployScript.ps1
@@ -4,7 +4,7 @@ if (!$env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:versionType) {
 	if ($env:APPVEYOR_REPO_BRANCH -eq "beta") {
 		# Upload files to Crowdin for translation
 		py -m pip install --no-warn-script-location requests
-		py appveyor\crowdinSync.py uploadSourceFile 2 nvda.pot output\nvda.pot 2>&1
+		py appveyor\crowdinSync.py uploadSourceFile 2 output\nvda.pot 2>&1
 	}
 	# Notify our server.
 	$exe = Get-ChildItem -Name output\*.exe

--- a/sconstruct
+++ b/sconstruct
@@ -523,7 +523,7 @@ potSourceFiles = [
 ]
 
 pot = env.Command(
-	outputDir.File("%s.pot" % outFilePrefix),
+	outputDir.File("nvda.pot"),
 	potSourceFiles,
 	makePot
 )


### PR DESCRIPTION
### Link to issue number:
None.

### Summary of the issue:
Currently nvda.pot is uploaded to Crowdin for translation manually.

### Description of user facing changes
Translators will see updates to source strings on Crowdin as soon as they are committed to beta.

### Description of development approach
* Borrowed crowdinSync.py from https://github.com/jcsteh/osara
* Cut down code to only what we require.
* For ease of locating, NvDA's pot file is now simply named nvda.pot, rather than including versioning info. That extra info in the file name is not useful as it is only being uploaded to Crowdin anyway and it was very tricky to locate for deployment.
* In appveyor's deploy script, upload nvda.pot to Crowdin, if the branch being built is beta.

### Testing strategy:
See successful Appveyor build where nvda.pot was uploaded to Crowdin: https://ci.appveyor.com/project/NVAccess/nvda/builds/48824278
Verified that Translators can see new strings in Crowdin.


### Known issues with pull request:
None known.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
