### PR TITLE
Mute microphone command

### DIFF
--- a/source/audio/__init__.py
+++ b/source/audio/__init__.py
@@ -8,9 +8,11 @@ from .soundSplit import (
 	setSoundSplitState,
 	toggleSoundSplitState,
 )
+from . import notifications
 
 __all__ = [
 	"SoundSplitState",
 	"setSoundSplitState",
 	"toggleSoundSplitState",
+	"notifications",
 ]

--- a/source/audio/notifications.py
+++ b/source/audio/notifications.py
@@ -43,7 +43,7 @@ def terminate():
 			try:
 				deviceEnumerator.UnregisterEndpointNotificationCallback(mmClient)
 			except COMError:
-				log.exception("Could not terminate audio notifications module"):
+				log.exception("Could not terminate audio notifications module")
 				return
 
 

--- a/source/audio/notifications.py
+++ b/source/audio/notifications.py
@@ -35,8 +35,11 @@ def initialize() -> None:
 
 @atexit.register
 def terminate():
-	if nvwave.usingWasapiWavePlayer():
-		if mmClient is not None and deviceEnumerator is not None:
+	if (
+		nvwave.usingWasapiWavePlayer():
+		and mmClient is not None
+		and deviceEnumerator is not None
+	):
 			try:
 				deviceEnumerator.UnregisterEndpointNotificationCallback(mmClient)
 			except COMError:

--- a/source/audio/notifications.py
+++ b/source/audio/notifications.py
@@ -1,0 +1,74 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2024 NV Access Limited
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+
+from comtypes import GUID, COMError
+from pycaw.callbacks import MMNotificationClient
+from pycaw.api.mmdeviceapi.depend.structures import PROPERTYKEY
+from pycaw.utils import AudioUtilities
+from pycaw.constants import EDataFlow
+from typing import Any
+from logHandler import log
+import ui
+import nvwave
+import atexit
+
+deviceEnumerator: Any | None = None
+mmClient: MMNotificationClient | None = None
+
+
+def initialize() -> None:
+	if nvwave.usingWasapiWavePlayer():
+		global mmClient, deviceEnumerator
+		try:
+			mmClient = MMNotificationClientImpl()
+			deviceEnumerator = AudioUtilities.GetDeviceEnumerator()
+			deviceEnumerator.RegisterEndpointNotificationCallback(mmClient)
+		except COMError as e:
+			log.exception("Could not initialize audio notifications module", e)
+			return
+
+	else:
+		log.debug("Cannot initialize audio notifications as WASAPI is disabled")
+
+
+@atexit.register
+def terminate():
+	if nvwave.usingWasapiWavePlayer():
+		if mmClient is not None and deviceEnumerator is not None:
+			try:
+				deviceEnumerator.UnregisterEndpointNotificationCallback(mmClient)
+			except COMError as e:
+				log.exception("Could not terminate audio notifications module", e)
+				return
+
+
+GUID_DEVICE_VOLUME_OR_MUTE = GUID("{9855C4CD-DF8C-449C-A181-8191B68BD06C}")
+EVENT_MUTE = (GUID_DEVICE_VOLUME_OR_MUTE, 1)
+
+
+class MMNotificationClientImpl(MMNotificationClient):
+	def on_property_value_changed(self, device_id: str, property_struct: PROPERTYKEY, fmtid: GUID, pid: int):
+		global EVENT_MUTE
+		match (fmtid, pid):
+			case EVENT_MUTE:
+				defaultMicrophone = AudioUtilities.GetMicrophone()
+				defaultMicrophoneId = defaultMicrophone .GetId() if defaultMicrophone is not None else None
+				device = deviceEnumerator.GetDevice(device_id)
+				deviceObject = AudioUtilities.CreateDevice(device)
+				if device_id == defaultMicrophoneId:
+					microphoneName = ""
+					isMicrophone = True
+				else:
+					microphoneName = deviceObject.FriendlyName
+					isMicrophone = AudioUtilities.GetEndpointDataFlow(device_id, 1) == EDataFlow.eCapture.value
+				if isMicrophone:
+					isMuted = deviceObject.EndpointVolume.GetMute()
+					if isMuted:
+						# Translators: notification spoken when microphone muted/unmuted
+						msg = _("Muted microphone %s") % microphoneName
+					else:
+						# Translators: notification spoken when microphone muted/unmuted
+						msg = _("Unmuted microphone %s") % microphoneName
+					ui.message(msg)

