### PR TITLE
Fix hanging during text paragraph navigation in UIA edge

### DIFF
--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -2545,17 +2545,7 @@ class BrowseModeDocumentTreeInterceptor(documentBase.DocumentWithTableNavigation
 			desiredValue = paragraphFunction(info)
 		for i in range(self.MAX_ITERATIONS_FOR_SIMILAR_PARAGRAPH):
 			# move by one paragraph in the desired direction
-			try:
-				info.collapse(end=direction == _Movement.NEXT)
-			except RuntimeError:
-				# Microsoft Word raises RuntimeError when collapsing textInfo to the last character of the document.
-				return
-
-			if direction == _Movement.PREVIOUS:
-				if info.move(textInfos.UNIT_CHARACTER, -1) == 0:
-					return
-			info.expand(textInfos.UNIT_PARAGRAPH)
-			if info.isCollapsed:
+			if not self._moveToNextParagraph(info, direction):
 				return
 			value = paragraphFunction(info)
 			if value == desiredValue:


### PR DESCRIPTION
### Link to issue number:
Closes #16436.
### Summary of the issue:
Text paragraph navigation hangs in UIA edge near the end of document.
### Description of user facing changes
N/A
### Description of development approach
Replaced logic to find next paragraph with already polished function from another PR. It's got a condition that prevents hanging in this case.
### Testing strategy:
Tested manually on provided test case.
### Known issues with pull request:
N/A
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
