### PR TITLE
Fix exception during vertical paragraph navigation

### DIFF
--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -503,7 +503,7 @@ class BrowseModeTreeInterceptor(treeInterceptorHandler.TreeInterceptor):
 		elif itemType == "verticalParagraph":
 			def paragraphFunc(info: textInfos.TextInfo) -> int | None:
 				try:
-					return info.pointAtStart.x
+					return info.NVDAObjectAtStart.location[0]
 				except AttributeError:
 					return None
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Closes #16274
### Summary of the issue:
Exception during vertical navigation when one of page items is offscreen.
### Description of user facing changes
N/A
### Description of development approach
Previously I was retrieving `x` coordinate by calling `textInfo.pointAtStart`. However it appears that this doesn't work when said `textInfo` is off screen.
Switching to another method:
`textInfo.NVDAObjectAtStart.location[0]`
### Testing strategy:
Passes specified test case.
### Known issues with pull request:
N/A
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
