### PR TITLE
Fix logic error in display tracking

### DIFF
--- a/source/winAPI/_displayTracking.py
+++ b/source/winAPI/_displayTracking.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2022 NV Access Limited
+# Copyright (C) 2022–2024 NV Access Limited, Bill Dengler
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -64,7 +64,7 @@ def getPrimaryDisplayOrientation() -> OrientationState:
 	return OrientationState(
 		width,
 		height,
-		_getOrientationStyle(width, height)
+		_getOrientationStyle(width=width, height=height)
 	)
 
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
None

### Summary of the issue:
On my machine (set to 1080p), after a while, NVDA repeatedly says "lanscape". In the Python console, I get:

``` python console
>>> _displayTracking.getPrimaryDisplayOrientation()
OrientationState(width=1920, height=1080, style=<Orientation.PORTRAIT: 1>)
```

However, since 1920 is greater than 1080, `getPrimaryDisplayOrientation().style` should be `Orientation.LANDSCAPE`.

### Description of how this pull request fixes the issue:
Declare parameter names in the call to `_getOrientationStyle`.

### Testing strategy:
Alpha testing

### Known issues with pull request:
None known

### Change log entry:
None needed

### Code Review Checklist:
<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
