### PR TITLE
Fix Edit.makeTextInfo(caret) when selection is present

### DIFF
--- a/source/NVDAObjects/window/edit.py
+++ b/source/NVDAObjects/window/edit.py
@@ -718,7 +718,11 @@ class ITextDocumentTextInfo(textInfos.TextInfo):
 			self._rangeObj=self.obj.ITextSelectionObject.duplicate
 		elif position==textInfos.POSITION_CARET:
 			self._rangeObj=self.obj.ITextSelectionObject.duplicate
-			self._rangeObj.Collapse(True)
+			startActive: bool = (self.obj.ITextSelectionObject.Flags & comInterfaces.tom.tomSelStartActive) > 0
+			# Notice: in the following line Collapse() method is called on ITextRange object, not on TextInfo.
+			# It's boolean argument has the opposite meaning from the one in TextInfo:
+			# True means collapse to the start, while False means collapse to the end
+			self._rangeObj.Collapse(startActive)
 		elif position==textInfos.POSITION_FIRST:
 			self._rangeObj=self.obj.ITextDocumentObject.range(0,0)
 		elif position==textInfos.POSITION_LAST:


### PR DESCRIPTION
### Link to issue number:
N/A - please let me know if you want me to create a proper issue first
### Summary of the issue:
Suppose some text is selected in NVDA log viewer. Caret can be either at the beginning or at the end of selection, depending on whether we selected text back or forward. Now when calling
```
focus.makeTextInfo('caret')
```
I observed that instead of actual caret position, it always returns the beginning of the selection, which is wrong.
### Description of user facing changes
N/A as far as I can tell.
### Description of development approach
This PR fixes bug in `NVDAObjects.window.edit.ITextDocumentTextInfo` class.
I query `ITextSelection.Flags` and check whetehr `tomSelStartActive` flag is set, and depending on that I collapse either to beginning or to the end depending where the curosr actually is located at the moment.
### Testing strategy:
Tested manually in NVDA log viewer. In order to figure out where caret resides I use the following snippet:
```
t=focus.makeTextInfo('caret')
t.move('character', 1, 'end')
t.text
```
### Known issues with pull request:
N/A
### Notes
Just for the record if anyone is interested why I'm proposing this change. I am working on customized word selection script for WordNav add-on and one thing I need is to be able to determine whether caret is currently residing at the beginning or at the end of the selection. It would help if this issue is fixed in the core.
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
