### PR TITLE
Add speechSequence filter extension point to speech.speak method

### DIFF
--- a/projectDocs/dev/developerGuide/developerGuide.t2t
+++ b/projectDocs/dev/developerGuide/developerGuide.t2t
@@ -1041,7 +1041,7 @@ For examples of how to define and use new extension points, please see the code 
 ++ speech ++[speechExtPts]
 || Type | Extension Point | Description |
 | ``Action`` | ``speechCanceled`` | Triggered when speech is canceled. |
-| ``Filter`` | ``speechFilter`` | Allows components or add-ons to filter speech sequence before it passes to the Synth driver. |
+| ``Filter`` | ``filter_speechSequence`` | Allows components or add-ons to filter speech sequence before it passes to the Synth driver. |
 
 ++ synthDriverHandler ++[synthDriverHandlerExtPts]
 || Type | Extension Point | Description |

--- a/projectDocs/dev/developerGuide/developerGuide.t2t
+++ b/projectDocs/dev/developerGuide/developerGuide.t2t
@@ -1041,6 +1041,7 @@ For examples of how to define and use new extension points, please see the code 
 ++ speech ++[speechExtPts]
 || Type | Extension Point | Description |
 | ``Action`` | ``speechCanceled`` | Triggered when speech is canceled. |
+| ``Filter`` | ``speechFilter`` | Allows components or add-ons to filter speech sequence before it passes to the Synth driver. |
 
 ++ synthDriverHandler ++[synthDriverHandlerExtPts]
 || Type | Extension Point | Description |

--- a/source/speech/extensions.py
+++ b/source/speech/extensions.py
@@ -19,7 +19,6 @@ Handlers are called without arguments.
 filter_speechSequence = Filter[SpeechSequence]()
 """
 Filters speech sequence before it passes to synthDriver.
-Handlers are called with speechSequence argument.
 
 :param value: the speech sequence to be filtered.
 :type value: SpeechSequence

--- a/source/speech/extensions.py
+++ b/source/speech/extensions.py
@@ -7,10 +7,16 @@
 Extension points for speech.
 """
 
-from extensionPoints import Action
+from extensionPoints import Action, Filter
 
 speechCanceled = Action()
 """
 Notifies when speech is canceled.
 Handlers are called without arguments.
+"""
+
+filterSpeechSequence = Filter()
+"""
+Filters speech sequence before it passes to synthDriver.
+Handlers are called with sequence argument.
 """

--- a/source/speech/extensions.py
+++ b/source/speech/extensions.py
@@ -16,8 +16,10 @@ Notifies when speech is canceled.
 Handlers are called without arguments.
 """
 
-filterSpeechSequence = Filter[SpeechSequence]()
+filter_speechSequence = Filter[SpeechSequence]()
 """
 Filters speech sequence before it passes to synthDriver.
-Handlers are called with sequence argument.
+Handlers are called with speechSequence argument.
+
+:param value: the speech sequence to be filtered.
 """

--- a/source/speech/extensions.py
+++ b/source/speech/extensions.py
@@ -22,4 +22,5 @@ Filters speech sequence before it passes to synthDriver.
 Handlers are called with speechSequence argument.
 
 :param value: the speech sequence to be filtered.
+:type value: SpeechSequence
 """

--- a/source/speech/extensions.py
+++ b/source/speech/extensions.py
@@ -8,6 +8,7 @@ Extension points for speech.
 """
 
 from extensionPoints import Action, Filter
+from speech.types import SpeechSequence
 
 speechCanceled = Action()
 """
@@ -15,7 +16,7 @@ Notifies when speech is canceled.
 Handlers are called without arguments.
 """
 
-filterSpeechSequence = Filter()
+filterSpeechSequence = Filter[SpeechSequence]()
 """
 Filters speech sequence before it passes to synthDriver.
 Handlers are called with sequence argument.

--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -25,7 +25,7 @@ import speechDictHandler
 import characterProcessing
 import languageHandler
 from . import manager
-from .extensions import speechCanceled
+from .extensions import filterSpeechSequence, speechCanceled
 from .commands import (
 	# Commands that are used in this file.
 	BreakCommand,
@@ -960,6 +960,7 @@ def speak(  # noqa: C901
 	@param symbolLevel: The symbol verbosity level; C{None} (default) to use the user's configuration.
 	@param priority: The speech priority.
 	"""
+	speechSequence = filterSpeechSequence.apply(speechSequence)
 	logBadSequenceTypes(speechSequence)
 	# in case priority was explicitly passed in as None, set to default.
 	priority: Spri = Spri.NORMAL if priority is None else priority

--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -25,7 +25,7 @@ import speechDictHandler
 import characterProcessing
 import languageHandler
 from . import manager
-from .extensions import filterSpeechSequence, speechCanceled
+from .extensions import filter_speechSequence, speechCanceled
 from .commands import (
 	# Commands that are used in this file.
 	BreakCommand,
@@ -960,7 +960,7 @@ def speak(  # noqa: C901
 	@param symbolLevel: The symbol verbosity level; C{None} (default) to use the user's configuration.
 	@param priority: The speech priority.
 	"""
-	speechSequence = filterSpeechSequence.apply(speechSequence)
+	speechSequence = filter_speechSequence.apply(speechSequence)
 	logBadSequenceTypes(speechSequence)
 	# in case priority was explicitly passed in as None, set to default.
 	priority: Spri = Spri.NORMAL if priority is None else priority


### PR DESCRIPTION
### Link to issue number:
Fixes #14520
### Summary of the issue:
Added a filterSpeechSequence to speech.speak method to make it possible for addons to filter speech in better way
### Description of user facing changes
None
### Description of development approach
Added filter extension point in speech.extensions and injected it in the beginning of speech.speak
### Testing strategy:
Tested with a plugin and confirmed that it is possible to filter and return filtered speech.
### Known issues with pull request:
None at the moment
### Code Review Checklist:
- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

### Additional notes:
@LeonarddeR I understand, that to make it ideal, some things should be refactored, but can it be considered for potential merging now to eliminate patching speech.speak by numerous addons?