### PR TITLE
Make it easier for devs outside of NV Access to utilize the Appveyor build process

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,6 @@ environment:
  crowdinAuthToken:
   secure: E3084gj4JeMZKvZIOLIhqZefuSo/tj7iYPt4yK0geOI/eQgmPvoXt37Xq0KwvXzvZiJny4AsMj1rKMTVxio8EG8KA0YsYYuy+WV1wpFRIn25zGQS+DZ/yycL75SmTWfr
  # Comment out/unset any of the feature_* variables to disable the respective build feature.
- feature_trackTiming: True
  feature_buildSymbols: True
  feature_uploadSymbolsToMozilla: True
  feature_buildAppx: True
@@ -37,29 +36,21 @@ environment:
 init:
   # set the init time for the build, used to calculate the time taken for each stage of the build.
   - ps: |
-      if ($env:feature_trackTiming) {
-        "INIT, $(Get-Date -Format 'o')"| Out-File ../timing.csv -Append
-      }
+      "INIT, $(Get-Date -Format 'o')"| Out-File ../timing.csv -Append
 
 install:
  - ps: |
-    if ($env:feature_trackTiming) {
-      "INSTALL_START, $(Get-Date -Format 'o')"| Out-File ../timing.csv -Append
-    }
+    "INSTALL_START, $(Get-Date -Format 'o')"| Out-File ../timing.csv -Append
  - ps: appveyor\scripts\setBuildVersionVars.ps1
  - ps: appveyor\scripts\decryptFilesForSigning.ps1
  - py -m pip install --upgrade --no-warn-script-location pip
  - git submodule update --init
  - ps: |
-    if ($env:feature_trackTiming) {
-      "INSTALL_END, $(Get-Date -Format 'o')"| Out-File ../timing.csv -Append
-    }
+    "INSTALL_END, $(Get-Date -Format 'o')"| Out-File ../timing.csv -Append
 
 build_script:
  - ps: |
-     if ($env:feature_trackTiming) {
-       "BUILD_START, $(Get-Date -Format 'o')"| Out-File ../timing.csv -Append
-     }
+     "BUILD_START, $(Get-Date -Format 'o')"| Out-File ../timing.csv -Append
  - ps: appveyor\scripts\setSconsArgs.ps1
  - scons source %sconsArgs%
  - scons %sconsOutTargets% %sconsArgs%
@@ -70,35 +61,25 @@ build_script:
  - 7z a -tzip -r ..\output\symbols.zip *.dl_ *.ex_ *.pd_
  - cd ..
  - ps: |
-     if ($env:feature_trackTiming) {
-       "BUILD_END, $(Get-Date -Format 'o')"| Out-File ../timing.csv -Append
-     }
+     "BUILD_END, $(Get-Date -Format 'o')"| Out-File ../timing.csv -Append
 
 before_test:
  - ps: |
-     if ($env:feature_trackTiming) {
-       "TESTSETUP_START, $(Get-Date -Format 'o')"| Out-File ../timing.csv -Append
-     }
+     "TESTSETUP_START, $(Get-Date -Format 'o')"| Out-File ../timing.csv -Append
  - ps: appveyor\scripts\tests\beforeTests.ps1
  - ps: appveyor\scripts\installNVDA.ps1
  - ps: |
-     if ($env:feature_trackTiming) {
-       "TESTSETUP_END, $(Get-Date -Format 'o')"| Out-File ../timing.csv -Append
-     }
+     "TESTSETUP_END, $(Get-Date -Format 'o')"| Out-File ../timing.csv -Append
 
 test_script:
  - ps: |
-     if ($env:feature_trackTiming) {
-       "TEST_START, $(Get-Date -Format 'o')"| Out-File ../timing.csv -Append
-     }
+     "TEST_START, $(Get-Date -Format 'o')"| Out-File ../timing.csv -Append
  - ps: appveyor\scripts\tests\translationCheck.ps1
  - ps: appveyor\scripts\tests\unitTests.ps1
  - ps: appveyor\scripts\tests\lintCheck.ps1
  - ps: appveyor\scripts\tests\systemTests.ps1
  - ps: |
