### PR TITLE
Update CLDR to version 45.0

### DIFF
--- a/projectDocs/dev/createDevEnvironment.md
+++ b/projectDocs/dev/createDevEnvironment.md
@@ -75,7 +75,7 @@ For reference, the following run time dependencies are included in Git submodule
 * [Sonic](https://github.com/waywardgeek/sonic), commit `8694c596378c24e340c09ff2cd47c065494233f1`
 * [IAccessible2](https://wiki.linuxfoundation.org/accessibility/iaccessible2/start), commit `3d8c7f0b833453f761ded6b12d8be431507bfe0b`
 * [liblouis](http://www.liblouis.io/), version 3.29.0
-* [Unicode Common Locale Data Repository (CLDR)](http://cldr.unicode.org/), version 44.0
+* [Unicode Common Locale Data Repository (CLDR)](http://cldr.unicode.org/), version 45.0
 * NVDA images and sounds
 * [Adobe Acrobat accessibility interface, version XI](https://download.macromedia.com/pub/developer/acrobat/AcrobatAccess.zip)
 * [Microsoft Detours](https://github.com/microsoft/Detours), commit `4b8c659f549b0ab21cf649377c7a84eb708f5e68`

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -11,6 +11,8 @@
 
 ### Changes
 
+* Component updates:
+  * Updated CLDR to version 45.0. (#16507, @OzancanKaratas)
 * The fallback braille input table is now equal to the fallback output table, which is Unified English Braille Code grade 1. (#9863, @JulienCochuyt, @LeonarddeR)
 * NVDA will now report figures with no accessible children, but with a label or description. (#14514)
 * When reading by line in browse mode, "caption" is no longer reported on each line of a long figure or table caption. (#14874)
@@ -96,7 +98,6 @@ There are many minor bug fixes for applications, such as Thunderbird, Adobe Read
   * The minimum and the last tested NVDA version for an add-on are now displayed in the "other details" area. (#15776, @Nael-Sayegh)
   * The community reviews action will be available, and the reviews webpage will be shown in the details panel, in all tabs of the store. (#16179, @nvdaes)
 * Component updates:
-  * Updated CLDR to 45.0. (#16507, @OzancanKaratas)
   * Updated LibLouis Braille translator to [3.29.0](https://github.com/liblouis/liblouis/releases/tag/v3.29.0). (#16259, @codeofdusk)
     * Added new detailed (with capital letters indicated) Belarusian and Ukrainian Braille tables, along with a Spanish table for reading Greek texts.
   * eSpeak NG has been updated to 1.52-dev commit `cb62d93fd7`. (#15913)

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -12,7 +12,7 @@
 ### Changes
 
 * Component updates:
-  * Updated CLDR to version 45.0. (#16507, @OzancanKaratas)
+  * Updated Unicode CLDR to version 45.0. (#16507, @OzancanKaratas)
 * The fallback braille input table is now equal to the fallback output table, which is Unified English Braille Code grade 1. (#9863, @JulienCochuyt, @LeonarddeR)
 * NVDA will now report figures with no accessible children, but with a label or description. (#14514)
 * When reading by line in browse mode, "caption" is no longer reported on each line of a long figure or table caption. (#14874)

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -96,6 +96,7 @@ There are many minor bug fixes for applications, such as Thunderbird, Adobe Read
   * The minimum and the last tested NVDA version for an add-on are now displayed in the "other details" area. (#15776, @Nael-Sayegh)
   * The community reviews action will be available, and the reviews webpage will be shown in the details panel, in all tabs of the store. (#16179, @nvdaes)
 * Component updates:
+  * Updated CLDR to 45.0. (#16507, @OzancanKaratas)
   * Updated LibLouis Braille translator to [3.29.0](https://github.com/liblouis/liblouis/releases/tag/v3.29.0). (#16259, @codeofdusk)
     * Added new detailed (with capital letters indicated) Belarusian and Ukrainian Braille tables, along with a Spanish table for reading Greek texts.
   * eSpeak NG has been updated to 1.52-dev commit `cb62d93fd7`. (#15913)


### PR DESCRIPTION
### Link to issue number:
None
### Summary of the issue:
The CLDR team has been released the 45.0 version of CLDR.
### Description of user facing changes
Maybe none or some symbols may have been changed.
### Description of development approach
None
### Testing strategy:
Daily usage is sufficient.
### Known issues with pull request:
None
### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.