### PR TITLE
Properly indicate wrapping of wx.CallAfter while monkeypatching

### DIFF
--- a/source/monkeyPatches/wxMonkeyPatches.py
+++ b/source/monkeyPatches/wxMonkeyPatches.py
@@ -5,12 +5,14 @@
 
 
 def apply(mainFrame, winUser, wx):
-	# In wxPython >= 4.1,
-	# wx.CallAfter no longer executes callbacks while NVDA's main thread is within a popup menu or message box.
-	# To work around this,
-	# MonkeyPatch wx.CallAfter to
-	# post a WM_NULL message to our top-level window after calling the original CallAfter,
-	# which causes wx's event loop to wake up enough to execute the callback.
+	"""Patch wx.CallAfter to overcome an execution timing issue.
+
+	In wxPython >= 4.1, wx.CallAfter no longer executes callbacks while NVDA's main thread is within
+	a popup menu or message box.
+	To work around this, monkeypatch wx.CallAfter to
+	post a WM_NULL message to our top-level window after calling the original CallAfter,
+	which causes wx's event loop to wake up enough to execute the callback.
+	"""
 	old_wx_CallAfter = wx.CallAfter
 
 	def wx_CallAfter_wrapper(func, *args, **kwargs):

--- a/source/monkeyPatches/wxMonkeyPatches.py
+++ b/source/monkeyPatches/wxMonkeyPatches.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2021 NV Access Limited
+# Copyright (C) 2021-2024 NV Access Limited
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 

--- a/source/monkeyPatches/wxMonkeyPatches.py
+++ b/source/monkeyPatches/wxMonkeyPatches.py
@@ -3,6 +3,7 @@
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
+from functools import wraps
 
 def apply(mainFrame, winUser, wx):
 	"""Patch wx.CallAfter to overcome an execution timing issue.
@@ -15,6 +16,7 @@ def apply(mainFrame, winUser, wx):
 	"""
 	old_wx_CallAfter = wx.CallAfter
 
+	@wraps(wx.CallAfter)
 	def wx_CallAfter_wrapper(func, *args, **kwargs):
 		old_wx_CallAfter(func, *args, **kwargs)
 		# mainFrame may be None as NVDA could be terminating.

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -37,6 +37,7 @@ It is especially useful to read the error location markers in tracebacks. (#1632
   * Table metadata can be added to an optional `brailleTables` section in the add-on manifest or to a `.ini` file with the same format found in the brailleTables subdirectory of the scratchpad directory.
   * Please consult the [braille translation tables section in the developer guide](https://www.nvaccess.org/files/nvda/documentation/developerGuide.html#BrailleTables) for more details.
 * When a `gainFocus` event is queued with an object that has a valid `focusRedirect` property, the object pointed to by the `focusRedirect` property is now held by `eventHandler.lastQueuedFocusObject`, rather than the originally queued object. (#15843)
+* `wx.CallAfter`, which is wrapped in `monkeyPatches/wxMonkeyPatches.py`, now includes proper `functools.wraps` indication. (#16520, @XLTechie)
 
 #### Deprecations
 


### PR DESCRIPTION
### Link to issue number:

None

### Summary of the issue:

The monkeypatch for `wx.CallAfter` didn't indicate wrapping.

```
>>> import wx
>>> help(wx.CallAfter)
Help on function wx_CallAfter_wrapper in module monkeyPatches.wxMonkeyPatches:

wx_CallAfter_wrapper(func, *args, **kwargs)
```

### Description of user facing changes

None

### Description of development approach

Imported wraps from functools, and added `@wraps` to the wrapper.
From a build after the modification:

```
>>> import wx
>>> help(wx.CallAfter)
Help on function CallAfter in module wx.core:

CallAfter(callableObj, *args, **kw)
    Call the specified function after the current and pending event
    handlers have been completed.  This is also good for making GUI
    method calls from non-GUI threads.  Any extra positional or
    keyword args are passed on to the callable when it is called.
```

Also converted the `apply()` function's comment into a docstring.

### Testing strategy:

Ran with the fix in a portable copy of NVDA.
I found no difficulties.

### Known issues with pull request:

I do not know what original STR prompted the wrapping of this callable. As far as I can tell, it was originally introduced in 528d5708aa13a0a384e, but there is no commit message for this change.

Did some issue/pr searches, but couldn't find any reasoning there either. So I don't know what caused the wrapping, to test that specifically. Do you remember, @michaelDCurran?

### Code Review Checklist:

- [X] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [X] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [X] API is compatible with existing add-ons.
- [X] Security precautions taken.
