### PR TITLE
Daemonize addon store, timeout web requests

### DIFF
--- a/source/NVDAObjects/behaviors.py
+++ b/source/NVDAObjects/behaviors.py
@@ -350,9 +350,9 @@ class LiveText(NVDAObject):
 			return
 		thread = self._monitorThread = threading.Thread(
 			name=f"{self.__class__.__qualname__}._monitorThread",
-			target=self._monitor
+			target=self._monitor,
+			daemon=True,
 		)
-		thread.daemon = True
 		self._keepMonitoring = True
 		self._event.clear()
 		thread.start()

--- a/source/UIAHandler/__init__.py
+++ b/source/UIAHandler/__init__.py
@@ -427,9 +427,9 @@ class UIAHandler(COMObject):
 		self.MTAThreadInitException=None
 		self.MTAThread = threading.Thread(
 			name=f"{self.__class__.__module__}.{self.__class__.__qualname__}.MTAThread",
-			target=self.MTAThreadFunc
+			target=self.MTAThreadFunc,
+			daemon=True,
 		)
-		self.MTAThread.daemon=True
 		self.MTAThread.start()
 		self.MTAThreadInitEvent.wait(2)
 		if self.MTAThreadInitException:

--- a/source/_addonStore/dataManager.py
+++ b/source/_addonStore/dataManager.py
@@ -109,7 +109,7 @@ class _DataManager:
 
 	def terminate(self):
 		if self._getAddonsThread.is_alive():
-			self._getAddonsThread.join(timeout=FETCH_TIMEOUT_S + 1)
+			self._getAddonsThread.join(timeout=1)
 
 	def _getLatestAddonsDataForVersion(self, apiVersion: str) -> Optional[bytes]:
 		url = _getAddonStoreURL(self._preferredChannel, self._lang, apiVersion)

--- a/source/_addonStore/dataManager.py
+++ b/source/_addonStore/dataManager.py
@@ -129,7 +129,7 @@ class _DataManager:
 	def _getCacheHash(self) -> Optional[str]:
 		url = _getCacheHashURL()
 		try:
-			response = requests.get(url)
+			response = requests.get(url, timeout=FETCH_TIMEOUT_S)
 		except requests.exceptions.RequestException as e:
 			log.debugWarning(f"Unable to get cache hash: {e}")
 			return None

--- a/source/_addonStore/dataManager.py
+++ b/source/_addonStore/dataManager.py
@@ -100,20 +100,23 @@ class _DataManager:
 		self._compatibleAddonCache = self._getCachedAddonData(self._cacheCompatibleFile)
 		self._installedAddonsCache = _InstalledAddonsCache()
 		# Fetch available add-ons cache early
