### PR TITLE
Directly determine oldMouseObject.sleepMode

### DIFF
--- a/source/mouseHandler.py
+++ b/source/mouseHandler.py
@@ -208,7 +208,7 @@ def executeMouseMoveEvent(x,y):
 	oldMouseObject = api.getMouseObject()
 	mouseObject = desktopObject.objectFromPoint(x, y)
 
-	if config.conf["mouse"]["audioCoordinatesOnMouseMove"] and not oldMouseObject.appModule.sleepMode:
+	if config.conf["mouse"]["audioCoordinatesOnMouseMove"] and not oldMouseObject.sleepMode:
 		playAudioCoordinates(x, y, screenWidth, screenHeight, minPos,
 			config.conf['mouse']['audioCoordinates_detectBrightness'],
 			config.conf['mouse']['audioCoordinates_blurFactor'])


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:

Related: #16220, #16243

### Summary of the issue:

After the window in which the mouse object is located is closed, the mouse object will not change, but the appModule of the mouse object will be lost.

### Description of user facing changes

When reporting mouse audio coordinates is turned on, the error no longer occurs when the window in which the cached mouse object is located is closed.

### Description of development approach

Directly determine oldMouseObject.sleepMode

### Testing strategy:

1. Open a program (e.g. Poedit)
2. Use mouse tracking to move the mouse to this program
3. Press `alt+f4` to close the program.
4. Move the mouse

Observe that no error occurs

### Known issues with pull request:

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
