### PR TITLE
review docs changes and add release blurb for 2024.2

### DIFF
--- a/projectDocs/dev/developerGuide/developerGuide.t2t
+++ b/projectDocs/dev/developerGuide/developerGuide.t2t
@@ -1043,7 +1043,7 @@ For examples of how to define and use new extension points, please see the code 
 | ``Action`` | ``speechCanceled`` | Triggered when speech is canceled. |
 | ``Action`` | ``pre_speechCanceled`` | Triggered before speech is canceled. |
 | ``Action`` | ``pre_speech`` | Triggered before NVDA handles prepared speech. |
-| ``Filter`` | ``filter_speechSequence`` | Allows components or add-ons to filter speech sequence before it passes to the Synth driver. |
+| ``Filter`` | ``filter_speechSequence`` | Allows components or add-ons to filter speech sequence before it passes to the synth driver. |
 
 ++ synthDriverHandler ++[synthDriverHandlerExtPts]
 || Type | Extension Point | Description |

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -4,6 +4,21 @@ What's New in NVDA
 %!includeconf: ../changes.t2tconf
 
 = 2024.2 =
+There are new commands for modifying the synth settings ring, allowing users to jump to the first or last setting, and to increase or decrease the current setting in a larger step.
+There are also new quick navigation commands, allowing userts to bind gestures to quickly jump between: paragraph, vertically aligned paragraph, same style text, different style text, menu item, toggle button, progress bar, figure, and math formula.
+
+There is a new feature called sound split.
+This allows splitting NVDA sounds into one channel (e.g. left) while sounds from all other applications are placed in the other channel (e.g. right).
+
+There are many new braille features and bug fixes.
+A new braille mode called "display speech output" has been added.
+When active, the braille display shows exactly what NVDA prepares to speak.
+Support was also added for the BrailleEdgeS2, BrailleEdgeS3 braille devices.
+LibLouis was updated, adding new detailed (with capital letters indicated) Belarusian and Ukrainian Braille tables, along with a Spanish table for reading Greek texts.
+
+eSpeak was updated, adding new language Tigrinya.
+
+There are many minor bug fixes for applications, such as Thunderbird, Adobe Reader, web browsers, Nudi and Geekbench.
 
 == New Features ==
 - New key commands:
