### PR TITLE
Use an older version of setuptools when installing requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools<70", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/venvUtils/ensureVenv.py
+++ b/venvUtils/ensureVenv.py
@@ -84,9 +84,19 @@ def populate():
 			"py", "-m", "pip",
 			"install", "--upgrade", "pip",
 			"&&",
+			# py2exe is not compatible with setuptools 70+
+			# wheel must be manually installed when creating an non-isolated build with a custom setuptools version.
+			"py", "-m", "pip",
+			"install", "setuptools==69.5.1", "wheel",
+			"&&",
 			# Install required packages with pip
 			"py", "-m", "pip",
-			"install", "-r", requirements_path,
+			# "--no-build-isolation" is used to avoid issues with py2exe.
+			# When AppVeyor creates an isolated build environment, it uses a different version of setuptools
+			# that is incompatible with py2exe.
+			# Using --no-build-isolation ensures that the same version of setuptools is used in the build environment,
+			# however requires us manually installing the wheel package.
+			"install", "--no-build-isolation", "-r", requirements_path,
 		],
 		check=True,
 		shell=True,


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
None

### Summary of the issue:
setuptools has been updated, breaking support with py2exe: https://github.com/py2exe/py2exe/issues/208.

When installing packages, pip automatically pulls in the latest build dependences as specified in [PEP 518](https://peps.python.org/pep-0518/).
pip creates a custom temporary build environment to install packages using the latest pip environment.

### Description of development approach
Create a `pyproject.toml` to specify the build environment we are using.
https://packaging.python.org/en/latest/guides/writing-pyproject-toml/

Use the flag `no-build-isolation` when installing requirements.txt.
This prevent pip from using the custom build environment and automatically pulling the latest setuptools when installing packages.

As such, we need to manually install the desired version of setuptools, and manually install pip's dependency wheel.
https://stackoverflow.com/questions/62889093/what-does-no-build-isolation-do

### Testing strategy:
Ensure build completes successfully

### Known issues with pull request:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
