### PR TITLE
wxGrid support

### DIFF
--- a/source/IAccessibleHandler/__init__.py
+++ b/source/IAccessibleHandler/__init__.py
@@ -758,7 +758,7 @@ def processFocusNVDAEvent(obj, force=False):
 	@return: C{True} if the focus event is valid and was queued, C{False} otherwise.
 	@rtype: boolean
 	"""
-	if not force and obj.role==Role.TABLEROW:
+	if not force and obj.role == Role.TABLEROW:
 		# when the focus changes to another cell within the same table row, the childID is still the same
 		log.debug(f"Forcing IAccessible focus event for table row {obj}")
 		force = True

--- a/source/IAccessibleHandler/__init__.py
+++ b/source/IAccessibleHandler/__init__.py
@@ -758,6 +758,10 @@ def processFocusNVDAEvent(obj, force=False):
 	@return: C{True} if the focus event is valid and was queued, C{False} otherwise.
 	@rtype: boolean
 	"""
+	if not force and obj.role==Role.TABLEROW:
+		# when the focus changes to another cell within the same table row, the childID is still the same
+		log.debug(f"Forcing IAccessible focus event for table row {obj}")
+		force = True
 	if not force and isinstance(obj, NVDAObjects.IAccessible.IAccessible):
 		focus = eventHandler.lastQueuedFocusObject
 		if isinstance(focus, NVDAObjects.IAccessible.IAccessible) and focus.isDuplicateIAccessibleEvent(obj):


### PR DESCRIPTION
### Summary of the issue:
I'm currently working on accessibility support for wxGrid.
This is a generic widget in wxWidgets and therefore does not inherit accessibility support from a native Windows widget.

I'm using a structure as described here: https://learn.microsoft.com/en-us/previous-versions/windows/desktop/dnacc/exposing-data-tables-through-microsoft-active-accessibility

So accessibility support is done via a hierarchy of IAccessible:
```
ROLE_SYSTEM_TABLE
  |- ROLE_SYSTEM_ROW
  |  |- ROLE_SYSTEM_ROWHEADER
  |  |- ROLE_SYSTEM_COLUMNHEADER
  |  |- ROLE_SYSTEM_COLUMNHEADER
  |     '- ..
  |- ROLE_SYSTEM_ROW
  |  |- ROLE_SYSTEM_ROWHEADER
  |  |- ROLE_SYSTEM_CELL
  |  |- ROLE_SYSTEM_CELL
  |   '- ..
  |- ROLE_SYSTEM_ROW
  |  |- ROLE_SYSTEM_ROWHEADER
  |  |- ROLE_SYSTEM_CELL
  |  |- ROLE_SYSTEM_CELL
  |   '- ..
   '- ..
```

I'm using two levels of IAccessible. One for the wxGrid itself and one for grid table rows. The cells just have childIds>0 within the table rows.
(I have also tried three levels, but the problems are the same.)

I have a basic structure running.
E.g. when moving the mouse, NVDA will recognize cells from the results provided by HitTest. It will display Name, Value, Description for the cell, as queried from the row via childId representing the column number.

There are problems, though, when the user is navigating through the grid using the arrow keys.
When the focus is moving to a new cell, I'm sending out `EVENT_OBJECT_FOCUS` like this:
`wxAccessible::NotifyEvent(wxACC_EVENT_OBJECT_FOCUS, this, wxOBJID_CLIENT, objectId);`

One problem is that `objectId` refers to the row number. So, if the user moves from one column to the next, NVDA will just discard the new focus event as it looks identical to the previous one.
This problem could be worked around by a change to `processFocusNVDAEvent`. See my commit.

The other problem is that NVDA will act as if the row is focused, not a cell. So it will just display Name, Value, Description for the row, not for the column.
I have experimented a bit, but could not see how to work around this. The row does not return a status `STATE_SYSTEM_FOCUSED`.
I looked around and added a method `event_gainFocus` to IAccessible.
Inside this, the focused column would be available as `self.IAccessibleObject.accFocus`, but I don't know how to make NVDA actually use this information.


An alternative implementation on the wxWidgets side would be to use only one level of IAccessible with childIds representing cells instead of rows. This seems odd, though.