### PR TITLE
Fix-up of #15864: pluralize battery time reporting string

### DIFF
--- a/source/winAPI/_powerTracking.py
+++ b/source/winAPI/_powerTracking.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2022 NV Access Limited, Rui Batista
+# Copyright (C) 2022 NV Access Limited, Rui Batista, Cyrille Bougot
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -229,9 +229,23 @@ def _getBatteryInformation(systemPowerStatus: SystemPowerStatus) -> List[str]:
 	SECONDS_PER_HOUR = 3600
 	SECONDS_PER_MIN = 60
 	if systemPowerStatus.BatteryLifeTime != BATTERY_LIFE_TIME_UNKNOWN:
-		# Translators: This is the estimated remaining runtime of the laptop battery.
-		text.append(_("{hours:d} hours and {minutes:d} minutes remaining").format(
-			hours=systemPowerStatus.BatteryLifeTime // SECONDS_PER_HOUR,
-			minutes=(systemPowerStatus.BatteryLifeTime % SECONDS_PER_HOUR) // SECONDS_PER_MIN
-		))
+		nHours = systemPowerStatus.BatteryLifeTime // SECONDS_PER_HOUR
+		hourText = ngettext(
+			# Translators: This is the hour string part of the estimated remaining runtime of the laptop battery.
+			# E.g. if the full string is "1 hour and 34 minutes remaining", this string is "1 hour".
+			"{hours:d} hour",
+			"{hours:d} hours",
+			nHours,
+		).format(hours=nHours)
+		nMinutes = (systemPowerStatus.BatteryLifeTime % SECONDS_PER_HOUR) // SECONDS_PER_MIN
+		minuteText = ngettext(
+			# Translators: This is the minute string part of the estimated remaining runtime of the laptop battery.
+			# E.g. if the full string is "1 hour and 34 minutes remaining", this string is "34 minutes".
+			"{minutes:d} minute",
+			"{minutes:d} minutes",
+			nMinutes,
+		).format(minutes=nMinutes)
+		# Translators: This is the main string for the estimated remaining runtime of the laptop battery.
+		# E.g. hourText is replaced by "1 hour" and minuteText by "34 minutes".
+		text.append(_("{hourText} and {minuteText} remaining").format(hourText=hourText, minuteText=minuteText))
 	return text

--- a/tests/unit/test_winAPI/test_powerTracking.py
+++ b/tests/unit/test_winAPI/test_powerTracking.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2022 NV Access Limited
+# Copyright (C) 2022 NV Access Limited, Cyrille Bougot
 # This file may be used under the terms of the GNU General Public License, version 2 or later.
 # For more details see: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -69,7 +69,7 @@ class Test_GetSpeechForBatteryStatus(unittest.TestCase):
 			oldPowerState=PowerState.AC_OFFLINE,
 		)
 		self.assertEqual(
-			['1 percent', '1 hours and 1 minutes remaining', "Unplugged"],
+			['1 percent', '1 hour and 1 minute remaining', "Unplugged"],
 			actualSpeech,
 		)
 
@@ -96,7 +96,7 @@ class Test_GetSpeechForBatteryStatus(unittest.TestCase):
 			oldPowerState=PowerState.AC_OFFLINE,
 		)
 		self.assertEqual(
-			["Plugged in", '1 percent', '1 hours and 1 minutes remaining'],
+			["Plugged in", '1 percent', '1 hour and 1 minute remaining'],
 			actualSpeech,
 		)
 
@@ -110,7 +110,7 @@ class Test_GetSpeechForBatteryStatus(unittest.TestCase):
 			oldPowerState=PowerState.AC_ONLINE,
 		)
 		self.assertEqual(
-			["Unplugged", '1 percent', '1 hours and 1 minutes remaining'],
+			["Unplugged", '1 percent', '1 hour and 1 minute remaining'],
 			actualSpeech,
 		)
 


### PR DESCRIPTION
Note: PR opened against beta since translation freeze has not yet happened and since translators are currently dealing with a lot of pluralization of strings during 2024.1 dev cycle.

### Link to issue number:

Fix-up of #15864.

Reported in [this thread](https://groups.io/g/nvda-translations/topic/103570458?p=Created,,,100,1,0,0::recentpostdate/sticky,,,100,2,0,103570458,previd=1704604492441880319,nextid=1680602778224648690) of the translators mailing list.

### Summary of the issue:
When pluralizing a lot of string in #15864, the one dedicated to battery time reporting was forgotten.

### Description of user facing changes
Battery time estimation will be reported with correct plural forms.

### Description of development approach
Split up the string in subparts and use `ngettext` for hours and for minutes.

### Testing strategy:
Manual test of various hour/minute combinations, forcing `systemPowerStatus.BatteryLifeTime` in the code.

### Known issues with pull request:
None

### Code Review Checklist:


- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
