### PR TITLE
Installer: try multiple times to remove the  NVDA exes, giving the installed NVDA extra time to fully exit on the UAC screen

### DIFF
--- a/source/installer.py
+++ b/source/installer.py
@@ -655,11 +655,13 @@ def _deleteFileGroupOrFail(
 		installDir: str,
 		relativeFilepaths: Iterable[str],
 		numTries: int = 6,
-		retryWeightInterval: float = 0.5
+		retryWaitInterval: float = 0.5
 ):
 	"""
 	Delete a group of files in the installer folder.
-	If any file fails to be deleted, revert the deletion of all other files.
+	Each file tries to be deleted up to `numTries` times,
+	with a wait of `retryWaitInterval` seconds between each attempt.
+	If all tries to delete a file fail, revert the deletion of all other files.
 
 	:param installDir: an iterable of file paths relative to installDir
 	:param relativeFilepaths: an iterable of file paths relative to installDir
@@ -678,7 +680,7 @@ def _deleteFileGroupOrFail(
 			shutil.copyfile(originalPath, tempPath)
 			for count in range(1, numTries + 1):
 				if count > 1:
-					time.sleep(retryWeightInterval)
+					time.sleep(retryWaitInterval)
 				try:
 					os.remove(originalPath)
 				except OSError as e:
@@ -724,7 +726,7 @@ def install(shouldCreateDesktopShortcut: bool = True, shouldRunAtLogon: bool = T
 		installDir,
 		_nvdaExes.union({"nvda_service.exe"}),
 		numTries=6,
-		retryWeightInterval=0.5
+		retryWaitInterval=0.5
 	)
 	unregisterInstallation(keepDesktopShortcut=shouldCreateDesktopShortcut)
 	if prevInstallPath:


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Fixes #16199
Fixes #16122

### Summary of the issue:
In pr #16174, effort was made to make the installer more robust, including better handling when the installed NVDA is still running, by trying to remove the NVDA exes first, and if any of them fail, restoring them all and not corrupting a user's install.
Although it no longer corrupts the install, it was too fast at at trying to remove the exes and no longer tried multiple times, which did not take into account that the installed NVDA has just been running on the UAC screen, and may still be exiting.

### Description of user facing changes
NVDA will try multiple times itself to remove the NVDA exes while waiting for the installed NvDA to fully exit.

### Description of development approach
* When the installer starts, it will now first wait an initial 1 second to give time for the installed NVDA to exit from the UAC screen.
* When trying to remove each of the NvDA exes, the installer will again try up to 6 times, waiting half a second before the next try. Again, giving much more chance for an installed NvDA to fully exit like it used to.
* NVDA will always clean up the temporary files it created while trying to remove all of the exes, whether or not it resulted in a retryableFailure.
 
### Testing strategy:
* [x] Installed NVDA on Windows 11 with no other logged on user. Confirm that after one or more tries, NvDA successfully installs.
* [x] Installed NVDA on Windows 11 with another logged on user currently running NVDA. Confirm that the installer should fail asking to retry for ever. If cancelled, the install should not be corrupt.
* [x] Again Install NVDA on Windows 11 with another logged on user currently running NVDA. Confirm that the installer should fail asking to retry until the other user quits NVDA / logs out.

### Known issues with pull request:
None known.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
