### PR TITLE
Windows 11 emoji panel/navigation menu item: handle UIA elemenet selected event by ignoring it or manipulating NVDA's focus object

### DIFF
--- a/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
+++ b/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
@@ -142,6 +142,8 @@ class NavigationMenuItem(ListItem):
 		if (
 			# #16346: system focus restored.
 			(focus := api.getFocusObject()).appModule != self.appModule
+			# #16532: repeat announcement due to pending gain focus event on category entries.
+			or eventHandler.isPendingEvents("gainFocus")
 		):
 			return
 		# Manipulate NVDA's focus object.

--- a/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
+++ b/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
@@ -136,7 +136,14 @@ class NavigationMenuItem(ListItem):
 	In addition to the choices above, Windows 11 adds GIF and clipboard history to navigation menu.
 	"""
 
-	pass
+	def event_UIA_elementSelected(self):
+		# Workarounds for Windows 11 emoji panel category items.
+		# Ignore the event altogether.
+		if (
+			# #16346: system focus restored.
+			(focus := api.getFocusObject()).appModule != self.appModule
+		):
+			return
 
 
 class AppModule(appModuleHandler.AppModule):

--- a/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
+++ b/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
@@ -149,9 +149,14 @@ class AppModule(appModuleHandler.AppModule):
 	disableBrowseModeByDefault: bool = True
 
 	def event_UIA_elementSelected(self, obj, nextHandler):
-		# Logic for IME candidate items is handled all within its own object
+		# Logic for the following items is handled by overlay classes
 		# Therefore pass these events straight on.
-		if isinstance(obj, ImeCandidateItem):
+		if isinstance(
+			obj, (
+				ImeCandidateItem,  # IME candidate items
+				NavigationMenuItem  # Windows 11 emoji panel navigation menu items
+			)
+		):
 			return nextHandler()
 		# #7273: When this is fired on categories,
 		# the first emoji from the new category is selected but not announced.

--- a/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
+++ b/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
@@ -144,6 +144,8 @@ class NavigationMenuItem(ListItem):
 			(focus := api.getFocusObject()).appModule != self.appModule
 			# #16532: repeat announcement due to pending gain focus event on category entries.
 			or eventHandler.isPendingEvents("gainFocus")
+			# #16533: system focus is located in GIF/kaomoji/symbol entry.
+			or focus.UIAAutomationId.startswith("item-")
 		):
 			return
 		# Manipulate NVDA's focus object.

--- a/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
+++ b/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
@@ -20,7 +20,7 @@ import ui
 import config
 import winVersion
 import controlTypes
-from NVDAObjects.UIA import UIA, XamlEditableText
+from NVDAObjects.UIA import UIA, XamlEditableText, ListItem
 from NVDAObjects.behaviors import CandidateItem as CandidateItemBehavior, EditableTextWithAutoSelectDetection
 from NVDAObjects import NVDAObject
 
@@ -126,6 +126,17 @@ class ImeCandidateItem(CandidateItemBehavior, UIA):
 			return
 		# Now just report the currently selected candidate item.
 		self.reportFocus()
+
+
+class NavigationMenuItem(ListItem):
+	"""
+	A Windows 11 emoji panel navigation menu item.
+	In Windows 10 Version 1903 and later, emoji panel can be used to insert emojis, kaomojis, and symbols.
+	System focus cannot move to these choices in Windows 10 but can do so in Windows 11.
+	In addition to the choices above, Windows 11 adds GIF and clipboard history to navigation menu.
+	"""
+
+	pass
 
 
 class AppModule(appModuleHandler.AppModule):

--- a/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
+++ b/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
@@ -408,7 +408,7 @@ class AppModule(appModuleHandler.AppModule):
 					)
 				):
 					clsList.insert(0, ImeCandidateItem)
-				elif obj.UIAAutomationId.startswith("navigation-menu-item")
+				elif obj.UIAAutomationId.startswith("navigation-menu-item"):
 					clsList.insert(0, NavigationMenuItem)
 			elif (
 				obj.role in (controlTypes.Role.PANE, controlTypes.Role.LIST, controlTypes.Role.POPUPMENU)

--- a/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
+++ b/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
@@ -144,6 +144,13 @@ class NavigationMenuItem(ListItem):
 			(focus := api.getFocusObject()).appModule != self.appModule
 		):
 			return
+		# Manipulate NVDA's focus object.
+		if (
+			# #16346: NVDA is stuck in a nonexistent edit field (location is None).
+			not any(focus.location)
+		):
+			eventHandler.queueEvent("gainFocus", self.objectWithFocus())
+			return
 		# Report the selected navigation menu item.
 		super().event_UIA_elementSelected()
 

--- a/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
+++ b/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
@@ -136,7 +136,7 @@ class NavigationMenuItem(ListItem):
 	In addition to the choices above, Windows 11 adds GIF and clipboard history to navigation menu.
 	"""
 