-     if ($env:feature_trackTiming) {
-       "TEST_END, $(Get-Date -Format 'o')"| Out-File ../timing.csv -Append
-     }
+     "TEST_END, $(Get-Date -Format 'o')"| Out-File ../timing.csv -Append
 
 after_test:
  - ps: appveyor\scripts\tests\checkTestFailure.ps1
@@ -116,7 +97,5 @@ on_failure:
 on_finish:
  - ps: appveyor\scripts\pushPackagingInfo.ps1
  - ps: |
-     if ($env:feature_trackTiming) {
-       "FINISH_END, $(Get-Date -Format 'o')"| Out-File ../timing.csv -Append
-     }
+     "FINISH_END, $(Get-Date -Format 'o')"| Out-File ../timing.csv -Append
  - ps: appveyor\scripts\logCiTiming.ps1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,12 +13,6 @@ branches:
   - /try-.*/
   - /release-.*/
 
-# scripts that are called at very beginning, before repo cloning
-init:
-  # set the init time for the build, used to calculate the time taken for each stage of the build.
-  - ps: |
-      "INIT, $(Get-Date -Format 'o')"| Out-File ../timing.csv -Append
-
 environment:
  PY_PYTHON: 3.11-32
  secure_authenticode_pass:
@@ -31,6 +25,12 @@ environment:
  crowdinProjectID: 598017
  crowdinAuthToken:
   secure: E3084gj4JeMZKvZIOLIhqZefuSo/tj7iYPt4yK0geOI/eQgmPvoXt37Xq0KwvXzvZiJny4AsMj1rKMTVxio8EG8KA0YsYYuy+WV1wpFRIn25zGQS+DZ/yycL75SmTWfr
+
+# scripts that are called at very beginning, before repo cloning
+init:
+  # set the init time for the build, used to calculate the time taken for each stage of the build.
+  - ps: |
+      "INIT, $(Get-Date -Format 'o')"| Out-File ../timing.csv -Append
 
 install:
  - ps: |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,6 +25,12 @@ environment:
  crowdinProjectID: 598017
  crowdinAuthToken:
   secure: E3084gj4JeMZKvZIOLIhqZefuSo/tj7iYPt4yK0geOI/eQgmPvoXt37Xq0KwvXzvZiJny4AsMj1rKMTVxio8EG8KA0YsYYuy+WV1wpFRIn25zGQS+DZ/yycL75SmTWfr
+ # Comment out/unset any of the feature_* variables to disable the respective build feature.
+ feature_buildSymbols: True
+ feature_uploadSymbolsToMozilla: True
+ feature_buildAppx: True
+ feature_crowdinSync: True
+ feature_signing: True
 
 # scripts that are called at very beginning, before repo cloning
 init:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,6 +26,7 @@ environment:
  crowdinAuthToken:
   secure: E3084gj4JeMZKvZIOLIhqZefuSo/tj7iYPt4yK0geOI/eQgmPvoXt37Xq0KwvXzvZiJny4AsMj1rKMTVxio8EG8KA0YsYYuy+WV1wpFRIn25zGQS+DZ/yycL75SmTWfr
  # Comment out/unset any of the feature_* variables to disable the respective build feature.
+ feature_trackTiming: True
  feature_buildSymbols: True
  feature_uploadSymbolsToMozilla: True
  feature_buildAppx: True
@@ -36,21 +37,29 @@ environment:
 init:
   # set the init time for the build, used to calculate the time taken for each stage of the build.
   - ps: |
-      "INIT, $(Get-Date -Format 'o')"| Out-File ../timing.csv -Append
+      if ($env:feature_trackTiming) {
+        "INIT, $(Get-Date -Format 'o')"| Out-File ../timing.csv -Append
+      }
 
 install:
  - ps: |
-    "INSTALL_START, $(Get-Date -Format 'o')"| Out-File ../timing.csv -Append
+    if ($env:feature_trackTiming) {
+      "INSTALL_START, $(Get-Date -Format 'o')"| Out-File ../timing.csv -Append
+    }
  - ps: appveyor\scripts\setBuildVersionVars.ps1
  - ps: appveyor\scripts\decryptFilesForSigning.ps1
  - py -m pip install --upgrade --no-warn-script-location pip
  - git submodule update --init
  - ps: |
