### PR TITLE
Exclude other files contained in the user_docs folder

### DIFF
--- a/source/setup.py
+++ b/source/setup.py
@@ -258,6 +258,14 @@ freeze(
 			) + (
 				"__pycache__",
 		))
-		+ getRecursiveDataFiles('documentation', '../user_docs', excludes=('*.t2t', '*.t2tconf', '*/developerGuide.*'))
+	+ getRecursiveDataFiles(
+		"documentation", "../user_docs",
+		excludes=(
+			"*.t2t", "*.t2tconf", "*.md",
+			"*.py", "__pycache__",
+			"*/user_docs/styles.css",
+			"*/developerGuide.*"
+		)
+	)
 	),
 )

--- a/source/setup.py
+++ b/source/setup.py
@@ -261,14 +261,15 @@ freeze(
 	+ getRecursiveDataFiles(
 		"documentation",
 		"../user_docs",
-		excludes=(
-			"*.t2t",
-			"*.t2tconf",
-			"*.md",
-			"*.py",
-			"*/user_docs/__pycache__/*",
-			"*/user_docs/styles.css",
-			"*/developerGuide.*"
+		excludes=tuple(
+			"*%s" % ext for ext in importlib.machinery.SOURCE_SUFFIXES + importlib.machinery.BYTECODE_SUFFIXES
+			) + (
+		"__pycache__",
+		"*.t2t",
+		"*.t2tconf",
+		"*.md",
+		"*/user_docs/styles.css",
+		"*/developerGuide.*"
 		)
 	)
 	),

--- a/source/setup.py
+++ b/source/setup.py
@@ -261,8 +261,11 @@ freeze(
 	+ getRecursiveDataFiles(
 		"documentation", "../user_docs",
 		excludes=(
-			"*.t2t", "*.t2tconf", "*.md",
-			"*.py", "__pycache__",
+			"*.t2t",
+			"*.t2tconf",
+			"*.md",
+			"*.py",
+			"*/__pycache__",
 			"*/user_docs/styles.css",
 			"*/developerGuide.*"
 		)

--- a/source/setup.py
+++ b/source/setup.py
@@ -259,13 +259,14 @@ freeze(
 				"__pycache__",
 		))
 	+ getRecursiveDataFiles(
-		"documentation", "../user_docs",
+		"documentation",
+		"../user_docs",
 		excludes=(
 			"*.t2t",
 			"*.t2tconf",
 			"*.md",
 			"*.py",
-			"*/__pycache__",
+			"*/user_docs/__pycache__/*",
 			"*/user_docs/styles.css",
 			"*/developerGuide.*"
 		)

--- a/source/setup.py
+++ b/source/setup.py
@@ -262,7 +262,7 @@ freeze(
 		"documentation",
 		"../user_docs",
 		excludes=tuple(
-			"*%s" % ext for ext in importlib.machinery.SOURCE_SUFFIXES + importlib.machinery.BYTECODE_SUFFIXES
+			f"*{ext}" for ext in importlib.machinery.SOURCE_SUFFIXES + importlib.machinery.BYTECODE_SUFFIXES
 			) + (
 		"__pycache__",
 		"*.t2t",


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:

Related #15945, #16024

### Summary of the issue:

The `documentation` folder in the NVDA directory contains files that the user does not need.

For example: `keyCommandsDoc.py`

### Description of user facing changes

The structure of the subfolders in documentation is the same as in the release version, with `documentation/styles.css` removed.

### Description of development approach

In `setup.py`, exclude the corresponding file

### Testing strategy:

Install a build of NVDA or create a portable version.
View the contents of the documentation folder.

### Known issues with pull request:

Unable to exclude `documentation/__pycache__` empty folder

Perhaps we could consider overriding the `getRecursiveDataFiles` function.
Without using list comprehensions.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [ ] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [ ] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [ ] API is compatible with existing add-ons.
- [ ] Security precautions taken.
