### PR TITLE
Add pre_filter_speechSequence and post_filter_speechSequence Action and use post_filter_speechSequence in speechViewer

### DIFF
--- a/projectDocs/dev/developerGuide/developerGuide.t2t
+++ b/projectDocs/dev/developerGuide/developerGuide.t2t
@@ -1041,6 +1041,7 @@ For examples of how to define and use new extension points, please see the code 
 ++ speech ++[speechExtPts]
 || Type | Extension Point | Description |
 | ``Action`` | ``speechCanceled`` | Triggered when speech is canceled. |
+| ``Action`` | ``speechSequencePreFilter`` | Triggered when new speech sequence appears. |
 | ``Filter`` | ``filter_speechSequence`` | Allows components or add-ons to filter speech sequence before it passes to the Synth driver. |
 
 ++ synthDriverHandler ++[synthDriverHandlerExtPts]

--- a/projectDocs/dev/developerGuide/developerGuide.t2t
+++ b/projectDocs/dev/developerGuide/developerGuide.t2t
@@ -1041,7 +1041,8 @@ For examples of how to define and use new extension points, please see the code 
 ++ speech ++[speechExtPts]
 || Type | Extension Point | Description |
 | ``Action`` | ``speechCanceled`` | Triggered when speech is canceled. |
-| ``Action`` | ``speechSequencePreFilter`` | Triggered when new speech sequence appears. |
+| ``Action`` | ``pre_filter_speechSequence`` | Notifies before filtering a speech sequence. |
+| ``Action`` | ``post_filter_speechSequence`` | Notifies when speech sequence has been filtered by NVDA components and/or addons. |
 | ``Filter`` | ``filter_speechSequence`` | Allows components or add-ons to filter speech sequence before it passes to the Synth driver. |
 
 ++ synthDriverHandler ++[synthDriverHandlerExtPts]

--- a/source/speech/extensions.py
+++ b/source/speech/extensions.py
@@ -16,11 +16,18 @@ Notifies when speech is canceled.
 Handlers are called without arguments.
 """
 
-speechSequencePreFilter = Action()
+post_filter_speechSequence = Action()
 """
-Notifies when new speech sequence appears.
+Notifies when requested speech has been filtered and is ready to be passed onto the synthesizer.
 
-:param value: the speech sequence before filtering .
+:param value: a planned speech sequence.
+:type value: SpeechSequence
+What NVDA would speak with speech turned on and uninterrupted.
+A speech sequence that has been requested somewhere in NVDA,
+and is finished being processed or modified by external modules such as add-ons.
+Prepared speech may be cancelled or processed further to prepare it for the synthesizer.
+This extension point is useful for tracking prepared speech in NVDA.
+i.e. for speech viewer, capturing speech history, or mirroring speech in braille.
 """
 
 filter_speechSequence = Filter[SpeechSequence]()

--- a/source/speech/extensions.py
+++ b/source/speech/extensions.py
@@ -16,6 +16,14 @@ Notifies when speech is canceled.
 Handlers are called without arguments.
 """
 
+pre_filter_speechSequence = Action()
+"""
+Notifies before filtering speech sequence.
+
+:param value: speech sequence.
+:type value: SpeechSequence
+"""
+
 post_filter_speechSequence = Action()
 """
 Notifies when requested speech has been filtered and is ready to be passed onto the synthesizer.

--- a/source/speech/extensions.py
+++ b/source/speech/extensions.py
@@ -16,6 +16,13 @@ Notifies when speech is canceled.
 Handlers are called without arguments.
 """
 
