### PR TITLE
HP Secure Browser support (#16377): Amend browseMode dead document detection to cope with VT_EMPTY runtimeID.

### DIFF
--- a/source/UIAHandler/browseMode.py
+++ b/source/UIAHandler/browseMode.py
@@ -6,7 +6,8 @@
 from typing import Optional
 from ctypes import byref
 from comtypes import COMError
-from comtypes.automation import VARIANT
+from comtypes.automation import VARIANT, VT_EMPTY
+
 import array
 import winUser
 import UIAHandler
@@ -527,6 +528,8 @@ class UIABrowseModeDocument(UIADocumentWithTableNavigation,browseMode.BrowseMode
 				UIAHandler.UIA_RuntimeIdPropertyId, byref(runtimeID)
 			)
 		except COMError:
+			runtimeID = VARIANT()
+		if runtimeID.vt == VT_EMPTY:
 			log.debugWarning(
 				"Could not get runtimeID of document. Most likely document is dead."
 			)


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
https://github.com/nvaccess/nvda/issues/16377

### Summary of the issue:
When enough websites are open in separate tabs, SB will suspend some of the virtual machines hosting the websites to disk. This can cause UIA documents representing these websites to become dead.

In this scenario querying UIA_RuntimeIdPropertyId of the dead document returns VT_EMPTY variant, causing uncaught exception raised from UIABrowseModeDocument.__contains__. This keeps repeating, preventing NVDA from working correctly, if at all.

### Description of user facing changes
NVDA works correctly regardless of vm suspensions or other scenarios where UIA documents can become dead.

### Description of development approach
UIABrowseModeDocument.__contains__ already has code to detect dead documents, however it relies on COMError being reported from UIA_RuntimeIdPropertyId property query.

In my testing, even when the server side reports an error HRESULT from IRawElementProviderFragment::GetRuntimeID() uia method, UIA core appears to translate it into a successful property query, yet with a VT_EMPTY variant as the property value. It's possible this behaviour is different between various UIA core versions, my testing is primarily on Windows 11 build 22631.

We amend the detection such that both COMError and VT_EMPTY variant are detected and treated equally, causing the dead document codepath to execute.

### Testing strategy:
Manual testing

### Known issues with pull request:
N/A

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [ ] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [ ] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [ ] API is compatible with existing add-ons.
- [ ] Security precautions taken.
