### PR TITLE
Document `addonHandler.initTranslation`

### DIFF
--- a/projectDocs/dev/developerGuide/developerGuide.t2t
+++ b/projectDocs/dev/developerGuide/developerGuide.t2t
@@ -877,8 +877,9 @@ All other fields will be ignored.
 
 +++ Locale-specific Messages +++
 Each language directory can also contain gettext information, which is the system used to translate the rest of NVDA's user interface and reported messages.
-As with the rest of NVDA, an nvda.mo compiled gettext database file should be placed in the LC_MESSAGES directory within this directory.
-To allow plugins in your add-on to access gettext message information via calls to _(), you must initialize translations at the top of each Python module by calling addonHandler.initTranslation().
+As with the rest of NVDA, an ``nvda.mo`` compiled gettext database file should be placed in the ``LC_MESSAGES`` directory within this directory.
+To allow plugins in your add-on to access gettext message information via calls to ``_()``, ``ngettext()``, ``npgettext()`` and ``pgettext()`` you must initialize translations at the top of each Python module by calling ``addonHandler.initTranslation()``.
+This function cannot be called in modules that do not belong to an add-on, e.g. in a scratchpad subdirectory.
 For more information about gettext and NVDA translation in general, please read the [Translating NVDA wiki page https://github.com/nvaccess/nvda/wiki/Translating]
 
 ++ Add-on Documentation ++[AddonDoc]

--- a/source/addonHandler/__init__.py
+++ b/source/addonHandler/__init__.py
@@ -833,6 +833,13 @@ def getCodeAddon(obj=None, frameDist=1):
 
 
 def initTranslation():
+	"""Initializes the translation of an add-on so that the Gettext functions (_, ngettext, npgettext and
+	pgettext) point to the add-on's translation rather than to NVDA's one.
+	This function should be called at the top of any module containing translatable strings and belonging to
+	an add-on. It cannot be called in a module that does not belong to an add-on (e.g. in a subdirectory of the
+	scratchpad).
+	"""
+
 	addon = getCodeAddon(frameDist=2)
 	translations = addon.getTranslationsInstance()
 	_TRANSLATION_FUNCTIONS = {


### PR DESCRIPTION
### Link to issue number:
Fixes #15318
### Summary of the issue:
Some users complained that calling `addonHandler.initTranslation` from the scratchpad raises an error.
### Description of user facing changes
Document the function and update the User Guide to clarify that it is expected result.
### Description of development approach
N/A
### Testing strategy:
Check docstring and generated dev guide.

### Known issues with pull request:
None

### Change log
not needed

### Code Review Checklist:


- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
