### PR TITLE
Ensure the C++ UIA rate limited event handler flusher thread is definitely terminated when NVDA shutts down

### DIFF
--- a/nvdaHelper/local/UIAEventLimiter/api.cpp
+++ b/nvdaHelper/local/UIAEventLimiter/api.cpp
@@ -42,7 +42,7 @@ HRESULT rateLimitedUIAEventHandler_create(IUnknown* pExistingHandler, RateLimite
 // @note This function will block until the RateLimitedEventHandler's flusher thread has terminated. 
 // @return S_OK on success or a failure code otherwise
 HRESULT rateLimitedUIAEventHandler_terminate(RateLimitedEventHandler* pRateLimitedEventHandler) {
-	if(activeRateLimitedEventHandlers.find(pRateLimitedEventHandler) == activeRateLimitedEventHandlers.end()) {
+	if (activeRateLimitedEventHandlers.find(pRateLimitedEventHandler) == activeRateLimitedEventHandlers.end()) {
 		LOG_ERROR(L"rateLimitedUIAEventHandler_terminate: pRateLimitedEventHandler not found in activeRateLimitedEventHandlers");
 		return E_INVALIDARG;
 	}

--- a/nvdaHelper/local/UIAEventLimiter/api.cpp
+++ b/nvdaHelper/local/UIAEventLimiter/api.cpp
@@ -12,9 +12,12 @@ This license can be found at:
 http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 */
 
+#include <set>
 #include <windows.h>
 #include <common/log.h>
 #include "rateLimitedEventHandler.h"
+
+std::set<RateLimitedEventHandler*> activeRateLimitedEventHandlers;
 
 HRESULT rateLimitedUIAEventHandler_create(IUnknown* pExistingHandler, RateLimitedEventHandler** ppRateLimitedEventHandler) {
 	LOG_DEBUG(L"rateLimitedUIAEventHandler_create called");
@@ -30,5 +33,20 @@ HRESULT rateLimitedUIAEventHandler_create(IUnknown* pExistingHandler, RateLimite
 		return E_OUTOFMEMORY;
 	}
 	LOG_DEBUG(L"rateLimitedUIAEventHandler_create: done");
+	activeRateLimitedEventHandlers.insert(*ppRateLimitedEventHandler);
+	return S_OK;
+}
+
+// @brief Terminates a RateLimitedEventHandler instance's flusher thread and removes it from the activeRateLimitedEventHandlers set.
+// @param pRateLimitedEventHandler the RateLimitedEventHandler instance to terminate.
+// @note This function will block until the RateLimitedEventHandler's flusher thread has terminated. 
+// @return S_OK on success or a failure code otherwise
+HRESULT rateLimitedUIAEventHandler_terminate(RateLimitedEventHandler* pRateLimitedEventHandler) {
+	if(activeRateLimitedEventHandlers.find(pRateLimitedEventHandler) == activeRateLimitedEventHandlers.end()) {
+		LOG_ERROR(L"rateLimitedUIAEventHandler_terminate: pRateLimitedEventHandler not found in activeRateLimitedEventHandlers");
+		return E_INVALIDARG;
+	}
+	activeRateLimitedEventHandlers.erase(pRateLimitedEventHandler);
+	pRateLimitedEventHandler->terminate();
 	return S_OK;
 }

--- a/nvdaHelper/local/UIAEventLimiter/rateLimitedEventHandler.cpp
+++ b/nvdaHelper/local/UIAEventLimiter/rateLimitedEventHandler.cpp
@@ -66,25 +66,38 @@ void RateLimitedEventHandler::flusherThreadFunc(std::stop_token stopToken) {
 	LOG_DEBUG(L"flusherThread started");
 	// If this thread is requested to stop, we need to ensure we wake up.
 	std::stop_callback stopCallback{stopToken, [this](){
+		LOG_DEBUG(L"flusherThreadFunc stop callback: stop requested")
 		this->m_flushConditionVar.notify_all();
 	}};
 	do { // thread main loop
-		LOG_DEBUG(L"flusherThreadFunc sleeping...");
+		bool needsFlush = false;
 		{ std::unique_lock lock(m_mtx);
 			// sleep until a flush is needed or this thread should stop.
+			LOG_DEBUG(L"flusherThreadFunc sleeping...");
 			m_flushConditionVar.wait(lock, [this, stopToken](){
-				return this->m_needsFlush || stopToken.stop_requested();
+				LOG_DEBUG(L"FLUSHER THREAD notified, CHECKING WAKE CONDITION");
+				if(this->m_needsFlush ) {
+					LOG_DEBUG(L"Will wake as needsFlush is true");
+					return true;
+				} else if(stopToken.stop_requested()) {
+					LOG_DEBUG(L"Will wake as stop requested");
+					return true;
+				}
+				LOG_DEBUG(L"Spurious wake, will sleep again");
+				return false;
 			});
 			LOG_DEBUG(L"flusherThread woke up");
-			if(stopToken.stop_requested()) {
-				LOG_DEBUG(L"flusherThread returning as stop requested"); 
-				return;
+			if(this->m_needsFlush ) {
+				m_needsFlush = false;
+				needsFlush = true;
 			}
-			m_needsFlush = false;
 		} // m_mtx released here.
-		flushEvents();
+		if(needsFlush) {
+			LOG_DEBUG(L"flusherThreadFunc: Flushing events...");
+			flushEvents();
+		}
 	} while(!stopToken.stop_requested());
-	LOG_DEBUG(L"flusherThread returning");
+	LOG_DEBUG(L"flusherThread returning as stop requested");
 }
 
 HRESULT RateLimitedEventHandler::emitEvent(const AutomationEventRecord_t& record) const {
@@ -245,4 +258,11 @@ void RateLimitedEventHandler::flushEvents() {
 		}, recordVar);
 	}
 		LOG_DEBUG(L"RateLimitedUIAEventHandler::flusherThreadFunc: Done emitting events");
+}
+
+void RateLimitedEventHandler::terminate() {
+	LOG_DEBUG(L"RateLimitedUIAEventHandler::terminate called");
+	// Stop the flusher thread.
+	m_flusherThread.request_stop();
+	m_flusherThread.join();
 }

--- a/nvdaHelper/local/UIAEventLimiter/rateLimitedEventHandler.cpp
+++ b/nvdaHelper/local/UIAEventLimiter/rateLimitedEventHandler.cpp
@@ -76,10 +76,10 @@ void RateLimitedEventHandler::flusherThreadFunc(std::stop_token stopToken) {
 			LOG_DEBUG(L"flusherThreadFunc sleeping...");
 			m_flushConditionVar.wait(lock, [this, stopToken](){
 				LOG_DEBUG(L"FLUSHER THREAD notified, CHECKING WAKE CONDITION");
-				if(this->m_needsFlush ) {
+				if (this->m_needsFlush) {
 					LOG_DEBUG(L"Will wake as needsFlush is true");
 					return true;
-				} else if(stopToken.stop_requested()) {
+				} else if (stopToken.stop_requested()) {
 					LOG_DEBUG(L"Will wake as stop requested");
 					return true;
 				}
@@ -87,12 +87,12 @@ void RateLimitedEventHandler::flusherThreadFunc(std::stop_token stopToken) {
 				return false;
 			});
 			LOG_DEBUG(L"flusherThread woke up");
-			if(this->m_needsFlush ) {
+			if (this->m_needsFlush) {
 				m_needsFlush = false;
 				needsFlush = true;
 			}
 		} // m_mtx released here.
-		if(needsFlush) {
+		if (needsFlush) {
 			LOG_DEBUG(L"flusherThreadFunc: Flushing events...");
 			flushEvents();
 		}

--- a/nvdaHelper/local/UIAEventLimiter/rateLimitedEventHandler.h
+++ b/nvdaHelper/local/UIAEventLimiter/rateLimitedEventHandler.h
@@ -88,4 +88,8 @@ private:
 	HRESULT STDMETHODCALLTYPE HandleNotificationEvent(IUIAutomationElement* sender, NotificationKind notificationKind, NotificationProcessing notificationProcessing, BSTR displayString, BSTR activityID);
 	HRESULT STDMETHODCALLTYPE HandleActiveTextPositionChangedEvent(IUIAutomationElement* sender, IUIAutomationTextRange* range);
 
+	/// @brief a function that stops the flusher thread.
+	// @note This call will block until the flusher thread has stopped.
+	void terminate();
+
 };

--- a/nvdaHelper/local/nvdaHelperLocal.def
+++ b/nvdaHelper/local/nvdaHelperLocal.def
@@ -70,6 +70,7 @@ EXPORTS
 	_nvdaControllerInternal_reportLiveRegion
 	_nvdaControllerInternal_openConfigDirectory
 	rateLimitedUIAEventHandler_create
+	rateLimitedUIAEventHandler_terminate
 	wasPlay_create
 	wasPlay_destroy
 	wasPlay_open

--- a/source/UIAHandler/__init__.py
+++ b/source/UIAHandler/__init__.py
@@ -443,7 +443,7 @@ class UIAHandler(COMObject):
 	def terminate(self):
 		# Terminate the rate limited event handler if it exists.
 		# We must do this from the main thread to totally ensure that the thread is terminated,
-		# As this is a c++ thread so Python canot kill it off at process exit.
+		# As this is a c++ thread so Python cannot kill it off at process exit.
 		if config.conf["UIA"]["enhancedEventProcessing"]:
 			if self._rateLimitedEventHandler:
 				log.debug("UIAHandler: Terminating enhanced event processing")


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Fixes #16072

### Summary of the issue:
If any background threads remain after NVDA exits, the NVDA process will stay alive until those background threads complete. For Python threads, setting daemon to true on the thread causes Python to kill off the thread when the main thread exits. However, Python is unaware of C++ threads.
One particular C++ thread which has proven to keep NvDA alive for at least one person (see #16072) is the UIA rate limited event handler flusher thread.
We should try much harder to ensure that this thread is terminated during NVDA exit so that it does not keep the NVDA process alive after the main thread exits.

### Description of user facing changes
The NVDA process is less likely to stay around after NvDA has exited, which means that NVDA should no longer freeze on restart and NvDA updates should be less likely to fail due to NVDA still running.

### Description of development approach
* UIA rate limited event handler: improve logic and logging of the flusher thread function to make it clearer as to why the thread will wake for flushes or when it should stop.
* Add the ability to terminate UIA rate limited event handler's flusher thread upon request via a new terminate API call. This allows NvDA to ensure that the flusher thread can be terminated, even if it may not release the rate limited event handler COM object reference for some reason.
* UIAHandler.terminate: specifically terminate the rate limited event handler from NvDA's main thread, before trying to terminate the UIA MTA thread. This ensures that the c++ UIA rate limitied event handler flusher thread is definitely terminated, even if there may be further errors terminating the UIA MTA Python thread.

### Testing strategy:
* Compiled NVDAHelperLocal with debug logging enabled.
* Ensured that NVDA's Enhanced UIA event processing advanced option is turned on.
* Started and quit NvDA several times.
* Confirmed in NvDA's log that the UIA rate limited event hander flusher thread correctly woke and terminated durng UIAHandler.terminate.
* [ ] The reporter of #16072 would still need to test and confirm that this change stops the issues they are experiencing.

### Known issues with pull request:
None known.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
