### PR TITLE
Fix numbered headings for Arabic

### DIFF
--- a/user_docs/numberedHeadings.css
+++ b/user_docs/numberedHeadings.css
@@ -52,31 +52,48 @@ This is because the first and only first level TOC element is the heading for th
   content: counter(toc1-counter) "." counter(toc2-counter) "." counter(toc3-counter) "." counter(toc4-counter) "." counters(toc5-counter) ". ";
 }
 
-/* RTL */
+/* Eastern Arabic */
 
-:lang(ar) .toc > ul > li > ul > li a:before,
 :lang(fa) .toc > ul > li > ul > li a:before {
   content: counter(toc1-counter, arabic-indic) ". ";
 }
 
-:lang(ar) .toc > ul > li > ul > li > ul > li a:before,
 :lang(fa) .toc > ul > li > ul > li > ul > li a:before {
   content: counter(toc2-counter, arabic-indic) "." counter(toc1-counter, arabic-indic) ". ";
 }
 
-:lang(ar) .toc > ul > li > ul > li > ul > li > ul > li a:before,
 :lang(fa) .toc > ul > li > ul > li > ul > li > ul > li a:before {
   content: counter(toc3-counter, arabic-indic) "." counter(toc2-counter, arabic-indic) "." counter(toc1-counter, arabic-indic) ". ";
 }
 
-:lang(ar) .toc > ul > li > ul > li > ul > li > ul > li > ul > li a:before,
 :lang(fa) .toc > ul > li > ul > li > ul > li > ul > li > ul > li a:before {
   content: counter(toc4-counter, arabic-indic) "." counter(toc3-counter, arabic-indic) "." counter(toc2-counter, arabic-indic) "." counter(toc1-counter, arabic-indic) ". ";
 }
 
-:lang(ar) .toc > ul > li > ul > li > ul > li > ul > li > ul > li > ul > li a:before,
 :lang(fa) .toc > ul > li > ul > li > ul > li > ul > li > ul > li > ul > li a:before {
   content: counter(toc5-counter, arabic-indic) "." counter(toc4-counter, arabic-indic) "." counter(toc3-counter, arabic-indic) "." counter(toc2-counter, arabic-indic) "." counter(toc1-counter, arabic-indic) ". ";
+}
+
+/* Western Arabic */
+
+:lang(ar) .toc > ul > li > ul > li a:before {
+  content: counter(toc1-counter) ". ";
+}
+
+:lang(ar) .toc > ul > li > ul > li > ul > li a:before {
+  content: counter(toc1-counter) "." counter(toc2-counter) ". ";
+}
+
+:lang(ar) .toc > ul > li > ul > li > ul > li > ul > li a:before {
+  content: counter(toc1-counter) "." counter(toc2-counter) "." counter(toc3-counter) ". ";
+}
+
+:lang(ar) .toc > ul > li > ul > li > ul > li > ul > li > ul > li a:before {
+  content: counter(toc1-counter) "." counter(toc2-counter) "." counter(toc3-counter) "." counter(toc4-counter) ". ";
+}
+
+:lang(ar) .toc > ul > li > ul > li > ul > li > ul > li > ul > li > ul > li a:before {
+  content: counter(toc1-counter) "." counter(toc2-counter) "." counter(toc3-counter) "." counter(toc4-counter) "." counter(toc5-counter) ". ";
 }
 
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Discussed here: https://groups.io/g/nvda-translations/message/3819

### Summary of the issue:
In [2023.2, the user guide](https://www.nvaccess.org/files/nvda/releases/2023.3/documentation/ar/userGuide.html) heading numbering for the Arabic translation switched to using Western Arabic numbering.
[2024.1](https://www.nvaccess.org/files/nvda/releases/2024.1/documentation/ar/userGuide.html) mistakenly switched this back to Eastern Arabic numbering.

### Description of user facing changes
Restore Western Arabic numbering style for headings.

### Description of development approach
Updated CSS to reflect Western Arabic numbering style i.e. `.1.2.3`, `.1.2.4`

### Testing strategy:
Compared:
- https://www.nvaccess.org/files/nvda/releases/2024.1/documentation/ar/userGuide.html
- https://www.nvaccess.org/files/nvda/releases/2023.3/documentation/ar/userGuide.html
- Checked generated Arabic and Persian documentation with new CSS: https://ci.appveyor.com/api/buildjobs/tjkhr1gm97nsutj9/artifacts/output%2Fnvda_snapshot_pr16425-31650%2C23d5c1a0.exe

### Known issues with pull request:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
