### PR TITLE
revert 16463 and 16501

### DIFF
--- a/source/braille.py
+++ b/source/braille.py
@@ -2616,8 +2616,6 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 			self.mainBuffer.update()
 			self.mainBuffer.restoreWindow()
 			if scrollTo is not None:
-				if self.buffer is self.messageBuffer:
-					self._dismissMessage(shouldUpdate=False)
 				self.scrollToCursorOrSelection(scrollTo)
 			elif self.buffer is self.mainBuffer:
 				self.update()

--- a/source/braille.py
+++ b/source/braille.py
@@ -2560,9 +2560,8 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 		self.mainBuffer.update()
 		# Last region should receive focus.
 		self.mainBuffer.focus(region)
-		if isinstance(region, TextInfoRegion):
-			self.scrollToCursorOrSelection(region)
-		elif self.buffer is self.mainBuffer:
+		self.scrollToCursorOrSelection(region)
+		if self.buffer is self.mainBuffer:
 			self.update()
 		elif self.buffer is self.messageBuffer and keyboardHandler.keyCounter>self._keyCountForLastMessage:
 			self._dismissMessage()
@@ -2617,7 +2616,7 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 			self.mainBuffer.restoreWindow()
 			if scrollTo is not None:
 				self.scrollToCursorOrSelection(scrollTo)
-			elif self.buffer is self.mainBuffer:
+			if self.buffer is self.mainBuffer:
 				self.update()
 			elif (
 				self.buffer is self.messageBuffer


### PR DESCRIPTION
### Reverts PR
Reverts #16463 and #16501

### Issues fixed
<!-- Issues that will be closed by reverting, i.e. the issues introduced via the PR getting reverted  -->


### Issues reopened
<!-- Issues that will be re-opened by reverting, i.e. the issues that were fixed via the PR getting reverted  -->
Reopens #16456  

### Reason for revert
complexity
### Can this PR be reimplemented? If so, what is required for the next attempt
at least execution of `scrollToCursorOrSelection` in `_doNewObject`