### PR TITLE
MS Word object model browse mode: ensure native selection mode toggle message reflects that it cannot be turned off

### DIFF
--- a/source/NVDAObjects/window/winword.py
+++ b/source/NVDAObjects/window/winword.py
@@ -1167,6 +1167,7 @@ class BrowseModeWordDocumentTextInfo(browseMode.BrowseModeDocumentTextInfo,treeI
 class WordDocumentTreeInterceptor(browseMode.BrowseModeDocumentTreeInterceptor):
 
 	TextInfo=BrowseModeWordDocumentTextInfo
+	_nativeAppSelectionMode = True
 
 	def _activateLongDesc(self,controlField):
 		longDesc=controlField.get('longdescription')


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Follow up from #16129
Fixes #16097


### Summary of the issue:
Selecting text in Browse mode in Microsoft Word moves the physical selection. Thus it is the equivalent to native selection mode. Pr #16129 ensured that Browse mode in MS word with UI Automation took this into account and made the toggle message report that native selection mode could not be turned off. However this has not been done for MS Word object model, and NVDA states that native selection mode is unsupported.
 
### Description of user facing changes
* When trying to toggle native selection mode in Browse mode in MS Word when not using UI Automation, NvDA will correctly state that native selection mode cannot be turned off.
* When copying text with control+c in browse mode in MS Word when not using UI Automation, formatting is now also copied.

 ### Description of development approach
Set browse mode for MS Word object model's `_nativeAppSelectionMode` to True.

### Testing strategy:
* Ensure NVDA's advanced setting for using UIA to access MS Word documents is set to only when necessary. 
*Open a document in MS Word.
* Switch on NVDA's browse mode with NvDA+space.
* Try to toggle native selection mode with NVDA+shift+f10. 
* confirm that NvDA reports that native selection mode cannot be turned off.

### Known issues with pull request:
None known.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
