### PR TITLE
Fix for dismiss braille message issue of remove redundant braille.BrailleHandler.update executions

### DIFF
--- a/source/braille.py
+++ b/source/braille.py
@@ -2591,6 +2591,8 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 			self.mainBuffer.update()
 			self.mainBuffer.restoreWindow()
 			if scrollTo is not None:
+				if self.buffer is self.messageBuffer:
+					self._dismissMessage(shouldUpdate=False)
 				self.scrollToCursorOrSelection(scrollTo)
 			elif self.buffer is self.mainBuffer:
 				self.update()


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
fixes #16463
### Summary of the issue:
Fix for issue of #16463
where braille message was not dismissed.
### Description of user facing changes
Braille message should be dismissed when moving cursor.
### Description of development approach
if buffer is message buffer `BrailleHandler._dismissMessage` is executed before `BrailleHandler.scrollToCursorOrSelection`.
### Testing strategy:
message dismissed
### Known issues with pull request:
none at this moment
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
