### PR TITLE
Hp Secure Browser support

### DIFF
--- a/source/UIAHandler/__init__.py
+++ b/source/UIAHandler/__init__.py
@@ -1204,7 +1204,9 @@ class UIAHandler(COMObject):
 				# As their IA2 implementation is still better at the moment.
 				# However, in cases where Chromium is running under another logon session,
 				# the IAccessible2 implementation is unavailable.
-				hasAccessToIA2 = not appModule.isRunningUnderDifferentLogonSession
+				# 'brchrome' is part of HP SureClick, a chromium-based browser which runs webpages to run in separate
+				# virtual machines - it supports UIA remoting but not IAccessible2 remoting.
+				hasAccessToIA2 = not appModule.isRunningUnderDifferentLogonSession and not appModule.appName == "brchrome"
 				if (
 					AllowUiaInChromium.getConfig() == AllowUiaInChromium.NO
 					# Disabling is only useful if we can inject in-process (and use our older code)

--- a/source/UIAHandler/browseMode.py
+++ b/source/UIAHandler/browseMode.py
@@ -6,7 +6,8 @@
 from typing import Optional
 from ctypes import byref
 from comtypes import COMError
-from comtypes.automation import VARIANT
+from comtypes.automation import VARIANT, VT_EMPTY
+
 import array
 import winUser
 import UIAHandler
@@ -527,6 +528,8 @@ class UIABrowseModeDocument(UIADocumentWithTableNavigation,browseMode.BrowseMode
 				UIAHandler.UIA_RuntimeIdPropertyId, byref(runtimeID)
 			)
 		except COMError:
+			runtimeID = VARIANT()
+		if runtimeID.vt == VT_EMPTY:
 			log.debugWarning(
 				"Could not get runtimeID of document. Most likely document is dead."
 			)

--- a/source/UIAHandler/utils.py
+++ b/source/UIAHandler/utils.py
@@ -124,13 +124,19 @@ def iterUIARangeByUnit(rangeObj,unit,reverse=False):
 	tempRange.MoveEndpointByRange(Endpoint_relativeEnd,rangeObj,Endpoint_relativeStart)
 	endRange=tempRange.Clone()
 	loopCount = 0
+	yieldRange = None
 	while relativeGTOperator(endRange.Move(unit,minRelativeDistance),0):
 		loopCount += 1
 		tempRange.MoveEndpointByRange(Endpoint_relativeEnd,endRange,Endpoint_relativeStart)
 		pastEnd=relativeGTOperator(tempRange.CompareEndpoints(Endpoint_relativeEnd,rangeObj,Endpoint_relativeEnd),0)
 		if pastEnd:
 			tempRange.MoveEndpointByRange(Endpoint_relativeEnd,rangeObj,Endpoint_relativeEnd)
-		yield tempRange.clone()
+		if yieldRange and bool(yieldRange.compare(tempRange)):
+			# we've looped onto range we've already yielded previously - shortcircuit to prevent
+			# infinite loop
+			return
+		yieldRange = tempRange.clone()
+		yield yieldRange
 		if pastEnd:
 			return
 		tempRange.MoveEndpointByRange(Endpoint_relativeStart,tempRange,Endpoint_relativeEnd)

--- a/source/editableText.py
+++ b/source/editableText.py
@@ -23,6 +23,7 @@ import textInfos
 import controlTypes
 from inputCore import InputGesture
 from logHandler import log
+from comtypes import COMError
 
 class EditableText(TextContainerObject,ScriptableObject):
 	"""Provides scripts to report appropriately when moving the caret in editable text fields.
@@ -261,7 +262,12 @@ class EditableText(TextContainerObject,ScriptableObject):
 			return
 		oldBookmark=oldInfo.bookmark
 		testInfo=oldInfo.copy()
-		res=testInfo.move(textInfos.UNIT_CHARACTER,-1)
+		try:
+			res = testInfo.move(textInfos.UNIT_CHARACTER, -1)
+		except COMError:
+			log.exception("Error in testInfo.move")
+			gesture.send()
+			return
 		if res<0:
 			testInfo.expand(unit)
 			delChunk=testInfo.text
@@ -395,7 +401,11 @@ class EditableText(TextContainerObject,ScriptableObject):
 			# There's nothing we can do, but at least the last selection will be right next time.
 			self.isTextSelectionAnchoredAtStart=True
 			return
-		self._updateSelectionAnchor(oldInfo,newInfo)
+		try:
+			self._updateSelectionAnchor(oldInfo, newInfo)
+		except COMError:
+			log.exception("Error in _updateSelectionAnchor")
+			return
 		hasContentChanged=getattr(self,'hasContentChangedSinceLastSelection',False)
 		self.hasContentChangedSinceLastSelection=False
 		speech.speakSelectionChange(oldInfo,newInfo,generalize=hasContentChanged)


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
https://github.com/nvaccess/nvda/issues/16377

### Summary of the issue:
HP Secure Browser is part of HP Wolf Security package. It is a chromium-based web browser where individual websites are isolated in separate virtual machines. To support screen readers, windows UIA trees are remoted between the virtual machines and the host. IAccessible2 interface is not remoted, hence HP Secure Browser is a rare case of chromium-browser which supports UIA but not IAccessible2.

In theory assuming perfect UIA support in both NVDA and Secure Browser, NVDA should work out-of-the-box. In practice there are a number of tweaks and fixes required to improve UIA-on-chromium scenario on the NVDA side.

### Description of user facing changes
* user no longer needs to explicitly configure Advanced option "use UIA with Edge and other chromium-based browser" for NVDA to work with Secure Browser. NVDA will detect "brchrome" process and correctly fallback to use UIA only with it, rather than IAccessible2
* When using Secure Browser (and possibly other chromium-based browsers in UIA mode), NVDA no longer locks up whilst trying to split some text ranges
* When using Secure Browser (and possibly other chromium-based browser in UIA mode), NVDA no longer locks up whilst trying to access dead documents
* Backspace key is fixed to work in UIA-mode chromium in gmail's signin fields

### Description of development approach
Made a commit per problem, described details in commit messages.

### Testing strategy:
Done manual testing with Secure Browser

### Known issues with pull request:

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [ ] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [ ] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [ ] API is compatible with existing add-ons.
- [ ] Security precautions taken.
