### PR TITLE
Several fixups for unicode normalization

### DIFF
--- a/source/braille.py
+++ b/source/braille.py
@@ -499,20 +499,20 @@ class Region(object):
 			mode |= louis.compbrlAtCursor
 
 		converter: UnicodeNormalizationOffsetConverter | None = None
-		if config.conf["braille"]["unicodeNormalization"] and not isUnicodeNormalized(self.rawText):
-			converter = UnicodeNormalizationOffsetConverter(self.rawText)
+		textToTranslate = self.rawText
+		textToTranslateTypeforms = self.rawTextTypeforms
+		cursorPos = self.cursorPos
+		if config.conf["braille"]["unicodeNormalization"] and not isUnicodeNormalized(textToTranslate):
+			converter = UnicodeNormalizationOffsetConverter(textToTranslate)
 			textToTranslate = converter.encoded
-			# Typeforms must be adapted to represent normalized characters.
-			textToTranslateTypeforms = [
-				self.rawTextTypeforms[strOffset] for strOffset in converter.computedEncodedToStrOffsets
-			] if self.rawTextTypeforms is not None else None
-			# Convert the cursor position to a normalized offset.
-			cursorPos = converter.strToEncodedOffsets(self.cursorPos)
-		else:
-			textToTranslate = self.rawText
-			textToTranslateTypeforms = self.rawTextTypeforms
-			cursorPos = self.cursorPos
-
+			if textToTranslateTypeforms is not None:
+				# Typeforms must be adapted to represent normalized characters.
+				textToTranslateTypeforms = [
+					textToTranslateTypeforms[strOffset] for strOffset in converter.computedEncodedToStrOffsets
+				]
+			if cursorPos is not None:
+				# Convert the cursor position to a normalized offset.
+				cursorPos = converter.strToEncodedOffsets(cursorPos)
 		self.brailleCells, brailleToRawPos, rawToBraillePos, self.brailleCursorPos = louisHelper.translate(
 			[handler.table.fileName, "braille-patterns.cti"],
 			textToTranslate,

--- a/source/braille.py
+++ b/source/braille.py
@@ -505,7 +505,7 @@ class Region(object):
 			# Typeforms must be adapted to represent normalized characters.
 			textToTranslateTypeforms = [
 				self.rawTextTypeforms[strOffset] for strOffset in converter.computedEncodedToStrOffsets
-			]
+			] if self.rawTextTypeforms is not None else None
 			# Convert the cursor position to a normalized offset.
 			cursorPos = converter.strToEncodedOffsets(self.cursorPos)
 		else:

--- a/source/textUtils.py
+++ b/source/textUtils.py
@@ -478,17 +478,24 @@ class UnicodeNormalizationOffsetConverter(OffsetConverter):
 					# and still matches the beginning of the normalized buffer.
 					for i in range(len(originBuffer)):
 						originPart = originBuffer[: (i + 1)]
+						originPartLen = len(originPart)
 						normalizedPart = unicodedata.normalize(self.normalizationForm, originPart)
+						normalizedPartLen = len(normalizedPart)
 						if (
 							originPart == normalizedPart
 							or not normalizedBuffer.startswith(normalizedPart)
 						):
 							continue
-						originPartLen = len(originPart)
 						originBuffer = originBuffer[originPartLen:]
-						normalizedPartLen = len(normalizedPart)
 						normalizedBuffer = normalizedBuffer[normalizedPartLen:]
 						break
+					else:
+						# No normalizable characters in originBuffer.
+						# All characters are now copied to originPart and normalizedPart.
+						assert originBuffer == originPart
+						assert normalizedBuffer == normalizedPart
+						# Reset buffers to ensure the while loop doesn't run next time.
+						originBuffer = normalizedBuffer = ""
 					# Map the original indices to the normalized indices.
 					# originMultiplier is used to multiply indices in origin
 					# when a character takes more space in origin than in normalized.

--- a/tests/unit/test_textUtils.py
+++ b/tests/unit/test_textUtils.py
@@ -268,3 +268,11 @@ class TestUnicodeNormalizationOffsetConverter(unittest.TestCase):
 		self.assertSequenceEqual(converter.computedStrToEncodedOffsets, expectedStrToEncoded)
 		expectedEncodedToStr = (0, 2, 1, 3, 4, 5, 6, 8, 7, 9, 10)
 		self.assertSequenceEqual(converter.computedEncodedToStrOffsets, expectedEncodedToStr)
