### PR TITLE
Fix status reporting of speech modes checkboxes

### DIFF
--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -1689,7 +1689,7 @@ class VoiceSettingsPanel(AutoSettingsMixin, SettingsPanel):
 
 	def _onSpeechModesListChange(self, evt: wx.CommandEvent):
 		# continue event propagation to custom control event handler
-		# to guarantee checkbox status notify
+		# to guarantee user is notified about checkbox being checked or unchecked
 		evt.Skip()
 		if (
 			evt.GetInt() == self._allSpeechModes.index(speech.SpeechMode.talk)

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -1688,6 +1688,9 @@ class VoiceSettingsPanel(AutoSettingsMixin, SettingsPanel):
 		]
 
 	def _onSpeechModesListChange(self, evt: wx.CommandEvent):
+		# continue event propagation to custom control event handler
+		# to guarantee checkbox status notify
+		evt.Skip()
 		if (
 			evt.GetInt() == self._allSpeechModes.index(speech.SpeechMode.talk)
 			and not self.speechModesList.IsChecked(evt.GetInt())


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:

Fixes #16005.

### Summary of the issue:

When enabling/disabling checkboxes in the speech modes list, under voice settings, the new status was not reported by speech or Braille.

### Description of user facing changes

Now user hears "enabled" or "disabled", and gets his Braille display refreshed.

### Description of development approach

PR #15960 has introduced a new handler of EVT_CHECKLISTBOX event for speechModesList.

But this latter is an nvdaControls.CustomCheckListBox, that already defines an handler for that event, to fix specifically this accessibility issue of wx.

So I simply put evt.Skip() at the beginning of new handler, to propagate event to custom control handler.

### Testing strategy:

Manual, with steps of #16005.

I verified also that, unchecking "talk" mode, the warning dialog (introduced by PR #15960) is still shown, and choosing "yes" or "no" the behavior remains coherent (checkbox disabled answering "yes" to continue, still enabled answering "no").

### Known issues with pull request:

None.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [ ] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [ ] Security precautions taken.
