### PR TITLE
Make installer process safer

### DIFF
--- a/appx/sconscript
+++ b/appx/sconscript
@@ -63,7 +63,6 @@ signExec=env['signExec'] if env['certFile'] else None
 # Files from NVDA's distribution that cannot be included in the appx due to policy or security restrictions
 excludedDistFiles=[
 	'nvda_eoaProxy.exe',
-	'nvda_service.exe',
 	'nvda_slave.exe',
 	'nvda_noUIAccess.exe',
 	'lib/IAccessible2Proxy.dll',
@@ -107,4 +106,3 @@ if signExec and not isStoreSubmission:
 	env.AddPostAction(appx,signExec)
 
 Return(['appx'])
-

--- a/source/buildVersion.py
+++ b/source/buildVersion.py
@@ -67,7 +67,7 @@ def formatVersionForGUI(year, major, minor):
 name = "NVDA"
 version_year = 2023
 version_major = 3
-version_minor = 3
+version_minor = 4
 version_build = 0  # Should not be set manually. Set in 'sconscript' provided by 'appVeyor.yml'
 version=_formatDevVersionString()
 publisher="unknown"

--- a/source/installer.py
+++ b/source/installer.py
@@ -696,7 +696,7 @@ def install(shouldCreateDesktopShortcut: bool = True, shouldRunAtLogon: bool = T
 	# Some exes are no longer used, but we remove them anyway from legacy copies.
 	# nvda_service.exe was removed in 2017.4 (#7625).
 	# TODO: nvda_eoaProxy.exe should be added to this list in 2024.1 (#15544).
-	_deleteInstallerFileGroupOrFail(prevInstallPath, _nvdaExes.union({"nvda_service.exe"}))
+	_deleteInstallerFileGroupOrFail(installDir, _nvdaExes.union({"nvda_service.exe"}))
 	unregisterInstallation(keepDesktopShortcut=shouldCreateDesktopShortcut)
 	if prevInstallPath:
 		removeOldLoggedFiles(prevInstallPath)

--- a/source/installer.py
+++ b/source/installer.py
@@ -651,7 +651,7 @@ def _revertGroupDelete(tempDir: str, installDir: str):
 			log.exception(f"Failed to rename {tempFile} back to {originalPath}")
 
 
-def _deleteInstallerFileGroupOrFail(installDir: str, relativeFilepaths: Iterable[str]):
+def _deleteFileGroupOrFail(installDir: str, relativeFilepaths: Iterable[str]):
 	"""
 	Delete a group of files in the installer folder.
 	If any file fails to be deleted, revert the deletion of all other files.
@@ -696,7 +696,7 @@ def install(shouldCreateDesktopShortcut: bool = True, shouldRunAtLogon: bool = T
 	# Some exes are no longer used, but we remove them anyway from legacy copies.
 	# nvda_service.exe was removed in 2017.4 (#7625).
 	# TODO: nvda_eoaProxy.exe should be added to this list in 2024.1 (#15544).
-	_deleteInstallerFileGroupOrFail(installDir, _nvdaExes.union({"nvda_service.exe"}))
+	_deleteFileGroupOrFail(installDir, _nvdaExes.union({"nvda_service.exe"}))
 	unregisterInstallation(keepDesktopShortcut=shouldCreateDesktopShortcut)
 	if prevInstallPath:
 		removeOldLoggedFiles(prevInstallPath)
@@ -737,7 +737,7 @@ def removeOldLoggedFiles(installPath):
 def createPortableCopy(destPath,shouldCopyUserConfig=True):
 	assert os.path.isabs(destPath), f"Destination path {destPath} is not absolute"
 	# Remove all the main executables always
-	_deleteInstallerFileGroupOrFail(destPath, {"nvda.exe", "nvda_noUIAccess.exe", "nvda_UIAccess.exe"})
+	_deleteFileGroupOrFail(destPath, {"nvda.exe", "nvda_noUIAccess.exe", "nvda_UIAccess.exe"})
 	removeOldProgramFiles(destPath)
 	copyProgramFiles(destPath)
 	tryCopyFile(os.path.join(destPath,"nvda_noUIAccess.exe"),os.path.join(destPath,"nvda.exe"))

--- a/tests/unit/test_installer.py
+++ b/tests/unit/test_installer.py
@@ -3,7 +3,7 @@
 # See the file COPYING for more details.
 # Copyright (C) 2024 NV Access Limited
 
-"""Unit tests for the installer  module.
+"""Unit tests for the installer module.
 """
 
 import pathlib
@@ -11,6 +11,7 @@ import tempfile
 import unittest
 
 import installer
+
 
 class Test_BatchDeletion(unittest.TestCase):
 	"""Tests for deleting previous installation files safely in a batch for the installation process.

--- a/tests/unit/test_installer.py
+++ b/tests/unit/test_installer.py
@@ -36,14 +36,14 @@ class Test_BatchDeletion(unittest.TestCase):
 				f.unlink()
 
 	def test_deleteFilesSuccess(self):
-		installer._deleteInstallerFileGroupOrFail(self._originalTempDir, self._sampleFiles)
+		installer._deleteFileGroupOrFail(self._originalTempDir, self._sampleFiles)
 		for file in self._sampleFiles:
 			self.assertFalse(pathlib.Path(self._originalTempDir, file).exists())
 
 	def test_deleteFilesFailure(self):
 		with self.assertRaises(installer.RetriableFailure):
 			with open(pathlib.Path(self._originalTempDir, self._sampleFiles[1]), "r"):
-				installer._deleteInstallerFileGroupOrFail(self._originalTempDir, self._sampleFiles)
+				installer._deleteFileGroupOrFail(self._originalTempDir, self._sampleFiles)
 
 		# Assert files are back where they started
 		for file in self._sampleFiles:
@@ -54,7 +54,7 @@ class Test_BatchDeletion(unittest.TestCase):
 		for file in self._sampleFiles:
 			pathlib.Path(self._originalTempDir, file).unlink()
 
-		installer._deleteInstallerFileGroupOrFail(self._originalTempDir, self._sampleFiles)
+		installer._deleteFileGroupOrFail(self._originalTempDir, self._sampleFiles)
 		for file in self._sampleFiles:
 			self.assertFalse(pathlib.Path(self._originalTempDir, file).exists())
 
@@ -62,6 +62,6 @@ class Test_BatchDeletion(unittest.TestCase):
 		# Delete 1 file
 		pathlib.Path(self._originalTempDir, self._sampleFiles[1]).unlink()
 
-		installer._deleteInstallerFileGroupOrFail(self._originalTempDir, self._sampleFiles)
+		installer._deleteFileGroupOrFail(self._originalTempDir, self._sampleFiles)
 		for file in self._sampleFiles:
 			self.assertFalse(pathlib.Path(self._originalTempDir, file).exists())

--- a/tests/unit/test_installer.py
+++ b/tests/unit/test_installer.py
@@ -1,0 +1,46 @@
+# A part of NonVisual Desktop Access (NVDA)
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+# Copyright (C) 2024 NV Access Limited
+
+"""Unit tests for the installer  module.
+"""
+
+import pathlib
+import tempfile
+import unittest
+
+import installer
+
+class Test_BatchDeletion(unittest.TestCase):
+	"""A test for the extension points on the input manager."""
+
+	def setUp(self) -> None:
+		self._originalTempDir = tempfile.mkdtemp()
+		self._sampleFiles = [
+			"file1.txt",
+			"file2.txt",
+			"file3.txt",
+		]
+		for file in self._sampleFiles:
+			pathlib.Path(self._originalTempDir, file).touch(exist_ok=False)
+
+	def tearDown(self) -> None:
+		for file in self._sampleFiles:
+			f = pathlib.Path(self._originalTempDir, file)
+			if f.exists():
+				f.unlink()
+
+	def test_deleteFilesSuccess(self):
+		installer._deleteInstallerFileGroupOrFail(self._originalTempDir, self._sampleFiles)
+		for file in self._sampleFiles:
+			self.assertFalse(pathlib.Path(self._originalTempDir, file).exists())
+
+	def test_deleteFilesFailure(self):
+		with self.assertRaises(installer.RetriableFailure):
+			with open(pathlib.Path(self._originalTempDir, self._sampleFiles[1]), "r"):
+				installer._deleteInstallerFileGroupOrFail(self._originalTempDir, self._sampleFiles)
+
+		# Assert files are back where they started
+		for file in self._sampleFiles:
+			self.assertTrue(pathlib.Path(self._originalTempDir, file).exists())

--- a/tests/unit/test_installer.py
+++ b/tests/unit/test_installer.py
@@ -13,7 +13,10 @@ import unittest
 import installer
 
 class Test_BatchDeletion(unittest.TestCase):
-	"""A test for the extension points on the input manager."""
+	"""Tests for deleting previous installation files safely in a batch for the installation process.
+	If any file fails to be deleted, the entire operation should be aborted.
+	This ensure installations don't end up in a partially uninstalled state.
+	"""
 
 	def setUp(self) -> None:
 		self._originalTempDir = tempfile.mkdtemp()
@@ -44,3 +47,20 @@ class Test_BatchDeletion(unittest.TestCase):
 		# Assert files are back where they started
 		for file in self._sampleFiles:
 			self.assertTrue(pathlib.Path(self._originalTempDir, file).exists())
+
+	def test_deleteNonExistantFilesSuccess(self):
+		# Delete all expected files
+		for file in self._sampleFiles:
+			pathlib.Path(self._originalTempDir, file).unlink()
+
+		installer._deleteInstallerFileGroupOrFail(self._originalTempDir, self._sampleFiles)
+		for file in self._sampleFiles:
+			self.assertFalse(pathlib.Path(self._originalTempDir, file).exists())
+
+	def test_deleteNonExistantFileSuccess(self):
+		# Delete 1 file
+		pathlib.Path(self._originalTempDir, self._sampleFiles[1]).unlink()
+
+		installer._deleteInstallerFileGroupOrFail(self._originalTempDir, self._sampleFiles)
+		for file in self._sampleFiles:
+			self.assertFalse(pathlib.Path(self._originalTempDir, file).exists())

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -4,6 +4,13 @@ What's New in NVDA
 %!includeconf: ../changes.t2tconf
 %!includeconf: ./locale.t2tconf
 
+= 2023.3.4 =
+This is a patch release to fix an installer issue.
+
+== Bug Fixes ==
+- Fixes bug which caused NVDA installation to fail to an unrecoverable state. (#16122)
+-
+
 = 2023.3.3 =
 This is a patch release to fix a security issue.
 Please responsibly disclose security issues following NVDA's [security policy https://github.com/nvaccess/nvda/blob/master/security.md].


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Fixes #16122

### Summary of the issue:
NVDA process sometimes fails to quit correctly (see #16123).
When running the installer, this causes the installer to fail partway through.
If the installer fails partway through, the installation may end up in an unrecoverable state.

For certain files, NVDA requests windows to move or delete these on reboot, if the move/delete fails initially.
However, if the Windows API request fails, NVDA does not handle the failure the same way as it handles other failures - raising a retryable failure and reverting the change if possible.

### Description of user facing changes
The NVDA installation process should be more resilient if the previous process is still running.

### Description of development approach

NVDA attempts to remove all known exes in a batch as the first operation in the installation. If any known NVDA exe is running, the installation is aborted with a retry able failure and all exes returned to their original state. This means the user can attempt the installation again - i.e. waiting a bit longer for the process to hopefully exit.

If NVDA fails to request windows to remove certain files on restart, this is handled the same as if the files are failed to be removed.

More logging has been added and improved.
### Testing strategy:
- [x] Tested manually triggering a retriable failure to ensure the handling is as expected.
- [ ] Manual testing from the community is required to confirm the fix.

### Known issues with pull request:
The installation process should be atomic - i.e. if it fails, the whole operation should be reverted. This is not the case of the current design. In future code to NVDA we can specify more files we want to include in the atomic and reversible operation.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
