### PR TITLE
Vertical quickNav fix

### DIFF
--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -450,8 +450,6 @@ class BrowseModeTreeInterceptor(treeInterceptorHandler.TreeInterceptor):
 	def _iterNotLinkBlock(self, direction="next", pos=None):
 		raise NotImplementedError
 
-	MAX_ITERATIONS_FOR_SIMILAR_PARAGRAPH = 100_000
-	
 	def _iterSimilarParagraph(
 			self,
 			kind: str,
@@ -460,26 +458,7 @@ class BrowseModeTreeInterceptor(treeInterceptorHandler.TreeInterceptor):
 			direction: _Movement,
 			pos: textInfos.TextInfo,
 	) -> Generator[TextInfoQuickNavItem, None, None]:
-		if direction not in [_Movement.NEXT, _Movement.PREVIOUS]:
-			raise RuntimeError
-		info = pos.copy()
-		info.collapse()
-		info.expand(textInfos.UNIT_PARAGRAPH)
-		if desiredValue is None:
-			desiredValue = paragraphFunction(info)
-		for i in range(self.MAX_ITERATIONS_FOR_SIMILAR_PARAGRAPH):
-			# move by one paragraph in the desired direction
-			info.collapse(end=direction == _Movement.NEXT)
-			if direction == _Movement.PREVIOUS:
-				if info.move(textInfos.UNIT_CHARACTER, -1) == 0:
-					return
-			info.expand(textInfos.UNIT_PARAGRAPH)
-			if info.isCollapsed:
-				return
-			value = paragraphFunction(info)
-			if value == desiredValue:
-				yield TextInfoQuickNavItem(kind, self, info.copy(), outputReason=OutputReason.CARET)
-
+		raise NotImplementedError
 
 	def _quickNavScript(self,gesture, itemType, direction, errorMessage, readUnit):
 		if itemType=="notLinkBlock":
@@ -2220,3 +2199,34 @@ class BrowseModeDocumentTreeInterceptor(documentBase.DocumentWithTableNavigation
 			self._nativeAppSelectionMode = False
 			# Translators: reported when native selection mode is toggled off.
 			ui.message(_("Native app selection mode disabled"))
+
+	MAX_ITERATIONS_FOR_SIMILAR_PARAGRAPH = 100_000
+
+	def _iterSimilarParagraph(
+			self,
+			kind: str,
+			paragraphFunction: Callable[[textInfos.TextInfo], Optional[Any]],
+			desiredValue: Optional[Any],
+			direction: _Movement,
+			pos: textInfos.TextInfo,
+	) -> Generator[TextInfoQuickNavItem, None, None]:
+		if direction not in [_Movement.NEXT, _Movement.PREVIOUS]:
+			raise RuntimeError
+		info = pos.copy()
+		info.collapse()
+		info.expand(textInfos.UNIT_PARAGRAPH)
+		if desiredValue is None:
+			desiredValue = paragraphFunction(info)
+		for i in range(self.MAX_ITERATIONS_FOR_SIMILAR_PARAGRAPH):
+			# move by one paragraph in the desired direction
+			info.collapse(end=direction == _Movement.NEXT)
+			if direction == _Movement.PREVIOUS:
+				if info.move(textInfos.UNIT_CHARACTER, -1) == 0:
+					return
+			info.expand(textInfos.UNIT_PARAGRAPH)
+			if info.isCollapsed:
+				return
+			value = paragraphFunction(info)
+			if value == desiredValue:
+				yield TextInfoQuickNavItem(kind, self, info.copy(), outputReason=OutputReason.CARET)
+

--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -2234,4 +2234,3 @@ class BrowseModeDocumentTreeInterceptor(documentBase.DocumentWithTableNavigation
 			value = paragraphFunction(info)
 			if value == desiredValue:
 				yield TextInfoQuickNavItem(kind, self, info.copy(), outputReason=OutputReason.CARET)
-

--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -2219,7 +2219,12 @@ class BrowseModeDocumentTreeInterceptor(documentBase.DocumentWithTableNavigation
 			desiredValue = paragraphFunction(info)
 		for i in range(self.MAX_ITERATIONS_FOR_SIMILAR_PARAGRAPH):
 			# move by one paragraph in the desired direction
-			info.collapse(end=direction == _Movement.NEXT)
+			try:
+				info.collapse(end=direction == _Movement.NEXT)
+			except RuntimeError:
+				# Microsoft Word raises RuntimeError when collapsing textInfo to the last character of the document.
+				return
+
 			if direction == _Movement.PREVIOUS:
 				if info.move(textInfos.UNIT_CHARACTER, -1) == 0:
 					return


### PR DESCRIPTION
### Link to issue number:
Closes #16387
Closes #16386
### Summary of the issue:
Exception when trying to use vertical quickNav in excel browse mode.
Exception when trying to use vertical quickNav on an empty word document.
### Description of user facing changes
Fixed exception. Now message "not available" is spoken in excel. In empty word document "no next paratgraph" message is spoken.
### Description of development approach
Moved `_iterSimilarParagraph()` method from `BrowseModeTreeInterceptor` to `BrowseModeDocumentTreeInterceptor` class.
Catching RuntimeError coming from MSWord textInfo when calling `.collapse()`.
### Testing strategy:
Tested manually on specified test cases.
### Known issues with pull request:
N/A
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
