### PR TITLE
Add-on store bugfix: the channel is now translated in Other details field

### DIFF
--- a/source/gui/addonStoreGui/controls/details.py
+++ b/source/gui/addonStoreGui/controls/details.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2022-2023 NV Access Limited, Cyrille Bougot
+# Copyright (C) 2022-2024 NV Access Limited, Cyrille Bougot
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -273,7 +273,7 @@ class AddonDetails(
 				self._appendDetailsLabelValue(
 					# Translators: Label for an extra detail field for the selected add-on. In the add-on store dialog.
 					pgettext("addonStore", "Channel:"),
-					details.channel
+					details.channel.displayString
 				)
 
 				incompatibleReason = details.getIncompatibleReason()


### PR DESCRIPTION
### Link to issue number:
None
### Summary of the issue:
In the Other details field of the Add-on Store, the name of the channel is always in English, no matter the language of the GUI.
### Description of user facing changes
The name of the channel is now translated.
### Description of development approach
Use the `displayString` of the enum.
### Testing strategy:
Manual test.
### Known issues with pull request:
None
### Change log
Not needed for such small fix.
### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
