### PR TITLE
No longer report "native copy" when copying text in native selection mode in browse mode

### DIFF
--- a/source/NVDAObjects/UIA/wordDocument.py
+++ b/source/NVDAObjects/UIA/wordDocument.py
@@ -554,12 +554,6 @@ class WordDocument(UIADocumentWithTableNavigation,WordDocumentNode,WordDocumentB
 		# such as "delete back word" when Control+Backspace is pressed.
 		if activityId == "AccSN2":  # Delete activity ID
 			return
-		# copy to clipboard
-		if activityId == 'AccSN3':
-			ti = self.treeInterceptor
-			if ti and not ti.passThrough:
-				# Browse mode provides its own copy to clipboard message.
-				return
 		super(WordDocument, self).event_UIA_notification(**kwargs)
 
 	# The following overide of the EditableText._caretMoveBySentenceHelper private method

--- a/source/cursorManager.py
+++ b/source/cursorManager.py
@@ -452,8 +452,6 @@ class CursorManager(documentBase.TextContainerObject,baseObject.ScriptableObject
 
 	def script_copyToClipboard(self, gesture: inputCore.InputGesture):
 		if self._nativeAppSelectionMode:
-			# Translators: Reported when browse mode passes the copy to clipboard command through to the application.
-			ui.message(_("native copy"))
 			gesture.send()
 			return
 		info=self.makeTextInfo(textInfos.POSITION_SELECTION)

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -38,10 +38,10 @@ Windows 8.1 is the minimum Windows version supported.
 - Added support for Bluetooth Low Energy HID Braille displays. (#15470)
 - A new Native Selection mode (toggled by ``NVDA+shift+f10``) is now available in NVDA's browse mode for Mozilla Firefox.
 When turned on, selecting text in browse mode will also manipulate Firefox's own native selection.
-Copying text with ``control+c`` will pass straight through to Firefox, thus copying the rich content, rather than NVDA's plain text representation. (#15830)
-Note however  that as Firefox is handling the actual copy, NVDA will not report a "copy to clipboard" message in this mode.
-- When copying text in Microsoft Word with NVDA's browse mode enabled, formatting is now also included. (#16129)
-A side affect of this is that NvDA will no longer report  a "copy to clipboard" message when pressing `control+c` in Microsoft Word / Outlook browse mode, as the application is now handling the copy, not NVDA. 
+Copying text with ``control+c`` will pass straight through to Firefox, thus copying the rich content, rather than NVDA's plain text representation.
+Note however  that as Firefox is handling the actual copy, NVDA will not report a "copy to clipboard" message in this mode. (#15830)
+- When copying text in Microsoft Word with NVDA's browse mode enabled, formatting is now also included.
+A side affect of this is that NvDA will no longer report  a "copy to clipboard" message when pressing `control+c` in Microsoft Word / Outlook browse mode, as the application is now handling the copy, not NVDA. (#16129)
 - A new "on-demand" speech mode has been added.
 When speech is on-demand, NVDA does not speak automatically (e.g. when moving the cursor) but still speaks when calling commands whose goal is explicitly to report something (e.g. report window title). (#481, @CyrilleB79)
 - In the Speech category of NVDA's settings, it is now possible to exclude unwanted speech modes from the Cycle speech modes command (``NVDA+s``). (#15806, @lukaszgo1)

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -39,9 +39,9 @@ Windows 8.1 is the minimum Windows version supported.
 - A new Native Selection mode (toggled by ``NVDA+shift+f10``) is now available in NVDA's browse mode for Mozilla Firefox.
 When turned on, selecting text in browse mode will also manipulate Firefox's own native selection.
 Copying text with ``control+c`` will pass straight through to Firefox, thus copying the rich content, rather than NVDA's plain text representation.
-Note however  that as Firefox is handling the actual copy, NVDA will not report a "copy to clipboard" message in this mode. (#15830)
+Note however that as Firefox is handling the actual copy, NVDA will not report a "copy to clipboard" message in this mode. (#15830)
 - When copying text in Microsoft Word with NVDA's browse mode enabled, formatting is now also included.
-A side affect of this is that NvDA will no longer report  a "copy to clipboard" message when pressing `control+c` in Microsoft Word / Outlook browse mode, as the application is now handling the copy, not NVDA. (#16129)
+A side affect of this is that NVDA will no longer report a "copy to clipboard" message when pressing ``control+c`` in Microsoft Word / Outlook browse mode, as the application is now handling the copy, not NVDA. (#16129)
 - A new "on-demand" speech mode has been added.
 When speech is on-demand, NVDA does not speak automatically (e.g. when moving the cursor) but still speaks when calling commands whose goal is explicitly to report something (e.g. report window title). (#481, @CyrilleB79)
 - In the Speech category of NVDA's settings, it is now possible to exclude unwanted speech modes from the Cycle speech modes command (``NVDA+s``). (#15806, @lukaszgo1)

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -39,7 +39,9 @@ Windows 8.1 is the minimum Windows version supported.
 - A new Native Selection mode (toggled by ``NVDA+shift+f10``) is now available in NVDA's browse mode for Mozilla Firefox.
 When turned on, selecting text in browse mode will also manipulate Firefox's own native selection.
 Copying text with ``control+c`` will pass straight through to Firefox, thus copying the rich content, rather than NVDA's plain text representation. (#15830)
+Note however  that as Firefox is handling the actual copy, NVDA will not report a "copy to clipboard" message in this mode.
 - When copying text in Microsoft Word with NVDA's browse mode enabled, formatting is now also included. (#16129)
+A side affect of this is that NvDA will no longer report  a "copy to clipboard" message when pressing `control+c` in Microsoft Word / Outlook browse mode, as the application is now handling the copy, not NVDA. 
 - A new "on-demand" speech mode has been added.
 When speech is on-demand, NVDA does not speak automatically (e.g. when moving the cursor) but still speaks when calling commands whose goal is explicitly to report something (e.g. report window title). (#481, @CyrilleB79)
 - In the Speech category of NVDA's settings, it is now possible to exclude unwanted speech modes from the Cycle speech modes command (``NVDA+s``). (#15806, @lukaszgo1)


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Related to #16202 and #16201.

### Summary of the issue:
In NVDA's new native selection mode in browse mode for Firefox, and MS word / Outlook browse mode, when native copying to clipboard with control+c, NVDA would report "native copy". this message has proven confusing and or unpopular. Thus this pr removes the message.
therefore, now when copying text with control+c  when native seleciton mode is turned on, in Firefox / MS word / Outlook browse mode, NVDA will not say anything at all, and just let the application react the way it normally would (E.g. MS word may announce "copy" via its UIA notification).

### Description of user facing changes
NVDA will no longer announce "native copy" when copying text with native selection mode.

### Description of development approach
* the "native copy" message has been removed from the clipyToclipboard script in cursorManager.
* MS word's own "copy" UIA notification message is no longer suppressed in browse mode.

### Testing strategy:
* Opened a new document in <s word. 
* Typed a heading level 1.
* Turned on browse mode.
* Selected and copied the heading.
* Opened a new blank document.
* Pasted the text.
* Confirmed that NVDA said "copy" rather than "native copy" and that the text was pasted, including its formatting.

### Known issues with pull request:
There still seems to be some confusion or disagreement on the appropriate UX for this. See comments on #16202. but for NVDA 2024.1 almost complete this will have to do.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
