### PR TITLE
Remove redundant braille.BrailleHandler.update executions

### DIFF
--- a/source/braille.py
+++ b/source/braille.py
@@ -2516,8 +2516,9 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 		self.mainBuffer.update()
 		# Last region should receive focus.
 		self.mainBuffer.focus(region)
-		self.scrollToCursorOrSelection(region)
-		if self.buffer is self.mainBuffer:
+		if isinstance(region, TextInfoRegion):
+			self.scrollToCursorOrSelection(region)
+		elif self.buffer is self.mainBuffer:
 			self.update()
 		elif self.buffer is self.messageBuffer and keyboardHandler.keyCounter>self._keyCountForLastMessage:
 			self._dismissMessage()
@@ -2572,7 +2573,7 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 			self.mainBuffer.restoreWindow()
 			if scrollTo is not None:
 				self.scrollToCursorOrSelection(scrollTo)
-			if self.buffer is self.mainBuffer:
+			elif self.buffer is self.mainBuffer:
 				self.update()
 			elif (
 				self.buffer is self.messageBuffer

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -104,7 +104,6 @@ There are many minor bug fixes for applications, such as Thunderbird, Adobe Read
 - Fixed a rare case when saving the configuration may fail to save all profiles. (#16343, @CyrilleB79)
 - In Firefox and Chromium-based browsers, NVDA will correctly enter focus mode when pressing enter when positioned within a presentational list (ul / ol) inside editable content. (#16325)
 - Column state change is automatically reported when selecting columns to display in Thunderbird message list. (#16323)
-- Braille was updated redundantly. (#16456)
 -
 
 

--- a/user_docs/en/changes.t2t
+++ b/user_docs/en/changes.t2t
@@ -104,6 +104,7 @@ There are many minor bug fixes for applications, such as Thunderbird, Adobe Read
 - Fixed a rare case when saving the configuration may fail to save all profiles. (#16343, @CyrilleB79)
 - In Firefox and Chromium-based browsers, NVDA will correctly enter focus mode when pressing enter when positioned within a presentational list (ul / ol) inside editable content. (#16325)
 - Column state change is automatically reported when selecting columns to display in Thunderbird message list. (#16323)
+- Braille was updated redundantly. (#16456)
 -
 
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
fixes #16456
### Summary of the issue:
In `braille.BrailleHandler._handlePendingUpdate` and `braille.BrailleHandler._doNewObject` functions `scrollTocursororSelection` function is called. `scrollToCursorOrSelection` calls `scrollTo` which in turns calls `braille.BrailleHandler.update`. Both `_handlePendingUpdate` and `_doNewObject` call `braille.BrailleHandler.update` after calling `scrollToCursorOrSelection`.
### Description of user facing changes
There should be less "Braille window dots" log lines when log level is debug. Maybe some minor effect on performance.
### Description of development approach
Minor modifications of `_handlePendingUpdate` and `_doNewObject` functions.
### Testing strategy:
Local testing in daily use
### Known issues with pull request:
none at this moment
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
