### PR TITLE
Fix Eclipse and Dbeaver Autocomplete on Windows 11

### DIFF
--- a/source/appModules/eclipse.py
+++ b/source/appModules/eclipse.py
@@ -181,10 +181,15 @@ class AppModule(appModuleHandler.AppModule):
 		try:
 
 			# Autocompletion items are placed outside the main eclipse window
-			if (obj.role == controlTypes.Role.LISTITEM
+			if (
+				obj.role == controlTypes.Role.LISTITEM
 				and obj.parent.parent.parent.role == controlTypes.Role.DIALOG
 				and obj.parent.parent.parent.simpleParent == api.getDesktopObject()
-				and obj.parent.parent.parent.parent.simpleNext.role in (controlTypes.Role.BUTTON, controlTypes.Role.TOGGLEBUTTON)):
+				and obj.parent.parent.parent.parent.simpleNext.role in (
+					controlTypes.Role.BUTTON,
+					controlTypes.Role.TOGGLEBUTTON
+				)
+			):
 				clsList.insert(0, AutocompletionListItem)
 		except:
 			pass

--- a/source/appModules/eclipse.py
+++ b/source/appModules/eclipse.py
@@ -183,8 +183,8 @@ class AppModule(appModuleHandler.AppModule):
 			# Autocompletion items are placed outside the main eclipse window
 			if (obj.role == controlTypes.Role.LISTITEM
 				and obj.parent.parent.parent.role == controlTypes.Role.DIALOG
-				and obj.parent.parent.parent.parent.parent == api.getDesktopObject()
-				and obj.parent.parent.parent.parent.simpleNext.role == controlTypes.Role.BUTTON):
+				and obj.parent.parent.parent.simpleParent == api.getDesktopObject()
+				and obj.parent.parent.parent.parent.simpleNext.role in (controlTypes.Role.BUTTON, controlTypes.Role.TOGGLEBUTTON)):
 				clsList.insert(0, AutocompletionListItem)
 		except:
 			pass

--- a/source/appModules/eclipse.py
+++ b/source/appModules/eclipse.py
@@ -184,7 +184,10 @@ class AppModule(appModuleHandler.AppModule):
 			if (
 				obj.role == controlTypes.Role.LISTITEM
 				and obj.parent.parent.parent.role == controlTypes.Role.DIALOG
-				and obj.parent.parent.parent.simpleParent == api.getDesktopObject()
+				and (
+					obj.parent.parent.parent.simpleParent == api.getDesktopObject()
+					or obj.parent.parent.parent.parent.parent == api.getDesktopObject()
+				)
 				and obj.parent.parent.parent.parent.simpleNext.role in (
 					controlTypes.Role.BUTTON,
 					controlTypes.Role.TOGGLEBUTTON

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -12,6 +12,7 @@
 
 ### Bug Fixes
 
+* NVDA will announce correctly the autocomplete suggestions in Eclipse and other Eclipse-based environments on Windows 11. (#16416, @thgcode)
 * Braille cursor routing is now much more reliable when a line contains one or more Unicode variation selectors or decomposed characters. (#10960, #16477, @mltony, @LeonarddeR)
 
 ### Changes for Developers


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
closes #16416 

### Summary of the issue:
On Windows 11, some controls are above the Dbeaver autocomplete suggestions dialog, causing the check to see if is an autocomplete list item to fail.

### Description of user facing changes
NVDA will speak the Dbeaver autocomplete list items on Windows 11 again.

### Description of development approach
The solution was to improve this check to use the simple object navigation mode to ignore unwanted objects from the check and add the check for the start menu that is a Toggle Button on Windows 11.

### Testing strategy:
1. Opened Dbveaver.

2. Pressed CTRL+ALT+ENTER on the sample database to open the console.

3. Typed selec. NVDA spoke the suggestions.

### Known issues with pull request:
None at present.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [ ] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [ ] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [ ] API is compatible with existing add-ons.
- [ ] Security precautions taken.