-		self._getAddonsThread = threading.Thread(
+		self._initialiseAvailableAddonsThread = threading.Thread(
 			target=self.getLatestCompatibleAddons,
 			name="initialiseAvailableAddons",
 			daemon=True,
 		)
-		self._getAddonsThread.start()
+		self._initialiseAvailableAddonsThread.start()
 
 	def terminate(self):
-		if self._getAddonsThread.is_alive():
-			self._getAddonsThread.join(timeout=1)
+		if self._initialiseAvailableAddonsThread.is_alive():
+			self._initialiseAvailableAddonsThread.join(timeout=1)
+		if self._initialiseAvailableAddonsThread.is_alive():
+			log.debugWarning("initialiseAvailableAddons thread did not terminate immediately")
 
 	def _getLatestAddonsDataForVersion(self, apiVersion: str) -> Optional[bytes]:
 		url = _getAddonStoreURL(self._preferredChannel, self._lang, apiVersion)
 		try:
+			log.debug(f"Fetching add-on data from {url}")
 			response = requests.get(url, timeout=FETCH_TIMEOUT_S)
 		except requests.exceptions.RequestException as e:
 			log.debugWarning(f"Unable to fetch addon data: {e}")
@@ -129,6 +132,7 @@ class _DataManager:
 	def _getCacheHash(self) -> Optional[str]:
 		url = _getCacheHashURL()
 		try:
+			log.debug(f"Fetching add-on data from {url}")
 			response = requests.get(url, timeout=FETCH_TIMEOUT_S)
 		except requests.exceptions.RequestException as e:
 			log.debugWarning(f"Unable to get cache hash: {e}")

--- a/source/_addonStore/network.py
+++ b/source/_addonStore/network.py
@@ -179,6 +179,7 @@ class AddonFileDownloader:
 			return False
 
 		# Some add-ons are quite large, so we need to allow for a long download time.
+		# 1GB at 0.5 MB/s takes 4.5hr to download.
 		MAX_ADDON_DOWNLOAD_TIME = 60 * 60 * 6  # 6 hours
 		with requests.get(addonData.model.URL, stream=True, timeout=MAX_ADDON_DOWNLOAD_TIME) as r:
 			with open(downloadFilePath, 'wb') as fd:

--- a/source/_addonStore/network.py
+++ b/source/_addonStore/network.py
@@ -178,7 +178,9 @@ class AddonFileDownloader:
 		if not NVDAState.shouldWriteToDisk():
 			return False
 
-		with requests.get(addonData.model.URL, stream=True) as r:
+		# Some add-ons are quite large, so we need to allow for a long download time.
+		MAX_ADDON_DOWNLOAD_TIME = 60 * 60 * 6  # 6 hours
+		with requests.get(addonData.model.URL, stream=True, timeout=MAX_ADDON_DOWNLOAD_TIME) as r:
 			with open(downloadFilePath, 'wb') as fd:
 				# Most add-ons are small. This value was chosen quite arbitrarily, but with the intention to allow
 				# interrupting the download. This is particularly important on a slow connection, to provide

--- a/source/buildVersion.py
+++ b/source/buildVersion.py
@@ -67,7 +67,7 @@ def formatVersionForGUI(year, major, minor):
 name = "NVDA"
 version_year = 2023
 version_major = 3
-version_minor = 3
+version_minor = 4
 version_build = 0  # Should not be set manually. Set in 'sconscript' provided by 'appVeyor.yml'
 version=_formatDevVersionString()
 publisher="unknown"

--- a/source/core.py
+++ b/source/core.py
@@ -240,6 +240,10 @@ def resetConfiguration(factoryDefaults=False):
 	hwIo.terminate()
 	log.debug("terminating addonHandler")
 	addonHandler.terminate()
+	# Addons
+	from _addonStore import dataManager
+	log.debug("terminating addon dataManager")
+	dataManager.terminate()
 	log.debug("Reloading config")
 	config.conf.reset(factoryDefaults=factoryDefaults)
 	logHandler.setLogLevelFromConfig()
@@ -250,8 +254,6 @@ def resetConfiguration(factoryDefaults=False):
 		lang = config.conf["general"]["language"]
 	log.debug("setting language to %s"%lang)
 	languageHandler.setLanguage(lang)
-	# Addons
-	from _addonStore import dataManager
 	dataManager.initialize()
 	addonHandler.initialize()
 	# Hardware background i/o
@@ -856,6 +858,7 @@ def main():
 	_terminate(bdDetect)
 	_terminate(hwIo)
 	_terminate(addonHandler)
+	_terminate(dataManager, name="addon dataManager")
 	_terminate(garbageHandler)
 	# DMP is only started if needed.
 	# Terminate manually (and let it write to the log if necessary)

--- a/source/gui/_addonStoreGui/viewModels/store.py
+++ b/source/gui/_addonStoreGui/viewModels/store.py
@@ -383,7 +383,12 @@ class AddonStoreVM:
 			_StatusFilterKey.AVAILABLE,
 			_StatusFilterKey.UPDATE,
 		}:
