### PR TITLE
If command for report the Word comment pressed twice, presents the information in browse mode

### DIFF
--- a/source/NVDAObjects/IAccessible/winword.py
+++ b/source/NVDAObjects/IAccessible/winword.py
@@ -317,8 +317,11 @@ class WordDocument(IAccessible, EditableTextWithoutAutoSelectDetection, winWordW
 		braille.handler.handleCaretMove(self)
 
 	@script(
-		# Translators: a description for a script
-		description=_("Reports the text of the comment where the system caret is located."),
+		description=_(
+			# Translators: a description for a script
+			"Reports the text of the comment where the system caret is located."
+			" If pressed twice, presents the information in browse mode"
+		),
 		gesture="kb:NVDA+alt+c",
 		category=SCRCAT_SYSTEMCARET,
 		speakOnDemand=True,
@@ -338,7 +341,14 @@ class WordDocument(IAccessible, EditableTextWithoutAutoSelectDetection, winWordW
 					except COMError:
 						break
 					if text:
-						ui.message(text)
+						if repeats == 0:
+							ui.message(text)
+						elif repeats == 1:
+							ui.browseableMessage(
+								text,
+								# Translators: title for Word comment dialog.
+								_("Comment")
+							)
 						return
 		# Translators: a message when there is no comment to report in Microsoft Word
 		ui.message(_("No comments"))

--- a/source/NVDAObjects/IAccessible/winword.py
+++ b/source/NVDAObjects/IAccessible/winword.py
@@ -341,6 +341,7 @@ class WordDocument(IAccessible, EditableTextWithoutAutoSelectDetection, winWordW
 					except COMError:
 						break
 					if text:
+						repeats = scriptHandler.getLastScriptRepeatCount()
 						if repeats == 0:
 							ui.message(text)
 						elif repeats == 1:

--- a/source/NVDAObjects/UIA/wordDocument.py
+++ b/source/NVDAObjects/UIA/wordDocument.py
@@ -598,8 +598,11 @@ class WordDocument(UIADocumentWithTableNavigation,WordDocumentNode,WordDocumentB
 
 	@script(
 		gesture="kb:NVDA+alt+c",
-		# Translators: a description for a script that reports the comment at the caret.
-		description=_("Reports the text of the comment where the system caret is located."),
+		description=_(
+			# Translators: a description for a script that reports the comment at the caret.
+			"Reports the text of the comment where the system caret is located."
+			" If pressed twice, presents the information in browse mode"
+		),
 		category=SCRCAT_SYSTEMCARET,
 		speakOnDemand=True,
 	)
@@ -607,7 +610,15 @@ class WordDocument(UIADocumentWithTableNavigation,WordDocumentNode,WordDocumentB
 		caretInfo=self.makeTextInfo(textInfos.POSITION_CARET)
 		commentInfo = getCommentInfoFromPosition(caretInfo)
 		if commentInfo is not None:
-			ui.message(getPresentableCommentInfoFromPosition(commentInfo))
+			text = getPresentableCommentInfoFromPosition(commentInfo)
+			if repeats == 0:
+				ui.message(text)
+			elif repeats == 1:
+				ui.browseableMessage(
+					text,
+					# Translators: title for Word comment dialog.
+					_("Comment")
+				)
 		else:
 			# Translators: a message when there is no comment to report in Microsoft Word
 			ui.message(_("No comments"))

--- a/source/NVDAObjects/UIA/wordDocument.py
+++ b/source/NVDAObjects/UIA/wordDocument.py
@@ -12,6 +12,7 @@ import enum
 from comtypes import COMError
 import winVersion
 import mathPres
+import scriptHandler
 from scriptHandler import isScriptWaiting
 import textInfos
 import UIAHandler
@@ -611,6 +612,7 @@ class WordDocument(UIADocumentWithTableNavigation,WordDocumentNode,WordDocumentB
 		commentInfo = getCommentInfoFromPosition(caretInfo)
 		if commentInfo is not None:
 			text = getPresentableCommentInfoFromPosition(commentInfo)
+			repeats = scriptHandler.getLastScriptRepeatCount()
 			if repeats == 0:
 				ui.message(text)
 			elif repeats == 1:

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -11,7 +11,7 @@ What's New in NVDA
 
 == Changes ==
 - Microsoft Office:
-  - When the command to report the text of the Word comment where the System caret is located is pressed twice  (``NVDA+alt+c``), the information is presented browse mode.
+  - When the command to report the text of the Word comment where the System caret is located is pressed twice  (``NVDA+alt+c``), the information is presented browse mode. (#15987, @tseykovets)
   -
 -
 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -10,6 +10,9 @@ What's New in NVDA
 
 
 == Changes ==
+- Microsoft Office:
+  - When command for report the text of the Word comment where the System caret is located (NVDA+Alt+C) pressed twice, presents the information in browse mode.
+-
 
 
 == Bug Fixes ==

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -11,7 +11,8 @@ What's New in NVDA
 
 == Changes ==
 - Microsoft Office:
-  - When command for report the text of the Word comment where the System caret is located (NVDA+Alt+C) pressed twice, presents the information in browse mode.
+  - When the command to report the text of the Word comment where the System caret is located is pressed twice  (``NVDA+alt+c``), the information is presented browse mode.
+  -
 -
 
 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -11,7 +11,7 @@ What's New in NVDA
 
 == Changes ==
 - Microsoft Office:
-  - When the command to report the text of the Word comment where the System caret is located is pressed twice  (``NVDA+alt+c``), the information is presented browse mode. (#15987, @tseykovets)
+  - Word: When "report any comments at the current caret position" (NVDA+alt+c) is pressed twice, the information is shown in a window. (#15987, @tseykovets)
   -
 -
 

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -1212,7 +1212,7 @@ The Elements List can list headings, links, annotations (which includes comments
 
 +++ Reporting Comments +++[WordReportingComments]
 %kc:beginInclude
-To report any comments at the current caret position, press NVDA+alt+c.
+To report any comments at the current caret position, press NVDA+alt+c. Pressing twice shows the information in a window.
 %kc:endInclude
 All comments for the document, along with other tracked changes, can also be listed in the NVDA Elements List  when selecting Annotations as the type.
 

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -1212,7 +1212,8 @@ The Elements List can list headings, links, annotations (which includes comments
 
 +++ Reporting Comments +++[WordReportingComments]
 %kc:beginInclude
-To report any comments at the current caret position, press NVDA+alt+c. Pressing twice shows the information in a window.
+To report any comments at the current caret position, press ``NVDA+alt+c``.
+Pressing twice shows the information in a window.
 %kc:endInclude
 All comments for the document, along with other tracked changes, can also be listed in the NVDA Elements List  when selecting Annotations as the type.
 


### PR DESCRIPTION
### Link to issue number:

This is a minor change that improves one command for Microsoft Word.

### Summary of the issue:

The text of comments often contains important voluminous information that is difficult to perceive in the mode of pronouncing a full phrase.

This pull request adds the ability to present the text of a comment in browse mode by pressing command twice (NVDA+Alt+C).

### Description of user facing changes

The previously existing command for Microsoft Word (NVDA+Alt+C) gained additional functionality when it is pressed twice.

### Description of development approach

* A handler for the number of presses has been added to the script (if repeats).
* If pressed twice, presents the information in browse mode (ui.browseableMessage).

### Testing strategy:

To test, just press the NVDA+Alt+C command twice on the comment.

The changes do not contain new code to interact with the operating system and Word application.

### Known issues with pull request:

No issues known.
Since the change does not contain new code to interact with the operating system and Word application, it is not expected to affect any other functionality of NVDA.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
