### PR TITLE
Focus tab title instead of panel switching tabs in add-on store

### DIFF
--- a/source/gui/addonStoreGui/controls/storeDialog.py
+++ b/source/gui/addonStoreGui/controls/storeDialog.py
@@ -334,20 +334,20 @@ class AddonStoreDialog(SettingsDialog):
 
 	def onListTabPageChange(self, evt: wx.EVT_CHOICE):
 		self.searchFilterCtrl.SetValue("")
-
 		self._storeVM._filterEnabledDisabled = EnabledStatus.ALL
 		self.enabledFilterCtrl.SetSelection(0)
-
 		self._storeVM._filteredStatusKey = self._statusFilterKey
 		self.addonListView._refreshColumns()
 		self._toggleFilterControls()
-
 		channelFilterIndex = list(_channelFilters.keys()).index(self._storeVM._filterChannelKey)
 		self.channelFilterCtrl.SetSelection(channelFilterIndex)
 		self._storeVM.listVM.setSelection(None)
 		self._setListLabels()
 		self._storeVM.refresh()
 		self.Layout()
+		# avoid erratic focus on the contained panel
+		if not self.addonListTabs.HasFocus():
+			self.addonListTabs.SetFocus()
 
 	def onChannelFilterChange(self, evt: wx.EVT_CHOICE):
 		self._storeVM._filterChannelKey = self._channelFilterKey

--- a/source/gui/addonStoreGui/controls/storeDialog.py
+++ b/source/gui/addonStoreGui/controls/storeDialog.py
@@ -334,11 +334,14 @@ class AddonStoreDialog(SettingsDialog):
 
 	def onListTabPageChange(self, evt: wx.EVT_CHOICE):
 		self.searchFilterCtrl.SetValue("")
+
 		self._storeVM._filterEnabledDisabled = EnabledStatus.ALL
 		self.enabledFilterCtrl.SetSelection(0)
+
 		self._storeVM._filteredStatusKey = self._statusFilterKey
 		self.addonListView._refreshColumns()
 		self._toggleFilterControls()
+
 		channelFilterIndex = list(_channelFilters.keys()).index(self._storeVM._filterChannelKey)
 		self.channelFilterCtrl.SetSelection(channelFilterIndex)
 		self._storeVM.listVM.setSelection(None)

--- a/source/gui/addonStoreGui/controls/storeDialog.py
+++ b/source/gui/addonStoreGui/controls/storeDialog.py
@@ -345,6 +345,7 @@ class AddonStoreDialog(SettingsDialog):
 		self._setListLabels()
 		self._storeVM.refresh()
 		self.Layout()
+
 		# avoid erratic focus on the contained panel
 		if not self.addonListTabs.HasFocus():
 			self.addonListTabs.SetFocus()

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -105,6 +105,7 @@ Users of Poedit 1 are encouraged to update to Poedit 3 if they want to rely on e
   - When reinstalling an incompatible add-on it is no longer forcefully disabled. (#15584, @lukaszgo1)
   - Disabled and incompatible add-ons can now be updated. (#15568, #15029)
   - NVDA now recovers and displays an error in a case where an add-on fails to download correctly. (#15796)
+  - When pressing ctrl+tab, focus properly moves to the new current tab title. (#14986, @ABuffEr)
   -
 - Audio:
   - NVDA no longer freezes briefly when multiple sounds are played in rapid succession. (#15311, #15757, @jcsteh)

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -16,7 +16,7 @@ What's New in NVDA
 - Backspace now works correctly when using Nudi 6.1 with NVDA's "Handle keys from other applications" setting enabled. (#15822, @jcsteh)
 - Fixed a bug where audio coordinates would be played while the application is in sleep mode when "Play audio coordinates when mouse moves" is enabled. (#8059, @hwf1324)
 - Add-on Store:
-  - When pressing ctrl+tab, focus properly moves to the new current tab title. (#14986, @ABuffEr)
+  - When pressing ``ctrl+tab``, focus properly moves to the new current tab title. (#14986, @ABuffEr)
   -
 -
 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -15,6 +15,9 @@ What's New in NVDA
 == Bug Fixes ==
 - Backspace now works correctly when using Nudi 6.1 with NVDA's "Handle keys from other applications" setting enabled. (#15822, @jcsteh)
 - Fixed a bug where audio coordinates would be played while the application is in sleep mode when "Play audio coordinates when mouse moves" is enabled. (#8059, @hwf1324)
+- Add-on Store:
+  - When pressing ctrl+tab, focus properly moves to the new current tab title. (#14986, @ABuffEr)
+  -
 -
 
 
@@ -105,7 +108,6 @@ Users of Poedit 1 are encouraged to update to Poedit 3 if they want to rely on e
   - When reinstalling an incompatible add-on it is no longer forcefully disabled. (#15584, @lukaszgo1)
   - Disabled and incompatible add-ons can now be updated. (#15568, #15029)
   - NVDA now recovers and displays an error in a case where an add-on fails to download correctly. (#15796)
-  - When pressing ctrl+tab, focus properly moves to the new current tab title. (#14986, @ABuffEr)
   -
 - Audio:
   - NVDA no longer freezes briefly when multiple sounds are played in rapid succession. (#15311, #15757, @jcsteh)


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:

See discussion in #14986

### Summary of the issue:

Switching tabs in add-on store with ctrl+tab announces "tab control panel", and moves the focus in a strange position.

### Description of user facing changes

Users will be positioned on tab list, over the new current tab, that will be read by NVDA.

### Description of development approach

Simply SetFocus on addonListTabs (wx.Notebook) if it's not already here, at the end of page change event handler.

### Testing strategy:

Manual, with steps in #14986.

### Known issues with pull request:

It's a partial fix, as discussed in #14986, because it doesn't move focus to a panel element like the channel filter or the add-on list, that seems unreasonably complex to reach. But it's certainly better than nothing/current situation.

Being a small but very perceptible change, I suggest to integrate into 2024.1, and only later to work on another better solution.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [ ] Security precautions taken.
