### PR TITLE
Update and migrate translating page from wiki

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -10,6 +10,6 @@ There are several ways in which you can contribute to the NVDA project:
 - [Reporting issues](../projectDocs/issues/readme.md)
 - [Issue triage and investigation](../projectDocs/issues/triage.md)
 - [Testing](../projectDocs/testing/contributing.md)
-- [Translating NVDA](https://github.com/nvaccess/nvda/wiki/Translating)
+- [Translating NVDA](../projectDocs/translating/readme.md)
 - [Code or documentation contributions](../projectDocs/dev/contributing.md)
 - [Creating add-ons](../projectDocs/dev/addons.md)

--- a/projectDocs/community/readme.md
+++ b/projectDocs/community/readme.md
@@ -9,7 +9,7 @@ Whether you are a beginner, an advanced user, a new or a long time developer; or
 This includes information on reporting issues, triaging issues, testing, translating, contributing code/documentation and creating add-ons.
 * The NVDA repository [Wiki](https://github.com/nvaccess/nvda/wiki) contains more guides and documentation.
 * [NVDA development snapshots](https://www.nvaccess.org/files/nvda/snapshots/): Automatically generated builds of the project in its current state of development
-* [Translating NVDA](https://github.com/nvaccess/nvda/wiki/Translating): Information about how to translate NVDA into another language
+* [Translating NVDA](../translating/readme.md): Information about how to translate NVDA into another language
 
 ### Documentation
 * [NVDA User Guide](https://www.nvaccess.org/files/nvda/documentation/userGuide.html)

--- a/projectDocs/dev/developerGuide/developerGuide.md
+++ b/projectDocs/dev/developerGuide/developerGuide.md
@@ -44,7 +44,7 @@ For an overview of nvdaHelper, including how to configure Visual Studio to enabl
 In order to support multiple languages/locales, NVDA must be translated and data specific to the locale must be provided.
 This section only includes information on custom NVDA file formats required for translation.
 Other items need to be translated, such as the NVDA user interface and documentation, but these use standard file formats.
-For complete documentation about translating NVDA, please see the [Translating wiki page](https://github.com/nvaccess/nvda/wiki/Translating)
+For complete documentation about translating NVDA, please see the [Translating page](https://github.com/nvaccess/nvda/blob/master/projectDocs/translating/readme.md)
 
 ### Character Descriptions {#toc7}
 
@@ -881,7 +881,7 @@ Each language directory can also contain gettext information, which is the syste
 As with the rest of NVDA, an `nvda.mo` compiled gettext database file should be placed in the `LC_MESSAGES` directory within this directory.
 To allow plugins in your add-on to access gettext message information via calls to `_()`, `ngettext()`, `npgettext()` and `pgettext()` you must initialize translations at the top of each Python module by calling `addonHandler.initTranslation()`.
 This function cannot be called in modules that do not belong to an add-on, e.g. in a scratchpad subdirectory.
-For more information about gettext and NVDA translation in general, please read the [Translating NVDA wiki page](https://github.com/nvaccess/nvda/wiki/Translating)
+For more information about gettext and NVDA translation in general, please read the [Translating NVDA page](https://github.com/nvaccess/nvda/blob/master/projectDocs/translating/readme.md)
 
 ### Add-on Documentation {#AddonDoc}
 
@@ -1176,4 +1176,3 @@ Please see the `EventExtensionPoints` class documentation for more information, 
 |`Action` |`post_reviewMove` |the position of the review cursor has changed.|
 |`Action` |`post_mouseMove` |the mouse has moved.|
 |`Action` |`post_coreCycle` |the end of each core cycle has been reached.|
-

--- a/projectDocs/translating/readme.md
+++ b/projectDocs/translating/readme.md
@@ -40,7 +40,7 @@ Together you should be able to agree on the best translation and terms to be use
 
 You can send an email to the translation mailing list to find out the correct person. 
 
-If your language is no longer maintained, you can request to be the new maintainer for the language.
+If your language is no longer maintained, you can request to be the new maintainer for the language via the [NVDA translations mailing list](https://groups.io/g/nvda-translations).
 
 ## Files to be Localized
 These files are listed in order of importance.

--- a/projectDocs/translating/readme.md
+++ b/projectDocs/translating/readme.md
@@ -4,101 +4,39 @@ Thank you for considering to localize NVDA to your language, or improving an exi
 In order to support multiple languages/locales, NVDA must be translated and data specific to the locale must be provided.
 There are several tasks to be done, and this document hopes to give you an overview and guide you through the process.
 
-
 ## Translation Mailing List
-Translators should subscribe to the [NVDA translations mailing list](https://groups.io/g/nvda-translations)
-hosted at Groups.IO.
+Translators should subscribe to the [NVDA translations mailing list](https://groups.io/g/nvda-translations) hosted at Groups.IO.
 
 It is an English low traffic list devoted for the discussion of translation. 
-Important messages that relate to translators will also be sent here, i.e. before official NVDA releases, to remind translators to make sure their localization is up to date.
+Important messages that relate to translators will also be sent here, e.g. before official NVDA releases, to remind translators to make sure their localization is up to date.
 
 ## Important Dates
 
-Translators should ensure their translation is up to date during the beta period before each new release, in order for it to be included in the upcoming final release.  A reminder will be posted on the translation mailing list giving two weeks notice of the translation string freeze.  Work submitted after the translation string freeze date will not be included in the upcoming release.  For further information please see the [ReleaseProcess page](https://github.com/nvaccess/nvda/wiki/ReleaseProcess).
+Translators should ensure their translation is up to date during the beta period before each new release, in order for it to be included in the upcoming final release.
+A reminder will be posted on the translation mailing list giving two weeks notice of the translation string freeze.
+Work submitted after the translation string freeze date will not be included in the upcoming release.
+For further information please see the [Release Process page](https://github.com/nvaccess/nvda/blob/master/projectDocs/community/releaseProcess.md).
 
 ## Translation Status
 
-Status for existing NVDA localizations are provided below. If you would like to improve or would like to work on a new language, please write to the [NVDA translations mailing list](https://groups.io/g/nvda-translations).
-Information updated as of August 2021 (2021.1).
-When 2021.1 is listed in the last updated column, it means that the localization is fully up to date and is ready for the current release. For the purposes of the information below, "up to date" refers to interface translation of at least 98%.
+You can view [Crowdin](https://crowdin.com/project/nvda) for an up to date report on the status of translating the NVDA interface.
+If you would like to improve or would like to work on a new language, please write to the [NVDA translations mailing list](https://groups.io/g/nvda-translations).
 
-Note (2023): We are currently working on a more streamlined process to update this page.  In the meantime, if you would like information on a particular language, you can also contact [NV Access](mailto:info@nvaccess.org).  The process for contributing to language translations is unchanged.
-
-
-| Language | Status | Last updated |
-|------------|----------|----------------|
-| af_ZA: Afrikaans | out of date, maintainer needed, barely translated. | Oct 2009 |
-| am: Amharic | out of date, maintainer needed, barely translated. | Jul 2012 |
-| an: Aragonese | up to date. | 2021.1 |
-| ar: Arabic | Up to date. | 2021.1 |
-| bg: Bulgarian | Up to date. | 2021.1 |
-| CA: Catalan | Work in progress. | 2018.4 |
-| CKB: Central Kurdish | Maintainer needed, hasn't begun. | n.a. |
-| cs: Czech |  Up to date, Documentation incomplete (Sept 2017). | 2021.1 | 
-| da: Danish | Up to date. | 2021.1 | 
-| de: German | Up to date. | 2021.1 | 
-| de_CH: Swiss German | work in progress. | 2018.3 | 
-| el: Greek | Up to date, Documentation incomplete (Sep 2017). | 2021.1 |
-| es: Spanish | Up to date. | 2021.1 | 
-| es_CO: Spanish (Columbia) | translation Out of date, maintainer needed. | Jun 2020 |
-| Et: Estonian | started translation of interface | Apr 2021 |
-| fa: Farsi | Up to date | 2021.1 |
-| fi: Finnish | Up to date. | 2021.1 | 
-| fr: French | Up to date. | 2021.1 | 
-| ga: Gaeilge (Ireland) | work in progress. | Jun 2021 |
-| gl: Galician | Up to date. | 2021.1 | 
-| he: Hebrew | Up to date. Documentation incomplete (Oct 2018). | 2021.1 |
-| hi: Hindi | Work in progress, documentation missing. | Mar 2021 |
-| hr: Croatian | Up to date. | 2021.1 |
-| hu: Hungarian | Work in progress. | 2020.4 |
-| is: Icelandic | out of date, maintainer needed. | Apr 2013 |
-| it: Italian | Up to date. | 2021.1 | 
-| ja: Japanese | Up to date. | 2021.1 | 
-| ka: Georgian | out of date, maintainer needed. | May 2015 |
-| kk: Kazakh | out of date, maintainer needed, barely translated. | n/a |
-| kmr: Northern Kurdish | Out of date, maintainer needed. | Dec 2018 |
-| kn: Kannada | Out of date, maintainer needed. | Sept 2015 |
-| ko: Korean | Up to date, | 2021.1 |
-| ky: Kyrgyz | Work in progress. | 2018.3 |
-| lt: Lithuanian | Out of date, maintainer needed. | 2016 |
-| lv: Latvian | Out of date, maintainer needed. | 2016 |
-| mk: Macedonian | Interface: Up to date. Documentation: Work in progress.. | 2021.1 |
-| mn: Mongolian | Work in progress. | Jul 2019 |
-| my: Burmese | Work in Progress. | August 2018 |
-| nb_NO: Norwegian | Out of date. | 2015 |
-| ne: Nepali  | Out of date, maintainer needed. | 2016 |
-| nl: Dutch | Up to date. | 2021.1 |
-| Pa: Punjabi | Out of date, maintainer needed. | Nov 2014 |
-| pl: Polish | Up to date. | 2021.1 |
-| pt_BR: Portuguese (Brazil) | Up to date. | 2021.1 |
-| pt_PT: Portuguese (Portugal) | Up to date. | 2021.1 |
-| ro: Romanian | Up to date. | 2021.1 |
-| ru: Russian | Up to date. | 2021.1 |
-| sk: Slovak | Up to date. | 2021.1 |
-| sl: Slovenian | Up to date. | 2021.1 |
-| so: somali | Out of Date, maintainer needed. | Feb 2019 |
-| sr: Serbian | Up to date. | 2021.1 |
-| sv: Swedish | out of date, maintainer needed. | May 2015 |
-| ta: Tamil | Up to date. | 2021.1 |
-| th: Tai | Out of date, maintainer needed, barely translated. | Feb 2011 |
-| tr: Turkish | Up to date. | 2021.1 |
-| uk: Ukranian | Up to date. | 2021.1 |
-| ur: Urdu | Out of date, maintainer needed, barely translated.| 2016 |
-| vi: Vietnamese | Up to date. | 2021.1 |
-| zh_CN: Simplified Chinese | Up to date. | 2021.1 |
-| zh_HK: Traditional Chinese Hong Kong | Up to date, Documentation missing. | 2021.1 |
-| zh_TW: Traditional Chinese Taiwan | Up to date. | 2021.1 |
-| kh: Traditional Khmer Cambodia | Starting, no files submitted | 2020.1 |
+The translation status of user documentation (User Guide and Changes) can only be checked by translators.
 
 ## New Localization
 Start by subscribing to the translation list above, so that you can get help and advice.
 
-It is recommended that you use our new more automated workflow, which will allow you to focus only on translation. See [the automated workflow section](#advantages-of-the-automatic-workflow-process ) below.
+The current process for translation is split between multiple processes:
+- Crowdin for the NVDA interface
+- The legacy SVN translation system for the User Guide and Changes files
+- GitHub for Character Descriptions, Symbols and Gestures
 
-If you still wish to go through the manual process, then follow the instructions on the [[TranslatingUsingManualProcess]] page after first reading [Files to be Localized](#files-to-be-localized) below.
+Read [Files to be Localized](#files-to-be-localized) to learn the translation for process for these.
 
 ## Improving an Existing Localization
-You should contact the existing maintainer of your language, and discuss your suggestions and changes. Together you should be able to agree on the best translation and terms to be used, and the necessary changes can be made.
+You should contact the existing maintainer of your language, and discuss your suggestions and changes.
+Together you should be able to agree on the best translation and terms to be used, and the necessary changes can be made.
 
 You can send an email to the translation mailing list to find out the correct person. 
 
@@ -106,31 +44,12 @@ If your language is no longer maintained, you can request to be the new maintain
 
 ## Files to be Localized
 These files are listed in order of importance.
+Note that linked guides may be out of date, as the translation system is undergoing the process of migration.
 
-- nvda.po: NVDA's interface messages, see [[TranslatingTheInterface]] page for more info.
-- characterDescriptions.dic: names of characters in your language, see [[TranslatingCharacterDescriptions]] for more info.
-- symbols.dic: names of symbols and punctuation in your language, see [[TranslatingSymbols]] for more information.
-- gestures.ini: remapping of gestures for your language, see [[TranslatingGestures]] for more information.
-- userGuide.t2t: the User Guide, see [[TranslatingUserGuide]] for more information.
-- locale.t2tconf: the locale txt2tags configuration file, see [[Translating-the-locale-txt2tags-configuration-file-(locale.t2tconf)]] for more information; this file is needed when translating userGuide.t2t or changes.t2t.
-- changes.t2t (optional): a list of changes between releases, see [[TranslatingChanges]] for more information.
-- Add-ons (optional): a set of optional features that users can install, see [[TranslatingAddons]] for more information.
-
-## Advantages of the Automatic Workflow Process
-- No need of a full NVDA development environment.
-- You will be sent an email or twitter message when your po file needs updating.
-- You will be sent an email or twitter message when your userGuide or changes file needs to be updated.
-- Automatic generation of html from t2t files, so that you can check the correctness of your t2t markup.
-- Automatically generated difference and word difference between previous and new versions, to help you quickly find the changes.
-- A higher quality User Guide since the difference files encourage you to keep the English and your localization closely updated.
-- Translation becomes many small tasks instead a big rush near a deadline. Maybe 10 minutes per week on average.
-- It is easier to contribute, since each work unit is self contained.
-- Your translation is regularly and automatically included into NVDA snapshots.
-- Instead of following nvda-dev mailing list emails, you can just subscribe to nvda translations and important messages related to translation will be sent there.
-- Auto generated structure difference between the English and your localized user guide, to quickly spot missing paragraphs, tables and lists.
-- Automatic checking of po files, making sure that there are no mistakes that could cause any runtime errors.
-
-If you want to follow the automatic workflow process, visit the [[TranslatingUsingAutomaticProcess]] page.
-
-## Missing information
-Please feel free to update this or any subsequent page with any tips or hints that you feel may be of use to other translators.
+- nvda.po: NVDA's interface messages, see [Translating The Interface](https://github.com/nvaccess/nvda/wiki/TranslatingTheInterface) page for more info.
+- characterDescriptions.dic: names of characters in your language, see [Translating Character Descriptions](https://github.com/nvaccess/nvda/wiki/TranslatingCharacterDescriptions) for more info.
+- symbols.dic: names of symbols and punctuation in your language, see [Translating Symbols](https://github.com/nvaccess/nvda/wiki/TranslatingSymbols) for more information.
+- gestures.ini: remapping of gestures for your language, see [Translating Gestures](https://github.com/nvaccess/nvda/wiki/TranslatingGestures) for more information.
+- userGuide.md: the User Guide, see [Translating the User Guide](https://github.com/nvaccess/nvda/wiki/TranslatingUserGuide) for more information.
+- changes.md (optional): a list of changes between releases, see [Translating Changes](https://github.com/nvaccess/nvda/wiki/TranslatingChanges) for more information.
+- Add-ons (optional): a set of optional features that users can install, see [Translating Addons](https://github.com/nvaccess/nvda/wiki/TranslatingAddons) for more information.

--- a/projectDocs/translating/readme.md
+++ b/projectDocs/translating/readme.md
@@ -1,0 +1,136 @@
+# NVDA Translation and Localization
+
+Thank you for considering to localize NVDA to your language, or improving an existing translation.
+In order to support multiple languages/locales, NVDA must be translated and data specific to the locale must be provided.
+There are several tasks to be done, and this document hopes to give you an overview and guide you through the process.
+
+
+## Translation Mailing List
+Translators should subscribe to the [NVDA translations mailing list](https://groups.io/g/nvda-translations)
+hosted at Groups.IO.
+
+It is an English low traffic list devoted for the discussion of translation. 
+Important messages that relate to translators will also be sent here, i.e. before official NVDA releases, to remind translators to make sure their localization is up to date.
+
+## Important Dates
+
+Translators should ensure their translation is up to date during the beta period before each new release, in order for it to be included in the upcoming final release.  A reminder will be posted on the translation mailing list giving two weeks notice of the translation string freeze.  Work submitted after the translation string freeze date will not be included in the upcoming release.  For further information please see the [ReleaseProcess page](https://github.com/nvaccess/nvda/wiki/ReleaseProcess).
+
+## Translation Status
+
+Status for existing NVDA localizations are provided below. If you would like to improve or would like to work on a new language, please write to the [NVDA translations mailing list](https://groups.io/g/nvda-translations).
+Information updated as of August 2021 (2021.1).
+When 2021.1 is listed in the last updated column, it means that the localization is fully up to date and is ready for the current release. For the purposes of the information below, "up to date" refers to interface translation of at least 98%.
+
+Note (2023): We are currently working on a more streamlined process to update this page.  In the meantime, if you would like information on a particular language, you can also contact [NV Access](mailto:info@nvaccess.org).  The process for contributing to language translations is unchanged.
+
+
+| Language | Status | Last updated |
+|------------|----------|----------------|
+| af_ZA: Afrikaans | out of date, maintainer needed, barely translated. | Oct 2009 |
+| am: Amharic | out of date, maintainer needed, barely translated. | Jul 2012 |
+| an: Aragonese | up to date. | 2021.1 |
+| ar: Arabic | Up to date. | 2021.1 |
+| bg: Bulgarian | Up to date. | 2021.1 |
+| CA: Catalan | Work in progress. | 2018.4 |
+| CKB: Central Kurdish | Maintainer needed, hasn't begun. | n.a. |
+| cs: Czech |  Up to date, Documentation incomplete (Sept 2017). | 2021.1 | 
+| da: Danish | Up to date. | 2021.1 | 
+| de: German | Up to date. | 2021.1 | 
+| de_CH: Swiss German | work in progress. | 2018.3 | 
+| el: Greek | Up to date, Documentation incomplete (Sep 2017). | 2021.1 |
+| es: Spanish | Up to date. | 2021.1 | 
+| es_CO: Spanish (Columbia) | translation Out of date, maintainer needed. | Jun 2020 |
+| Et: Estonian | started translation of interface | Apr 2021 |
+| fa: Farsi | Up to date | 2021.1 |
+| fi: Finnish | Up to date. | 2021.1 | 
+| fr: French | Up to date. | 2021.1 | 
+| ga: Gaeilge (Ireland) | work in progress. | Jun 2021 |
+| gl: Galician | Up to date. | 2021.1 | 
+| he: Hebrew | Up to date. Documentation incomplete (Oct 2018). | 2021.1 |
+| hi: Hindi | Work in progress, documentation missing. | Mar 2021 |
+| hr: Croatian | Up to date. | 2021.1 |
+| hu: Hungarian | Work in progress. | 2020.4 |
+| is: Icelandic | out of date, maintainer needed. | Apr 2013 |
+| it: Italian | Up to date. | 2021.1 | 
+| ja: Japanese | Up to date. | 2021.1 | 
+| ka: Georgian | out of date, maintainer needed. | May 2015 |
+| kk: Kazakh | out of date, maintainer needed, barely translated. | n/a |
+| kmr: Northern Kurdish | Out of date, maintainer needed. | Dec 2018 |
+| kn: Kannada | Out of date, maintainer needed. | Sept 2015 |
+| ko: Korean | Up to date, | 2021.1 |
+| ky: Kyrgyz | Work in progress. | 2018.3 |
+| lt: Lithuanian | Out of date, maintainer needed. | 2016 |
+| lv: Latvian | Out of date, maintainer needed. | 2016 |
+| mk: Macedonian | Interface: Up to date. Documentation: Work in progress.. | 2021.1 |
+| mn: Mongolian | Work in progress. | Jul 2019 |
+| my: Burmese | Work in Progress. | August 2018 |
+| nb_NO: Norwegian | Out of date. | 2015 |
+| ne: Nepali  | Out of date, maintainer needed. | 2016 |
+| nl: Dutch | Up to date. | 2021.1 |
+| Pa: Punjabi | Out of date, maintainer needed. | Nov 2014 |
+| pl: Polish | Up to date. | 2021.1 |
+| pt_BR: Portuguese (Brazil) | Up to date. | 2021.1 |
+| pt_PT: Portuguese (Portugal) | Up to date. | 2021.1 |
+| ro: Romanian | Up to date. | 2021.1 |
+| ru: Russian | Up to date. | 2021.1 |
+| sk: Slovak | Up to date. | 2021.1 |
+| sl: Slovenian | Up to date. | 2021.1 |
+| so: somali | Out of Date, maintainer needed. | Feb 2019 |
+| sr: Serbian | Up to date. | 2021.1 |
+| sv: Swedish | out of date, maintainer needed. | May 2015 |
+| ta: Tamil | Up to date. | 2021.1 |
+| th: Tai | Out of date, maintainer needed, barely translated. | Feb 2011 |
+| tr: Turkish | Up to date. | 2021.1 |
+| uk: Ukranian | Up to date. | 2021.1 |
+| ur: Urdu | Out of date, maintainer needed, barely translated.| 2016 |
+| vi: Vietnamese | Up to date. | 2021.1 |
+| zh_CN: Simplified Chinese | Up to date. | 2021.1 |
+| zh_HK: Traditional Chinese Hong Kong | Up to date, Documentation missing. | 2021.1 |
+| zh_TW: Traditional Chinese Taiwan | Up to date. | 2021.1 |
+| kh: Traditional Khmer Cambodia | Starting, no files submitted | 2020.1 |
+
+## New Localization
+Start by subscribing to the translation list above, so that you can get help and advice.
+
+It is recommended that you use our new more automated workflow, which will allow you to focus only on translation. See [the automated workflow section](#advantages-of-the-automatic-workflow-process ) below.
+
+If you still wish to go through the manual process, then follow the instructions on the [[TranslatingUsingManualProcess]] page after first reading [Files to be Localized](#files-to-be-localized) below.
+
+## Improving an Existing Localization
+You should contact the existing maintainer of your language, and discuss your suggestions and changes. Together you should be able to agree on the best translation and terms to be used, and the necessary changes can be made.
+
+You can send an email to the translation mailing list to find out the correct person. 
+
+If your language is no longer maintained, you can request to be the new maintainer for the language.
+
+## Files to be Localized
+These files are listed in order of importance.
+
+- nvda.po: NVDA's interface messages, see [[TranslatingTheInterface]] page for more info.
+- characterDescriptions.dic: names of characters in your language, see [[TranslatingCharacterDescriptions]] for more info.
+- symbols.dic: names of symbols and punctuation in your language, see [[TranslatingSymbols]] for more information.
+- gestures.ini: remapping of gestures for your language, see [[TranslatingGestures]] for more information.
+- userGuide.t2t: the User Guide, see [[TranslatingUserGuide]] for more information.
+- locale.t2tconf: the locale txt2tags configuration file, see [[Translating-the-locale-txt2tags-configuration-file-(locale.t2tconf)]] for more information; this file is needed when translating userGuide.t2t or changes.t2t.
+- changes.t2t (optional): a list of changes between releases, see [[TranslatingChanges]] for more information.
+- Add-ons (optional): a set of optional features that users can install, see [[TranslatingAddons]] for more information.
+
+## Advantages of the Automatic Workflow Process
+- No need of a full NVDA development environment.
+- You will be sent an email or twitter message when your po file needs updating.
+- You will be sent an email or twitter message when your userGuide or changes file needs to be updated.
+- Automatic generation of html from t2t files, so that you can check the correctness of your t2t markup.
+- Automatically generated difference and word difference between previous and new versions, to help you quickly find the changes.
+- A higher quality User Guide since the difference files encourage you to keep the English and your localization closely updated.
+- Translation becomes many small tasks instead a big rush near a deadline. Maybe 10 minutes per week on average.
+- It is easier to contribute, since each work unit is self contained.
+- Your translation is regularly and automatically included into NVDA snapshots.
+- Instead of following nvda-dev mailing list emails, you can just subscribe to nvda translations and important messages related to translation will be sent there.
+- Auto generated structure difference between the English and your localized user guide, to quickly spot missing paragraphs, tables and lists.
+- Automatic checking of po files, making sure that there are no mistakes that could cause any runtime errors.
+
+If you want to follow the automatic workflow process, visit the [[TranslatingUsingAutomaticProcess]] page.
+
+## Missing information
+Please feel free to update this or any subsequent page with any tips or hints that you feel may be of use to other translators.


### PR DESCRIPTION
### Summary of the issue:
NV Access is intending to move most of the wiki into the repository, so changes are tracked better and easier to propose.
The documentation for translating NVDA is very dated, particularly since the update of the translation system.

### Description of user facing changes
In order to start the process of updating and migrating the translating documentation, the first page was moved from the wiki:
- https://github.com/nvaccess/nvda/wiki/Translating

The following changes were made to update the contents:
- the translation status links to Crowdin, which neatly tracks the status for the NVDA interface. Instructions for generating structured diffs to check the status of user docs will be linked when they are made.
- warnings are added to note that docs are out of date in general, until all referenced pages are updated
- links to the manual process are removed. The manual process was only ever documented for the interface, which has moved crowdin. References [to this page](https://github.com/nvaccess/nvda/wiki/TranslatingUsingManualProcess) will be removed.
- references to text2tags were updated to markdown, such as removing references to the no longer needed locale.t2tconf
- Additionally, some grammar and formatting fixes were made such as new lines
- Removed "Missing information" now that this in the repo, normal issues/PRs apply

### Future work
On merge, this wiki page should be updated to link to this doc.
Moving and updating the rest of the translating wiki pages.
