### PR TITLE
Poedit: ensure scripts work no matter how many plurals a language has

### DIFF
--- a/source/appModules/poedit.py
+++ b/source/appModules/poedit.py
@@ -99,12 +99,9 @@ class AppModule(appModuleHandler.AppModule):
 		splitterControlID = dataViewControlId + _WindowControlIdOffsetFromDataView.MAIN_SPLITTER_IDENTIFIER
 		fg = api.getForegroundObject()
 		splitterHwnd = windowUtils.findDescendantWindow(fg.windowHandle, controlID=splitterControlID)
-		print(f"splitter: {winUser.getClassName(splitterHwnd)}")
 		sidebarHwnd = winUser.getWindow(splitterHwnd, winUser.GW_HWNDNEXT)
 		while sidebarHwnd and not ctypes.windll.user32.IsWindowVisible(sidebarHwnd):
-			print(f"skipping non-sidebar: {winUser.getClassName(sidebarHwnd)}")
 			sidebarHwnd = winUser.getWindow(sidebarHwnd, winUser.GW_HWNDNEXT)
-		print(f"sidebar? {winUser.getClassName(sidebarHwnd)}")
 		if not sidebarHwnd:
 			return None
 		return winUser.getControlID(sidebarHwnd)

--- a/source/appModules/poedit.py
+++ b/source/appModules/poedit.py
@@ -8,6 +8,7 @@
 
 from enum import IntEnum
 
+import ctypes
 import api
 import appModuleHandler
 import controlTypes
@@ -19,6 +20,8 @@ import winUser
 from NVDAObjects import NVDAObject
 from NVDAObjects.window import Window
 from scriptHandler import getLastScriptRepeatCount, script
+from logHandler import log
+
 
 LEFT_TO_RIGHT_EMBEDDING = "\u202a"
 """Character often found in translator comments."""
@@ -27,7 +30,7 @@ LEFT_TO_RIGHT_EMBEDDING = "\u202a"
 SCRCAT_POEDIT = _("Poedit")
 
 
-class _WindowControlIdOffset(IntEnum):
+class _WindowControlIdOffsetFromDataView(IntEnum):
 	"""Window control ID's are not static, however, the order of ids stays the same.
 	Therefore, using a wxDataView control in the translations list as a reference,
 	we can safely calculate control ids accross releases or instances.
@@ -35,14 +38,23 @@ class _WindowControlIdOffset(IntEnum):
 	"""
 
 	PRO_IDENTIFIER = -10  # This is a button in the free version
-	OLD_SOURCE_TEXT_PRO = 60
-	OLD_SOURCE_TEXT = 65
-	TRANSLATOR_NOTES_PRO = 63
-	TRANSLATOR_NOTES = 68  # 63 in Pro
-	COMMENT_PRO = 66
-	COMMENT = 71
+	MAIN_SPLITTER_IDENTIFIER = -2  # The splitter that holds the translation list
 	TRANSLATION_WARNING = 17
 	NEEDS_WORK_SWITCH = 21
