### PR TITLE
HP Secure Browser support (#16377): Detect & prevent infinite loop in iterUIARangeByUnit

### DIFF
--- a/source/UIAHandler/utils.py
+++ b/source/UIAHandler/utils.py
@@ -124,13 +124,19 @@ def iterUIARangeByUnit(rangeObj,unit,reverse=False):
 	tempRange.MoveEndpointByRange(Endpoint_relativeEnd,rangeObj,Endpoint_relativeStart)
 	endRange=tempRange.Clone()
 	loopCount = 0
+	yieldRange = None
 	while relativeGTOperator(endRange.Move(unit,minRelativeDistance),0):
 		loopCount += 1
 		tempRange.MoveEndpointByRange(Endpoint_relativeEnd,endRange,Endpoint_relativeStart)
 		pastEnd=relativeGTOperator(tempRange.CompareEndpoints(Endpoint_relativeEnd,rangeObj,Endpoint_relativeEnd),0)
 		if pastEnd:
 			tempRange.MoveEndpointByRange(Endpoint_relativeEnd,rangeObj,Endpoint_relativeEnd)
-		yield tempRange.clone()
+		if yieldRange and bool(yieldRange.compare(tempRange)):
+			# we've looped onto range we've already yielded previously - shortcircuit to prevent
+			# infinite loop
+			return
+		yieldRange = tempRange.clone()
+		yield yieldRange
 		if pastEnd:
 			return
 		tempRange.MoveEndpointByRange(Endpoint_relativeStart,tempRange,Endpoint_relativeEnd)


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
https://github.com/nvaccess/nvda/issues/16377

### Summary of the issue:
We're experiencing NVDA locking up trying to infinitely split some text ranges, for example on www.bat.org when it tries to split the range representing "Submit" button into individual characters.

NVDA hangs completely in this scenario and has to be forcibly killed.

If the offending split is attempted, the hang always happens. Secure Browser seems to be provoking this split more, but we've also seen that in normal chromium-based browsers when using UIA instead of IAccessible2. This could be due to significant timing differences etc, as the virtualized browser has higher overhead.

Typical repro scenario involves navigating to www.bat.org then duplicating the tab & closing some of the dupes, until NVDA attempts the split and hangs.

### Description of user facing changes
Detect & prevent the infinite loop so that NVDA remains responsive

### Description of development approach
This is likely a deficiency in UIA text range implementation on the chromium side, as I don't see anything obviously wrong with the algorithm in iterRangeByUnit which is doing the split. Rewriting this UIA algorithm in C++ and running against offending website also hangs, always, in regular Google Chrome, Edge, and Secure Browser.

At the cost of extra Compare COM call we can detect that chromium is yielding same range infinitely, and therefore detect & shortcircuit the infinite loop on the NVDA side.


### Testing strategy:
Manual testing

### Known issues with pull request:
N/A

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [ ] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [ ] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [ ] API is compatible with existing add-ons.
- [ ] Security precautions taken.
