### PR TITLE
User guide: Update the section on reading math to recommend MathCAT, and also clarify some information about MathPlayer.

### DIFF
--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -915,13 +915,13 @@ Also, although the application will try its best to match the native selection t
 However, for scenarios where you wish to copy an entire table or paragraph of rich content, this feature should prove useful.
  
 + Reading Mathematical Content +[ReadingMath]
-NVDA can  read and navigate mathematical content on the web and in other applications, providing access in both speech and braille. 
+NVDA can read and navigate mathematical content on the web and in other applications, providing access in both speech and braille. 
 However, in order for NVDA to read and interact with mathematical content, you will first need to install a Math component for NvDA.
 There are several NVDA add-ons available in the NVDA Add-on Store that provide support for math, including the [MathCAT NVDA add-on https://nsoiffer.github.io/MathCAT/] and [Access8Math https://addons.nvda-project.org/addons/access8math.en.html]. 
-Please refer to the [Add-on Store section #AddonsManager] to learn how to browse for and install available add-ons in NVDA.
+Please refer to the [Add-on Store section #AddonsManager] to learn how to browse and install available add-ons in NVDA.
 NVDA also can make use of the older [MathPlayer https://info.wiris.com/mathplayer-info] software from Wiris if found on your system, though this software is no longer maintained.
   
-++ Supported math content ++
+++ Supported math content ++[SupportedMathContent]
 With an appropriate math component installed, NVDA supports the following types of mathematical content:
 - MathML in Mozilla Firefox, Microsoft Internet Explorer and Google Chrome.
 - Microsoft Word 365 Modern Math Equations via UI automation:
@@ -961,13 +961,13 @@ By default, the review cursor follows the system caret, so you can usually use t
 | Interact with math content | NVDA+alt+m | Begins interaction with math content. |
 %kc:endInclude
 
-At this point, NVDA will enter Math mode, where  you can use commands such as the arrow keys to explore the expression.
+At this point, NVDA will enter Math mode, where you can use commands such as the arrow keys to explore the expression.
 For example, you can move through the expression with the left and right arrow keys and zoom into a portion of the expression such as a fraction using the down arrow key.
 
 When you wish to return to the document, simply press the escape key.
 
 For more information on available commands and preferences for reading and navigating within math content, please refer to the documentation for your particular math component you have installed.
-- [mathCAT documentation https://nsoiffer.github.io/MathCAT/users.html]
+- [MathCAT documentation https://nsoiffer.github.io/MathCAT/users.html]
 - [Access8Math documentation https://addons.nvda-project.org/addons/access8math.en.html]
 - [MathPlayer documentation https://docs.wiris.com/mathplayer/en/mathplayer-user-manual.html]
 -
@@ -975,13 +975,13 @@ For more information on available commands and preferences for reading and navig
 Sometimes mathematical content might be displayed as a button or other type of element which, when activated, can display a dialog or more information related to the formula.
 To activate the button or the element containing the formula, press ctrl+enter.
 
-++ Installing MathPlayer ++
+++ Installing MathPlayer ++[InstallingMathPlayer]
 Although it is generally recommended to use one of the newer NVDA add-ons to support math in NVDA, in certain limited scenarios MathPlayer may still be a more suitable choice, as other options may not yet support a particular language or Braille code.
 MathPlayer is available for free from the Wiris website.
-[download MathPlayer https://downloads.wiris.com/mathplayer/MathPlayerSetup.exe].
+[Download MathPlayer https://downloads.wiris.com/mathplayer/MathPlayerSetup.exe].
 After installing MathPlayer, you will need to restart NVDA. 
 Please note that information about MathPlayer may state that it is only for older browsers such as Internet Explorer 8.
-this is only referring to using mathPlayer to display mathematical content visually, and can be ignored by those using it to read or navigate math with NvDA.
+This is only referring to using MathPlayer to display mathematical content visually, and can be ignored by those using it to read or navigate math with NVDA.
 
 + Braille +[Braille]
 If you own a braille display, NVDA can display information in braille.

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -916,23 +916,13 @@ However, for scenarios where you wish to copy an entire table or paragraph of ri
  
 + Reading Mathematical Content +[ReadingMath]
 NVDA can  read and navigate mathematical content on the web and in other applications, providing access in both speech and braille. 
-However, in order for NVDA to read and interact with mathematical content, you will first need to install either the [MathCAT NVDA add-on https://nsoiffer.github.io/MathCAT/] from Neil Soiffer, or the older [MathPlayer https://info.wiris.com/mathplayer-info] software from Design Science.
-It is generally recommended to choose mathCAT, as it is a modern replacement for the older MathPlayer which is no longer maintained.
-However, in certain limited scenarios MathPlayer may still be a more suitable choice, as MathCAT may not yet support a particular language or Braille code.
-
-++ Installing MathCAT ++
-[MathCAT https://nsoiffer.github.io/MathCAT/] is available for free from the NVDA Add-on Store.
+However, in order for NVDA to read and interact with mathematical content, you will first need to install a Math component for NvDA.
+There are several NVDA add-ons available in the NVDA Add-on Store that provide support for math, including the [MathCAT NVDA add-on https://nsoiffer.github.io/MathCAT/] and [Access8Math https://addons.nvda-project.org/addons/access8math.en.html]. 
 Please refer to the [Add-on Store section #AddonsManager] to learn how to browse for and install available add-ons in NVDA.
-
-++ Installing MathPlayer ++
-MathPlayer is available for free from the Wiris website.
-[download MathPlayer https://downloads.wiris.com/mathplayer/MathPlayerSetup.exe].
-After installing MathPlayer, you will need to restart NVDA. 
-Please note that information about MathPlayer may state that it is only for older browsers such as Internet Explorer 8.
-this is only referring to using mathPlayer to display mathematical content visually, and can be ignored by those using it to read or navigate math with NvDA.
- 
+NVDA also can make use of the older [MathPlayer https://info.wiris.com/mathplayer-info] software from Wiris if found on your system, though this software is no longer maintained.
+  
 ++ Supported math content ++
-With mathCAT or MathPlayer installed, NVDA supports the following types of mathematical content:
+With an appropriate math component installed, NVDA supports the following types of mathematical content:
 - MathML in Mozilla Firefox, Microsoft Internet Explorer and Google Chrome.
 - Microsoft Word 365 Modern Math Equations via UI automation:
 NVDA is able to read and interact with math equations in Microsoft Word 365/2016 build 14326 and higher.
@@ -976,10 +966,22 @@ For example, you can move through the expression with the left and right arrow k
 
 When you wish to return to the document, simply press the escape key.
 
-For more information on available commands and preferences for reading and navigating within math content, please refer to either the [mathCAT documentation https://nsoiffer.github.io/MathCAT/users.html] or the [MathPlayer documentation https://docs.wiris.com/mathplayer/en/mathplayer-user-manual.html] depending on which solution you have installed. 
+For more information on available commands and preferences for reading and navigating within math content, please refer to the documentation for your particular math component you have installed.
+- [mathCAT documentation https://nsoiffer.github.io/MathCAT/users.html]
+- [Access8Math documentation https://addons.nvda-project.org/addons/access8math.en.html]
+- [MathPlayer documentation https://docs.wiris.com/mathplayer/en/mathplayer-user-manual.html]
+-
 
 Sometimes mathematical content might be displayed as a button or other type of element which, when activated, can display a dialog or more information related to the formula.
 To activate the button or the element containing the formula, press ctrl+enter.
+
+++ Installing MathPlayer ++
+Although it is generally recommended to use one of the newer NVDA add-ons to support math in NVDA, in certain limited scenarios MathPlayer may still be a more suitable choice, as other options may not yet support a particular language or Braille code.
+MathPlayer is available for free from the Wiris website.
+[download MathPlayer https://downloads.wiris.com/mathplayer/MathPlayerSetup.exe].
+After installing MathPlayer, you will need to restart NVDA. 
+Please note that information about MathPlayer may state that it is only for older browsers such as Internet Explorer 8.
+this is only referring to using mathPlayer to display mathematical content visually, and can be ignored by those using it to read or navigate math with NvDA.
 
 + Braille +[Braille]
 If you own a braille display, NVDA can display information in braille.

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -915,12 +915,24 @@ Also, although the application will try its best to match the native selection t
 However, for scenarios where you wish to copy an entire table or paragraph of rich content, this feature should prove useful.
  
 + Reading Mathematical Content +[ReadingMath]
-Using MathPlayer 4 from Design Science, NVDA can read and interactively navigate supported mathematical content.
-This requires that MathPlayer 4 is installed on the computer.
-MathPlayer is available as a free download from the [MathPlayer information page https://info.wiris.com/mathplayer-info].
-After installing MathPlayer, restart NVDA.
+NVDA can  read and navigate mathematical content on the web and in other applications, providing access in both speech and braille. 
+However, in order for NVDA to read and interact with mathematical content, you will first need to install either the [MathCAT NVDA add-on https://nsoiffer.github.io/MathCAT/] from Neil Soiffer, or the older [MathPlayer https://info.wiris.com/mathplayer-info] software from Design Science.
+It is generally recommended to choose mathCAT, as it is a modern replacement for the older MathPlayer which is no longer maintained.
+However, in certain limited scenarios MathPlayer may still be a more suitable choice, as MathCAT may not yet support a particular language or Braille code.
 
-NVDA supports the following types of mathematical content:
+++ Installing MathCAT ++
+MathCAT is available for free from the NVDA Add-on Store.
+Please refer to the [Add-on Store section #AddonsManager] to learn how to browse for and install available add-ons.
+
+++ Installing MathPlayer ++
+MathPlayer is available for free from the Wiris website.
+[download MathPlayer https://downloads.wiris.com/mathplayer/MathPlayerSetup.exe]
+After installing MathPlayer, you will need to restart NVDA. 
+Please note that information about MathPlayer may state that it is only for older browsers such as Internet Explorer 8.
+this is only referring to using mathPlayer to display mathematical content visually, and can be ignored by those using it to read or navigate math with NvDA.
+ 
+++ Supported math content ++
+With mathCAT or MathPlayer installed, NVDA supports the following types of mathematical content:
 - MathML in Mozilla Firefox, Microsoft Internet Explorer and Google Chrome.
 - Microsoft Word 365 Modern Math Equations via UI automation:
 NVDA is able to read and interact with math equations in Microsoft Word 365/2016 build 14326 and higher.
@@ -959,11 +971,12 @@ By default, the review cursor follows the system caret, so you can usually use t
 | Interact with math content | NVDA+alt+m | Begins interaction with math content. |
 %kc:endInclude
 
-At this point, you can use MathPlayer commands such as the arrow keys to explore the expression.
+At this point, NVDA will enter Math mode, where  you can use commands such as the arrow keys to explore the expression.
 For example, you can move through the expression with the left and right arrow keys and zoom into a portion of the expression such as a fraction using the down arrow key.
-Please see the [MathPlayer documentation https://docs.wiris.com/mathplayer/en/mathplayer-user-manual.html] for further information.
 
 When you wish to return to the document, simply press the escape key.
+
+For more information on available commands and preferences for reading and navigating within math content, please refer to either the [mathCAT documentation https://nsoiffer.github.io/MathCAT/users.html] or the [MathPlayer documentation https://docs.wiris.com/mathplayer/en/mathplayer-user-manual.html] depending on which solution you have installed. 
 
 Sometimes mathematical content might be displayed as a button or other type of element which, when activated, can display a dialog or more information related to the formula.
 To activate the button or the element containing the formula, press ctrl+enter.

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -921,12 +921,12 @@ It is generally recommended to choose mathCAT, as it is a modern replacement for
 However, in certain limited scenarios MathPlayer may still be a more suitable choice, as MathCAT may not yet support a particular language or Braille code.
 
 ++ Installing MathCAT ++
-MathCAT is available for free from the NVDA Add-on Store.
-Please refer to the [Add-on Store section #AddonsManager] to learn how to browse for and install available add-ons.
+[MathCAT https://nsoiffer.github.io/MathCAT/] is available for free from the NVDA Add-on Store.
+Please refer to the [Add-on Store section #AddonsManager] to learn how to browse for and install available add-ons in NVDA.
 
 ++ Installing MathPlayer ++
 MathPlayer is available for free from the Wiris website.
-[download MathPlayer https://downloads.wiris.com/mathplayer/MathPlayerSetup.exe]
+[download MathPlayer https://downloads.wiris.com/mathplayer/MathPlayerSetup.exe].
 After installing MathPlayer, you will need to restart NVDA. 
 Please note that information about MathPlayer may state that it is only for older browsers such as Internet Explorer 8.
 this is only referring to using mathPlayer to display mathematical content visually, and can be ignored by those using it to read or navigate math with NvDA.

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -976,7 +976,8 @@ Sometimes mathematical content might be displayed as a button or other type of e
 To activate the button or the element containing the formula, press ctrl+enter.
 
 ++ Installing MathPlayer ++[InstallingMathPlayer]
-Although it is generally recommended to use one of the newer NVDA add-ons to support math in NVDA, in certain limited scenarios MathPlayer may still be a more suitable choice, as other options may not yet support a particular language or Braille code.
+Although it is generally recommended to use one of the newer NVDA add-ons to support math in NVDA, in certain limited scenarios MathPlayer may still be a more suitable choice.
+E.g. MathPlayer may support a particular language or Braille code that is unsupported in newer add-ons.
 MathPlayer is available for free from the Wiris website.
 [Download MathPlayer https://downloads.wiris.com/mathplayer/MathPlayerSetup.exe].
 After installing MathPlayer, you will need to restart NVDA. 

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -917,7 +917,7 @@ However, for scenarios where you wish to copy an entire table or paragraph of ri
 + Reading Mathematical Content +[ReadingMath]
 NVDA can read and navigate mathematical content on the web and in other applications, providing access in both speech and braille. 
 However, in order for NVDA to read and interact with mathematical content, you will first need to install a Math component for NvDA.
-There are several NVDA add-ons available in the NVDA Add-on Store that provide support for math, including the [MathCAT NVDA add-on https://nsoiffer.github.io/MathCAT/] and [Access8Math https://addons.nvda-project.org/addons/access8math.en.html]. 
+There are several NVDA add-ons available in the NVDA Add-on Store that provide support for math, including the [MathCAT NVDA add-on https://nsoiffer.github.io/MathCAT/] and [Access8Math https://github.com/tsengwoody/Access8Math]. 
 Please refer to the [Add-on Store section #AddonsManager] to learn how to browse and install available add-ons in NVDA.
 NVDA also can make use of the older [MathPlayer https://info.wiris.com/mathplayer-info] software from Wiris if found on your system, though this software is no longer maintained.
   
@@ -968,7 +968,7 @@ When you wish to return to the document, simply press the escape key.
 
 For more information on available commands and preferences for reading and navigating within math content, please refer to the documentation for your particular math component you have installed.
 - [MathCAT documentation https://nsoiffer.github.io/MathCAT/users.html]
-- [Access8Math documentation https://addons.nvda-project.org/addons/access8math.en.html]
+- [Access8Math documentation https://github.com/tsengwoody/Access8Math]
 - [MathPlayer documentation https://docs.wiris.com/mathplayer/en/mathplayer-user-manual.html]
 -
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Fixes #16036
Fixes #15352 

### Summary of the issue:
When reading the section of the User guide about Math support, and then the MathPlayer page from Wiris, it is unclear as to whether MathPlayer is actually needed for NvDA unless you are using an older browser such as Internet Explorer 8.
Also, Nthe User Guide does not recommend let alone mention, MathCAT, which is now the replacement for the older and unmaintained MathPlayer.

### Description of user facing changes
Update the math section in the User guide to mention and recommend MathCAT, and clarify that MathPlayer  is still relevant on newer browsers. 

### Description of development approach
n/a

### Testing strategy:
Built the user guide as html.

### Known issues with pull request:
None known.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
