### PR TITLE
Remove profile from dirty list when deleting it

### DIFF
--- a/source/config/__init__.py
+++ b/source/config/__init__.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2006-2023 NV Access Limited, Aleksey Sadovoy, Peter Vágner, Rui Batista, Zahari Yurukov,
+# Copyright (C) 2006-2024 NV Access Limited, Aleksey Sadovoy, Peter Vágner, Rui Batista, Zahari Yurukov,
 # Joseph Lee, Babbage B.V., Łukasz Golonka, Julien Cochuyt, Cyrille Bougot
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
@@ -786,6 +786,12 @@ class ConfigManager(object):
 			for trigSpec in delTrigs:
 				del allTriggers[trigSpec]
 			self.saveProfileTriggers()
+		# Remove the profile from the dirty profile list
+		try:
+			self._dirtyProfiles.remove(name)
+		except KeyError:
+			# The profile wasn't dirty.
+			pass
 		# Check if this profile was active.
 		delProfile = None
 		for index in range(len(self.profiles) - 1, -1, -1):

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -62,6 +62,7 @@ What's New in NVDA
   - ``alt+downArrow`` is now mapped to ``dot5+dot6+dot7+space``
   -
 - Fixed a bug causing NVDA to fail to read the ribbon and options within Geekbench. (#16251, @mzanm)
+- Fixed a rare case when saving the configuration may fail to save all profiles.  (#16343, @CyrilleB79)
 -
 
 


### PR DESCRIPTION
### Link to issue number:
Closes #16343
### Summary of the issue:
When a dirty (modified) profile is deleted and the config is then saved, an error is raised in the function that saves the configuration. This may lead to other dirty profiles not being saved.

### Description of user facing changes
A rare case where profiles are not saved is fixed.
### Description of development approach
Remove the profile from dirty profiles list when it is deleted.
### Testing strategy:
Manual testing STR from #16343.
### Known issues with pull request:
None
### Code Review Checklist:


- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
