### PR TITLE
Added security and privacy note for add-ons to the user guide

### DIFF
--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -321,6 +321,7 @@ Before you're able to press the Continue button you will have to use the checkbo
 There will also be a button present to review the add-ons that will be disabled.
 Refer to the [incompatible add-ons dialog section #incompatibleAddonsManager] for more help on this button.
 After installation, you are able to re-enable incompatible add-ons at your own risk from within the [Add-on Store #AddonsManager].
+But note that add-ons might introduce vulnerabilities, so check out the [note on security and privacy #AddonSecurityandPrivacy] to make sure you have all information needed before installing them.
 
 +++ Use NVDA during sign-in +++[StartAtWindowsLogon]
 This option allows you to choose whether or not NVDA should automatically start while at the Windows sign-in screen, before you have entered a password.
@@ -2924,6 +2925,32 @@ If you install an add-on with paid components and change your mind about using i
 
 The Add-on Store is accessed from the Tools submenu of the NVDA menu.
 To access the Add-on Store from anywhere, assign a custom gesture using the [Input Gestures dialog #InputGestures].
+
++ Note on security and privacy when using Add-ons +[AddonSecurityandPrivacy]
+Installing add-ons in NVDA leads to integration of external code into NVDA's functionality in order to enhance NVDA or make new features possible.
+Add-ons can also use external libraries and third party services to serve the purpose and provide the features for which they have been developed.
+Add-ons can be developed by every person or company, and the review process for these external feature providers happens when they are submitted to the NVDA’s official add-on store.
+
+The review process of add-ons is still in development, so most of add-ons are not officially reviewed yet.
+However, many add-ons have discussions areas where users can exchange feedback. The [community review area #AddonStoreReviews] can be accessed via the actions menu of the add-on.
+
+Installed Add-ons or extensions (not only in NVDA) might in general introduce security and/or privacy vulnerabilities, depending on the permissions they need and actions they perform in order to provide the desired functionality.
+Risks can be e.g.
+- Insecure network connections
+- Files stored with insecure file permissions or in an unprotected location
+- Sensitive information written to an easily available log file
+- Web browser vulnerabilities
+- Vulnerabilities in third-party libraries
+- Cryptographic vulnerabilities, and more.
+-
+
+Users install NVDA add-ons at their own risk. Therefore, everyone should be aware of following aspects when installing them:
+- Check out the developer’s website to see if it’s a serious source you can trust.
+- Read the description carefully. Does the add-on need questionable permissions? Does it track data? Does it share sensitive data with other sources that you don’t trust?
+- Check out the [community reviews #AddonStoreReviews] for the add-on. Are there any complaints about the add-on? Are there any reports about data being taken, or for anything that makes you feel unsafe?
+- The risk of vulnerabilities increases the more add-ons you installed. So be careful to keep the overview of the sources your add-ons come from.
+- If possible, check the permissions the add-on requests. If you don’t feel safe about a permission the add-on needs, maybe it is better to uninstall it.
+-
 
 ++ Browsing add-ons ++[AddonStoreBrowsing]
 When opened, the Add-on Store displays a list of add-ons.

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -2926,7 +2926,7 @@ If you install an add-on with paid components and change your mind about using i
 The Add-on Store is accessed from the Tools submenu of the NVDA menu.
 To access the Add-on Store from anywhere, assign a custom gesture using the [Input Gestures dialog #InputGestures].
 
-+ Note on security and privacy when using Add-ons +[AddonSecurityandPrivacy]
+++ Note on security and privacy when using Add-ons ++[AddonSecurityandPrivacy]
 Installing add-ons in NVDA leads to integration of external code into NVDA's functionality in order to enhance NVDA or make new features possible.
 Add-ons can also use external libraries and third party services to serve the purpose and provide the features for which they have been developed.
 Add-ons can be developed by every person or company, and the review process for these external feature providers happens when they are submitted to the NVDA’s official add-on store.


### PR DESCRIPTION
### Link to issue number:
n/a
### Summary of the issue:
In many discussions, especially in corporate environments but also when users of other screen readers change to NVDA, there is no common perception of security and privacy status when using add-ons throughout the community of NVDA users.
### Description of user facing changes
Users will get a common sense for the perception of the status of security and privacy when using add-ons.
### Description of development approach
Discussion #16241 provides more details and current developments.

### Testing strategy:
Tested that the formating of the text appears correctly in the user guide, including the link to the community review section.

### Known issues with pull request:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - User Documentation
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [ ] API is compatible with existing add-ons.
- [x] Security precautions taken.
