### PR TITLE
Create PR revert template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/revert.md
+++ b/.github/PULL_REQUEST_TEMPLATE/revert.md
@@ -1,0 +1,20 @@
+---
+name: Revert PR
+about: Revert an existing pull request
+
+---
+
+### Reverts PR
+Reverts #issueNumber
+
+### Issues fixed
+<!-- Issues that will be closed by reverting, i.e. the issues introduced via the PR getting reverted  -->
+Fixes #issueNumber
+
+### Issues reopened
+<!-- Issues that will be re-opened by reverting, i.e. the issues that were fixed via the PR getting reverted  -->
+Reopens #issueNumber
+
+### Reason for revert
+
+### Can this PR be reimplemented? If so, what is required for the next attempt

--- a/projectDocs/community/releaseProcess.md
+++ b/projectDocs/community/releaseProcess.md
@@ -44,6 +44,7 @@ This is however unlikely to be an issue as build checks on the pull request itse
 * If a merged pull request has been identified as causing a regression, new bug, or does not work as originally reported, the pull request may be reverted at the discretion of the lead developers. Reasons in favor of not reverting the pull request may be: 
   * The pull request was submitted by an active collaborator who is likely to follow up with a suitable pull request to address the issues.
   * The bug is trivial enough to be fixed by a collaborator.
+  * Use the [PR revert template](../../.github/PULL_REQUEST_TEMPLATE/revert.md) when reverting.
 * Automatic 'alpha snapshots' are made available to the public for very early testing. See [testing guide](../testing/contributing.md).
 
 ### Beta phase
@@ -60,7 +61,8 @@ This is however unlikely to be an issue as build checks on the pull request itse
 * If a merged pull request that reached beta has been identified as causing a regression, new bug, or does not work as originally reported:
   - The pull request may be reverted at the discretion of the lead developers.
   - It may be fixed by a collaborator if the bug is trivial enough.
-  - Once a PR is reverted from `beta`, a replacement PR is very unlikely to get into the current release.
+  - Once a PR is reverted from `beta`, a replacement PR is very unlikely to be accepted into the current release.
+  - Use the [PR revert template](../../.github/PULL_REQUEST_TEMPLATE/revert.md) when reverting.
 
 ### Release Candidate phase
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
None

### Summary of the issue:
Revert PRs are janitorial actions which do not make sense to follow the PR template.
Typically these are made adhoc using the GitHub UX.
When performing a revert, it is important to note issues being opened and closed by the reversion.
It is also vital to note the PR being reverted.
Adding a short reason for reversion will help people understand a summary of what is going on.

### Description of user facing changes
None

### Description of development approach
Created a new template to be copy-pasted when performing a revert

### Testing strategy:
N/A

### Known issues with pull request:
GitHub has a suggested UX for multiple PR templates: https://github.blog/2018-01-25-multiple-issue-and-pull-request-templates/
The GitHub UX for having multiple PR templates is  less than ideal.
It's like landing at https://github.com/nvaccess/nvda/issues/new rather than https://github.com/nvaccess/nvda/issues/new/choose.
I figure this process may annoy some contributors.

Additionally, when performing a revert through GitHubs UX, the PR template is automatically overriden anyway, meaning the UX for multiple PR templates is bypassed anyway.
I've opened a feature request here to improve this design: https://github.com/orgs/community/discussions/121757

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