-			threading.Thread(target=self._getAvailableAddonsInBG, name="getAddonData").start()
+			self._refreshAddonsThread = threading.Thread(
+				target=self._getAvailableAddonsInBG,
+				name="getAddonData",
+				daemon=True,
+			)
+			self._refreshAddonsThread.start()
 
 		elif self._filteredStatusKey in {
 			_StatusFilterKey.INSTALLED,

--- a/source/nvwave.py
+++ b/source/nvwave.py
@@ -721,7 +721,8 @@ def playWaveFile(
 			fileWavePlayerThread.join()
 		fileWavePlayerThread = threading.Thread(
 			name=f"{__name__}.playWaveFile({os.path.basename(fileName)})",
-			target=play
+			target=play,
+			daemon=True,
 		)
 		fileWavePlayerThread.start()
 	else:

--- a/source/remotePythonConsole.py
+++ b/source/remotePythonConsole.py
@@ -79,7 +79,6 @@ def initialize():
 		target=server.serve_forever,
 		daemon=True,
 	)
-	thread.daemon = True
 	thread.start()
 
 def terminate():

--- a/source/remotePythonConsole.py
+++ b/source/remotePythonConsole.py
@@ -76,7 +76,8 @@ def initialize():
 	server.daemon_threads = True
 	thread = threading.Thread(
 		name=__name__,  # remotePythonConsole
-		target=server.serve_forever
+		target=server.serve_forever,
+		daemon=True,
 	)
 	thread.daemon = True
 	thread.start()

--- a/source/updateCheck.py
+++ b/source/updateCheck.py
@@ -256,9 +256,9 @@ class UpdateChecker(garbageHandler.TrackedObject):
 		"""
 		t = threading.Thread(
 			name=f"{self.__class__.__module__}.{self.check.__qualname__}",
-			target=self._bg
+			target=self._bg,
+			daemon = True,
 		)
-		t.daemon = True
 		self._started()
 		t.start()
 
@@ -617,9 +617,9 @@ class UpdateDownloader(garbageHandler.TrackedObject):
 		self._progressDialog.Raise()
 		t = threading.Thread(
 			name=f"{self.__class__.__module__}.{self.start.__qualname__}",
-			target=self._bg
+			target=self._bg,
+			daemon=True,
 		)
-		t.daemon = True
 		t.start()
 
 	def _guiExec(self, func, *args):

--- a/source/updateCheck.py
+++ b/source/updateCheck.py
@@ -257,7 +257,7 @@ class UpdateChecker(garbageHandler.TrackedObject):
 		t = threading.Thread(
 			name=f"{self.__class__.__module__}.{self.check.__qualname__}",
 			target=self._bg,
-			daemon = True,
+			daemon=True,
 		)
 		self._started()
 		t.start()

--- a/source/updateCheck.py
+++ b/source/updateCheck.py
@@ -107,6 +107,9 @@ def getQualifiedDriverClassNameForStats(cls):
 	return "%s (core)"%name
 
 
+UPDATE_FETCH_TIMEOUT_S = 30  # seconds
+
+
 def checkForUpdate(auto: bool = False) -> Optional[Dict]:
 	"""Check for an updated version of NVDA.
 	This will block, so it generally shouldn't be called from the main thread.
@@ -151,14 +154,14 @@ def checkForUpdate(auto: bool = False) -> Optional[Dict]:
 		params.update(extraParams)
 	url = "%s?%s" % (CHECK_URL, urllib.parse.urlencode(params))
 	try:
-		res = urllib.request.urlopen(url)
+		res = urllib.request.urlopen(url, timeout=UPDATE_FETCH_TIMEOUT_S)
 	except IOError as e:
 		if isinstance(e.reason, ssl.SSLCertVerificationError) and e.reason.reason == "CERTIFICATE_VERIFY_FAILED":
 			# #4803: Windows fetches trusted root certificates on demand.
 			# Python doesn't trigger this fetch (PythonIssue:20916), so try it ourselves
 			_updateWindowsRootCertificates()
 			# and then retry the update check.
-			res = urllib.request.urlopen(url)
+			res = urllib.request.urlopen(url, timeout=UPDATE_FETCH_TIMEOUT_S)
 		else:
 			raise
 	if res.code != 200:
@@ -656,7 +659,12 @@ class UpdateDownloader(garbageHandler.TrackedObject):
 		# #2352: Some security scanners such as Eset NOD32 HTTP Scanner
 		# cause huge read delays while downloading.
 		# Therefore, set a higher timeout.
-		remote = urllib.request.urlopen(url, timeout=120)
+		# The NVDA exe is about 35 MB.
+		# The average download speed in the world is 0.5 MB/s
+		# in some developing countries with the slowest internet.
+		# This yields an expected download time of 10min on slower networks.
+		UPDATE_DOWNLOAD_TIMEOUT = 60 * 30  # 30 min
+		remote = urllib.request.urlopen(url, timeout=UPDATE_DOWNLOAD_TIMEOUT)
 		if remote.code != 200:
 			raise RuntimeError("Download failed with code %d" % remote.code)
 		size = int(remote.headers["content-length"])
@@ -856,7 +864,11 @@ def _updateWindowsRootCertificates():
 	sslCont = ssl._create_unverified_context()
 	# We must specify versionType so the server doesn't return a 404 error and
 	# thus cause an exception.
-	u = urllib.request.urlopen(CHECK_URL + "?versionType=stable", context=sslCont)
+	u = urllib.request.urlopen(
+		CHECK_URL + "?versionType=stable",
+		context=sslCont,
+		timeout=UPDATE_FETCH_TIMEOUT_S,
+	)
 	cert = u.fp.raw._sock.getpeercert(True)
 	u.close()
 	# Convert to a form usable by Windows.

--- a/source/updateCheck.py
+++ b/source/updateCheck.py
@@ -154,6 +154,7 @@ def checkForUpdate(auto: bool = False) -> Optional[Dict]:
 		params.update(extraParams)
 	url = "%s?%s" % (CHECK_URL, urllib.parse.urlencode(params))
 	try:
+		log.debug(f"Fetching update data from {url}")
 		res = urllib.request.urlopen(url, timeout=UPDATE_FETCH_TIMEOUT_S)
 	except IOError as e:
 		if isinstance(e.reason, ssl.SSLCertVerificationError) and e.reason.reason == "CERTIFICATE_VERIFY_FAILED":
@@ -161,6 +162,7 @@ def checkForUpdate(auto: bool = False) -> Optional[Dict]:
 			# Python doesn't trigger this fetch (PythonIssue:20916), so try it ourselves
 			_updateWindowsRootCertificates()
 			# and then retry the update check.
+			log.debug(f"Fetching update data from {url}")
 			res = urllib.request.urlopen(url, timeout=UPDATE_FETCH_TIMEOUT_S)
 		else:
 			raise
@@ -859,6 +861,7 @@ class CERT_CHAIN_PARA(ctypes.Structure):
 	)
 
 def _updateWindowsRootCertificates():
