### PR TITLE
add warning note that NLS eReader Zoomax is not supported

### DIFF
--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -4035,7 +4035,7 @@ The following extra devices are also supported (and do not require any special d
 * APH Chameleon 20
 * Humanware BrailleOne
 * NLS eReader
-  * Note that the Zoomax is currently not supported
+  * Note that the Zoomax is currently not supported without external drivers
 
 Following are the key assignments for  the Brailliant BI/B and BrailleNote touch displays with NVDA.
 Please see the display's documentation for descriptions of where these keys can be found.

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -4035,6 +4035,7 @@ The following extra devices are also supported (and do not require any special d
 * APH Chameleon 20
 * Humanware BrailleOne
 * NLS eReader
+  * Note that the Zoomax is currently not supported
 
 Following are the key assignments for  the Brailliant BI/B and BrailleNote touch displays with NVDA.
 Please see the display's documentation for descriptions of where these keys can be found.


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Related to #15863

### Summary of the issue:
The NLS eReader Zoomax is not supported by NVDA currently, despite a message in the user guide suggesting the contrary.
See #15863 for discussion on adding support for the eReader

### Description of user facing changes
add warning note that NLS eReader Zoomax is not supported
