### PR TITLE
Adding the minimum version and the latest tested version of NVDA for add-on

### DIFF
--- a/source/gui/addonStoreGui/controls/details.py
+++ b/source/gui/addonStoreGui/controls/details.py
@@ -264,6 +264,19 @@ class AddonDetails(
 						pgettext("addonStore", "Installed version:"),
 						details._addonHandlerModel.version
 					)
+
+					self._appendDetailsLabelValue(
+						# Translators: Label for an extra detail field for the selected add-on. In the add-on store dialog.
+						pgettext("addonStore", "Minimum NVDA version:"),
+						"".join(map(str, details._addonHandlerModel.minimumNVDAVersion))
+					)
+
+					self._appendDetailsLabelValue(
+						# Translators: Label for an extra detail field for the selected add-on. In the add-on store dialog.
+						pgettext("addonStore", "Last tested NVDA version:"),
+						"".join(map(str, details._addonHandlerModel.lastTestedNVDAVersion))
+					)
+
 				if currentStatusKey not in AddonListField.availableAddonVersionName.hideStatuses:
 					self._appendDetailsLabelValue(
 						# Translators: Label for an extra detail field for the selected add-on. In the add-on store dialog.

--- a/source/gui/addonStoreGui/controls/details.py
+++ b/source/gui/addonStoreGui/controls/details.py
@@ -19,6 +19,8 @@ from ..viewModels.addonList import AddonDetailsVM, AddonListField
 
 from .actions import _MonoActionsContextMenu
 
+from buildVersion import formatVersionForGUI
+
 _fontFaceName = "Segoe UI"
 _fontFaceName_semiBold = "Segoe UI Semibold"
 
@@ -268,13 +270,13 @@ class AddonDetails(
 					self._appendDetailsLabelValue(
 						# Translators: Label for an extra detail field for the selected add-on. In the add-on store dialog.
 						pgettext("addonStore", "Minimum NVDA version:"),
-						"".join(map(str, details._addonHandlerModel.minimumNVDAVersion))
+						formatVersionForGUI(*details._addonHandlerModel.minimumNVDAVersion)
 					)
 
 					self._appendDetailsLabelValue(
 						# Translators: Label for an extra detail field for the selected add-on. In the add-on store dialog.
 						pgettext("addonStore", "Last tested NVDA version:"),
-						"".join(map(str, details._addonHandlerModel.lastTestedNVDAVersion))
+						formatVersionForGUI(*details._addonHandlerModel.lastTestedNVDAVersion)
 					)
 
 				if currentStatusKey not in AddonListField.availableAddonVersionName.hideStatuses:

--- a/source/gui/addonStoreGui/controls/details.py
+++ b/source/gui/addonStoreGui/controls/details.py
@@ -270,13 +270,13 @@ class AddonDetails(
 					self._appendDetailsLabelValue(
 						# Translators: Label for an extra detail field for the selected add-on. In the add-on store dialog.
 						pgettext("addonStore", "Minimum NVDA version:"),
-						formatVersionForGUI(*details._addonHandlerModel.minimumNVDAVersion)
+						formatVersionForGUI(*details.minimumNVDAVersion)
 					)
 
 					self._appendDetailsLabelValue(
 						# Translators: Label for an extra detail field for the selected add-on. In the add-on store dialog.
 						pgettext("addonStore", "Last tested NVDA version:"),
-						formatVersionForGUI(*details._addonHandlerModel.lastTestedNVDAVersion)
+						formatVersionForGUI(*details.lastTestedNVDAVersion)
 					)
 
 				if currentStatusKey not in AddonListField.availableAddonVersionName.hideStatuses:

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -12,7 +12,7 @@ What's New in NVDA
 == Changes ==
 
 - Add-on Store:
-  - The minimum NVDA version and the last tested version of NVDA for an add-on is now displayed in the "other details" area. (#15776, @Nael-Sayegh)
+  - The minimum NVDA version and the last tested NVDA version of NVDA for an add-on are now displayed in the "other details" area. (#15776, @Nael-Sayegh)
   -
 -
 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -7,7 +7,9 @@ What's New in NVDA
 
 == New Features ==
 - In Windows 11, NVDA will announce alerts from voice typing and suggested actions including the top suggestion when copying data such as phone numbers to the clipboard (Windows 11 2022 Update and later). (#16009, @josephsl)
--
+- Add-on Store:
+  - The minimal version and the latest tested version of NVDA for an extension appear in the "Other Information" field of an extension
+
 
 
 == Changes ==
@@ -62,7 +64,6 @@ Windows 8.1 is the minimum Windows version supported.
 - Add-on Store:
   - The Add-on Store now supports bulk actions (e.g. installing, enabling add-ons) by selecting multiple add-ons. (#15350, #15623, @CyrilleB79)
   - A new action has been added to open a dedicated webpage to see or provide feedback about the selected add-on. (#15576, @nvdaes)
-  -
 - Added support for Bluetooth Low Energy HID Braille displays. (#15470)
 - A new Native Selection mode (toggled by ``NVDA+shift+f10``) is now available in NVDA's browse mode for Mozilla Firefox.
 When turned on, selecting text in browse mode will also manipulate Firefox's own native selection.

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -9,6 +9,7 @@ What's New in NVDA
 - In Windows 11, NVDA will announce alerts from voice typing and suggested actions including the top suggestion when copying data such as phone numbers to the clipboard (Windows 11 2022 Update and later). (#16009, @josephsl)
 -
 
+
 == Changes ==
 
 - Add-on Store:

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -8,7 +8,7 @@ What's New in NVDA
 == New Features ==
 - In Windows 11, NVDA will announce alerts from voice typing and suggested actions including the top suggestion when copying data such as phone numbers to the clipboard (Windows 11 2022 Update and later). (#16009, @josephsl)
 - Add-on Store:
-  - The minimal version and the latest tested version of NVDA for an extension appear in the "Other Information" field of an extension
+  - Display of the minimum version and the latest tested version of NVDA of an extension in the other information area of an extension. (#16053, @Nael-Sayegh)
 
 
 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -13,7 +13,7 @@ What's New in NVDA
 == Changes ==
 
 - Add-on Store:
-  - The minimum NVDA version and the last tested NVDA version of NVDA for an add-on are now displayed in the "other details" area. (#15776, @Nael-Sayegh)
+  - The minimum and the last tested NVDA version for an add-on are now displayed in the "other details" area. (#15776, @Nael-Sayegh)
   -
 -
 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -12,7 +12,7 @@ What's New in NVDA
 == Changes ==
 
 - Add-on Store:
-  - The minimum NVDA version and the last tested version of NVDA for an add-on is now displayed in the "other information" area. (#15776, @Nael-Sayegh)
+  - The minimum NVDA version and the last tested version of NVDA for an add-on is now displayed in the "other details" area. (#15776, @Nael-Sayegh)
   -
 -
 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -7,13 +7,14 @@ What's New in NVDA
 
 == New Features ==
 - In Windows 11, NVDA will announce alerts from voice typing and suggested actions including the top suggestion when copying data such as phone numbers to the clipboard (Windows 11 2022 Update and later). (#16009, @josephsl)
-- Display of the minimum version and the latest tested version of NVDA of an add-on in the "other information" area. (#15776, @Nael-Sayegh)
 -
-
-
 
 == Changes ==
 
+- Add-on Store:
+  - The minimum NVDA version and the last tested version of NVDA for an add-on is now displayed in the "other information" area. (#15776, @Nael-Sayegh)
+  -
+-
 
 == Bug Fixes ==
 - Backspace now works correctly when using Nudi 6.1 with NVDA's "Handle keys from other applications" setting enabled. (#15822, @jcsteh)

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -65,6 +65,7 @@ Windows 8.1 is the minimum Windows version supported.
 - Add-on Store:
   - The Add-on Store now supports bulk actions (e.g. installing, enabling add-ons) by selecting multiple add-ons. (#15350, #15623, @CyrilleB79)
   - A new action has been added to open a dedicated webpage to see or provide feedback about the selected add-on. (#15576, @nvdaes)
+  -
 - Added support for Bluetooth Low Energy HID Braille displays. (#15470)
 - A new Native Selection mode (toggled by ``NVDA+shift+f10``) is now available in NVDA's browse mode for Mozilla Firefox.
 When turned on, selecting text in browse mode will also manipulate Firefox's own native selection.

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -7,8 +7,8 @@ What's New in NVDA
 
 == New Features ==
 - In Windows 11, NVDA will announce alerts from voice typing and suggested actions including the top suggestion when copying data such as phone numbers to the clipboard (Windows 11 2022 Update and later). (#16009, @josephsl)
-- Add-on Store:
-  - Display of the minimum version and the latest tested version of NVDA of an extension in the other information area of an extension. (#16053, @Nael-Sayegh)
+- Display of the minimum version and the latest tested version of NVDA of an add-on in the "other information" area. (#15776, @Nael-Sayegh)
+-
 
 
 


### PR DESCRIPTION

<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
closes #15776 

### Summary of the issue:
Having the ability to see the minimum version and the latest tested version of NVDA for an extension in the addonStore.

### Description of user facing changes
In the addonStore, the user will be able to see the minimum version and the latest tested version of NVDA in the details of an extension.

### Description of development approach
Added in the source file\gui\addonStoreGui\controls\details.py in the refresh method, I added compatibility information under the installed version of the module.

### Testing strategy:
Go to the addonStore, then select an installed extension, go to the "Other Information" editing area and read the section to see the minimum version and latest tested version.

### Known issues with pull request:

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
