### PR TITLE
User Guide: Indicate incompatibility of screen curtain with inverted colors in the Magnifier

### DIFF
--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -1190,6 +1190,8 @@ Due to a change in the Windows Magnification API, Screen Curtain had to be updat
 Use NVDA 2021.2 to activate Screen Curtain with Windows 10 21H2 (10.0.19044) or later.
 For security purposes, when using a new version of Windows, get visual confirmation that the Screen Curtain makes the screen entirely black.
 
+Please note that while Windows Magnifier is running and inverted screen colors are being used, the screen curtain cannot be enabled.
+
 + Content Recognition +[ContentRecognition]
 When authors don't provide sufficient information for a screen reader user to determine the content of something, various tools can be used to attempt to recognize the content from an image.
 NVDA supports the optical character recognition (OCR) functionality built into Windows 10 and later to recognize text from images.


### PR DESCRIPTION
### Link to issue number:
Partial fix for #10545
### Summary of the issue:
Screen curtain cannot be activated while Windows Magnifier is running with inverted screen colors.
An error message can be heard when trying to activate the screen curtain.
Though, this incompatibility is not documented in the User Guide.

### Description of user facing changes
Update the User Guide.
### Description of development approach
N/A
### Testing strategy:
Check User Guide.
### Known issues with pull request:
None
### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
