### PR TITLE
[Hims] Add SPP connection [BrailleEdge]

### DIFF
--- a/source/brailleDisplayDrivers/hims.py
+++ b/source/brailleDisplayDrivers/hims.py
@@ -190,12 +190,12 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 		# Bulk devices
 		driverRegistrar.addUsbDevices(bdDetect.DeviceType.CUSTOM, {
 			"VID_045E&PID_930A",  # Braille Sense & Smart Beetle
-			"VID_045E&PID_930B",  # Braille EDGE 40
 		})
 
 		# Sync Braille, serial device
 		driverRegistrar.addUsbDevices(bdDetect.DeviceType.SERIAL, {
 			"VID_0403&PID_6001",
+   			"VID_1A86&PID_55D3",  # Braille Emotion 40
 		})
 
 		driverRegistrar.addBluetoothDevices(lambda m: any(m.id.startswith(prefix) for prefix in (

--- a/source/brailleDisplayDrivers/hims.py
+++ b/source/brailleDisplayDrivers/hims.py
@@ -121,6 +121,7 @@ class BrailleEmotion(BrailleEdge):
 	name = "Braille Emotion"
 	usbId = "VID_1A86&PID_55D3"
 
+
 class BrailleSense2S(BrailleSense):
 	"""Braille Sense with one scroll key on both sides.
 	Also referred to as Braille Sense Classic."""

--- a/source/brailleDisplayDrivers/hims.py
+++ b/source/brailleDisplayDrivers/hims.py
@@ -122,7 +122,7 @@ class BrailleEdge2S(BrailleEdge):
 	"""
 	usbId = "VID_1A86&PID_55D3"
 
-	def _get_keys(self):
+	def _get_keys(self) -> dict[str, str]:
 		keys = Model._get_keys(self)
 
 		keys.update({

--- a/source/brailleDisplayDrivers/hims.py
+++ b/source/brailleDisplayDrivers/hims.py
@@ -118,7 +118,8 @@ class BrailleEdge(Model):
 
 
 class BrailleEdge2S(BrailleEdge):
-	"""This device is BrailleEdge which doesn't use hims driver. It only use spp connection.
+	"""This device is the BrailleEdge which doesn't use the hims driver.
+	It only uses a SPP connection.
 	"""
 	usbId = "VID_1A86&PID_55D3"
 

--- a/source/brailleDisplayDrivers/hims.py
+++ b/source/brailleDisplayDrivers/hims.py
@@ -116,6 +116,7 @@ class BrailleEdge(Model):
 		})
 		return keys
 
+
 class BrailleEmotion(BrailleEdge):
 	name = "Braille Emotion"
 	usbId = "VID_1A86&PID_55D3"

--- a/source/brailleDisplayDrivers/hims.py
+++ b/source/brailleDisplayDrivers/hims.py
@@ -117,8 +117,8 @@ class BrailleEdge(Model):
 		return keys
 
 class BrailleEmotion(BrailleEdge):
-    name = "Braille Emotion"
-    usbId = "VID_1A86&PID_55D3"
+	name = "Braille Emotion"
+	usbId = "VID_1A86&PID_55D3"
 
 class BrailleSense2S(BrailleSense):
 	"""Braille Sense with one scroll key on both sides.
@@ -195,13 +195,13 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 		# Bulk devices
 		driverRegistrar.addUsbDevices(bdDetect.DeviceType.CUSTOM, {
 			"VID_045E&PID_930A",  # Braille Sense & Smart Beetle
-   			"VID_045E&PID_930B",  # Braille EDGE 40
+			"VID_045E&PID_930B",  # Braille EDGE 40
 		})
 
 		# Sync Braille, serial device
 		driverRegistrar.addUsbDevices(bdDetect.DeviceType.SERIAL, {
 			"VID_0403&PID_6001",
-   			"VID_1A86&PID_55D3",  # Braille Emotion 40
+			"VID_1A86&PID_55D3",  # Braille Emotion 40
 		})
 
 		driverRegistrar.addBluetoothDevices(lambda m: any(m.id.startswith(prefix) for prefix in (

--- a/source/brailleDisplayDrivers/hims.py
+++ b/source/brailleDisplayDrivers/hims.py
@@ -190,6 +190,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 		# Bulk devices
 		driverRegistrar.addUsbDevices(bdDetect.DeviceType.CUSTOM, {
 			"VID_045E&PID_930A",  # Braille Sense & Smart Beetle
+   			"VID_045E&PID_930B",  # Braille EDGE 40
 		})
 
 		# Sync Braille, serial device

--- a/source/brailleDisplayDrivers/hims.py
+++ b/source/brailleDisplayDrivers/hims.py
@@ -116,6 +116,10 @@ class BrailleEdge(Model):
 		})
 		return keys
 
+class BrailleEmotion(BrailleEdge):
+    name = "Braille Emotion"
+    usbId = "VID_1A86&PID_55D3"
+
 class BrailleSense2S(BrailleSense):
 	"""Braille Sense with one scroll key on both sides.
 	Also referred to as Braille Sense Classic."""
@@ -171,6 +175,7 @@ modelMap = [(cls.deviceId,cls) for cls in (
 	BrailleSenseQX,
 	BrailleSenseQ,
 	BrailleEdge,
+	BrailleEmotion,
 	SmartBeetle,
 	BrailleSense4S,
 	BrailleSense2S,

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -10,6 +10,7 @@ What's New in NVDA
 - Added support for the BrailleEdgeS2 braille device. (#16033)
 -
 
+
 == Changes ==
 
 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -7,7 +7,7 @@ What's New in NVDA
 
 == New Features ==
 - In Windows 11, NVDA will announce alerts from voice typing and suggested actions including the top suggestion when copying data such as phone numbers to the clipboard (Windows 11 2022 Update and later). (#16009, @josephsl)
-- NVDA will now automatically detect the BrailleEdgeS2 devices via USB. (#16033)
+- Added support for the BrailleEdgeS2 braille device. (#16033)
 -
 
 == Changes ==

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -7,8 +7,8 @@ What's New in NVDA
 
 == New Features ==
 - In Windows 11, NVDA will announce alerts from voice typing and suggested actions including the top suggestion when copying data such as phone numbers to the clipboard (Windows 11 2022 Update and later). (#16009, @josephsl)
+- NVDA will now automatically detect the BrailleEdgeS2 devices via USB. (#16033)
 -
-
 
 == Changes ==
 


### PR DESCRIPTION
### Link to issue number:

### Summary of the issue:
Support for spp connection with a Braille Edge device.

### Description of user facing changes
Support for all BrailleEdge devices NVDA's usb connection.

### Description of development approach
Support for Braille Edge device SPP connection in the Hims display. Only BrailleEdge devices with changed hardware chips can connect to SPP(Not use Hims Driver). Original BrailleEdge should use Hims driver to connect.

### Testing strategy:
How have you tested to ensure that your change works as intended?
yes.
Have you ensured testing coverage across all supported operating systems?
yes.
Have you considered possible regressions (related features or behaviours that may break)?
yes.

### Known issues with pull request:


### Code Review Checklist:


<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
