### PR TITLE
Create a build artifact listing included python standard library modules

### DIFF
--- a/appveyor/scripts/setSconsArgs.ps1
+++ b/appveyor/scripts/setSconsArgs.ps1
@@ -1,5 +1,5 @@
 $ErrorActionPreference = "Stop";
-$sconsOutTargets = "launcher developerGuide changes userGuide keyCommands client"
+$sconsOutTargets = "launcher developerGuide changes userGuide keyCommands client moduleList"
 if(!$env:APPVEYOR_PULL_REQUEST_NUMBER) {
 	$sconsOutTargets += " appx"
 }

--- a/sconstruct
+++ b/sconstruct
@@ -10,7 +10,6 @@ import os
 import platform
 import multiprocessing
 
-
 # Ensure we are inside the Python virtual environment.
 nvdaVenv = os.getenv("NVDA_VENV")
 virtualEnv = os.getenv("VIRTUAL_ENV")
@@ -557,9 +556,9 @@ def generate_module_list(target, source, env):
     modules to a specified output file for packaging as an AppVeyor artefact.
 
     Args:
-        target (list of SCons.Node.FS.File): A single element list containing the target file node(s) where the 
+        target (list of SCons.Node.FS.File): A single element list containing the target file node where the 
 											 list of modules will be written.
-        source (list of SCons.Node.FS.File): A single element list containing the source file node(s) to be 
+        source (list of SCons.Node.FS.File): A single element list containing the source file node to be 
 											 processed. It should contain only the zipfile from which the 
 											 '.pyc' files will be listed.
         env (SCons.Environment): The SCons environment context under which this function is executed. This
@@ -582,7 +581,8 @@ def generate_module_list(target, source, env):
 		raise FileNotFoundError(f"The zipfile {library_zip_path} does not exist.")
 	pyc_files = [f for f in zipfile.ZipFile(library_zip_path, 'r').namelist() if f.endswith('.pyc')]
 
