### PR TITLE
Changed keyboard command for find previous and next search string after searching with NVDA find dialog

### DIFF
--- a/source/cursorManager.py
+++ b/source/cursorManager.py
@@ -215,7 +215,7 @@ class CursorManager(documentBase.TextContainerObject,baseObject.ScriptableObject
 			# Translators: Input help message for find next command.
 			"find the next occurrence of the previously entered text string from the current cursor's position"
 		),
-		gesture="kb:NVDA+f3",
+		gesture="kb:NVDA+x",
 		resumeSayAllMode=sayAll.CURSOR.CARET,
 	)
 	def script_findNext(self,gesture):
@@ -233,7 +233,7 @@ class CursorManager(documentBase.TextContainerObject,baseObject.ScriptableObject
 			# Translators: Input help message for find previous command.
 			"find the previous occurrence of the previously entered text string from the current cursor's position"
 		),
-		gesture="kb:NVDA+shift+f3",
+		gesture="kb:NVDA+shift+x",
 		resumeSayAllMode=sayAll.CURSOR.CARET,
 	)
 	def script_findPrevious(self,gesture):

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -52,6 +52,7 @@ What's New in NVDA
   -
 - Padding dots commonly used in tables of contents are not reported anymore at low punctuation levels. (#15845, @CyrilleB79)
 - Shortcut for finding next and previous search string in a document changed from nvda+f3 and nvda+shift+f3 to nvda+x and nvda+shift+x (#6499, @adriani90)
+-
 
 == Bug Fixes ==
 - Backspace now works correctly when using Nudi 6.1 with NVDA's "Handle keys from other applications" setting enabled. (#15822, @jcsteh)

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -51,7 +51,7 @@ What's New in NVDA
     -
   -
 - Padding dots commonly used in tables of contents are not reported anymore at low punctuation levels. (#15845, @CyrilleB79)
--
+- Shortcut for finding next and previous search string in a document changed from nvda+f3 and nvda+shift+f3 to nvda+x and nvda+shift+x (#6499, @adriani90)
 
 == Bug Fixes ==
 - Backspace now works correctly when using Nudi 6.1 with NVDA's "Handle keys from other applications" setting enabled. (#15822, @jcsteh)

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -804,8 +804,8 @@ In addition, you can manually force focus mode, after which it will remain in ef
 | Exit focus mode | escape | Switches back to browse mode if focus mode was previously switched to automatically |
 | Refresh browse mode document | NVDA+f5 | Reloads the current document content (useful if certain content seems to be missing from the document. Not available in Microsoft Word and Outlook.) |
 | Find | NVDA+control+f | Pops up a dialog in which you can type some text to find in the current document. See [searching for text #SearchingForText] for more information. |
-| Find next | NVDA+f3 | Finds the next occurrence of the text in the document that you previously searched for |
-| Find previous | NVDA+shift+f3 | Finds the previous occurrence of the text in the document you previously searched for |
+| Find next | NVDA+x | Finds the next occurrence of the text in the document that you previously searched for |
+| Find previous | NVDA+shift+x | Finds the previous occurrence of the text in the document you previously searched for |
 %kc:endInclude
 
 ++ Single Letter Navigation ++[SingleLetterNavigation]
@@ -917,8 +917,8 @@ Use the following keys for performing searches:
 %kc:beginInclude
 || Name | Key | Description |
 | Find text | NVDA+control+f | Opens the  search dialog |
-| Find next | NVDA+f3 | searches the next occurrence of the current search term  |
-| Find previous | NVDA+shift+f3 | searches the previous  occurrence of the current search term  |
+| Find next | NVDA+x | searches the next occurrence of the current search term  |
+| Find previous | NVDA+shift+x | searches the previous  occurrence of the current search term  |
 %kc:endInclude
 
 ++ Embedded Objects ++[ImbeddedObjects]


### PR DESCRIPTION
### Link to issue number:
Fixes #6499 
### Summary of the issue:
The current commands (nvda+f3 and nvda+shift+f3 are too heavy to perform for many users, finger gymnastics is needed.
### Description of user facing changes
The users can use now nvda+x or nvda+shift+x.
Advantages:
* The x letter is on most keyboards on the same place, and thus very near to capslock key
* this command does not depend on whether the f keys are assigned to other functions or not, i.e. on Lenovo laptops f keys are used for other features by default such as volume change, brightness change etc.

### Description of development approach
Changed the kb commands in cursor manager and adjusted docs

### Testing strategy:
Tested running from source in a browser that the command works as expected.

### Known issues with pull request:
None

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
x  - Manual testing
- [ ] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [ ] API is compatible with existing add-ons.
- [ ] Security precautions taken.
