### PR TITLE
Windows 11 24H2/ShellHost: mark "Control Center Window" class as good UIA window

### DIFF
--- a/source/appModules/__init__.py
+++ b/source/appModules/__init__.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2009-2023 NV Access Limited, Łukasz Golonka
+# Copyright (C) 2009-2024 NV Access Limited, Łukasz Golonka, Joseph Lee
 # This file may be used under the terms of the GNU General Public License, version 2 or later.
 # For more details see: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -38,6 +38,8 @@ EXECUTABLE_NAMES_TO_APP_MODS: dict[str, str] = {
 	"searchapp": "searchui",
 	# Windows search in Windows 11.
 	"searchhost": "searchui",
+	# Quick settings in Windows 11 24H2 (2024 Update and Server 2025).
+	"shellhost": "shellexperiencehost",
 	# Spring Tool Suite is based on Eclipse and should use its appModule.
 	"springtoolsuite4": "eclipse",
 	"sts": "eclipse",

--- a/source/appModules/shellexperiencehost.py
+++ b/source/appModules/shellexperiencehost.py
@@ -1,10 +1,11 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2015-2022 NV Access Limited, Joseph Lee
+# Copyright (C) 2015-2024 NV Access Limited, Joseph Lee
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
-"""App module for Shell Experience Host, part of Windows 10.
+"""App module for Shell Experience Host, part of Windows 10 and later.
 Shell Experience Host is home to a number of things, including Action Center and other shell features.
+In Windows 11 24H2 (2024 Update and Server 2025), quick settings component is part of ShellHost.exe.
 """
 
 from typing import Optional

--- a/source/appModules/shellexperiencehost.py
+++ b/source/appModules/shellexperiencehost.py
@@ -8,8 +8,6 @@ Shell Experience Host is home to a number of things, including Action Center and
 In Windows 11 24H2 (2024 Update and Server 2025), quick settings component is part of ShellHost.exe.
 """
 
-from typing import Optional
-
 import appModuleHandler
 from NVDAObjects.IAccessible import IAccessible, ContentGenericClient
 from NVDAObjects.UIA import UIA
@@ -21,7 +19,7 @@ from winAPI.types import HWNDValT
 
 
 class CalendarViewDayItem(UIA):
-	def _getTextFromHeaderElement(self, element: IUIAutomationElement) -> Optional[str]:
+	def _getTextFromHeaderElement(self, element: IUIAutomationElement) -> str | None:
 		# Generally we prefer text content as the header text.
 		# But although this element does expose a UIA text pattern,
 		# The text content is only the 2 character week day abbreviation.

--- a/source/appModules/shellexperiencehost.py
+++ b/source/appModules/shellexperiencehost.py
@@ -16,6 +16,8 @@ from NVDAObjects.UIA import UIA
 from UIAHandler import IUIAutomationElement, UIA_NamePropertyId
 import controlTypes
 import ui
+import winUser
+from winAPI.types import HWNDValT
 
 
 class CalendarViewDayItem(UIA):
@@ -72,3 +74,9 @@ class AppModule(appModuleHandler.AppModule):
 			and obj.UIAElement.cachedClassName == "CalendarViewDayItem"
 		):
 			clsList.insert(0, CalendarViewDayItem)
+
+	def isGoodUIAWindow(self, hwnd: HWNDValT) -> bool:
+		# #16348: reclassify Windows 11 24H2 control center window as UIA to allow mouse/touch interaction.
+		if winUser.getClassName(hwnd) == "ControlCenterWindow":
+			return True
+		return False

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -67,7 +67,10 @@ What's New in NVDA
   - ``alt+downArrow`` is now mapped to ``dot5+dot6+dot7+space``
   -
 - Fixed a bug causing NVDA to fail to read the ribbon and options within Geekbench. (#16251, @mzanm)
-- In Windows 11, NVDA will once again announce hardware keyboard input suggestions. (#16283, @josephsl)
+- Windows 11 fixes:
+  - NVDA will once again announce hardware keyboard input suggestions. (#16283, @josephsl)
+  - In Version 24H2 (2024 Update and Windows Server 2025), mouse and touch interaction can be used in quick settings. (#16348, @josephsl)
+  -
 - Fixed a rare case when saving the configuration may fail to save all profiles.  (#16343, @CyrilleB79)
 -In Firefox and Chromium-based browsers,  NVDA will correctly enter focus mode when pressing enter when positioned within a presentational list (ul / ol) inside editable content. (#16325)
 -


### PR DESCRIPTION
Hi,

Windows 11 24H2 RTM is close at hand, thus this pull request:

### Link to issue number:
Closes #16348 

### Summary of the issue:
In Windows 11 Version 24H2 (2024 Update and Server 2025), mouse and touch interaction cannot be used in quick settings (Windows+A).

### Description of user facing changes
Mouse and touch interaction can be used to navigate and interact with quick settings, cast, and similar elements.

### Description of development approach
Quick settings component (including cast) was separated from ShellExperienceHost.exe (now ShellHost.exe) in Windows 11 Version 24H2. Therefore, an app alias will be used to handle this case - "ControlCenterWindow" is marked as UIA, allowing mouse and touch interaction.

### Testing strategy:
Manual testing (requires Windows 11 24H2 builds): open quick settings (Windows+A) and use mouse and/or touch to navigate quick settings elements.

### Known issues with pull request:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
