### PR TITLE
Ignore padding dots at low symbol reporting levels

### DIFF
--- a/source/characterProcessing.py
+++ b/source/characterProcessing.py
@@ -528,7 +528,7 @@ class SpeechSymbolProcessor(object):
 		multiChars.sort(key=lambda identifier: len(identifier), reverse=True)
 
 		# Build the regexp.
-		patterns = []
+		patterns: list[str] = []
 		# Complex symbols.
 		# Each complex symbol has its own named group so we know which symbol matched.
 		patterns.extend(

--- a/source/characterProcessing.py
+++ b/source/characterProcessing.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2010-2023 NV Access Limited, World Light Information Limited,
+# Copyright (C) 2010-2024 NV Access Limited, World Light Information Limited,
 # Hong Kong Blind Union, Babbage B.V., Julien Cochuyt, Cyrille Bougot
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
@@ -528,17 +528,18 @@ class SpeechSymbolProcessor(object):
 		multiChars.sort(key=lambda identifier: len(identifier), reverse=True)
 
 		# Build the regexp.
-		patterns = [
-			# Strip repeated spaces from the end of the line to stop them from being picked up by repeated.
-			r"(?P<rstripSpace>  +$)",
-			# Repeated characters: more than 3 repeats.
-			r"(?P<repeated>(?P<repTmp>%s)(?P=repTmp){3,})" % characters
-		]
+		patterns = []
 		# Complex symbols.
 		# Each complex symbol has its own named group so we know which symbol matched.
 		patterns.extend(
 			u"(?P<c{index}>{pattern})".format(index=index, pattern=symbol.pattern)
 			for index, symbol in enumerate(complexSymbolsList))
+		patterns.extend([
+			# Strip repeated spaces from the end of the line to stop them from being picked up by repeated.
+			r"(?P<rstripSpace>  +$)",
+			# Repeated characters: more than 3 repeats.
+			r"(?P<repeated>(?P<repTmp>%s)(?P=repTmp){3,})" % characters
+		])
 		# Simple symbols.
 		# These are all handled in one named group.
 		# Because the symbols are just text, we know which symbol matched just by looking at the matched text.

--- a/source/locale/en/symbols.dic
+++ b/source/locale/en/symbols.dic
@@ -11,6 +11,8 @@ complexSymbols:
 # Phrase endings.
 ; phrase ending	(?<=[^\s;]);(?=\s|$)
 : phrase ending	(?<=[^\s:]):(?=\s|$)
+# Series of dots used for visual presentation, e.g. in table of contents
+padding .	\.{4,}
 # Others
 decimal point	(?<![^\d -])\.(?=\d)
 in-word '	(?<=[^\W_])['’]
@@ -25,6 +27,7 @@ symbols:
 ? sentence ending	question	all	always
 ; phrase ending	semi	most	always
 : phrase ending	colon	most	always
+padding .	padding dots	all	always
 decimal point		none	always
 in-word '	tick	all	norep
 negative number	minus	none	norep

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -20,6 +20,7 @@ What's New in NVDA
 - Add-on Store:
   - The minimum and the last tested NVDA version for an add-on are now displayed in the "other details" area. (#15776, @Nael-Sayegh)
   -
+- Padding dots commonly used in tables of contents are not reported anymore at low punctuation levels. (#15845, @CyrilleB79)
 -
 
 == Bug Fixes ==


### PR DESCRIPTION
### Link to issue number:
Closes #15845
### Summary of the issue:
Padding dots in table of contents are reported even at low punctuation levels.
### Description of user facing changes
Padding dots are not reported anymore at low punctuation levels.
### Description of development approach
In symbol file, define a complex symbol to identify padding dots as 4 or more dots. Assign level to "all", e.g. as "end of sentence dot". And define "send real symbol to synthesizer" to "always" so that a pause is kept between the text before the dots and the text after them.

In character processing, change the order of symbol processing as follows:
* complex symbols rules
* repetition rules
* simple symbol rules

Before, repetition rule was the first. This has been done so that the repetition rule do not override the new rule for the padding dots complex symbol.
In any case, I do not think that there was any use case of the repetition rule being used with complex symbols.

### Testing strategy:
Tested the following expressions at low or high symbol level:
```
a.1
a ... 1
a ........ 1
¿
¿¿¿¿
```

### Known issues with pull request:
In browse mode, e.g. while reading a PDF, the text of the line may contain more characters than the max number of characters by line defined in Browse mode settings in some usual cases. In this case, the line is still split depending on its original number of characters, what can be undesirable.
To address this, the maximum number of characters in a line should be increased; 200 should be enough in most common use cases.

### Code Review Checklist:


- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
