### PR TITLE
Fix reading the last empty line of a text in apps using Java Access Bridge

### DIFF
--- a/source/NVDAObjects/JAB/__init__.py
+++ b/source/NVDAObjects/JAB/__init__.py
@@ -173,8 +173,11 @@ class JABTextInfo(textInfos.offsets.OffsetsTextInfo):
 		if end==-1 and offset>0:
 			# #1892: JAB returns -1 for the end insertion position
 			# instead of returning the offsets for the last line.
-			# Try one character back.
-			(start,end)=self.obj.jabContext.getAccessibleTextLineBounds(offset-1)
+			# Try one character back, unless we're on a new line.
+			if self.obj.jabContext.getAccessibleTextRange(offset - 1, offset - 1) != "\n":
+				(start, end) = self.obj.jabContext.getAccessibleTextLineBounds(offset - 1)
+			else:
+				(start, end) = (offset, offset)
 		#Java gives end as the last character, not one past the last character
 		end=end+1
 		return (start,end)

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -28,6 +28,7 @@
   * NVDA will announce visible candidates again when opening the Windows 11 IME interface. (#14023, @josephsl)
   * NVDA will no longer announce "clipboard history" twice when navigating through the emoji panel menu items. (#16532, @josephsl)
   * NVDA will no longer cut off speech and braille when reviewing kaomojis and symbols in the emoji panel. (#16533, @josephsl)
+* In applications using Java Access Bridge, NVDA will now correctly read the last blank line of a text instead of repeating the previous line. (#9376, @dmitrii-drobotov)
 
 ### Changes for Developers
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:

Fixes #9376.

### Summary of the issue:

In applications using Java Access Bridge, if the last line of a text is an empty line, then NVDA reads the previous line as the last line.

### Description of user facing changes

NVDA will now correctly read the last empty line as "blank".
For example, here is NVDA output (with Speak command keys turned on) for the following text in a Java Swing text area:
```
1
2
3

```

#### Before changes

>edit  multi line  1
>down arrow
>2
>down arrow
>3
>down arrow
>3


#### After changes

>edit  multi line  1
>down arrow
>2
>down arrow
>3
>down arrow
>blank


### Description of development approach

The issue is related to fixes of #1892 in https://github.com/nvaccess/nvda/commit/7ef99c3d37486a50ed32c383d1805e2dbd6dd7f3, which work around the line bounds returned by JAB for the last character of a text. Specifically, the current behavior is to get the line bounds of the previous character, which works well for single-line text inputs. But if the text is multi-line, and we're on the last empty line, then getting the line bounds of the previous character results in repeating the penultimate line.

The fix is to separately handle the case of empty last line, which is determined by having "\n" as the previous character.

### Testing strategy:
Tested manually in a simple Swing app, and in IntelliJ-based IDEs (PyCharm, Android Studio, etc.). Also tested the case from #1892, which didn't regress.

### Known issues with pull request:
None.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
