### PR TITLE
replace mktemp usages with mkstemp

### DIFF
--- a/source/addonHandler/__init__.py
+++ b/source/addonHandler/__init__.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2012-2023 Rui Batista, NV Access Limited, Noelia Ruiz Martínez,
+# Copyright (C) 2012-2024 Rui Batista, NV Access Limited, Noelia Ruiz Martínez,
 # Joseph Lee, Babbage B.V., Arnold Loubriat, Łukasz Golonka, Leonard de Ruijter
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
@@ -10,7 +10,6 @@ from abc import abstractmethod, ABC
 import sys
 import os.path
 import gettext
-import tempfile
 import inspect
 import itertools
 import collections
@@ -45,6 +44,7 @@ from addonStore.models.status import AddonStateCategory, SupportsAddonState
 from addonStore.models.version import MajorMinorPatch, SupportsVersionCheck
 import extensionPoints
 from utils.caseInsensitiveCollections import CaseInsensitiveSet
+from utils.tempFile import _createEmptyTempFileForDeletingFile
 
 from .addonVersionCheck import (
 	isAddonCompatible,
@@ -535,7 +535,7 @@ class Addon(AddonBase):
 			return None
 
 		try:
-			os.rename(self.pendingInstallPath, self.installPath)
+			os.replace(self.pendingInstallPath, self.installPath)
 			state[AddonStateCategory.PENDING_INSTALL].discard(self.name)
 			return self.installPath
 		except OSError:
@@ -573,9 +573,9 @@ class Addon(AddonBase):
 			finally:
 				del _availableAddons[self.path]
 				self._cleanupAddonImports()
-		tempPath=tempfile.mktemp(suffix=DELETEDIR_SUFFIX,dir=os.path.dirname(self.path))
+		tempPath = _createEmptyTempFileForDeletingFile(suffix=DELETEDIR_SUFFIX, dir=os.path.dirname(self.path))
 		try:
-			os.rename(self.path,tempPath)
+			os.replace(self.path, tempPath)
 		except (WindowsError,IOError):
 			raise RuntimeError("Cannot rename add-on path for deletion")
 		shutil.rmtree(tempPath,ignore_errors=True)

--- a/source/addonStore/network.py
+++ b/source/addonStore/network.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2022-2023 NV Access Limited
+# Copyright (C) 2022-2024 NV Access Limited
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -247,7 +247,7 @@ class AddonFileDownloader:
 				_addonDownloadFailureMessageTitle,
 			)
 		log.debug(f"Download complete: {inProgressFilePath}")
-		os.rename(src=inProgressFilePath, dst=cacheFilePath)
+		os.replace(src=inProgressFilePath, dst=cacheFilePath)
 		log.debug(f"Cache file available: {cacheFilePath}")
 		return cast(os.PathLike, cacheFilePath)
 

--- a/source/installer.py
+++ b/source/installer.py
@@ -620,7 +620,7 @@ def tryCopyFile(sourceFilePath,destFilePath):
 		log.debugWarning("Unable to copy %s, error %d"%(sourceFilePath,errorCode))
 		if not os.path.exists(destFilePath):
 			raise OSError("error %d copying %s to %s"%(errorCode,sourceFilePath,destFilePath))
