### PR TITLE
Fix routing to account for rawToContentPos

### DIFF
--- a/source/braille.py
+++ b/source/braille.py
@@ -1362,11 +1362,11 @@ class TextInfoRegion(Region):
 		else:
 			self._brailleInputIndStart = None
 
-	def getTextInfoForBraillePos(self, braillePos):
+	def getTextInfoForBraillePos(self, braillePos: int) -> textInfos.TextInfo:
+		"""Fetches a collapsed TextInfo at the specified braille position in the region."""
 		rawPos = self.brailleToRawPos[braillePos]
 		contentPos = self._rawToContentPos[rawPos]
-		useMoveToCodepointOffset = contentPos > 0
-		if useMoveToCodepointOffset:
+		if contentPos > 0:
 			# rawPos is relative to the start of the reading unit.
 			# Therefore, move rawPos code points from there.
 			# Note that, as liblouis uses 32 bit encoding internally,
@@ -1376,15 +1376,13 @@ class TextInfoRegion(Region):
 			except (ValueError, RuntimeError):
 				log.exception(
 					f"Error in moveToCodepointOffset with {rawPos} offsets, "
-					f"falling back to moving by {contentPos} characters"
+					f"falling back to moving by {contentPos} characters",
 				)
-				useMoveToCodepointOffset = False
-		if not useMoveToCodepointOffset:
-			dest = self._readingInfo.copy()
-			dest.collapse()
-			if contentPos > 0:
-				dest.move(textInfos.UNIT_CHARACTER, contentPos)
-			return dest
+		dest = self._readingInfo.copy()
+		dest.collapse()
+		if contentPos > 0:
+			dest.move(textInfos.UNIT_CHARACTER, contentPos)
+		return dest
 
 	def routeTo(self, braillePos: int):
 		if self._brailleInputIndStart is not None and self._brailleInputIndStart <= braillePos < self._brailleInputIndEnd:


### PR DESCRIPTION
### Link to issue number:
Fixup of #16477 

### Summary of the issue:
When writing #16477, I hadn't realized that `TextInfoRegion` compensated for characters that aren't part of the text info. This mapping is stored in the `_rawToContentPos` attribute. This compensation is necessary for character movement based routing, but not for code point offset based routing. The following would happen without this pr.

1. In Word, write a list item, e.g. `1. Hello`
2. Route to the fourth cell (offset 3)
3. The third raw position (h) would correspond with content position zero (1)
4. With `moveToCodepointOffset`, moving to offset 0 means moving to `1` not to `h`. Basically, the cursor would end up at the first cell, not at the fourth.

### Description of user facing changes
Routing works again in Word list items.

### Description of development approach
1. When using `moveToCodepointOffset`, move to the raw position, not to the actual content position. `moveToCodepointOffset` expects raw positions, not content positions.
2. Don't use `moveToCodepointOffset` when the content position is 0, since we can simply collapse the textInfo at the start of the reading unit and return that. Note that `moveToCodepointOffset` would fail for everything up to offset 3 anyway, since it wouldn't be able to move.

### Testing strategy:
Tested the steps to reproduce as mentioned above.

### Known issues with pull request:
None known

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