@@ -18,32 +33,32 @@ What's New in NVDA
     - same style text (#16000, @mltony)
     - different style text (#16000, @mltony)
     -
-  -
-- Reporting row and column headers is now supported in contenteditable HTML elements. (#14113)
-- Added the option to disable the reporting of figures and captions in Document Formatting settings. (#10826, #14349)
-- In Windows 11, NVDA will announce alerts from voice typing and suggested actions including the top suggestion when copying data such as phone numbers to the clipboard (Windows 11 2022 Update and later). (#16009, @josephsl)
-- New input gestures:
-  - Added commands to jump first, last, forward and backward through the synth settings ring. (#13768, #16095, @rmcpantoja)
-    - Setting the first/last setting in the synth settings ring has no assigned gesture
-    - Decrease and increase the current setting of the synth settings ring in a larger step:
+    - Added commands to jump first, last, forward and backward through the synth settings ring. (#13768, #16095, @rmcpantoja)
+    - Setting the first/last setting in the synth settings ring has no assigned gesture. (#13768)
+    - Decrease and increase the current setting of the synth settings ring in a larger step (#13768):
       - Desktop: ``NVDA+control+pageUp`` or ``NVDA+control+pageDown``.
       - Laptop: ``NVDA+control+shift+pageUp`` or ``NVDA+control+shift+pageDown``.
       -
     -
   - Added a new unassigned input gesture to toggle the reporting of figures and captions. (#10826, #14349)
   -
-- A new braille mode called "display speech output" has been added. (#15898, @Emil-18)
-  - When active, the braille display shows exactly what NVDA prepares to speak.
-  - It can be toggled by pressing ``NVDA+alt+t``, or from the braille settings dialog.
+- Braille:
+  - Added support for the BrailleEdgeS2, BrailleEdgeS3 braille device. (#16033, #16279, @EdKweon)
+  - A new braille mode called "display speech output" has been added. (#15898, @Emil-18)
+    - When active, the braille display shows exactly what NVDA prepares to speak.
+    - It can be toggled by pressing ``NVDA+alt+t``, or from the braille settings dialog.
+    -
   -
-- Added support for the BrailleEdgeS2, BrailleEdgeS3 braille device. (#16033, #16279, @EdKweon)
-- NVDA will keep the audio device awake after speech stops, in order to prevent the start of the next speech being clipped with some audio devices such as Bluetooth headphones. (#14386, @jcsteh, @mltony)
 - Sound split: (#12985, @mltony)
   - Allows splitting NVDA sounds into one channel (e.g. left) while sounds from all other applications are placed in the other channel (e.g. right).
   - Toggled by ``NVDA+alt+s``.
   - The volume of the other applications can be adjusted by ``NVDA+alt+pageUp`` and ``NVDA+alt+pageDown``. (#16052, @mltony)
   - The sound of the other applications can be muted with ``NVDA+alt+delete``. (#16052, @mltony)
   -
+- Reporting row and column headers is now supported in contenteditable HTML elements. (#14113)
+- Added the option to disable the reporting of figures and captions in Document Formatting settings. (#10826, #14349)
+- In Windows 11, NVDA will announce alerts from voice typing and suggested actions including the top suggestion when copying data such as phone numbers to the clipboard (Windows 11 2022 Update and later). (#16009, @josephsl)
+- NVDA will keep the audio device awake after speech stops, in order to prevent the start of the next speech being clipped with some audio devices such as Bluetooth headphones. (#14386, @jcsteh, @mltony)
 - HP Secure Browser is now supported. (#16377)
 -
 
@@ -51,6 +66,7 @@ What's New in NVDA
 == Changes ==
 - Add-on Store:
   - The minimum and the last tested NVDA version for an add-on are now displayed in the "other details" area. (#15776, @Nael-Sayegh)
+  - The community reviews action will be available, and the reviews webpage will be shown in the details panel, in all tabs of the store. (#16179, @nvdaes)
   -
 - Component updates:
   - Updated LibLouis Braille translator to [3.29.0 https://github.com/liblouis/liblouis/releases/tag/v3.29.0]. (#16259, @codeofdusk)
@@ -60,35 +76,34 @@ What's New in NVDA
     - Added new language Tigrinya. 
     -
   -
-- Padding dots commonly used in tables of contents are not reported anymore at low punctuation levels. (#15845, @CyrilleB79)
--
-
-== Bug Fixes ==
-- Backspace now works correctly when using Nudi 6.1 with NVDA's "Handle keys from other applications" setting enabled. (#15822, @jcsteh)
-- Fixed a bug where audio coordinates would be played while the application is in sleep mode when "Play audio coordinates when mouse moves" is enabled. (#8059, @hwf1324)
-- Add-on Store:
-  - When pressing ``ctrl+tab``, focus properly moves to the new current tab title. (#14986, @ABuffEr)
-  - The community reviews action will be available, and the reviews webpage will be shown in the details panel, in all tabs of the store (#16179, @nvdaes)
-  -
-- In Adobe Reader, NVDA no longer ignores alternative text set on formulas in PDFs. (#12715)
 - Changed several gestures for BrailleSense devices to avoid conflicts with characters of the French braille table. (#15306)
   - ``alt+leftArrow`` is now mapped to ``dot2+dot7+space``
   - ``alt+rightArrow`` is now mapped to ``dot5+dot7+space``
   - ``alt+upArrow`` is now mapped to ``dot2+dot3+dot7+space``
   - ``alt+downArrow`` is now mapped to ``dot5+dot6+dot7+space``
   -
-- Fixed a bug causing NVDA to fail to read the ribbon and options within Geekbench. (#16251, @mzanm)
+- Padding dots commonly used in tables of contents are not reported anymore at low punctuation levels. (#15845, @CyrilleB79)
+-
+
+== Bug Fixes ==
 - Windows 11 fixes:
   - NVDA will once again announce hardware keyboard input suggestions. (#16283, @josephsl)
   - In Version 24H2 (2024 Update and Windows Server 2025), mouse and touch interaction can be used in quick settings. (#16348, @josephsl)
   -
-- Fixed a rare case when saving the configuration may fail to save all profiles.  (#16343, @CyrilleB79)
--In Firefox and Chromium-based browsers,  NVDA will correctly enter focus mode when pressing enter when positioned within a presentational list (ul / ol) inside editable content. (#16325)
-- Column state change is automatically reported when selecting columns to display in Thunderbird message list. (#16323)
+- Add-on Store:
+  - When pressing ``ctrl+tab``, focus properly moves to the new current tab title. (#14986, @ABuffEr)
+  -
 - Fixes for Chromium-based browsers when used with UIA:
   - Fixed bugs causing NVDA to hang. (#16393, #16394)
   - Backspace key is now working correctly in Gmail sign-in fields. (#16395)
   -
+- Backspace now works correctly when using Nudi 6.1 with NVDA's "Handle keys from other applications" setting enabled. (#15822, @jcsteh)
+- Fixed a bug where audio coordinates would be played while the application is in sleep mode when "Play audio coordinates when mouse moves" is enabled. (#8059, @hwf1324)
+- In Adobe Reader, NVDA no longer ignores alternative text set on formulas in PDFs. (#12715)
+- Fixed a bug causing NVDA to fail to read the ribbon and options within Geekbench. (#16251, @mzanm)
+- Fixed a rare case when saving the configuration may fail to save all profiles.  (#16343, @CyrilleB79)
+- In Firefox and Chromium-based browsers, NVDA will correctly enter focus mode when pressing enter when positioned within a presentational list (ul / ol) inside editable content. (#16325)
+- Column state change is automatically reported when selecting columns to display in Thunderbird message list. (#16323)
 -
 
 
@@ -99,9 +114,6 @@ Please refer to [the developer guide https://www.nvaccess.org/files/nvda/documen
 - Make the AppVeyor build process easier for NVDA forks, by adding configurable variables in appveyor.yml to disable or modify NV Access specific portions of the build scripts. (#16216, @XLTechie)
 - Added a how-to document, explaining the process of building NVDA forks on AppVeyor. (#16293, @XLTechie)
 -
-
-=== Deprecations ===
-
 
 = 2024.1 =
 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -4,11 +4,11 @@ What's New in NVDA
 %!includeconf: ../changes.t2tconf
 
 = 2024.2 =
-There are new commands for modifying the synth settings ring, allowing users to jump to the first or last setting, and to increase or decrease the current setting in a larger step.
-There are also new quick navigation commands, allowing userts to bind gestures to quickly jump between: paragraph, vertically aligned paragraph, same style text, different style text, menu item, toggle button, progress bar, figure, and math formula.
-
 There is a new feature called sound split.
 This allows splitting NVDA sounds into one channel (e.g. left) while sounds from all other applications are placed in the other channel (e.g. right).
+
+There are new commands for modifying the synth settings ring, allowing users to jump to the first or last setting, and to increase or decrease the current setting in a larger step.
+There are also new quick navigation commands, allowing userts to bind gestures to quickly jump between: paragraph, vertically aligned paragraph, same style text, different style text, menu item, toggle button, progress bar, figure, and math formula.
 
 There are many new braille features and bug fixes.
 A new braille mode called "display speech output" has been added.
@@ -101,7 +101,7 @@ There are many minor bug fixes for applications, such as Thunderbird, Adobe Read
 - Fixed a bug where audio coordinates would be played while the application is in sleep mode when "Play audio coordinates when mouse moves" is enabled. (#8059, @hwf1324)
 - In Adobe Reader, NVDA no longer ignores alternative text set on formulas in PDFs. (#12715)
 - Fixed a bug causing NVDA to fail to read the ribbon and options within Geekbench. (#16251, @mzanm)
-- Fixed a rare case when saving the configuration may fail to save all profiles.  (#16343, @CyrilleB79)
+- Fixed a rare case when saving the configuration may fail to save all profiles. (#16343, @CyrilleB79)
 - In Firefox and Chromium-based browsers, NVDA will correctly enter focus mode when pressing enter when positioned within a presentational list (ul / ol) inside editable content. (#16325)
 - Column state change is automatically reported when selecting columns to display in Thunderbird message list. (#16323)
 -


### PR DESCRIPTION
**Must be a squash merge**

Changes from this PR to the previous release:
- Files to check: `user_docs/en/userGuide.t2t`, `user_docs/en/changes.t2t` `developerGuide.t2t`
- [Compare this branch to the previous release](https://github.com/nvaccess/nvda/compare/release-2024.1...addReleaseBlurb?expand=1)
- Comparison command:
`git diff release-2024.1...addReleaseBlurb-- "**/en/*.t2t" "**/developerGuide.t2t"`

Common mistakes to check for:
- Issue/PR reference in changes file is incorrect
- Incorrect spelling.
- Lists not terminated with a final `-` on a new line, matching indentation
- List items not indented by a multiple of 2 spaces (regex `^ (  )*-`)
- Single grave marks \` instead of double grave marks \`\` (regex ``` [^`]`[^`] ```)
- Shortcuts added without code markdown, use two 'grave' characters (e.g. ` ``NVDA+d`` `)
- Double spaces (regex `[^ ]  `)
- Inconsistent use of single vs double quote. (regex `' `)