### PR TITLE
Restore channel volume of applications upon exit

### DIFF
--- a/source/audio/soundSplit.py
+++ b/source/audio/soundSplit.py
@@ -10,12 +10,14 @@ import globalVars
 from logHandler import log
 import nvwave
 from pycaw.api.audiopolicy import IAudioSessionManager2
-from pycaw.callbacks import AudioSessionNotification
+from pycaw.callbacks import AudioSessionNotification, AudioSessionEvents
 from pycaw.utils import AudioSession, AudioUtilities
 import ui
 from utils.displayString import DisplayStringIntEnum
 from dataclasses import dataclass
 from comtypes import COMError
+from threading import Lock
+import core
 
 VolumeTupleT = tuple[float, float]
 
@@ -99,6 +101,20 @@ def terminate():
 		log.debug("Skipping terminating sound split as WASAPI is disabled.")
 
 
+@dataclass(unsafe_hash=True)
+class AudioSessionNotificationWrapper(AudioSessionNotification):
+	listener: AudioSessionNotification
+
+	def on_session_created(self, new_session: AudioSession):
+		pid = new_session.ProcessId
+		with applicationExitCallbacksLock:
+			if pid not in applicationExitCallbacks:
+				volumeRestorer = VolumeRestorer(pid, new_session)
+				new_session.register_notification(volumeRestorer)
+				applicationExitCallbacks[pid] = volumeRestorer
+		self.listener.on_session_created(new_session)
+
+
 def applyToAllAudioSessions(
 		callback: AudioSessionNotification,
 		applyToFuture: bool = True,
@@ -111,6 +127,7 @@ def applyToAllAudioSessions(
 		or until unregisterCallback() is called.
 	"""
 	unregisterCallback()
+	callback = AudioSessionNotificationWrapper(callback)
 	if applyToFuture:
 		audioSessionManager.RegisterSessionNotification(callback)
 		# The following call is required to make callback to work:
@@ -192,3 +209,45 @@ def toggleSoundSplitState() -> None:
 			"one of audio sessions is either mono, or has more than 2 audio channels."
 		)
 		ui.message(msg)
+
+
+@dataclass(unsafe_hash=True)
+class VolumeRestorer(AudioSessionEvents):
+	pid: int
+	audioSession: AudioSession
+
+	def on_state_changed(self, new_state: str, new_state_id: int):
+		if new_state == "Expired":
+			# For some reason restoring volume doesn't work in this thread, so scheduling in the main thread.
+			core.callLater(0, self.restoreVolume)
+
+	def restoreVolume(self):
+		# Application connected to this audio session is terminating. Restore its volume.
+		try:
+			channelVolume = self.audioSession.channelAudioVolume()
+			channelCount = channelVolume.GetChannelCount()
+			if channelCount != 2:
+				log.warning(
+					f"Audio session for pid {self.pid} has {channelCount} channels instead of 2 - cannot set volume!"
+				)
+				return
+			channelVolume.SetChannelVolume(0, 1.0, None)
+			channelVolume.SetChannelVolume(1, 1.0, None)
+		except Exception:
+			log.exception(f"Could not restore volume of process {self.pid} upon exit.")
+		self.unregister()
+
+	def unregister(self):
+		with applicationExitCallbacksLock:
+			try:
+				del applicationExitCallbacks[self.pid]
+			except KeyError:
+				pass
+			try:
+				self.audioSession.unregister_notification()
+			except Exception:
+				log.exception(f"Cannot unregister audio session for process {self.pid}")
+
+
+applicationExitCallbacksLock = Lock()
+applicationExitCallbacks: dict[int, VolumeRestorer] = {}


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Closes #16292
### Summary of the issue:
When sound split is enabled, if an application is closed while NVDA is still running, its channel volume would be preserved even after the app is restarted later without NVDA.
### Description of user facing changes
N/A
### Description of development approach
Catching `on_state_changed` notification and when `new_state == "Expired"` - this means that the applciation just exited - we restore both left and right channel to full volume.
### Testing strategy:
Manual.
### Known issues with pull request:
N/A
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