+	log.debug("Updating Windows root certificates")
 	crypt = ctypes.windll.crypt32
 	# Get the server certificate.
 	sslCont = ssl._create_unverified_context()

--- a/source/virtualBuffers/__init__.py
+++ b/source/virtualBuffers/__init__.py
@@ -451,8 +451,9 @@ class VirtualBuffer(browseMode.BrowseModeDocumentTreeInterceptor):
 		self._loadProgressCallLater = wx.CallLater(1000, self._loadProgress)
 		threading.Thread(
 			name=f"{self.__class__.__module__}.{self.loadBuffer.__qualname__}",
-			target=self._loadBuffer).start(
-		)
+			target=self._loadBuffer,
+			daemon=True,
+		).start()
 
 	def _loadBuffer(self):
 		try:

--- a/source/visionEnhancementProviders/NVDAHighlighter.py
+++ b/source/visionEnhancementProviders/NVDAHighlighter.py
@@ -418,10 +418,10 @@ class NVDAHighlighter(providerBase.VisionEnhancementProvider):
 		winGDI.gdiPlusInitialize()
 		self._highlighterThread = threading.Thread(
 			name=f"{self.__class__.__module__}.{self.__class__.__qualname__}",
-			target=self._run
+			target=self._run,
+			daemon=True,
 		)
 		self._highlighterRunningEvent = threading.Event()
