### PR TITLE
Revert diff_match_patch upgrade

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ requests==2.31.0
 Pillow==10.2.0 -C "zlib=disable" -C "jpeg=disable"
 
 #NVDA_DMP requires diff-match-patch
-fast_diff_match_patch==2.0.1
+diff_match_patch_python==1.0.2
 
 # Packaging NVDA
 git+https://github.com/py2exe/py2exe@4e7b2b2c60face592e67cb1bc935172a20fa371d#egg=py2exe

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -192,6 +192,8 @@ Setting ``numCells`` is still supported for single line braille displays and ``n
 - Fixed bug where deleting git-tracked files during ``scons -c`` resulted in missing UIA COM interfaces on rebuild. (#7070, #10833, @hwf1324)
 - Fix a bug where some code changes were not detected when building ``dist``, that prevented a new build from being triggered.
 Now ``dist`` always rebuilds. (#13372, @hwf1324)
+- Updated Comtypes to version 1.2.0. (#15513)
+- Added extension point: ``treeInterceptorHandler.post_browseModeStateChange``. (#14969)
 -
 
 === API Breaking Changes ===

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -192,8 +192,6 @@ Setting ``numCells`` is still supported for single line braille displays and ``n
 - Fixed bug where deleting git-tracked files during ``scons -c`` resulted in missing UIA COM interfaces on rebuild. (#7070, #10833, @hwf1324)
 - Fix a bug where some code changes were not detected when building ``dist``, that prevented a new build from being triggered.
 Now ``dist`` always rebuilds. (#13372, @hwf1324)
-- Updated Comtypes to version 1.2.0. (#15513)
-- Added extension point: ``treeInterceptorHandler.post_browseModeStateChange``. (#14969)
 -
 
 === API Breaking Changes ===
@@ -204,7 +202,6 @@ Please open a GitHub issue if your Add-on has an issue with updating to the new 
 - Updated pip dependencies:
   - configobj to 5.1.0dev commit ``e2ba4457c4651fa54f8d59d8dcdd3da950e956b8``. (#15544)
   - Comtypes to 1.2.0. (#15513, @codeofdusk)
-  - fast_diff_match_patch to 2.0.1. (#15514, @codeofdusk)
   - Flake8 to 4.0.1. (#15636, @lukaszgo1)
   - py2exe to 0.13.0.1dev commit ``4e7b2b2c60face592e67cb1bc935172a20fa371d``. (#15544) 
   - robotframework to 6.1.1. (#15544)


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Fixes #16027
Reverts #15514
This reverts commit 69a16ccfc90b2d52710edbdbb76dfc8f74585379.

### Summary of the issue:
PR #15514 upgraded diff_match_patch from 1.0.2 to fast_diff_match_patch 2.0.1.
However, the newer version cannot handle particular unicode characters such as `🍰`. The diff_match_patch process dies, NvDA can no longer report text changes, and NvDA hangs on exit.

### Description of user facing changes
Printing unicode characters such as `🍰` in a terminal withn using diff_match_patch for speaking changes no longer causes NvDA to no longer report text changes and lock up on exit.

### Description of development approach
Downgrade back to diff_match_patch 1.0.2.

### Testing strategy:
Followed steps in #16027 and ensured that NVDA spoke the `🍰` character when printed, that it continued to speak further text changes, and that NvDA did not lock up when exiting / restarting.

### Known issues with pull request:
An alternative approach was shown in #16027 where NVDA could filter bad characters from diff_match_patch. this may be necessary in future if we do need to upgrade again eventually. But as this broke in the current (2024.1) cycle, there was no critical reason for the upgrade originally that I could see, and downgrading was clean, then this is the most appropriate solution at this late stage in the 2024.1 cycle.
 @codeOfDusk was there any other motivation to upgrade other than just keeping up to date with the latest version?

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
