### PR TITLE
Enter focus mode when activating editable list

### DIFF
--- a/source/NVDAObjects/IAccessible/__init__.py
+++ b/source/NVDAObjects/IAccessible/__init__.py
@@ -958,8 +958,12 @@ the NVDAObject for IAccessible
 		IAccessible2States = self.IA2States
 		states |= IAccessibleHandler.getStatesSetFromIAccessible2States(IAccessible2States)
 
-		# Readonly should override editable, except in the case of lists and listitems, where the readonly state differentiates between interactive and noninteractive lists in Firefox
-		if controlTypes.State.READONLY in states and self.role not in (controlTypes.Role.LIST, controlTypes.Role.LISTITEM):
+		# Readonly should override editable, except in the case of lists and listitems, where the readonly state
+		# differentiates between interactive and non-interactive lists in Firefox.
+		if (
+			self.role not in (controlTypes.Role.LIST, controlTypes.Role.LISTITEM)
+			and controlTypes.State.READONLY in states
+		):
 			states.discard(controlTypes.State.EDITABLE)
 		try:
 			IA2Attribs=self.IA2Attributes

--- a/source/NVDAObjects/IAccessible/__init__.py
+++ b/source/NVDAObjects/IAccessible/__init__.py
@@ -958,8 +958,8 @@ the NVDAObject for IAccessible
 		IAccessible2States = self.IA2States
 		states |= IAccessibleHandler.getStatesSetFromIAccessible2States(IAccessible2States)
 
-		# Readonly should override editable
-		if controlTypes.State.READONLY in states:
+		# Readonly should override editable, except in the case of lists and listitems, where the readonly state differentiates between interactive and noninteractive lists in Firefox
+		if controlTypes.State.READONLY in states and self.role not in (controlTypes.Role.LIST, controlTypes.Role.LISTITEM):
 			states.discard(controlTypes.State.EDITABLE)
 		try:
 			IA2Attribs=self.IA2Attributes

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -68,6 +68,7 @@ What's New in NVDA
   -
 - Fixed a bug causing NVDA to fail to read the ribbon and options within Geekbench. (#16251, @mzanm)
 - Fixed a rare case when saving the configuration may fail to save all profiles.  (#16343, @CyrilleB79)
+-In Firefox and Chromium-based browsers,  NVDA will correctly enter focus mode when pressing enter when positioned within a presentational list (ul / ol) inside editable content. (#16325)
 -
 
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:

Fixes #13642 

### Summary of the issue:

In Firefox, pressing enter on a list item in an editable region does not switch to focus mode.


### Description of user facing changes

NVDA will switch to focus mode when pressing enter on an editable list item.


### Description of development approach

Restricted the cases in which NVDA will drop the `controlTypes.State.EDITABLE` to exclude objects with a role of `controlTypes.Role.LIST` and `LISTITEM`. 


### Testing strategy:

Tested using the test case given in #13642. Tested in a Google sheet with Braille mode enabled to make sure this does not regress changes implemented in #7935.


### Known issues with pull request:

None


### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation: None needed
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