--- a/source/audio/notifications.py
+++ b/source/audio/notifications.py
@@ -36,7 +36,7 @@ def initialize() -> None:
 @atexit.register
 def terminate():
 	if (
-		nvwave.usingWasapiWavePlayer():
+		nvwave.usingWasapiWavePlayer()
 		and mmClient is not None
 		and deviceEnumerator is not None
 	):

--- a/source/audio/notifications.py
+++ b/source/audio/notifications.py
@@ -39,8 +39,8 @@ def terminate():
 		if mmClient is not None and deviceEnumerator is not None:
 			try:
 				deviceEnumerator.UnregisterEndpointNotificationCallback(mmClient)
-			except COMError as e:
-				log.exception("Could not terminate audio notifications module", e)
+			except COMError:
+				log.exception("Could not terminate audio notifications module"):
 				return
 
 

--- a/source/audio/notifications.py
+++ b/source/audio/notifications.py
@@ -25,8 +25,8 @@ def initialize() -> None:
 			mmClient = MMNotificationClientImpl()
 			deviceEnumerator = AudioUtilities.GetDeviceEnumerator()
 			deviceEnumerator.RegisterEndpointNotificationCallback(mmClient)
-		except COMError as e:
-			log.exception("Could not initialize audio notifications module", e)
+		except COMError:
+			log.exception("Could not initialize audio notifications module")
 			return
 
 	else:

--- a/source/audio/notifications.py
+++ b/source/audio/notifications.py
@@ -57,7 +57,7 @@ class MMNotificationClientImpl(MMNotificationClient):
 		match (fmtid, pid):
 			case EVENT_MUTE:
 				defaultMicrophone = AudioUtilities.GetMicrophone()
-				defaultMicrophoneId = defaultMicrophone .GetId() if defaultMicrophone is not None else None
+				defaultMicrophoneId = defaultMicrophone.GetId() if defaultMicrophone is not None else None
 				device = deviceEnumerator.GetDevice(device_id)
 				deviceObject = AudioUtilities.CreateDevice(device)
 				if device_id == defaultMicrophoneId:

--- a/source/core.py
+++ b/source/core.py
@@ -289,6 +289,8 @@ def resetConfiguration(factoryDefaults=False):
 	tones.terminate()
 	log.debug("terminating sound split")
 	audio.soundSplit.terminate()
+	log.debug("terminating audio notifications")
+	audio.notifications.terminate()
 	log.debug("Terminating background braille display detection")
 	bdDetect.terminate()
 	log.debug("Terminating background i/o")
@@ -321,6 +323,8 @@ def resetConfiguration(factoryDefaults=False):
 	# Sound split
 	log.debug("initializing sound split")
 	audio.soundSplit.initialize()
+	log.debug("initializing audio notifications")
+	audio.notifications.initialize()
 	#Speech
 	log.debug("initializing speech")
 	speech.initialize()
@@ -679,9 +683,11 @@ def main():
 	log.debug("Initializing tones")
 	import tones
 	tones.initialize()
-	log.debug("Initializing sound split")
 	import audio
+	log.debug("Initializing sound split")
 	audio.soundSplit.initialize()
+	log.debug("Initializing audio notifications")
+	audio.notifications.initialize()
 	import speechDictHandler
 	log.debug("Speech Dictionary processing")
 	speechDictHandler.initialize()

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -4481,7 +4481,7 @@ class GlobalCommands(ScriptableObject):
 	@script(
 		description=_(
 			# Translators: Describes a command.
-			"Toggles microphone mute",
+			"Toggle microphone mute",
 		),
 		category=SCRCAT_AUDIO,
 		gesture=None,

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -4489,7 +4489,7 @@ class GlobalCommands(ScriptableObject):
 	def script_toggleMicrophoneMute(self, gesture: "inputCore.InputGesture") -> None:
 		if not nvwave.usingWasapiWavePlayer():
 			# Translators: error message for toggle microphone mute command
-			ui.message(_("Please enable wasapi in order to mute microphone"))
+			ui.message(_("Please enable WASAPI in order to mute microphone"))
 			return
 		microphoneInterface = AudioUtilities.GetMicrophone()
 		if microphoneInterface is None:

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -67,7 +67,8 @@ from base64 import b16encode
 import vision
 from utils.security import objectBelowLockScreenAndWindowsIsLocked
 import audio
-
+from pycaw.utils import AudioUtilities
+import nvwave
 
 #: Script category for text review commands.
 # Translators: The name of a category of NVDA commands.
@@ -4476,6 +4477,32 @@ class GlobalCommands(ScriptableObject):
 	)
 	def script_cycleSoundSplit(self, gesture: "inputCore.InputGesture") -> None:
 		audio.toggleSoundSplitState()
