### PR TITLE
Fix exception when triggering style navigation commands in an empty document

### DIFF
--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -2392,6 +2392,8 @@ class BrowseModeDocumentTreeInterceptor(documentBase.DocumentWithTableNavigation
 		# if direction == "previous" then it spans from the beginning of current paragraph until cursor+1
 		# For all following iterations paragraph will represent a complete paragraph.
 		styles = self._mergeIdenticalStyles(self._extractStyles(paragraph))
+		if len(styles) < 2:
+			return
 		initialStyle = styles[0 if direction == documentBase._Movement.NEXT else -2]
 		# Creating currentTextInfo - text written in initialStyle in this paragraph.
 		currentTextInfo = initialTextInfo.copy()


### PR DESCRIPTION
### Link to issue number:
Closes #16407 
### Summary of the issue:
Exception during style navigation command in an empty document
### Description of user facing changes
N/A
### Description of development approach
Detecting this case and returning early.
### Testing strategy:
Tested on use case from the issue.
### Known issues with pull request:
N/A
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
