### PR TITLE
Revert "Ignore padding dots at low symbol reporting levels (#16141)"

### DIFF
--- a/source/characterProcessing.py
+++ b/source/characterProcessing.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2010-2024 NV Access Limited, World Light Information Limited,
+# Copyright (C) 2010-2023 NV Access Limited, World Light Information Limited,
 # Hong Kong Blind Union, Babbage B.V., Julien Cochuyt, Cyrille Bougot
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
@@ -528,18 +528,17 @@ class SpeechSymbolProcessor(object):
 		multiChars.sort(key=lambda identifier: len(identifier), reverse=True)
 
 		# Build the regexp.
-		patterns: list[str] = []
+		patterns = [
+			# Strip repeated spaces from the end of the line to stop them from being picked up by repeated.
+			r"(?P<rstripSpace>  +$)",
+			# Repeated characters: more than 3 repeats.
+			r"(?P<repeated>(?P<repTmp>%s)(?P=repTmp){3,})" % characters
+		]
 		# Complex symbols.
 		# Each complex symbol has its own named group so we know which symbol matched.
 		patterns.extend(
 			u"(?P<c{index}>{pattern})".format(index=index, pattern=symbol.pattern)
 			for index, symbol in enumerate(complexSymbolsList))
-		patterns.extend([
-			# Strip repeated spaces from the end of the line to stop them from being picked up by repeated.
-			r"(?P<rstripSpace>  +$)",
-			# Repeated characters: more than 3 repeats.
-			r"(?P<repeated>(?P<repTmp>%s)(?P=repTmp){3,})" % characters
-		])
 		# Simple symbols.
 		# These are all handled in one named group.
 		# Because the symbols are just text, we know which symbol matched just by looking at the matched text.

--- a/source/locale/en/symbols.dic
+++ b/source/locale/en/symbols.dic
@@ -11,8 +11,6 @@ complexSymbols:
 # Phrase endings.
 ; phrase ending	(?<=[^\s;]);(?=\s|$)
 : phrase ending	(?<=[^\s:]):(?=\s|$)
-# Series of dots used for visual presentation, e.g. in table of contents
-padding .	\.{4,}
 # Others
 decimal point	(?<![^\d -])\.(?=\d)
 in-word '	(?<=[^\W_])['’]
@@ -27,7 +25,6 @@ symbols:
 ? sentence ending	question	all	always
 ; phrase ending	semi	most	always
 : phrase ending	colon	most	always
-padding .	padding dots	all	always
 decimal point		none	always
 in-word '	tick	all	norep
 negative number	minus	none	norep

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -50,7 +50,6 @@ What's New in NVDA
     - Added new language Tigrinya. 
     -
   -
-- Padding dots commonly used in tables of contents are not reported anymore at low punctuation levels. (#15845, @CyrilleB79)
 -
 
 == Bug Fixes ==


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Closes #16345.

### Summary of the issue:
In some situations, such as Chinese text (which often uses more than three dots to form an ellipsis) and Windows notifications read with a symbol level of "all", the collapsing of more than three dots into "padding dots" is confusing and unwanted.

### Description of how this pull request fixes the issue:
Reverts the offending PR, pending a refined, more flexible approach.

### Known issues with pull request:
Reopens #15845.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
