### PR TITLE
Add custom hooks for unraisable exceptions, to log exceptions raised in ctypes callback functions in a more readable way

### DIFF
--- a/source/logHandler.py
+++ b/source/logHandler.py
@@ -493,7 +493,7 @@ def _unraisableExceptHook(unraisable: _UnraisableHookArgs) -> None:
 	if unraisable.err_msg:
 		msg = f"{unraisable.err_msg}: {unraisable.object!r}"
 	else:
-		msg = "{Exception ignored in}: {unraisable.object!r}"
+		msg = f"Exception ignored in: {unraisable.object!r}"
 	log.exception(exc_info=(unraisable.exc_type, unraisable.exc_value, unraisable.exc_traceback), codepath=msg)
 
 

--- a/source/logHandler.py
+++ b/source/logHandler.py
@@ -1,6 +1,6 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2007-2023 NV Access Limited, Rui Batista, Joseph Lee, Leonard de Ruijter, Babbage B.V.,
-# Accessolutions, Julien Cochuyt, Cyrille Bougot
+# Copyright (C) 2007-2024 NV Access Limited, Rui Batista, Joseph Lee, Leonard de Ruijter, Babbage B.V.,
+# Accessolutions, Julien Cochuyt, Cyrille Bougot, Łukasz Golonka
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -23,6 +23,7 @@ from typing import (
 	Literal,
 	NamedTuple,
 	Optional,
+	Protocol,
 	TYPE_CHECKING,
 )
 import exceptions
@@ -479,6 +480,23 @@ def _threadExceptHook(excInfoObj: _ThreadExceptHookArgs_t) -> None:
 	log.exception(msg, (excInfoObj.exc_type, excInfoObj.exc_value, excInfoObj.exc_traceback))
 
 
+class _UnraisableHookArgs(Protocol):
+
+	exc_type: type[BaseException]
+	exc_value: BaseException | None
+	exc_traceback: TracebackType | None
+	err_msg: str | None
+	object: object
+
+
+def _unraisableExceptHook(unraisable: _UnraisableHookArgs) -> None:
+	if unraisable.err_msg:
+		msg = f"{unraisable.err_msg}: {unraisable.object!r}"
+	else:
+		msg = "{Exception ignored in}: {unraisable.object!r}"
+	log.exception(exc_info=(unraisable.exc_type, unraisable.exc_value, unraisable.exc_traceback), codepath=msg)
+
+
 def _showwarning(message, category, filename, lineno, file=None, line=None):
 	log.debugWarning(warnings.formatwarning(message, category, filename, lineno, line).rstrip(), codepath="Python warning")
 
@@ -559,6 +577,7 @@ def initialize(shouldDoRemoteLogging=False):
 	log.root.addHandler(logHandler)
 	redirectStdout(log)
 	sys.excepthook = _excepthook
+	sys.unraisablehook = _unraisableExceptHook
 	threading.excepthook = _threadExceptHook
 	warnings.showwarning = _showwarning
 	warnings.simplefilter("default", DeprecationWarning)


### PR DESCRIPTION
Opened against beta since this PR fixes regression caused by the upgrade to Python 3.11, and the change is very low risk.

### Link to issue number:
Fixes #16115

### Summary of the issue:
When an exception is raised in `ctypes` callback function Python cannot handle it in any reasonable way, so the traceback gets printed to stderr. Somewhere after Python 3.7 a change was made, so that it is printed line by line. As a result we get as many log entries as there were lines in the traceback making logging extremely noisy. 
### Description of user facing changes
Exceptions from `ctypes` callback functions once again results in a single log entry.

### Description of development approach
Since Python 3.8 it is possible to customize how these so called unraisable exceptions are handle. This PR adds a handler which logs them in a readable format, mostly based on how the native Python's hook does this.
### Testing strategy:
Raised an exception in `winInputHook.keyboardHook`, ensured it results in a single, readable log entry.
### Known issues with pull request:
None known
### Code Review Checklist:


- [X] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [X] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [X] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [X] API is compatible with existing add-ons.
- [X] Security precautions taken.
