### PR TITLE
Make the incompatibility message more explicit

### DIFF
--- a/source/addonStore/models/version.py
+++ b/source/addonStore/models/version.py
@@ -123,7 +123,7 @@ class SupportsVersionCheck(Protocol):
 				# The placeholder will be replaced with Year.Major.Minor (e.g. 2019.1).
 				"An updated version of this add-on is required. "
 				"This add-on was last tested with {lastTestedNVDAVersion}. "
-				"The current version of NVDA requires that the extension be tested with NVDA {nvdaVersion} or higher. "
+				"NVDA requires this add-on to be tested with NVDA {nvdaVersion} or higher. "
 				"You can enable this add-on at your own risk. "
 				).format(
 			nvdaVersion=addonAPIVersion.formatForGUI(backwardsCompatToVersion),

--- a/source/addonStore/models/version.py
+++ b/source/addonStore/models/version.py
@@ -1,6 +1,6 @@
 # -*- coding: UTF-8 -*-
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2018-2023 NV Access Limited
+# Copyright (C) 2018-2024 NV Access Limited, Cyrille Bougot
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -122,8 +122,8 @@ class SupportsVersionCheck(Protocol):
 				# The addon relies on older, removed features of NVDA, an updated add-on is required.
 				# The placeholder will be replaced with Year.Major.Minor (e.g. 2019.1).
 				"An updated version of this add-on is required. "
-				"The minimum supported API version is now {nvdaVersion}. "
 				"This add-on was last tested with {lastTestedNVDAVersion}. "
+				"The current version of NVDA requires that the extension be tested with NVDA {nvdaVersion} or higher. "
 				"You can enable this add-on at your own risk. "
 				).format(
 			nvdaVersion=addonAPIVersion.formatForGUI(backwardsCompatToVersion),


### PR DESCRIPTION
### Link to issue number:

Discussion in https://nvda.groups.io/g/nvda/topic/clock_add_on_add_on_store/105313955?p=,,,100,0,0,0::recentpostdate/sticky,,,100,2,0,105313955,previd%3D1712173725527803825,nextid%3D1710680040743854194&previd=1712173725527803825&nextid=1710680040743854194

### Summary of the issue:

The current incompatibility message for too old add-ons in the add-on store's details is as follows:
> An updated version of this add-on is required. The minimum supported API version is now 2024.1. This add-on was last tested with 2023.1. You can enable this add-on at your own risk. 

The concept of API is not clear for everyone and it is not explained in NVDA's GUI, nor in the User Guide. Thus, the logic of this sentence explaining why the add-on is not compatible is not easily understandable.

### Description of user facing changes
Modify the incompatibility reason for too old add-ons as follows:
> An updated version of this add-on is required. This add-on was last tested with 2023.1. The current version of NVDA requires that the extension be tested with NVDA 2024.1 or higher. You can enable this add-on at your own risk. 

### Description of development approach
Just changed the corresponding string.
### Testing strategy:
Manual check of the string in the GUI.
### Known issues with pull request:
None.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