-    "INSTALL_END, $(Get-Date -Format 'o')"| Out-File ../timing.csv -Append
+    if ($env:feature_trackTiming) {
+      "INSTALL_END, $(Get-Date -Format 'o')"| Out-File ../timing.csv -Append
+    }
 
 build_script:
  - ps: |
-     "BUILD_START, $(Get-Date -Format 'o')"| Out-File ../timing.csv -Append
+     if ($env:feature_trackTiming) {
+       "BUILD_START, $(Get-Date -Format 'o')"| Out-File ../timing.csv -Append
+     }
  - ps: appveyor\scripts\setSconsArgs.ps1
  - scons source %sconsArgs%
  - scons %sconsOutTargets% %sconsArgs%
@@ -61,25 +70,35 @@ build_script:
  - 7z a -tzip -r ..\output\symbols.zip *.dl_ *.ex_ *.pd_
  - cd ..
  - ps: |
-     "BUILD_END, $(Get-Date -Format 'o')"| Out-File ../timing.csv -Append
+     if ($env:feature_trackTiming) {
+       "BUILD_END, $(Get-Date -Format 'o')"| Out-File ../timing.csv -Append
+     }
 
 before_test:
  - ps: |
-     "TESTSETUP_START, $(Get-Date -Format 'o')"| Out-File ../timing.csv -Append
+     if ($env:feature_trackTiming) {
+       "TESTSETUP_START, $(Get-Date -Format 'o')"| Out-File ../timing.csv -Append
+     }
  - ps: appveyor\scripts\tests\beforeTests.ps1
  - ps: appveyor\scripts\installNVDA.ps1
  - ps: |
-     "TESTSETUP_END, $(Get-Date -Format 'o')"| Out-File ../timing.csv -Append
+     if ($env:feature_trackTiming) {
+       "TESTSETUP_END, $(Get-Date -Format 'o')"| Out-File ../timing.csv -Append
+     }
 
 test_script:
  - ps: |
-     "TEST_START, $(Get-Date -Format 'o')"| Out-File ../timing.csv -Append
+     if ($env:feature_trackTiming) {
+       "TEST_START, $(Get-Date -Format 'o')"| Out-File ../timing.csv -Append
+     }
  - ps: appveyor\scripts\tests\translationCheck.ps1
  - ps: appveyor\scripts\tests\unitTests.ps1
  - ps: appveyor\scripts\tests\lintCheck.ps1
  - ps: appveyor\scripts\tests\systemTests.ps1
  - ps: |
-     "TEST_END, $(Get-Date -Format 'o')"| Out-File ../timing.csv -Append
+     if ($env:feature_trackTiming) {
+       "TEST_END, $(Get-Date -Format 'o')"| Out-File ../timing.csv -Append
+     }
 
 after_test:
  - ps: appveyor\scripts\tests\checkTestFailure.ps1
@@ -97,5 +116,7 @@ on_failure:
 on_finish:
  - ps: appveyor\scripts\pushPackagingInfo.ps1
  - ps: |
-     "FINISH_END, $(Get-Date -Format 'o')"| Out-File ../timing.csv -Append
+     if ($env:feature_trackTiming) {
+       "FINISH_END, $(Get-Date -Format 'o')"| Out-File ../timing.csv -Append
+     }
  - ps: appveyor\scripts\logCiTiming.ps1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -57,9 +57,12 @@ build_script:
  - ps: appveyor\scripts\buildSymbolStore.ps1
  # The server expects the symbols archive to be structured as ./*.ex_ not ./symbols/*.ex_.
  # Change directory to package, as 7z will structure the archive using the relative path.
- - cd symbols
- - 7z a -tzip -r ..\output\symbols.zip *.dl_ *.ex_ *.pd_
- - cd ..
+ - ps: >-
+     if ($env:feature_buildSymbols) {
+        cd symbols
+        7z a -tzip -r ..\output\symbols.zip *.dl_ *.ex_ *.pd_
+        cd ..
+     }
  - ps: |
      "BUILD_END, $(Get-Date -Format 'o')"| Out-File ../timing.csv -Append
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,6 +25,7 @@ environment:
  crowdinProjectID: 598017
  crowdinAuthToken:
   secure: E3084gj4JeMZKvZIOLIhqZefuSo/tj7iYPt4yK0geOI/eQgmPvoXt37Xq0KwvXzvZiJny4AsMj1rKMTVxio8EG8KA0YsYYuy+WV1wpFRIn25zGQS+DZ/yycL75SmTWfr
