### PR TITLE
Making sound split classes and functions private

### DIFF
--- a/source/audio/__init__.py
+++ b/source/audio/__init__.py
@@ -5,12 +5,12 @@
 
 from .soundSplit import (
 	SoundSplitState,
-	setSoundSplitState,
-	toggleSoundSplitState,
+	_setSoundSplitState,
+	_toggleSoundSplitState,
 )
 
 __all__ = [
 	"SoundSplitState",
-	"setSoundSplitState",
-	"toggleSoundSplitState",
+	"_setSoundSplitState",
+	"_toggleSoundSplitState",
 ]

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -4509,7 +4509,7 @@ class GlobalCommands(ScriptableObject):
 		gesture="kb:NVDA+alt+s",
 	)
 	def script_cycleSoundSplit(self, gesture: "inputCore.InputGesture") -> None:
-		audio.toggleSoundSplitState()
+		audio._toggleSoundSplitState()
 
 
 #: The single global commands instance.

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -2839,7 +2839,7 @@ class AudioPanel(SettingsPanel):
 		index = self.soundSplitComboBox.GetSelection()
 		config.conf["audio"]["soundSplitState"] = index
 		if nvwave.usingWasapiWavePlayer():
-			audio.setSoundSplitState(audio.SoundSplitState(index))
+			audio._setSoundSplitState(audio.SoundSplitState(index))
 		config.conf["audio"]["includedSoundSplitModes"] = [
 			mIndex
 			for mIndex in range(len(self._allSoundSplitModes))


### PR DESCRIPTION
### Link to issue number:
N/A
### Summary of the issue:
Following @seanbudd's suggestion in #16591 making classes and functions private.
The rationale is that we would like to refactor sound split code so that more code is going to be reused in application volume adjuster, but #16591 will have to be postponed  to  v2024.3. So we need to make sound split API private to avoid breaking API changes.
### Description of user facing changes
N/A
### Description of development approach
Prefixing with underscore.
### Testing strategy:
Manual.
### Known issues with pull request:
N/A
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
