### PR TITLE
Bump Pillow version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ wxPython==4.2.1
 git+https://github.com/DiffSK/configobj@e2ba4457c4651fa54f8d59d8dcdd3da950e956b8#egg=configobj
 requests==2.31.0
 # Pillow is an implicit dependency and requires zlib and jpeg by default, but we don't need it
-Pillow==10.0.1 -C "zlib=disable" -C "jpeg=disable"
+Pillow==10.2.0 -C "zlib=disable" -C "jpeg=disable"
 
 #NVDA_DMP requires diff-match-patch
 fast_diff_match_patch==2.0.1


### PR DESCRIPTION
Reported by dependabot: https://github.com/nvaccess/nvda/security/dependabot/2

Pillow < 10.2.0 has a known security issue
This PR bumps the Pillow version

Note Pillow was introduced as a pinned implicit dependency as part of https://github.com/nvaccess/nvda/pull/15544