### PR TITLE
Ensure scons source isn't obfuscated by liblouis test tables target

### DIFF
--- a/nvdaHelper/liblouis/sconscript
+++ b/nvdaHelper/liblouis/sconscript
@@ -111,5 +111,5 @@ env.Depends(testTable, env.Install(unitTestTablesDir, [
 	louisTableDir.File("latinLetterDef8Dots.uti"),
 	louisTableDir.File("en-us-comp8-ext.utb")
 ]))
-# Ensure the braille tables for tests are installed with scons source
-env.Alias("source", testTable)
+# Ensure the braille tables for tests are installed when copying the louis wrapper
+env.Depends(louisPython, testTable)


### PR DESCRIPTION
### Link to issue number:
Fixes #16535 
Fixup of #16208

### Summary of the issue:
#16208 introduced test tables SCons didn't want to copy to the test directory by default. I tried to fix that by binding testTable to the source target with env.Alias, but that's definitely the wrong way.

### Description of user facing changes
Fixed build system.

### Description of development approach
Added the test tables as a dependency to the liblouis python wrapper. This ensures that test tables will be there when the python wrapper is build.

### Testing strategy:
Removed `tests/unit/brailleTables` and ensured they were copied properly.

### Known issues with pull request:
None known

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
