### PR TITLE
A gui.nvdaControls.MessageDialog with default type of standard, should no longer throw a None conversion exception

### DIFF
--- a/source/gui/nvdaControls.py
+++ b/source/gui/nvdaControls.py
@@ -1,6 +1,6 @@
 # -*- coding: UTF-8 -*-
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2016-2022 NV Access Limited, Derek Riemer, Cyrille Bougot
+# Copyright (C) 2016-2024 NV Access Limited, Derek Riemer, Cyrille Bougot, Luke Davis
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 import collections
@@ -291,7 +291,8 @@ class MessageDialog(DPIScaledDialog):
 			return
 
 	def _playSound(self):
-		winsound.MessageBeep(self._soundID)
+		if self._soundID is not None:
+			winsound.MessageBeep(self._soundID)
 
 	def __init__(self, parent, title, message, dialogType=DIALOG_TYPE_STANDARD):
 		DPIScaledDialog.__init__(self, parent, title=title)

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -192,7 +192,9 @@ Setting ``numCells`` is still supported for single line braille displays and ``n
 - Fixed bug where deleting git-tracked files during ``scons -c`` resulted in missing UIA COM interfaces on rebuild. (#7070, #10833, @hwf1324)
 - Fix a bug where some code changes were not detected when building ``dist``, that prevented a new build from being triggered.
 Now ``dist`` always rebuilds. (#13372, @hwf1324)
+- A ``gui.nvdaControls.MessageDialog`` with default type of standard, no longer throws a None conversion exception because no sound is assigned. (#16223, @XLTechie)
 -
+
 
 === API Breaking Changes ===
 These are breaking API changes.


### PR DESCRIPTION

### Link to issue number:

None

### Summary of the issue:

Using `gui.nvdaControls.MessageDialog` with standard type (the default), generates this exception:

```
ERROR - unhandled exception (03:21:22.395) - MainThread (16784):
Traceback (most recent call last):
  File "gui\nvdaControls.pyc", line 335, in _onShowEvt
  File "gui\nvdaControls.pyc", line 294, in _playSound
TypeError: 'NoneType' object cannot be interpreted as an integer
```

This is happening because there is no sound assigned for standard type dialogs, but the method which plays sound does not check for this. Which, ironically, caused a sound, at least in test builds.

### Description of user facing changes

Beta/alpha users will no longer hear an error sound when one of these is used.

### Description of development approach

Check whether the int is actually a None, before trying to play the sound. If so, don't play it.

### Testing strategy:

TBD

### Known issues with pull request:

none

### Code Review Checklist:
- [X] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [X] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [X] API is compatible with existing add-ons.
- [X] Security precautions taken.
