### PR TITLE
Use the add-on's (translated) display name in the removal confirmation dialog

### DIFF
--- a/source/gui/addonStoreGui/controls/messageDialogs.py
+++ b/source/gui/addonStoreGui/controls/messageDialogs.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2023 NV Access Limited, Cyrille Bougot
+# Copyright (C) 2023-2024 NV Access Limited, Cyrille Bougot
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -124,7 +124,7 @@ def _shouldProceedToRemoveAddonDialog(
 		# {addon} is replaced with the add-on name.
 		"Are you sure you wish to remove the {addon} add-on from NVDA? "
 		"This cannot be undone."
-	).format(addon=addon.name)
+	).format(addon=addon.displayName)
 	dlg = ErrorAddonInstallDialogWithYesNoButtons(
 		parent=parent,
 		# Translators: Title for message asking if the user really wishes to remove the selected Add-on.


### PR DESCRIPTION
### Link to issue number:
None
### Summary of the issue:
When removing an add-on, there is a confirmation dialog.
The add-on's name used in this dialog is NVDA's internal name (formerly "id"). It should be the name displayed in the GUI instead; this name displayed in the GUI is also translated whereas the internal name is not.

### Description of user facing changes
The translated full name will be used in the add-on removal confirmation dialog, instead of the internal name.
### Description of development approach
See code
### Testing strategy:
Manually tested the dialog.

### Known issues with pull request:
None

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
