### PR TITLE
Fix the CLI -h and --help switches

### DIFF
--- a/source/nvda.pyw
+++ b/source/nvda.pyw
@@ -139,8 +139,8 @@ parser.add_argument(
 	"--log-file",
 	dest="logFileName",
 	type=str,
-	help="The file where log messages should be written to. "
-	"Default destination is %TEMP%/nvda.log. "
+	help="The file to which log messages should be written. "
+	"Default destination is \"%%TEMP%%\\nvda.log\". "
 	"Logging is always disabled if secure mode is enabled. "
 )
 parser.add_argument(

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -89,6 +89,7 @@ There are many minor bug fixes for applications, such as Thunderbird, Adobe Read
 * Fixed a rare case when saving the configuration may fail to save all profiles. (#16343, @CyrilleB79)
 * In Firefox and Chromium-based browsers, NVDA will correctly enter focus mode when pressing enter when positioned within a presentational list (ul / ol) inside editable content. (#16325)
 * Column state change is automatically reported when selecting columns to display in Thunderbird message list. (#16323)
+* The commandline switches `-h` and `--help` work properly again.. (#16522, @XLTechie)
 
 ### Changes for Developers
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -89,7 +89,7 @@ There are many minor bug fixes for applications, such as Thunderbird, Adobe Read
 * Fixed a rare case when saving the configuration may fail to save all profiles. (#16343, @CyrilleB79)
 * In Firefox and Chromium-based browsers, NVDA will correctly enter focus mode when pressing enter when positioned within a presentational list (ul / ol) inside editable content. (#16325)
 * Column state change is automatically reported when selecting columns to display in Thunderbird message list. (#16323)
-* The commandline switches `-h` and `--help` work properly again.. (#16522, @XLTechie)
+* The command line switch `-h`/`--help` works properly again. (#16522, @XLTechie)
 
 ### Changes for Developers
 


### PR DESCRIPTION

### Link to issue number:

Closes #16522 

### Summary of the issue:

The commandline help switches `-h` and `--help` stopped working as of NVDA 2023.3.4.

### Description of user facing changes

`-h`, `--help` CLI flags work again.

### Description of development approach

The actual error was in `nvda.pyw`, line 143, where the log file destination was given as:
```
%TEMP%/nvda.log
```
This was introduced in 13978bc395.

Because `argparse` uses `%` characters to initiate escape sequences, this line was being interpreted as containing two escapes: "`%T`" and "`%/`", though the second one was never reached.

Changed:

1. The percent signs to double percent signs ("`%%`"), to prevent them being treated as escape sequences.
2. Changed the slash ("`/`"), to a Windows-appropriate backslash, properly escaped ("`\\`").
3. Quoted the whole string for display purposes, to separate it from the closing period of the sentence.
4. Fixed the grammar of the previous line.

### Testing strategy:

Ran the STR from the issue. Confirmed that the problem was no longer observed, and the help was properly rendered.

### Known issues with pull request:

None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
