### PR TITLE
Actually terminate (clean up) the Microsoft UIA Abstraction remote operations library on NVDA exit.

### DIFF
--- a/nvdaHelper/UIARemote/UIARemote.cpp
+++ b/nvdaHelper/UIARemote/UIARemote.cpp
@@ -153,6 +153,17 @@ extern "C" __declspec(dllexport) bool __stdcall initialize(bool doRemote, IUIAut
 	return true;
 }
 
+// Cleans up the remote opperations library.
+extern "C" __declspec(dllexport) void __stdcall cleanup() {
+	if(_isInitialized) {
+		LOG_INFO(L"Cleaning up the UIA Remote Operations abstraction library...")
+		UiaOperationAbstraction::Cleanup();
+		_isInitialized = false;
+		LOG_INFO(L"Done")
+	}
+}
+
+
 BOOL WINAPI DllMain(HINSTANCE hModule,DWORD reason,LPVOID lpReserved) {
 	if(reason==DLL_PROCESS_ATTACH) {
 		GetModuleFileName(hModule,dllDirectory,MAX_PATH);

--- a/nvdaHelper/UIARemote/UIARemote.cpp
+++ b/nvdaHelper/UIARemote/UIARemote.cpp
@@ -153,9 +153,9 @@ extern "C" __declspec(dllexport) bool __stdcall initialize(bool doRemote, IUIAut
 	return true;
 }
 
-// Cleans up the remote opperations library.
+// Cleans up the remote operations library.
 extern "C" __declspec(dllexport) void __stdcall cleanup() {
-	if(_isInitialized) {
+	if (_isInitialized) {
 		LOG_INFO(L"Cleaning up the UIA Remote Operations abstraction library...")
 		UiaOperationAbstraction::Cleanup();
 		_isInitialized = false;

--- a/source/UIAHandler/__init__.py
+++ b/source/UIAHandler/__init__.py
@@ -528,6 +528,8 @@ class UIAHandler(COMObject):
 			else:
 				break
 		self.clientObject.RemoveAllEventHandlers()
+		if winVersion.getWinVer() >= winVersion.WIN11:
+			UIARemote.terminate()
 
 	def _registerGlobalEventHandlers(self):
 		self.clientObject.AddFocusChangedEventHandler(self.baseCacheRequest, self)

--- a/source/UIAHandler/remote.py
+++ b/source/UIAHandler/remote.py
@@ -25,7 +25,9 @@ def initialize(doRemote: bool, UIAClient: POINTER(UIA.IUIAutomation)):
 	_dll = windll[os.path.join(NVDAHelper.versionedLibPath, "UIARemote.dll")]
 	_dll.initialize(doRemote, UIAClient)
 
+
 def terminate():
+	""" Terminates UIA remote operations support."""
 	_dll.cleanup()
 
 

--- a/source/UIAHandler/remote.py
+++ b/source/UIAHandler/remote.py
@@ -25,6 +25,9 @@ def initialize(doRemote: bool, UIAClient: POINTER(UIA.IUIAutomation)):
 	_dll = windll[os.path.join(NVDAHelper.versionedLibPath, "UIARemote.dll")]
 	_dll.initialize(doRemote, UIAClient)
 
+def terminate():
+	_dll.cleanup()
+
 
 def msWord_getCustomAttributeValue(
 		docElement: POINTER(UIA.IUIAutomationElement),


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Fixes #16072

### Summary of the issue:
As seen in a dump file provided by @irrah68 when debugging #16072 , NVDA can hang on exit while trying to destruct an instance of the CUIAutomation8 COMClass object:
<summary>
Call stack
</summary>
<details>
<pre>
win32u.dll!_NtUserMsgWaitForMultipleObjectsEx@20()	Unknown
user32.dll!MsgWaitForMultipleObjectsEx()	Unknown
combase.dll!CCliModalLoop::BlockFn(void * * ahEvent, unsigned long cEvents, unsigned long * lpdwSignaled) Line 2116	C++
combase.dll!ClassicSTAThreadWaitForHandles(unsigned long dwFlags, unsigned long dwTimeout, unsigned long cHandles, void * * pHandles, unsigned long * pdwIndex) Line 54	C++
combase.dll!CoWaitForMultipleHandles(unsigned long dwFlags, unsigned long dwTimeout, unsigned long cHandles, void * * pHandles, unsigned long * lpdwindex) Line 126	C++
combase.dll!CGIPTable::_RevokeInterfaceFromGlobal(unsigned long dwCookie, bool bPostedRevoke, bool waitIfBusy) Line 1010	C++
combase.dll!CGIPTable::RevokeInterfaceFromGlobal(unsigned long dwCookie) Line 935	C++
uiautomationcore.dll!ViewManagerEventTracker::Uninitialize(void)	Unknown
uiautomationcore.dll!ClientEventManager::~ClientEventManager(void)	Unknown
uiautomationcore.dll!CUIAutomation::~CUIAutomation(void)	Unknown
uiautomationcore.dll!ATL::CComObject<class CUIAutomation8>::`scalar deleting destructor'(unsigned int)	Unknown
uiautomationcore.dll!ATL::CComObject<class CUIAutomation8>::Release(void)	Unknown
[Inline Frame] UIARemote.dll!wil::com_ptr_t<IUIAutomation,wil::err_exception_policy>::{dtor}() Line 260	C++
[Inline Frame] UIARemote.dll!wil::object_without_destructor_on_shutdown<wil::com_ptr_t<IUIAutomation,wil::err_exception_policy>>::{dtor}() Line 2209	C++
UIARemote.dll!UiaOperationAbstraction::`anonymous namespace'::`dynamic atexit destructor for 'g_automation''()	C++
ucrtbase.dll!<lambda>(void)()	Unknown
ucrtbase.dll!__crt_seh_guarded_call<int>::operator()<<lambda_69a2805e680e0e292e8ba93315fe43a8>,<lambda>(void) &,<lambda>(void)>()	Unknown
ucrtbase.dll!__execute_onexit_table()	Unknown
UIARemote.dll!__scrt_dllmain_uninitialize_c() Line 398	C++
UIARemote.dll!dllmain_crt_process_detach(const bool is_terminating) Line 182	C++
</pre>
</details>
In short, it looks as if the destruction of the CUIAutomation8 COMClass object held by the UIA abstraction Remote Operations library locks up as it is happening from a different thread from where it was created. It was originally created in NvDA's UIA MTA thread, but it is being automatically cleaned up by the CRT of NVDA's UIARemote.dll in NVDA's main thread.
I'm not entirely sure why this is only a problem on @irrah68's machine, and why it is more likely to happen with the UIA Rate Limited event handler in #14888.
Either way though, NVDA is not cleaning it up correctly.

### Description of user facing changes
NVDA is less likely to hang on NvDA exit.

### Description of development approach
* Add a `cleanup` function to `UIARemote.dll` which calls the UIA abstraction remote operations library's `cleanup` function. This function frees all remote contexts, but most importantly, releases the CUIAutomation8 COMClass object which was  passed in on initialization.
* Add a `terminate` function to `UIAHandler/remote.py` which calls UIARemote.dll's `cleanup` function.
* at the end of UIA's MTA thread in Python, after removing event handlers, finally call `UIAHandler.remtoe.terminate`, ensuring that the UIA abstraction remote ops library is correctly cleaned up in the UIA MTA thread, where it was originally initialized.

### Testing strategy:
* Restarted NVDA multiple times. Ensured the NvDA's log showed the appropriate log messages in UIARemote.dll's `cleanup` method.
* [x] @irrah68 has tested a try build of this pr based on master and has confirmed the issue has been fixed for them.

### Known issues with pull request:
None known.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
