### PR TITLE
Disable application volume and mute features when sound split is off or when wasapi is off

### DIFF
--- a/source/audio/soundSplit.py
+++ b/source/audio/soundSplit.py
@@ -212,13 +212,13 @@ def setSoundSplitState(
 			# We need to restore volume of all applications, but then don't set up callback for future audio sessions
 			state = SoundSplitState.NVDA_BOTH_APPS_BOTH
 			applyToFuture = False
+			appsVolume = appsVolume or 1.0
 	leftVolume, rightVolume = state.getAppVolume()
 	if appsVolume is None:
 		appsVolume = (
 			config.conf["audio"]["applicationsSoundVolume"] / 100
 			* (1 - int(config.conf["audio"]["applicationsMuted"]))
 		)
-
 	leftVolume *= appsVolume
 	rightVolume *= appsVolume
 	leftNVDAVolume, rightNVDAVolume = state.getNVDAVolume()

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -68,6 +68,7 @@ from base64 import b16encode
 import vision
 from utils.security import objectBelowLockScreenAndWindowsIsLocked
 import audio
+import nvwave
 
 
 #: Script category for text review commands.
@@ -4520,6 +4521,14 @@ class GlobalCommands(ScriptableObject):
 		gesture="kb:NVDA+alt+pageUp",
 	)
 	def script_increaseApplicationsVolume(self, gesture: "inputCore.InputGesture") -> None:
+		if not nvwave.usingWasapiWavePlayer():
+			message = _(
+				# Translators: error message when wasapi is turned off.
+				"Cannot adjust volume of other applications. "
+				"Please enable WASAPI in the Advanced category in NVDA Settings to use it."
+			)
+			ui.message(message)
+			return
 		state = audio.soundSplit.SoundSplitState(config.conf["audio"]["soundSplitState"])
 		if state == audio.soundSplit.SoundSplitState.OFF:
 			# Translators: An error message while trying to adjust applications volume
@@ -4544,6 +4553,14 @@ class GlobalCommands(ScriptableObject):
 		gesture="kb:NVDA+alt+pageDown",
 	)
 	def script_decreaseApplicationsVolume(self, gesture: "inputCore.InputGesture") -> None:
+		if not nvwave.usingWasapiWavePlayer():
+			message = _(
+				# Translators: error message when wasapi is turned off.
+				"Cannot adjust volume of other applications. "
+				"Please enable WASAPI in the Advanced category in NVDA Settings to use it."
+			)
+			ui.message(message)
+			return
 		state = audio.soundSplit.SoundSplitState(config.conf["audio"]["soundSplitState"])
 		if state == audio.soundSplit.SoundSplitState.OFF:
 			# Translators: An error message while trying to adjust applications volume
@@ -4568,6 +4585,14 @@ class GlobalCommands(ScriptableObject):
 		gesture="kb:NVDA+alt+delete",
 	)
 	def script_toggleApplicationsMute(self, gesture: "inputCore.InputGesture") -> None:
+		if not nvwave.usingWasapiWavePlayer():
+			message = _(
+				# Translators: error message when wasapi is turned off.
+				"Cannot mute other applications. "
+				"Please enable WASAPI in the Advanced category in NVDA Settings to use it."
+			)
+			ui.message(message)
+			return
 		state = audio.soundSplit.SoundSplitState(config.conf["audio"]["soundSplitState"])
 		if state == audio.soundSplit.SoundSplitState.OFF:
 			# Translators: An error message while trying to adjust applications volume

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -4520,6 +4520,12 @@ class GlobalCommands(ScriptableObject):
 		gesture="kb:NVDA+alt+pageUp",
 	)
 	def script_increaseApplicationsVolume(self, gesture: "inputCore.InputGesture") -> None:
+		state = audio.soundSplit.SoundSplitState(config.conf["audio"]["soundSplitState"])
+		if state == audio.soundSplit.SoundSplitState.OFF:
+			# Translators: An error message while trying to adjust applications volume
+			msg = _("Please enable sound split to use this command")
+			ui.message(msg)
+			return
 		volume = config.conf["audio"]["applicationsSoundVolume"]
 		volume = min(100, volume + 5)
 		config.conf["audio"]["applicationsSoundVolume"] = volume
@@ -4538,6 +4544,12 @@ class GlobalCommands(ScriptableObject):
 		gesture="kb:NVDA+alt+pageDown",
 	)
 	def script_decreaseApplicationsVolume(self, gesture: "inputCore.InputGesture") -> None:
+		state = audio.soundSplit.SoundSplitState(config.conf["audio"]["soundSplitState"])
+		if state == audio.soundSplit.SoundSplitState.OFF:
+			# Translators: An error message while trying to adjust applications volume
+			msg = _("Please enable sound split to use this command")
+			ui.message(msg)
+			return
 		volume = config.conf["audio"]["applicationsSoundVolume"]
 		volume = max(0, volume - 5)
 		config.conf["audio"]["applicationsSoundVolume"] = volume
@@ -4556,6 +4568,12 @@ class GlobalCommands(ScriptableObject):
 		gesture="kb:NVDA+alt+delete",
 	)
 	def script_toggleApplicationsMute(self, gesture: "inputCore.InputGesture") -> None:
+		state = audio.soundSplit.SoundSplitState(config.conf["audio"]["soundSplitState"])
+		if state == audio.soundSplit.SoundSplitState.OFF:
+			# Translators: An error message while trying to adjust applications volume
+			msg = _("Please enable sound split to use this command")
+			ui.message(msg)
+			return
 		muted = config.conf["audio"]["applicationsMuted"]
 		muted = not muted
 		config.conf["audio"]["applicationsMuted"] = muted


### PR DESCRIPTION
### Link to issue number:
Closes #16402
Closes #16409
### Summary of the issue:
Mute applications command works incorrectly when sound split is off. or when wasapi is off.
### Description of user facing changes
Now muting other apps or adjusting other apps volume only works when sound split is not set to off.
Also speaking error message when wasapi is off.
### Description of development approach
Since #16287 I had to introduce explicit sound split off mode, which is not supposed to touch volumes of other applications through wasapi. Since adjusting and muting volume of other apps done through the same logic, disabling it for sound split off mode.
### Testing strategy:
Tested the following conditions:
* Muting and adjusting volumes of other apps doesn't work when sound split is off.
* muting is temporary when sound split is enabled. That is after restart all apps are unmuted.
* Adjusting volumes of other apps is permanent across restarts - as expected.

### Known issues with pull request:
N/A
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
