### PR TITLE
Add spanish for Greek text braille table, added in Liblouis 3.29

### DIFF
--- a/source/brailleTables.py
+++ b/source/brailleTables.py
@@ -302,6 +302,9 @@ addTable("gu-in-g1.utb", _("Gujarati grade 1"))
 addTable("grc-international-en.utb", _("Greek international braille"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
+addTable("grc-international-es.utb", _("Spanish for Greek text"))
+# Translators: The name of a braille table displayed in the
+# braille settings dialog.
 addTable("he-IL.utb", _("Israeli grade 1"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -44,7 +44,7 @@ What's New in NVDA
   -
 - Component updates:
   - Updated LibLouis Braille translator to [3.29.0 https://github.com/liblouis/liblouis/releases/tag/v3.29.0]. (#16259, @codeofdusk)
-    - Added new detailed (with capital letters indicated) Belarusian and Ukrainian Braille tables.
+    - Added new detailed (with capital letters indicated) Belarusian and Ukrainian Braille tables, along with a Spanish table for reading Greek texts.
     -
   - eSpeak NG has been updated to 1.52-dev commit ``cb62d93fd7``. (#15913)
     - Added new language Tigrinya. 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
None
### Summary of the issue:
The Liblouis braille transcriber was updated in #16259, but the newly added grc-international-es.utb table, as noted in the release notes at https://github.com/liblouis/liblouis/releases/tag/v3.29.0 (New features section), was not added to the NVDA's table list.
### Description of user facing changes
New table in the table list called "Spanish for Greek text".
Changelog entry added in #16259 has been also extended to reflect this update.
### Description of development approach
Call addTable() as for all other tables.
### Testing strategy:
UI test.
### Known issues with pull request:
None
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
