### PR TITLE
Sound split fixes in GUI and User Guide

### DIFF
--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -2791,34 +2791,7 @@ class AudioPanel(SettingsPanel):
 		self.soundSplitModesList.Checked = [
 			mIndex for mIndex in range(len(self._allSoundSplitModes)) if mIndex in includedModes
 		]
-		self.soundSplitModesList.Bind(wx.EVT_CHECKLISTBOX, self._onSoundSplitModesListChange)
 		self.soundSplitModesList.Select(0)
-
-	def _onSoundSplitModesListChange(self, evt: wx.CommandEvent):
-		# continue event propagation to custom control event handler
-		# to guarantee user is notified about checkbox being checked or unchecked
-		evt.Skip()
-		if (
-			evt.GetInt() == self._allSoundSplitModes.index(audio.SoundSplitState.OFF)
-			and not self.soundSplitModesList.IsChecked(evt.GetInt())
-		):
-			if gui.messageBox(
-				_(
-					# Translators: Warning shown when 'OFF' sound split mode is disabled in settings.
-					"You did not choose 'Off' as one of your sound split mode options. "
-					"Please note that this may result in no speech output at all "
-					"in case one of your audio channels is malfunctioning. "
-					"Are you sure you want to continue?"
-				),
-				# Translators: Title of the warning message.
-				_("Warning"),
-				wx.YES | wx.NO | wx.ICON_WARNING,
-				self,
-			) == wx.NO:
-				self.soundSplitModesList.SetCheckedItems(
-					list(self.soundSplitModesList.GetCheckedItems())
-					+ [self._allSoundSplitModes.index(audio.SoundSplitState.OFF)]
-				)
 
 	def onSave(self):
 		if config.conf["speech"]["outputDevice"] != self.deviceList.GetStringSelection():

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -2274,7 +2274,7 @@ This option is not available if you have started NVDA with [WASAPI disabled for 
 
 The sound split feature allows users to make use of their stereo output devices, such as headphones and speakers.
 Sound split makes it possible to have NVDA speech in one channel (e.g. left) and have all other applications play their sounds in the other channel (e.g. right).
-By default sound split is disabled, which means that all applications including NVDA will play sounds in both left and right channels.
+By default sound split is disabled.
 A gesture allows cycling through the various sound split modes:
 <!-- KC:beginInclude -->
 
@@ -2286,18 +2286,21 @@ A gesture allows cycling through the various sound split modes:
 
 By default this command will cycle between the following modes:
 
-* Disabled sound split: both NVDA and other applications output sounds to both left and right channels.
+* Sound split disabled: NVDA does not apply any sound split processing.
 * NVDA on the left and applications on the right: NVDA will speak in the left channel, while other applications will play sounds in the right channel.
 * NVDA on the left and applications in both channels: NVDA will speak in the left channel, while other applications will play sounds in  both left and right channels.
 
 There are more advanced sound split modes available in NVDA setting combo box.
+Among these modes, "NVDA in both channels and applications in both channels" forces all the sounds to be directed in both channels.
+This mode may differ from "Sound split disabled" mode in case other audio processing interfers with channel volumes.
+
 Please note, that sound split doesn't work as a mixer.
 For example, if an application is playing a stereo sound track while sound split is set to "NVDA on the left and applications on the right", then you will only hear the right channel of the sound track, while the left channel of the sound track will be muted.
 
 This option is not available if you have started NVDA with [WASAPI disabled for audio output](#WASAPI) in Advanced Settings.
 
 Please note, that if NVDA crashes, then it won't be able to restore application sounds volume, and those applications might still output sound only in one channel after NVDA crash.
-In order to mitigate this, please restart NVDA.
+In order to mitigate this, please restart NVDA and select the mode "NVDA in both channels and applications in both channels".
 
 ##### Customizing Sound split modes {#CustomizeSoundSplitModes}
 
@@ -2305,7 +2308,7 @@ This checkable list allows selecting which sound split modes are included when c
 Modes which are unchecked are excluded.
 By default only three modes are included.
 
-* Disabled sound split.
+* Sound split disabled.
 * NVDA on the left and applications on the right.
 * NVDA on the left and applications in both channels.
 


### PR DESCRIPTION
### Link to issue number:
None
### Summary of the issue:
Various issues found in Sound Split feature description in the User Guide and in the GUI:
* The User Guide does not explain the difference between "Sound split disabled" mode and "NVDA in both channels and applications in both channels" mode.
* In the User Guide, the default option is called "Disabled sound split", but "Sound split disabled" in the GUI.
* In the User Guide, the description of the way to restore the sound in both channels after a crash is not always correct, especially now that the "disabled" option does not modify audio processing at all.
* The GUI warning when unchecking the Disabled mode is not correct since there are various other possible modes with speech in both channels (among them the new "NVDA both and app both"). The removal of this warning had been discussed and approved in https://github.com/nvaccess/nvda/pull/16071#discussion_r1498438921 but never completed.

### Description of user facing changes
* User Guide updated for 3 first items.
* Warning removed from the GUI

### Description of development approach
N/A
### Testing strategy:
* Check the generated User Guide.
* Manual check of the GUI
### Known issues with pull request:
None
### Code Review Checklist:


- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
