### PR TITLE
Add sound split disabled mode

### DIFF
--- a/source/audio/soundSplit.py
+++ b/source/audio/soundSplit.py
@@ -108,7 +108,9 @@ def initialize() -> None:
 @atexit.register
 def terminate():
 	if nvwave.usingWasapiWavePlayer():
-		setSoundSplitState(SoundSplitState.NVDA_BOTH_APPS_BOTH)
+		state = SoundSplitState(config.conf["audio"]["soundSplitState"])
+		if state != SoundSplitState.OFF:
+			setSoundSplitState(SoundSplitState.OFF)
 		unregisterCallback()
 	else:
 		log.debug("Skipping terminating sound split as WASAPI is disabled.")

--- a/source/audio/soundSplit.py
+++ b/source/audio/soundSplit.py
@@ -38,7 +38,10 @@ class SoundSplitState(DisplayStringIntEnum):
 			# Translators: Sound split state
 			SoundSplitState.OFF: pgettext("SoundSplit", "Sound split disabled"),
 			# Translators: Sound split state
-			SoundSplitState.NVDA_BOTH_APPS_BOTH: pgettext("SoundSplit", "NVDA in both channels and applications in both channels"),
+			SoundSplitState.NVDA_BOTH_APPS_BOTH: pgettext(
+				"SoundSplit",
+				"NVDA in both channels and applications in both channels",
+			),
 			# Translators: Sound split state
 			SoundSplitState.NVDA_LEFT_APPS_RIGHT: _("NVDA on the left and applications on the right"),
 			# Translators: Sound split state
@@ -55,7 +58,11 @@ class SoundSplitState(DisplayStringIntEnum):
 
 	def getAppVolume(self) -> VolumeTupleT:
 		match self:
-			case SoundSplitState.NVDA_BOTH_APPS_BOTH | SoundSplitState.NVDA_LEFT_APPS_BOTH | SoundSplitState.NVDA_RIGHT_APPS_BOTH:
+			case (
+				SoundSplitState.NVDA_BOTH_APPS_BOTH
+				| SoundSplitState.NVDA_LEFT_APPS_BOTH
+				| SoundSplitState.NVDA_RIGHT_APPS_BOTH
+			):
 				return (1.0, 1.0)
 			case SoundSplitState.NVDA_RIGHT_APPS_LEFT | SoundSplitState.NVDA_BOTH_APPS_LEFT:
 				return (1.0, 0.0)
@@ -66,7 +73,11 @@ class SoundSplitState(DisplayStringIntEnum):
 
 	def getNVDAVolume(self) -> VolumeTupleT:
 		match self:
-			case SoundSplitState.NVDA_BOTH_APPS_BOTH | SoundSplitState.NVDA_BOTH_APPS_LEFT | SoundSplitState.NVDA_BOTH_APPS_RIGHT:
+			case (
+				SoundSplitState.NVDA_BOTH_APPS_BOTH
+				| SoundSplitState.NVDA_BOTH_APPS_LEFT
+				| SoundSplitState.NVDA_BOTH_APPS_RIGHT
+			):
 				return (1.0, 1.0)
 			case SoundSplitState.NVDA_LEFT_APPS_RIGHT | SoundSplitState.NVDA_LEFT_APPS_BOTH:
 				return (1.0, 0.0)

--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -58,7 +58,7 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 	audioAwakeTime = integer(default=30, min=0, max=3600)
 	whiteNoiseVolume = integer(default=0, min=0, max=100)
 	soundSplitState = integer(default=0)
-	includedSoundSplitModes = int_list(default=list(0, 1, 2))
+	includedSoundSplitModes = int_list(default=list(0, 2, 3))
 
 # Braille settings
 [braille]


### PR DESCRIPTION
### Link to issue number:
Closes #16287
### Summary of the issue:
Adding disabled sound split mode
### Description of user facing changes
Adding disabled sound split mode
### Description of development approach
1. If sound split mode is disabled at startup, we're not touching any volumes.
2. If user toggles to disabled mode, then first we set mode to NVDA_BOTH_APPS_BOTH to effectively restore the volumes, then set sound pslit state to off.
### Testing strategy:
Manual
### Known issues with pull request:

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
