### PR TITLE
Recognize Windows 11 build 26100 as 24H2 RTM

### DIFF
--- a/appx/manifest.xml.subst
+++ b/appx/manifest.xml.subst
@@ -24,7 +24,7 @@
 		<TargetDeviceFamily 
 			Name="Windows.Desktop" 
 			MinVersion="10.0.18990.0" 
-			MaxVersionTested="10.0.22631.0" 
+			MaxVersionTested="10.0.26100.0" 
 		/>
 	</Dependencies>
 	<Capabilities>

--- a/source/winVersion.py
+++ b/source/winVersion.py
@@ -42,6 +42,7 @@ _BUILDS_TO_RELEASE_NAMES: dict[int, str] = {
 	22000: "Windows 11 21H2",
 	22621: "Windows 11 22H2",
 	22631: "Windows 11 23H2",
+	26100: "Windows 11 24H2",
 }
 
 
@@ -166,6 +167,7 @@ WINSERVER_2022 = WinVersion(major=10, minor=0, build=20348)
 WIN11 = WIN11_21H2 = WinVersion(major=10, minor=0, build=22000)
 WIN11_22H2 = WinVersion(major=10, minor=0, build=22621)
 WIN11_23H2 = WinVersion(major=10, minor=0, build=22631)
+WIN11_24H2 = WinVersion(major=10, minor=0, build=26100)
 
 
 @functools.lru_cache(maxsize=1)


### PR DESCRIPTION
### Link to issue number:
Closes #16439 

### Summary of the issue:
Recognize Windows 11 build 26100 as 24H2 (2024 Update and Server 2025) RTM build.

### Description of user facing changes
None

### Description of development approach
winVersion.WIN11_24H2 constant is defined, as wel as updating last tested Widows version in AppX manifest to 10.0.26100.

### Testing strategy:
Manual testing: on Windows 11 24H2 build 26100, make sure winVersion.getWinVer() == winVersion.WIN11_24H2.

### Known issues with pull request:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

### Additional context:
With OEM's planning to release AI PC's powered by Windows 11 2024 Update as early as June, the normal timeline for recording new Windows 11 public build was sped up. NOrmaly this pull request would be scheduled once release preview Windows Insiders receive the RTM build (end of northern summer), but for 24H2, build 26100 was finalized in late March (earlier than usual).

Thanks.