### PR TITLE
Use value of `aria-label*` to provide accessible name for tables in Firefox

### DIFF
--- a/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.cpp
+++ b/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.cpp
@@ -954,7 +954,7 @@ VBufStorage_fieldNode_t* GeckoVBufBackend_t::fillVBuf(
 			
 			{ // Add the table summary if one is present and the table is visible.
 				VBufStorage_fieldNode_t* summaryTempNode = nullptr;
-				if (isVisible && description.has_value()) {
+				if (isVisible && description.has_value() && !description.value().empty()) {
 					tempNode = summaryTempNode = buffer->addTextFieldNode(parentNode, previousNode, description.value());
 				}
 				else if (

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -32,6 +32,7 @@
   * NVDA will no longer announce "clipboard history" twice when navigating through the emoji panel menu items. (#16532, @josephsl)
   * NVDA will no longer cut off speech and braille when reviewing kaomojis and symbols in the emoji panel. (#16533, @josephsl)
 * In applications using Java Access Bridge, NVDA will now correctly read the last blank line of a text instead of repeating the previous line. (#9376, @dmitrii-drobotov)
+* If present, NVDA will now use `aria-labelledby` to provide accessible names for tables in Mozilla Firefox. (#5183)
 
 ### Changes for Developers
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:

Fixes #5183

### Summary of the issue:

In Firefox, tables labelled with `aria-label` or `aria-labelledby` (where the referenced element is not visible) do not have a virtual buffer node inserted with the accessible name of the table.

### Description of user facing changes

Tables now have this node inserted in Firefox, as they already do in Chrome.

### Description of development approach

Since Firefox returns the empty string if no description is given (rather than `null` as returned by Chrome), update `gecko_ia2.cpp` to check for the empty string as well as `null`.

### Testing strategy:

Manually tested with the following snippet in Chrome and Firefox:

```
data:text/html,<p>Table for testing follows:</p><table aria-label="Foo"><tr><th>Test 1</th><th>Test 2</th></tr></table>
```

### Known issues with pull request:

None.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
