### PR TITLE
Sentence navigation

### DIFF
--- a/source/config/configDefaults.py
+++ b/source/config/configDefaults.py
@@ -6,7 +6,7 @@ import json
 
 
 DEFAULT_TEXT_PARAGRAPH_REGEX = (
-	r"^|({plb}{nlb}{optQuote}{dot}{optQuote}|{punc2}{optQuote}|{cjk}){optWiki}{spaces}|{n2}|\Z".format(
+	r"^|({plb}{nlb}{optQuote}{dot}{optQuote}|{punc2}{optQuote}){optWiki}{spaces}|{cjk}|{n2}|\Z".format(
 		# Look behind clause ensures that we have a text character before text punctuation mark.
 		# We have a positive lookBehind \w that resolves to a text character in any language,
 		# coupled with negative lookBehind \d that excludes digits.

--- a/source/config/configDefaults.py
+++ b/source/config/configDefaults.py
@@ -34,7 +34,7 @@ DEFAULT_TEXT_PARAGRAPH_REGEX = (
 		# since they don't trigger as many false positives.
 		punc2=r"[?!…]",
 		# We also check for CJK full-width punctuation marks without any extra rules.
-		cjk=r"[．！？：；]",
+		cjk=r"[。．！？]",
 		# Double newline means end of sentence too.
 		n2=r"([  \t]*\n){{2,}}",
 	)

--- a/source/config/configDefaults.py
+++ b/source/config/configDefaults.py
@@ -2,13 +2,19 @@
 # Copyright (C) 2024 NV Access Limited
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
+import json
+
 
 DEFAULT_TEXT_PARAGRAPH_REGEX = (
-	r"({lookBehind}{optQuote}{punc}{optQuote}{optWiki}{lookAhead}|{punc2}|{cjk})".format(
+	r"^|({plb}{nlb}{optQuote}{dot}{optQuote}|{punc2}{optQuote}|{cjk}){optWiki}{spaces}|{n2}|\Z".format(
 		# Look behind clause ensures that we have a text character before text punctuation mark.
 		# We have a positive lookBehind \w that resolves to a text character in any language,
 		# coupled with negative lookBehind \d that excludes digits.
-		lookBehind=r'(?<=\w)(?<!\d)',
+		plb=r"(?<=\w)(?<!\d)",
+		# Language-specific exceptions: characters suggesting that the following dot is not indicative
+		# of a sentence stop.
+		# This is a negative look-behind and will be inserted later when language is specified.
+		nlb="{nonBreakingRegex}",
 		# In some cases quote or closing parenthesis might appear right before or right after text punctuation.
 		# For example:
 		# > He replied, "That's wonderful."
@@ -16,18 +22,26 @@ DEFAULT_TEXT_PARAGRAPH_REGEX = (
 		# Actual punctuation marks that suggest end of sentence.
 		# We don't include symbols like comma and colon, because of too many false positives.
 		# We include question mark and exclamation mark below in punc2.
-		punc=r'[.…]{1,3}',
+		dot=r"[.]{{1,3}}",
 		# On Wikipedia references appear right after period in sentences, the following clause takes this
 		# into account. For example:
 		# > On his father's side, he was a direct descendant of John Churchill.[3]
-		optWiki=r'(\[\d+\])*',
-		# LookAhead clause checks that punctuation mark must be followed by either space,
+		optWiki=r"(\[\d+\])*",
+		# spaces clause checks that punctuation mark must be followed by either space,
 		# or newLine symbol or end of string.
-		lookAhead=r'(?=[\r\n  ]|$)',
+		spaces=r"([  ]+|([  \t]*\n)+|$)",
 		# Include question mark and exclamation mark with no extra conditions,
 		# since they don't trigger as many false positives.
-		punc2=r'[?!]',
+		punc2=r"[?!…]",
 		# We also check for CJK full-width punctuation marks without any extra rules.
-		cjk=r'[．！？：；]',
+		cjk=r"[．！？：；]",
+		# Double newline means end of sentence too.
+		n2=r"([  \t]*\n){{2,}}",
 	)
 )
+
+
+nonBreakingPrefix = json.dumps({
+	"en": r"\b[A-Z]|\bMr|\bMs|\bMrs|\bDr|\bProf|\bSt|\be.g|\bi.e",
+	"ru": r"\b[A-ZА-Я]|\b[Тт]ов|\b[Уу]л|\bт.[ке]|\bт. [ке]",
+})

--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -244,6 +244,8 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 
 [documentNavigation]
 	paragraphStyle = featureFlag(optionsEnum="ParagraphNavigationFlag", behaviorOfDefault="application")
+	sentenceReconstruction = featureFlag(optionsEnum="SentenceReconstructionFlag", behaviorOfDefault="same_style_paragraphs")  # noqa: E501 Breaking this line makes invalid config
+	nonBreakingPrefixRegex = string(default='{configDefaults.nonBreakingPrefix}')
 
 [reviewCursor]
 	simpleReviewMode = boolean(default=True)

--- a/source/config/featureFlagEnums.py
+++ b/source/config/featureFlagEnums.py
@@ -100,6 +100,25 @@ class ReviewRoutingMovesSystemCaretFlag(DisplayStringEnum):
 	ALWAYS = enum.auto()
 
 
+class SentenceReconstructionFlag(DisplayStringEnum):
+	@property
+	def _displayStringLabels(self):
+		return {
+			# Translators: Sentence reconstruction mode
+			SentenceReconstructionFlag.NEVER: _("Never reconstruct sentences across paragraphs"),
+			# Translators: Sentence reconstruction mode
+			SentenceReconstructionFlag.SAME_STYLE_PARAGRAPHS: _("Reconstruct sentences across same style paragraphs"),
+			# Translators: Sentence reconstruction mode
+			SentenceReconstructionFlag.ANY_PARAGRAPHS: _("Reconstruct sentences across any paragraphs"),
+		}
+
+	DEFAULT = enum.auto()
+	NEVER = enum.auto()
+	SAME_STYLE_PARAGRAPHS = enum.auto()
+	ANY_PARAGRAPHS = enum.auto()
+
+
+
 class WindowsTerminalStrategyFlag(DisplayStringEnum):
 	"""
 	A feature flag for defining how new text is calculated in Windows Terminal

--- a/source/documentNavigation/sentenceNavigation.py
+++ b/source/documentNavigation/sentenceNavigation.py
@@ -142,7 +142,10 @@ def getSentenceStopRegex(
 		for s in nonBreakingPrefixes.split("|")
 		if len(s) > 0
 	)
-	regex = regex.format(nonBreakingRegex=nonBreakingNLBs)
+	try:
+		regex = regex.format(nonBreakingRegex=nonBreakingNLBs)
+	except KeyError as e:
+		raise RuntimeError("Failed to substitute non-breaking prefixes into sentence regular expression. Please make sure your sentence regular expression is valid.")
 	return re.compile(regex)
 
 

--- a/source/documentNavigation/sentenceNavigation.py
+++ b/source/documentNavigation/sentenceNavigation.py
@@ -145,7 +145,7 @@ def getSentenceStopRegex(
 	try:
 		regex = regex.format(nonBreakingRegex=nonBreakingNLBs)
 	except KeyError as e:
-		raise RuntimeError("Failed to substitute non-breaking prefixes into sentence regular expression. Please make sure your sentence regular expression is valid.")
+		raise RuntimeError("Failed to substitute non-breaking prefixes into sentence regular expression. Please make sure your sentence regular expression is valid.", e)
 	return re.compile(regex)
 
 

--- a/source/documentNavigation/sentenceNavigation.py
+++ b/source/documentNavigation/sentenceNavigation.py
@@ -1,0 +1,394 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2024 NV Access Limited.
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+
+import textInfos
+from dataclasses import dataclass
+import bisect
+import re
+from typing import Any, Callable
+import config
+from config.featureFlagEnums import SentenceReconstructionFlag
+import json
+import speech
+
+
+def preprocessNewLines(s: str) -> str:
+	stripped = s.rstrip("\r\n")
+	n = len(s) - len(stripped)
+	return stripped + (" " * n)
+
+
+def sign(x: int) -> int:
+	if x > 0:
+		return 1
+	elif x < 0:
+		return -1
+	else:
+		return 0
+
+
+def bisect_right_dict(d: dict[int, int], value: int) -> int:
+	keys = list(d.keys())
+	values = list(d.values())
+	i = bisect.bisect_right(values, value)
+	return keys[i]
+
+
+def getParagraphUnitForTextInfo(info: textInfos.TextInfo):
+	from appModules.devenv import VsWpfTextViewTextInfo
+	if isinstance(info, VsWpfTextViewTextInfo):
+		# TextInfo in Visual Studio doesn't understand UNIT_PARAGRAPH
+		return textInfos.UNIT_LINE
+	return textInfos.UNIT_PARAGRAPH
+
+
+def moveParagraph(textInfo: textInfos.TextInfo, direction: int) -> textInfos.TextInfo | None:
+	originalTextInfo = textInfo.copy()
+	textInfo = textInfo.copy()
+	if direction > 0:
+		textInfo.collapse(end=True)
+	else:
+		textInfo.collapse(end=False)
+		result = textInfo.move(textInfos.UNIT_CHARACTER, -1)
+		if result == 0:
+			return None
+	textInfo.expand(getParagraphUnitForTextInfo(textInfo))
+	if direction > 0 and textInfo.compareEndPoints(originalTextInfo, "startToStart") <= 0:
+		return None
+	if textInfo.isCollapsed:
+		return None
+	return textInfo
+
+
+ExtractStyleFunc = Callable[[textInfos.TextInfo], Any]
+StyleCompatibilityFunc = Callable[[Any, Any], bool]
+
+
+def defaultCompatibilityFunc(style1: Any, style2: Any) -> bool:
+	return style1 == style2
+
+
+def falseCompatibilityFunc(style1: Any, style2: Any) -> bool:
+	return False
+
+
+def emptyStyleFunc(textInfo: textInfos.TextInfo):
+	return None
+
+
+PARAGRAPH_styleFields = frozenset([
+	"level",
+	"font-family",
+	"font-size",
+	"color",
+	"background-color",
+])
+
+
+def defaultStyleFunc(textInfo: textInfos.TextInfo):
+	result = {}
+	try:
+		result['xOffset'] = textInfo.NVDAObjectAtStart.location[0]
+	except Exception:
+		pass
+	info = textInfo.copy()
+	info.collapse()
+	code = info.move(textInfos.UNIT_CHARACTER, 1, "end")
+	if code != 0:
+		fields = info.getTextWithFields()
+		formatFields = [
+			f
+			for f in fields
+			if isinstance(f, textInfos.FieldCommand)
+			and f.command == "formatChange"
+		]
+		if len(formatFields) > 0:
+			formatField = formatFields[0]
+			styleProperties = {k: v for k, v in formatField.field.items() if k in PARAGRAPH_styleFields}
+			result = {
+				**result,
+				**styleProperties,
+			}
+	return result
+
+
+def getStyleAndCompatibilityFuncs(
+) -> tuple[ExtractStyleFunc, StyleCompatibilityFunc]:
+	flag: config.featureFlag.FeatureFlag = config.conf["documentNavigation"]["sentenceReconstruction"]
+	match flag.calculated():
+		case SentenceReconstructionFlag.NEVER:
+			return (emptyStyleFunc, falseCompatibilityFunc)
+		case SentenceReconstructionFlag.SAME_STYLE_PARAGRAPHS:
+			return (defaultStyleFunc, defaultCompatibilityFunc)
+		case SentenceReconstructionFlag.ANY_PARAGRAPHS:
+			return (emptyStyleFunc, defaultCompatibilityFunc)
+		case _:
+			raise RuntimeError(f"Invalid sentence reconstruction flag {flag}")
+
+
+def getSentenceStopRegex(
+		regex: str = None,
+		nonBreakingPrefixes: str = None,
+) -> re.Pattern:
+	regex = regex or config.conf["virtualBuffers"]["textParagraphRegex"]
+	if nonBreakingPrefixes is None:
+		j = json.loads(config.conf["documentNavigation"]["nonBreakingPrefixRegex"])
+		language = speech.getCurrentLanguage()
+		nonBreakingPrefixes = j.get(language, "")
+	nonBreakingNLBs = "".join(
+		f"(?<!{s})"
+		for s in nonBreakingPrefixes.split("|")
+		if len(s) > 0
+	)
+	regex = regex.format(nonBreakingRegex=nonBreakingNLBs)
+	return re.compile(regex)
+
+
+class ContextParagraph:
+	textInfo: textInfos.TextInfo
+	text: str
+	pythonicLen: int
+	style: Any
+
+	def __init__(
+			self,
+			textInfo: textInfos.TextInfo,
+			extractStyleFunc: ExtractStyleFunc,
+	):
+		self.textInfo = textInfo
+		self.text = preprocessNewLines(textInfo.text)
+		self.pythonicLen = len(self.text)
+		self.style = extractStyleFunc(textInfo)
+
+
+@dataclass
+class IndexAndOffset:
+	paragraphIndex: int
+	offset: int
+
+
+@dataclass
+class FindSentenceResult:
+	start: IndexAndOffset
+	end: IndexAndOffset
+	shouldExpandStart: bool
+	shouldExpandEnd: bool
+	sentenceText: str | None
+
+
+class SentenceContext:
+	SEPARATOR: str = "\n"
+	paragraphs: dict[int, ContextParagraph]  # we use dict in order to be able to use negative indices
+	minIndex: int  # Smallest value for which paragraphs[minIndex] has been fetched
+	maxIndex: int  # Largest value for which paragraphs[maxIndex] has been fetched
+	currentPos: IndexAndOffset
+	caret: IndexAndOffset
+	caretInfo: textInfos.TextInfo
+	regex: re.Pattern
+	extractStyleFunc: ExtractStyleFunc
+	styleCompatibilityFunc: StyleCompatibilityFunc
+
+	def __init__(
+			self,
+			caretInfo: textInfos.TextInfo,
+			regex: re.Pattern = None,
+	):
+		self.extractStyleFunc, self.styleCompatibilityFunc = getStyleAndCompatibilityFuncs()
+		paragraphInfo = caretInfo.copy()
+		paragraphInfo.collapse()
+		paragraphInfo.expand(getParagraphUnitForTextInfo(paragraphInfo))
+		self.paragraphs = {0: ContextParagraph(paragraphInfo, self.extractStyleFunc)}
+		preInfo = paragraphInfo.copy()
+		preInfo.setEndPoint(caretInfo, "endToEnd")
+		self.currentPos = IndexAndOffset(0, len(preInfo.text))
+		self.caret = IndexAndOffset(0, len(preInfo.text))
+		self.caretInfo = caretInfo
+		self.minIndex = self.maxIndex = 0
+		if regex is None:
+			regex = getSentenceStopRegex()
+		self.regex = regex
+
+	def get(self, i: int) -> ContextParagraph:
+		try:
+			return self.paragraphs[i]
+		except KeyError:
+			pass
+		if i > 0:
+			j = i - 1
+		else:
+			j = i + 1
+		anchorParagraph = self.get(j)
+		if anchorParagraph is None:
+			return None
+		newParagraph = moveParagraph(anchorParagraph.textInfo, i - j)
+		if newParagraph is None:
+			return None
+		result = ContextParagraph(newParagraph, self.extractStyleFunc)
+		if not self.styleCompatibilityFunc(anchorParagraph .style, result.style):
+			return None
+		self.paragraphs[i] = result
+		self.minIndex = min(self.minIndex, i)
+		self.maxIndex = max(self.maxIndex, i)
+		return result
+
+	def computeParagraphStartIndices(self) -> list[int]:
+		parStartIndices = {self.minIndex: 0}
+		for i in range(self.minIndex + 1, self.maxIndex + 2):
+			parStartIndices[i] = parStartIndices[i - 1] + self.paragraphs[i - 1].pythonicLen + len(self.SEPARATOR)
+		return parStartIndices
+
+	def stringIndexToIndexAndOffset(
+			self,
+			index: int,
+			parStartIndices: list[int],
+	) -> IndexAndOffset:
+		paragraphIndex: int = bisect_right_dict(parStartIndices, index) - 1
+		offset = index - parStartIndices[paragraphIndex]
+		return IndexAndOffset(paragraphIndex=paragraphIndex, offset=offset)
+
+	def indexAndOffsetToStringIndex(
+			self,
+			io: IndexAndOffset,
+			parStartIndices: list[int]
+	) -> int:
+		return parStartIndices[io.paragraphIndex] + io.offset
+	
+	def indexAndOffsetToTextInfo(
+			self,
+			io: IndexAndOffset,
+	) -> textInfos.TextInfo:
+		return self.paragraphs[io.paragraphIndex].textInfo.moveToCodepointOffset(io.offset)
+
+	def FindSentenceResultToTextInfo(
+			self,
+			fsr: FindSentenceResult | None,
+	) -> textInfos.TextInfo:
+		if fsr is None:
+			return None
+		textInfo = self.indexAndOffsetToTextInfo(fsr.start)
+		endTextInfo = self.indexAndOffsetToTextInfo(fsr.end)
+		textInfo.setEndPoint(endTextInfo, which="endToEnd")
+		return textInfo
+
+	def findCurrentSentence(self) -> FindSentenceResult:
+		"""
+			This function finds current sentence among paragraphs already present in this context.
+			This function doesn't expand the context, although within its return value it provides recommendation
+			on whether to expand either start or end of context based on whether the resulting sentence touches
+			# the corresponding endpoint.
+		"""
+		text = self.SEPARATOR.join(self.paragraphs[i].text for i in range(self.minIndex, self.maxIndex + 1))
+
+		# parStartIndices Denotes indices in s where new paragraphs start in text.
+		# These are pythonic indices of characters within text string.
+		parStartIndices = self.computeParagraphStartIndices()
+		caretIndex = self.indexAndOffsetToStringIndex(self.currentPos, parStartIndices)
+		sentenceBoundaries: list[int] = [m.end() for m in self.regex.finditer(text)]
+		# Dedupe list as sometimes there are duplicate matches near the end.
+		sentenceBoundaries = sorted(list(set(sentenceBoundaries)))
+		if len(sentenceBoundaries) == 0:
+			raise RuntimeError("Found no sentence boundaries")
+		elif len(sentenceBoundaries) == 1:
+			# we must be working with empty context. Return the entire context as a single sentence.
+			return FindSentenceResult(
+				start=self.stringIndexToIndexAndOffset(0, parStartIndices),
+				end=self.stringIndexToIndexAndOffset(len(text), parStartIndices),
+				shouldExpandStart=True,
+				shouldExpandEnd=True,
+				sentenceText="",
+			)
+		# Use bisection to find indices i and j, such that current sentence is
+		# defined by indices sentenceBoundaries[i] ... sentenceBoundaries[j].
+		j: int = bisect.bisect_right(sentenceBoundaries, caretIndex)
+		if j >= len(sentenceBoundaries):
+			# This can happen if the cursor is at the last position of the line or document.
+			j -= 1
+		i: int = j - 1
+		sentenceText = text[sentenceBoundaries[i]:sentenceBoundaries[j]]
+
+		return FindSentenceResult(
+			start=self.stringIndexToIndexAndOffset(sentenceBoundaries[i], parStartIndices),
+			end=self.stringIndexToIndexAndOffset(sentenceBoundaries[j], parStartIndices),
+			shouldExpandStart=sentenceBoundaries[i] == 0,
+			shouldExpandEnd=sentenceBoundaries[j] == len(text),
+			sentenceText=sentenceText,
+		)
+	
+	def expandCurrentSentence(self, direction: int = 0) -> FindSentenceResult:
+		"""
+			Expands context if necessary, to make sure, that if sentence spans across multiple paragraphs,
+			we capture that sentence completely.
+			For example, if we're moving forward (direction==1), then we check if the end of the sentence is
+			touching the end of the last paragraph of the context. If it is the case,
+			then we expand our context forward, and find current sentence again.
+			We repeat this process until we either reach the end of the document, or we reach a paragraph,
+			that is incompatible due to different formatting, or until the end of current sentence is
+			no longer touching the end of the last paragraph.
+		"""
+		if direction == 0:
+			# Expand both forward and backward
+			self.expandCurrentSentence(-1)
+			return self.expandCurrentSentence(1)
+		MAX_EXPANSION_ATTEMPTS = 1000
+		for __ in range(MAX_EXPANSION_ATTEMPTS):
+			result = self.findCurrentSentence()
+			if (
+				(direction > 0 and not result.shouldExpandEnd)
+				or (direction < 0 and not result.shouldExpandStart)
+			):
+				return result
+			
+			nextParagraph = self.get(self.maxIndex + 1 if direction > 0 else self.minIndex - 1)
+			if nextParagraph is None:
+				return result
+
+	def moveSentence(self, direction: int) -> textInfos.TextInfo | None:
+		"""
+			This function either retrieves current sentence when direction = 0, or
+			moves to previous/next sentence when direction is not 0.
+			Please note that this function can only retrieve immediate previous/immediate next sentences.
+		"""
+		result = self.expandCurrentSentence(direction)
+		if direction == 0:
+			textInfo = self.FindSentenceResultToTextInfo(result)
+			return textInfo
+		elif (
+			(direction > 0 and result.shouldExpandEnd)
+			or (direction < 0 and result.shouldExpandStart)
+		):
+			# It is possible that the next paragraph is incompatible, in which case we need to move textInfo there
+			# and create a new SentenceContext.
+			textInfo = moveParagraph(self.paragraphs[self.maxIndex].textInfo, direction)
+			if textInfo is None:
+				return None
+			textInfo.collapse(end=direction < 0)
+			if direction < 0:
+				result = textInfo.move(textInfos.UNIT_CHARACTER, -1)
+				if result == 0:
+					return None
+			newContext = SentenceContext(textInfo, self.regex, self.extractStyleFunc, self.styleCompatibilityFunc)
+			return self.indexAndOffsetToTextInfo(
+				newContext.expandCurrentSentence(direction)
+			)
+		else:
+			# There is likely another sentence available within the same context. Move currentPos to either end
+			# or start - 1 in order to retrieve next/previous sentence
+			# from this context.
+			if direction > 0:
+				self.currentPos = result.end
+			else:
+				# This case is more complicated, since we need to move back 1 character from result.start.
+				parStartIndices = self.computeParagraphStartIndices()
+				index = self.indexAndOffsetToStringIndex(result.start, parStartIndices)
+				if index in parStartIndices:
+					# We need to be mindful of extra \n character added between paragraphs.
+					# So in this case we skip over fake \n character plus one more real character from the string.
+					index -= 2
+				else:
+					index -= 1
+				if index < 0:
+					raise RuntimeError("index supposed to stay positive")
+				self.currentPos = self.stringIndexToIndexAndOffset(index, parStartIndices)
+			return self.FindSentenceResultToTextInfo(self.expandCurrentSentence(direction))

--- a/source/editableText.py
+++ b/source/editableText.py
@@ -227,7 +227,7 @@ class EditableText(TextContainerObject,ScriptableObject):
 			info.move(textInfos.UNIT_SENTENCE, direction)
 			info.updateCaret()
 			self._caretScriptPostMovedHelper(textInfos.UNIT_SENTENCE,gesture,info)
-		except:
+		except Exception:
 			gesture.send()
 			return
 
@@ -252,6 +252,11 @@ class EditableText(TextContainerObject,ScriptableObject):
 	def script_caret_nextSentence(self,gesture):
 		self._caretMoveBySentenceHelper(gesture, 1)
 	script_caret_nextSentence.resumeSayAllMode = sayAll.CURSOR.CARET
+
+	def script_speakCurrentSentence(self, gesture):
+		info = self.makeTextInfo(textInfos.POSITION_CARET)
+		info.expand(textInfos.UNIT_SENTENCE)
+		speech.speakTextInfo(info)
 
 	def _backspaceScriptHelper(self,unit,gesture):
 		try:

--- a/source/textInfos/offsets.py
+++ b/source/textInfos/offsets.py
@@ -24,6 +24,7 @@ from typing import (
 	Self,
 )
 from logHandler import log
+from documentNavigation.sentenceNavigation import SentenceContext
 
 @dataclass
 class Offsets:
@@ -505,6 +506,12 @@ class OffsetsTextInfo(textInfos.TextInfo):
 			return 0,self._getStoryLength()
 		elif unit==textInfos.UNIT_OFFSET:
 			return offset,offset+1
+		elif unit == textInfos.UNIT_SENTENCE:
+			textInfo = self.copy()
+			textInfo._startOffset, textInfo._endOffset = offset, offset
+			context = SentenceContext(textInfo)
+			sentence = context.moveSentence(0)
+			return sentence._startOffset, sentence._endOffset
 		else:
 			raise ValueError("unknown unit: %s"%unit)
 		return offsetsFunc(offset)

--- a/tests/unit/test_sentenceNavigation.py
+++ b/tests/unit/test_sentenceNavigation.py
@@ -1,0 +1,126 @@
+# tests/unit/test_sentenceNavigation.py
+# A part of NonVisual Desktop Access (NVDA)
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+# Copyright (C) 2024 NV Access Limited
+""" Unit tests for sentence navigation."""
+
+import unittest
+from .textProvider import BasicTextProvider
+from textInfos.offsets import Offsets
+from documentNavigation import sentenceNavigation
+
+
+class TestSentenceNavigation(unittest.TestCase):
+	def runTestImpl(self, text: str, expected: str, direction: int = 0):
+		caretOffset = text.index("^")
+		text = text.replace("^", "")
+		expected = expected.replace("^", "")
+		obj = BasicTextProvider(text=text)
+		info = obj.makeTextInfo(Offsets(caretOffset, caretOffset))
+		context = sentenceNavigation.SentenceContext(info)
+		result = context.moveSentence(direction)
+		resultText = result.text
+		self.assertEqual(resultText, expected)
+
+	def test_simple(self):
+		self.runTestImpl(
+			"Hello. ^My name is John Smith. Good bye!",
+			"My name is John Smith. ",
+		)
+		self.runTestImpl(
+			"Hello. My name is Jo^hn Smith. Good bye!",
+			"My name is John Smith. ",
+		)
+		self.runTestImpl(
+			"Hello. My name is John Smith.^ Good bye!",
+			"My name is John Smith. ",
+		)
+		self.runTestImpl(
+			"Hello.^ My name is John Smith. Good bye!",
+			"Hello. ",
+		)
+		self.runTestImpl(
+			"Hello. My name is John Smith. ^Good bye!",
+			"Good bye!",
+		)
+		self.runTestImpl(
+			"Hello. ^My name is John Smith. Good bye!",
+			"My name is John Smith. ",
+		)
+
+	def test_wiki(self):
+		self.runTestImpl(
+			"The Greek god of blacksmiths, Hephaestus, created several different humanoid automata in various myths. "
+			"In Homer's Iliad, ^Hephaestus created golden handmaidens and imbued them with human-like voices.[1] "
+			"Another Greek myth details how Hephaestus crafted a giant bronze automaton named Talos.[2]",
+			"In Homer's Iliad, ^Hephaestus created golden handmaidens and imbued them with human-like voices.[1] "
+		)
+
+	def test_reconstructAcrossParagraphs(self):
+		self.runTestImpl(
+			"""
+				lorem ipsum. One must be
+				careful of books, and
+				what is inside them, for
+				words have the power to
+				^change us.
+			""",
+			"""One must be
+				careful of books, and
+				what is inside them, for
+				words have the power to
+				change us.\n""",
+		)
+
+	def test_nonBreakingPrefixes(self):
+		self.runTestImpl(
+			"^J. R. R. Tolkien",
+			"J. R. R. Tolkien",
+		)
+		self.runTestImpl(
+			"^I enjoy playing various sports, i.e., basketball, soccer, and tennis, etc. Lorem ipsum.",
+			"I enjoy playing various sports, i.e., basketball, soccer, and tennis, etc. ",
+		)
+
+	def test_doubleNewLine(self):
+		self.runTestImpl(
+			"""^This is a
+
+			test.""",
+			"""This is a\n\n""",
+		)
+
+	def test_exclamationQuestionMarks(self):
+		self.runTestImpl(
+			"What’s in a name? That ^which we call a rose By any other name would smell as sweet! Lorem ipsum.",
+			"That which we call a rose By any other name would smell as sweet! ",
+		)
+
+	def test_negative(self):
+		self.runTestImpl(
+			"^A. b.b 5.0 42. test,. test.... Lorem ipsum",
+			"A. b.b 5.0 42. test,. test.... Lorem ipsum",
+		)
+
+	def test_quote(self):
+		self.runTestImpl(
+			'^"So we beat on, boats against the current, borne back ceaselessly into the past." Lorem ipsum',
+			'"So we beat on, boats against the current, borne back ceaselessly into the past." ',
+		)
+
+	def test_movement(self):
+		gatsby = [
+			"Gatsby believed in the green light, the orgastic future that year by year recedes before us. ",
+			"So we beat on, boats against the current, borne back ceaselessly into the past. ",
+			"I am still a little afraid of missing something if I forget that, as my father snobbishly "
+			"suggested, and I snobbishly repeat, a sense of the fundamental decencies is parcelled out unequally "
+			"at birth. "
+		]
+		greatGatsby = gatsby[0] + "^" + gatsby[1] + gatsby[2]
+		for direction in [-1, 0, 1]:
+			self.runTestImpl(
+				greatGatsby,
+				gatsby[1 + direction],
+				direction=direction,
+			)

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -8,6 +8,7 @@ What's New in NVDA
 == New Features ==
 - New key commands:
   - New Quick Navigation command ``p`` for jumping to next/previous text paragraph in browse mode. (#15998, @mltony)
+  - Sentence navigation via ``alt+Up/DownArrow``. (#16384, @mltony)
   - New unassigned Quick Navigation commands, which can be used to jump to the next/previous:
     - figure (#10826)
     - vertically aligned paragraph (#15999, @mltony)

--- a/user_docs/en/userGuide.t2t
+++ b/user_docs/en/userGuide.t2t
@@ -594,8 +594,8 @@ NVDA provides the following key commands in relation to the system caret:
 | Report text formatting | NVDA+f | NVDA+f | Reports the formatting of the text where the caret is currently situated. Pressing twice shows the information in browse mode |
 | Report link destination | ``NVDA+k`` | ``NVDA+k`` | Pressing once speaks the destination URL of the link at the current caret or focus position. Pressing twice shows it in a window for more careful review |
 | Report caret location | NVDA+numpadDelete | NVDA+delete | Reports information about the location of the text or object at the position of system caret. For example, this might include the percentage through the document, the distance from the edge of the page or the exact screen position. Pressing twice may provide further detail. |
-| Next sentence | alt+downArrow | alt+downArrow | Moves the caret to the next sentence and announces it. (only supported in Microsoft Word and Outlook) |
-| Previous sentence | alt+upArrow | alt+upArrow | Moves the caret to the previous sentence and announces it. (only supported in Microsoft Word and Outlook) |
+| Next sentence | alt+downArrow | alt+downArrow | Moves the caret to the next sentence and announces it. |
+| Previous sentence | alt+upArrow | alt+upArrow | Moves the caret to the previous sentence and announces it. |
 
 When within a table, the following key commands are also available:
 || Name | Key | Description |
@@ -2501,6 +2501,26 @@ Note that this paragraph style cannot be used in Microsoft Word or Microsoft Out
 -
 
 You may toggle through the available paragraph styles from anywhere by assigning a key in the [Input Gestures dialog #InputGestures].
+
+==== Sentence reconstruction = ====[SentenceReconstruction]
+
+|| . {.hideHeaderRow} | . |
+| Options | Default (Reconstruct across same style paragraphs), Reconstruct across same style paragraphs, Never reconstruct sentences across paragraphs, Reconstruct sentences across any paragraphs|
+| Default | Reconstruct across same style paragraphs |
+
+
+This combo box allows you to select whether NVDA will try to identify and reconstruct sentences spanning across multiple paragraphs when navigating by sentence via``alt+upArrow`` and ``alt+downArrow``.
+Sentence reconstruction comes in handy in two typical use cases:
+- In most Most PDF files text is incorrectly split into paragraphs. Every line typically denotes a paragraph and thus most sentences span many adjacent paragraphs and in order to identify complete sentences NVDA must look into adjacent paragraphs.
+- Many email clients send emails broken up into lines, where each line also appears as a paragraph.
+-
+
+The available sentence reconstruction modes are:
+- Reconstruct sentences across same style paragraphs: NVDA will analyze preceding and following paragraphs only if they look visually similar.
+This style works best in most use cases.
+- Never reconstruct sentences across paragraphs: NVDA will never reconstruct sentences that span into adjacent paragraphs.
+- Reconstruct sentences across any paragraphs: NVDA will always attempt to reconstruct sentences spanning across paragraphs, even if paragraphs are of different style.
+-
 
 +++ Windows OCR Settings +++[Win10OcrSettings]
 The settings in this category allow you to configure [Windows OCR #Win10Ocr].


### PR DESCRIPTION
### Link to issue number:
Closes #8518.
### Summary of the issue:
Sentence navigation.
### Description of user facing changes
1. `Alt+Down/UpArrow` now navigates by sentence in editables and in browse mode.
2. Sentence reconstruction option added to document navigation panel in settings. This defines to what extent sentence navigation can look into adjacent paragraphs when trying to reconstruct a sentence.
3. Alsoadded an option to specify non-breaking prefixes for current language.
### Description of development approach
1. Sentence splitting algorithm is implemented in `documentNavigation\sentenceNavigation.py`. It is generic enough and works with different types of textInfos. I left some comments throughout to explain inner workings, but LMK if more clarification/ explanation is needed. I ended up rewriting the algorithm (compared to SentenceNav add-on) from scratch - now the code should be cleaner and more elegant.
2. In `editableText.py` I added `speakCurrentSentence` script - not assigned any default keystroke. Hope that's ok - since SentenceNav users requested that in the past.
4. In `OffsetsTextInfo` updated `_getUnitOffsets()` function to deal with `UNIT_SENTENCE`.
5. In `UIATextInfo` updated `expand()` and `move()` methods to work with `UNIT_SENTENCE`.
6. In `browseMode.py` updated `script_collapseOrExpandControl`: if current item is not collapsable, then treat alt+Up/Down as sentence navigation commands.
7. Existing sentence navigation logic for MSWord is not affected.
### Testing strategy:
* Manual testing in:
  * Notepad
  * Notepad++
  * Visual Studio
  * VSCode
  * Chrome - browse mode and textArea
  * Firefox browse mode and TextArea
* Unit tests
### Known issues with pull request:
Ready for review.
~~This is a draft, but fully working. Feel free to test or even start reviewing. Things I plan to address in the coming few days:~~
* ~~Figure out how to deal with language-specific non-breaking prefixes.~~
* ~~Add docuemntation~~
* ~~Add unit tests~~
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
