### PR TITLE
Update symbols.dic with fullwidth punctuation symbols

### DIFF
--- a/source/locale/en/symbols.dic
+++ b/source/locale/en/symbols.dic
@@ -1,5 +1,5 @@
 ﻿# A part of NonVisual Desktop Access (NVDA)
-# Copyright (c) 2011-2023 NVDA Contributors
+# Copyright (c) 2011-2024 NVDA Contributors
 # This file is covered by the GNU General Public License.
 
 complexSymbols:
@@ -43,6 +43,7 @@ negative number	minus	none	norep
 
 # Standard punctuation/symbols
 !	bang	all
+！	fullwidth exclamation mark	all
 "	quote	most
 \#	number	some
 $	dollar	all	norep
@@ -65,12 +66,16 @@ $	dollar	all	norep
 ،	arabic comma	all	always
 -	dash	most	always
 .	dot	some
+．	fullwidth full stop	some
 /	slash	some
 :	colon	most	norep
+：	fullwidth colon	most	norep
 ;	semi	most
 ؛	arabic semicolon	most
+；	fullwidth semicolon	most
 ?	question	all
 ؟	arabic question mark	all
+？	fullwidth question mark	all
 @	at	some
 [	left bracket	most
 ]	right bracket	most


### PR DESCRIPTION
### Link to issue number:
Closes #16288
### Summary of the issue:
Some fullwidth punctuation symbols are not reported when exploring a default regex present in NVDA's own GUI.
### Description of user facing changes
The following symbols are reported when navigating character by character or or read at high enough levels of symbol reporting:
`．！？：`；
The way they are reported is now customizable in the symbols dialog.
### Description of development approach
Added these symbols in the English symbols file with the following parameters:
* name: used the Unicode name; no need to use another shorter name since these symbols are not common in English
* level: same as their western counterpart
* repetition: same as their western counterpart

These symbols will then be added in other languages symbols files by translators.

For languages commonly using these symbols (e.g. Chinese), translators may find more suitable to use the level / repetition of the western "sentence end" corresponding symbol. E.g. use level / repetition of ". sentence ending" for "dot" instead of "dot" for "fullwidth full stop".

### Testing strategy:
Manual tests reading the regex containing them:
* with eSpeak, OneCore and IBMTTS (similar to Eloquence)
* reading the line at punctuation levels None and all
* navigated character by character

### Known issues with pull request:
None
### Code Review Checklist:


- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