-	def event_UIA_elementSelected(self):
+	def event_UIA_elementSelected(self) -> None:
 		# Workarounds for Windows 11 emoji panel category items.
 		# Ignore the event altogether.
 		if (

--- a/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
+++ b/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
@@ -152,6 +152,9 @@ class NavigationMenuItem(ListItem):
 		if (
 			# #16346: NVDA is stuck in a nonexistent edit field (location is None).
 			not any(focus.location)
+			# #16347: focus is once again stuck in top-level modern keyboard window
+			# after switching to clipboard history from other emoji panel screens.
+			or focus.firstChild and focus.firstChild.UIAAutomationId == "Windows.Shell.InputApp.FloatingSuggestionUI"
 		):
 			eventHandler.queueEvent("gainFocus", self.objectWithFocus())
 			return

--- a/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
+++ b/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
@@ -364,21 +364,24 @@ class AppModule(appModuleHandler.AppModule):
 
 	def chooseNVDAObjectOverlayClasses(self, obj, clsList):
 		if isinstance(obj, UIA):
-			if obj.role == controlTypes.Role.LISTITEM and (
-				(
-					obj.parent.UIAAutomationId in (
-						"ExpandedCandidateList",
-						"TEMPLATE_PART_AdaptiveSuggestionList",
+			if obj.role == controlTypes.Role.LISTITEM:
+				if (
+					(
+						obj.parent.UIAAutomationId in (
+							"ExpandedCandidateList",
+							"TEMPLATE_PART_AdaptiveSuggestionList",
+						)
+						and obj.parent.parent.UIAAutomationId == "IME_Candidate_Window"
 					)
-					and obj.parent.parent.UIAAutomationId == "IME_Candidate_Window"
-				)
-				or obj.parent.UIAAutomationId in (
-					"IME_Candidate_Window",
-					"IME_Prediction_Window",
-					"TEMPLATE_PART_CandidatePanel",
-				)
-			):
-				clsList.insert(0, ImeCandidateItem)
+					or obj.parent.UIAAutomationId in (
+						"IME_Candidate_Window",
+						"IME_Prediction_Window",
+						"TEMPLATE_PART_CandidatePanel",
+					)
+				):
+					clsList.insert(0, ImeCandidateItem)
+				elif obj.UIAAutomationId.startswith("navigation-menu-item")
+					clsList.insert(0, NavigationMenuItem)
 			elif (
 				obj.role in (controlTypes.Role.PANE, controlTypes.Role.LIST, controlTypes.Role.POPUPMENU)
 				and obj.UIAAutomationId in (

--- a/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
+++ b/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
@@ -144,6 +144,8 @@ class NavigationMenuItem(ListItem):
 			(focus := api.getFocusObject()).appModule != self.appModule
 		):
 			return
+		# Report the selected navigation menu item.
+		super().event_UIA_elementSelected()
 
 
 class AppModule(appModuleHandler.AppModule):

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -24,8 +24,10 @@
 * Improved reliability of automatic text readout, particularly in terminal applications. (#15850, #16027, @Danstiv)
 * NVDA will correctly announce selection changes when editing a cell's text in Microsoft Excel. (#15843)
 * Windows 11 fixes:
-  * In emoji panel, NVDA will no longer appear to get stuck when closing clipboard history. (#16347, @josephsl)
+  * In emoji panel, NVDA will no longer appear to get stuck when closing clipboard history and emoji panel. (#16346, #16347, @josephsl)
   * NVDA will once again announce visible candidates when opening Windows 11 IME interface. (#14023, @josephsl)
+  * NVDA will no longer announce "clipboard history" twice when reviewing emoji panel navigation menu items. (#16532, @josephsl)
+  * NVDA will no longer cut off speech and braille while reviewing kaomojis and symbols in emoji panel. (#16533, @josephsl)
 
 ### Changes for Developers
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -24,10 +24,10 @@
 * Improved reliability of automatic text readout, particularly in terminal applications. (#15850, #16027, @Danstiv)
 * NVDA will correctly announce selection changes when editing a cell's text in Microsoft Excel. (#15843)
 * Windows 11 fixes:
-  * In emoji panel, NVDA will no longer appear to get stuck when closing clipboard history and emoji panel. (#16346, #16347, @josephsl)
-  * NVDA will once again announce visible candidates when opening Windows 11 IME interface. (#14023, @josephsl)
-  * NVDA will no longer announce "clipboard history" twice when reviewing emoji panel navigation menu items. (#16532, @josephsl)
-  * NVDA will no longer cut off speech and braille while reviewing kaomojis and symbols in emoji panel. (#16533, @josephsl)
+  * NVDA will no longer appear to get stuck when closing the clipboard history and emoji panel. (#16346, #16347, @josephsl)
+  * NVDA will announce visible candidates again when opening the Windows 11 IME interface. (#14023, @josephsl)
+  * NVDA will no longer announce "clipboard history" twice when navigating through the emoji panel menu items. (#16532, @josephsl)
+  * NVDA will no longer cut off speech and braille when reviewing kaomojis and symbols in the emoji panel. (#16533, @josephsl)
 
 ### Changes for Developers
 


### PR DESCRIPTION

### Link to issue number:
Closes #16346 
Closes #16532 
Closes #16533 
Follow-up to #16347 

### Summary of the issue:
NVDA cuts off speech, repeats items, and does not report system focus upon closing emji panel when handling element selected event in Windows 11 emoji panel's navigation menu items.

### Description of user facing changes
NVDA will:

* No longer cut off speech when reviewing kaomojis and symbols in fullscreen
* Nl longer announce "clipboard history" twice when reviewing amoji panel categories
* No longer get stuck in emoji panel items when the panel closes

### Description of development approach
A dedicated overlay class was added for Windows 11 emoji panel navigation menu items along with UIA element selected event for them that does the following:

* Ignores the event when the panel closes, system focus moves to menu items, and while kaomojis and symbols are shown on screen
* Sets NVDA focus to system focus when emoji panel closes and NVDA finds itself stuck in emoji panel main window.

### Testing strategy:
Manual testing: see #16346, #16532, and #16533. Specifically, test to make sure that NVDA is no longer announcing "clipboard history" twice while navigating parts of the emoji panel and speech is no longer cut off while reviewing kaomojis and symbols.

### Known issues with pull request:
This PR may not cover all the cases of element selected event mishap, but it covers most noticeable cases.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced `NavigationMenuItem` for better navigation in the Windows 11 emoji panel.

- **Bug Fixes**
  - Enhanced NVDA's behavior with the Windows 11 emoji panel and clipboard history.
  - Improved text readout reliability in terminal applications and Excel cell editing announcements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->