### PR TITLE
Fix up for numbered headings for Western Arabic

### DIFF
--- a/user_docs/numberedHeadings.css
+++ b/user_docs/numberedHeadings.css
@@ -171,21 +171,21 @@ h6:before {
 /* Western Arabic */
 
 :lang(ar) h2:before {
-  content: counter(h2counter, arabic-indic) ". ";
+  content: counter(h2counter) ". ";
 }
 
 :lang(ar) h3:before {
-  content: counter(h2counter, arabic-indic) "." counter(h3counter, arabic-indic) ". ";
+  content: counter(h2counter) "." counter(h3counter) ". ";
 }
 
 :lang(ar) h4:before {
-  content: counter(h2counter, arabic-indic) "."  counter(h3counter, arabic-indic) "." counter(h4counter, arabic-indic) ". ";
+  content: counter(h2counter) "."  counter(h3counter) "." counter(h4counter) ". ";
 }
 
 :lang(ar) h5:before {
-  content: counter(h2counter, arabic-indic) "." counter(h3counter, arabic-indic) "."  counter(h4counter, arabic-indic) "." counter(h5counter, arabic-indic) ". ";
+  content: counter(h2counter) "." counter(h3counter) "."  counter(h4counter) "." counter(h5counter) ". ";
 }
 
 :lang(ar) h6:before {
-  content: counter(h2counter, arabic-indic) "." counter(h3counter, arabic-indic) "." counter(h4counter, arabic-indic) "."  counter(h5counter, arabic-indic) "." counter(h6counter, arabic-indic) ". ";
+  content: counter(h2counter) "." counter(h3counter) "." counter(h4counter) "."  counter(h5counter) "." counter(h6counter) ". ";
 }

--- a/user_docs/numberedHeadings.css
+++ b/user_docs/numberedHeadings.css
@@ -147,23 +147,45 @@ h6:before {
   content: counter(h2counter) "." counter(h3counter) "." counter(h4counter) "." counter(h5counter) "." counter(h6counter) ". ";
 }
 
-/* RTL */
-:lang(ar) h2:before, :lang(fa) h2:before {
+/* Eastern Arabic */
+:lang(fa) h2:before {
   content: counter(h2counter, arabic-indic) ". ";
 }
 
-:lang(ar) h3:before, :lang(fa) h3:before {
+:lang(fa) h3:before {
   content: counter(h3counter, arabic-indic) "." counter(h2counter, arabic-indic) ". ";
 }
 
-:lang(ar) h4:before, :lang(fa) h4:before {
+:lang(fa) h4:before {
   content: counter(h4counter, arabic-indic) "."  counter(h3counter, arabic-indic) "." counter(h2counter, arabic-indic) ". ";
 }
 
-:lang(ar) h5:before, :lang(fa) h5:before {
+:lang(fa) h5:before {
   content: counter(h5counter, arabic-indic) "." counter(h4counter, arabic-indic) "."  counter(h3counter, arabic-indic) "." counter(h2counter, arabic-indic) ". ";
 }
 
-:lang(ar) h6:before, :lang(fa) h6:before {
+:lang(fa) h6:before {
   content: counter(h6counter, arabic-indic) "." counter(h5counter, arabic-indic) "." counter(h4counter, arabic-indic) "."  counter(h3counter, arabic-indic) "." counter(h2counter, arabic-indic) ". ";
+}
+
+/* Western Arabic */
+
+:lang(ar) h2:before {
+  content: counter(h2counter, arabic-indic) ". ";
+}
+
+:lang(ar) h3:before {
+  content: counter(h2counter, arabic-indic) "." counter(h3counter, arabic-indic) ". ";
+}
+
+:lang(ar) h4:before {
+  content: counter(h2counter, arabic-indic) "."  counter(h3counter, arabic-indic) "." counter(h4counter, arabic-indic) ". ";
+}
+
+:lang(ar) h5:before {
+  content: counter(h2counter, arabic-indic) "." counter(h3counter, arabic-indic) "."  counter(h4counter, arabic-indic) "." counter(h5counter, arabic-indic) ". ";
+}
+
+:lang(ar) h6:before {
+  content: counter(h2counter, arabic-indic) "." counter(h3counter, arabic-indic) "." counter(h4counter, arabic-indic) "."  counter(h5counter, arabic-indic) "." counter(h6counter, arabic-indic) ". ";
 }


### PR DESCRIPTION

### Link to issue number:
Fixup of #16425
Discussed here: https://groups.io/g/nvda-translations/message/3819

### Summary of the issue:
In [2023.2, the user guide](https://www.nvaccess.org/files/nvda/releases/2023.3/documentation/ar/userGuide.html) heading numbering for the Arabic translation switched to using Western Arabic numbering.
[2024.1](https://www.nvaccess.org/files/nvda/releases/2024.1/documentation/ar/userGuide.html) mistakenly switched this back to Eastern Arabic numbering.
In #16425, the headers in the table of contents were fixed for Western Arabic, but not in the body.

### Description of user facing changes
Restore Western Arabic numbering style for headings in the body of the document

### Description of development approach
Updated CSS to reflect Western Arabic numbering style i.e. `.1.2.3`, `.1.2.4`

### Testing strategy:
Compared:
- https://www.nvaccess.org/files/nvda/releases/2024.1/documentation/ar/userGuide.html
- https://www.nvaccess.org/files/nvda/releases/2023.3/documentation/ar/userGuide.html
- Checked generated Arabic and Persian documentation with new CSS: https://ci.appveyor.com/project/NVAccess/nvda/builds/49846213

### Known issues with pull request:
None
