### PR TITLE
Disable vertical, style and text QuickNav commands in Kindle

### DIFF
--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -2338,6 +2338,9 @@ class BrowseModeDocumentTreeInterceptor(documentBase.DocumentWithTableNavigation
 			paragraph: textInfos.TextInfo,
 			direction: documentBase._Movement,
 	) -> bool:
+		from appModules.kindle import BookPageViewTreeInterceptor
+		if isinstance(paragraph._obj(), BookPageViewTreeInterceptor):
+			raise NotImplementedError("Kindle textInfo implementation is broken and doesn't support this - #16570")
 		oldParagraph = paragraph.copy()
 		if direction == documentBase._Movement.NEXT:
 			try:


### PR DESCRIPTION
### Link to issue number:
Closes #16559
Closes #16558
### Summary of the issue:
Fancy QuickNav commands (style navigation, text navigation, vertical navigation) don't work correctly in Kindle desktop app. 
### Description of user facing changes
Fancy quickNav commands will be disabled in Kindle.
### Description of development approach
Throwing a `NotImplementedException`.
### Testing strategy:
Manual
### Known issues with pull request:
N/A
### More details
Root cause issue: #16570
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- x ] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
