### PR TITLE
Disable style navigation quickNav in MS Word

### DIFF
--- a/source/NVDAObjects/UIA/wordDocument.py
+++ b/source/NVDAObjects/UIA/wordDocument.py
@@ -6,6 +6,7 @@
 from typing import (
 	Optional,
 	Dict,
+	Generator,
 )
 
 import enum
@@ -38,6 +39,7 @@ from NVDAObjects import NVDAObject
 from scriptHandler import script
 import eventHandler
 from globalCommands import SCRCAT_SYSTEMCARET
+import documentBase
 
 """Support for Microsoft Word via UI Automation."""
 
@@ -513,6 +515,17 @@ class WordBrowseModeDocument(UIABrowseModeDocument):
 		return super(WordBrowseModeDocument,self)._iterNodesByType(nodeType,direction=direction,pos=pos)
 
 	ElementsListDialog=ElementsListDialog
+
+	def _iterTextStyle(
+			self,
+			kind: str,
+			direction: documentBase._Movement = documentBase._Movement.NEXT,
+			pos: textInfos.TextInfo | None = None
+	) -> Generator[browseMode.TextInfoQuickNavItem, None, None]:
+		raise NotImplementedError(
+			"word textInfos are not supported due to multiple issues with them - #16569"
+		)
+
 
 class WordDocumentNode(UIA):
 	TextInfo=WordDocumentTextInfo

--- a/source/NVDAObjects/window/winword.py
+++ b/source/NVDAObjects/window/winword.py
@@ -9,6 +9,7 @@ import time
 from typing import (
 	Optional,
 	Dict,
+	Generator,
 	TYPE_CHECKING,
 )
 
@@ -44,6 +45,7 @@ from ..behaviors import EditableTextWithoutAutoSelectDetection
 from . import _msOfficeChart
 import locationHelper
 from enum import IntEnum
+import documentBase
 
 if TYPE_CHECKING:
 	import inputCore
@@ -1252,6 +1254,16 @@ class WordDocumentTreeInterceptor(browseMode.BrowseModeDocumentTreeInterceptor):
 	def script_previousColumn(self,gesture):
 		self.rootNVDAObject._moveInTable(row=False,forward=False)
 		braille.handler.handleCaretMove(self)
+
+	def _iterTextStyle(
+			self,
+			kind: str,
+			direction: documentBase._Movement = documentBase._Movement.NEXT,
+			pos: textInfos.TextInfo | None = None
+	) -> Generator[browseMode.TextInfoQuickNavItem, None, None]:
+		raise NotImplementedError(
+			"word textInfos are not supported due to multiple issues with them - #16569"
+		)
 
 	__gestures={
 		"kb:tab":"trapNonCommandGesture",

--- a/source/appModules/outlook.py
+++ b/source/appModules/outlook.py
@@ -44,6 +44,9 @@ from NVDAObjects.behaviors import RowWithFakeNavigation, Dialog
 from NVDAObjects.UIA import UIA
 from NVDAObjects.UIA.wordDocument import WordDocument as UIAWordDocument
 import languageHandler
+from typing import Generator
+import documentBase
+import browseMode
 
 PR_LAST_VERB_EXECUTED=0x10810003
 VERB_REPLYTOSENDER=102
@@ -604,6 +607,14 @@ class MailViewerTreeInterceptor(WordDocumentTreeInterceptor):
 		if not isCollapsed:
 			speech.speakTextInfo(info, reason=controlTypes.OutputReason.FOCUS)
 		braille.handler.handleCaretMove(self)
+
+	def _iterTextStyle(
+			self,
+			kind: str,
+			direction: documentBase._Movement = documentBase._Movement.NEXT,
+			pos: textInfos.TextInfo | None = None
+	) -> Generator[browseMode.TextInfoQuickNavItem, None, None]:
+		raise NotImplementedError("Outlook is not supported due to performance - #16408")
 
 	__gestures={
 		"kb:tab":"tab",

--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -2370,14 +2370,6 @@ class BrowseModeDocumentTreeInterceptor(documentBase.DocumentWithTableNavigation
 			direction: documentBase._Movement = documentBase._Movement.NEXT,
 			pos: textInfos.TextInfo | None = None
 	) -> Generator[TextInfoQuickNavItem, None, None]:
-		from NVDAObjects.window.winword import BrowseModeWordDocumentTextInfo
-		if isinstance(pos, BrowseModeWordDocumentTextInfo):
-			raise NotImplementedError(
-				"non-UIA word textInfos are not supported due to multiple issues with them - #16569"
-			)
-		from appModules.outlook import OutlookUIAWordDocument
-		if isinstance(api.getFocusObject(), OutlookUIAWordDocument):
-			raise NotImplementedError("Outlook is not supported due to performance - #16408")
 		if direction not in [
 			documentBase._Movement.NEXT,
 			documentBase._Movement.PREVIOUS,


### PR DESCRIPTION
### Link to issue number:
Fixes #16546
Fixes #16527

### Summary of the issue:
Style navigation is too slow in MSWord even with UIA enabled.
### Description of user facing changes
Message "not supported in this document" is spoken when trying style navigation in MSWord.
### Description of development approach
I did a bit of refactoring. Instead of trying to catch all the conditions in `browseMode.BrowseModeDocumentTreeInterceptor`, I overrode `_iterTextStyle()` method in corresponding child subclasses.
### Testing strategy:
Tested manually with both UIA enabled and disabled in both MSWord and Outlook.
### Known issues with pull request:
N/A
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
