### PR TITLE
Add pfx files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ source/locale/*/cldr.dic
 .vs
 .venv
 nvdaHelper/docs/
+*.pfx


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:

None

### Summary of the issue:

The current development documentation on creating self-signed builds of NVDA instructs users to [save their PFX file to their NVDA repository root](https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/selfSignedBuild.md#export-certificate-as-pfx). As this directory is under version control, Git will then recognise the PFX file as a candidate for versioning. However, signing certificates should not be committed to VC.

### Description of user facing changes

Git will now ignore PFX files in this repository. There are no end-user facing changes.

### Description of development approach

Added `*.pfx` to `.gitignore`.

### Testing strategy:

Ran `git status` to ensure that Git no-longer shows PFX certificates as untracked files.

### Known issues with pull request:

None

### Code Review Checklist:

N/A