-		self._highlighterThread.daemon = True
 		self._highlighterThread.start()
 		# Make sure the highlighter thread doesn't exit early.
 		waitResult = self._highlighterRunningEvent.wait(0.2)

--- a/source/watchdog.py
+++ b/source/watchdog.py
@@ -292,7 +292,9 @@ def initialize():
 	NVDAHelper._setDllFuncPointer(NVDAHelper.localLib, "_notifySendMessageCancelled", _notifySendMessageCancelled)
 	_watcherThread = threading.Thread(
 		name=__name__,
-		target=_watcher
+		target=_watcher,
+		# TODO: should we change this? does this need to be kept alive to handle crashes?
+		daemon=True,
 	)
 	alive()
 	_watcherThread.start()

--- a/source/watchdog.py
+++ b/source/watchdog.py
@@ -293,7 +293,6 @@ def initialize():
 	_watcherThread = threading.Thread(
 		name=__name__,
 		target=_watcher,
-		# TODO: should we change this? does this need to be kept alive to handle crashes?
 		daemon=True,
 	)
 	alive()

--- a/source/winInputHook.py
+++ b/source/winInputHook.py
@@ -91,7 +91,8 @@ def initialize():
 	if hookThreadRefCount==1:
 		hookThread = threading.Thread(
 			name=__name__,  # winInputHook
-			target=hookThreadFunc
+			target=hookThreadFunc,
+			daemon=True,
 		)
 		hookThread.start()
 

--- a/tests/system/libraries/SystemTestSpy/speechSpyGlobalPlugin.py
+++ b/tests/system/libraries/SystemTestSpy/speechSpyGlobalPlugin.py
@@ -534,7 +534,11 @@ class SystemTestSpyServer(globalPluginHandler.GlobalPlugin):
 			serve=False  # we want to start this serving on another thread so as not to block.
 		)
 		log.debug("Server address: {}".format(server.server_address))
-		server_thread = threading.Thread(target=server.serve, name="RF Test Spy Thread")
+		server_thread = threading.Thread(
+			target=server.serve,
+			name="RF Test Spy Thread",
+			daemon=True,
+		)
 		server_thread.start()
 
 	def terminate(self):

--- a/tests/system/libraries/SystemTestSpy/speechSpySynthDriver.py
+++ b/tests/system/libraries/SystemTestSpy/speechSpySynthDriver.py
@@ -39,6 +39,7 @@ class SpeechSpySynthDriver(synthDriverHandler.SynthDriver):
 		self._doSpeechThread = threading.Thread(
 			target=self._processSpeech,
 			name="speech spy synth driver",
+			daemon=True,
 		)
 		self._doSpeechThread.start()
 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -4,6 +4,14 @@ What's New in NVDA
 %!includeconf: ../changes.t2tconf
 %!includeconf: ./locale.t2tconf
 
+= 2023.3.4 =
+This is a patch release to fix an installer issue.
+
+== Bug Fixes ==
+- Fixed bug which caused the NVDA process to fail to exit correctly.
+When running the installer, this resulted in the installation entering an unrecoverable state. (#16122, #16123)
+-
+
 = 2023.3.3 =
 This is a patch release to fix a security issue.
 Please responsibly disclose security issues following NVDA's [security policy https://github.com/nvaccess/nvda/blob/master/security.md].


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
May fix most cases of #16123 and https://github.com/nvaccess/nvda/issues/16122

### Summary of the issue:
`requests.get` has no default timeout, meaning a connection may hang until it is closed by the server.
The add-on store uses `requests` with no timeout to fetch data from the add-on store, and download add-ons.
This can cause threads to hang, preventing NVDA from exiting correctly.

Update check also has similar risks with usage of `urllib` like `requests`.

Many threads started in NVDA should also be daemonized.

### Description of user facing changes
NVDA should exit properly in more cases, make installs safer

### Description of development approach
Add timeouts for web requests and daemonize all threads in NVDA.

### Testing strategy:
Smoke tested running the installer and using the add-on store

### Known issues with pull request:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
