### PR TITLE
Update documentation in 2 places: new security team and setting up initial nvda development git repo

### DIFF
--- a/projectDocs/dev/createDevEnvironment.md
+++ b/projectDocs/dev/createDevEnvironment.md
@@ -3,12 +3,14 @@ The NVDA project uses the [git](https://www.git-scm.com/) version control system
 
 The NVDA repository is located at https://github.com/nvaccess/nvda.
 
-If you plan on contributing to NVDA, you should [fork and clone](https://docs.github.com/en/get-started/quickstart/fork-a-repo) the repository.
+If you plan on contributing to NVDA, you will need to [fork and clone](https://docs.github.com/en/get-started/quickstart/fork-a-repo) the repository.
 
-Use the `--recursive` option when performing `git clone` to fetch the required git submodules we use.
 
 ```
-git clone --recursive https://github.com/nvaccess/nvda.git
+# Fork the repository into your user account (YOUR-USERNAME)
+
+# Clone with --recursive to fetch all required submodules
+git clone --recursive https://github.com/YOUR-USERNAME/nvda.git
 ```
 
 ### Keeping the fork in sync

--- a/projectDocs/dev/createDevEnvironment.md
+++ b/projectDocs/dev/createDevEnvironment.md
@@ -5,13 +5,12 @@ The NVDA repository is located at https://github.com/nvaccess/nvda.
 
 If you plan on contributing to NVDA, you will need to [fork and clone](https://docs.github.com/en/get-started/quickstart/fork-a-repo) the repository.
 
+After forking the repository into your user account (`YOUR-USERNAME`), clone with `--recursive` to fetch all required submodules.
 
-```
-# Fork the repository into your user account (YOUR-USERNAME)
-
-# Clone with --recursive to fetch all required submodules
+```sh
 git clone --recursive https://github.com/YOUR-USERNAME/nvda.git
 ```
+
 
 ### Keeping the fork in sync
 When you fork the repository, GitHub will create a copy of the master branch.

--- a/projectDocs/dev/createDevEnvironment.md
+++ b/projectDocs/dev/createDevEnvironment.md
@@ -7,6 +7,10 @@ If you plan on contributing to NVDA, you should [fork and clone](https://docs.gi
 
 Use the `--recursive` option when performing `git clone` to fetch the required git submodules we use.
 
+```
+git clone --recursive https://github.com/nvaccess/nvda.git
+```
+
 ### Keeping the fork in sync
 When you fork the repository, GitHub will create a copy of the master branch.
 However, this branch will not be updated when the nvaccess master branch is updated.

--- a/security.md
+++ b/security.md
@@ -20,3 +20,16 @@ This information will help us triage your report more quickly.
 * If there is a known solution or approach to fixing this issue
 
 Examples of handled security issues in NVDA can be found in the [NVDA GitHub Security Advisories page](https://github.com/nvaccess/nvda/security/advisories).
+
+## Security Advisory Group
+
+NV Access is committed to maintaining the highest standards of security in NVDA. In line with this commitment, we have established a Security Advisory Group. This group plays a pivotal role in enhancing the security of NVDA.
+
+Objectives and Functioning:
+
+* The group is composed of dedicated users and security enthusiasts who volunteer their expertise.
+* It focuses on identifying, analysing and resolving security issues in a collaborative manner.
+* The group's contributions are instrumental in maintaining and elevating our security standards.
+* Their insights and recommendations are directly incorporated into our development process, leading to more secure and reliable software.
+
+We welcome participation from our user community. If you have a keen interest in security and wish to contribute, please [contact us](mailto:info@nvaccess.org]).


### PR DESCRIPTION
### Link to issue number:
https://github.com/nvaccess/nvda/issues/16088

### Summary of the issue / description of user facing changes
This PR is to update the documentation in 2 places:

* include information on the NVDA security team
* for consistency, show the git clone command explicity when initially creating your nvda environment

### Code Review Checklist:

No code changes.

