### PR TITLE
Improve speech output for UIA notifications, honoring all NotificationProcessing_* constants

### DIFF
--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -2463,7 +2463,7 @@ class UIA(Window):
 			speechPriority=speechPriority,
 			messageID=messageID,
 			speakOnlyMostRecentWithSameID=speakOnlyMostRecentWithSameID,
-			interuptCurrentWithSameID=interuptCurrentWithSameID
+			interuptCurrentWithSameID=interuptCurrentWithSameID,
 		)
 
 	def event_UIA_dragDropEffect(self):

--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -2440,13 +2440,31 @@ class UIA(Window):
 			messageID = None
 		# Add a new UIA notification processing constant.
 		NotificationProcessing_ImportantCurrentThenMostRecent = 5
-		speakOnlyMostRecentWithSameID = notificationProcessing in (UIAHandler.NotificationProcessing_MostRecent, UIAHandler.NotificationProcessing_CurrentThenMostRecent, UIAHandler.NotificationProcessing_ImportantMostRecent, NotificationProcessing_ImportantCurrentThenMostRecent)
-		interuptCurrentWithSameID = notificationProcessing in (UIAHandler.NotificationProcessing_MostRecent, UIAHandler.NotificationProcessing_ImportantMostRecent)
-		if notificationProcessing in (UIAHandler.NotificationProcessing_ImportantAll, UIAHandler.NotificationProcessing_ImportantMostRecent, NotificationProcessing_ImportantCurrentThenMostRecent):
+		speakOnlyMostRecentWithSameID = notificationProcessing in (
+			UIAHandler.NotificationProcessing_MostRecent,
+			UIAHandler.NotificationProcessing_CurrentThenMostRecent,
+			UIAHandler.NotificationProcessing_ImportantMostRecent,
+			NotificationProcessing_ImportantCurrentThenMostRecent,
+		)
+		interuptCurrentWithSameID = notificationProcessing in (
+			UIAHandler.NotificationProcessing_MostRecent,
+			UIAHandler.NotificationProcessing_ImportantMostRecent,
+		)
+		if notificationProcessing in (
+			UIAHandler.NotificationProcessing_ImportantAll,
+			UIAHandler.NotificationProcessing_ImportantMostRecent,
+			NotificationProcessing_ImportantCurrentThenMostRecent,
+		):
 			speechPriority = speech.Spri.NOW
 		else:
 			speechPriority = speech.Spri.NEXT
-		ui.message(displayString, speechPriority=speechPriority, messageID=messageID, speakOnlyMostRecentWithSameID=speakOnlyMostRecentWithSameID, interuptCurrentWithSameID=interuptCurrentWithSameID)
+		ui.message(
+			displayString,
+			speechPriority=speechPriority,
+			messageID=messageID,
+			speakOnlyMostRecentWithSameID=speakOnlyMostRecentWithSameID,
+			interuptCurrentWithSameID=interuptCurrentWithSameID
+		)
 
 	def event_UIA_dragDropEffect(self):
 		# UIA drag drop effect was introduced in Windows 8.

--- a/source/ui.py
+++ b/source/ui.py
@@ -154,7 +154,7 @@ class OnlyMostRecent(_CancellableSpeechCommand):
 			if oldCommand._uniqueID == uniqueID and not oldCommand._killed:
 				if not firstLoop:
 					oldCommand._killed = True
-				firstLoop=False
+				firstLoop = False
 
 	def _checkIfValid(self):
 		return not self._killed
@@ -164,7 +164,7 @@ def message(
 	text: str,
 	speechPriority: Optional[speech.Spri] = None,
 	brailleText: Optional[str] = None,
-		messageID: str| None = None,
+		messageID: str | None = None,
 		speakOnlyMostRecentWithSameID=False,
 		interuptCurrentWithSameID=False,
 ):


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

this is a prototype to see how NVDA's UIA notification support can be improved, both for the bennofit of UIA notifications in general, but also laying groundwork for supporting  the proposed ariaNotify specification allowing web authors to instruct screen readers to speak messages without resorting to live regions: https://github.com/WICG/aom/blob/gh-pages/notification-api.md
 
### Link to issue number:
None

### Summary of the issue:
Currently, NVDA's speech output for UIA notifications is very basic in that it just cancels speech and then speaks the display string. It does not honor the importants, or whether only the most recent notification should be spoken etc.
NVDA should appropriately support all NotificationProcessing_* constants:
* ImportantAll
* ImportantMostRecent
* ImportantCurrentThenMostRecent
* MostRecent
* CurrentThenMostRecent


### Description of user facing changes
NVDA now honors the importants of UI Automation notifications sent by applications.

### Description of development approach
ui.message: add optional arguments:
* messageID: a unique string identify for this message. This could be used to filter or customize the message, and is used with the following  arguments to configure how multiple messages with the same message ID interrupt each other.
    * speakOnlyMostRecent: If a message with the same message ID has already been queued, the already queued message/s are dropped and only the most recent one is spoken.
    * interuptCurrentIfSameID: if speakOnlyMostRecentIfSameID is also true, but this argument is false, the first existing message in the queue is not dropped, thus a full message is always spoken. E.g. a progress bar quickly going from 0 to 100 in jumps of 1, might say "0, 25, 55, 100" rather than just stuttering until it gets to 100.
                                                                                                                                                            
UIA NvDAObject's event_UIA_notify: suitably map the UIA notificationProgress argument to appropriate values for speakOnlyMostRecentIfSameID and interuptCurrentIfSameID. Also map them to an appropriate speech priority. E.g.:
* NotificationProcessing_Important*: priority=NOW
* NotificationProcessing_*ThenMostRecent: speakOnlyMostRecentIfSameID=True
* NotificationProcessing_*CurrentThenMostRecent: interuptcurrentIfSameID=False
* NotificationProcessing_*: priority=NEXT
 
### Testing strategy:
Private testing done, but will be outlined when browser prototypes become public.

### Known issues with pull request:
this is a prototype draft. It is functional, but the code could be better abstracted.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [ ] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [ ] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [ ] API is compatible with existing add-ons.
- [ ] Security precautions taken.
