### PR TITLE
If command for report the note on the current Excel cell pressed twice, presents the information in browse mode

### DIFF
--- a/source/NVDAObjects/window/excel.py
+++ b/source/NVDAObjects/window/excel.py
@@ -1692,6 +1692,7 @@ class ExcelCell(ExcelBase):
 		commentObj=self.excelCellObject.comment
 		text=commentObj.text() if commentObj else None
 		if text:
+			repeats = scriptHandler.getLastScriptRepeatCount()
 			if repeats == 0:
 				ui.message(text)
 			elif repeats == 1:

--- a/source/NVDAObjects/window/excel.py
+++ b/source/NVDAObjects/window/excel.py
@@ -1680,7 +1680,7 @@ class ExcelCell(ExcelBase):
 	# Thus, messages dialog title and so on should refer to notes.
 	@script(
 		description=_(
-			# Translators: the description  for a script for Excel
+			# Translators: the description for a script for Excel
 			"Reports the note on the current cell. "
 			"If pressed twice, presents the information in browse mode"
 		),

--- a/source/NVDAObjects/window/excel.py
+++ b/source/NVDAObjects/window/excel.py
@@ -1679,8 +1679,11 @@ class ExcelCell(ExcelBase):
 	# In Office 2016, 365 and newer, comments are now called notes.
 	# Thus, messages dialog title and so on should refer to notes.
 	@script(
-		# Translators: the description  for a script for Excel
-		description=_("Reports the note on the current cell"),
+		description=_(
+			# Translators: the description  for a script for Excel
+			"Reports the note on the current cell. "
+			"If pressed twice, presents the information in browse mode"
+		),
 		gesture="kb:NVDA+alt+c",
 		category=SCRCAT_SYSTEMCARET,
 		speakOnDemand=True,
@@ -1689,7 +1692,14 @@ class ExcelCell(ExcelBase):
 		commentObj=self.excelCellObject.comment
 		text=commentObj.text() if commentObj else None
 		if text:
-			ui.message(text)
+			if repeats == 0:
+				ui.message(text)
+			elif repeats == 1:
+				ui.browseableMessage(
+					text,
+					# Translators: title for note on the current Excel cell dialog.
+					_("Note")
+				)
 		else:
 			# Translators: A message in Excel when there is no note
 			ui.message(_("Not on a note"))

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -11,7 +11,7 @@ What's New in NVDA
 
 == Changes ==
 - Microsoft Office:
-  - When the command to report the note of the current Excel cell is located is pressed twice  (``NVDA+alt+c``), the information is presented browse mode. (#15986, @tseykovets)
+  - Excel: When "report any notes for the currently focused cell" (NVDA+alt+c) is pressed twice, the information is shown in a window. (#15986, @tseykovets)
   -
 -
 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -11,7 +11,8 @@ What's New in NVDA
 
 == Changes ==
 - Microsoft Office:
-  - When command for report the note on the current Excel cell (NVDA+Alt+C) pressed twice, presents the information in browse mode.
+  - When the command to report the note of the current Excel cell is located is pressed twice  (``NVDA+alt+c``), the information is presented browse mode.
+  -
 -
 
 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -11,7 +11,7 @@ What's New in NVDA
 
 == Changes ==
 - Microsoft Office:
-  - When the command to report the note of the current Excel cell is located is pressed twice  (``NVDA+alt+c``), the information is presented browse mode.
+  - When the command to report the note of the current Excel cell is located is pressed twice  (``NVDA+alt+c``), the information is presented browse mode. (#15986, @tseykovets)
   -
 -
 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -10,6 +10,9 @@ What's New in NVDA
 
 
 == Changes ==
+- Microsoft Office:
+  - When command for report the note on the current Excel cell (NVDA+Alt+C) pressed twice, presents the information in browse mode.
+-
 
 
 == Bug Fixes ==

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -1255,7 +1255,7 @@ Selecting a form field and pressing enter or the Move to button moves to that fi
 
 +++ Reporting Notes +++[ExcelReportingComments]
 %kc:beginInclude
-To report any notes for the currently focused cell, press NVDA+alt+c.
+To report any notes for the currently focused cell, press NVDA+alt+c. Pressing twice shows the information in a window.
 In Microsoft 2016, 365 and newer, the classic comments in Microsoft Excel have been renamed to "notes".
 %kc:endInclude
 All notes for the worksheet can also be listed in the NVDA Elements List after pressing NVDA+f7.

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -1255,7 +1255,8 @@ Selecting a form field and pressing enter or the Move to button moves to that fi
 
 +++ Reporting Notes +++[ExcelReportingComments]
 %kc:beginInclude
-To report any notes for the currently focused cell, press NVDA+alt+c. Pressing twice shows the information in a window.
+To report any notes for the currently focused cell, press ``NVDA+alt+c``.
+Pressing twice shows the information in a window.
 In Microsoft 2016, 365 and newer, the classic comments in Microsoft Excel have been renamed to "notes".
 %kc:endInclude
 All notes for the worksheet can also be listed in the NVDA Elements List after pressing NVDA+f7.


### PR DESCRIPTION
### Link to issue number:

This is a minor change that improves one command for Microsoft Excel.

### Summary of the issue:

The text of cell notes often contains important voluminous information that is difficult to perceive in the mode of pronouncing a full phrase.

This pull request adds the ability to present the text of a note in browse mode by pressing command twice (NVDA+Alt+C).

### Description of user facing changes

The previously existing command for Microsoft Excel (NVDA+Alt+C) gained additional functionality when it is pressed twice.

### Description of development approach

* A handler for the number of presses has been added to the script (if repeats).
* If pressed twice, presents the information in browse mode (ui.browseableMessage).

### Testing strategy:

To test, just press the NVDA+Alkt+C command twice on the cell with the note.

The changes do not contain new code to interact with the operating system and Excel application.

### Known issues with pull request:

No issues known.
Since the change does not contain new code to interact with the operating system and Excel application, it is not expected to affect any other functionality of NVDA.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