-	# Convert the module paths to python module format
+	# Convert the file paths to python module format
+	# eg: NVDAObjects/IAccessible/__init__.pyc --> NVDAObjects.IAccessible
 	imported_modules = sorted(set([
 		re.sub(r'(.__init__|.__version__|._version)?\.pyc$', '', module_path).replace('/', '.')
 		for module_path in pyc_files
@@ -592,7 +592,7 @@ def generate_module_list(target, source, env):
 	if "NVDAObjects.UIA" not in imported_modules:
 		raise ValueError(f"Expected module NVDAObjects.UIA not found in the zipfile.")
 
-	# Store the list to file and export as an artefact
+	# Store the list to file
 	with open(str(target[0]), 'w') as file:
 		file.write('\n'.join(imported_modules))
 
@@ -600,7 +600,8 @@ def generate_module_list(target, source, env):
 # Create a new builder that uses a custom action using the generate_module_list function
 env["BUILDERS"]["GenerateModuleList"] = Builder(action=Action(generate_module_list))
 
-# Define the target and source and tell SCons to use the builder
+# Define the target and source
+# Putting the target in the output dir automatically causes AppVeyor to package it as an artefact
 target = os.path.join(os.getcwd(), 'output', 'library_modules.txt')
 source = os.path.join(os.getcwd(), 'dist', 'library.zip')
 

--- a/sconstruct
+++ b/sconstruct
@@ -550,7 +550,6 @@ env.SConscript("tests/sconscript", exports=["env", "sourceDir", "pot"])
 
 # Generate a list of Python modules from compiled '.pyc' files in library.zip
 env.Tool("listModules")
-source = os.path.join(os.getcwd(), "dist", "library.zip")
 # Putting the target in the output dir automatically causes AppVeyor to package it as an artefact
 target = os.path.join(outputDir.abspath, "library_modules.txt")
-env.Alias("moduleList", env.GenerateModuleList(target, source))
+env.Alias("moduleList", env.GenerateModuleList(target, "dist"))

--- a/sconstruct
+++ b/sconstruct
@@ -10,6 +10,7 @@ import os
 import platform
 import multiprocessing
 
+
 # Ensure we are inside the Python virtual environment.
 nvdaVenv = os.getenv("NVDA_VENV")
 virtualEnv = os.getenv("VIRTUAL_ENV")
@@ -545,3 +546,60 @@ env.Alias('appx',[installed_appx_storeSubmission,installed_appx_sideLoadable])
 env.Default(dist)
 
 env.SConscript("tests/sconscript", exports=["env", "sourceDir", "pot"])
+
+
+def generate_module_list(target, source, env):
+	""" 
+	Generate a list of Python modules from compiled '.pyc' files within a specified zipfile.
+
+    This function lists all '.pyc' files contained in a given zipfile, converts their paths to Python module
+    format, performs a sanity check to ensure a specific module is present, and then writes the list of
+    modules to a specified output file for packaging as an AppVeyor artefact.
+
+    Args:
+        target (list of SCons.Node.FS.File): A single element list containing the target file node(s) where the list of modules
+                                             will be written.
+        source (list of SCons.Node.FS.File): A single element list containing the source file node(s) to be processed. 
+											 It should contain only the zipfile from which the '.pyc' files
+                                             will be listed.
+        env (SCons.Environment): The SCons environment context under which this function is executed. This
+                                 parameter provides access to SCons construction variables, methods, and tools.
+
+    Returns:
+        None: The function does not return anything but writes the list of modules to the target file.
+
+    Raises:
+        ValueError: If the specified sanity check module (e.g., 'NVDAObjects.UIA') is not found in the
+					list of modules extracted from the zipfile.
+        FileNotFoundError: If the specified zipfile in `source` does not exist.
+	"""
+	import zipfile
+	import re
+
+	# List all .pyc files in the library.zip
+	library_zip_path = str(source[0])
+	if not os.path.exists(library_zip_path):
+		raise FileNotFoundError(f"The zipfile {library_zip_path} does not exist.")
+	pyc_files = [f for f in zipfile.ZipFile(library_zip_path, 'r').namelist() if f.endswith('.pyc')]
+
+	# convert the module paths to python module format
+	imported_modules = sorted(set([
+		re.sub(r'(.__init__|.__version__|._version)?\.pyc$', '', module_path).replace('/', '.')
+		for module_path in pyc_files
+	]))
+
+	# Sanity check for something guaranteed to be in library.zip
+	if "NVDAObjects.UIA" not in imported_modules:
+		raise ValueError(f"Expected module NVDAObjects.UIA not found in the zipfile.")
+
+	# store the list to file and export as an artefact
+	with open(str(target[0]), 'w') as file:
+		file.write('\n'.join(imported_modules))
+
+
+# Create a new builder that uses a custom action using the generate_module_list function
+env["BUILDERS"]["GenerateModuleList"] = Builder(action=Action(generate_module_list))
+
+# Define the target and source and tell SCons to use the builder
+target = os.path.join(os.getcwd(), 'output', 'library_modules.txt')
+source = os.path.join(os.getcwd(), 'dist', 'library.zip')

--- a/sconstruct
+++ b/sconstruct
@@ -550,6 +550,7 @@ env.SConscript("tests/sconscript", exports=["env", "sourceDir", "pot"])
 
 # Generate a list of Python modules from compiled '.pyc' files in library.zip
 env.Tool("listModules")
+source = env.Dir(os.path.join(os.getcwd(), "dist"))
 # Putting the target in the output dir automatically causes AppVeyor to package it as an artefact
-target = os.path.join(outputDir.abspath, "library_modules.txt")
-env.Alias("moduleList", env.GenerateModuleList(target, "dist"))
+target = env.File(os.path.join(outputDir.abspath, "library_modules.txt"))
+env.Alias("moduleList", env.GenerateModuleList(target, source))

--- a/sconstruct
+++ b/sconstruct
@@ -557,11 +557,11 @@ def generate_module_list(target, source, env):
     modules to a specified output file for packaging as an AppVeyor artefact.
 
     Args:
-        target (list of SCons.Node.FS.File): A single element list containing the target file node(s) where the list of modules
-                                             will be written.
-        source (list of SCons.Node.FS.File): A single element list containing the source file node(s) to be processed. 
-											 It should contain only the zipfile from which the '.pyc' files
-                                             will be listed.
+        target (list of SCons.Node.FS.File): A single element list containing the target file node(s) where the 
+											 list of modules will be written.
+        source (list of SCons.Node.FS.File): A single element list containing the source file node(s) to be 
+											 processed. It should contain only the zipfile from which the 
+											 '.pyc' files will be listed.
         env (SCons.Environment): The SCons environment context under which this function is executed. This
                                  parameter provides access to SCons construction variables, methods, and tools.
 
@@ -582,7 +582,7 @@ def generate_module_list(target, source, env):
 		raise FileNotFoundError(f"The zipfile {library_zip_path} does not exist.")
 	pyc_files = [f for f in zipfile.ZipFile(library_zip_path, 'r').namelist() if f.endswith('.pyc')]
 
-	# convert the module paths to python module format
+	# Convert the module paths to python module format
 	imported_modules = sorted(set([
 		re.sub(r'(.__init__|.__version__|._version)?\.pyc$', '', module_path).replace('/', '.')
 		for module_path in pyc_files
@@ -592,7 +592,7 @@ def generate_module_list(target, source, env):
 	if "NVDAObjects.UIA" not in imported_modules:
 		raise ValueError(f"Expected module NVDAObjects.UIA not found in the zipfile.")
 
-	# store the list to file and export as an artefact
+	# Store the list to file and export as an artefact
 	with open(str(target[0]), 'w') as file:
 		file.write('\n'.join(imported_modules))
 
@@ -604,4 +604,6 @@ env["BUILDERS"]["GenerateModuleList"] = Builder(action=Action(generate_module_li
 target = os.path.join(os.getcwd(), 'output', 'library_modules.txt')
 source = os.path.join(os.getcwd(), 'dist', 'library.zip')
 
-env.GenerateModuleList(target, source)
+# env.GenerateModuleList(target, source)
+# Associate with 'source' target
+env.Alias('source', env.GenerateModuleList(target, source))

--- a/sconstruct
+++ b/sconstruct
@@ -575,12 +575,12 @@ def generateModuleList(
 	library_zip_path = str(source[0])
 	if not os.path.exists(library_zip_path):
 		raise FileNotFoundError(f"The zipfile {library_zip_path} does not exist.")
-	pyc_files = [f for f in zipfile.ZipFile(library_zip_path, 'r').namelist() if f.endswith('.pyc')]
+	pyc_files = [f for f in zipfile.ZipFile(library_zip_path, "r").namelist() if f.endswith(".pyc")]
 
 	# Convert the file paths to python module format
 	# eg: NVDAObjects/IAccessible/__init__.pyc --> NVDAObjects.IAccessible
 	imported_modules = sorted(set([
-		re.sub(r'(.__init__|.__version__|._version)?\.pyc$', '', module_path).replace('/', '.')
+		re.sub(r"(.__init__|.__version__|._version)?\.pyc$", "", module_path).replace("/", ".")
 		for module_path in pyc_files
 	]))
 
@@ -589,8 +589,8 @@ def generateModuleList(
 		raise ValueError(f"Expected module NVDAObjects.UIA not found in the zipfile.")
 
 	# Store the list to file
-	with open(str(target[0]), 'w', encoding="utf-8") as file:
-		file.write('\n'.join(imported_modules))
+	with open(str(target[0]), "w", encoding="utf-8") as file:
+		file.write("\n".join(imported_modules))
 
 
 # Create a new builder that uses a custom action using the generate_module_list function
@@ -598,8 +598,8 @@ env["BUILDERS"]["GenerateModuleList"] = Builder(action=Action(generateModuleList
 
 # Define the target and source
 # Putting the target in the output dir automatically causes AppVeyor to package it as an artefact
-target = os.path.join(outputDir.abspath, 'library_modules.txt')
-source = os.path.join(os.getcwd(), 'dist', 'library.zip')
+target = os.path.join(outputDir.abspath, "library_modules.txt")
+source = os.path.join(os.getcwd(), "dist", "library.zip")
 
 # Execute along with 'dist' target
-env.Depends('dist', env.GenerateModuleList(target, source))
+env.Depends("dist", env.GenerateModuleList(target, source))

--- a/sconstruct
+++ b/sconstruct
@@ -8,11 +8,7 @@
 import multiprocessing
 import os
 import platform
-import re
 import sys
-import zipfile
-
-import SCons
 
 
 # Ensure we are inside the Python virtual environment.
@@ -552,54 +548,10 @@ env.Default(dist)
 env.SConscript("tests/sconscript", exports=["env", "sourceDir", "pot"])
 
 
-def generateModuleList(
-		target: list[SCons.Node.FS.File],
-		source: list[SCons.Node.FS.File],
-		env: SCons.Environment.Environment
-) -> None:
-	""" 
-	Generate a list of Python modules from compiled '.pyc' files within a specified zipfile.
-
-	This function lists all '.pyc' files contained in a given zipfile, converts their paths to Python module
-	format, performs a sanity check to ensure a specific module is present, and then writes the list of
-	modules to a specified output file for packaging as an AppVeyor artefact.
-
-	:param target: A single element list containing the target file node where the list of modules will be written.
-	:param source: A single element list containing the source file node to be processed. It should contain only the zipfile from which the '.pyc' files will be listed.
-	:param env: The SCons environment context under which this function is executed. This parameter provides access to SCons construction variables, methods, and tools.
-	:return: None. The function does not return anything but writes the list of modules to the target file.
-	:raises ValueError: If the specified sanity check module (e.g., 'NVDAObjects.UIA') is not found in the list of modules extracted from the zipfile.
-	:raises FileNotFoundError: If the specified zipfile in `source` does not exist.
-	"""
-	# List all .pyc files in the library.zip
-	library_zip_path = str(source[0])
-	if not os.path.exists(library_zip_path):
-		raise FileNotFoundError(f"The zipfile {library_zip_path} does not exist.")
-	pyc_files = [f for f in zipfile.ZipFile(library_zip_path, "r").namelist() if f.endswith(".pyc")]
-
-	# Convert the file paths to python module format
-	# eg: NVDAObjects/IAccessible/__init__.pyc --> NVDAObjects.IAccessible
-	imported_modules = sorted(set([
-		re.sub(r"(.__init__|.__version__|._version)?\.pyc$", "", module_path).replace("/", ".")
-		for module_path in pyc_files
-	]))
-
-	# Sanity check for something guaranteed to be in library.zip
-	if "NVDAObjects.UIA" not in imported_modules:
-		raise ValueError(f"Expected module NVDAObjects.UIA not found in the zipfile.")
-
-	# Store the list to file
-	with open(str(target[0]), "w", encoding="utf-8") as file:
-		file.write("\n".join(imported_modules))
-
-
-# Create a new builder that uses a custom action using the generate_module_list function
-env["BUILDERS"]["GenerateModuleList"] = Builder(action=Action(generateModuleList))
-
-# Define the target and source
+# Generate a list of Python modules from compiled '.pyc' files in library.zip
+# along with 'dist' target
+env.Tool("listModules")
+source = os.path.join(os.getcwd(), "dist", "library.zip")
 # Putting the target in the output dir automatically causes AppVeyor to package it as an artefact
 target = os.path.join(outputDir.abspath, "library_modules.txt")
-source = os.path.join(os.getcwd(), "dist", "library.zip")
-
-# Execute along with 'dist' target
 env.Depends("dist", env.GenerateModuleList(target, source))

--- a/sconstruct
+++ b/sconstruct
@@ -603,3 +603,5 @@ env["BUILDERS"]["GenerateModuleList"] = Builder(action=Action(generate_module_li
 # Define the target and source and tell SCons to use the builder
 target = os.path.join(os.getcwd(), 'output', 'library_modules.txt')
 source = os.path.join(os.getcwd(), 'dist', 'library.zip')
+
+env.GenerateModuleList(target, source)

--- a/sconstruct
+++ b/sconstruct
@@ -549,9 +549,8 @@ env.SConscript("tests/sconscript", exports=["env", "sourceDir", "pot"])
 
 
 # Generate a list of Python modules from compiled '.pyc' files in library.zip
-# along with 'dist' target
 env.Tool("listModules")
 source = os.path.join(os.getcwd(), "dist", "library.zip")
 # Putting the target in the output dir automatically causes AppVeyor to package it as an artefact
 target = os.path.join(outputDir.abspath, "library_modules.txt")
-env.Depends("dist", env.GenerateModuleList(target, source))
+env.Alias("moduleList", env.GenerateModuleList(target, source))

--- a/sconstruct
+++ b/sconstruct
@@ -602,7 +602,7 @@ env["BUILDERS"]["GenerateModuleList"] = Builder(action=Action(generate_module_li
 
 # Define the target and source
 # Putting the target in the output dir automatically causes AppVeyor to package it as an artefact
-target = os.path.join(os.getcwd(), 'output', 'library_modules.txt')
+target = os.path.join(outputDir.abspath, 'library_modules.txt')
 source = os.path.join(os.getcwd(), 'dist', 'library.zip')
 
 # Execute along with 'dist' target

--- a/sconstruct
+++ b/sconstruct
@@ -11,7 +11,6 @@ import platform
 import re
 import sys
 import zipfile
-from typing import List
 
 import SCons
 
@@ -553,9 +552,11 @@ env.Default(dist)
 env.SConscript("tests/sconscript", exports=["env", "sourceDir", "pot"])
 
 
-def generateModuleList(target: List[SCons.Node.FS.File], 
-					   source: List[SCons.Node.FS.File], 
-					   env: SCons.Environment.Environment) -> None:
+def generateModuleList(
+		target: list[SCons.Node.FS.File],
+		source: list[SCons.Node.FS.File],
+		env: SCons.Environment.Environment
+) -> None:
 	""" 
 	Generate a list of Python modules from compiled '.pyc' files within a specified zipfile.
 

--- a/sconstruct
+++ b/sconstruct
@@ -5,10 +5,16 @@
 # This file may be used under the terms of the GNU General Public License, version 2 or later.
 # For more details see: https://www.gnu.org/licenses/gpl-2.0.html
 
-import sys
+import multiprocessing
 import os
 import platform
-import multiprocessing
+import re
+import sys
+import zipfile
+from typing import List
+
+import SCons
+
 
 # Ensure we are inside the Python virtual environment.
 nvdaVenv = os.getenv("NVDA_VENV")
@@ -547,34 +553,23 @@ env.Default(dist)
 env.SConscript("tests/sconscript", exports=["env", "sourceDir", "pot"])
 
 
-def generate_module_list(target, source, env):
+def generateModuleList(target: List[SCons.Node.FS.File], 
+					   source: List[SCons.Node.FS.File], 
+					   env: SCons.Environment.Environment) -> None:
 	""" 
 	Generate a list of Python modules from compiled '.pyc' files within a specified zipfile.
 
-    This function lists all '.pyc' files contained in a given zipfile, converts their paths to Python module
-    format, performs a sanity check to ensure a specific module is present, and then writes the list of
-    modules to a specified output file for packaging as an AppVeyor artefact.
+	This function lists all '.pyc' files contained in a given zipfile, converts their paths to Python module
+	format, performs a sanity check to ensure a specific module is present, and then writes the list of
+	modules to a specified output file for packaging as an AppVeyor artefact.
 
-    Args:
-        target (list of SCons.Node.FS.File): A single element list containing the target file node where the 
-											 list of modules will be written.
-        source (list of SCons.Node.FS.File): A single element list containing the source file node to be 
-											 processed. It should contain only the zipfile from which the 
-											 '.pyc' files will be listed.
-        env (SCons.Environment): The SCons environment context under which this function is executed. This
-                                 parameter provides access to SCons construction variables, methods, and tools.
-
-    Returns:
-        None: The function does not return anything but writes the list of modules to the target file.
-
-    Raises:
-        ValueError: If the specified sanity check module (e.g., 'NVDAObjects.UIA') is not found in the
-					list of modules extracted from the zipfile.
-        FileNotFoundError: If the specified zipfile in `source` does not exist.
+	:param target: A single element list containing the target file node where the list of modules will be written.
+	:param source: A single element list containing the source file node to be processed. It should contain only the zipfile from which the '.pyc' files will be listed.
+	:param env: The SCons environment context under which this function is executed. This parameter provides access to SCons construction variables, methods, and tools.
+	:return: None. The function does not return anything but writes the list of modules to the target file.
+	:raises ValueError: If the specified sanity check module (e.g., 'NVDAObjects.UIA') is not found in the list of modules extracted from the zipfile.
+	:raises FileNotFoundError: If the specified zipfile in `source` does not exist.
 	"""
-	import zipfile
-	import re
-
 	# List all .pyc files in the library.zip
 	library_zip_path = str(source[0])
 	if not os.path.exists(library_zip_path):
@@ -598,7 +593,7 @@ def generate_module_list(target, source, env):
 
 
 # Create a new builder that uses a custom action using the generate_module_list function
-env["BUILDERS"]["GenerateModuleList"] = Builder(action=Action(generate_module_list))
+env["BUILDERS"]["GenerateModuleList"] = Builder(action=Action(generateModuleList))
 
 # Define the target and source
 # Putting the target in the output dir automatically causes AppVeyor to package it as an artefact

--- a/sconstruct
+++ b/sconstruct
@@ -593,7 +593,7 @@ def generate_module_list(target, source, env):
 		raise ValueError(f"Expected module NVDAObjects.UIA not found in the zipfile.")
 
 	# Store the list to file
-	with open(str(target[0]), 'w') as file:
+	with open(str(target[0]), 'w', encoding="utf-8") as file:
 		file.write('\n'.join(imported_modules))
 
 

--- a/sconstruct
+++ b/sconstruct
@@ -604,6 +604,5 @@ env["BUILDERS"]["GenerateModuleList"] = Builder(action=Action(generate_module_li
 target = os.path.join(os.getcwd(), 'output', 'library_modules.txt')
 source = os.path.join(os.getcwd(), 'dist', 'library.zip')
 
-# env.GenerateModuleList(target, source)
-# Associate with 'source' target
-env.Alias('source', env.GenerateModuleList(target, source))
+# Execute along with 'dist' target
+env.Depends('dist', env.GenerateModuleList(target, source))

--- a/site_scons/site_tools/listModules.py
+++ b/site_scons/site_tools/listModules.py
@@ -28,7 +28,7 @@ def _generateModuleList(
 	:param target: A single element list containing the target file node where the list of modules will be
 				written.
 	:param source: A single element list containing the source file node to be processed. It should contain
-	 			only the zipfile from which the '.pyc' files will be listed.
+				only the zipfile from which the '.pyc' files will be listed.
 	:param env: The SCons environment context under which this function is executed. This parameter provides
 				access to SCons construction variables, methods, and tools.
 	:return: None. The function does not return anything but writes the list of modules to the target file.
@@ -59,10 +59,9 @@ def _generateModuleList(
 
 
 def generate(env: SCons.Environment.Environment):
-	env["BUILDERS"]["GenerateModuleList"] = \
-		SCons.Builder.Builder(
-			action=SCons.Action.Action(_generateModuleList))
+	env["BUILDERS"]["GenerateModuleList"] = SCons.Builder.Builder(
+		action=SCons.Action.Action(_generateModuleList))
 
 
 def exists(env: SCons.Environment.Environment) -> bool:
-    return True
+	return True

--- a/site_scons/site_tools/listModules.py
+++ b/site_scons/site_tools/listModules.py
@@ -25,14 +25,14 @@ def _generateModuleList(
 	format, performs a sanity check to ensure a specific module is present, and then writes the list of
 	modules to a specified output file for packaging as an AppVeyor artefact.
 
-	:param target: A single element list containing the target file node where the list of modules will be 
+	:param target: A single element list containing the target file node where the list of modules will be
 				written.
 	:param source: A single element list containing the source file node to be processed. It should contain
 	 			only the zipfile from which the '.pyc' files will be listed.
-	:param env: The SCons environment context under which this function is executed. This parameter provides 
+	:param env: The SCons environment context under which this function is executed. This parameter provides
 				access to SCons construction variables, methods, and tools.
 	:return: None. The function does not return anything but writes the list of modules to the target file.
-	:raises ValueError: If the specified sanity check module (e.g., 'NVDAObjects.UIA') is not found in the 
+	:raises ValueError: If the specified sanity check module (e.g., 'NVDAObjects.UIA') is not found in the
 						list of modules extracted from the zipfile.
 	:raises FileNotFoundError: If the specified zipfile in `source` does not exist.
 	"""

--- a/site_scons/site_tools/listModules.py
+++ b/site_scons/site_tools/listModules.py
@@ -40,10 +40,10 @@ def _generateModuleList(
 
 	# Convert the file paths to python module format
 	# eg: NVDAObjects/IAccessible/__init__.pyc --> NVDAObjects.IAccessible
-	importedModules = sorted(set([
+	importedModules = sorted({
 		re.sub(r"(.__init__|.__version__|._version)?\.pyc$", "", module_path).replace("/", ".")
 		for module_path in pycFiles
-	]))
+	})
 
 	# Sanity check for something guaranteed to be in library.zip
 	if "NVDAObjects.UIA" not in importedModules:

--- a/site_scons/site_tools/listModules.py
+++ b/site_scons/site_tools/listModules.py
@@ -1,7 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2010-2024 NV Access Limited, James Teh, Michael Curran, Peter Vágner, Joseph Lee,
-# Reef Turner, Babbage B.V., Leonard de Ruijter, Łukasz Golonka, Accessolutions, Julien Cochuyt,
-# Cyrille Bougot, Gerald Hartig
+# Copyright (C) 2024 NV Access Limited
 # This file may be used under the terms of the GNU General Public License, version 2 or later.
 # For more details see: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -27,8 +25,8 @@ def _generateModuleList(
 
 	:param target: A single element list containing the target file node where the list of modules will be
 				written.
-	:param source: A single element list containing the source file node to be processed. It should contain
-				only the zipfile from which the '.pyc' files will be listed.
+	:param source: A single element list containing the source NVDA dist folder to be processed.
+	The folder should contain `library.zip` from which the '.pyc' files will be listed.
 	:param env: The SCons environment context under which this function is executed. This parameter provides
 				access to SCons construction variables, methods, and tools.
 	:return: None. The function does not return anything but writes the list of modules to the target file.
@@ -37,7 +35,7 @@ def _generateModuleList(
 	:raises FileNotFoundError: If the specified zipfile in `source` does not exist.
 	"""
 	# List all .pyc files in the library.zip
-	libraryZipPath = str(source[0])
+	libraryZipPath = os.path.join(source[0].path, "library.zip")
 	if not os.path.exists(libraryZipPath):
 		raise FileNotFoundError(f"The zipfile {libraryZipPath} does not exist.")
 	pycFiles = [f for f in zipfile.ZipFile(libraryZipPath, "r").namelist() if f.endswith(".pyc")]

--- a/site_scons/site_tools/listModules.py
+++ b/site_scons/site_tools/listModules.py
@@ -18,18 +18,22 @@ def _generateModuleList(
 		source: list[SCons.Node.FS.File],
 		env: SCons.Environment.Environment
 ) -> None:
-	""" 
+	"""
 	Generate a list of Python modules from compiled '.pyc' files within a specified zipfile.
 
 	This function lists all '.pyc' files contained in a given zipfile, converts their paths to Python module
 	format, performs a sanity check to ensure a specific module is present, and then writes the list of
 	modules to a specified output file for packaging as an AppVeyor artefact.
 
-	:param target: A single element list containing the target file node where the list of modules will be written.
-	:param source: A single element list containing the source file node to be processed. It should contain only the zipfile from which the '.pyc' files will be listed.
-	:param env: The SCons environment context under which this function is executed. This parameter provides access to SCons construction variables, methods, and tools.
+	:param target: A single element list containing the target file node where the list of modules will be 
+				written.
+	:param source: A single element list containing the source file node to be processed. It should contain
+	 			only the zipfile from which the '.pyc' files will be listed.
+	:param env: The SCons environment context under which this function is executed. This parameter provides 
+				access to SCons construction variables, methods, and tools.
 	:return: None. The function does not return anything but writes the list of modules to the target file.
-	:raises ValueError: If the specified sanity check module (e.g., 'NVDAObjects.UIA') is not found in the list of modules extracted from the zipfile.
+	:raises ValueError: If the specified sanity check module (e.g., 'NVDAObjects.UIA') is not found in the 
+						list of modules extracted from the zipfile.
 	:raises FileNotFoundError: If the specified zipfile in `source` does not exist.
 	"""
 	# List all .pyc files in the library.zip

--- a/site_scons/site_tools/listModules.py
+++ b/site_scons/site_tools/listModules.py
@@ -1,0 +1,64 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2010-2024 NV Access Limited, James Teh, Michael Curran, Peter Vágner, Joseph Lee,
+# Reef Turner, Babbage B.V., Leonard de Ruijter, Łukasz Golonka, Accessolutions, Julien Cochuyt,
+# Cyrille Bougot, Gerald Hartig
+# This file may be used under the terms of the GNU General Public License, version 2 or later.
+# For more details see: https://www.gnu.org/licenses/gpl-2.0.html
+
+
+import os
+import re
+import zipfile
+
+import SCons
+
+
+def _generateModuleList(
+		target: list[SCons.Node.FS.File],
+		source: list[SCons.Node.FS.File],
+		env: SCons.Environment.Environment
+) -> None:
+	""" 
+	Generate a list of Python modules from compiled '.pyc' files within a specified zipfile.
+
+	This function lists all '.pyc' files contained in a given zipfile, converts their paths to Python module
+	format, performs a sanity check to ensure a specific module is present, and then writes the list of
+	modules to a specified output file for packaging as an AppVeyor artefact.
+
+	:param target: A single element list containing the target file node where the list of modules will be written.
+	:param source: A single element list containing the source file node to be processed. It should contain only the zipfile from which the '.pyc' files will be listed.
+	:param env: The SCons environment context under which this function is executed. This parameter provides access to SCons construction variables, methods, and tools.
+	:return: None. The function does not return anything but writes the list of modules to the target file.
+	:raises ValueError: If the specified sanity check module (e.g., 'NVDAObjects.UIA') is not found in the list of modules extracted from the zipfile.
+	:raises FileNotFoundError: If the specified zipfile in `source` does not exist.
+	"""
+	# List all .pyc files in the library.zip
+	libraryZipPath = str(source[0])
+	if not os.path.exists(libraryZipPath):
+		raise FileNotFoundError(f"The zipfile {libraryZipPath} does not exist.")
+	pycFiles = [f for f in zipfile.ZipFile(libraryZipPath, "r").namelist() if f.endswith(".pyc")]
+
+	# Convert the file paths to python module format
+	# eg: NVDAObjects/IAccessible/__init__.pyc --> NVDAObjects.IAccessible
+	importedModules = sorted(set([
+		re.sub(r"(.__init__|.__version__|._version)?\.pyc$", "", module_path).replace("/", ".")
+		for module_path in pycFiles
+	]))
+
+	# Sanity check for something guaranteed to be in library.zip
+	if "NVDAObjects.UIA" not in importedModules:
+		raise ValueError(f"Expected module NVDAObjects.UIA not found in the zipfile.")
+
+	# Store the list to file
+	with open(str(target[0]), "w", encoding="utf-8") as file:
+		file.write("\n".join(importedModules))
+
+
+def generate(env):
+	env["BUILDERS"]["GenerateModuleList"] = \
+		SCons.Builder.Builder(
+			action=SCons.Action.Action(_generateModuleList))
+
+
+def exists(env):
+    return True

--- a/site_scons/site_tools/listModules.py
+++ b/site_scons/site_tools/listModules.py
@@ -13,20 +13,20 @@ import SCons
 
 def _generateModuleList(
 		target: list[SCons.Node.FS.File],
-		source: list[SCons.Node.FS.File],
+		source: list[SCons.Node.FS.Dir],
 		env: SCons.Environment.Environment
 ) -> None:
 	"""
-	Generate a list of Python modules from compiled '.pyc' files within a specified zipfile.
+	Generate a list of Python modules from compiled '.pyc' files within `library.zip` in the source folder.
 
-	This function lists all '.pyc' files contained in a given zipfile, converts their paths to Python module
+	This function lists all '.pyc' files contained in `library.zip`, converts their paths to Python module
 	format, performs a sanity check to ensure a specific module is present, and then writes the list of
 	modules to a specified output file for packaging as an AppVeyor artefact.
 
 	:param target: A single element list containing the target file node where the list of modules will be
 				written.
 	:param source: A single element list containing the source NVDA dist folder to be processed.
-	The folder should contain `library.zip` from which the '.pyc' files will be listed.
+				The folder should contain `library.zip` from which the '.pyc' files will be listed.
 	:param env: The SCons environment context under which this function is executed. This parameter provides
 				access to SCons construction variables, methods, and tools.
 	:return: None. The function does not return anything but writes the list of modules to the target file.

--- a/site_scons/site_tools/listModules.py
+++ b/site_scons/site_tools/listModules.py
@@ -47,18 +47,18 @@ def _generateModuleList(
 
 	# Sanity check for something guaranteed to be in library.zip
 	if "NVDAObjects.UIA" not in importedModules:
-		raise ValueError(f"Expected module NVDAObjects.UIA not found in the zipfile.")
+		raise ValueError("Expected module NVDAObjects.UIA not found in the zipfile.")
 
 	# Store the list to file
 	with open(str(target[0]), "w", encoding="utf-8") as file:
 		file.write("\n".join(importedModules))
 
 
-def generate(env):
+def generate(env: SCons.Environment.Environment):
 	env["BUILDERS"]["GenerateModuleList"] = \
 		SCons.Builder.Builder(
 			action=SCons.Action.Action(_generateModuleList))
 
 
-def exists(env):
+def exists(env: SCons.Environment.Environment) -> bool:
     return True


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Fixes https://github.com/nvaccess/nvda/issues/15971

### Summary of the issue:
List the Python standard library modules included in nvda's binary builds as an AppVeyor artefact

### Description of user facing changes
None

### Description of development approach

- Added a new function to sconstruct
- Hooked the new function to "dist" using env.Depends()
- Located the new file in output\ so that it is automatically picked up by AppVeyor

### Testing strategy:
Executed `scons dist` and confirmed the creation of the output file.

### Known issues with pull request:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
