### PR TITLE
Revert "Run the uninstaller with administrator privileges"

### DIFF
--- a/uninstaller/uninst.nsi
+++ b/uninstaller/uninst.nsi
@@ -9,7 +9,7 @@ SetCompressor /SOLID LZMA
 CRCCheck On
 XPStyle on
 InstProgressFlags Smooth
-RequestExecutionLevel admin
+RequestExecutionLevel user
 
 Name "${appName}"
 VIProductVersion "${VERSION_YEAR}.${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_BUILD}" ;Needs to be here so other version info shows up


### PR DESCRIPTION
### Reverts PR
Reverts nvaccess/nvda#16505

### Issues fixed
None

### Issues reopened
None

### Reason for revert
The approach in nvaccess/nvda#16505 appears incorrect.
Admin level is requested when generating the uninstaller, not when running it.
It is also dubious if the original issue is valid.

### Can this PR be reimplemented? If so, what is required for the next attempt
An issue should be filed first and investigated