### PR TITLE
Fix exception during textInfos.moveToCodepointOffset when some characters correspond to 0 pythonic characters

### DIFF
--- a/source/textInfos/__init__.py
+++ b/source/textInfos/__init__.py
@@ -835,7 +835,7 @@ class TextInfo(baseObject.AutoPropertyObject):
 				lastRecursed = 0
 				continue
 			if actualCodepointOffset < 0 or actualCodepointOffset > totalCodepointOffset:
-				raise RuntimeError(f"{actualCodepointOffset =} went out of the boundaries; {totalCodepointOffset=}")
+				raise RuntimeError(f"{actualCodepointOffset=} went out of the boundaries; {totalCodepointOffset=}")
 			if actualCodepointOffset == codepointOffsetLeft:
 				return tmpInfo
 			elif actualCodepointOffset < codepointOffsetLeft:

--- a/source/textInfos/__init__.py
+++ b/source/textInfos/__init__.py
@@ -777,6 +777,7 @@ class TextInfo(baseObject.AutoPropertyObject):
 			tmpInfo = info.copy()
 			if codepointOffsetLeft <= codepointOffsetRight:
 				# Move from the left end of info. Let's compute by how many characters in moveCharacters variable.
+				moveFromLeft = True
 				tmpInfo.collapse()
 				if (
 					lastRecursed is not None and (
@@ -802,6 +803,7 @@ class TextInfo(baseObject.AutoPropertyObject):
 				tmpInfo.collapse(end=True)
 			else:
 				# Move from the right end of info.
+				moveFromLeft = False
 				tmpInfo.collapse(end=True)
 				if (
 					lastRecursed is not None and (
@@ -825,10 +827,15 @@ class TextInfo(baseObject.AutoPropertyObject):
 				tmpInfo.collapse()
 			if code == 0:
 				raise RuntimeError("Move by character operation unexpectedly failed.")
-			if actualCodepointOffset <= 0 or actualCodepointOffset >= totalCodepointOffset:
+			if (
+				(not moveFromLeft and actualCodepointOffset <= 0)
+				or (moveFromLeft and actualCodepointOffset >= totalCodepointOffset)
+			):
 				# We overshot, call this recursion attempt failed and try again lower movement
 				lastRecursed = 0
 				continue
+			if actualCodepointOffset < 0 or actualCodepointOffset > totalCodepointOffset:
+				raise RuntimeError(f"{actualCodepointOffset =} went out of the boundaries; {totalCodepointOffset=}")
 			if actualCodepointOffset == codepointOffsetLeft:
 				return tmpInfo
 			elif actualCodepointOffset < codepointOffsetLeft:

--- a/tests/unit/test_textInfos.py
+++ b/tests/unit/test_textInfos.py
@@ -180,6 +180,7 @@ class TestMoveToCodepointOffsetInBlackBoxTextInfo(unittest.TestCase):
 	THREE_CHARS = "012"
 	TEN_CHARS = "0123456789"
 	TWELVE_CHARS = "0123456789AB"
+	LETTERS = "ABCDEFGHIJ"
 
 	def runTestImpl(self, tokens: list[str], target: str):
 		info = MockBlackBoxTextInfo(tokens)
@@ -213,6 +214,13 @@ class TestMoveToCodepointOffsetInBlackBoxTextInfo(unittest.TestCase):
 	def test_doubleRightRecursion(self):
 		self.runTestImpl([self.THREE_CHARS, self.THREE_CHARS, self.THREE_CHARS, "a", self.THREE_CHARS], "a")
 
+	def test_emptyCharacter(self):
+		for c in self.LETTERS:
+			self.runTestImpl(list(self.LETTERS) + [""], c)
+
+	def test_emptyCharacterAtStart(self):
+		for c in self.LETTERS:
+			self.runTestImpl([""] + list(self.LETTERS), c)
 
 class TestMoveToCodepointOffsetInOffsetsTextInfo(unittest.TestCase):
 	encodings = [


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Partially closes #16406.
### Summary of the issue:
When trying to navigate by style an exception is thrown:
```
RuntimeError: Unable to find desired offset in TextInfo.
```
### Description of user facing changes
N/A
### Description of development approach
Investigation showed that in Outlook with word UIA enabled, sometimes there are characters that translate into 0 codepoint characters. To illustrate this further:
```
>>> p=focus.treeInterceptor.makeTextInfo('caret')
>>> p.expand('paragraph')
>>> p.text
'View in browser'
>>> p.collapse(end=True)
>>> p.move('character', -1, 'start')
-1
>>> p.text
''
>>> len(p.text)
0
```

E.g. we move a collapsed text info start by -1 character, and the resulting textInfo still appears to be empty- at least its Python text is empty.
I anticipated this to happen somewhere, but didn't encounter a single example when I was implementing `moveToCodepointOffset` function, so I missed one edge case. Now fixing this edge case. Also adding unit tests.
### Testing strategy:
Unit test.
Tested on test case from the original issue with UIA enabled.
### Known issues with pull request:
N/A
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
