### PR TITLE
HP Secure Browser support (#16377): Fixup backspace not working in gmail sign-in fields when chromium is using UIA text ranges

### DIFF
--- a/source/editableText.py
+++ b/source/editableText.py
@@ -23,6 +23,7 @@ import textInfos
 import controlTypes
 from inputCore import InputGesture
 from logHandler import log
+from comtypes import COMError
 
 class EditableText(TextContainerObject,ScriptableObject):
 	"""Provides scripts to report appropriately when moving the caret in editable text fields.
@@ -261,7 +262,12 @@ class EditableText(TextContainerObject,ScriptableObject):
 			return
 		oldBookmark=oldInfo.bookmark
 		testInfo=oldInfo.copy()
-		res=testInfo.move(textInfos.UNIT_CHARACTER,-1)
+		try:
+			res = testInfo.move(textInfos.UNIT_CHARACTER, -1)
+		except COMError:
+			log.exception("Error in testInfo.move")
+			gesture.send()
+			return
 		if res<0:
 			testInfo.expand(unit)
 			delChunk=testInfo.text
@@ -395,7 +401,11 @@ class EditableText(TextContainerObject,ScriptableObject):
 			# There's nothing we can do, but at least the last selection will be right next time.
 			self.isTextSelectionAnchoredAtStart=True
 			return
-		self._updateSelectionAnchor(oldInfo,newInfo)
+		try:
+			self._updateSelectionAnchor(oldInfo, newInfo)
+		except COMError:
+			log.exception("Error in _updateSelectionAnchor")
+			return
 		hasContentChanged=getattr(self,'hasContentChangedSinceLastSelection',False)
 		self.hasContentChangedSinceLastSelection=False
 		speech.speakSelectionChange(oldInfo,newInfo,generalize=hasContentChanged)


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
https://github.com/nvaccess/nvda/issues/16377

### Summary of the issue:
When using Secure Browser, Backspace key is not working in gmail's signin fields (email address, password etc)

### Description of user facing changes
Backspace key works after the changes, but this is a partial fix only since the deleted character is still not spoken.

### Description of development approach
UIA exceptions are preventing codepaths such as reinjection of backspace event from working properly. Catch&log exceptions rather than letting them escape.

### Testing strategy:
Manual testing

### Known issues with pull request:
Although backspace works now, deleted characters are not spoken

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [ ] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [ ] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [ ] API is compatible with existing add-ons.
- [ ] Security precautions taken.
