### PR TITLE
Make add-on reviews available from all tabs of the store

### DIFF
--- a/source/addonStore/models/addon.py
+++ b/source/addonStore/models/addon.py
@@ -303,7 +303,7 @@ def _createInstalledStoreModelFromData(addon: Dict[str, Any]) -> InstalledAddonS
 		sha256=addon["sha256"],
 		minNVDAVersion=MajorMinorPatch(**addon["minNVDAVersion"]),
 		lastTestedVersion=MajorMinorPatch(**addon["lastTestedVersion"]),
-		reviewURL=addon.get("reviewUrl"),
+		reviewURL=addon.get("reviewURL"),
 		legacy=addon.get("legacy", False),
 	)
 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -58,6 +58,7 @@ What's New in NVDA
 - Fixed a bug where audio coordinates would be played while the application is in sleep mode when "Play audio coordinates when mouse moves" is enabled. (#8059, @hwf1324)
 - Add-on Store:
   - When pressing ``ctrl+tab``, focus properly moves to the new current tab title. (#14986, @ABuffEr)
+  - The community reviews action will be available, and the reviews webpage will be shown in the details panel, in all tabs of the store (#16179, @nvdaes)
   -
 - In Adobe Reader, NVDA no longer ignores alternative text set on formulas in PDFs. (#12715)
 - Changed several gestures for BrailleSense devices to avoid conflicts with characters of the French braille table. (#15306)

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -3016,8 +3016,8 @@ Just like when you install or remove add-ons, you need to restart NVDA in order 
 You can also enable or disable multiple add-ons at once by selecting multiple add-ons in the available add-ons tab, then activating the context menu on the selection and choosing the appropriate action.
 
 +++ Reviewing add-ons and reading reviews +++[AddonStoreReviews]
-Before installing an add-on, you may want to read reviews by others.
-Also, it may be helpful to other users to provide feedback about add-ons you have tried.
+You may want to read reviews by other users who have experienced an add-on, for example before you install it, or as you are learning to use it.
+Also, it is helpful to other users to provide feedback about add-ons you have tried.
 To read reviews for an add-on, select it, and use the "Community reviews" action.
 This links to a GitHub Discussion webpage, where you will be able to read and write reviews for the add-on.
 Please be aware that this doesn't replace direct communication with add-on developers.

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -3018,7 +3018,7 @@ You can also enable or disable multiple add-ons at once by selecting multiple ad
 +++ Reviewing add-ons and reading reviews +++[AddonStoreReviews]
 Before installing an add-on, you may want to read reviews by others.
 Also, it may be helpful to other users to provide feedback about add-ons you have tried.
-To read reviews for an add-on, select an add-on from the Available or Updatable add-ons tab, and use the "Community reviews" action.
+To read reviews for an add-on, select it, and use the "Community reviews" action.
 This links to a GitHub Discussion webpage, where you will be able to read and write reviews for the add-on.
 Please be aware that this doesn't replace direct communication with add-on developers.
 Instead, the purpose of this feature is to share feedback to help users decide if an add-on may be useful for them.


### PR DESCRIPTION
- Show review URL for installed add-ons
- Update changelog
- Update user guide

<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Fixes #16179
### Summary of the issue:
The community reviews action, and the reviews URL, is not available in installed and incompatible add-ons tab of the store.
### Description of user facing changes
The community reviews action, and the reviews URL, will be available in all tabs of the store.
### Description of development approach
Fix reviewUrl variable assignment in the `_createInstalledStoreModelFromData` function of addonStore/models/addon.py
### Testing strategy:
- Checked that the community reviews action is available from the installed and incompatible tabs for add-ons installed from the store, and the reviews webpage is shown in the details panel.
- Checked that, when an add-on like clipContentsDesigner is installed from an external source, the reviews URL action and webpage aren't presented.

### Known issues with pull request:
None.
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
