### PR TITLE
Recover safely if the add-on store cache is invalid

### DIFF
--- a/source/addonStore/dataManager.py
+++ b/source/addonStore/dataManager.py
@@ -17,6 +17,7 @@ from typing import (
 
 import requests
 from requests.structures import CaseInsensitiveDict
+from json import JSONDecodeError
 
 import addonAPIVersion
 from baseObject import AutoPropertyObject
@@ -183,16 +184,17 @@ class _DataManager:
 			return None
 		try:
 			data = cacheData["data"]
+			cachedAddonData = _createStoreCollectionFromJson(data)
 			cacheHash = cacheData["cacheHash"]
 			cachedLanguage = cacheData["cachedLanguage"]
 			nvdaAPIVersion = cacheData["nvdaAPIVersion"]
-		except KeyError:
+		except (KeyError, JSONDecodeError):
 			log.exception(f"Invalid add-on store cache:\n{cacheData}")
 			if NVDAState.shouldWriteToDisk():
 				os.remove(cacheFilePath)
 			return None
 		return CachedAddonsModel(
-			cachedAddonData=_createStoreCollectionFromJson(data),
+			cachedAddonData=cachedAddonData,
 			cacheHash=cacheHash,
 			cachedLanguage=cachedLanguage,
 			nvdaAPIVersion=tuple(nvdaAPIVersion),  # loads as list,

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -78,6 +78,7 @@ There are many minor bug fixes for applications, such as Thunderbird, Adobe Read
   * In Version 24H2 (2024 Update and Windows Server 2025), mouse and touch interaction can be used in quick settings. (#16348, @josephsl)
 * Add-on Store:
   * When pressing `ctrl+tab`, focus properly moves to the new current tab title. (#14986, @ABuffEr)
+  * If cache files are not correct, NVDA no longer will restart. (#16362, @nvdaes)
 * Fixes for Chromium-based browsers when used with UIA:
   * Fixed bugs causing NVDA to hang. (#16393, #16394)
   * Backspace key is now working correctly in Gmail sign-in fields. (#16395)


### PR DESCRIPTION
- Don't restart if cache files in add-on store are not correct
- Update changelog

<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Fixes #16362
### Summary of the issue:
When cache files of the add-on store contain invalid data, NVDA is restarted.
### Description of user facing changes
None
### Description of development approach
In the `_getCachedAddonData` function of the `_DataManager` class, a `cachedAddonData`variable will try to get the value of the _createStoreCollectionFromJson(data)`.
So, if data doesn't match that model, the same exception of other invalid required values will be raised, and NVDA won't be restarted.
### Testing strategy:
- The addonId of the searchWith add-on has been removed from a cache file.
- - Pressed NVDA+q to restart NVDA.
- Confirmed that NVDA was restarted befor aplying this fix, but not after.
### Known issues with pull request:
None
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