+speechSequencePreFilter = Action()
+"""
+Notifies when new speech sequence appears.
+
+:param value: the speech sequence before filtering .
+"""
+
 filter_speechSequence = Filter[SpeechSequence]()
 """
 Filters speech sequence before it passes to synthDriver.

--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -25,7 +25,11 @@ import speechDictHandler
 import characterProcessing
 import languageHandler
 from . import manager
-from .extensions import filter_speechSequence, post_filter_speechSequence, pre_filter_speechSequence, speechCanceled
+from .extensions import (
+	filter_speechSequence,
+	post_filter_speechSequence,
+	pre_filter_speechSequence, speechCanceled
+)
 from .commands import (
 	# Commands that are used in this file.
 	BreakCommand,

--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -25,7 +25,7 @@ import speechDictHandler
 import characterProcessing
 import languageHandler
 from . import manager
-from .extensions import filter_speechSequence, speechCanceled
+from .extensions import filter_speechSequence, speechCanceled, speechSequencePreFilter
 from .commands import (
 	# Commands that are used in this file.
 	BreakCommand,
@@ -960,6 +960,7 @@ def speak(  # noqa: C901
 	@param symbolLevel: The symbol verbosity level; C{None} (default) to use the user's configuration.
 	@param priority: The speech priority.
 	"""
+	speechSequencePreFilter.notify(sequence=speechSequence)
 	speechSequence = filter_speechSequence.apply(speechSequence)
 	logBadSequenceTypes(speechSequence)
 	# in case priority was explicitly passed in as None, set to default.

--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -25,7 +25,7 @@ import speechDictHandler
 import characterProcessing
 import languageHandler
 from . import manager
