### PR TITLE
Once again warn about instances of settings dialog kept alive after they are closed

### DIFF
--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -220,9 +220,7 @@ class MainFrame(wx.Frame):
 	def popupSettingsDialog(self, dialog: Type[SettingsDialog], *args, **kwargs):
 		self.prePopup()
 		try:
-			d = dialog(self, *args, **kwargs)
-			if d:
-				d.Show()
+			dialog(self, *args, **kwargs).Show()
 		except SettingsDialog.MultiInstanceErrorWithDialog as errorWithDialog:
 			errorWithDialog.dialog.SetFocus()
 		except MultiCategorySettingsDialog.CategoryUnavailableError:

--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -220,7 +220,9 @@ class MainFrame(wx.Frame):
 	def popupSettingsDialog(self, dialog: Type[SettingsDialog], *args, **kwargs):
 		self.prePopup()
 		try:
-			dialog(self, *args, **kwargs).Show()
+			d = dialog(self, *args, **kwargs)
+			if d:
+				d.Show()
 		except SettingsDialog.MultiInstanceErrorWithDialog as errorWithDialog:
 			errorWithDialog.dialog.SetFocus()
 		except MultiCategorySettingsDialog.CategoryUnavailableError:

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -145,13 +145,11 @@ class SettingsDialog(
 		if state is cls.DialogState.DESTROYED and not multiInstanceAllowed:
 			# The dialog has been destroyed by wx, but the instance is still available.
 			# This indicates there is something keeping it alive.
-			log.debugWarning(f"Opening new settings dialog while instance still exists: {firstMatchingInstance!r}")
-			# Handle gracefully
-			SettingsDialog._instances[firstMatchingInstance] = cls.DialogState.CREATED
-			return firstMatchingInstance
-		obj = super(SettingsDialog, cls).__new__(cls, *args, **kwargs)
-		SettingsDialog._instances[obj] = cls.DialogState.CREATED
-		return obj
+			log.error(f"Opening new settings dialog while instance still exists: {firstMatchingInstance!r}")
+		else:
+			obj = super().__new__(cls, *args, **kwargs)
+			SettingsDialog._instances[obj] = cls.DialogState.CREATED
+			return obj
 
 	def _setInstanceDestroyedState(self):
 		# prevent race condition with object deletion

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -145,7 +145,9 @@ class SettingsDialog(
 		if state is cls.DialogState.DESTROYED and not multiInstanceAllowed:
 			# The dialog has been destroyed by wx, but the instance is still available.
 			# This indicates there is something keeping it alive.
-			raise RuntimeError(f"Cannot open new settings dialog while instance still exists: {firstMatchingInstance!r}")
+			raise RuntimeError(
+				f"Cannot open new settings dialog while instance still exists: {firstMatchingInstance!r}"
+			)
 		obj = super().__new__(cls, *args, **kwargs)
 		SettingsDialog._instances[obj] = cls.DialogState.CREATED
 		return obj

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -145,11 +145,10 @@ class SettingsDialog(
 		if state is cls.DialogState.DESTROYED and not multiInstanceAllowed:
 			# The dialog has been destroyed by wx, but the instance is still available.
 			# This indicates there is something keeping it alive.
-			log.error(f"Opening new settings dialog while instance still exists: {firstMatchingInstance!r}")
-		else:
-			obj = super().__new__(cls, *args, **kwargs)
-			SettingsDialog._instances[obj] = cls.DialogState.CREATED
-			return obj
+			raise RuntimeError(f"Cannot open new settings dialog while instance still exists: {firstMatchingInstance!r}")
+		obj = super().__new__(cls, *args, **kwargs)
+		SettingsDialog._instances[obj] = cls.DialogState.CREATED
+		return obj
 
 	def _setInstanceDestroyedState(self):
 		# prevent race condition with object deletion


### PR DESCRIPTION
### Link to issue number:
Follow up from PR #16019

### Summary of the issue:
Normally it should not be possible to open the same NVDA's settings dialog multiple times. To make sure this does not happen settings dialog constructor verifies if the given dialog is already opened, and either focuses it when it is, or creates a new dialog when it is not. In rare cases the dialog should be destroyed after user closed it, but due to circular reference Python's garbage collector cannot clean it up. Before PR #15105 this was causing an error making it impossible to reopen the dialog. In that PR the behavior was changed, so that when the instance is still kept alive it is just marked as created and reused. As described in PR #16019 when dialogs are not destroyed properly NVDA may malfunction, so having an error and non working dialog is better than a hard to debug error in other part of NVDA.
### Description of user facing changes
This should not have user visible impact, as long as there are no dialogs which fail to be destroyed when they are closed.
### Description of development approach
When there is an existing instance of a given dialog which is marked as destroyed there is an error in the log, and no other instances of this dialog can be created.
### Testing strategy:
Temporarily reintroduced a circular reference for the Add-on Store dialog, and verified that it cannot be reopened. Ensured that expected warning is in the log.
### Known issues with pull request:
None known
### Code Review Checklist:


- [X] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [X] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [X] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [X] API is compatible with existing add-ons.
- [X] Security precautions taken.