+
+	def test_normalizedOffsetsMixedSpaces(self):
+		text = "\xa0 "
+		converter = UnicodeNormalizationOffsetConverter(text, "NFKC")
+		expectedStrToEncoded = (0, 1)
+		self.assertSequenceEqual(converter.computedStrToEncodedOffsets, expectedStrToEncoded)
+		expectedEncodedToStr = (0, 1)
+		self.assertSequenceEqual(converter.computedEncodedToStrOffsets, expectedEncodedToStr)

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -8,9 +8,10 @@
 
 * Error messages referenced with `aria-errormessage` are now reported in Google Chrome and Mozilla Firefox. (#8318)
 * In LibreOffice Writer (version 24.8 and newer), when toggling text formatting (bold, italic, underline, subscript/superscript, alignment) using the corresponding keyboard shortcut, NVDA announces the new formatting attribute (e.g. "Bold on", "Bold off"). (#4248, @michaelweghorn)
-* Added support for Unicode Normalization to speech and braille output, which is enabled by default. (#11570, #16466 @LeonarddeR).
+* Added support for Unicode Normalization to speech and braille output. (#11570, #16466 @LeonarddeR).
   * This can be of help when reading characters that are unknown to a particular speech synthesizer or braille table and which have a compatible alternative, like the bold and italic characters commonly uses on social media.
-  * You can disable this functionality for both speech and braille in their respective settings categories in the NVDA Settings dialog.
+  * It also allows reading of equations in de Microsoft Word equation editor. (#4631)
+  * You can enable this functionality for both speech and braille in their respective settings categories in the NVDA Settings dialog.
 
 ### Changes
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -10,7 +10,7 @@
 * In LibreOffice Writer (version 24.8 and newer), when toggling text formatting (bold, italic, underline, subscript/superscript, alignment) using the corresponding keyboard shortcut, NVDA announces the new formatting attribute (e.g. "Bold on", "Bold off"). (#4248, @michaelweghorn)
 * Added support for Unicode Normalization to speech and braille output. (#11570, #16466 @LeonarddeR).
   * This can be of help when reading characters that are unknown to a particular speech synthesizer or braille table and which have a compatible alternative, like the bold and italic characters commonly uses on social media.
-  * It also allows reading of equations in de Microsoft Word equation editor. (#4631)
+  * It also allows reading of equations in the Microsoft Word equation editor. (#4631)
   * You can enable this functionality for both speech and braille in their respective settings categories in the NVDA Settings dialog.
 
 ### Changes

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -8,9 +8,9 @@
 
 * Error messages referenced with `aria-errormessage` are now reported in Google Chrome and Mozilla Firefox. (#8318)
 * In LibreOffice Writer (version 24.8 and newer), when toggling text formatting (bold, italic, underline, subscript/superscript, alignment) using the corresponding keyboard shortcut, NVDA announces the new formatting attribute (e.g. "Bold on", "Bold off"). (#4248, @michaelweghorn)
-* Added support for Unicode Normalization to speech and braille output. (#16466 @LeonarddeR).
+* Added support for Unicode Normalization to speech and braille output, which is enabled by default. (#11570, #16466 @LeonarddeR).
   * This can be of help when reading characters that are unknown to a particular speech synthesizer or braille table and which have a compatible alternative, like the bold and italic characters commonly uses on social media.
-  * You can enable this functionality for both speech and braille in their respective settings categories in the NVDA Settings dialog.
+  * You can disable this functionality for both speech and braille in their respective settings categories in the NVDA Settings dialog.
 
 ### Changes
 

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -1818,7 +1818,7 @@ NVDA uses the NFKC (Normalization Form Compatibility Composition) algorithm, whi
 
 1. The bold and italic versions of characters that are part of the unicode standard and are commonly used on social media are normalized to their most common compatible equivalent.
 For example, the latin letter "h" can also be presented as "𝐡" (bold), "ℎ" (itallic), etc. but will always be spoken as "h" when normalization is enabled.
-This aspect of normalization also aids in reading equations in de Microsoft Word equation editor.
+This aspect of normalization also aids in reading equations in the Microsoft Word equation editor.
 
 1. Normalization to composed characters.
 For example, the character "ü" (u with umlaut/diaeresis), a common character in languages like German and Turkish can be represented in two forms.

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -1818,6 +1818,7 @@ NVDA uses the NFKC (Normalization Form Compatibility Composition) algorithm, whi
 
 1. The bold and italic versions of characters that are part of the unicode standard and are commonly used on social media are normalized to their most common compatible equivalent.
 For example, the latin letter "h" can also be presented as "𝐡" (bold), "ℎ" (itallic), etc. but will always be spoken as "h" when normalization is enabled.
+This aspect of normalization also aids in reading equations in de Microsoft Word equation editor.
 
 1. Normalization to composed characters.
 For example, the character "ü" (u with umlaut/diaeresis), a common character in languages like German and Turkish can be represented in two forms.


### PR DESCRIPTION
### Link to issue number:
Fixup of #16521 
Fixes #11570
Partial fix for #4631 

### Summary of the issue:
1. It turns out that rawTextTypeforms on a region may be None, this was an oversight on my end.
2. cursorPos may also be None.
3. @burmancomp reported a zero division error in case a string ended with a non breaking space and a space.

### Description of user facing changes
No longer errors in the log when getting flash messages in Thunderbird and/or reading messages in WhatsApp UWP.

### Description of development approach
1. Explicitly check for None typeforms and cursorPos, thereby improving readability as well.
2. Improve the calculateOffsets method in textUtils to ensure it can handle the case as reported by @burmancomp 

### Testing strategy:
From a python console
`braille.TextRegion("ĳ").update()`
No longer results in an error.
Same for `braille.TextRegion("\xa0 ").update()`

### Known issues with pull request:
None known

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
