### PR TITLE
Update the titles of the message windows in the Add-on Store

### DIFF
--- a/source/gui/addonStoreGui/controls/messageDialogs.py
+++ b/source/gui/addonStoreGui/controls/messageDialogs.py
@@ -104,7 +104,7 @@ def _shouldProceedWhenInstalledAddonVersionUnknown(
 	dlg = ErrorAddonInstallDialogWithYesNoButtons(
 		parent=parent,
 		# Translators: The title of a dialog presented when an error occurs.
-		title=pgettext("addonStore", "Add-on not compatible"),
+		title=pgettext("addonStore", "Install add-on"),
 		message=incompatibleMessage,
 		showAddonInfoFunction=lambda: _showAddonInfo(addon),
 		useRememberChoiceCheckbox=useRememberChoiceCheckbox,
@@ -128,7 +128,7 @@ def _shouldProceedToRemoveAddonDialog(
 	dlg = ErrorAddonInstallDialogWithYesNoButtons(
 		parent=parent,
 		# Translators: Title for message asking if the user really wishes to remove the selected Add-on.
-		title=pgettext("addonStore", "Remove Add-on"),
+		title=pgettext("addonStore", "Remove add-on"),
 		message=removeMessage,
 		showAddonInfoFunction=lambda: _showAddonInfo(addon),
 		useRememberChoiceCheckbox=useRememberChoiceCheckbox,
@@ -161,7 +161,7 @@ def _shouldInstallWhenAddonTooOldDialog(
 	dlg = ErrorAddonInstallDialogWithYesNoButtons(
 		parent=parent,
 		# Translators: The title of a dialog presented when an error occurs.
-		title=pgettext("addonStore", "Add-on not compatible"),
+		title=pgettext("addonStore", "Install add-on"),
 		message=incompatibleMessage,
 		showAddonInfoFunction=lambda: _showAddonInfo(addon),
 		useRememberChoiceCheckbox=useRememberChoiceCheckbox,
@@ -194,7 +194,7 @@ def _shouldEnableWhenAddonTooOldDialog(
 	dlg = ErrorAddonInstallDialogWithYesNoButtons(
 		parent=parent,
 		# Translators: The title of a dialog presented when an error occurs.
-		title=pgettext("addonStore", "Add-on not compatible"),
+		title=pgettext("addonStore", "Enable add-on"),
 		message=incompatibleMessage,
 		showAddonInfoFunction=lambda: _showAddonInfo(addon),
 		useRememberChoiceCheckbox=useRememberChoiceCheckbox,
@@ -221,7 +221,7 @@ def _showAddonRequiresNVDAUpdateDialog(
 	displayDialogAsModal(ErrorAddonInstallDialog(
 		parent=parent,
 		# Translators: The title of a dialog presented when an error occurs.
-		title=_("Add-on not compatible"),
+		title=pgettext("addonStore", "Add-on installation failure"),
 		message=incompatibleMessage,
 		showAddonInfoFunction=lambda: _showAddonInfo(addon)
 	))


### PR DESCRIPTION
### Link to issue number:
None
### Summary of the issue:
When migrating an add-on update for which the version cannot be compared, the title of the confirmation dialog is "Add-on not compatible"; this is somewhat confusing because the add-on being installed may be compatible.

### Description of user facing changes
Changed the title of this dialog with "Install add-on", as it is done for the "Remove add-on" action.

While at it, changed the title of other confirmation dialogs in the add-on store with the action being performed.

### Description of development approach
Changed the strings in the code.

### Testing strategy:
Manually tested messages
### Known issues with pull request:
None.
### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