-		tempPath = _createEmptyTempFileForDeletingFile(dir=os.path.dirname(destFilePath)
+		tempPath = _createEmptyTempFileForDeletingFile(dir=os.path.dirname(destFilePath))
 		try:
 			os.replace(destFilePath, tempPath)
 		except (WindowsError,OSError):

--- a/source/installer.py
+++ b/source/installer.py
@@ -29,6 +29,7 @@ from typing import (
 )
 import NVDAState
 from NVDAState import WritePaths
+from utils.tempFile import _createEmptyTempFileForDeletingFile
 
 _wsh=None
 def _getWSH():
@@ -576,9 +577,9 @@ def tryRemoveFile(
 		rebootOK: bool = False
 ):
 	dirPath=os.path.dirname(path)
-	tempPath=tempfile.mktemp(dir=dirPath)
+	tempPath = _createEmptyTempFileForDeletingFile(dir=dirPath)
 	try:
-		os.rename(path,tempPath)
+		os.replace(path, tempPath)
 	except (WindowsError,IOError):
 		raise RetriableFailure("Failed to rename file %s before  remove"%path)
 	for count in range(numRetries):
@@ -604,7 +605,7 @@ def tryRemoveFile(
 		else:
 			return
 	try:
-		os.rename(tempPath,path)
+		os.replace(tempPath, path)
 	except Exception:
 		log.exception(f"Unable to rename back to {path} before retriable failure")
 	raise RetriableFailure("File %s could not be removed"%path)
@@ -619,9 +620,9 @@ def tryCopyFile(sourceFilePath,destFilePath):
 		log.debugWarning("Unable to copy %s, error %d"%(sourceFilePath,errorCode))
 		if not os.path.exists(destFilePath):
 			raise OSError("error %d copying %s to %s"%(errorCode,sourceFilePath,destFilePath))
-		tempPath=tempfile.mktemp(dir=os.path.dirname(destFilePath))
+		tempPath = _createEmptyTempFileForDeletingFile(dir=os.path.dirname(destFilePath)
 		try:
-			os.rename(destFilePath,tempPath)
+			os.replace(destFilePath, tempPath)
 		except (WindowsError,OSError):
 			log.error("Failed to rename %s after failed overwrite"%destFilePath,exc_info=True)
 			raise RetriableFailure("Failed to rename %s after failed overwrite"%destFilePath) 
@@ -646,7 +647,7 @@ def _revertGroupDelete(tempDir: str, installDir: str):
 		relativePath = tempFile.relative_to(tempDir)
 		originalPath = os.path.join(installDir, relativePath.as_posix())
 		try:
-			os.rename(tempFile.absolute(), originalPath)
+			os.replace(tempFile.absolute(), originalPath)
 		except OSError:
 			log.exception(f"Failed to rename {tempFile} back to {originalPath}")
 

--- a/source/updateCheck.py
+++ b/source/updateCheck.py
@@ -37,7 +37,6 @@ import pickle
 # #9818: one must import at least urllib.request in Python 3 in order to use full urllib functionality.
 import urllib.request
 import urllib.parse
-import tempfile
 import hashlib
 import ctypes.wintypes
 import requests
@@ -61,6 +60,7 @@ import shellapi
 import winUser
 import winKernel
 import fileUtils
+from utils.tempFile import _createEmptyTempFileForDeletingFile
 
 #: The URL to use for update checks.
 CHECK_URL = "https://www.nvaccess.org/nvdaUpdateCheck"
@@ -562,6 +562,7 @@ class UpdateAskInstallDialog(
 			# In Python 2, os.renames did rename files across drives, no longer allowed in Python 3 (error 17 (cannot move files across drives) is raised).
 			# This is prominent when trying to postpone an update for portable copy of NVDA if this runs from a USB flash drive or another internal storage device.
 			# Therefore use kernel32::MoveFileEx with copy allowed (0x2) flag set.
+			# TODO: consider moving to shutil.move, which supports moves across filesystems.
 			winKernel.moveFileEx(self.destPath, finalDest, winKernel.MOVEFILE_COPY_ALLOWED)
 		except:
 			log.debugWarning("Unable to rename the file from {} to {}".format(self.destPath, finalDest), exc_info=True)
@@ -601,7 +602,7 @@ class UpdateDownloader(garbageHandler.TrackedObject):
 		self.backCompatToAPIVersion = getAPIVersionTupleFromString(updateInfo["apiCompatTo"])
 		self.versionTuple = None
 		self.fileHash = updateInfo.get("launcherHash")
-		self.destPath = tempfile.mktemp(prefix="nvda_update_", suffix=".exe")
+		self.destPath = _createEmptyTempFileForDeletingFile(prefix="nvda_update_", suffix=".exe")
 
 	def start(self):
 		"""Start the download.

--- a/source/utils/tempFile.py
+++ b/source/utils/tempFile.py
@@ -1,0 +1,26 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2024 NV Access Limited
+# This file may be used under the terms of the GNU General Public License, version 2 or later.
+# For more details see: https://www.gnu.org/licenses/gpl-2.0.html
+
+import os
+import tempfile
+
+
+def _createEmptyTempFileForDeletingFile(
+		dir: str | None = None,
+		prefix: str | None = None,
+		suffix: str | None = None,
+	) -> str:
+	"""
+	Create an empty temporary file and return its path.
+
+	tempfile.mktemp is deprecated as creating a temporary file in the system's temporary directory is a security risk,
+	without holding it open, as the file could be created by an attacker with the same name.
+	tempfile.mkstemp / tempfile.NamedTemporaryFile was created for the purpose of creating temporary files securely.
+	However, we do not need this secure behaviour, as we are just creating a temp file to move files for future deletion.
+	As such, we close the file handle and return the path.
+	"""
+	fh, tempPath = tempfile.mkstemp(dir=dir, suffix=suffix, prefix=prefix)
+	os.close(fh)
+	return tempPath

--- a/source/utils/tempFile.py
+++ b/source/utils/tempFile.py
@@ -11,14 +11,15 @@ def _createEmptyTempFileForDeletingFile(
 		dir: str | None = None,
 		prefix: str | None = None,
 		suffix: str | None = None,
-	) -> str:
+) -> str:
 	"""
 	Create an empty temporary file and return its path.
 
-	tempfile.mktemp is deprecated as creating a temporary file in the system's temporary directory is a security risk,
+	tempfile.mktemp is deprecated as creating a temp file in the system's temp directory is a security risk,
 	without holding it open, as the file could be created by an attacker with the same name.
-	tempfile.mkstemp / tempfile.NamedTemporaryFile was created for the purpose of creating temporary files securely.
-	However, we do not need this secure behaviour, as we are just creating a temp file to move files for future deletion.
+	mkstemp / NamedTemporaryFile was created for the purpose of creating temporary files securely.
+	However, we do not need this secure behaviour,
+	as we are just creating a temp file to move a file to for future deletion.
 	As such, we close the file handle and return the path.
 	"""
 	fh, tempPath = tempfile.mkstemp(dir=dir, suffix=suffix, prefix=prefix)


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Fixes https://github.com/nvaccess/nvda/security/code-scanning/2
Fixes https://github.com/nvaccess/nvda/security/code-scanning/3
Fixes https://github.com/nvaccess/nvda/security/code-scanning/4
Fixes https://github.com/nvaccess/nvda/security/code-scanning/5

### Summary of the issue:
From CodeQL: "Functions that create temporary file names (such as `tempfile.mktemp` and `os.tempnam`) are fundamentally insecure, as they do not ensure exclusive access to a file with the temporary name they return. The file name returned by these functions is guaranteed to be unique on creation but the file must be opened in a separate operation. There is no guarantee that the creation and open operations will happen atomically. This provides an opportunity for an attacker to interfere with the file before it is opened.

Note that mktemp has been deprecated since Python 2.3."

Given our usage of `tempfile.mktemp` is to safely delete files, this is not a security concern, as exclusive access to these files is not required. However, given that the function is deprecated and strongly discouraged, we should modernise our code to use what is recommended by python.

### Description of user facing changes
None

### Description of development approach
Replace usages of `tempfile.mktemp` with the secure alternative `tempfile.mkstemp`.

- https://docs.python.org/3/library/tempfile.html#tempfile.mktemp
- https://docs.python.org/3/library/tempfile.html#tempfile.mkstemp

`os.rename` does not work if the file already exists, so instances have been replaced by `os.replace`:

- https://docs.python.org/3/library/os.html#os.replace
- https://docs.python.org/3/library/os.html#os.rename

### Testing strategy:
- [x] Manually tested the installer
- [x] Manually tested removing add-ons

### Known issues with pull request:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