+
+
+class _WindowControlIdOffsetFromSidebar(IntEnum):
+	"""Window control ID's are not static, however, the order of ids stays the same.
+	Therefore, using the Sidebar window as a reference,
+	we can safely calculate control ids accross releases or instances.
+	This class contains window control id offsets relative to the Sidebar window.
+	Note that this Sidebar window itself is found relative to the dataview's ancestor splitter control.
+	"""
+
+	PRO_OFFSET = -5
+	OLD_SOURCE_TEXT = 36
+	TRANSLATOR_NOTES = 39
+	COMMENT = 42
 
 
 def _findDescendantObject(
@@ -79,42 +91,61 @@ class AppModule(appModuleHandler.AppModule):
 			return None
 		return dataView.windowControlID
 
+	_sidebarControlId: int | None
+	"""Type definition for auto prop '_get__sidebarControlId'"""
+
+	def _get__sidebarControlId(self) -> int | None:
+		dataViewControlId = self._dataViewControlId
+		splitterControlID = dataViewControlId + _WindowControlIdOffsetFromDataView.MAIN_SPLITTER_IDENTIFIER
+		fg = api.getForegroundObject()
+		splitterHwnd = windowUtils.findDescendantWindow(fg.windowHandle, controlID=splitterControlID)
+		print(f"splitter: {winUser.getClassName(splitterHwnd)}")
+		sidebarHwnd = winUser.getWindow(splitterHwnd, winUser.GW_HWNDNEXT)
+		while sidebarHwnd and not ctypes.windll.user32.IsWindowVisible(sidebarHwnd):
+			print(f"skipping non-sidebar: {winUser.getClassName(sidebarHwnd)}")
+			sidebarHwnd = winUser.getWindow(sidebarHwnd, winUser.GW_HWNDNEXT)
+		print(f"sidebar? {winUser.getClassName(sidebarHwnd)}")
+		if not sidebarHwnd:
+			return None
+		return winUser.getControlID(sidebarHwnd)
+
 	_isPro: bool
 	"""Type definition for auto prop '_get__isPro'"""
 
 	def _get__isPro(self) -> bool:
 		"""Returns whether this instance of Poedit is a pro version."""
-		obj = self._getNVDAObjectForWindowControlIdOffset(_WindowControlIdOffset.PRO_IDENTIFIER)
+		obj = self._getNVDAObjectForWindowControlIdOffsetFromDataView(
+			_WindowControlIdOffsetFromDataView.PRO_IDENTIFIER
+		)
 		return obj is None
 
-	def _correctWindowControllIdOfset(
+	def _getNVDAObjectForWindowControlIdOffsetFromDataView(
 			self,
-			windowControlIdOffset: _WindowControlIdOffset
-	) -> _WindowControlIdOffset:
-		"""Corrects a _WindowControlIdOffset when a pro version of Poedit is active."""
-		if self._isPro:
-			match windowControlIdOffset:
-				case _WindowControlIdOffset.OLD_SOURCE_TEXT:
-					return _WindowControlIdOffset.OLD_SOURCE_TEXT_PRO
-				case _WindowControlIdOffset.TRANSLATOR_NOTES:
-					return _WindowControlIdOffset.TRANSLATOR_NOTES_PRO
-				case _WindowControlIdOffset.COMMENT:
-					return _WindowControlIdOffset.COMMENT_PRO
-		return windowControlIdOffset
-
-	def _getNVDAObjectForWindowControlIdOffset(
-			self,
-			windowControlIdOffset: _WindowControlIdOffset
+			windowControlIdOffset: _WindowControlIdOffsetFromDataView
 	) -> Window | None:
 		fg = api.getForegroundObject()
 		return _findDescendantObject(fg.windowHandle, self._dataViewControlId + windowControlIdOffset)
+
+	def _getNVDAObjectForWindowControlIdOffsetFromSidebar(
+			self,
+			windowControlIdOffset: _WindowControlIdOffsetFromSidebar
+	) -> Window | None:
+		fg = api.getForegroundObject()
+		sidebarControlId = self._sidebarControlId
+		if sidebarControlId is None:
+			log.error("Sidebar can not be found")
+			return None
+		extraOffset = 0
+		if self._isPro:
+			extraOffset = _WindowControlIdOffsetFromSidebar.PRO_OFFSET
+		return _findDescendantObject(fg.windowHandle, sidebarControlId + extraOffset + windowControlIdOffset)
 
 	_translatorNotesObj: Window | None
 	"""Type definition for auto prop '_get__translatorNotesObj'"""
 
 	def _get__translatorNotesObj(self) -> Window | None:
-		return self._getNVDAObjectForWindowControlIdOffset(
-			self._correctWindowControllIdOfset(_WindowControlIdOffset.TRANSLATOR_NOTES)
+		return self._getNVDAObjectForWindowControlIdOffsetFromSidebar(
+			_WindowControlIdOffsetFromSidebar.TRANSLATOR_NOTES
 		)
 
 	def _reportControlScriptHelper(self, obj: Window, description: str):
@@ -164,8 +195,8 @@ class AppModule(appModuleHandler.AppModule):
 	"""Type definition for auto prop '_get__commentObj'"""
 
 	def _get__commentObj(self) -> Window | None:
-		return self._getNVDAObjectForWindowControlIdOffset(
-			self._correctWindowControllIdOfset(_WindowControlIdOffset.COMMENT)
+		return self._getNVDAObjectForWindowControlIdOffsetFromSidebar(
+			_WindowControlIdOffsetFromSidebar.COMMENT
 		)
 
 	@script(
@@ -191,8 +222,8 @@ class AppModule(appModuleHandler.AppModule):
 	"""Type definition for auto prop '_get__oldSourceTextObj'"""
 
 	def _get__oldSourceTextObj(self) -> Window | None:
-		return self._getNVDAObjectForWindowControlIdOffset(
-			self._correctWindowControllIdOfset(_WindowControlIdOffset.OLD_SOURCE_TEXT)
+		return self._getNVDAObjectForWindowControlIdOffsetFromSidebar(
+			_WindowControlIdOffsetFromSidebar.OLD_SOURCE_TEXT
 		)
 
 	@script(
@@ -217,7 +248,9 @@ class AppModule(appModuleHandler.AppModule):
 	"""Type definition for auto prop '_get__translationWarningObj'"""
 
 	def _get__translationWarningObj(self) -> Window | None:
-		return self._getNVDAObjectForWindowControlIdOffset(_WindowControlIdOffset.TRANSLATION_WARNING)
+		return self._getNVDAObjectForWindowControlIdOffsetFromDataView(
+			_WindowControlIdOffsetFromDataView.TRANSLATION_WARNING
+		)
 
 	@script(
 		description=pgettext(
@@ -241,7 +274,9 @@ class AppModule(appModuleHandler.AppModule):
 	"""Type definition for auto prop '_get__needsWorkObj'"""
 
 	def _get__needsWorkObj(self) -> Window | None:
-		obj = self._getNVDAObjectForWindowControlIdOffset(_WindowControlIdOffset.NEEDS_WORK_SWITCH)
+		obj = self._getNVDAObjectForWindowControlIdOffsetFromDataView(
+			_WindowControlIdOffsetFromDataView.NEEDS_WORK_SWITCH
+		)
 		if obj and obj.role == controlTypes.Role.CHECKBOX:
 			return obj
 		return None
@@ -270,19 +305,19 @@ class PoeditRichEdit(NVDAObject):
 
 
 class PoeditListItem(NVDAObject):
-	_warningControlToReport: _WindowControlIdOffset | None
+	_warningControlToReport: _WindowControlIdOffsetFromDataView | None
 	appModule: AppModule
 
-	def _get__warningControlToReport(self) -> _WindowControlIdOffset | None:
+	def _get__warningControlToReport(self) -> int | None:
 		obj = self.appModule._needsWorkObj
 		if obj and controlTypes.State.CHECKED in obj.states:
-			return _WindowControlIdOffset.NEEDS_WORK_SWITCH
+			return _WindowControlIdOffsetFromDataView.NEEDS_WORK_SWITCH
 		obj = self.appModule._oldSourceTextObj
 		if obj and not obj.hasIrrelevantLocation:
-			return _WindowControlIdOffset.OLD_SOURCE_TEXT
+			return _WindowControlIdOffsetFromSidebar.OLD_SOURCE_TEXT
 		obj = self.appModule._translationWarningObj
 		if obj and obj.parent and obj.parent.parent and not obj.parent.parent.hasIrrelevantLocation:
-			return _WindowControlIdOffset.TRANSLATION_WARNING
+			return _WindowControlIdOffsetFromDataView.TRANSLATION_WARNING
 		return None
 
 	def _get_name(self):
@@ -301,9 +336,9 @@ class PoeditListItem(NVDAObject):
 			tones.beep(440, 50)
 			return
 		match self._warningControlToReport:
-			case _WindowControlIdOffset.OLD_SOURCE_TEXT:
+			case _WindowControlIdOffsetFromSidebar.OLD_SOURCE_TEXT:
 				tones.beep(495, 50)
-			case _WindowControlIdOffset.TRANSLATION_WARNING:
+			case _WindowControlIdOffsetFromDataView.TRANSLATION_WARNING:
 				tones.beep(550, 50)
-			case _WindowControlIdOffset.NEEDS_WORK_SWITCH:
+			case _WindowControlIdOffsetFromDataView.NEEDS_WORK_SWITCH:
 				tones.beep(660, 50)

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -90,7 +90,7 @@ There are many minor bug fixes for applications, such as Thunderbird, Adobe Read
 * In Firefox and Chromium-based browsers, NVDA will correctly enter focus mode when pressing enter when positioned within a presentational list (ul / ol) inside editable content. (#16325)
 * Column state change is now correctly reported when selecting columns to display in Thunderbird message list. (#16323)
 * The command line switch `-h`/`--help` works properly again. (#16522, @XLTechie)
-* NVDA's support for the Poedit 3.4 translation software correctly functions when translating languages with 0 or more than 2 plurals (E.g. Chinese, Polish). (#16318) 
+* NVDA's support for the Poedit 3.4+ translation software correctly functions when translating languages with 0 or more than 2 plurals (e.g. Chinese, Polish). (#16318) 
 
 ### Changes for Developers
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -90,7 +90,7 @@ There are many minor bug fixes for applications, such as Thunderbird, Adobe Read
 * In Firefox and Chromium-based browsers, NVDA will correctly enter focus mode when pressing enter when positioned within a presentational list (ul / ol) inside editable content. (#16325)
 * Column state change is now correctly reported when selecting columns to display in Thunderbird message list. (#16323)
 * The command line switch `-h`/`--help` works properly again. (#16522, @XLTechie)
-* NVDA's support for the Poedit 3.4+ translation software correctly functions when translating languages with 0 or more than 2 plurals (e.g. Chinese, Polish). (#16318) 
+* NVDA's support for the Poedit translation software version 3.4 or higher correctly functions when translating languages with 1 or more than 2 plural forms (e.g. Chinese, Polish). (#16318)
 
 ### Changes for Developers
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -90,6 +90,7 @@ There are many minor bug fixes for applications, such as Thunderbird, Adobe Read
 * In Firefox and Chromium-based browsers, NVDA will correctly enter focus mode when pressing enter when positioned within a presentational list (ul / ol) inside editable content. (#16325)
 * Column state change is now correctly reported when selecting columns to display in Thunderbird message list. (#16323)
 * The command line switch `-h`/`--help` works properly again. (#16522, @XLTechie)
+* NVDA's support for the Poedit 3.4 translation software correctly functions when translating languages with 0 or more than 2 plurals (E.g. Chinese, Polish). (#16318) 
 
 ### Changes for Developers
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Fixes #16318

### Summary of the issue:
Recently the poedit appModule was rewritten to support poedit 3.4. However, scripts for reading translation nodes, comments and old source text did not function for languages that had no plurals (Chinese) or 2 or more plurals (Polish). It did however function for languages with exactly one plural (such as French).
As the controlIDs for windows in poedit are not static, but do stay relative to each other, the appModule originally used offsets from the main dataView control. This worked okay for the translation warning, but did not work for controls in the sidebar in all cases, as it seems that there are extra controlIDs consumed for some hidden windows between the main splitter and the sidebar, depending on how many plurals a language has.
E.g. In French, the controlID offset for the Sidebar (relative to the Dataview control) is 29. In Chinese it is 27, and in Plish it is 33. I think it might be roughly two offsets per plural.
  
### Description of user facing changes
Poedit scripts such as Report translation notes (control+shift+a), Report comments (control+shift+c) and Report old source text (control+shift+o) now function no matter how many plurals a language has.

### Description of development approach
* Control ID offsets for controls in the sidebar (such as translation notes, old source text, and comments) are now relative to the sidebar itself, rather than the Dataview control.
* The sidebar window is located by first finding the main splitter window (using a controlID relative to the dataview control) and then finding the next visible sibling window from there.
* To aide in refactoring, support for controlID offsets in the Pro version are now handled by simply minusing 5 from the given controlID offset, as all the offsets in the pro version differed by 5.

### Testing strategy:
With a fr, zh_CN, and pl po files, tested control+shift+w, control+shift+a, control+shift+c and control+shift+o on an entry that contained a warning, a translation note, a comment, and old source text respectively.
* [ ] Do the same tests with the Pro version. Anyone have the pro version?

### Known issues with pull request:
None known.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
