### PR TITLE
winVersion.WinVersion: return "Windows 11 unknown" if an unknown build above 10.0.22000 is seen when instantiating

### DIFF
--- a/source/winVersion.py
+++ b/source/winVersion.py
@@ -105,18 +105,22 @@ class WinVersion(object):
 		On server systems, unless noted otherwise, client release names will be returned.
 		For example, 'Windows 10 1809' will be returned on Server 2019 systems.
 		"""
-		if (self.major, self.minor) == (6, 3):
-			return "Windows 8.1"
-		elif self.major == 10:
-			# From Version 1511 (build 10586), release Id/display version comes from Windows Registry.
+		match (self.major, self.minor):
+			case (6, 3):
+				return "Windows 8.1"
+			# From Windows 10 1511 (build 10586), release Id/display version comes from Windows Registry.
 			# However there are builds with no release name (Version 1507/10240)
 			# or releases with different builds.
 			# Look these up first before asking Windows Registry.
-			if self.build in _BUILDS_TO_RELEASE_NAMES:
+			case (10, 0) if self.build in _BUILDS_TO_RELEASE_NAMES:
 				return _BUILDS_TO_RELEASE_NAMES[self.build]
-			return "Windows 10 unknown"
-		else:
-			return "Windows release unknown"
+			# #15992: 10.0.22000 or later is Windows 11.
+			case (10, 0) if self.build >= 22000:
+				return "Windows 11 unknown"
+			case (10, 0):
+				return "Windows 10 unknown"
+			case _:
+				return "Windows release unknown"
 
 	def __repr__(self):
 		winVersionText = [self.releaseName]

--- a/source/winVersion.py
+++ b/source/winVersion.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2006-2023 NV Access Limited, Bill Dengler, Joseph Lee
+# Copyright (C) 2006-2024 NV Access Limited, Bill Dengler, Joseph Lee
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 

--- a/source/winVersion.py
+++ b/source/winVersion.py
@@ -10,7 +10,7 @@ making sure NVDA can run on a minimum supported version of Windows.
 When working on this file, consider moving to winAPI.
 """
 
-from typing import Optional, Dict, Any
+from typing import Any
 import sys
 import os
 import functools
@@ -23,7 +23,7 @@ from logHandler import log
 # Records a mapping between Windows builds and release names.
 # These include build 10240 for Windows 10 1507 and releases with multiple release builds.
 # These are applicable to Windows 10 and later as they report the same system version (10.0).
-_BUILDS_TO_RELEASE_NAMES: Dict[int, str] = {
+_BUILDS_TO_RELEASE_NAMES: dict[int, str] = {
 	10240: "Windows 10 1507",
 	10586: "Windows 10 1511",
 	14393: "Windows 10 1607",
@@ -81,7 +81,7 @@ class WinVersion(object):
 			major: int = 0,
 			minor: int = 0,
 			build: int = 0,
-			releaseName: Optional[str] = None,
+			releaseName: str | None = None,
 			servicePack: str = "",
 			productType: str = "",
 			processorArchitecture: str = ""

--- a/tests/unit/test_winVersion.py
+++ b/tests/unit/test_winVersion.py
@@ -1,7 +1,7 @@
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-# Copyright (C) 2021-2022 NV Access Limited, Joseph Lee
+# Copyright (C) 2021-2024 NV Access Limited, Joseph Lee
 
 """Unit tests for the Windows version module."""
 
@@ -85,3 +85,12 @@ class TestWinVersion(unittest.TestCase):
 		# Use os.environ to guard against platform.machine() giving odd results.
 		actualArchitecture = os.environ.get("PROCESSOR_ARCHITEW6432", os.environ["PROCESSOR_ARCHITECTURE"])
 		self.assertEqual(winVersion.getWinVer().processorArchitecture, actualArchitecture)
+
+	def test_winVerUnknownWin11BuildToReleaseName(self):
+		# Despite system version being 10.0, build 22000 or later is Windows 11.
+		# See if build 25398 (zinc milestone) is recognized as a Windows 11 "unknown" release.
+		zincMajor, zincMinor, zincBuild = 10, 0, 25398
+		win11ZincInfo = winVersion.WinVersion(
+			major=zincMajor, minor=zincMinor, build=zincBuild
+		)
+		self.assertEqual(win11ZincInfo.releaseName, "Windows 11 unknown")

--- a/tests/unit/test_winVersion.py
+++ b/tests/unit/test_winVersion.py
@@ -31,10 +31,10 @@ class TestWinVersion(unittest.TestCase):
 
 	def test_moreRecentWinVer(self):
 		# Specifically to test operators.
-		minimumWinVer = winVersion.WIN7_SP1
-		audioDuckingAvailable = winVersion.WIN8
+		minimumWinVer = winVersion.WIN81
+		emojiPanelIntroduced = winVersion.WIN10_1709
 		self.assertGreaterEqual(
-			audioDuckingAvailable, minimumWinVer
+			emojiPanelIntroduced, minimumWinVer
 		)
 
 	def test_winVerKnownReleaseNameForWinVersionConstant(self):

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -21,6 +21,9 @@ What's New in NVDA
 == Changes for Developers ==
 Please refer to [the developer guide https://www.nvaccess.org/files/nvda/documentation/developerGuide.html#API] for information on NVDA's API deprecation and removal process.
 
+- Instantiating ``winVersion.WinVersion`` objects with unknown Windows versions above 10.0.22000 such as 10.0.25398 returns "Windows 11 unknown" instead of "Windows 10 unknown" for release name. (#15992, @josephsl)
+-
+
 === Deprecations ===
 
 


### PR DESCRIPTION

### Link to issue number:
Closes #15992

### Summary of the issue:
When an unknown build above 10.0.22000 is instantiated, winVersion.WinVersion says "Windows 10 unknown".

### Description of user facing changes
None

### Description of development approach
Using structural pattern matching, say "Windows 11 unknown" if major == 10, minor == 0, build >= 22000 and the build is not recorded in builds to release names private map. This PR also includes modernized type hints and a unit test for this issue.

### Testing strategy:
Manual and unit tests:

* Manual: instantiate winVersion.WinVersion class with major = 10, minor = 0, and a build that is not a public build (21390, 22635, 25398, for instance) and observe that "Windows 11 unknown" is returned as release name if build is 22000 or above.
* Unit test: an example of a build that is meant for specialized workloads such as Windows Server 23H2 annual container release (build 25398) with no PC version is provided.

### Known issues with pull request:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

### Note:
Changelog for this PR is listed under "changes for developers" section.

Thanks.