### PR TITLE
Disable style navigation in Outlook and non-UIA word (duplicate)

### DIFF
--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -2370,7 +2370,7 @@ class BrowseModeDocumentTreeInterceptor(documentBase.DocumentWithTableNavigation
 		from NVDAObjects.window.winword import BrowseModeWordDocumentTextInfo
 		if isinstance(pos, BrowseModeWordDocumentTextInfo):
 			raise NotImplementedError(
-				"non-UIA word textInfos is not supported due to multiple issues with them - #16569"
+				"non-UIA word textInfos are not supported due to multiple issues with them - #16569"
 			)
 		from appModules.outlook import OutlookUIAWordDocument
 		if isinstance(api.getFocusObject(), OutlookUIAWordDocument):

--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -2367,6 +2367,14 @@ class BrowseModeDocumentTreeInterceptor(documentBase.DocumentWithTableNavigation
 			direction: documentBase._Movement = documentBase._Movement.NEXT,
 			pos: textInfos.TextInfo | None = None
 	) -> Generator[TextInfoQuickNavItem, None, None]:
+		from NVDAObjects.window.winword import BrowseModeWordDocumentTextInfo
+		if isinstance(pos, BrowseModeWordDocumentTextInfo):
+			raise NotImplementedError(
+				"We don't support non-UIA word textInfos due to multiple issues with textInfo implementation "
+			)
+		from appModules.outlook import OutlookUIAWordDocument
+		if isinstance(api.getFocusObject(), OutlookUIAWordDocument):
+			raise NotImplementedError("We don't support Outlook due to its slowness")
 		if direction not in [
 			documentBase._Movement.NEXT,
 			documentBase._Movement.PREVIOUS,

--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -2370,11 +2370,11 @@ class BrowseModeDocumentTreeInterceptor(documentBase.DocumentWithTableNavigation
 		from NVDAObjects.window.winword import BrowseModeWordDocumentTextInfo
 		if isinstance(pos, BrowseModeWordDocumentTextInfo):
 			raise NotImplementedError(
-				"We don't support non-UIA word textInfos due to multiple issues with textInfo implementation - #16569"
+				"non-UIA word textInfos is not supported due to multiple issues with them - #16569"
 			)
 		from appModules.outlook import OutlookUIAWordDocument
 		if isinstance(api.getFocusObject(), OutlookUIAWordDocument):
-			raise NotImplementedError("We don't support Outlook due to its slowness - #16408")
+			raise NotImplementedError("Outlook is not supported due to performance - #16408")
 		if direction not in [
 			documentBase._Movement.NEXT,
 			documentBase._Movement.PREVIOUS,

--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -2370,11 +2370,11 @@ class BrowseModeDocumentTreeInterceptor(documentBase.DocumentWithTableNavigation
 		from NVDAObjects.window.winword import BrowseModeWordDocumentTextInfo
 		if isinstance(pos, BrowseModeWordDocumentTextInfo):
 			raise NotImplementedError(
-				"We don't support non-UIA word textInfos due to multiple issues with textInfo implementation "
+				"We don't support non-UIA word textInfos due to multiple issues with textInfo implementation - #16569"
 			)
 		from appModules.outlook import OutlookUIAWordDocument
 		if isinstance(api.getFocusObject(), OutlookUIAWordDocument):
-			raise NotImplementedError("We don't support Outlook due to its slowness")
+			raise NotImplementedError("We don't support Outlook due to its slowness - #16408")
 		if direction not in [
 			documentBase._Movement.NEXT,
 			documentBase._Movement.PREVIOUS,


### PR DESCRIPTION
Note: this PR is a duplicate of #16543 that appears to have merged as status due to github glitch. Recreating as requested.

### Link to issue number:
Closes #16459
Closes #16408
Closes #16458
Closes #16405

### Summary of the issue:
We have discovered multiple problemds with non-UIA textInfo implementation in MS Word. Some examples are #16527, #16459, #16458. Also TextInfo implenetation in Outlook has proven to be too slow for style navigation. Therefore disabling both.
### Description of user facing changes
"Not supported in this document" message is spoken.
### Description of development approach
Raising an error when Outlook or non-UIA Word is detected.
### Testing strategy:
Manual
### Known issues with pull request:
N/A
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
