### PR TITLE
Clarify speech mode

### DIFF
--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -2,7 +2,7 @@
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-# Copyright (C) 2006-2023 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Rui Batista, Joseph Lee,
+# Copyright (C) 2006-2024 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Rui Batista, Joseph Lee,
 # Leonard de Ruijter, Derek Riemer, Babbage B.V., Davy Kager, Ethan Holliger, Łukasz Golonka, Accessolutions,
 # Julien Cochuyt, Jakub Lukowicz, Bill Dengler, Cyrille Bougot, Rob Meredith, Luke Davis,
 # Burman's Computer and Education Ltd.
@@ -932,7 +932,7 @@ class GlobalCommands(ScriptableObject):
 	@script(
 		description=_(
 			# Translators: Input help mode message for cycle through automatic language switching mode command.
-			"Cycles through speech modes for automatic language switching: "
+			"Cycles through the possible choices for automatic language switching: "
 			"off, language only and language and dialect."
 		),
 		category=SCRCAT_SPEECH,

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -1609,7 +1609,7 @@ This can be useful if it is hard to distinguish between pronunciation of symbols
 The delayed character description will be cancelled if other text is spoken during that time, or if you press the ``control`` key.
 
 ==== Modes available in the Cycle speech mode command ====[SpeechModesDisabling]
-This checkable list allows selecting which speech modes are included when cycling between them using ``NVDA+s``.
+This checkable list allows selecting which [speech modes #SpeechModes] are included when cycling between them using ``NVDA+s``.
 Modes which are unchecked are excluded.
 By default all modes are included.
 


### PR DESCRIPTION
Note: targeting beta since the changes are small and it may help better understanding and advertising the new on-demand speech mode, for which there have already been some questions from beta users.

### Link to issue number:
None
(following discussions on the new speech on-demand feature)

### Summary of the issue:
Everyone may not know what speech modes are, especially the new on-demand mode.

### Description of user facing changes
* In the User Guide, there is a paragraph describing the setting to change available speech mode in the cycling command. A link has been added to the paragraph describing the speech modes.
* While at it, I have also rephrased a script's documentation, which inappropriately mentions "peech modes" when referring to language switching possible values; this way, it's not confusing anymore when searching for "speech mode" in the UG.
### Description of development approach
N/A
### Testing strategy:
Manual check of the UG and the input script help.
### Known issues with pull request:
None
### Code Review Checklist:


- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
