### PR TITLE
Properly destroy Add-on Store dialog when it is closed

### DIFF
--- a/source/gui/addonStoreGui/controls/storeDialog.py
+++ b/source/gui/addonStoreGui/controls/storeDialog.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2022-2023 NV Access Limited, Cyrille Bougot
+# Copyright (C) 2022-2024 NV Access Limited, Cyrille Bougot, łukasz Golonka
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -86,9 +86,9 @@ class AddonStoreDialog(SettingsDialog):
 			self.addonListTabs.SetSelection(availableTabIndex)
 		self.addonListTabs.Bind(wx.EVT_NOTEBOOK_PAGE_CHANGED, self.onListTabPageChange, self.addonListTabs)
 
-		self.filterCtrlHelper = guiHelper.BoxSizerHelper(self, wx.VERTICAL)
-		self._createFilterControls()
-		tabPageHelper.addItem(self.filterCtrlHelper.sizer, flag=wx.EXPAND)
+		filterCtrlHelper = guiHelper.BoxSizerHelper(self, wx.VERTICAL)
+		self._createFilterControls(filterCtrlHelper)
+		tabPageHelper.addItem(filterCtrlHelper.sizer, flag=wx.EXPAND)
 
 		tabPageHelper.sizer.AddSpacer(5)
 
@@ -141,16 +141,16 @@ class AddonStoreDialog(SettingsDialog):
 		self.banner.SetGradient(normalBgColour, normalBgColour)
 		self.settingsSizer.Add(self.banner, flag=wx.CENTER)
 
-	def _createFilterControls(self):
+	def _createFilterControls(self, filterCtrlHelper: guiHelper.BoxSizerHelper) -> None:
 		filterCtrlsLine0 = guiHelper.BoxSizerHelper(self, wx.HORIZONTAL)
 		filterCtrlsLine1 = guiHelper.BoxSizerHelper(self, wx.HORIZONTAL)
-		self.filterCtrlHelper.addItem(filterCtrlsLine0.sizer)
+		filterCtrlHelper.addItem(filterCtrlsLine0.sizer)
 
 		# Add margin left padding
 		FILTER_MARGIN_PADDING = 15
 		filterCtrlsLine0.sizer.AddSpacer(FILTER_MARGIN_PADDING)
 		filterCtrlsLine1.sizer.AddSpacer(FILTER_MARGIN_PADDING)
-		self.filterCtrlHelper.addItem(filterCtrlsLine1.sizer, flag=wx.EXPAND, proportion=1)
+		filterCtrlHelper.addItem(filterCtrlsLine1.sizer, flag=wx.EXPAND, proportion=1)
 
 		self.channelFilterCtrl = cast(wx.Choice, filterCtrlsLine0.addLabeledControl(
 			# Translators: The label of a selection field to filter the list of add-ons in the add-on store dialog.

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -85,7 +85,7 @@ Users of Poedit 1 are encouraged to update to Poedit 3 if they want to rely on e
   - When reinstalling an incompatible add-on it is no longer forcefully disabled. (#15584, @lukaszgo1)
   - Disabled and incompatible add-ons can now be updated. (#15568, #15029)
   - NVDA now recovers and displays an error in a case where an add-on fails to download correctly. (#15796)
-  - NVDA no longer fails to restart intermittently after opening and closing Add-on Store (#16019, @lukaszgo1)
+  - NVDA no longer fails to restart intermittently after opening and closing Add-on Store. (#16019, @lukaszgo1)
   -
 - Audio:
   - NVDA no longer freezes briefly when multiple sounds are played in rapid succession. (#15311, #15757, @jcsteh)

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -85,6 +85,7 @@ Users of Poedit 1 are encouraged to update to Poedit 3 if they want to rely on e
   - When reinstalling an incompatible add-on it is no longer forcefully disabled. (#15584, @lukaszgo1)
   - Disabled and incompatible add-ons can now be updated. (#15568, #15029)
   - NVDA now recovers and displays an error in a case where an add-on fails to download correctly. (#15796)
+  - NVDA no longer fails to restart intermittently after opening and closing Add-on Store (#16019, @lukaszgo1)
   -
 - Audio:
   - NVDA no longer freezes briefly when multiple sounds are played in rapid succession. (#15311, #15757, @jcsteh)


### PR DESCRIPTION
Opened against beta, since even though the issue was not introduced in 2024.1 development cycle, its effect can be quite serious. Additionally this  change is small and very low risk.
### Link to issue number:
Related to #15041 and #15105
### Summary of the issue:
Ever since Add-on Store was introduced NVDA was intermittently failing to restart on my machine. This occurred only when I've opened Add-on Store before restarting. After debugging it turned out the following happens:
- When exiting NVDA had to destroy the store dialog, as it was kept alive due to circular reference
- The new instance of NVDA tried to wait for the old instance to exit, but since the exit process took extra long due to destroying the dialog the new copy gave up and didn't start
### Description of user facing changes
NVDA should no longer fail to restart intermittently after opening and closing Add-on Store.
### Description of development approach
The reference to one of `BoxSizerHelper` objects was stored on the store dialog. Since each `BoxSizerHelper` also stores reference to its parent the store dialog could not be destroyed properly when closing. This circular reference cycle was broken by no longer storing the `BoxSizerHelper` on the instance - it is either used as a local variable, or passed to the method which needs it as an parameter.
### Testing strategy:
- Ensured store dialog is still functioning
- Stress tested restarting NVDA on a machine where this was failing and verified it restarts successfully every single time
- Ensured no instances are stored in `gui.settingsDialogs.SettingsDialog._instances` when the Add-on Store dialog is closed
### Known issues with pull request:
- Storing a `BoxSizerHelper` as a dialog member is an  easy mistake to make in the future. I will submit a PR which makes it less likely to occur by storing a weak reference to the parent in the helper instance. Since this is a bigger and more risky change it will target master
- The approach taken by #15105 i.e. ignoring the warning about existing instances is sub-optimal. As demonstrated by this PR ignoring these alive references may cause issues in unrelated areas of NVDA. In my opinion we should restore the old behavior i.e. live references should once again cause a warning. If this is fine I'll submit a PR to that effect against master.
### Code Review Checklist:


- [X] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [X] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [X] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [X] API is compatible with existing add-ons.
- [X] Security precautions taken.
