### PR TITLE
Fix occasional error when the session is locked/unlocked

### DIFF
--- a/source/keyboardHandler.py
+++ b/source/keyboardHandler.py
@@ -140,23 +140,19 @@ def shouldUseToUnicodeEx(focus: Optional["NVDAObject"] = None):
 	from NVDAObjects.window import Window
 	from NVDAObjects.behaviors import KeyboardHandlerBasedTypedCharSupport
 	return (
+		# The focused NVDA object should be a real window
+		isinstance(focus, Window)
 		# This is only possible in Windows 10 1607 and above
-		winVersion.getWinVer() >= winVersion.WIN10_1607
+		and winVersion.getWinVer() >= winVersion.WIN10_1607
 		and (  # Either of
 			# We couldn't inject in-process, and its not a legacy console window without keyboard support.
 			# console windows have their own specific typed character support.
 			(
 				not focus.appModule.helperLocalBindingHandle
-				and (
-					not isinstance(focus, Window)
-					or focus.windowClassName != 'ConsoleWindowClass'
-				)
+				and focus.windowClassName != 'ConsoleWindowClass'
 			)
 			# or the focus is within a UWP app, where WM_CHAR never gets sent
-			or (
-				isinstance(focus, Window)
-				and focus.windowClassName.startswith('Windows.UI.Core')
-			)
+			or focus.windowClassName.startswith('Windows.UI.Core')
 			# Or this is a console with keyboard support, where WM_CHAR messages are doubled
 			or isinstance(focus, KeyboardHandlerBasedTypedCharSupport)
 		)

--- a/source/watchdog.py
+++ b/source/watchdog.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2008-2021 NV Access Limited
+# Copyright (C) 2008-2024 NV Access Limited, Cyrille Bougot
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -200,17 +200,19 @@ def _shouldRecoverAfterMinTimeout():
 		return True
 	# Import late to avoid circular import.
 	import api
+	from NVDAObjects.window import Window
 	#If a system menu has been activated but NVDA's focus is not yet in the menu then use min timeout
 	if info.flags&winUser.GUI_SYSTEMMENUMODE and info.hwndMenuOwner and api.getFocusObject().windowClassName!='#32768':
 		return True 
 	if winUser.getClassName(info.hwndFocus) in safeWindowClassSet:
 		return False
-	if not winUser.isDescendantWindow(info.hwndActive, api.getFocusObject().windowHandle):
+	focus = api.getFocusObject()
+	if (not isinstance(focus, Window)) or (not winUser.isDescendantWindow(info.hwndActive, focus.windowHandle)):
 		# The foreground window has changed.
 		return True
 	newHwnd=info.hwndFocus
 	newThreadID=winUser.getWindowThreadProcessID(newHwnd)[1]
-	return newThreadID!=api.getFocusObject().windowThreadID
+	return newThreadID != focus.windowThreadID
 
 def _recoverAttempt():
 	try:


### PR DESCRIPTION
### Link to issue number:
Fix #16120
Related to #15400.
### Summary of the issue:
Sporadic errors still occur when locking/unlocking Windows session. As per #15400, this is due to the fact that `api.getFocusObject` returns an `NVDAObjects.NVDAObject` but we use it as it was an `NVDAObjects.window.Window`. But that's not the case when the focus is (or was) `winAPI.secureDesktop._handleSecureDesktopChange._SecureDesktopNVDAObject`.

### Description of user facing changes
Probably none; these errors did not seem to have any visible impact.

### Description of development approach
Check the class of the object returned by `api.getFocusObject` before using its properties.

### Testing strategy:
* Lock and unlock the session. However, this test is not complete since the issue only occurred sporadically.
* When merged to beta, check that such errors are not there anymore.

### Known issues with pull request:
Maybe there are other places where we use an `NVDAObject` as if it was a `Window`. We'll fix them the same way if we encounter them in the future.

### Change log
None. Error appeared during 2024.1 dev cycle.

### Code Review Checklist:


- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
