### PR TITLE
removed unusable shortcuts from the (Synthesizer) and (Braille display) groupings

### DIFF
--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -3584,7 +3584,7 @@ class BrailleSettingsPanel(SettingsPanel):
 			evt.Skip()
 
 	def onChangeDisplay(self, evt):
-		changeDisplay = BrailleDisplaySelectionDialog(None, multiInstanceAllowed=True)
+		changeDisplay = BrailleDisplaySelectionDialog(self, multiInstanceAllowed=True)
 		ret = changeDisplay.ShowModal()
 		if ret == wx.ID_OK:
 			self.Freeze()

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -1073,7 +1073,7 @@ class SpeechSettingsPanel(SettingsPanel):
 			evt.Skip()
 
 	def onChangeSynth(self, evt):
-		changeSynth = SynthesizerSelectionDialog(self, multiInstanceAllowed=True)
+		changeSynth = SynthesizerSelectionDialog(None, multiInstanceAllowed=True)
 		ret = changeSynth.ShowModal()
 		if ret == wx.ID_OK:
 			self.Freeze()
@@ -3584,7 +3584,7 @@ class BrailleSettingsPanel(SettingsPanel):
 			evt.Skip()
 
 	def onChangeDisplay(self, evt):
-		changeDisplay = BrailleDisplaySelectionDialog(self, multiInstanceAllowed=True)
+		changeDisplay = BrailleDisplaySelectionDialog(None, multiInstanceAllowed=True)
 		ret = changeDisplay.ShowModal()
 		if ret == wx.ID_OK:
 			self.Freeze()

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -1030,7 +1030,7 @@ class SpeechSettingsPanel(SettingsPanel):
 	def makeSettings(self, settingsSizer):
 		settingsSizerHelper = guiHelper.BoxSizerHelper(self, sizer=settingsSizer)
 		# Translators: A label for the synthesizer on the speech panel.
-		synthLabel = _("&Synthesizer")
+		synthLabel = _("Synthesizer")
 		synthBoxSizer = wx.StaticBoxSizer(wx.HORIZONTAL, self, label=synthLabel)
 		synthBox = synthBoxSizer.GetStaticBox()
 		synthGroup = guiHelper.BoxSizerHelper(self, sizer=synthBoxSizer)
@@ -3548,7 +3548,7 @@ class BrailleSettingsPanel(SettingsPanel):
 
 		settingsSizerHelper = guiHelper.BoxSizerHelper(self, sizer=settingsSizer)
 		# Translators: A label for the braille display on the braille panel.
-		displayLabel = _("Braille &display")
+		displayLabel = _("Braille display")
 
 		displaySizer = wx.StaticBoxSizer(wx.HORIZONTAL, self, label=displayLabel)
 		displayBox = displaySizer.GetStaticBox()

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -1073,7 +1073,7 @@ class SpeechSettingsPanel(SettingsPanel):
 			evt.Skip()
 
 	def onChangeSynth(self, evt):
-		changeSynth = SynthesizerSelectionDialog(None, multiInstanceAllowed=True)
+		changeSynth = SynthesizerSelectionDialog(self, multiInstanceAllowed=True)
 		ret = changeSynth.ShowModal()
 		if ret == wx.ID_OK:
 			self.Freeze()

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -1105,7 +1105,7 @@ class SpeechSettingsPanel(SettingsPanel):
 		return self.voicePanel.isValid()
 
 
-class SynthesizerSelectionDialog(SettingsDialog):
+class SynthesizerSelectionDialog:
 	# Translators: This is the label for the synthesizer selection dialog
 	title = _("Select Synthesizer")
 	helpId = "SynthesizerSelection"
@@ -3615,7 +3615,7 @@ class BrailleSettingsPanel(SettingsPanel):
 		self.brailleSubPanel.onSave()
 
 
-class BrailleDisplaySelectionDialog(SettingsDialog):
+class BrailleDisplaySelectionDialog:
 	# Translators: This is the label for the braille display selection dialog.
 	title = _("Select Braille Display")
 	helpId = "SelectBrailleDisplay"

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -1105,7 +1105,7 @@ class SpeechSettingsPanel(SettingsPanel):
 		return self.voicePanel.isValid()
 
 
-class SynthesizerSelectionDialog:
+class SynthesizerSelectionDialog(SettingsDialog):
 	# Translators: This is the label for the synthesizer selection dialog
 	title = _("Select Synthesizer")
 	helpId = "SynthesizerSelection"
@@ -3615,7 +3615,7 @@ class BrailleSettingsPanel(SettingsPanel):
 		self.brailleSubPanel.onSave()
 
 
-class BrailleDisplaySelectionDialog:
+class BrailleDisplaySelectionDialog(SettingsDialog):
 	# Translators: This is the label for the braille display selection dialog.
 	title = _("Select Braille Display")
 	helpId = "SelectBrailleDisplay"


### PR DESCRIPTION
### Link to issue number:
non found
### Summary of the issue:
in the nvda settings dialog, under Speech and Braille Categories, we have Synthesizer, and Braille display  groupings, which these groupings had shortcuts. (Synthesizer alt+s), and (Braille display alt+d). But, when we were navigating these groupings with tab key, their shortcuts were not announced, and it just announces (name) grouping. Only when we were navigating these groupings with object navigation, their shortcuts were announced, but again, when pressing these shortcuts, there were not reachable with these shortcuts. For example, when we pressed alt+s in the speech Categorie so many times, we would only reach (Use spelling functionality if supported  check box  checked  Alt+s). Or when pressed alt+d in Braille Categorie, we'd just here the windows sound and not reach any option. So, the shortcuts for these groupings were completely unusable, and also, the shortcut of the change button in these groupings can take you to these groupings, so all these reasons can be the result of removing the shortcuts of these groupings.
### Description of user facing changes
When navigating the (Synthesizer) and the (Braille display) groupings with nvda's object navigation, their unusable shortcuts (alt+s) and (alt+d) will no longer be announced, they have been removed because they didn't have any usage.
### Description of development approach
removed & symbol from the related code lines, to remove the (S) and (D) shortcuts from them.
### Testing strategy:
tested that the shortcuts of these groupings are no longer announced when navigating them with object navigation.
### Known issues with pull request:
non
### Code Review Checklist:

- [ ] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
