### PR TITLE
Report the code of combined characters

### DIFF
--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -1922,13 +1922,17 @@ class GlobalCommands(ScriptableObject):
 			speech.spellTextInfo(info,useCharacterDescriptions=True)
 		else:
 			try:
-				c = ord(info.text)
+				cList = [ord(c) for c in info.text]
 			except TypeError:
 				c = None
-			if c is not None:
-				speech.speakMessage("%d," % c)
-				speech.speakSpelling(hex(c))
-				braille.handler.message(f"{c}, {hex(c)}")
+			if cList:
+				
+				for c in cList:
+					speech.speakMessage("%d," % c)
+					# Report hex along with decimal only when there is one character; else, it's confusing.
+					if len(cList) == 1:
+						speech.speakSpelling(hex(c))
+				braille.handler.message("; ".join(f"{c}, {hex(c)}" for c in cList))
 			else:
 				log.debugWarning("Couldn't calculate ordinal for character %r" % info.text)
 				speech.speakTextInfo(info, unit=textInfos.UNIT_CHARACTER, reason=controlTypes.OutputReason.CARET)


### PR DESCRIPTION
### Link to issue number:
Closes #5011.

### Summary of the issue:
Some characters are built with two or more Unicode characters: the first is a normal character and the following ones are combining characters. For example the character "é". It is built from the character "e" and the character "combining acute accent".

Pressing numpad2 twice, the description of the two characters are reported. However pressing numpad2 3 times, no character code is reported and the compound character is just reported as at first press; thus, triple press brings no useful information in this case.

### Description of user facing changes

When pressing three times numpad2:
* if the character under the review cursor is a single character, its decimal and hexadecimal codes will be reported as in pevious NVDA versions
* if the character under the review cursor is compound of two or more characters, the codes for each character building it will be reported:
  * In braille, both decimal and hexadecimal codes will be reported for each character
  * With speech, only the decimal code is reported to avoid cluttering the speech output with too much numeric information that may be hard to parse.

### Description of development approach
Modified the dedicated function.

### Testing strategy:
Manual test with the character in #5011 and with "é".
### Known issues with pull request:
In some applications (Firefox edit field, NVDA Python console output), navigating with the caret by character jumps over the whole compound character but navigating with the review cursor goes through each individual character building the compound character. In this case, each character is considered a separate character and handled as such. This PR does not change anything in this case.

### Code Review Checklist:


- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
