### PR TITLE
Update wxPython to 4.2.2a0205c7c1b

### DIFF
--- a/projectDocs/dev/buildSystemNotes.md
+++ b/projectDocs/dev/buildSystemNotes.md
@@ -64,7 +64,6 @@ Ensures the build environment is clean, and there are no conflicts with other in
 NVDA and its build system have many Python dependencies.
 Using `pip` and a virtual environment means:
 - Updating is easier than git submodules.
-  E.G. wxPython no longer has to be pre-built and stored in our bin repo.
 - Developers need to sync/update their submodules less often.
 - More consistency for dependencies.
 - IDE's can be configured more easily.

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ SCons==4.5.2
 # NVDA's runtime dependencies
 comtypes==1.2.0
 pyserial==3.5
-wxPython==4.2.1
+./miscDeps/python/wxPython-4.2.2a1-cp311-cp311-win32.whl
 git+https://github.com/DiffSK/configobj@e2ba4457c4651fa54f8d59d8dcdd3da950e956b8#egg=configobj
 requests==2.31.0
 # Pillow is an implicit dependency and requires zlib and jpeg by default, but we don't need it

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -210,7 +210,7 @@ Please open a GitHub issue if your Add-on has an issue with updating to the new 
   - robotframework to 6.1.1. (#15544)
   - SCons to 4.5.2. (#15529, @LeonarddeR)
   - sphinx to 7.2.6. (#15544)
-  - wxPython to 4.2.1. (#12551)
+  - wxPython to 4.2.2a commit ``0205c7c1b9022a5de3e3543f9304cfe53a32b488``. (#12551, #16257)
   -
 - Removed pip dependencies:
   - typing_extensions, these should be supported natively in Python 3.11 (#15544)


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Fixes #15714
See also https://github.com/nvaccess/nvda-misc-deps/pull/32

### Summary of the issue:
wxPython introduced a bug in 4.2.1: https://github.com/wxWidgets/Phoenix/issues/2446
This caused #15714

wxPython is yet to release the commit which fixes this issue.
However, an alpha build wheel can be incorporate

The build used is from:

- https://alldunn.visualstudio.com/wxPython-CI/_build/results?buildId=1246&view=results
- https://github.com/wxWidgets/Phoenix/commit/0205c7c1b9022a5de3e3543f9304cfe53a32b488

### Description of user facing changes
Emojis and other unicode symbols are displayed properly in NVDA

### Description of development approach
Update wxPython to an alpha snapshot

### Testing strategy:
Tested using emojis in the symbol pronunciation dialog to confirm #15714  is fixed

### Known issues with pull request:
I have asked Robin what the quality of alpha builds are - i.e. if they throw errors, log, or otherwise act differently due to not being an official release

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
