### PR TITLE
Fast vertical QuickNav in Gecko-based textInfos

### DIFF
--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -503,8 +503,8 @@ class BrowseModeTreeInterceptor(treeInterceptorHandler.TreeInterceptor):
 		elif itemType == "verticalParagraph":
 			def paragraphFunc(info: textInfos.TextInfo) -> int | None:
 				try:
-					return info.NVDAObjectAtStart.location[0]
-				except AttributeError:
+					return info.location[0]
+				except (AttributeError, TypeError):
 					return None
 
 			def iterFactory(direction: str, pos: textInfos.TextInfo) -> Generator[TextInfoQuickNavItem, None, None]:

--- a/source/textInfos/__init__.py
+++ b/source/textInfos/__init__.py
@@ -847,8 +847,8 @@ class TextInfo(baseObject.AutoPropertyObject):
 				info.setEndPoint(tmpInfo, which="endToEnd")
 		raise RuntimeError("Infinite loop during binary search.")
 
-
-
+	def _get_location(self) -> locationHelper.RectLTWH:
+		return self.NVDAObjectAtStart.location
 
 
 RE_EOL = re.compile("\r\n|[\n\r]")

--- a/source/virtualBuffers/gecko_ia2.py
+++ b/source/virtualBuffers/gecko_ia2.py
@@ -261,7 +261,6 @@ class Gecko_ia2_TextInfo(VirtualBufferTextInfo):
 		return locationHelper.RectLTWH(*location)
 
 
-
 class Gecko_ia2(VirtualBuffer):
 
 	TextInfo=Gecko_ia2_TextInfo

--- a/source/virtualBuffers/gecko_ia2.py
+++ b/source/virtualBuffers/gecko_ia2.py
@@ -29,6 +29,7 @@ import aria
 import config
 from NVDAObjects.IAccessible import normalizeIA2TextFormatField, IA2TextTextInfo
 import documentBase
+import locationHelper
 
 
 def _getNormalizedCurrentAttrs(attrs: textInfos.ControlField) -> typing.Dict[str, typing.Any]:
@@ -252,6 +253,13 @@ class Gecko_ia2_TextInfo(VirtualBufferTextInfo):
 			if val is not None:
 				attrs[name] = int(val)
 		return super(Gecko_ia2_TextInfo,self)._normalizeFormatField(attrs)
+
+	def _get_location(self) -> locationHelper.RectLTWH:
+		document = self.obj.rootNVDAObject.IAccessibleObject
+		docHandle, ID = self._getFieldIdentifierFromOffset(self._startOffset)
+		location = document.accLocation(ID)
+		return locationHelper.RectLTWH(*location)
+
 
 
 class Gecko_ia2(VirtualBuffer):


### PR DESCRIPTION
### Link to issue number:
Closes #16382.
### Summary of the issue:
Vertical navigation is too slow.
### Description of user facing changes
N/A
### Description of development approach
Retrieving x coordinate faster in Gecko textInfo by doing a direct IAccessible2 call - as opposed to creating an NVDAObject. According to my rough measurement, this speeds up vertical navigation about 10 times.
### Testing strategy:
Tested on usecase provided in the issue above.
### Known issues with pull request:
N/A
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