+
+	@script(
+		description=_(
+			# Translators: Describes a command.
+			"Toggles microphone mute",
+		),
+		category=SCRCAT_AUDIO,
+		gesture=None,
+	)
+	def script_toggleMicrophoneMute(self, gesture: "inputCore.InputGesture") -> None:
+		if not nvwave.usingWasapiWavePlayer():
+			# Translators: error message for toggle microphone mute command
+			ui.message(_("Please enable wasapi in order to mute microphone"))
+			return
+		microphoneInterface = AudioUtilities.GetMicrophone()
+		if microphoneInterface is None:
+			# Translators: error message for toggle microphone mute command
+			msg = _("No microphone present")
+			ui.message(msg)
+			return
+		microphone = AudioUtilities.CreateDevice(microphoneInterface)
+		muted = microphone.EndpointVolume.GetMute()
+		muted = not muted
+		microphone.EndpointVolume.SetMute(muted, None)
+		# We do not speak microphone mute status here, since this will trigger a wasapi notification,
+		# that will trigger a spoken message. See: source/audio/notifications.py
 
 
 #: The single global commands instance.

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -23,6 +23,7 @@ What's New in NVDA
       -
     -
   - Added a new unassigned input gesture to toggle the reporting of figures and captions. (#10826, #14349)
+  - Added a new unassigned input gesture to toggle microphone mute. (#16056, @mltony)
   -
 - Added support for the BrailleEdgeS2 braille device. (#16033)
 - NVDA will keep the audio device awake after speech stops, in order to prevent the start of the next speech being clipped with some audio devices such as Bluetooth headphones. (#14386, @jcsteh, @mltony)

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -555,7 +555,7 @@ If you only need to switch between a limited subset of speech modes, see [Modes 
 
 ++ Toggle microphone mute ++[MuteMicrophone]
 
-The toggle microphone mute command allows you to mute or unmute default microphone with a single keystroke.
+The toggle microphone mute command allows you to mute or unmute the default microphone with a single keystroke.
 By default, there is no keyboard gesture assigned to this command.
 If you would like to use this command, please assign a keyboard gesture to it in [Input Gestures dialog #InputGestures], under the audio category.
 

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -553,6 +553,14 @@ A gesture allows cycling through the various speech modes:
 
 If you only need to switch between a limited subset of speech modes, see [Modes available in the Cycle speech mode command #SpeechModesDisabling] for a way to disable unwanted modes.
 
+++ Toggle microphone mute ++[MuteMicrophone]
+
+Toggle microphone mute command allows you to mute or unmute default microphone with a single keystroke.
+By default, there is no keyboard gesture assigned to this command.
+If you would like to use this command, please assign a keyboard gesture to it in [Input Gestures dialog #InputGestures], under the audio category.
+
+This command doesn't work if you have started NVDA with [WASAPI disabled for audio output #WASAPI] in Advanced Settings.
+
 + Navigating with NVDA +[NavigatingWithNVDA]
 NVDA allows you to explore and navigate the system in several ways, including both normal interaction and review.
 

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -555,7 +555,7 @@ If you only need to switch between a limited subset of speech modes, see [Modes 
 
 ++ Toggle microphone mute ++[MuteMicrophone]
 
-Toggle microphone mute command allows you to mute or unmute default microphone with a single keystroke.
+The toggle microphone mute command allows you to mute or unmute default microphone with a single keystroke.
 By default, there is no keyboard gesture assigned to this command.
 If you would like to use this command, please assign a keyboard gesture to it in [Input Gestures dialog #InputGestures], under the audio category.
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Closes #16056
### Summary of the issue:
A command to mute/unmute microphone.
### Description of user facing changes
Added a global command to mute/unmute microphone. No default gesture assigned.
Added wasapi notification listener; when it detects microphone mute/unmute event - it speaks it. This would speak notification even if microphone is muted by other means, e.g. laptop-specific keystroke or windows settings.
### Description of development approach
Made use of pycaw for both mute command and notification listener.
### Testing strategy:
Tested manually on Windows 11.
### Known issues with pull request:
Wasapi notification comes in with a noticeable delay of about 1 second.
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
