### PR TITLE
No longer store strong references to parent object in guiHelper.BoxSizerHelper to decrease likelihood of circular references in NVDA's GUI

### DIFF
--- a/source/gui/guiHelper.py
+++ b/source/gui/guiHelper.py
@@ -1,6 +1,5 @@
-# -*- coding: UTF-8 -*-
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2016-2023 NV Access Limited
+# Copyright (C) 2016-2024 NV Access Limited, Łukasz Golonka
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -44,6 +43,7 @@ class myDialog(wx.Dialog):
 	...
 """
 from contextlib import contextmanager
+import weakref
 from typing import (
 	Generic,
 	Optional,
@@ -314,7 +314,7 @@ class BoxSizerHelper:
 			@type orientation: wx.HORIZONTAL or wx.VERTICAL
 			@param sizer: the sizer to use rather than constructing one.
 		"""
-		self._parent = parent
+		self._parentRef = weakref.ref(parent)
 		self.hasFirstItemBeenAdded = False
 		if orientation and sizer:
 			raise ValueError("Supply either orientation OR sizer. Not both.")
@@ -384,7 +384,7 @@ class BoxSizerHelper:
 			Relies on guiHelper.LabeledControlHelper and thus guiHelper.associateElements, and therefore inherits any
 			limitations from there.
 		"""
-		parent = self._parent
+		parent = self._parentRef()
 		if isinstance(self.sizer, wx.StaticBoxSizer):
 			parent = self.sizer.GetStaticBox()
 		labeledControl = LabeledControlHelper(parent, labelText, wxCtrlClass, **kwargs)
@@ -422,11 +422,11 @@ class BoxSizerHelper:
 		elif isinstance(buttons, (wx.Sizer, wx.Button)):
 			toAdd = buttons
 		elif isinstance(buttons, int):
-			toAdd = self._parent.CreateButtonSizer(buttons)
+			toAdd = self._parentRef().CreateButtonSizer(buttons)
 		else:
 			raise NotImplementedError("Unknown type: {}".format(buttons))
 		if separated:
-			parentBox = self._parent
+			parentBox = self._parentRef()
 			if isinstance(self.sizer, wx.StaticBoxSizer):
 				parentBox = self.sizer.GetStaticBox()
 			self.addItem(wx.StaticLine(parentBox), flag=wx.EXPAND)


### PR DESCRIPTION
### Link to issue number:
Related to #16019

### Summary of the issue:
`BoxSizerHelper` class stores a strong reference to its parent. When it is mistakenly assigned to a member of its parent a circular reference is created making it impossible for Python's garbage collector to destroy the dialog when it goes out of scope.
### Description of user facing changes
Should not be noticeable.
### Description of development approach
`BoxSizerHelper` now stores a weak reference to its parent.
### Testing strategy:
Temporarily introduced a circular  reference between the Add-on Store dialog and one of its sizer helpers - ensured the dialog can be garbage collected when closed.
### Known issues with pull request:
None known.
### Code Review Checklist:

- [X] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [X] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [X] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [X] API is compatible with existing add-ons.
- [X] Security precautions taken.
