### PR TITLE
Replace padding dots symbol by multiple dots

### DIFF
--- a/source/locale/en/symbols.dic
+++ b/source/locale/en/symbols.dic
@@ -12,7 +12,7 @@ complexSymbols:
 ; phrase ending	(?<=[^\s;]);(?=\s|$)
 : phrase ending	(?<=[^\s:]):(?=\s|$)
 # Series of dots used for visual presentation, e.g. in table of contents
-padding .	\.{4,}
+multiple .	\.{4,}
 # Others
 decimal point	(?<![^\d -])\.(?=\d)
 in-word '	(?<=[^\W_])['’]
@@ -27,7 +27,7 @@ symbols:
 ? sentence ending	question	all	always
 ; phrase ending	semi	most	always
 : phrase ending	colon	most	always
-padding .	padding dots	all	always
+multiple .	multiple dots	all	always
 decimal point		none	always
 in-word '	tick	all	norep
 negative number	minus	none	norep


### PR DESCRIPTION
### Link to issue number:
Related to #16345.
### Summary of the issue:
Multiple dots are reported as "padding dots" in situations where these dots have no padding function. "padding" is too restrictive and is also more difficult to understand; by the way, some translators have actually translated "padding dots" to "multiple dots" in their translations.

### Description of user facing changes
Multiple dots (4 or more) will now be reported withe the more neutral "multiple dots" instead of "padding dots" when the symbol level is high enough.

### Description of development approach
Changed both the symbol name and what is reported in symbol file.

### Testing strategy:
Tested with various symbol level.

### Known issues with pull request:
This issues does not address all the concerns raised in #16345:
* in case of more than 4 dots, the number of dots is not reported anymore; only "multiple dots" is reported
* in Chinese 6 dotes are sometimes used for ellipsis. In NVDA 2024.1 there was nothing to handle this case though. So I'd recommend to add a symbol in the Chinese symbol file, since it has no meaning in English.

Although there are these known issues, this change is already an improvement with respect to #16141.


### Code Review Checklist:


- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

### Note
* I have not modified the change log mentioning "padding" since it refers specifically to the table of content use case.
* An alternative solution could be to revert #16141
as proposed in PR #16364. Mentioning here for awareness (@seanbudd or @gerald-hartig) because PR #16364 has been triaged / closed, but not sure than NV Access has had the opportunity to have a look at it.
* Maybe a better solution allowing to identify "one dot among 4 or more" exists but I have not found one. And I will probably not have the time to investigate such solution before beta translation freeze.