+ scons_publisher: NV Access
  # Comment out/unset any of the feature_* variables to disable the respective build feature.
  feature_buildSymbols: True
  feature_uploadSymbolsToMozilla: True

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,8 @@ environment:
  crowdinAuthToken:
   secure: E3084gj4JeMZKvZIOLIhqZefuSo/tj7iYPt4yK0geOI/eQgmPvoXt37Xq0KwvXzvZiJny4AsMj1rKMTVxio8EG8KA0YsYYuy+WV1wpFRIn25zGQS+DZ/yycL75SmTWfr
  scons_publisher: NV Access
- # Comment out/unset any of the feature_* variables to disable the respective build feature.
+ # Comment out any of the feature_* variables to disable the respective build feature.
+ # They are checked for existence of content, not specific value.
  feature_buildSymbols: True
  feature_uploadSymbolsToMozilla: True
  feature_buildAppx: True

--- a/appveyor/scripts/buildSymbolStore.ps1
+++ b/appveyor/scripts/buildSymbolStore.ps1
@@ -1,4 +1,8 @@
 $ErrorActionPreference = "Stop";
+if (!$env:feature_buildSymbols) {
+	exit
+}
+
 foreach ($syms in
 	# We don't just include source\*.dll because that would include system dlls.
 	"source\liblouis.dll", "source\*.pdb",

--- a/appveyor/scripts/decryptFilesForSigning.ps1
+++ b/appveyor/scripts/decryptFilesForSigning.ps1
@@ -1,4 +1,4 @@
-if(!$env:APPVEYOR_PULL_REQUEST_NUMBER) {
+if(!$env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:feature_signing) {
 	openssl enc -d -md sha256 -aes-256-cbc -pbkdf2 -salt -pass pass:$env:secure_authenticode_pass -in appveyor\authenticode.pfx.enc -out appveyor\authenticode.pfx
 	if($LastExitCode -ne 0) {
 		$errorCode=$LastExitCode

--- a/appveyor/scripts/deployScript.ps1
+++ b/appveyor/scripts/deployScript.ps1
@@ -6,30 +6,32 @@ if (!$env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:versionType) {
 		py -m pip install --no-warn-script-location requests
 		py appveyor\crowdinSync.py uploadSourceFile 2 output\nvda.pot 2>&1
 	}
-	# Notify our server.
-	$exe = Get-ChildItem -Name output\*.exe
-	$hash = (Get-FileHash "output\$exe" -Algorithm SHA1).Hash.ToLower()
-	$apiVersion = (py -c "import sys; sys.path.append('source'); from addonAPIVersion import CURRENT; print('{}.{}.{}'.format(*CURRENT))")
-	echo apiversion: $apiVersion
-	$apiCompatTo = (py -c "import sys; sys.path.append('source'); from addonAPIVersion import BACK_COMPAT_TO; print('{}.{}.{}'.format(*BACK_COMPAT_TO))")
-	echo apiBackCompatTo: $apiCompatTo
-	$data = @{
-		jobId=$env:APPVEYOR_JOB_ID;
-		commit=$env:APPVEYOR_REPO_COMMIT;
-		version=$env:version; versionType=$env:versionType;
-		apiVersion=$apiVersion; apiCompatTo=$apiCompatTo;
-		avVersion=$env:APPVEYOR_BUILD_VERSION;
-		branch=$env:APPVEYOR_REPO_BRANCH;
-		exe=$exe; hash=$hash;
-		artifacts=$artifacts
+	# Notify our server, if this is an NV Access build.
+	if ($env:APPVEYOR_REPO_NAME.StartsWith("nvaccess/")) {
+		$exe = Get-ChildItem -Name output\*.exe
+		$hash = (Get-FileHash "output\$exe" -Algorithm SHA1).Hash.ToLower()
+		$apiVersion = (py -c "import sys; sys.path.append('source'); from addonAPIVersion import CURRENT; print('{}.{}.{}'.format(*CURRENT))")
+		echo apiversion: $apiVersion
+		$apiCompatTo = (py -c "import sys; sys.path.append('source'); from addonAPIVersion import BACK_COMPAT_TO; print('{}.{}.{}'.format(*BACK_COMPAT_TO))")
+		echo apiBackCompatTo: $apiCompatTo
+		$data = @{
+			jobId=$env:APPVEYOR_JOB_ID;
+			commit=$env:APPVEYOR_REPO_COMMIT;
+			version=$env:version; versionType=$env:versionType;
+			apiVersion=$apiVersion; apiCompatTo=$apiCompatTo;
+			avVersion=$env:APPVEYOR_BUILD_VERSION;
+			branch=$env:APPVEYOR_REPO_BRANCH;
+			exe=$exe; hash=$hash;
+			artifacts=$artifacts
+		}
+		ConvertTo-Json -InputObject $data -Compress | Out-File -FilePath deploy.json
+		Push-AppveyorArtifact deploy.json
+		# Execute the deploy script on the NV Access server via ssh.
+		# Warning: if the server address is changed, 
+		# The new address must be also included in appveyor\ssh_known_hosts in this repo
+		# Otherwise ssh will freeze on input!
+		cat deploy.json | ssh nvaccess@deploy.nvaccess.org nvdaAppveyorHook
 	}
-	ConvertTo-Json -InputObject $data -Compress | Out-File -FilePath deploy.json
-	Push-AppveyorArtifact deploy.json
-	# Execute the deploy script on the NV Access server via ssh.
-	# Warning: if the server address is changed, 
-	# The new address must be also included in appveyor\ssh_known_hosts in this repo
-	# Otherwise ssh will freeze on input!
-	cat deploy.json | ssh nvaccess@deploy.nvaccess.org nvdaAppveyorHook
 
 	# Upload symbols to Mozilla if feature enabled.
 	if ($env:feature_buildSymbols -and $env:feature_uploadSymbolsToMozilla) {

--- a/appveyor/scripts/deployScript.ps1
+++ b/appveyor/scripts/deployScript.ps1
@@ -1,7 +1,7 @@
 $ErrorActionPreference = "Stop";
 if (!$env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:versionType) {
 	# Not a try build.
-	if ($env:APPVEYOR_REPO_BRANCH -eq "beta") {
+	if ($env:APPVEYOR_REPO_BRANCH -eq "beta" -and $env:feature_crowdinSync) {
 		# Upload files to Crowdin for translation
 		py -m pip install --no-warn-script-location requests
 		py appveyor\crowdinSync.py uploadSourceFile 2 output\nvda.pot 2>&1

--- a/appveyor/scripts/deployScript.ps1
+++ b/appveyor/scripts/deployScript.ps1
@@ -6,7 +6,7 @@ if (!$env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:versionType) {
 		py -m pip install --no-warn-script-location requests
 		py appveyor\crowdinSync.py uploadSourceFile 2 output\nvda.pot 2>&1
 	}
-	# Notify our server, if this is an NV Access build.
+	# Notify the NV Access server if this is an NV Access build.
 	if ($env:APPVEYOR_REPO_NAME.StartsWith("nvaccess/")) {
 		$exe = Get-ChildItem -Name output\*.exe
 		$hash = (Get-FileHash "output\$exe" -Algorithm SHA1).Hash.ToLower()

--- a/appveyor/scripts/deployScript.ps1
+++ b/appveyor/scripts/deployScript.ps1
@@ -31,13 +31,15 @@ if (!$env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:versionType) {
 	# Otherwise ssh will freeze on input!
 	cat deploy.json | ssh nvaccess@deploy.nvaccess.org nvdaAppveyorHook
 
-	# Upload symbols to Mozilla.
-	py -m pip install --upgrade --no-warn-script-location pip
-	py -m pip install --no-warn-script-location requests
-	Try {
-		py appveyor\mozillaSyms.py
-	}
-	Catch {
-		Add-AppveyorMessage "Unable to upload symbols to Mozilla"
+	# Upload symbols to Mozilla if feature enabled.
+	if ($env:feature_buildSymbols -and $env:feature_uploadSymbolsToMozilla) {
+		py -m pip install --upgrade --no-warn-script-location pip
+		py -m pip install --no-warn-script-location requests
+		Try {
+			py appveyor\mozillaSyms.py
+		}
+		Catch {
+			Add-AppveyorMessage "Unable to upload symbols to Mozilla"
+		}
 	}
 }

--- a/appveyor/scripts/logCiTiming.ps1
+++ b/appveyor/scripts/logCiTiming.ps1
@@ -9,6 +9,11 @@
 $inputFile = "../timing.csv"
 $processedTimesFile = "buildStageTimingWithElapsed.csv"
 
+# Don't run if timing record was not created for some reason
+if (!(Test-Path -LiteralPath $inputFile)) {
+	exit
+}
+
 $entries = Import-Csv -Path $inputFile -Header Stage, Time
 $lastTime = Get-Date -Date $entries[0].Time
 

--- a/appveyor/scripts/pushPackagingInfo.ps1
+++ b/appveyor/scripts/pushPackagingInfo.ps1
@@ -6,5 +6,9 @@ $appVeyorUrl = "https://ci.appveyor.com"
 $exe = Get-ChildItem -Name output\*.exe
 if($?){
 	$exeUrl="$appVeyorUrl/api/buildjobs/$env:APPVEYOR_JOB_ID/artifacts/output/$exe"
-	Add-AppveyorMessage "Build (for testing PR): $exeUrl"
+	if ($env:APPVEYOR_PULL_REQUEST_NUMBER -ne $null) {
+		Add-AppveyorMessage "Build (for testing PR): $exeUrl"
+	} else {
+		Add-AppveyorMessage "Build (for testing branch): $exeUrl"
+	}
 }

--- a/appveyor/scripts/setSconsArgs.ps1
+++ b/appveyor/scripts/setSconsArgs.ps1
@@ -1,6 +1,6 @@
 $ErrorActionPreference = "Stop";
 $sconsOutTargets = "launcher developerGuide changes userGuide keyCommands client moduleList"
-if(!$env:APPVEYOR_PULL_REQUEST_NUMBER) {
+if(!$env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:feature_buildAppx) {
 	$sconsOutTargets += " appx"
 }
 $sconsArgs = "version=$env:version"

--- a/appveyor/scripts/setSconsArgs.ps1
+++ b/appveyor/scripts/setSconsArgs.ps1
@@ -10,7 +10,7 @@ if ($env:release) {
 if ($env:versionType) {
 	$sconsArgs += " updateVersionType=$env:versionType"
 }
-$sconsArgs += ' publisher="NV Access"'
+$sconsArgs += " publisher=`"$env:scons_publisher`""
 if(!$env:APPVEYOR_PULL_REQUEST_NUMBER) {
 	$sconsArgs += " certFile=appveyor\authenticode.pfx certTimestampServer=http://timestamp.digicert.com"
 }

--- a/appveyor/scripts/setSconsArgs.ps1
+++ b/appveyor/scripts/setSconsArgs.ps1
@@ -11,7 +11,7 @@ if ($env:versionType) {
 	$sconsArgs += " updateVersionType=$env:versionType"
 }
 $sconsArgs += " publisher=`"$env:scons_publisher`""
-if(!$env:APPVEYOR_PULL_REQUEST_NUMBER) {
+if (!$env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:feature_signing) {
 	$sconsArgs += " certFile=appveyor\authenticode.pfx certTimestampServer=http://timestamp.digicert.com"
 }
 $sconsArgs += " version_build=$env:APPVEYOR_BUILD_NUMBER"

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -63,7 +63,7 @@ What's New in NVDA
 Please refer to [the developer guide https://www.nvaccess.org/files/nvda/documentation/developerGuide.html#API] for information on NVDA's API deprecation and removal process.
 
 - Instantiating ``winVersion.WinVersion`` objects with unknown Windows versions above 10.0.22000 such as 10.0.25398 returns "Windows 11 unknown" instead of "Windows 10 unknown" for release name. (#15992, @josephsl)
-- Make the Appveyor compilation process easier for private NVDA builds, by using variables in appveyor.yml to disable or modify portions of the build scripts which are otherwise difficult for those outside NV Access to run in their default form. (#16216, @XLTechie)
+- Make the AppVeyor build process easier for NVDA forks, by adding configurable variables in appveyor.yml to disable or modify NV Access specific portions of the build scripts. (#16216, @XLTechie)
 -
 
 === Deprecations ===

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -63,6 +63,7 @@ What's New in NVDA
 Please refer to [the developer guide https://www.nvaccess.org/files/nvda/documentation/developerGuide.html#API] for information on NVDA's API deprecation and removal process.
 
 - Instantiating ``winVersion.WinVersion`` objects with unknown Windows versions above 10.0.22000 such as 10.0.25398 returns "Windows 11 unknown" instead of "Windows 10 unknown" for release name. (#15992, @josephsl)
+- Make the Appveyor compilation process easier for private NVDA builds, by using variables in appveyor.yml to disable or modify portions of the build scripts which are otherwise difficult for those outside NV Access to run in their default form. (#16216, @XLTechie)
 -
 
 === Deprecations ===


### PR DESCRIPTION
### Link to issue number:

Closes #16216 
Fixed #8806 (Issue discovered after merge)

### Summary of the issue:

Currently, for a developer to make a private AppVeyor build of NVDA, requires maintaining different build scripts, in addition to an intricately modified `appveyor.yml` file, and feeding them to AppVeyor on every build.

This PR removes much of the difficulty from private AppVeyor builds, by making the build process more configurable in `appveyor.yml`, without having to modify the build scripts at all to make a basic build work.

In addition, it adds a few sensible state checks to a couple build scripts.

It tries to avoid changing any of the existing logic, except where an `if` condition could be anded with another to achieve the desired result.

### Description of user facing changes

None

Edit after merge: developer usage documentation can now be found in `project_docs/dev/buildingNVDAOnAppVeyor.md`.

### Description of development approach

* appveyor.yml:
    + Move the environment section above the init section.
    + Added a `scons_publisher` variable, to avoid hard-coding "NV Access" in the scons variable script. Those doing private builds should change it to reflect their (org) name.
    + Added a feature subsection to the environment section. Included features to control:
        - building symbols,
        - Uploading symbols to Mozilla,
        - building the appx,
        - crowdinSync, and
        - package signing.
    + (For private builds, all of those features should be commented out, except, optionally, the one for building symbols.)
    + Added logic to check the setting of the buildSymbols feature before building symbols.
* appveyor/scripts/buildSymbolStore.ps1: Added a test for feature_buildSymbols.
* appveyor/scripts/deployScript.ps1:
    + Make symbol upload dependent on both the buildSymbols and uploadSymbolsToMozilla features being set in appveyor.yml.
    + Cause crowdin synchronization to be dependent on its feature from appveyor.yml.
    + Only deploy to the NV Access server, if it's an nvaccess owned repo.
* appveyor/scripts/setSconsArgs.ps1:
    + Use the `scons_publisher` variable from appveyor.yml to designate the publisher, instead of hardcoding in the script.
    + Don't include cert options if not signing based on feature in appveyor.yml.
    + Respond to the buildAppx feature in appveyor.yml.
* appveyor/scripts/pushPackagingInfo.ps1: Change the appVeyor message with the exe link to mention a "branch" instead of a "PR", if no PR number is set in the build. It is assumed that most private builds will be for branches, not PRs against their own clone.
* appveyor/scripts/decryptFilesForSigning.ps1: Do not attempt to decrypt files if signing feature is not set in appveyor.yml.
* appveyor/scripts/logCiTiming.ps1: added a test to exit successfully if the timing record file is not found.

Regarding the last: originally I included a feature to disable CI timing checks. I decided that feature was unnecessary so reverted it, but I kept the change to detect the missing timing file and silently exit rather than failing hard, since it makes sense that something else may cause that file not to exist, and we wouldn't want the build failing over it.

### Testing strategy:

Built several versions of NVDA with various combinations of the features disabled, and reached a successful build. Enabling any of them (except buildSymbols) on a non-NV Access build, causes a failure of one kind or another, only sometimes resulting in an executable being made. This is as expected and intended.

This PR built successfully in an NV Access configured environment.

### Known issues with pull request:

None

### Code Review Checklist:
- [X] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation (In #16293))
  - Context sensitive help for GUI changes
- [X] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
