### PR TITLE
Windows 11 IME: announce visible candidates when the IME interface opens

### DIFF
--- a/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
+++ b/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
@@ -93,14 +93,6 @@ class ImeCandidateItem(CandidateItemBehavior, UIA):
 		return super(ImeCandidateItem, self).name
 
 	def event_UIA_elementSelected(self):
-		# In Windows 11, focus event is fired when a candidate item receives focus,
-		# therefore ignore this event for now.
-		# #16283: do handle hardware keyboard input suggestions.
-		if (
-			winVersion.getWinVer() >= winVersion.WIN11
-			and isinstance(api.getFocusObject().parent, ImeCandidateUI)
-		):
-			return
 		oldNav = api.getNavigatorObject()
 		if isinstance(oldNav, ImeCandidateItem) and self.name == oldNav.name:
 			# Duplicate selection event fired on the candidate item. Ignore it.
@@ -116,6 +108,14 @@ class ImeCandidateItem(CandidateItemBehavior, UIA):
 				self.appModule._lastImeCandidateVisibleText = newText
 				# speak the new page
 				ui.message(newText)
+		# In Windows 11, focus event is fired when a candidate item receives focus,
+		# therefore ignore this event for now.
+		# #16283: do handle hardware keyboard input suggestions.
+		if (
+			winVersion.getWinVer() >= winVersion.WIN11
+			and isinstance(api.getFocusObject().parent, ImeCandidateUI)
+		):
+			return
 		# Now just report the currently selected candidate item.
 		self.reportFocus()
 

--- a/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
+++ b/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
@@ -50,7 +50,6 @@ class ImeCandidateUI(UIA):
 			candidateItem = self.firstChild.firstChild
 			eventHandler.queueEvent("UIA_elementSelected", candidateItem)
 
-
 	def event_focusEntered(self):
 		# #14023: announce visible IME candidates.
 		if (

--- a/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
+++ b/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
@@ -51,6 +51,15 @@ class ImeCandidateUI(UIA):
 			eventHandler.queueEvent("UIA_elementSelected", candidateItem)
 
 
+	def event_focusEntered(self):
+		# #14023: announce visible IME candidates.
+		if (
+			self.parent.UIAAutomationId == "IME_Candidate_Window"
+			and config.conf["inputComposition"]["autoReportAllCandidates"]
+		):
+			ui.message(self.firstChild.visibleCandidateItemsText)
+
+
 class ImeCandidateItem(CandidateItemBehavior, UIA):
 	"""
 	A UIAutomation-based IME candidate Item (such as for  the modern Chinese Microsoft Quick input).

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -24,8 +24,9 @@
 * Improved reliability of automatic text readout, particularly in terminal applications. (#15850, #16027, @Danstiv)
 * Braille cursor routing is now much more reliable when a line contains one or more Unicode variation selectors or decomposed characters. (#10960, #16477, @mltony, @LeonarddeR)
 * NVDA will correctly announce selection changes when editing a cell's text in Microsoft Excel. (#15843)
-* In Windows 11 emoji panel, NVDA will no longer appear to get stuck when closing clipboard history. (#16347, @josephsl)
-* NVDA will once again announce visible candidates when opening Windows 11 IME interface. (#14023, @josephsl)
+* Windows 11 fixes:
+  * In emoji panel, NVDA will no longer appear to get stuck when closing clipboard history. (#16347, @josephsl)
+  * NVDA will once again announce visible candidates when opening Windows 11 IME interface. (#14023, @josephsl)
 
 ### Changes for Developers
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -25,6 +25,7 @@
 * Braille cursor routing is now much more reliable when a line contains one or more Unicode variation selectors or decomposed characters. (#10960, #16477, @mltony, @LeonarddeR)
 * NVDA will correctly announce selection changes when editing a cell's text in Microsoft Excel. (#15843)
 * In Windows 11 emoji panel, NVDA will no longer appear to get stuck when closing clipboard history. (#16347, @josephsl)
+* NVDA will once again announce visible candidates when opening Windows 11 IME interface. (#14023, @josephsl)
 
 ### Changes for Developers
 


### PR DESCRIPTION

### Link to issue number:
Closes #14023

### Summary of the issue:
NVDA does not announce visible IME candidates in Windows 11.

### Description of user facing changes
NVDA wil once again announce visible IME candidates when Windows 11 modern IME interface opens.

### Description of development approach
Modern keyboard app module changes:

* IME candidate UI lass: handle focus entered evdent, announcing visible candidates when IME interface opens.
* IME candidate item: move Windows 11/Automation Id check to the end of the element selected event handler just before self.reportFocus() call so visible candidates can be anounced when switching between IME pages.

### Testing strategy:
Manual testing (requires presence of IME interface language(s) such as Chinese, Japanese, and Korean):

1. In Windows 11, switch input language to a language offering IME interface.
2. Switch to native keyboard input mode.
3. Type something in the native language.
4. Press a key to open IME interface (in Korean, this is right Control key)
5. Optional: move through the IME candidates, switching between multiple pages.

### Known issues with pull request:
Visible IME candidates could be announced twice when the IME interface first opens - this is because element selected event is fired prior to focus entered/gain focus event. Thankfully, the app module holds visible candidates for the first page, so IME candidates list will not be repeated if the candidates list are the same. Also, if the visible IME candidates are less than 9, NVDA will just announce candidate number instead of entries (perhaps this could be a separate issue).

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
