### PR TITLE
Adobe Reader: support alternative text on formulas in PDFs

### DIFF
--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -19,6 +19,7 @@ What's New in NVDA
 - Add-on Store:
   - When pressing ``ctrl+tab``, focus properly moves to the new current tab title. (#14986, @ABuffEr)
   -
+- In Adobe Reader, NVDA no longer ignores alternative text set on formulas in PDFs. (#12715)
 -
 
 


### PR DESCRIPTION
- Adobe Acrobat vbuf backend: Don't replace content in formula tags with a space, rather only do this for math nodes. this ensures NvDA still exposes alt text on formulas. this approach still alows for supporting embedded mathml trees in NVDA, though this was never standardized in PDF.
- Update what's new

<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Fixes #12715

### Summary of the issue:
Authors of PDFs can provide alternative text on formular nodes via the 'alt' attribute.  However, NvDA ignores this and replaces it with a single space, with the assumption that the formula will contain an inner mathml tree structure.
The idea of embedding a full mathml tree structure with in formula nodes was never standardized, and only a few experimental PDFs actually exist. However, it is becoming common for authors to place alt text (perhaps a simple english representation of math) on formula nodes.

### Description of user facing changes
In Adobe Reader, alternative text for formulas will be reported if provided by the author.
 
 
### Description of development approach
Adobe Acrobat vbuf backend: Don't replace content in formula tags with a space, rather only do this for math nodes. this ensures NvDA still exposes alt text on formulas. this approach still allows for supporting embedded mathml trees if they exist as a direct child of the formula.

### Testing strategy:
* Opened the pdf provided in #12715 in Adobe Reader. Arrowed up and down through the content ensuring that the formular was read.
* Opened a pdf containing a mathml tree in a formular in Adobe Reader. Ensured that NvDA still reported the math using a Math Presentor such as MathCAT.

### Known issues with pull request:
None known.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
