### PR TITLE
Windows 11 clipboard history: redirect NVDA focus if Windows Input Experience window receives focus when clipboard history window closes

### DIFF
--- a/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
+++ b/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
@@ -330,6 +330,19 @@ class AppModule(appModuleHandler.AppModule):
 			displayString = obj.name
 		ui.message(displayString)
 
+	def event_gainFocus(self, obj: NVDAObject, nextHandler: Callable[[], None]):
+		# #16347: focus gets stuck in Modern keyboard when clipboard history closes in Windows 11.
+		if (
+			winVersion.getWinVer() >= winVersion.WIN11
+			and obj.firstChild
+			and obj.firstChild.UIAAutomationId == "Windows.Shell.InputApp.FloatingSuggestionUI"
+		):
+			# Do not queue events if events are pending, otherwise move to system focus.
+			if not eventHandler.isPendingEvents():
+				eventHandler.queueEvent("gainFocus", obj.objectWithFocus())
+			return
+		nextHandler()
+
 	def chooseNVDAObjectOverlayClasses(self, obj, clsList):
 		if isinstance(obj, UIA):
 			if obj.role == controlTypes.Role.LISTITEM and (

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -24,7 +24,7 @@
 * Improved reliability of automatic text readout, particularly in terminal applications. (#15850, #16027, @Danstiv)
 * Braille cursor routing is now much more reliable when a line contains one or more Unicode variation selectors or decomposed characters. (#10960, #16477, @mltony, @LeonarddeR)
 * NVDA will correctly announce selection changes when editing a cell's text in Microsoft Excel. (#15843)
-* In Windows 11 emoji panel, NVDA will no longer appear to get stuck when closing clipboard history. (#16347, @josephsl)`
+* In Windows 11 emoji panel, NVDA will no longer appear to get stuck when closing clipboard history. (#16347, @josephsl)
 
 ### Changes for Developers
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -24,6 +24,7 @@
 * Improved reliability of automatic text readout, particularly in terminal applications. (#15850, #16027, @Danstiv)
 * Braille cursor routing is now much more reliable when a line contains one or more Unicode variation selectors or decomposed characters. (#10960, #16477, @mltony, @LeonarddeR)
 * NVDA will correctly announce selection changes when editing a cell's text in Microsoft Excel. (#15843)
+* In Windows 11 emoji panel, NVDA will no longer appear to get stuck when closing clipboard history. (#16347, @josephsl)`
 
 ### Changes for Developers
 


### PR DESCRIPTION

### Link to issue number:
Closes #16347 

### Summary of the issue:
In Windows 11, Windows Input Experience window receives focus when clipboard history closes.

### Description of user facing changes
NVDA will no longer appear to get stuck when closing Windows 11 clipboard history.

### Description of development approach
In emoji panel app module, added again focus event handler that will check if Windows Input Experience window receives focus in Windows 11, and if yes and if no events are pending, will queue gain focus on system focus control (obj.objectWithFocus()).

### Testing strategy:
Manual testing: in Windows 11, open clipboard history, then press Escape to close it.

### Known issues with pull request:
This is raised when 32-bit AccEvent is run but not while using 64-bit AccEvent, so this issue should be revisited as part of #16304. For now, the PR works.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
