### PR TITLE
Fix sound split exception during startup on AppVeyor CI runner

### DIFF
--- a/source/audio/soundSplit.py
+++ b/source/audio/soundSplit.py
@@ -15,7 +15,7 @@ from pycaw.utils import AudioSession, AudioUtilities
 import ui
 from utils.displayString import DisplayStringIntEnum
 from dataclasses import dataclass
-import _ctypes
+from comtypes import COMError
 
 VolumeTupleT = tuple[float, float]
 
@@ -81,8 +81,8 @@ def initialize() -> None:
 		global audioSessionManager
 		try:
 			audioSessionManager = AudioUtilities.GetAudioSessionManager()
-		except _ctypes.COMError as e:
-			log.error("Could not initialize audio session manager! ", e)
+		except COMError:
+			log.exception("Could not initialize audio session manager")
 			return
 		state = SoundSplitState(config.conf["audio"]["soundSplitState"])
 		setSoundSplitState(state)

--- a/source/audio/soundSplit.py
+++ b/source/audio/soundSplit.py
@@ -15,6 +15,7 @@ from pycaw.utils import AudioSession, AudioUtilities
 import ui
 from utils.displayString import DisplayStringIntEnum
 from dataclasses import dataclass
+import _ctypes
 
 VolumeTupleT = tuple[float, float]
 

--- a/source/audio/soundSplit.py
+++ b/source/audio/soundSplit.py
@@ -78,7 +78,11 @@ activeCallback: AudioSessionNotification | None = None
 def initialize() -> None:
 	if nvwave.usingWasapiWavePlayer():
 		global audioSessionManager
-		audioSessionManager = AudioUtilities.GetAudioSessionManager()
+		try:
+			audioSessionManager = AudioUtilities.GetAudioSessionManager()
+		except _ctypes.COMError as e:
+			log.error("Could not initialize audio session manager! ", e)
+			return
 		state = SoundSplitState(config.conf["audio"]["soundSplitState"])
 		setSoundSplitState(state)
 	else:


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Closes #16269
Fixup of #16071 
### Summary of the issue:
Exception _ctypes.COMError is thrown at startup on AppVeyor CI runner because hno sound device is present.
### Description of user facing changes
N/A
### Description of development approach
Catching and logging exception. Returning from soundSplit.initialize function so that initialization can continue.
### Testing strategy:
Not sure how to test on AppVeyor, but judging by the exception providded - this should fix the error.
Tested on my local computer to avoid syntax errors.
### Known issues with pull request:
N/A
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
