### PR TITLE
Update security policy: private advisory reporting

### DIFF
--- a/projectDocs/issues/securityAdvisoryTemplate.md
+++ b/projectDocs/issues/securityAdvisoryTemplate.md
@@ -1,0 +1,29 @@
+### Summary
+*A summary of the issue.*
+*Include the class of vulnerability (e.g. denial of service, privilege escalation).*
+*Describe the impact to the user or victim.*
+
+### Patch commit(s)
+*Created publicly on NVDA when merging the advisory pull request(s)*
+https://github.com/nvaccess/nvda/commit/
+
+### Limitations
+*Any caveats on when the software is vulnerable. For example, if only certain configurations are affected.*
+
+### Technical details
+
+#### Proof of concept
+
+#### Indicators of compromise
+
+### Workarounds
+
+### Timeline
+*history of the disclosure and release process*
+- Reported: YYYY/MM/DD
+- Acknowledged by NV Access: YYYY/MM/DD
+- Fix released - NVDA 20XX.YY: YYYY/MM/DD
+
+### For more information
+If you have any questions or comments about this advisory:
+* Email us at [info@nvaccess.org](mailto:info@nvaccess.org)

--- a/security.md
+++ b/security.md
@@ -1,9 +1,11 @@
 # Reporting Security Issues
 
 Please do not report security vulnerabilities through public GitHub issues.
-Instead, please report them via an email to info@nvaccess.org.
+You can report security issues directly through [a GitHub Security Advisory](https://github.com/nvaccess/nvda/security/advisories/new).
+Please use [our advisory template](./projectDocs/issues/securityAdvisoryTemplate.md).
+Alternatively, please report security issues via an email to [info@nvaccess.org](mailto:info@nvaccess.org).
 
-You should receive an acknowledgement email response within 3 business days.
+You should receive an acknowledgement in the advisory or via email response within 3 business days.
 If for some reason you do not, please follow up via email to ensure we received your original message. 
 
 Please include the requested information listed below (as much as you can provide) to help us better understand the nature and scope of the possible issue.


### PR DESCRIPTION
NVDA now uses GitHubs new feature for reporting Security Issues privately through the advisory system.

The security process should be updated to encourage using this new process rather than email