### PR TITLE
Normalize references to Insert keys

### DIFF
--- a/source/gui/startupDialogs.py
+++ b/source/gui/startupDialogs.py
@@ -35,7 +35,7 @@ class WelcomeDialog(
 		# Translators: The main message for the Welcome dialog when the user starts NVDA for the first time.
 		"Most commands for controlling NVDA require you to hold down"
 		" the NVDA key while pressing other keys.\n"
-		"By default, the numpad Insert and main Insert keys may both be used as the NVDA key.\n"
+		"By default, the Insert and numpad Insert keys may both be used as the NVDA key.\n"
 		"You can also configure NVDA to use the CapsLock as the NVDA key.\n"
 		"Press NVDA+n at any time to activate the NVDA menu.\n"
 		"From this menu, you can configure NVDA, get help, and access other NVDA functions."

--- a/tests/system/robot/startupShutdownNVDA.py
+++ b/tests/system/robot/startupShutdownNVDA.py
@@ -137,7 +137,7 @@ def read_welcome_dialog():
 		"\n".join([
 			(
 				"Welcome to NVDA  dialog  Welcome to NVDA! Most commands for controlling NVDA require you to hold "
-				"down the NVDA key while pressing other keys. By default, the numpad Insert and main Insert keys "
+				"down the NVDA key while pressing other keys. By default, the Insert and numpad Insert keys "
 				"may both be used as the NVDA key. You can also configure NVDA to use the Caps Lock as the NVDA "
 				"key. Press NVDA plus n at any time to activate the NVDA menu. From this menu, you can configure "
 				"NVDA, get help, and access other NVDA functions."

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -434,8 +434,8 @@ However, you can enable or disable the data gathering process manually in NVDA's
 Most NVDA-specific keyboard commands consist of pressing a particular key called the NVDA modifier key in conjunction with one or more other keys.
 Notable exceptions to this are the text review commands for the desktop keyboard layout which just use the numpad keys by themselves, but there are some other exceptions as well.
 
-NVDA can be configured so that the numpad Insert, Extended Insert and/or Caps Lock key can be used as the NVDA modifier key.
-By default, both the numpad Insert and Extended Insert keys are set as NVDA modifier keys.
+NVDA can be configured so that the Insert, numpad Insert, and/or Caps Lock key can be used as the NVDA modifier key.
+By default, both the Insert and numpad Insert keys are set as NVDA modifier keys.
 
 If you wish to cause one of the NVDA modifier keys to behave as it usually would if NVDA were not running (e.g. you wish to turn Caps Lock on when you have set Caps Lock to be an NVDA modifier key), you can press the key twice in quick succession.
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:

Fixes #13648 

### Summary of the issue:

The Welcome Screen and User Guide used different terms, "main Insert" and "Extended Insert" respectively, to refer to the same key.

### Description of user facing changes

Both the Welcome Screen and User Guide now call Extended/main Insert by simply "Insert."

### Description of development approach

Modified wording in userGuide and startupDialogs files, as well as the startup system test that checks the Welcome Screen text.

### Testing strategy:

Rebuilt NVDA with `scons source user_docs` and `scons dist` and checked both places where changes are made. Ran all system tests.

### Known issues with pull request:

* No translations of either the Welcome Screen or User Guide were updated.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

### Notes

Translations were not attempted, as I don't speak any other languages, and it looks to me like there are other people and processes to handle that. I am new to NVDA, though, so if I need to do anything to make that happen, or if I forgot anything or made any errors in the code or starting the PR, please let me know. Thank you in advance.