### PR TITLE
Simplify self signed build docs

### DIFF
--- a/projectDocs/dev/selfSignedBuild.md
+++ b/projectDocs/dev/selfSignedBuild.md
@@ -41,8 +41,8 @@ Replace the following in this PowerShell script:
 - `<Certificate Thumbprint>`: The thumbprint from [creating the certificate](#create-a-self-signed-certificate).
 ```ps1
 cd <nvdaRepositoryRoot>
-$password = ConvertTo-SecureString -String <Password> -Force -AsPlainText 
-Export-PfxCertificate -cert "Cert:\CurrentUser\My\<Certificate Thumbprint>" -FilePath local.pfx -Password $password
+$password = ConvertTo-SecureString -Force -AsPlainText -String <Password>
+Export-PfxCertificate -FilePath local.pfx -Password $password -cert "Cert:\CurrentUser\My\<Certificate Thumbprint>"
 ```
 
 ### Import the certificate
@@ -57,7 +57,7 @@ Replace the following in the PowerShell script:
 - `<Password>`: your password for the exported certificate file.
 ```ps1
 cd <nvdaRepositoryRoot>
-$password = ConvertTo-SecureString -String <Password> -Force -AsPlainText
+$password = ConvertTo-SecureString -Force -AsPlainText -String <Password>
 Import-PfxCertificate -Password $password -CertStoreLocation "Cert:\LocalMachine\Root" -FilePath local.pfx
 ```
 
@@ -109,8 +109,5 @@ Use PowerShell, running as administrator.
 Replace the following in this PowerShell script:
 - `<Certificate Thumbprint>`: The thumbprint from [creating the certificate](#create-a-self-signed-certificate).
 ```ps1
-Remove-Item -Path "Cert:\LocalMachine\Root\<Certificate Thumbprint>" -DeleteKey
+Remove-Item -DeleteKey -Path "Cert:\LocalMachine\Root\<Certificate Thumbprint>"
 ```
-
-For Windows 7, you will need to use an alternative method.
-On any supported version of Windows, you can manage certifications through the "Certificate Manager".


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Summary of the issue:
Some commands in the self signed build documents require substitution in the example strings.
This PR reorders some commands to put the string which needs to be substituted at the end to make it easier to change as a developer.

this also removes mentions of testing on windows 7, which support has been removed for.
