### PR TITLE
remove unused codehilite extension

### DIFF
--- a/site_scons/site_tools/md2html.py
+++ b/site_scons/site_tools/md2html.py
@@ -18,8 +18,6 @@ DEFAULT_EXTENSIONS = frozenset({
 	"markdown.extensions.extra",
 	# Allows TOC with [TOC]"
 	"markdown.extensions.toc",
-	# Adds code highlighting to code blocks
-	"markdown.extensions.codehilite",
 	# Makes list behaviour better, including 2 space indents by default
 	"mdx_truly_sane_lists",
 	# External links will open in a new tab, and title will be set to the link text


### PR DESCRIPTION
The markdown codehilite extension, used for code highlighting, requires the installation of a separate program to be useful.
The set up required for this is not considered worthwhile for now.

https://python-markdown.github.io/extensions/code_hilite/