-from .extensions import filter_speechSequence, speechCanceled, speechSequencePreFilter
+from .extensions import filter_speechSequence, post_filter_speechSequence, pre_filter_speechSequence, speechCanceled
 from .commands import (
 	# Commands that are used in this file.
 	BreakCommand,
@@ -960,7 +960,7 @@ def speak(  # noqa: C901
 	@param symbolLevel: The symbol verbosity level; C{None} (default) to use the user's configuration.
 	@param priority: The speech priority.
 	"""
-	speechSequencePreFilter.notify(sequence=speechSequence)
+	pre_filter_speechSequence.notify(sequence=speechSequence)
 	speechSequence = filter_speechSequence.apply(speechSequence)
 	logBadSequenceTypes(speechSequence)
 	# in case priority was explicitly passed in as None, set to default.
@@ -968,6 +968,7 @@ def speak(  # noqa: C901
 
 	if not speechSequence:  # Pointless - nothing to speak
 		return
+	post_filter_speechSequence.notify(sequence=speechSequence)
 	if _speechState.speechMode == SpeechMode.off:
 		return
 	elif _speechState.speechMode == SpeechMode.beeps:

--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -967,9 +967,6 @@ def speak(  # noqa: C901
 
 	if not speechSequence:  # Pointless - nothing to speak
 		return
-	import speechViewer
-	if speechViewer.isActive:
-		speechViewer.appendSpeechSequence(speechSequence)
 	if _speechState.speechMode == SpeechMode.off:
 		return
 	elif _speechState.speechMode == SpeechMode.beeps:

--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -28,7 +28,8 @@ from . import manager
 from .extensions import (
 	filter_speechSequence,
 	post_filter_speechSequence,
-	pre_filter_speechSequence, speechCanceled
+	pre_filter_speechSequence,
+	speechCanceled,
 )
 from .commands import (
 	# Commands that are used in this file.

--- a/source/speechViewer.py
+++ b/source/speechViewer.py
@@ -12,7 +12,7 @@ import gui
 import config
 from logHandler import log
 from speech import SpeechSequence
-from speech.extensions import speechSequencePreFilter
+from speech.extensions import post_filter_speechSequence
 from gui import blockAction
 import gui.contextHelp
 from utils.security import isLockScreenModeActive, post_sessionLockStateChanged
@@ -48,7 +48,7 @@ class SpeechViewerFrame(
 			style=wx.CAPTION | wx.CLOSE_BOX | wx.RESIZE_BORDER | wx.STAY_ON_TOP
 		)
 		post_sessionLockStateChanged.register(self.onSessionLockStateChange)
-		speechSequencePreFilter.register(appendSpeechSequence)
+		post_filter_speechSequence.register(appendSpeechSequence)
 		self._isDestroyed = False
 		self.onDestroyCallBack = onDestroyCallBack
 		self.Bind(wx.EVT_CLOSE, self.onClose)
@@ -130,7 +130,7 @@ class SpeechViewerFrame(
 	def onDestroy(self, evt: wx.Event):
 		self._isDestroyed = True
 		post_sessionLockStateChanged.unregister(self.onSessionLockStateChange)
-		speechSequencePreFilter.unregister(appendSpeechSequence)
+		post_filter_speechSequence.unregister(appendSpeechSequence)
 		log.debug("SpeechViewer destroyed")
 		self.onDestroyCallBack()
 		evt.Skip()

--- a/source/speechViewer.py
+++ b/source/speechViewer.py
@@ -12,6 +12,7 @@ import gui
 import config
 from logHandler import log
 from speech import SpeechSequence
+from speech.extensions import filter_speechSequence
 from gui import blockAction
 import gui.contextHelp
 from utils.security import isLockScreenModeActive, post_sessionLockStateChanged
@@ -47,6 +48,7 @@ class SpeechViewerFrame(
 			style=wx.CAPTION | wx.CLOSE_BOX | wx.RESIZE_BORDER | wx.STAY_ON_TOP
 		)
 		post_sessionLockStateChanged.register(self.onSessionLockStateChange)
+		filter_speechSequence.register(appendSpeechSequence)
 		self._isDestroyed = False
 		self.onDestroyCallBack = onDestroyCallBack
 		self.Bind(wx.EVT_CLOSE, self.onClose)
@@ -128,6 +130,7 @@ class SpeechViewerFrame(
 	def onDestroy(self, evt: wx.Event):
 		self._isDestroyed = True
 		post_sessionLockStateChanged.unregister(self.onSessionLockStateChange)
+		filter_speechSequence.unregister(appendSpeechSequence)
 		log.debug("SpeechViewer destroyed")
 		self.onDestroyCallBack()
 		evt.Skip()
@@ -181,25 +184,26 @@ SPEECH_ITEM_SEPARATOR = "  "
 SPEECH_SEQUENCE_SEPARATOR = "\n"
 
 
-def appendSpeechSequence(sequence: SpeechSequence) -> None:
+def appendSpeechSequence(sequence: SpeechSequence) -> SpeechSequence:
 	""" Appends a speech sequence to the speech viewer.
 	@param sequence: To append, items are separated with . Concluding with a newline.
 	"""
 	if not isActive:
-		return
+		return sequence
 	# If the speech viewer text control has the focus, we want to disable updates
 	# Otherwise it would be impossible to select text, or even just read it (as a blind person).
 	if (
 		_guiFrame.FindFocus() == _guiFrame.textCtrl
 		or _guiFrame.textCtrl.GetScreenRect().Contains(wx.GetMousePosition())
 	):
-		return
+		return sequence
 
 	# to make the speech easier to read, we must separate the items.
 	text = SPEECH_ITEM_SEPARATOR.join(
 		speech for speech in sequence if isinstance(speech, str)
 	)
 	_guiFrame.textCtrl.AppendText(text + SPEECH_SEQUENCE_SEPARATOR)
+	return sequence
 
 
 def _cleanup():

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -56,6 +56,10 @@ What's New in NVDA
 Please refer to [the developer guide https://www.nvaccess.org/files/nvda/documentation/developerGuide.html#API] for information on NVDA's API deprecation and removal process.
 
 - Instantiating ``winVersion.WinVersion`` objects with unknown Windows versions above 10.0.22000 such as 10.0.25398 returns "Windows 11 unknown" instead of "Windows 10 unknown" for release name. (#15992, @josephsl)
+- Added the following extension points:
+  - ``speech.filter_speechSequence``. (#16191, @beqabeqa473)
+  - ``speech.pre_filter_speechSequence``. (#16213, @beqabeqa473)
+  - ``speech.post_filter_speechSequence``. (#16213, @beqabeqa473)
 -
 
 === Deprecations ===


### PR DESCRIPTION
### Link to issue number:
None
### Summary of the issue:
Add speechSequencePreFilter extensionPoint Action, inject it just before filter in speech.speak and use it in speechViewer as @LeonarddeR stated in #14520
### Description of user facing changes
Nothing changed
### Description of development approach
Removed code responsible for appending speechSequence to speech_viewer from speech.speak and registered appendSpeechSequence as extensionPoint handler function.
### Testing strategy:
Manually tested that speech is still visible on the screen when activating speech_viewer
### Known issues with pull request:
None at this moment
### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
