### PR TITLE
i15653: better handle opening combo boxes in browse mode with automatically focus focusable elements disabled

### DIFF
--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -24,6 +24,7 @@ import mouseHandler
 from logHandler import log
 import documentBase
 import review
+import inputCore
 import scriptHandler
 import eventHandler
 import nvwave
@@ -1502,9 +1503,16 @@ class BrowseModeDocumentTreeInterceptor(documentBase.DocumentWithTableNavigation
 		scriptHandler.queueScript(script, gesture)
 
 	currentExpandedControl=None #: an NVDAObject representing the control that has just been expanded with the collapseOrExpandControl script.
-	def script_collapseOrExpandControl(self, gesture):
+
+	def script_collapseOrExpandControl(self, gesture: inputCore.InputGesture):
 		if not config.conf["virtualBuffers"]["autoFocusFocusableElements"]:
 			self._focusLastFocusableObject()
+			# Give the application time to focus the control.
+			core.callLater(100, self._collapseOrExpandControl_scriptHelper, gesture)
+		else:
+			self._collapseOrExpandControl_scriptHelper(gesture)
+
+	def _collapseOrExpandControl_scriptHelper(self, gesture: inputCore.InputGesture):
 		oldFocus = api.getFocusObject()
 		oldFocusStates = oldFocus.states
 		gesture.send()

--- a/source/virtualBuffers/webKit.py
+++ b/source/virtualBuffers/webKit.py
@@ -49,7 +49,17 @@ class WebKit(VirtualBuffer):
 		super(WebKit,self).__init__(rootNVDAObject,backendName="webKit")
 
 	def __contains__(self,obj):
-		return winUser.isDescendantWindow(self.rootNVDAObject.windowHandle, obj.windowHandle)
+		if not winUser.isDescendantWindow(self.rootNVDAObject.windowHandle, obj.windowHandle):
+			return False
+		# #15653: The list items within combo boxes should not be classed as part of the browse mode document.
+		# Otherwise arrowing to them will switch back to browse mode.
+		if obj.role == controlTypes.Role.STATICTEXT:
+			parent = obj.parent
+			if parent and parent.role == controlTypes.Role.LIST:
+				parent = parent.parent
+				if parent and parent.role == controlTypes.Role.COMBOBOX:
+					return False
+		return True
 
 	def _get_isAlive(self):
 		if self.isLoading:

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -128,7 +128,7 @@ Users of Poedit 1 are encouraged to update to Poedit 3 if they want to rely on e
   -
 - NVDA is again able to track the focus in applications running within Windows Defender Application Guard (WDAG). (#15164)
 - The speech text is no longer updated when the mouse moves in the Speech Viewer. (#15953, @hwf1324)
-- NVDA will again switch back to browse mode when closing combo boxes with escape or alt+upArrow in Firefox or Chrome. (#15653)
+- NVDA will again switch back to browse mode when closing combo boxes with ``escape`` or ``alt+upArrow`` in Firefox or Chrome. (#15653)
 - Arrowing up and down in combo boxes in iTunes will no longer inappropriately switch back to browse mode. (#15653)
 -
 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -128,6 +128,8 @@ Users of Poedit 1 are encouraged to update to Poedit 3 if they want to rely on e
   -
 - NVDA is again able to track the focus in applications running within Windows Defender Application Guard (WDAG). (#15164)
 - The speech text is no longer updated when the mouse moves in the Speech Viewer. (#15953, @hwf1324)
+- NVDA will again switch back to browse mode when closing combo boxes with escape or alt+upArrow in Firefox or Chrome. (#15653)
+- Arrowing up and down in combo boxes in iTunes will no longer inappropriately switch back to browse mode. (#15653)
 -
 
 == Changes for Developers ==


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Fixes #15653

### Summary of the issue:
Two bugs are seen if automatically focus focus elements in browse mode is disabled. Possibly introduced when that setting was introduced, and made worse when browse mode focus code was further refacted in #14611. 
* In iTunes, arrowing up and down inside a combo box incorrectly switches back to browse mode.
* In Firefox / Chrome, closing a combo box does not automatically switch back to browse mode.

### Description of user facing changes
* NVDA will again switch back to browse mode when closing combo boxes with escape or alt+upArrow in Firefox or Chrome. (#15653)
* Arrowing up and down in combo boxes in iTunes will no longer inappropriately switch back to browse mode. (#15653)

### Description of development approach
BrowseModeDocument's collapseOrExpandControl script: if automatic focus focusable elements is disabled, delay the rest of the script to give time for the control to actually get focus.
* Webkit (iTunes) virtualBuffer: do not treat the list items of a combo box as being part of the virtualBuffer.
 
### Testing strategy:
* Followed steps in #15653 and ensured that NVDA did not automatically switch to browse mode when arrowing up and down a combo box in iTunes.
* In both Firefox and Chrome, arrowed to a standard combo box in browse mode, presed alt down arrow, arrowed up and down the combo box, and presse alt+upArrow, and confirmed that NvDA switched back to browse mode.

### Known issues with pull request:
* iTunes combo boxes do not fire focus or statechange events when opening or closing the combo box. So although NvDA now correctly focuses the combo box and manages focus mode and browse mode appropriately, nothing is spoken when opening or closing the combo box. this is a limitation of iTunes and is not new.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
