### PR TITLE
fix minor bug in synth settings ring

### DIFF
--- a/source/synthSettingsRing.py
+++ b/source/synthSettingsRing.py
@@ -95,8 +95,8 @@ class BooleanSynthSetting(SynthSetting):
 
 class SynthSettingsRing(baseObject.AutoPropertyObject):
 	"""
-	A synth settings ring which enables the user to change to the next and previous settings and adjust the selected one.
-	It was written to facilitate the implementation of a way to change the settings resembling the window-eyes way.
+	A synth settings ring which enables the user to change to the next and previous settings,
+	as well as adjust the selected one.
 	"""
 
 	settings: list[SynthSetting] | None

--- a/source/synthSettingsRing.py
+++ b/source/synthSettingsRing.py
@@ -1,8 +1,15 @@
+# A part of NonVisual Desktop Access (NVDA)
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+# Copyright (C) 2006-2024 NV Access Limited
+
+from typing import Any
+
+from autoSettingsUtils.driverSetting import BooleanDriverSetting, NumericDriverSetting
 import baseObject
 import config
-import synthDriverHandler
 import queueHandler
-from autoSettingsUtils.driverSetting import BooleanDriverSetting, NumericDriverSetting
+import synthDriverHandler
 
 
 class SynthSetting(baseObject.AutoPropertyObject):
@@ -85,11 +92,14 @@ class BooleanSynthSetting(SynthSetting):
 	def _getReportValue(self, val):
 		return _("on") if val else _("off")
 
+
 class SynthSettingsRing(baseObject.AutoPropertyObject):
 	"""
-	A synth settings ring which enables the user to change to the next and previous settings and ajust the selected one
+	A synth settings ring which enables the user to change to the next and previous settings and adjust the selected one.
 	It was written to facilitate the implementation of a way to change the settings resembling the window-eyes way.
 	"""
+
+	settings: list[SynthSetting] | None
 
 	def __init__(self,synth):
 		try:
@@ -107,9 +117,9 @@ class SynthSettingsRing(baseObject.AutoPropertyObject):
 	def _get_currentSettingValue(self):
 		return self.settings[self._current].reportValue
 
-	def _set_currentSettingValue(self,value):
+	def _set_currentSettingValue(self, value: Any):
 		if self._current is not None:
-			self.settings[_current].value = val
+			self.settings[self._current].value = value
 
 	def next(self):
 		""" changes to the next setting and returns its name """
@@ -145,7 +155,7 @@ class SynthSettingsRing(baseObject.AutoPropertyObject):
 			if self._current is not None and hasattr(self,'settings')
 			else None
 		)
-		list = []
+		list: list[SynthSetting] = []
 		for s in synth.supportedSettings:
 			if not s.availableInSettingsRing: continue
 			if prevID == s.id: #restore the last setting


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
None
### Summary of the issue:
`_set_currentSettingValue` had invalid syntax, with two symbols not being referenced correctly
The function is currently not used in NVDA core, so the bug went unnoticed

### Description of user facing changes
None

### Description of development approach
Use correct references for symbols.

linting and typing fixes
### Testing strategy:
None
### Known issues with pull request:
None
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
