### PR TITLE
Play silence to keep audio device awake

### DIFF
--- a/nvdaHelper/local/nvdaHelperLocal.def
+++ b/nvdaHelper/local/nvdaHelperLocal.def
@@ -81,3 +81,6 @@ EXPORTS
 	wasPlay_resume
 	wasPlay_setChannelVolume
 	wasPlay_startup
+	wasSilence_init
+	wasSilence_playFor
+	wasSilence_terminate

--- a/nvdaHelper/local/wasapi.cpp
+++ b/nvdaHelper/local/wasapi.cpp
@@ -190,6 +190,7 @@ class WasapiPlayer {
 	HRESULT pause();
 	HRESULT resume();
 	HRESULT setChannelVolume(unsigned int channel, float level);
+
 	private:
 	void maybeFireCallback();
 

--- a/nvdaHelper/local/wasapi.cpp
+++ b/nvdaHelper/local/wasapi.cpp
@@ -12,6 +12,7 @@ This license can be found at:
 http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 */
 
+#include <thread>
 #include <vector>
 #include <windows.h>
 #include <atlbase.h>
@@ -27,11 +28,12 @@ http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
  * Support for audio playback using WASAPI.
  * Most of the core work happens in the WasapiPlayer class. Because Python
  * ctypes can't call C++ classes, NVDA interfaces with this using the wasPlay_*
- * functions.
+ * and wasSilence_* functions.
  */
 
 constexpr REFERENCE_TIME REFTIMES_PER_MILLISEC = 10000;
-constexpr REFERENCE_TIME BUFFER_SIZE = 400 * REFTIMES_PER_MILLISEC;
+constexpr DWORD BUFFER_MS = 400;
+constexpr REFERENCE_TIME BUFFER_SIZE = BUFFER_MS * REFTIMES_PER_MILLISEC;
 
 const CLSID CLSID_MMDeviceEnumerator = __uuidof(MMDeviceEnumerator);
 const IID IID_IMMDeviceEnumerator = __uuidof(IMMDeviceEnumerator);
@@ -385,8 +387,13 @@ HRESULT WasapiPlayer::feed(unsigned char* data, unsigned int size,
 		if (FAILED(hr)) {
 			return hr;
 		}
-		memcpy(buffer, data, sendBytes);
-		hr = render->ReleaseBuffer(sendFrames, 0);
+		if (data) {
+			memcpy(buffer, data, sendBytes);
+			hr = render->ReleaseBuffer(sendFrames, 0);
+		} else {
+			// Null data means play silence.
+			hr = render->ReleaseBuffer(sendFrames, AUDCLNT_BUFFERFLAGS_SILENT);
+		}
 		if (FAILED(hr)) {
 			return hr;
 		}
@@ -403,7 +410,9 @@ HRESULT WasapiPlayer::feed(unsigned char* data, unsigned int size,
 			playState = PlayState::playing;
 		}
 		maybeFireCallback();
-		data += sendBytes;
+		if (data) {
+			data += sendBytes;
+		}
 		size -= sendBytes;
 		remainingFrames -= sendFrames;
 		sentFrames += sendFrames;
@@ -624,9 +633,99 @@ HRESULT WasapiPlayer::setChannelVolume(unsigned int channel, float level) {
 	return volume->SetChannelVolume(channel, level);
 }
 
+/**
+ * Asynchronously play silence for requested durations.
+ * Silence is played in a background thread. The duration can be adjusted from
+ * any thread.
+ */
+class SilencePlayer {
+	public:
+	SilencePlayer(wchar_t* deviceName);
+	HRESULT init();
+	// Play silence for the specified duration.
+	void playFor(DWORD ms);
+	void terminate();
+
+	private:
+	static WAVEFORMATEX getFormat();
+	// The code which is run in the silence thread.
+	void run();
+
+	static constexpr DWORD SAMPLES_PER_SEC = 48000;
+	// How many bytes of silence in each buffer.
+	static constexpr unsigned int SILENCE_BYTES = SAMPLES_PER_SEC * 2 * BUFFER_MS
+		/ 1000;
+	WasapiPlayer player;
+	AutoHandle wakeEvent;
+	// The time (not duration) at which silence should end.
+	ULONGLONG endTime = 0;
+	std::thread silenceThread;
+};
+
+SilencePlayer::SilencePlayer(wchar_t* deviceName):
+player(deviceName, getFormat(), nullptr) {
+	wakeEvent = CreateEvent(nullptr, false, false, nullptr);
+}
+
+WAVEFORMATEX SilencePlayer::getFormat() {
+	WAVEFORMATEX format;
+	format.wFormatTag = WAVE_FORMAT_PCM;
+	format.nChannels = 1;
+	format.nSamplesPerSec = SAMPLES_PER_SEC;
+	format.wBitsPerSample = 16;
+	format.nBlockAlign = 2;
+	format.nAvgBytesPerSec = SAMPLES_PER_SEC * 2;
+	format.cbSize = 0;
+	return format;
+}
+
+HRESULT SilencePlayer::init() {
+	HRESULT hr = player.open();
+	if (FAILED(hr)) {
+		return hr;
+	}
+	silenceThread = std::thread(&SilencePlayer::run, this);
+	return S_OK;
+}
+
+void SilencePlayer::run() {
+	for (;;) {
+		// Wait for silence or termination to be requested.
+		WaitForSingleObject(wakeEvent, INFINITE);
+		if (endTime == 0) {
+			// We have been asked to terminate.
+			// std::thread cannot be destroyed while it is attached, so detach it first.
+			silenceThread.detach();
+			delete this;
+			return;
+		}
+		// Play silence until the desired time. This time might increase or decrease
+		// as we're looping. This is fine because we're only pushing BUFFER_MS each
+		// iteration.
+		while (GetTickCount64() < endTime) {
+			player.feed(nullptr, SILENCE_BYTES, nullptr);
+		}
+		player.idle();
+	}
+}
+
+void SilencePlayer::playFor(DWORD ms) {
+	endTime = ms == INFINITE ? ULLONG_MAX : GetTickCount64() + ms;
+	SetEvent(wakeEvent);
+}
+
+void SilencePlayer::terminate() {
+	// 0 signals silenceThread to exit.
+	endTime = 0;
+	// If silenceThread is feeding, this will make feed return early.
+	player.stop();
+	// If silenceThread is waiting, this will wake it up.
+	SetEvent(wakeEvent);
+}
+
 /*
  * NVDA calls the functions below. Most of these just wrap calls to
- * WasapiPlayer, with the exception of wasPlay_startup.
+ * WasapiPlayer or SilencePlayer, with the exception of wasPlay_startup.
  */
 
 WasapiPlayer* wasPlay_create(wchar_t* deviceName, WAVEFORMATEX format,
@@ -689,4 +788,24 @@ HRESULT wasPlay_startup() {
 	}
 	notificationClient = new NotificationClient();
 	return enumerator->RegisterEndpointNotificationCallback(notificationClient);
+}
+
+SilencePlayer* silence = nullptr;
+
+HRESULT wasSilence_init(wchar_t* deviceName) {
+	assert(!silence);
+	silence = new SilencePlayer(deviceName);
+	return silence->init();
+}
+
+void wasSilence_playFor(DWORD ms) {
+	assert(silence);
+	silence->playFor(ms);
+}
+
+void wasSilence_terminate() {
+	assert(silence);
+	silence->terminate();
+	// silence will delete itself once the thread terminates.
+	silence = nullptr;
 }

--- a/nvdaHelper/local/wasapi.cpp
+++ b/nvdaHelper/local/wasapi.cpp
@@ -702,6 +702,7 @@ void SilencePlayer::generateWhiteNoise(float volume) {
 		whiteNoiseData[i] = (INT16)dist(generator);
 	}
 }
+
 HRESULT SilencePlayer::init() {
 	HRESULT hr = player.open();
 	if (FAILED(hr)) {

--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -54,7 +54,7 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 	WASAPI = featureFlag(optionsEnum="BoolFlag", behaviorOfDefault="enabled")
 	soundVolumeFollowsVoice = boolean(default=false)
 	soundVolume = integer(default=100, min=0, max=100)
-	silenceTimeSeconds = integer(default=30,min=0,max=3600)
+	silenceTimeSeconds = integer(default=30, min=0, max=3600)
 	whiteNoiseVolume = integer(default=0, min=0, max=100)
 
 # Braille settings

--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -54,7 +54,7 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 	WASAPI = featureFlag(optionsEnum="BoolFlag", behaviorOfDefault="enabled")
 	soundVolumeFollowsVoice = boolean(default=false)
 	soundVolume = integer(default=100, min=0, max=100)
-	silenceTimeSeconds = integer(default=30, min=0, max=3600)
+	keepAudioAwakeTimeSeconds = integer(default=30, min=0, max=3600)
 	whiteNoiseVolume = integer(default=0, min=0, max=100)
 
 # Braille settings

--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -54,6 +54,8 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 	WASAPI = featureFlag(optionsEnum="BoolFlag", behaviorOfDefault="enabled")
 	soundVolumeFollowsVoice = boolean(default=false)
 	soundVolume = integer(default=100, min=0, max=100)
+	silenceTimeSeconds = integer(default=30,min=0,max=3600)
+	whiteNoiseVolume = integer(default=0, min=0, max=100)
 
 # Braille settings
 [braille]

--- a/source/core.py
+++ b/source/core.py
@@ -945,6 +945,7 @@ def main():
 			)
 		except:
 			pass
+	# We cannot terminate nvwave until after we perform nvwave.playWaveFile
 	_terminate(nvwave)
 	# #5189: Destroy the message window as late as possible
 	# so new instances of NVDA can find this one even if it freezes during exit.

--- a/source/core.py
+++ b/source/core.py
@@ -906,7 +906,6 @@ def main():
 	_terminate(bdDetect)
 	_terminate(hwIo)
 	_terminate(addonHandler)
-	_terminate(nvwave)
 	_terminate(garbageHandler)
 	# DMP is only started if needed.
 	# Terminate manually (and let it write to the log if necessary)
@@ -925,6 +924,7 @@ def main():
 			)
 		except:
 			pass
+	_terminate(nvwave)
 	# #5189: Destroy the message window as late as possible
 	# so new instances of NVDA can find this one even if it freezes during exit.
 	messageWindow.destroy()

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -3239,22 +3239,22 @@ class AdvancedPanelControls(
 		self.bindHelpEvent("WASAPI", self.wasapiComboBox)
 
 		silenceDurationLabelText = _(
-			# Translators: The label for a setting in advanced panel to change silence duration
-			"Duration in seconds of silence to keep audio device open"
+			# Translators: The label for a setting in advanced panel to change the duration of keeping audio device awake
+			"Duration in seconds of keeping audio device awake"
 		)
 		minDuration = int(config.conf.getConfigValidation(
-			("audio", "silenceTimeSeconds")
+			("audio", "keepAudioAwakeTimeSeconds")
 		).kwargs["min"])
-		maxDuration = int(config.conf.getConfigValidation(("audio", "silenceTimeSeconds")).kwargs["max"])
+		maxDuration = int(config.conf.getConfigValidation(("audio", "keepAudioAwakeTimeSeconds")).kwargs["max"])
 		self.silenceDurationEdit = audioGroup.addLabeledControl(
 			silenceDurationLabelText,
 			nvdaControls.SelectOnFocusSpinCtrl,
 			min=minDuration,
 			max=maxDuration,
-			initial=config.conf["audio"]["silenceTimeSeconds"]
+			initial=config.conf["audio"]["keepAudioAwakeTimeSeconds"]
 		)
-		self.silenceDurationEdit.defaultValue = self._getDefaultValue(["audio", "silenceTimeSeconds"])
-		self.bindHelpEvent("SilenceDuration", self.silenceDurationEdit)
+		self.silenceDurationEdit.defaultValue = self._getDefaultValue(["audio", "keepAudioAwakeTimeSeconds"])
+		self.bindHelpEvent("KeepAudioAwakeDuration", self.silenceDurationEdit)
 		self._onWasapiChange(None)
 
 		# Translators: This is the label for a group of advanced options in the
@@ -3421,7 +3421,7 @@ class AdvancedPanelControls(
 		for index,key in enumerate(self.logCategories):
 			config.conf['debugLog'][key]=self.logCategoriesList.IsChecked(index)
 		config.conf["featureFlag"]["playErrorSound"] = self.playErrorSoundCombo.GetSelection()
-		config.conf["audio"]["silenceTimeSeconds"] = self.silenceDurationEdit.GetValue()
+		config.conf["audio"]["keepAudioAwakeTimeSeconds"] = self.silenceDurationEdit.GetValue()
 
 
 class AdvancedPanel(SettingsPanel):

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -3252,7 +3252,7 @@ class AdvancedPanelControls(
 			max=maxDuration,
 			initial=config.conf["audio"]["silenceTimeSeconds"]
 		)
-		self.bindHelpEvent("silenceDuration", self.silenceDurationEdit)
+		self.bindHelpEvent("SilenceDuration", self.silenceDurationEdit)
 
 		# Translators: This is the label for a group of advanced options in the
 		# Advanced settings panel

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -3235,6 +3235,7 @@ class AdvancedPanelControls(
 			keyPath=["audio", "WASAPI"],
 			conf=config.conf,
 		))
+		self.wasapiComboBox .Bind(wx.EVT_CHOICE, self._onWasapiChange)
 		self.bindHelpEvent("WASAPI", self.wasapiComboBox)
 
 		silenceDurationLabelText = _(
@@ -3252,7 +3253,9 @@ class AdvancedPanelControls(
 			max=maxDuration,
 			initial=config.conf["audio"]["silenceTimeSeconds"]
 		)
+		self.silenceDurationEdit.defaultValue = self._getDefaultValue(["audio", "silenceTimeSeconds"])
 		self.bindHelpEvent("SilenceDuration", self.silenceDurationEdit)
+		self._onWasapiChange(None)
 
 		# Translators: This is the label for a group of advanced options in the
 		# Advanced settings panel
@@ -3316,6 +3319,12 @@ class AdvancedPanelControls(
 		path=config.getScratchpadDir(ensureExists=True)
 		os.startfile(path)
 
+	def _onWasapiChange(self, evt: wx.CommandEvent) -> None:
+		self.silenceDurationEdit.Enable(
+			config.conf["audio"]["WASAPI"]
+			and self.wasapiComboBox._getControlCurrentValue().value != 2 # wasapi not disabled
+		)
+
 	def _getDefaultValue(self, configPath):
 		return config.conf.getConfigValidation(configPath).default
 
@@ -3371,6 +3380,7 @@ class AdvancedPanelControls(
 		self.caretMoveTimeoutSpinControl.SetValue(self.caretMoveTimeoutSpinControl.defaultValue)
 		self.reportTransparentColorCheckBox.SetValue(self.reportTransparentColorCheckBox.defaultValue)
 		self.wasapiComboBox.resetToConfigSpecDefault()
+		self.silenceDurationEdit.SetValue(self.silenceDurationEdit.defaultValue)
 		self.logCategoriesList.CheckedItems = self.logCategoriesList.defaultCheckedItems
 		self.playErrorSoundCombo.SetSelection(self.playErrorSoundCombo.defaultValue)
 		self._defaultsRestored = True

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -3239,7 +3239,8 @@ class AdvancedPanelControls(
 		self.bindHelpEvent("WASAPI", self.wasapiComboBox)
 
 		silenceDurationLabelText = _(
-			# Translators: The label for a setting in advanced panel to change the duration of keeping audio device awake
+			# Translators: The label for a setting in advanced panel
+			# to change the duration of keeping audio device awake
 			"Duration in seconds of keeping audio device awake"
 		)
 		minDuration = int(config.conf.getConfigValidation(

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -3297,7 +3297,7 @@ class AdvancedPanelControls(
 
 		silenceDurationLabelText = _(
 			# Translators: The label for a setting in advanced panel to change silence duration
-			"Duration in seconds of silence or white noise played to keep audio device open (or 0 to disable)"
+			"Duration in seconds of silence to keep audio device open"
 		)
 		minDuration = int(config.conf.getConfigValidation(
 			("audio", "silenceTimeSeconds")

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -3295,6 +3295,40 @@ class AdvancedPanelControls(
 
 		self.Layout()
 
+		silenceDurationLabelText = _(
+			# Translators: The label for a setting in advanced panel to change silence duration
+			"Duration in seconds of silence or white noise played to keep audio device open (or 0 to disable)"
+		)
+		minDuration = int(config.conf.getConfigValidation(
+			("audio", "silenceTimeSeconds")
+		).kwargs["min"])
+		maxDuration = int(config.conf.getConfigValidation(("audio", "silenceTimeSeconds")).kwargs["max"])
+		self.silenceDurationEdit = sHelper.addLabeledControl(
+			silenceDurationLabelText,
+			nvdaControls.SelectOnFocusSpinCtrl,
+			min=minDuration,
+			max=maxDuration,
+			initial=config.conf["audio"]["silenceTimeSeconds"]
+		)
+		self.bindHelpEvent("silenceDuration", self.silenceDurationEdit)
+		self.silenceDurationEdit.Bind(wx.EVT_TEXT, self._onSilenceDurationChanged)
+
+		# Translators: This is the label for a slider control in the
+		# advanced settings panel.
+		label = _("White noise Volume - or set to 0 for silence")
+		self.whiteNoiseVolSlider: nvdaControls.EnhancedInputSlider = sHelper.addLabeledControl(
+			label,
+			nvdaControls.EnhancedInputSlider,
+			minValue=0,
+			maxValue=100
+		)
+		self.bindHelpEvent("whiteNoiseVolume", self.whiteNoiseVolSlider)
+		self.whiteNoiseVolSlider.SetValue(config.conf["audio"]["whiteNoiseVolume"])
+		self._onSilenceDurationChanged(None)
+
+	def _onSilenceDurationChanged(self, event: wx.Event) -> None:
+		self.whiteNoiseVolSlider.Enable(self.silenceDurationEdit.GetValue() > 0)
+
 	def onOpenScratchpadDir(self,evt):
 		path=config.getScratchpadDir(ensureExists=True)
 		os.startfile(path)
@@ -3394,6 +3428,8 @@ class AdvancedPanelControls(
 		for index,key in enumerate(self.logCategories):
 			config.conf['debugLog'][key]=self.logCategoriesList.IsChecked(index)
 		config.conf["featureFlag"]["playErrorSound"] = self.playErrorSoundCombo.GetSelection()
+		config.conf["audio"]["silenceTimeSeconds"] = self.silenceDurationEdit.GetValue()
+		config.conf["audio"]["whiteNoiseVolume"] = self.whiteNoiseVolSlider.GetValue()
 
 
 class AdvancedPanel(SettingsPanel):

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -3322,7 +3322,7 @@ class AdvancedPanelControls(
 	def _onWasapiChange(self, evt: wx.CommandEvent) -> None:
 		self.silenceDurationEdit.Enable(
 			config.conf["audio"]["WASAPI"]
-			and self.wasapiComboBox._getControlCurrentValue().value != 2 # wasapi not disabled
+			and self.wasapiComboBox._getControlCurrentValue().value != 2  # wasapi not disabled
 		)
 
 	def _getDefaultValue(self, configPath):

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -3237,6 +3237,23 @@ class AdvancedPanelControls(
 		))
 		self.bindHelpEvent("WASAPI", self.wasapiComboBox)
 
+		silenceDurationLabelText = _(
+			# Translators: The label for a setting in advanced panel to change silence duration
+			"Duration in seconds of silence to keep audio device open"
+		)
+		minDuration = int(config.conf.getConfigValidation(
+			("audio", "silenceTimeSeconds")
+		).kwargs["min"])
+		maxDuration = int(config.conf.getConfigValidation(("audio", "silenceTimeSeconds")).kwargs["max"])
+		self.silenceDurationEdit = audioGroup.addLabeledControl(
+			silenceDurationLabelText,
+			nvdaControls.SelectOnFocusSpinCtrl,
+			min=minDuration,
+			max=maxDuration,
+			initial=config.conf["audio"]["silenceTimeSeconds"]
+		)
+		self.bindHelpEvent("silenceDuration", self.silenceDurationEdit)
+
 		# Translators: This is the label for a group of advanced options in the
 		# Advanced settings panel
 		label = _("Debug logging")
@@ -3294,23 +3311,6 @@ class AdvancedPanelControls(
 		self.playErrorSoundCombo.defaultValue = self._getDefaultValue(["featureFlag", "playErrorSound"])
 
 		self.Layout()
-
-		silenceDurationLabelText = _(
-			# Translators: The label for a setting in advanced panel to change silence duration
-			"Duration in seconds of silence to keep audio device open"
-		)
-		minDuration = int(config.conf.getConfigValidation(
-			("audio", "silenceTimeSeconds")
-		).kwargs["min"])
-		maxDuration = int(config.conf.getConfigValidation(("audio", "silenceTimeSeconds")).kwargs["max"])
-		self.silenceDurationEdit = sHelper.addLabeledControl(
-			silenceDurationLabelText,
-			nvdaControls.SelectOnFocusSpinCtrl,
-			min=minDuration,
-			max=maxDuration,
-			initial=config.conf["audio"]["silenceTimeSeconds"]
-		)
-		self.bindHelpEvent("silenceDuration", self.silenceDurationEdit)
 
 	def onOpenScratchpadDir(self,evt):
 		path=config.getScratchpadDir(ensureExists=True)

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -3311,23 +3311,6 @@ class AdvancedPanelControls(
 			initial=config.conf["audio"]["silenceTimeSeconds"]
 		)
 		self.bindHelpEvent("silenceDuration", self.silenceDurationEdit)
-		self.silenceDurationEdit.Bind(wx.EVT_TEXT, self._onSilenceDurationChanged)
-
-		# Translators: This is the label for a slider control in the
-		# advanced settings panel.
-		label = _("White noise Volume - or set to 0 for silence")
-		self.whiteNoiseVolSlider: nvdaControls.EnhancedInputSlider = sHelper.addLabeledControl(
-			label,
-			nvdaControls.EnhancedInputSlider,
-			minValue=0,
-			maxValue=100
-		)
-		self.bindHelpEvent("whiteNoiseVolume", self.whiteNoiseVolSlider)
-		self.whiteNoiseVolSlider.SetValue(config.conf["audio"]["whiteNoiseVolume"])
-		self._onSilenceDurationChanged(None)
-
-	def _onSilenceDurationChanged(self, event: wx.Event) -> None:
-		self.whiteNoiseVolSlider.Enable(self.silenceDurationEdit.GetValue() > 0)
 
 	def onOpenScratchpadDir(self,evt):
 		path=config.getScratchpadDir(ensureExists=True)
@@ -3429,7 +3412,6 @@ class AdvancedPanelControls(
 			config.conf['debugLog'][key]=self.logCategoriesList.IsChecked(index)
 		config.conf["featureFlag"]["playErrorSound"] = self.playErrorSoundCombo.GetSelection()
 		config.conf["audio"]["silenceTimeSeconds"] = self.silenceDurationEdit.GetValue()
-		config.conf["audio"]["whiteNoiseVolume"] = self.whiteNoiseVolSlider.GetValue()
 
 
 class AdvancedPanel(SettingsPanel):

--- a/source/nvwave.py
+++ b/source/nvwave.py
@@ -834,11 +834,11 @@ class WasapiWavePlayer(garbageHandler.TrackedObject):
 		self.open()
 		self._lastActiveTime: typing.Optional[float] = None
 		self._isPaused: bool = False
-		if config.conf["audio"]["silenceTimeSeconds"] > 0 and WasapiWavePlayer._silenceDevice != outputDevice:
+		if config.conf["audio"]["keepAudioAwakeTimeSeconds"] > 0 and WasapiWavePlayer._silenceDevice != outputDevice:
 			# The output device has changed. (Re)initialize silence.
 			if self._silenceDevice is not None:
 				NVDAHelper.localLib.wasSilence_terminate()
-			if config.conf["audio"]["silenceTimeSeconds"] > 0:
+			if config.conf["audio"]["keepAudioAwakeTimeSeconds"] > 0:
 				NVDAHelper.localLib.wasSilence_init(outputDevice)
 				WasapiWavePlayer._silenceDevice = outputDevice
 
@@ -921,9 +921,9 @@ class WasapiWavePlayer(garbageHandler.TrackedObject):
 			self._doneCallbacks[feedId.value] = onDone
 		self._lastActiveTime = time.time()
 		self._scheduleIdleCheck()
-		if config.conf["audio"]["silenceTimeSeconds"] > 0:
+		if config.conf["audio"]["keepAudioAwakeTimeSeconds"] > 0:
 			NVDAHelper.localLib.wasSilence_playFor(
-				1000 * config.conf["audio"]["silenceTimeSeconds"],
+				1000 * config.conf["audio"]["keepAudioAwakeTimeSeconds"],
 				c_float(config.conf["audio"]["whiteNoiseVolume"] / 100.0),
 			)
 

--- a/source/nvwave.py
+++ b/source/nvwave.py
@@ -834,7 +834,10 @@ class WasapiWavePlayer(garbageHandler.TrackedObject):
 		self.open()
 		self._lastActiveTime: typing.Optional[float] = None
 		self._isPaused: bool = False
-		if config.conf["audio"]["keepAudioAwakeTimeSeconds"] > 0 and WasapiWavePlayer._silenceDevice != outputDevice:
+		if (
+			config.conf["audio"]["keepAudioAwakeTimeSeconds"] > 0
+			and WasapiWavePlayer._silenceDevice != outputDevice
+		):
 			# The output device has changed. (Re)initialize silence.
 			if self._silenceDevice is not None:
 				NVDAHelper.localLib.wasSilence_terminate()

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -12,7 +12,7 @@ What's New in NVDA
 - Reporting row and column headers is now supported in contenteditable HTML elements. (#14113)
 - In Windows 11, NVDA will announce alerts from voice typing and suggested actions including the top suggestion when copying data such as phone numbers to the clipboard (Windows 11 2022 Update and later). (#16009, @josephsl)
 - Added support for the BrailleEdgeS2 braille device. (#16033)
-- NVDA will play silence after every utterance in order to prevent the start of the next speech being clipped with some audio devices such as Bluetooth headphones. (#14386, @jcsteh, @mltony)
+- NVDA will play silence after every speech sequence in order to prevent the start of the next speech being clipped with some audio devices such as Bluetooth headphones. (#14386, @jcsteh, @mltony)
 -
 
 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -11,6 +11,7 @@ What's New in NVDA
 - NVDA will play silence after every utterance in order to prevent the start of the next speech being clipped with some audio devices such as Bluetooth headphones. (#14386, @jcsteh, @mltony)
 -
 
+
 == Changes ==
 
 - Add-on Store:

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -7,6 +7,7 @@ What's New in NVDA
 
 == New Features ==
 - In Windows 11, NVDA will announce alerts from voice typing and suggested actions including the top suggestion when copying data such as phone numbers to the clipboard (Windows 11 2022 Update and later). (#16009, @josephsl)
+- Playing silence after every utterance in order to keep audio device open (#14386, @jcsteh, @mltony)
 -
 
 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -8,7 +8,7 @@ What's New in NVDA
 == New Features ==
 - In Windows 11, NVDA will announce alerts from voice typing and suggested actions including the top suggestion when copying data such as phone numbers to the clipboard (Windows 11 2022 Update and later). (#16009, @josephsl)
 - Added support for the BrailleEdgeS2 braille device. (#16033)
-- NVDA will play silence after every utterance in order to prevent the start of next speech to be clipped with some audio devices such as Bluetooth headphones. (#14386, @jcsteh, @mltony)
+- NVDA will play silence after every utterance in order to prevent the start of the next speech being clipped with some audio devices such as Bluetooth headphones. (#14386, @jcsteh, @mltony)
 -
 
 == Changes ==

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -8,7 +8,7 @@ What's New in NVDA
 == New Features ==
 - In Windows 11, NVDA will announce alerts from voice typing and suggested actions including the top suggestion when copying data such as phone numbers to the clipboard (Windows 11 2022 Update and later). (#16009, @josephsl)
 - Added support for the BrailleEdgeS2 braille device. (#16033)
-- Playing silence after every utterance in order to keep audio device open (#14386, @jcsteh, @mltony)
+- NVDA will play silence after every utterance in order to prevent the start of next speech to be clipped with some audio devices such as Bluetooth headphones. (#14386, @jcsteh, @mltony)
 -
 
 == Changes ==

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2586,7 +2586,9 @@ Disabling WASAPI will disable the following options:
 
 ==== Silence duration ====[SilenceDuration]
 
-This edit box specifies how long NVDA plays silence after every utterance. NVDA plays silence to keep audio device open and avoid certain glitches like dropped parts of utterances, that happen due to audio devices (especially Bluetooth and wireless devices) entering stand by mode.
+This edit box specifies how long NVDA plays silence after every utterance.
+NVDA plays silence to keep audio device open and avoid certain glitches like dropped parts of utterances.
+This can happen due to audio devices (especially Bluetooth and wireless devices) entering stand-by mode.
 
 * Too low value would mean  audio may be cut-off more often.
 * Too high value would mean the battery of sound output device discharges faster.

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2602,7 +2602,7 @@ You can specify silence duration to be 0 in order to disable this feature.
 
 ==== White noise volume slider ====[whiteNoiseVolume]
 
-When you set white noise volume to any value above zero, then instead of silence NVDA would playh white noise in order to keep audio device open. This feature is useful for debugging audio issues.
+When you set white noise volume to any value above zero, then instead of silence NVDA would play white noise in order to keep audio device open. This feature is useful for debugging audio issues.
 
 ++ miscellaneous Settings ++[MiscSettings]
 Besides the [NVDA Settings #NVDASettings] dialog, The Preferences sub-menu of the NVDA Menu contains several other items which are outlined below.

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2591,7 +2591,7 @@ This edit box specifies how long NVDA plays silence after every utterance. NVDA 
 * Too low value would mean  audio may be cut-off more often.
 * Too high value would mean the battery of sound output device discharges faster.
 
-You can specify silence duration to be 0 in order to disable this feature.
+You can specify silence duration to be 0 in order to disable this feature. This slider is only availabel when wasapi mode is enabled.
 
 ==== Debug logging categories ====[AdvancedSettingsDebugLoggingCategories]
 The checkboxes in this list allow you to enable specific categories of debug messages in NVDA's log.

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2598,6 +2598,9 @@ Choosing Yes allows to enable error sounds whatever your current NVDA version is
 
 This edit box specifies how long NVDA plays silence after every utterance. We play silence to keep audio device open and avoid certain glitches like dropped parts of utterances, that happen due to audio devices (especially Bluetooth and wireless devices) entering stand by mode.
 
+* Too low value would mean  audio may be cut-off more often.
+• Too high value would mean the battery of sound output device discharges faster.
+
 You can specify silence duration to be 0 in order to disable this feature.
 
 ==== White noise volume slider ====[whiteNoiseVolume]

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2607,8 +2607,8 @@ Disabling WASAPI will disable the following options:
 
 ==== Duration of keeping audio device awake ====[KeepAudioAwakeDuration]
 
-This edit box specifies how long NVDA keeps audio device awake after every utterance.
-NVDA does that by playing silence to keep audio device open and avoid certain glitches like dropped parts of utterances.
+This edit box specifies how long NVDA keeps audio device awake after every speech sequence.
+NVDA does that by playing silence to keep audio device open and avoid certain glitches like dropped parts of speech sequences.
 This can happen due to audio devices (especially Bluetooth and wireless devices) entering stand-by mode.
 
 Lower values may mean audio would be cut-off more often, as a device may enter stand-by mode, causing the next speech to be clipped.

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2584,6 +2584,15 @@ Disabling WASAPI will disable the following options:
 - [Volume of NVDA sounds #SoundVolume]
 -
 
+==== Silence duration ====[silenceDuration]
+
+This edit box specifies how long NVDA plays silence after every utterance. We play silence to keep audio device open and avoid certain glitches like dropped parts of utterances, that happen due to audio devices (especially Bluetooth and wireless devices) entering stand by mode.
+
+* Too low value would mean  audio may be cut-off more often.
+• Too high value would mean the battery of sound output device discharges faster.
+
+You can specify silence duration to be 0 in order to disable this feature.
+
 ==== Debug logging categories ====[AdvancedSettingsDebugLoggingCategories]
 The checkboxes in this list allow you to enable specific categories of debug messages in NVDA's log.
 Logging these messages can result in decreased performance and large log files.
@@ -2593,15 +2602,6 @@ Only turn one of these on if specifically instructed to by an NVDA developer e.g
 This option allows you to specify if NVDA will play an error sound in case an error is logged.
 Choosing Only in test versions (default) makes NVDA play error sounds only if the current NVDA version is a test version (alpha, beta or run from source).
 Choosing Yes allows to enable error sounds whatever your current NVDA version is.
-
-==== Silence duration ====[silenceDuration]
-
-This edit box specifies how long NVDA plays silence after every utterance. We play silence to keep audio device open and avoid certain glitches like dropped parts of utterances, that happen due to audio devices (especially Bluetooth and wireless devices) entering stand by mode.
-
-* Too low value would mean  audio may be cut-off more often.
-• Too high value would mean the battery of sound output device discharges faster.
-
-You can specify silence duration to be 0 in order to disable this feature.
 
 ++ miscellaneous Settings ++[MiscSettings]
 Besides the [NVDA Settings #NVDASettings] dialog, The Preferences sub-menu of the NVDA Menu contains several other items which are outlined below.

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2594,6 +2594,16 @@ This option allows you to specify if NVDA will play an error sound in case an er
 Choosing Only in test versions (default) makes NVDA play error sounds only if the current NVDA version is a test version (alpha, beta or run from source).
 Choosing Yes allows to enable error sounds whatever your current NVDA version is.
 
+==== Silence duration ====[silenceDuration]
+
+This edit box specifies how long NVDA plays silence after every utterance. We play silence to keep audio device open and avoid certain glitches like dropped parts of utterances, that happen due to audio devices (especially Bluetooth and wireless devices) entering stand by mode.
+
+You can specify silence duration to be 0 in order to disable this feature.
+
+==== White noise volume slider ====[whiteNoiseVolume]
+
+When you set white noise volume to any value above zero, then instead of silence NVDA would playh white noise in order to keep audio device open. This feature is useful for debugging audio issues.
+
 ++ miscellaneous Settings ++[MiscSettings]
 Besides the [NVDA Settings #NVDASettings] dialog, The Preferences sub-menu of the NVDA Menu contains several other items which are outlined below.
 

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2603,10 +2603,6 @@ This edit box specifies how long NVDA plays silence after every utterance. We pl
 
 You can specify silence duration to be 0 in order to disable this feature.
 
-==== White noise volume slider ====[whiteNoiseVolume]
-
-When you set white noise volume to any value above zero, then instead of silence NVDA would play white noise in order to keep audio device open. This feature is useful for debugging audio issues.
-
 ++ miscellaneous Settings ++[MiscSettings]
 Besides the [NVDA Settings #NVDASettings] dialog, The Preferences sub-menu of the NVDA Menu contains several other items which are outlined below.
 

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2589,7 +2589,7 @@ Disabling WASAPI will disable the following options:
 This edit box specifies how long NVDA plays silence after every utterance. We play silence to keep audio device open and avoid certain glitches like dropped parts of utterances, that happen due to audio devices (especially Bluetooth and wireless devices) entering stand by mode.
 
 * Too low value would mean  audio may be cut-off more often.
-• Too high value would mean the battery of sound output device discharges faster.
+* Too high value would mean the battery of sound output device discharges faster.
 
 You can specify silence duration to be 0 in order to disable this feature.
 

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2607,15 +2607,15 @@ Disabling WASAPI will disable the following options:
 
 ==== Duration of keeping audio device awake ====[KeepAudioAwakeDuration]
 
-This edit box specifies how long NVDA keeps audio device awake after every speech sequence.
-NVDA does that by playing silence to keep audio device open and avoid certain glitches like dropped parts of speech sequences.
+This edit box specifies how long NVDA keeps the audio device awake after every speech sequence.
+NVDA does this by playing silence to keep the audio device open and avoid certain glitches like dropped parts of speech sequences.
 This can happen due to audio devices (especially Bluetooth and wireless devices) entering stand-by mode.
 
 Lower values may mean audio would be cut-off more often, as a device may enter stand-by mode, causing the next speech to be clipped.
 Too high a value may mean the battery of the sound output device discharges faster, as it stays active for longer while no sound is being sent.
 
 You can specify silence duration to be 0 in order to disable this feature.
-This slider is only available when WASAPI mode is enabled.
+This slider is only available when [WASAPI mode #WASAPI] is enabled.
 
 ==== Debug logging categories ====[AdvancedSettingsDebugLoggingCategories]
 The checkboxes in this list allow you to enable specific categories of debug messages in NVDA's log.

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2610,6 +2610,7 @@ Disabling WASAPI will disable the following options:
 This edit box specifies how long NVDA keeps the audio device awake after every speech sequence.
 NVDA does this by playing silence to keep the audio device open and avoid certain glitches like dropped parts of speech sequences.
 This can happen due to audio devices (especially Bluetooth and wireless devices) entering stand-by mode.
+This might also be helpful in certain other use cases, such as running NVDA inside a virtual machine, such as Citrix Virtual Desktop, or on certain models of laptops.
 
 Lower values may mean audio would be cut-off more often, as a device may enter stand-by mode, causing the next speech to be clipped.
 Too high a value may mean the battery of the sound output device discharges faster, as it stays active for longer while no sound is being sent.

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2584,10 +2584,10 @@ Disabling WASAPI will disable the following options:
 - [Volume of NVDA sounds #SoundVolume]
 -
 
-==== Silence duration ====[SilenceDuration]
+==== Duration of keeping audio device awake ====[KeepAudioAwakeDuration]
 
-This edit box specifies how long NVDA plays silence after every utterance.
-NVDA plays silence to keep audio device open and avoid certain glitches like dropped parts of utterances.
+This edit box specifies how long NVDA keeps audio device awake after every utterance.
+NVDA does that by playing silence to keep audio device open and avoid certain glitches like dropped parts of utterances.
 This can happen due to audio devices (especially Bluetooth and wireless devices) entering stand-by mode.
 
 Lower values may mean audio would be cut-off more often, as a device may enter stand-by mode, causing the next speech to be clipped.

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2590,8 +2590,8 @@ This edit box specifies how long NVDA plays silence after every utterance.
 NVDA plays silence to keep audio device open and avoid certain glitches like dropped parts of utterances.
 This can happen due to audio devices (especially Bluetooth and wireless devices) entering stand-by mode.
 
-* Too low value would mean  audio may be cut-off more often.
-* Too high value would mean the battery of sound output device discharges faster.
+Lower values may mean audio would be cut-off more often, as a device may enter stand-by mode, causing the next speech to be clipped.
+Too high a value may mean the battery of the sound output device discharges faster, as it stays active for longer while no sound is being sent.
 
 You can specify silence duration to be 0 in order to disable this feature. This slider is only availabel when wasapi mode is enabled.
 

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2584,7 +2584,7 @@ Disabling WASAPI will disable the following options:
 - [Volume of NVDA sounds #SoundVolume]
 -
 
-==== Silence duration ====[silenceDuration]
+==== Silence duration ====[SilenceDuration]
 
 This edit box specifies how long NVDA plays silence after every utterance. We play silence to keep audio device open and avoid certain glitches like dropped parts of utterances, that happen due to audio devices (especially Bluetooth and wireless devices) entering stand by mode.
 

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2593,7 +2593,8 @@ This can happen due to audio devices (especially Bluetooth and wireless devices)
 Lower values may mean audio would be cut-off more often, as a device may enter stand-by mode, causing the next speech to be clipped.
 Too high a value may mean the battery of the sound output device discharges faster, as it stays active for longer while no sound is being sent.
 
-You can specify silence duration to be 0 in order to disable this feature. This slider is only availabel when wasapi mode is enabled.
+You can specify silence duration to be 0 in order to disable this feature.
+This slider is only available when WASAPI mode is enabled.
 
 ==== Debug logging categories ====[AdvancedSettingsDebugLoggingCategories]
 The checkboxes in this list allow you to enable specific categories of debug messages in NVDA's log.

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2586,7 +2586,7 @@ Disabling WASAPI will disable the following options:
 
 ==== Silence duration ====[SilenceDuration]
 
-This edit box specifies how long NVDA plays silence after every utterance. We play silence to keep audio device open and avoid certain glitches like dropped parts of utterances, that happen due to audio devices (especially Bluetooth and wireless devices) entering stand by mode.
+This edit box specifies how long NVDA plays silence after every utterance. NVDA plays silence to keep audio device open and avoid certain glitches like dropped parts of utterances, that happen due to audio devices (especially Bluetooth and wireless devices) entering stand by mode.
 
 * Too low value would mean  audio may be cut-off more often.
 * Too high value would mean the battery of sound output device discharges faster.


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Fixes #14386
### Summary of the issue:
Play silence in order to keep audio device open
### Description of user facing changes
By default most users won't notice anything as default volume is 0 (playing silence).
I added two config options in the advanced panel: silence duration (default = 30 seconds) and white noise volume (default is set to 0). Playing white noise would be helpfulin order to debug any user issues related to audio dropout.
### Description of development approach
Most of heavylifting has  been done by @jcsteh.
In `wasapi.cpp` there has been added `class SilencePlayer` that spawns a new thread, that just plays silence/white noise when requested. Requests are coming from python code in `nvwave.py` from `WasapiWavePlayer.feed()` function.

### Testing strategy:
Tested with white noise that it is being played as expected. Tested that config changes reflect immediately.
Couldn't test with silence as apparently my bluetooth headphones are not suffering from dropout problem in the first place.
### Known issues with pull request:
N/A
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
