### PR TITLE
Fix text paragraph navigation speech

### DIFF
--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -175,13 +175,20 @@ class QuickNavItem(object, metaclass=ABCMeta):
 class TextInfoQuickNavItem(QuickNavItem):
 	""" Represents a quick nav item in a browse mode document who's positions are represented by a L{textInfos.TextInfo}. """
 
-	def __init__(self,itemType,document,textInfo):
+	def __init__(
+			self,
+			itemType: str,
+			document: treeInterceptorHandler.TreeInterceptor,
+			textInfo: textInfos.TextInfo,
+			outputReason: OutputReason = OutputReason.QUICKNAV,
+	):
 		"""
 		See L{QuickNavItem.__init__} for itemType and document argument definitions.
 		@param textInfo: the textInfo position this item represents.
 		@type textInfo: L{textInfos.TextInfo}
 		"""
 		self.textInfo=textInfo
+		self.outputReason = outputReason
 		super(TextInfoQuickNavItem,self).__init__(itemType,document)
 
 	def __lt__(self,other):
@@ -213,7 +220,7 @@ class TextInfoQuickNavItem(QuickNavItem):
 			if info.compareEndPoints(fieldInfo, "endToEnd") > 0:
 				# We've expanded past the end of the field, so limit to the end of the field.
 				info.setEndPoint(fieldInfo, "endToEnd")
-		speech.speakTextInfo(info, reason=OutputReason.QUICKNAV)
+		speech.speakTextInfo(info, reason=self.outputReason)
 
 	def activate(self):
 		self.textInfo.obj._activatePosition(info=self.textInfo)
@@ -471,7 +478,7 @@ class BrowseModeTreeInterceptor(treeInterceptorHandler.TreeInterceptor):
 				return
 			value = paragraphFunction(info)
 			if value == desiredValue:
-				yield TextInfoQuickNavItem(kind, self, info.copy())
+				yield TextInfoQuickNavItem(kind, self, info.copy(), outputReason=OutputReason.CARET)
 
 
 	def _quickNavScript(self,gesture, itemType, direction, errorMessage, readUnit):


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Closes #16143
### Summary of the issue:
NVDA reports roles incorrectly when navigating using P quickNav
### Description of user facing changes
Fixed speech so that p quickNav command behaves as expected.
### Description of development approach
A quick investigation shows that this is the behavior of `speech.speakTextInfo(info, reason=OutputReason.QUICKNAV)` as called in `browseMode.py:216`. I didn't change that in textNav PR.

This makes sense for other QuickNav commands. For example on that page if you press B, you get:
```
Open global navigation menu Button
```
Note that the word button goes in the end. If you stumble upon the same button via `Control+Up/Down` then the speech is 
```
Button Open global navigation menu
```

So since text paragraph navigation is more similar to caret navigation in the sense that it navigates to text that might contain different roles, I propose to change to `reason=OutputReason.CARET` for text paragraph navigation as it seems to fix this issue.
### Testing strategy:
Tested via test case provided in the issue.
### Known issues with pull request:
N/A
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
