### PR TITLE
Fix TextInfo.moveToCodepointOffset() in PoEdit

### DIFF
--- a/source/NVDAObjects/window/edit.py
+++ b/source/NVDAObjects/window/edit.py
@@ -844,7 +844,8 @@ class ITextDocumentTextInfo(textInfos.TextInfo):
 		self.obj.ITextSelectionObject.end=self._rangeObj.end
 
 	def getTextInfoForCodepointMovement(self) -> Self:
-		# # In PoEdit ITextDocumentTextInfo sometimes cannot access the last character when that character is
+		# In PoEdit ITextDocumentTextInfo sometimes cannot access the last character when that character is
+
 		# a newline. In this case collapse(True) takes us not to the end of textInfo, but right before
 		# trailing newline character, which causes adverse side effects in moveToCodepointOffset() function.
 		# Trimming trailing newline character here to work around.

--- a/source/NVDAObjects/window/edit.py
+++ b/source/NVDAObjects/window/edit.py
@@ -6,6 +6,7 @@
 from typing import (
 	Dict,
 	Optional,
+	Self,
 	Union,
 )
 
@@ -841,6 +842,18 @@ class ITextDocumentTextInfo(textInfos.TextInfo):
 	def updateSelection(self):
 		self.obj.ITextSelectionObject.start=self._rangeObj.start
 		self.obj.ITextSelectionObject.end=self._rangeObj.end
+
+	def getTextInfoForCodepointMovement(self) -> Self:
+		# # In PoEdit ITextDocumentTextInfo sometimes cannot access the last character when that character is
+		# a newline. In this case collapse(True) takes us not to the end of textInfo, but right before
+		# trailing newline character, which causes adverse side effects in moveToCodepointOffset() function.
+		# Trimming trailing newline character here to work around.
+		info = self.copy()
+		collapsedInfo = info.copy()
+		collapsedInfo.collapse(end=True)
+		if collapsedInfo.compareEndPoints(info, "endToEnd") < 0:
+			info.setEndPoint(collapsedInfo, "endToEnd")
+		return info
 
 
 class EditBase(Window):

--- a/source/textInfos/__init__.py
+++ b/source/textInfos/__init__.py
@@ -655,7 +655,10 @@ class TextInfo(baseObject.AutoPropertyObject):
 		@raise LookupError: If MathML can't be retrieved for this field.
 		"""
 		raise NotImplementedError
-	
+
+	def getTextInfoForCodepointMovement(self) -> Self:
+		return self.copy()
+
 	def moveToCodepointOffset(
 			self,
 			codepointOffset: int,
@@ -748,15 +751,15 @@ class TextInfo(baseObject.AutoPropertyObject):
 				we reduce the count of characters in order to make sure
 				the algorithm makes some progress on each iteration.
 		"""
-		text = self.text
+		info = self.getTextInfoForCodepointMovement()
+		text = info.text
 		if codepointOffset < 0 or codepointOffset > len(text):
 			raise ValueError
 		if codepointOffset == 0 or codepointOffset == len(text):
-			result = self.copy()
+			result = info.copy()
 			result.collapse(end=codepointOffset > 0)
 			return result
 		
-		info = self.copy()
 		# Total codepoint Length represents length in python characters of Current TextInfo we're workoing with.
 		# We start with self, and then gradually divide and conquer in order to find desired offset.
 		totalCodepointOffset = len(text)


### PR DESCRIPTION
### Link to issue number:
N/A
### Summary of the issue:
TextInfo.moveToCodepointOffset() somtimes raises exception in PoEdit:
```
RuntimeError: Inner textInfo text ' lock' doesn't match outer textInfo text 'Toggle input lock
```

### Description of user facing changes
N/A
### Description of development approach
This is caused by a bug (or peculiarity) of TextInfo implementation in PoEdit. It is using `ITextDocumentTextInfo` and when calling `.collapse(True)` in some cases it actually doesn't collapse to the very end. This seems to be happening when there is only a single line in the text box and when you expand to paragraph, it reports newline being the last character of that paragraph, however when collapsing to the end, it places textInfo right before that last newline character. This breaks my assumption that `collapse(True)` always collapses to the end.
In order to work around this peculiarity I created `TextInfo.getTextInfoForCodepointMovement()` method, which just returns a copy of current textInfo, except for overloaded implementation in `ITextDocumentTextInfo`, where it checks for collapse peculiarity, and, if detected, then trims that last fake newline character.

### Testing strategy:
Tested manually in PoEdit.
### Known issues with pull request:
N/A
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
