### PR TITLE
Resolve variable masking issue in ui.browseableMessage

### DIFF
--- a/source/ui.py
+++ b/source/ui.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2008-2020 NV Access Limited, James Teh, Dinesh Kaushal, Davy Kager, André-Abush Clause,
-# Babbage B.V., Leonard de Ruijter, Michael Curran, Accessolutions, Julien Cochuyt
+# Copyright (C) 2008-2024 NV Access Limited, James Teh, Dinesh Kaushal, Davy Kager, André-Abush Clause,
+# Babbage B.V., Leonard de Ruijter, Michael Curran, Accessolutions, Julien Cochuyt, Cyrille Bougot
 # This file may be used under the terms of the GNU General Public License, version 2 or later.
 # For more details see: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -113,10 +113,13 @@ def browseableMessage(message: str, title: Optional[str] = None, isHtml: bool = 
 		message = f"<pre>{escape(message)}</pre>"
 	try:
 		d = comtypes.client.CreateObject("Scripting.Dictionary")
-	except COMError:
-		log.error("Scripting.Dictionary component unavailable")
+	except (COMError, OSError):
+		log.error("Scripting.Dictionary component unavailable", exc_info=True)
+		# Store the module level message function in a new variable since it is masked by a local variable with
+		# the same name
+		messageFunction = globals()['message']
 		# Translators: reported when unable to display a browsable message.
-		message(_("Unable to display browseable message"))
+		messageFunction(_("Unable to display browseable message"))
 		return
 	d.add("title", title)
 	d.add("message", message)


### PR DESCRIPTION
### Link to issue number:
Fix-up of PR from GHSA-xg6w-23rw-39r8.
### Summary of the issue:
A masking issue was found in `ui.browseableMessage` where we try to call the module level function `message` but it is masked by the local variable `message` which is an argument of `ui.browseableMessage`.

### Description of user facing changes
In case an installation cannot create a `Scripting.Dictionary` COM object, a message will now be reported.

### Description of development approach
I access the module level `message` function through `globals()` dictionary and store it in a new local variable to use it.
It would have been cleaner to rename the argument of `ui.browseableMessage` but I have not done so because changing the signature of a function is API-breaking.

I have also caught one more exception type because I have realized while testing that calling `comtypes.client.CreateObject` with an unknown class string raises `OSError`.

### Testing strategy:
Manual test: modify the class string to force the exception. E.g. call:
`comtypes.client.CreateObject('Scripting.TestUnexistingClass')`

### Known issues with pull request:
None
### Change log
Not needed: I guess no one has ever fallen in this code path.
### Note
I have found this issue while doing tests.
But fortunately, I have not found any plateform where `Scripting.Dictionary` cannot be created.
### Code Review Checklist:


- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
