### PR TITLE
Notifying users of available add-on updates

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ pyserial==3.5
 ./miscDeps/python/wxPython-4.2.2a1-cp311-cp311-win32.whl
 git+https://github.com/DiffSK/configobj@e2ba4457c4651fa54f8d59d8dcdd3da950e956b8#egg=configobj
 requests==2.32.0
+schedule==1.2.1
 # Pillow is an implicit dependency and requires zlib and jpeg by default, but we don't need it
 Pillow==10.3.0 -C "zlib=disable" -C "jpeg=disable"
 
@@ -17,7 +18,7 @@ fast-diff-match-patch==2.1.0
 typing-extensions==4.9.0 
 
 # pycaw is a Core Audio Windows Library used for sound split
-pycaw==20240210                                                                                   
+pycaw==20240210
 
 # Packaging NVDA
 git+https://github.com/py2exe/py2exe@4e7b2b2c60face592e67cb1bc935172a20fa371d#egg=py2exe

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ Pillow==10.3.0 -C "zlib=disable" -C "jpeg=disable"
 fast-diff-match-patch==2.1.0
 
 # typing_extensions are required for specifying default value for `TypeVar`, which is not yet possible with any released version of Python (see PEP 696)
-typing-extensions==4.9.0 
+typing-extensions==4.9.0
 
 # pycaw is a Core Audio Windows Library used for sound split
 pycaw==20240210

--- a/source/addonStore/dataManager.py
+++ b/source/addonStore/dataManager.py
@@ -315,7 +315,9 @@ class _DataManager:
 		for channel in compatibleAddons:
 			for addon in compatibleAddons[channel].values():
 				if getStatus(addon, _StatusFilterKey.UPDATE) == AvailableAddonStatus.UPDATE:
-					addonsPendingUpdate.add(addon)
+					# Only consider add-on updates for the same channel
+					if addon.channel == addon._addonHandlerModel._addonStoreData.channel:
+						addonsPendingUpdate.add(addon)
 		return addonsPendingUpdate
 
 

--- a/source/addonStore/dataManager.py
+++ b/source/addonStore/dataManager.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2022-2023 NV Access Limited
+# Copyright (C) 2022-2024 NV Access Limited
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -309,15 +309,15 @@ class _DataManager:
 			return None
 		return _createInstalledStoreModelFromData(cacheData)
 
-	def _addonsPendingUpdate(self) -> set["_AddonGUIModel"]:
-		addonsPendingUpdate = set()
+	def _addonsPendingUpdate(self) -> list["_AddonGUIModel"]:
+		addonsPendingUpdate: list["_AddonGUIModel"] = []
 		compatibleAddons = self.getLatestCompatibleAddons()
 		for channel in compatibleAddons:
 			for addon in compatibleAddons[channel].values():
 				if getStatus(addon, _StatusFilterKey.UPDATE) == AvailableAddonStatus.UPDATE:
 					# Only consider add-on updates for the same channel
 					if addon.channel == addon._addonHandlerModel._addonStoreData.channel:
-						addonsPendingUpdate.add(addon)
+						addonsPendingUpdate.append(addon)
 		return addonsPendingUpdate
 
 

--- a/source/addonStore/dataManager.py
+++ b/source/addonStore/dataManager.py
@@ -315,9 +315,9 @@ class _DataManager:
 		for channel in compatibleAddons:
 			for addon in compatibleAddons[channel].values():
 				if (
+					getStatus(addon, _StatusFilterKey.UPDATE) == AvailableAddonStatus.UPDATE
 					# Only consider add-ons that have been installed through the Add-on Store
-					addon._addonHandlerModel._addonStoreData is not None
-					and getStatus(addon, _StatusFilterKey.UPDATE) == AvailableAddonStatus.UPDATE
+					and addon._addonHandlerModel._addonStoreData is not None
 				):
 					# Only consider add-on updates for the same channel
 					if addon.channel == addon._addonHandlerModel._addonStoreData.channel:

--- a/source/addonStore/dataManager.py
+++ b/source/addonStore/dataManager.py
@@ -314,7 +314,11 @@ class _DataManager:
 		compatibleAddons = self.getLatestCompatibleAddons()
 		for channel in compatibleAddons:
 			for addon in compatibleAddons[channel].values():
-				if getStatus(addon, _StatusFilterKey.UPDATE) == AvailableAddonStatus.UPDATE:
+				if (
+					# Only consider add-ons that have been installed through the Add-on Store
+					addon._addonHandlerModel._addonStoreData is not None
+					and getStatus(addon, _StatusFilterKey.UPDATE) == AvailableAddonStatus.UPDATE
+				):
 					# Only consider add-on updates for the same channel
 					if addon.channel == addon._addonHandlerModel._addonStoreData.channel:
 						addonsPendingUpdate.append(addon)

--- a/source/addonStore/dataManager.py
+++ b/source/addonStore/dataManager.py
@@ -37,6 +37,7 @@ from .models.addon import (
 	_createStoreCollectionFromJson,
 )
 from .models.channel import Channel
+from .models.status import AvailableAddonStatus, getStatus, _StatusFilterKey
 from .network import (
 	_getCurrentApiVersionForURL,
 	_getAddonStoreURL,
@@ -47,7 +48,7 @@ from .network import (
 if TYPE_CHECKING:
 	from addonHandler import Addon as AddonHandlerModel  # noqa: F401
 	# AddonGUICollectionT must only be imported when TYPE_CHECKING
-	from .models.addon import AddonGUICollectionT, _AddonStoreModel  # noqa: F401
+	from .models.addon import AddonGUICollectionT, _AddonGUIModel, _AddonStoreModel  # noqa: F401
 	from gui.addonStoreGui.viewModels.addonList import AddonListItemVM  # noqa: F401
 	from gui.message import DisplayableError  # noqa: F401
 
@@ -307,6 +308,15 @@ class _DataManager:
 		if not cacheData:
 			return None
 		return _createInstalledStoreModelFromData(cacheData)
+
+	def _addonsPendingUpdate(self) -> set["_AddonGUIModel"]:
+		addonsPendingUpdate = set()
+		compatibleAddons = self.getLatestCompatibleAddons()
+		for channel in compatibleAddons:
+			for addon in compatibleAddons[channel].values():
+				if getStatus(addon, _StatusFilterKey.UPDATE) == AvailableAddonStatus.UPDATE:
+					addonsPendingUpdate.add(addon)
+		return addonsPendingUpdate
 
 
 class _InstalledAddonsCache(AutoPropertyObject):

--- a/source/config/__init__.py
+++ b/source/config/__init__.py
@@ -506,12 +506,13 @@ class ConfigManager(object):
 
 	#: Sections that only apply to the base configuration;
 	#: i.e. they cannot be overridden in profiles.
-	BASE_ONLY_SECTIONS = {
-	"general", 
-	"update", 
-	"upgrade",
-	"development",
-}
+	BASE_ONLY_SECTIONS = frozenset({
+		"general", 
+		"update", 
+		"upgrade",
+		"development",
+		"addonStore",
+	})
 
 	def __init__(self):
 		self.spec = confspec

--- a/source/config/__init__.py
+++ b/source/config/__init__.py
@@ -507,8 +507,8 @@ class ConfigManager(object):
 	#: Sections that only apply to the base configuration;
 	#: i.e. they cannot be overridden in profiles.
 	BASE_ONLY_SECTIONS = frozenset({
-		"general", 
-		"update", 
+		"general",
+		"update",
 		"upgrade",
 		"development",
 		"addonStore",

--- a/source/config/configFlags.py
+++ b/source/config/configFlags.py
@@ -204,7 +204,7 @@ class ReportCellBorders(DisplayStringIntEnum):
 		}
 
 
-class AutomaticUpdateBehaviour(DisplayStringStrEnum):
+class AddonsAutomaticUpdate(DisplayStringStrEnum):
 	NOTIFY = "notify"
 	# UPDATE = "update"
 	DISABLED = "disabled"
@@ -212,10 +212,10 @@ class AutomaticUpdateBehaviour(DisplayStringStrEnum):
 	@property
 	def _displayStringLabels(self):
 		return {
-			# Translators: This is a label for the automatic update behaviour of an add-on.
-			# It will notify the user when an update is available.
+			# Translators: This is a label for the automatic update behaviour for add-ons.
+			# It will notify the user when updates are available.
 			self.NOTIFY: _("Notify (default)"),
 			# self.UPDATE: _("Update Automatically"),
-			# Translators: This is a label for the automatic update behaviour of an add-on.
+			# Translators: This is a label for the automatic update behaviour for add-ons.
 			self.DISABLED: _("Disabled"),
 		}

--- a/source/config/configFlags.py
+++ b/source/config/configFlags.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2022-2023 NV Access Limited, Cyrille Bougot
+# Copyright (C) 2022-2024 NV Access Limited, Cyrille Bougot
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 

--- a/source/config/configFlags.py
+++ b/source/config/configFlags.py
@@ -202,3 +202,20 @@ class ReportCellBorders(DisplayStringIntEnum):
 			# document formatting settings panel.
 			ReportCellBorders.COLOR_AND_STYLE: _("Both Colors and Styles"),
 		}
+
+
+class AutomaticUpdateBehaviour(DisplayStringStrEnum):
+	NOTIFY = "notify"
+	# UPDATE = "update"
+	DISABLED = "disabled"
+
+	@property
+	def _displayStringLabels(self):
+		return {
+			# Translators: This is a label for the automatic update behaviour of an add-on.
+			# It will notify the user when an update is available.
+			self.NOTIFY: _("Notify (default)"),
+			# self.UPDATE: _("Update Automatically"),
+			# Translators: This is a label for the automatic update behaviour of an add-on.
+			self.DISABLED: _("Disabled"),
+		}

--- a/source/config/configFlags.py
+++ b/source/config/configFlags.py
@@ -206,6 +206,7 @@ class ReportCellBorders(DisplayStringIntEnum):
 
 class AddonsAutomaticUpdate(DisplayStringStrEnum):
 	NOTIFY = "notify"
+	# TODO: uncomment when implementing #3208
 	# UPDATE = "update"
 	DISABLED = "disabled"
 

--- a/source/config/configFlags.py
+++ b/source/config/configFlags.py
@@ -214,7 +214,7 @@ class AddonsAutomaticUpdate(DisplayStringStrEnum):
 		return {
 			# Translators: This is a label for the automatic update behaviour for add-ons.
 			# It will notify the user when updates are available.
-			self.NOTIFY: _("Notify (default)"),
+			self.NOTIFY: _("Notify"),
 			# self.UPDATE: _("Update Automatically"),
 			# Translators: This is a label for the automatic update behaviour for add-ons.
 			self.DISABLED: _("Disabled"),

--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2006-2023 NV Access Limited, Babbage B.V., Davy Kager, Bill Dengler, Julien Cochuyt,
+# Copyright (C) 2006-2024 NV Access Limited, Babbage B.V., Davy Kager, Bill Dengler, Julien Cochuyt,
 # Joseph Lee, Dawid Pieper, mltony, Bram Duvigneau, Cyrille Bougot, Rob Meredith,
 # Burman's Computer and Education Ltd., Leonard de Ruijter, Łukasz Golonka
 # This file is covered by the GNU General Public License.

--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -324,6 +324,7 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 
 [addonStore]
 	showWarning = boolean(default=true)
+	automaticUpdates = option("notify", "disabled", default="notify")
 """
 
 #: The configuration specification

--- a/source/core.py
+++ b/source/core.py
@@ -661,6 +661,8 @@ def main():
 	log.info(f"Windows version: {winVersion.getWinVer()}")
 	log.info("Using Python version %s"%sys.version)
 	log.info("Using comtypes version %s"%comtypes.__version__)
+	from utils import schedule
+	schedule.initialize()
 	import configobj
 	log.info("Using configobj version %s with validate version %s"%(configobj.__version__,configobj.validate.__version__))
 	# Set a reasonable timeout for any socket connections NVDA makes.
@@ -670,6 +672,8 @@ def main():
 	from addonStore import dataManager
 	dataManager.initialize()
 	addonHandler.initialize()
+	from gui import addonStoreGui
+	addonStoreGui.initialize()
 	if globalVars.appArgs.disableAddons:
 		log.info("Add-ons are disabled. Restart NVDA to enable them.")
 	import appModuleHandler
@@ -959,6 +963,7 @@ def main():
 	_terminate(addonHandler)
 	_terminate(dataManager, name="addon dataManager")
 	_terminate(garbageHandler)
+	_terminate(schedule, name="task scheduler")
 	# DMP is only started if needed.
 	# Terminate manually (and let it write to the log if necessary)
 	# as core._terminate always writes an entry.

--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: UTF-8 -*-
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2006-2023 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Mesar Hameed, Joseph Lee,
+# Copyright (C) 2006-2024 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Mesar Hameed, Joseph Lee,
 # Thomas Stivers, Babbage B.V., Accessolutions, Julien Cochuyt, Cyrille Bougot, Luke Davis
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.

--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -408,6 +408,21 @@ class MainFrame(wx.Frame):
 		_storeVM.refresh()
 		self.popupSettingsDialog(AddonStoreDialog, _storeVM)
 
+	@blockAction.when(
+		blockAction.Context.SECURE_MODE,
+		blockAction.Context.MODAL_DIALOG_OPEN,
+		blockAction.Context.WINDOWS_LOCKED,
+		blockAction.Context.WINDOWS_STORE_VERSION,
+		blockAction.Context.RUNNING_LAUNCHER,
+	)
+	def onAddonStoreUpdatableCommand(self, evt: wx.MenuEvent):
+		from .addonStoreGui import AddonStoreDialog
+		from .addonStoreGui.viewModels.store import AddonStoreVM
+		from addonStore.models.status import _StatusFilterKey
+		_storeVM = AddonStoreVM()
+		_storeVM.refresh()
+		self.popupSettingsDialog(AddonStoreDialog, _storeVM, openToTab=_StatusFilterKey.UPDATE)
+
 	def onReloadPluginsCommand(self, evt):
 		import appModuleHandler, globalPluginHandler
 		from NVDAObjects import NVDAObject

--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -415,7 +415,7 @@ class MainFrame(wx.Frame):
 		blockAction.Context.WINDOWS_STORE_VERSION,
 		blockAction.Context.RUNNING_LAUNCHER,
 	)
-	def onAddonStoreUpdatableCommand(self, evt: wx.MenuEvent):
+	def onAddonStoreUpdatableCommand(self, evt: wx.MenuEvent | None):
 		from .addonStoreGui import AddonStoreDialog
 		from .addonStoreGui.viewModels.store import AddonStoreVM
 		from addonStore.models.status import _StatusFilterKey

--- a/source/gui/addonStoreGui/__init__.py
+++ b/source/gui/addonStoreGui/__init__.py
@@ -3,8 +3,18 @@
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
+import wx
+
 from .controls.storeDialog import AddonStoreDialog
+from .controls.messageDialogs import UpdatableAddonsDialog
 
 __all__ = [
 	"AddonStoreDialog",
+	"initialize",
 ]
+
+
+def initialize():
+	from utils.schedule import ScheduleThread
+	# Ensure the GUI functionality is called from the wx thread from the schedule thread
+	ScheduleThread.scheduleDailyJobAtStartUp(lambda: wx.CallAfter(UpdatableAddonsDialog._checkForUpdatableAddons))

--- a/source/gui/addonStoreGui/__init__.py
+++ b/source/gui/addonStoreGui/__init__.py
@@ -3,7 +3,7 @@
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
-from utils.schedule import ScheduleThread, ThreadTarget
+from utils.schedule import scheduleThread, ThreadTarget
 
 from .controls.storeDialog import AddonStoreDialog
 from .controls.messageDialogs import UpdatableAddonsDialog
@@ -15,7 +15,7 @@ __all__ = [
 
 
 def initialize():
-	ScheduleThread.scheduleDailyJobAtStartUp(
+	scheduleThread.scheduleDailyJobAtStartUp(
 		UpdatableAddonsDialog._checkForUpdatableAddons,
 		queueToThread=ThreadTarget.GUI,
 	)

--- a/source/gui/addonStoreGui/__init__.py
+++ b/source/gui/addonStoreGui/__init__.py
@@ -17,4 +17,6 @@ __all__ = [
 def initialize():
 	from utils.schedule import ScheduleThread
 	# Ensure the GUI functionality is called from the wx thread from the schedule thread
-	ScheduleThread.scheduleDailyJobAtStartUp(lambda: wx.CallAfter(UpdatableAddonsDialog._checkForUpdatableAddons))
+	ScheduleThread.scheduleDailyJobAtStartUp(
+		lambda: wx.CallAfter(UpdatableAddonsDialog._checkForUpdatableAddons)
+	)

--- a/source/gui/addonStoreGui/__init__.py
+++ b/source/gui/addonStoreGui/__init__.py
@@ -1,9 +1,11 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2022 NV Access Limited
+# Copyright (C) 2022-2024 NV Access Limited
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
 import wx
+
+from utils.schedule import ScheduleThread
 
 from .controls.storeDialog import AddonStoreDialog
 from .controls.messageDialogs import UpdatableAddonsDialog
@@ -15,7 +17,6 @@ __all__ = [
 
 
 def initialize():
-	from utils.schedule import ScheduleThread
 	# Ensure the GUI functionality is called from the wx thread from the schedule thread
 	ScheduleThread.scheduleDailyJobAtStartUp(
 		lambda: wx.CallAfter(UpdatableAddonsDialog._checkForUpdatableAddons)

--- a/source/gui/addonStoreGui/__init__.py
+++ b/source/gui/addonStoreGui/__init__.py
@@ -3,9 +3,7 @@
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
-import wx
-
-from utils.schedule import ScheduleThread
+from utils.schedule import ScheduleThread, ThreadTarget
 
 from .controls.storeDialog import AddonStoreDialog
 from .controls.messageDialogs import UpdatableAddonsDialog
@@ -17,7 +15,7 @@ __all__ = [
 
 
 def initialize():
-	# Ensure the GUI functionality is called from the wx thread from the schedule thread
 	ScheduleThread.scheduleDailyJobAtStartUp(
-		lambda: wx.CallAfter(UpdatableAddonsDialog._checkForUpdatableAddons)
+		UpdatableAddonsDialog._checkForUpdatableAddons,
+		queueToThread=ThreadTarget.GUI,
 	)

--- a/source/gui/addonStoreGui/controls/messageDialogs.py
+++ b/source/gui/addonStoreGui/controls/messageDialogs.py
@@ -19,6 +19,7 @@ from addonStore.dataManager import addonDataManager
 from addonStore.models.status import AvailableAddonStatus
 import config
 from config.configFlags import AddonsAutomaticUpdate
+import globalVars
 import gui
 from gui import nvdaControls
 from gui.addonGui import ConfirmAddonInstallDialog, ErrorAddonInstallDialog, promptUserForRestart
@@ -534,8 +535,11 @@ class UpdatableAddonsDialog(
 
 	@classmethod
 	def _checkForUpdatableAddons(cls):
-		if AddonsAutomaticUpdate.DISABLED == config.conf["addonStore"]["automaticUpdates"]:
-			log.debug("automatic updates are disabled")
+		if (
+			globalVars.appArgs.secure
+			or (AddonsAutomaticUpdate.DISABLED == config.conf["addonStore"]["automaticUpdates"])
+		):
+			log.debug("automatic add-on updates are disabled")
 			return
 		log.debug("checking for updatable add-ons")
 		addonsPendingUpdate = addonDataManager._addonsPendingUpdate()

--- a/source/gui/addonStoreGui/controls/messageDialogs.py
+++ b/source/gui/addonStoreGui/controls/messageDialogs.py
@@ -371,11 +371,21 @@ class UpdatableAddonsDialog(
 		super().__init__(parent, title=pgettext("addonStore", "Add-on updates available"))
 		self.addonsPendingUpdate = addonsPendingUpdate
 		self.onDisplayableError = DisplayableError.OnDisplayableErrorT()
-		self.Bind(wx.EVT_CLOSE, self.onClose)
+		self._setupUI()
 
+	def _setupUI(self):
+		self.Bind(wx.EVT_CLOSE, self.onClose)
 		mainSizer = wx.BoxSizer(wx.VERTICAL)
 		sHelper = BoxSizerHelper(self, orientation=wx.VERTICAL)
+		self._setupMessage(sHelper)
+		self._createAddonsPanel(sHelper)
+		self._setupButtons(sHelper)
+		mainSizer.Add(sHelper.sizer, border=BORDER_FOR_DIALOGS, flag=wx.ALL)
+		self.Sizer = mainSizer
+		mainSizer.Fit(self)
+		self.CentreOnScreen()
 
+	def _setupMessage(self, sHelper: BoxSizerHelper):
 		_message = pgettext(
 			"addonStore",
 			# Translators: Message displayed when updates are available for some installed add-ons.
@@ -386,15 +396,10 @@ class UpdatableAddonsDialog(
 		sText = sHelper.addItem(wx.StaticText(self, label=_message))
 		# the wx.Window must be constructed before we can get the handle.
 		self.scaleFactor = windowUtils.getWindowScalingFactor(self.GetHandle())
-		sText.Wrap(
-			# 600 was fairly arbitrarily chosen by a visual user to look acceptable on their machine.
-			self.scaleFactor * 600
-		)
+		# 600 was fairly arbitrarily chosen by a visual user to look acceptable on their machine.
+		sText.Wrap(self.scaleFactor * 600)
 
-		sHelper.sizer.AddSpacer(SPACE_BETWEEN_VERTICAL_DIALOG_ITEMS)
-
-		self._createAddonsPanel(sHelper)
-
+	def _setupButtons(self, sHelper: BoxSizerHelper):
 		bHelper = sHelper.addDialogDismissButtons(ButtonHelper(wx.HORIZONTAL))
 
 		# Translators: The label of a button in a dialog
@@ -408,11 +413,6 @@ class UpdatableAddonsDialog(
 		# Translators: The label of a button in a dialog
 		closeButton = bHelper.addButton(self, wx.ID_CLOSE, label=pgettext("addonStore", "&Close"))
 		closeButton.Bind(wx.EVT_BUTTON, self.onCloseButton)
-
-		mainSizer.Add(sHelper.sizer, border=BORDER_FOR_DIALOGS, flag=wx.ALL)
-		self.Sizer = mainSizer
-		mainSizer.Fit(self)
-		self.CentreOnScreen()
 
 	def _createAddonsPanel(self, sHelper: BoxSizerHelper):
 		# Translators: the label for the addons list in the updatable addons dialog.

--- a/source/gui/addonStoreGui/controls/messageDialogs.py
+++ b/source/gui/addonStoreGui/controls/messageDialogs.py
@@ -17,7 +17,7 @@ from addonStore.models.addon import (
 )
 from addonStore.dataManager import addonDataManager
 import config
-from config.configFlags import AutomaticUpdateBehaviour
+from config.configFlags import AddonsAutomaticUpdate
 from logHandler import log
 import gui
 from gui.addonGui import ConfirmAddonInstallDialog, ErrorAddonInstallDialog
@@ -406,7 +406,7 @@ class UpdatableAddonsDialog(
 
 	@classmethod
 	def _checkForUpdatableAddons(cls):
-		if AutomaticUpdateBehaviour.DISABLED == config.conf["addonStore"]["automaticUpdates"]:
+		if AddonsAutomaticUpdate.DISABLED == config.conf["addonStore"]["automaticUpdates"]:
 			log.debug("automatic updates are disabled")
 			return
 		log.debug("checking for updatable add-ons")

--- a/source/gui/addonStoreGui/controls/messageDialogs.py
+++ b/source/gui/addonStoreGui/controls/messageDialogs.py
@@ -411,7 +411,8 @@ class UpdatableAddonsDialog(
 		bHelper = sHelper.addDialogDismissButtons(ButtonHelper(wx.HORIZONTAL))
 
 		# Translators: The label of a button in a dialog
-		self.openStoreButton = bHelper.addButton(self, wx.ID_CLOSE, label=pgettext("addonStore", "Open Add-on &Store"))
+		openStoreLabel = pgettext("addonStore", "Open Add-on &Store")
+		self.openStoreButton = bHelper.addButton(self, wx.ID_CLOSE, label=openStoreLabel)
 		self.openStoreButton.Bind(wx.EVT_BUTTON, self.onOpenStoreButton)
 
 		# Translators: The label of a button in a dialog
@@ -477,6 +478,7 @@ class UpdatableAddonsDialog(
 		self.updateAllButton.Disable()
 		self.openStoreButton.Disable()
 		self.addonsList.SetFocus()
+		self.addonsList.Focus(0)
 
 	def _statusUpdate(self, addonListItemVM: AddonListItemVM):
 		log.debug(f"{addonListItemVM.Id} status: {addonListItemVM.status}")

--- a/source/gui/addonStoreGui/controls/messageDialogs.py
+++ b/source/gui/addonStoreGui/controls/messageDialogs.py
@@ -434,11 +434,11 @@ class UpdatableAddonsDialog(
 		# Translators: Label for an extra detail field for an add-on. In the add-on store UX.
 		statusLabel = pgettext("addonStore", "Status:")
 
-		self.addonsList.AppendColumn(nameLabel, width=self.scaleFactor * 300)
-		self.addonsList.AppendColumn(installedVersionLabel, width=self.scaleFactor * 200)
-		self.addonsList.AppendColumn(availableVersionLabel, width=self.scaleFactor * 200)
-		self.addonsList.AppendColumn(channelLabel, width=self.scaleFactor * 150)
-		self.addonsList.AppendColumn(statusLabel, width=self.scaleFactor * 300)
+		self.addonsList.AppendColumn(nameLabel, width=300)
+		self.addonsList.AppendColumn(installedVersionLabel, width=200)
+		self.addonsList.AppendColumn(availableVersionLabel, width=200)
+		self.addonsList.AppendColumn(channelLabel, width=150)
+		self.addonsList.AppendColumn(statusLabel, width=300)
 		for addon in self.addonsPendingUpdate:
 			self.addonsList.Append((
 				addon.name,

--- a/source/gui/addonStoreGui/controls/messageDialogs.py
+++ b/source/gui/addonStoreGui/controls/messageDialogs.py
@@ -411,8 +411,8 @@ class UpdatableAddonsDialog(
 		bHelper = sHelper.addDialogDismissButtons(ButtonHelper(wx.HORIZONTAL))
 
 		# Translators: The label of a button in a dialog
-		openStoreButton = bHelper.addButton(self, wx.ID_CLOSE, label=pgettext("addonStore", "Open Add-on &Store"))
-		openStoreButton.Bind(wx.EVT_BUTTON, self.onOpenStoreButton)
+		self.openStoreButton = bHelper.addButton(self, wx.ID_CLOSE, label=pgettext("addonStore", "Open Add-on &Store"))
+		self.openStoreButton.Bind(wx.EVT_BUTTON, self.onOpenStoreButton)
 
 		# Translators: The label of a button in a dialog
 		self.updateAllButton = bHelper.addButton(self, wx.ID_CLOSE, label=pgettext("addonStore", "&Update all"))
@@ -449,7 +449,7 @@ class UpdatableAddonsDialog(
 		self.addonsList.AppendColumn(statusLabel, width=300)
 		for addon in self.addonsPendingUpdate:
 			self.addonsList.Append((
-				addon.name,
+				addon.displayName,
 				addon._addonHandlerModel.version,
 				addon.addonVersionName,
 				addon.channel.displayString,
@@ -475,6 +475,7 @@ class UpdatableAddonsDialog(
 		# Translators: Message shown when updating add-ons in the updatable add-ons dialog
 		ui.message(pgettext("addonStore", "Updating add-ons..."))
 		self.updateAllButton.Disable()
+		self.openStoreButton.Disable()
 		self.addonsList.SetFocus()
 
 	def _statusUpdate(self, addonListItemVM: AddonListItemVM):

--- a/source/gui/addonStoreGui/controls/messageDialogs.py
+++ b/source/gui/addonStoreGui/controls/messageDialogs.py
@@ -391,7 +391,6 @@ class UpdatableAddonsDialog(
 			"addonStore",
 			# Translators: Message displayed when updates are available for some installed add-ons.
 			"Updates are available for some of your installed add-ons. "
-			"Open the Add-on Store to update them. "
 		)
 
 		sText = sHelper.addItem(wx.StaticText(self, label=_message))
@@ -435,11 +434,11 @@ class UpdatableAddonsDialog(
 		# Translators: Label for an extra detail field for an add-on. In the add-on store UX.
 		statusLabel = pgettext("addonStore", "Status:")
 
-		self.addonsList.AppendColumn(nameLabel, width=300)
-		self.addonsList.AppendColumn(installedVersionLabel, width=200)
-		self.addonsList.AppendColumn(availableVersionLabel, width=200)
-		self.addonsList.AppendColumn(channelLabel, width=150)
-		self.addonsList.AppendColumn(statusLabel, width=300)
+		self.addonsList.AppendColumn(nameLabel, width=self.scaleFactor * 300)
+		self.addonsList.AppendColumn(installedVersionLabel, width=self.scaleFactor * 200)
+		self.addonsList.AppendColumn(availableVersionLabel, width=self.scaleFactor * 200)
+		self.addonsList.AppendColumn(channelLabel, width=self.scaleFactor * 150)
+		self.addonsList.AppendColumn(statusLabel, width=self.scaleFactor * 300)
 		for addon in self.addonsPendingUpdate:
 			self.addonsList.Append((
 				addon.name,
@@ -465,6 +464,7 @@ class UpdatableAddonsDialog(
 			self.listItemVMs.append(listItemVM)
 		AddonStoreVM.getAddons(self.listItemVMs)
 		self.addonsList.Refresh()
+		self.addonsList.Focus(0)
 		# Translators: Message shown when updating add-ons in the updatable add-ons dialog
 		ui.message(pgettext("addonStore", "Updating add-ons..."))
 		self.updateAllButton.Disable()

--- a/source/gui/addonStoreGui/controls/messageDialogs.py
+++ b/source/gui/addonStoreGui/controls/messageDialogs.py
@@ -466,10 +466,10 @@ class UpdatableAddonsDialog(
 			self.listItemVMs.append(listItemVM)
 		AddonStoreVM.getAddons(self.listItemVMs)
 		self.addonsList.Refresh()
-		self.addonsList.Focus(0)
 		# Translators: Message shown when updating add-ons in the updatable add-ons dialog
 		ui.message(pgettext("addonStore", "Updating add-ons..."))
 		self.updateAllButton.Disable()
+		self.addonsList.SetFocus()
 
 	def _statusUpdate(self, addonListItemVM: AddonListItemVM):
 		log.debug(f"{addonListItemVM.Id} status: {addonListItemVM.status}")

--- a/source/gui/addonStoreGui/controls/messageDialogs.py
+++ b/source/gui/addonStoreGui/controls/messageDialogs.py
@@ -378,6 +378,7 @@ class UpdatableAddonsDialog(
 
 	def _setupUI(self):
 		self.Bind(wx.EVT_CLOSE, self.onClose)
+		self.Bind(wx.EVT_CHAR_HOOK, self.onCharHook)
 		mainSizer = wx.BoxSizer(wx.VERTICAL)
 		sHelper = BoxSizerHelper(self, orientation=wx.VERTICAL)
 		self._setupMessage(sHelper)
@@ -387,6 +388,11 @@ class UpdatableAddonsDialog(
 		self.Sizer = mainSizer
 		mainSizer.Fit(self)
 		self.CentreOnScreen()
+
+	def onCharHook(self, evt: wx.KeyEvent):
+		if evt.KeyCode == wx.WXK_ESCAPE:
+			self.Close()
+		evt.Skip()
 
 	def _setupMessage(self, sHelper: BoxSizerHelper):
 		_message = pgettext(
@@ -426,15 +432,15 @@ class UpdatableAddonsDialog(
 		)
 
 		# Translators: Label for an extra detail field for an add-on. In the add-on store UX.
-		nameLabel = pgettext("addonStore", "Name:")
+		nameLabel = pgettext("addonStore", "Name")
 		# Translators: Label for an extra detail field for an add-on. In the add-on store UX.
-		installedVersionLabel = pgettext("addonStore", "Installed version:")
+		installedVersionLabel = pgettext("addonStore", "Installed version")
 		# Translators: Label for an extra detail field for an add-on. In the add-on store UX.
-		availableVersionLabel = pgettext("addonStore", "Available version:")
+		availableVersionLabel = pgettext("addonStore", "Available version")
 		# Translators: Label for an extra detail field for an add-on. In the add-on store UX.
-		channelLabel = pgettext("addonStore", "Channel:")
+		channelLabel = pgettext("addonStore", "Channel")
 		# Translators: Label for an extra detail field for an add-on. In the add-on store UX.
-		statusLabel = pgettext("addonStore", "Status:")
+		statusLabel = pgettext("addonStore", "Status")
 
 		self.addonsList.AppendColumn(nameLabel, width=300)
 		self.addonsList.AppendColumn(installedVersionLabel, width=200)

--- a/source/gui/addonStoreGui/controls/messageDialogs.py
+++ b/source/gui/addonStoreGui/controls/messageDialogs.py
@@ -17,6 +17,7 @@ from addonStore.models.addon import (
 )
 from addonStore.dataManager import addonDataManager
 import config
+from config.configFlags import AutomaticUpdateBehaviour
 from logHandler import log
 import gui
 from gui.addonGui import ConfirmAddonInstallDialog, ErrorAddonInstallDialog
@@ -359,7 +360,7 @@ class UpdatableAddonsDialog(
 ):
 	"""A dialog notifying users that updatable add-ons are available"""
 
-	helpId = "UpdatingAddons"  # TODO make custom
+	helpId = "AutomaticAddonUpdates"
 
 	def __init__(self, parent: wx.Window, addonsPendingUpdate: set[_AddonGUIModel]):
 		# Translators: The warning of a dialog
@@ -405,6 +406,9 @@ class UpdatableAddonsDialog(
 
 	@classmethod
 	def _checkForUpdatableAddons(cls):
+		if AutomaticUpdateBehaviour.DISABLED == config.conf["addonStore"]["automaticUpdates"]:
+			log.debug("automatic updates are disabled")
+			return
 		log.debug("checking for updatable add-ons")
 		addonsPendingUpdate = addonDataManager._addonsPendingUpdate()
 		if addonsPendingUpdate:

--- a/source/gui/addonStoreGui/controls/messageDialogs.py
+++ b/source/gui/addonStoreGui/controls/messageDialogs.py
@@ -373,6 +373,8 @@ class UpdatableAddonsDialog(
 		self.addonsPendingUpdate = addonsPendingUpdate
 		self.onDisplayableError = DisplayableError.OnDisplayableErrorT()
 		self._setupUI()
+		self.Raise()
+		self.SetFocus()
 
 	def _setupUI(self):
 		self.Bind(wx.EVT_CLOSE, self.onClose)

--- a/source/gui/addonStoreGui/controls/storeDialog.py
+++ b/source/gui/addonStoreGui/controls/storeDialog.py
@@ -47,10 +47,11 @@ class AddonStoreDialog(SettingsDialog):
 	# point to the Add-on Store one.
 	helpId = "AddonsManager"
 
-	def __init__(self, parent: wx.Window, storeVM: AddonStoreVM):
+	def __init__(self, parent: wx.Window, storeVM: AddonStoreVM, openToTab: _StatusFilterKey | None = None):
 		self._storeVM = storeVM
 		self._storeVM.onDisplayableError.register(self.handleDisplayableError)
 		self._actionsContextMenu = _MonoActionsContextMenu(self._storeVM)
+		self.openToTab = openToTab
 		super().__init__(parent, resizeable=True, buttons={wx.CLOSE})
 		if config.conf["addonStore"]["showWarning"]:
 			displayDialogAsModal(_SafetyWarningDialog(parent))
@@ -78,12 +79,14 @@ class AddonStoreDialog(SettingsDialog):
 		for statusFilter in _statusFilters:
 			self.addonListTabs.AddPage(dynamicTabPage, statusFilter.displayString)
 		tabPageHelper.addItem(self.addonListTabs, flag=wx.EXPAND)
-		if any(self._storeVM._installedAddons[channel] for channel in self._storeVM._installedAddons):
-			# If there's any installed add-ons, use the installed add-ons page by default
-			self.addonListTabs.SetSelection(0)
-		else:
-			availableTabIndex = list(_statusFilters.keys()).index(_StatusFilterKey.AVAILABLE)
-			self.addonListTabs.SetSelection(availableTabIndex)
+		openToTab = self.openToTab
+		if openToTab is None:
+			if any(self._storeVM._installedAddons[channel] for channel in self._storeVM._installedAddons):
+				openToTab = _StatusFilterKey.INSTALLED
+			else:
+				openToTab = _StatusFilterKey.AVAILABLE
+		openToTabIndex = list(_statusFilters.keys()).index(openToTab)
+		self.addonListTabs.SetSelection(openToTabIndex)
 		self.addonListTabs.Bind(wx.EVT_NOTEBOOK_PAGE_CHANGED, self.onListTabPageChange, self.addonListTabs)
 
 		filterCtrlHelper = guiHelper.BoxSizerHelper(self, wx.VERTICAL)

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -27,6 +27,7 @@ import installer
 from synthDriverHandler import changeVoice, getSynth, getSynthList, setSynth, SynthDriver
 import config
 from config.configFlags import (
+	AutomaticUpdateBehaviour,
 	NVDAKey,
 	ShowMessages,
 	TetherTo,
@@ -2873,11 +2874,22 @@ class AddonStorePanel(SettingsPanel):
 	helpId = "AddonStoreSettings"
 
 	def makeSettings(self, settingsSizer: wx.BoxSizer) -> None:
-		# sHelper = guiHelper.BoxSizerHelper(self, sizer=settingsSizer)
-		pass
+		sHelper = guiHelper.BoxSizerHelper(self, sizer=settingsSizer)
+		# Translators: This is a label for the automatic updates combo box in the Add-on Store Settings dialog.
+		automaticUpdatesLabelText = _("&Update notifications:")
+		# TODO: change label to the following when the feature is implemented
+		# automaticUpdatesLabelText = _("Automatic &updates:")
+		self.automaticUpdatesComboBox = sHelper.addLabeledControl(
+			automaticUpdatesLabelText,
+			wx.Choice,
+			choices=[mode.displayString for mode in AutomaticUpdateBehaviour]
+		)
+		self.bindHelpEvent("AutomaticAddonUpdates", self.automaticUpdatesComboBox)
+		index = [x.value for x in AutomaticUpdateBehaviour].index(config.conf["addonStore"]["automaticUpdates"])
+		self.automaticUpdatesComboBox.SetSelection(index)
 
 	def onSave(self):
-		pass
+		config.conf["addonStore"]["automaticUpdates"] = [x.value for x in AutomaticUpdateBehaviour][self.automaticUpdatesComboBox.GetSelection()]
 
 
 class TouchInteractionPanel(SettingsPanel):
@@ -4638,7 +4650,7 @@ class NVDASettingsDialog(MultiCategorySettingsDialog):
 		BrowseModePanel,
 		DocumentFormattingPanel,
 		DocumentNavigationPanel,
-		# AddonStorePanel, currently empty
+		AddonStorePanel,
 	]
 	if touchHandler.touchSupported():
 		categoryClasses.append(TouchInteractionPanel)

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -2889,7 +2889,8 @@ class AddonStorePanel(SettingsPanel):
 		self.automaticUpdatesComboBox.SetSelection(index)
 
 	def onSave(self):
-		config.conf["addonStore"]["automaticUpdates"] = [x.value for x in AddonsAutomaticUpdate][self.automaticUpdatesComboBox.GetSelection()]
+		index = self.automaticUpdatesComboBox.GetSelection()
+		config.conf["addonStore"]["automaticUpdates"] = [x.value for x in AddonsAutomaticUpdate][index]
 
 
 class TouchInteractionPanel(SettingsPanel):

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -4671,7 +4671,11 @@ class NVDASettingsDialog(MultiCategorySettingsDialog):
 	def _doOnCategoryChange(self):
 		global NvdaSettingsDialogActiveConfigProfile
 		NvdaSettingsDialogActiveConfigProfile = config.conf.profiles[-1].name
-		if not NvdaSettingsDialogActiveConfigProfile or isinstance(self.currentCategory, GeneralSettingsPanel):
+		if (
+			not NvdaSettingsDialogActiveConfigProfile
+			or isinstance(self.currentCategory, GeneralSettingsPanel)
+			or isinstance(self.currentCategory, AddonStorePanel)
+		):
 			# Translators: The profile name for normal configuration
 			NvdaSettingsDialogActiveConfigProfile = _("normal configuration")
 		self.SetTitle(self._getDialogTitle())

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -27,7 +27,7 @@ import installer
 from synthDriverHandler import changeVoice, getSynth, getSynthList, setSynth, SynthDriver
 import config
 from config.configFlags import (
-	AutomaticUpdateBehaviour,
+	AddonsAutomaticUpdate,
 	NVDAKey,
 	ShowMessages,
 	TetherTo,
@@ -2882,14 +2882,14 @@ class AddonStorePanel(SettingsPanel):
 		self.automaticUpdatesComboBox = sHelper.addLabeledControl(
 			automaticUpdatesLabelText,
 			wx.Choice,
-			choices=[mode.displayString for mode in AutomaticUpdateBehaviour]
+			choices=[mode.displayString for mode in AddonsAutomaticUpdate]
 		)
 		self.bindHelpEvent("AutomaticAddonUpdates", self.automaticUpdatesComboBox)
-		index = [x.value for x in AutomaticUpdateBehaviour].index(config.conf["addonStore"]["automaticUpdates"])
+		index = [x.value for x in AddonsAutomaticUpdate].index(config.conf["addonStore"]["automaticUpdates"])
 		self.automaticUpdatesComboBox.SetSelection(index)
 
 	def onSave(self):
-		config.conf["addonStore"]["automaticUpdates"] = [x.value for x in AutomaticUpdateBehaviour][self.automaticUpdatesComboBox.GetSelection()]
+		config.conf["addonStore"]["automaticUpdates"] = [x.value for x in AddonsAutomaticUpdate][self.automaticUpdatesComboBox.GetSelection()]
 
 
 class TouchInteractionPanel(SettingsPanel):

--- a/source/utils/schedule.py
+++ b/source/utils/schedule.py
@@ -18,6 +18,16 @@ scheduleThread: "ScheduleThread | None" = None
 
 
 class ThreadTarget(Enum):
+	"""
+	When running a task, specify the thread to run the task on.
+	ScheduleThread blocks until the scheduled task is complete.
+	To avoid blocking the ScheduleThread, all tasks should be run on a separate thread.
+	Using GUI or DAEMON thread targets ensures that the ScheduleThread is not blocked.
+	CUSTOM thread target is used for tasks where the supplier of the task is responsible
+	for running the task on a separate thread.
+	"""
+
+
 	GUI = auto()
 	"""
 	Uses wx.CallAfter to run the job on the GUI thread.
@@ -33,7 +43,8 @@ class ThreadTarget(Enum):
 	"""
 	No thread target.
 	Runs directly and blocks `scheduleThread`.
-	Run code on a custom thread to ensure `scheduleThread` is not blocked.
+	Authors of tasks are responsible for running the task on a
+	separate thread to ensure that `scheduleThread` is not blocked.
 	"""
 
 

--- a/source/utils/schedule.py
+++ b/source/utils/schedule.py
@@ -1,0 +1,61 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2024 NV Access Limited
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+
+from datetime import datetime
+import threading
+import time
+from typing import Callable
+
+import schedule
+
+import NVDAState
+
+scheduleThread: "ScheduleThread | None" = None
+
+
+class ScheduleThread(threading.Thread):
+	name = "ScheduleThread"
+
+	KILL = threading.Event()
+	"""Event which can be set to cease continuous run."""
+
+	SLEEP_INTERVAL_SECS = 0.5
+	"""Note that the behaviour of ScheduleThread is to not run missed jobs.
+	For example, if you've registered a job that should run every minute and
+	you set a continuous run interval of one hour then your job won't be run 60 times
+	at each interval but only once.
+	"""
+
+	scheduledJobs: list[Callable[[], None]] = []
+
+	@classmethod
+	def run(cls):
+		while not cls.KILL.is_set():
+			schedule.run_pending()
+			time.sleep(cls.SLEEP_INTERVAL_SECS)
+
+	@classmethod
+	def scheduleDailyJobAtStartUp(cls, job: Callable, *args, **kwargs):
+		"""Schedule a daily job to run at startup."""
+		startTime = datetime.fromtimestamp(NVDAState.getStartTime())
+		# We add the length of the scheduled jobs to the minute offset to avoid overlapping jobs.
+		startTimeMinuteOffset = startTime.minute + len(cls.scheduledJobs) + 1
+		scheduledJob = schedule.every().day.at(f"{startTime.hour}:{startTimeMinuteOffset}").do(job, *args, **kwargs)
+		cls.scheduledJobs.append(scheduledJob)
+
+
+def initialize():
+	global scheduleThread
+	scheduleThread = ScheduleThread()
+	scheduleThread.start()
+
+
+def terminate():
+	global scheduleThread
+	if scheduleThread is not None:
+		schedule.clear()
+		scheduleThread.KILL.set()
+		scheduleThread.join()
+		scheduleThread = None

--- a/source/utils/schedule.py
+++ b/source/utils/schedule.py
@@ -29,7 +29,7 @@ class ScheduleThread(threading.Thread):
 	at each interval but only once.
 	"""
 
-	scheduledJobs: list[Callable[[], None]] = []
+	scheduledJobs: list[schedule.Job] = []
 
 	@classmethod
 	def run(cls):

--- a/source/utils/schedule.py
+++ b/source/utils/schedule.py
@@ -41,9 +41,13 @@ class ScheduleThread(threading.Thread):
 	def scheduleDailyJobAtStartUp(cls, job: Callable, *args, **kwargs):
 		"""Schedule a daily job to run at startup."""
 		startTime = datetime.fromtimestamp(NVDAState.getStartTime())
-		# We add the length of the scheduled jobs to the minute offset to avoid overlapping jobs.
-		startTimeMinuteOffset = startTime.minute + len(cls.scheduledJobs) + 1
-		scheduledJob = schedule.every().day.at(f"{startTime.hour}:{startTimeMinuteOffset}").do(job, *args, **kwargs)
+		# Schedule jobs so that they occur offset by 3 minutes to avoid overlapping jobs.
+		# Start with a delay to give time for NVDA to start up.
+		startTimeMinuteOffset = startTime.minute + (len(cls.scheduledJobs) + 1) * 3
+		# Handle the case where the minute offset is greater than 60.
+		startTimeHourOffset = startTime.hour + (startTimeMinuteOffset // 60)
+		startTimeMinuteOffset = startTimeMinuteOffset % 60
+		scheduledJob = schedule.every().day.at(f"{startTimeHourOffset}:{startTimeMinuteOffset}").do(job, *args, **kwargs)
 		cls.scheduledJobs.append(scheduledJob)
 
 

--- a/source/utils/schedule.py
+++ b/source/utils/schedule.py
@@ -27,7 +27,6 @@ class ThreadTarget(Enum):
 	for running the task on a separate thread.
 	"""
 
-
 	GUI = auto()
 	"""
 	Uses wx.CallAfter to run the job on the GUI thread.

--- a/source/utils/schedule.py
+++ b/source/utils/schedule.py
@@ -29,7 +29,7 @@ class ScheduleThread(threading.Thread):
 	at each interval but only once.
 	"""
 
-	DAILY_JOB_MINUTE_OFFSET = 3
+	DAILY_JOB_MINUTE_OFFSET = 1
 	"""
 	Offset in minutes to schedule daily jobs.
 	Daily scheduled jobs occur offset by X minutes to avoid overlapping jobs.

--- a/source/utils/schedule.py
+++ b/source/utils/schedule.py
@@ -22,7 +22,8 @@ class ScheduleThread(threading.Thread):
 	"""Event which can be set to cease continuous run."""
 
 	SLEEP_INTERVAL_SECS = 0.5
-	"""Note that the behaviour of ScheduleThread is to not run missed jobs.
+	"""
+	Note that the behaviour of ScheduleThread is to not run missed jobs.
 	For example, if you've registered a job that should run every minute and
 	you set a continuous run interval of one hour then your job won't be run 60 times
 	at each interval but only once.

--- a/tests/manual/addonStore.md
+++ b/tests/manual/addonStore.md
@@ -161,7 +161,6 @@ For example: "Clock".
 1. Install the add-on again to test the "migrate" path.
 
 ### Updating multiple add-ons
-### Updating from add-on installed from add-on store
 1. [Install an add-on from the add-on store](#install-add-on)
 For example: "Clock".
 1. Go to your NVDA user configuration folder:
@@ -185,8 +184,7 @@ For example: "Clock".
 1. Restart NVDA as prompted.
 1. Confirm the up-to-date add-ons are listed in the installed add-ons tab of the Add-ons Store.
 
-### Automatic updating
-### Updating from add-on installed from add-on store
+### Automatic update notifications
 1. [Install an add-on from the add-on store](#install-add-on)
 For example: "Clock".
 1. Go to your NVDA user configuration folder:
@@ -217,6 +215,9 @@ For example: "Clock".
     - Press "Update All": Ensure NVDA installs the add-ons.
     - Press "Close": Ensure if Add-ons have been installed that NVDA prompts for restart afterwards
     - Press "Open Add-on Store": Ensure NVDA opens to the Updatable tab in the Add-on Store
+
+### Automatic updating
+Full automatic updates is currently unsupported.
 
 ## Other add-on actions
 

--- a/tests/manual/addonStore.md
+++ b/tests/manual/addonStore.md
@@ -177,12 +177,12 @@ For example: "Clock".
 1. Trigger the update notification manually, or alternatively wait for the notification to occur
     1. From the NVDA Python console, find the scheduled thread
         ```py
-        from utils.schedule import ScheduleThread
-        ScheduleThread.scheduledJobs
+        import schedule
+        schedule.jobs
         ```
     1. Replace `i` with the index of the scheduled thread to find the job
         ```py
-        ScheduleThread.scheduledJobs[i].run()
+        schedule.jobs[i].run()
         ```
 1. Test various buttons:
     - Press "Update All": Ensure NVDA installs the add-ons.

--- a/tests/manual/addonStore.md
+++ b/tests/manual/addonStore.md
@@ -100,8 +100,8 @@ You can do this by:
 
 ## Updating add-ons
 
-### Simulate creating an updatable add-on from the Add-on Store
-Without having a previously installed add-on get an update, it is hard to naturally test updatable add-ons.
+### Simulate creating an updatable add-on
+Without having an installed add-on which has an update pending, it is hard to test updatable add-ons.
 This process allows you to spoof an update for an add-on.
 
 1. [Install an add-on from the Add-on Store](#install-add-on)
@@ -117,17 +117,18 @@ For example: "Clock".
         - Example: `source\userConfig\addons\clock\manifest.ini`
         - Edit "version": decrease the major release value number to match earlier edits.
 
-### Updating from add-on installed from Add-on Store
+### Updating from add-on originally installed via Add-on Store
+
 1. [Simulate creating an updatable add-on from the Add-on Store](#simulate-creating-an-updatable-add-on-from-the-add-on-store)
 1. Open the Add-on Store
-1. Ensure the same add-on you edited is available on the Add-on Store with the status "update".
+1. Ensure the same add-on you edited is available on the Add-on Store with the status "update available".
 1. Install the add-on again to test the "update" path.
 
 ### Updating from add-on installed externally with valid version
 1. [Install an add-on from the Add-on Store](#install-add-on)
 For example: "Clock".
 1. Go to your NVDA user configuration folder:
-    - For source: `.\source\userConfig\addons`
+    - For source: `source\userConfig\addons`
     - For installed copies: `%APPDATA%\nvda\addons`
 1. To spoof an externally loaded older release, we need to edit 2 files:
     - Add-on Store JSON metadata
@@ -163,11 +164,11 @@ For example: "Clock".
 ### Updating multiple add-ons
 1. Repeatedly [create updatable add-ons](#simulate-creating-an-updatable-add-on-from-the-add-on-store).
 1. Open the Add-on Store
-1. Ensure the same add-on you edited is available on the Add-on Store with the status "update".
+1. Ensure the same add-on you edited is available on the Add-on Store with the status "update available".
 1. Select multiple add-ons using `shift` and `ctrl`.
 1. Using the context menu, install the add-ons.
 1. Exit the dialog
-1. Restart NVDA as prompted.
+1. Restart NVDA when prompted.
 1. Confirm the up-to-date add-ons are listed in the installed add-ons tab of the Add-ons Store.
 
 ### Automatic update notifications
@@ -186,11 +187,11 @@ For example: "Clock".
         ```
 1. Test various buttons:
     - Press "Update All": Ensure NVDA installs the add-ons.
-    - Press "Close": Ensure if Add-ons have been installed that NVDA prompts for restart afterwards
+    - Press "Close": Ensure that NVDA prompts for restart if any add-ons have been installed, enabled, disabled or removed
     - Press "Open Add-on Store": Ensure NVDA opens to the Updatable tab in the Add-on Store
 
 ### Automatic updating
-Full automatic updates is currently unsupported.
+Full automatic updating is not currently supported.
 
 ## Other add-on actions
 

--- a/tests/manual/addonStore.md
+++ b/tests/manual/addonStore.md
@@ -107,6 +107,8 @@ You can do this by:
 Without having an installed add-on which has an update pending, it is hard to test updatable add-ons.
 This process allows you to mock an update for an add-on.
 
+#### Manual process
+
 1. [Install an add-on from the Add-on Store](#install-add-on)
 For example: "Clock".
 1. Go to the "addons" folder in your [NVDA user configuration folder](#editing-user-configuration)
@@ -117,6 +119,17 @@ For example: "Clock".
     - Add-on manifest
         - Example: `source\userConfig\addons\clock\manifest.ini`
         - Edit "version": decrease the major release value number to match earlier edits.
+
+#### Using a script
+1. [Install an add-on from the Add-on Store](#install-add-on)
+For example: "Clock".
+1. From PowerShell, call the following script to make the add-on updatable.
+  - `tests\manual\createUpdatableAddons.ps1 $addonName $configPath`
+  - Replace `$configPath` with your [NVDA user configuration folder](#editing-user-configuration).
+  This script defaults to using the installed user config folder in `%APPDATA%`.
+  - Example when running from source: `tests\manual\createUpdatableAddons.ps1 clock source\userConfig`
+  - Example when running an installed copy: `tests\manual\createUpdatableAddons.ps1 clock`
+  - Note this script sets the add-on version to 0.0.0.
 
 ### Updating from add-on originally installed via Add-on Store
 

--- a/tests/manual/addonStore.md
+++ b/tests/manual/addonStore.md
@@ -100,38 +100,40 @@ You can do this by:
 
 ## Updating add-ons
 
-### Updating from add-on installed from add-on store
-1. [Install an add-on from the add-on store](#install-add-on)
+### Simulate creating an updatable add-on from the Add-on Store
+Without having a previously installed add-on get an update, it is hard to naturally test updatable add-ons.
+This process allows you to spoof an update for an add-on.
+
+1. [Install an add-on from the Add-on Store](#install-add-on)
 For example: "Clock".
 1. Go to your NVDA user configuration folder:
-    - For source: `.\source\userConfig`
-    - For installed copies: `%APPDATA%\nvda`
+    - For source: `.\source\userConfig\addons`
+    - For installed copies: `%APPDATA%\nvda\addons`
 1. To spoof an old release, we need to edit 2 files:
-    - Add-on store JSON metadata
-        - Located in: `.\addonStore\addons\`.
-        - Example: `source\userConfig\addonStore\addons\clock.json`
+    - Add-on Store JSON metadata
+        - Example: `source\userConfig\addons\clock.json`
         - Edit "addonVersionNumber" and "addonVersionName": decrease the major release value number.
     - Add-on manifest
-        - Located in: `.\addons\`.
         - Example: `source\userConfig\addons\clock\manifest.ini`
         - Edit "version": decrease the major release value number to match earlier edits.
-1. Open the add-on store
-1. Ensure the same add-on you edited is available on the add-on store with the status "update".
+
+### Updating from add-on installed from Add-on Store
+1. [Simulate creating an updatable add-on from the Add-on Store](#simulate-creating-an-updatable-add-on-from-the-add-on-store)
+1. Open the Add-on Store
+1. Ensure the same add-on you edited is available on the Add-on Store with the status "update".
 1. Install the add-on again to test the "update" path.
 
 ### Updating from add-on installed externally with valid version
-1. [Install an add-on from the add-on store](#install-add-on)
+1. [Install an add-on from the Add-on Store](#install-add-on)
 For example: "Clock".
 1. Go to your NVDA user configuration folder:
-    - For source: `.\source\userConfig`
-    - For installed copies: `%APPDATA%\nvda`
+    - For source: `.\source\userConfig\addons`
+    - For installed copies: `%APPDATA%\nvda\addons`
 1. To spoof an externally loaded older release, we need to edit 2 files:
-    - Add-on store JSON metadata
-        - Located in: `.\addonStore\addons\`.
-        - Example: `source\userConfig\addonStore\addons\clock.json`
+    - Add-on Store JSON metadata
+        - Example: `source\userConfig\addons\clock.json`
       - Delete this file.
     - Add-on manifest
-        - Located in: `.\addons\`.
         - Example: `source\userConfig\addons\clock\manifest.ini`
         - Edit "version": decrease the major release value number to match earlier edits.
 1. Open the add-on store
@@ -145,15 +147,13 @@ This means using the latest add-on store version might be a downgrade or sidegra
 1. [Install an add-on from the add-on store](#install-add-on)
 For example: "Clock".
 1. Go to your NVDA user configuration folder:
-    - For source: `.\source\userConfig`
-    - For installed copies: `%APPDATA%\nvda`
+    - For source: `.\source\userConfig\addons`
+    - For installed copies: `%APPDATA%\nvda\addons`
 1. To spoof an externally loaded release, with an invalid version, we need to edit 2 files:
-    - Add-on store JSON metadata
-        - Located in: `.\addonStore\addons\`.
-        - Example: `source\userConfig\addonStore\addons\clock.json`
+    - Add-on Store JSON metadata
+        - Example: `source\userConfig\addons\clock.json`
         - Delete this file.
     - Add-on manifest
-        - Located in: `.\addons\`.
         - Example: `source\userConfig\addons\clock\manifest.ini`
         - Edit "version": to something invalid e.g. "foo".
 1. Open the add-on store
@@ -161,21 +161,7 @@ For example: "Clock".
 1. Install the add-on again to test the "migrate" path.
 
 ### Updating multiple add-ons
-1. [Install an add-on from the add-on store](#install-add-on)
-For example: "Clock".
-1. Go to your NVDA user configuration folder:
-    - For source: `.\source\userConfig`
-    - For installed copies: `%APPDATA%\nvda`
-1. To spoof an old release, we need to edit 2 files:
-    - Add-on store JSON metadata
-        - Located in: `.\addonStore\addons\`.
-        - Example: `source\userConfig\addonStore\addons\clock.json`
-        - Edit "addonVersionNumber" and "addonVersionName": decrease the major release value number.
-    - Add-on manifest
-        - Located in: `.\addons\`.
-        - Example: `source\userConfig\addons\clock\manifest.ini`
-        - Edit "version": decrease the major release value number to match earlier edits.
-1. Repeat several times to ensure multiple add-on updates are available.
+1. Repeatedly [create updatable add-ons](#simulate-creating-an-updatable-add-on-from-the-add-on-store).
 1. Open the Add-on Store
 1. Ensure the same add-on you edited is available on the Add-on Store with the status "update".
 1. Select multiple add-ons using `shift` and `ctrl`.
@@ -185,20 +171,7 @@ For example: "Clock".
 1. Confirm the up-to-date add-ons are listed in the installed add-ons tab of the Add-ons Store.
 
 ### Automatic update notifications
-1. [Install an add-on from the add-on store](#install-add-on)
-For example: "Clock".
-1. Go to your NVDA user configuration folder:
-    - For source: `.\source\userConfig`
-    - For installed copies: `%APPDATA%\nvda`
-1. To spoof an old release, we need to edit 2 files:
-    - Add-on store JSON metadata
-        - Located in: `.\addonStore\addons\`.
-        - Example: `source\userConfig\addonStore\addons\clock.json`
-        - Edit "addonVersionNumber" and "addonVersionName": decrease the major release value number.
-    - Add-on manifest
-        - Located in: `.\addons\`.
-        - Example: `source\userConfig\addons\clock\manifest.ini`
-        - Edit "version": decrease the major release value number to match earlier edits.
+1. Repeatedly [create updatable add-ons](#simulate-creating-an-updatable-add-on-from-the-add-on-store).
 1. Start NVDA
 1. Ensure Automatic update notifications are enabled in the Add-on Store panel
 1. Trigger the update notification manually, or alternatively wait for the notification to occur

--- a/tests/manual/addonStore.md
+++ b/tests/manual/addonStore.md
@@ -161,10 +161,62 @@ For example: "Clock".
 1. Install the add-on again to test the "migrate" path.
 
 ### Updating multiple add-ons
-Updating multiple add-ons at once is currently unsupported.
+### Updating from add-on installed from add-on store
+1. [Install an add-on from the add-on store](#install-add-on)
+For example: "Clock".
+1. Go to your NVDA user configuration folder:
+    - For source: `.\source\userConfig`
+    - For installed copies: `%APPDATA%\nvda`
+1. To spoof an old release, we need to edit 2 files:
+    - Add-on store JSON metadata
+        - Located in: `.\addonStore\addons\`.
+        - Example: `source\userConfig\addonStore\addons\clock.json`
+        - Edit "addonVersionNumber" and "addonVersionName": decrease the major release value number.
+    - Add-on manifest
+        - Located in: `.\addons\`.
+        - Example: `source\userConfig\addons\clock\manifest.ini`
+        - Edit "version": decrease the major release value number to match earlier edits.
+1. Repeat several times to ensure multiple add-on updates are available.
+1. Open the Add-on Store
+1. Ensure the same add-on you edited is available on the Add-on Store with the status "update".
+1. Select multiple add-ons using `shift` and `ctrl`.
+1. Using the context menu, install the add-ons.
+1. Exit the dialog
+1. Restart NVDA as prompted.
+1. Confirm the up-to-date add-ons are listed in the installed add-ons tab of the Add-ons Store.
 
 ### Automatic updating
-Automatic updating of add-ons is currently unsupported.
+### Updating from add-on installed from add-on store
+1. [Install an add-on from the add-on store](#install-add-on)
+For example: "Clock".
+1. Go to your NVDA user configuration folder:
+    - For source: `.\source\userConfig`
+    - For installed copies: `%APPDATA%\nvda`
+1. To spoof an old release, we need to edit 2 files:
+    - Add-on store JSON metadata
+        - Located in: `.\addonStore\addons\`.
+        - Example: `source\userConfig\addonStore\addons\clock.json`
+        - Edit "addonVersionNumber" and "addonVersionName": decrease the major release value number.
+    - Add-on manifest
+        - Located in: `.\addons\`.
+        - Example: `source\userConfig\addons\clock\manifest.ini`
+        - Edit "version": decrease the major release value number to match earlier edits.
+1. Start NVDA
+1. Ensure Automatic update notifications are enabled in the Add-on Store panel
+1. Trigger the update notification manually, or alternatively wait for the notification to occur
+    1. From the NVDA Python console, find the scheduled thread
+        ```py
+        from utils.schedule import ScheduleThread
+        ScheduleThread.scheduledJobs
+        ```
+    1. Replace `i` with the index of the scheduled thread to find the job
+        ```py
+        ScheduleThread.scheduledJobs[i].run()
+        ```
+1. Test various buttons:
+    - Press "Update All": Ensure NVDA installs the add-ons.
+    - Press "Close": Ensure if Add-ons have been installed that NVDA prompts for restart afterwards
+    - Press "Open Add-on Store": Ensure NVDA opens to the Updatable tab in the Add-on Store
 
 ## Other add-on actions
 

--- a/tests/manual/addonStore.md
+++ b/tests/manual/addonStore.md
@@ -32,9 +32,7 @@ Add-ons can be filtered by display name, publisher and description.
 
 ### Failure to fetch add-ons available for download
 1. Disable your internet connection
-1. Go to your NVDA user configuration folder:
-    - For source: `.\source\userConfig`
-    - For installed copies: `%APPDATA%\nvda`
+1. Go to your [NVDA user configuration folder](#editing-user-configuration)
 1. To delete the current cache of available add-on store add-ons, delete the file: `addonStore\_cachedCompatibleAddons.json`
 1. Open the Add-on Store
 1. Ensure a warning is displayed: "Unable to fetch latest compatible add-ons"
@@ -43,7 +41,8 @@ Add-ons can be filtered by display name, publisher and description.
 
 ## Installing add-ons
 
-### Install add-on from add-on store
+### Install add-on
+
 1. Open the add-on store.
 1. Navigate to the available add-ons tab.
 1. Select an add-on.
@@ -52,7 +51,8 @@ Add-ons can be filtered by display name, publisher and description.
 1. Restart NVDA as prompted.
 1. Confirm the add-ons are listed in the installed add-ons tab of the add-ons store.
 
-### Batch install add-ons from add-on store
+### Batch install add-ons
+
 1. Open the add-on store.
 1. Navigate to the available add-ons tab.
 1. Select multiple add-ons using `shift` and `ctrl`.
@@ -61,13 +61,15 @@ Add-ons can be filtered by display name, publisher and description.
 1. Restart NVDA as prompted.
 1. Confirm the add-ons are listed in the installed add-ons tab of the add-ons store.
 
-### Install add-on from external source in add-on store
+### Install add-on from external source
+
 1. Open the add-on store.
 1. Jump to the install from external source button (`alt+x`)
 1. Find an `*.nvda-addon` file, and open it
 1. Proceed with the installation
 
-### Install and override incompatible add-on from add-on store
+### Install and override incompatible add-on
+
 1. Open the add-on store.
 1. Find an add-on listed as "incompatible" for download.
 1. Navigate to and press the "install (override compatibility)" button for the add-on.
@@ -101,15 +103,14 @@ You can do this by:
 ## Updating add-ons
 
 ### Simulate creating an updatable add-on
+
 Without having an installed add-on which has an update pending, it is hard to test updatable add-ons.
-This process allows you to spoof an update for an add-on.
+This process allows you to mock an update for an add-on.
 
 1. [Install an add-on from the Add-on Store](#install-add-on)
 For example: "Clock".
-1. Go to your NVDA user configuration folder:
-    - For source: `.\source\userConfig\addons`
-    - For installed copies: `%APPDATA%\nvda\addons`
-1. To spoof an old release, we need to edit 2 files:
+1. Go to the "addons" folder in your [NVDA user configuration folder](#editing-user-configuration)
+1. To mock an old release, we need to edit 2 files:
     - Add-on Store JSON metadata
         - Example: `source\userConfig\addons\clock.json`
         - Edit "addonVersionNumber" and "addonVersionName": decrease the major release value number.
@@ -119,18 +120,17 @@ For example: "Clock".
 
 ### Updating from add-on originally installed via Add-on Store
 
-1. [Simulate creating an updatable add-on from the Add-on Store](#simulate-creating-an-updatable-add-on-from-the-add-on-store)
+1. [Simulate creating an updatable add-on](#simulate-creating-an-updatable-add-on)
 1. Open the Add-on Store
 1. Ensure the same add-on you edited is available on the Add-on Store with the status "update available".
 1. Install the add-on again to test the "update" path.
 
 ### Updating from add-on installed externally with valid version
+
 1. [Install an add-on from the Add-on Store](#install-add-on)
 For example: "Clock".
-1. Go to your NVDA user configuration folder:
-    - For source: `source\userConfig\addons`
-    - For installed copies: `%APPDATA%\nvda\addons`
-1. To spoof an externally loaded older release, we need to edit 2 files:
+1. Go to the "addons" folder in your [NVDA user configuration folder](#editing-user-configuration)
+1. To mock an externally loaded older release, we need to edit 2 files:
     - Add-on Store JSON metadata
         - Example: `source\userConfig\addons\clock.json`
       - Delete this file.
@@ -147,10 +147,8 @@ This means using the latest add-on store version might be a downgrade or sidegra
 
 1. [Install an add-on from the add-on store](#install-add-on)
 For example: "Clock".
-1. Go to your NVDA user configuration folder:
-    - For source: `.\source\userConfig\addons`
-    - For installed copies: `%APPDATA%\nvda\addons`
-1. To spoof an externally loaded release, with an invalid version, we need to edit 2 files:
+1. Go to the "addons" folder in your [NVDA user configuration folder](#editing-user-configuration)
+1. To mock an externally loaded release, with an invalid version, we need to edit 2 files:
     - Add-on Store JSON metadata
         - Example: `source\userConfig\addons\clock.json`
         - Delete this file.
@@ -162,7 +160,8 @@ For example: "Clock".
 1. Install the add-on again to test the "migrate" path.
 
 ### Updating multiple add-ons
-1. Repeatedly [create updatable add-ons](#simulate-creating-an-updatable-add-on-from-the-add-on-store).
+
+1. Repeatedly [create updatable add-ons](#simulate-creating-an-updatable-add-on).
 1. Open the Add-on Store
 1. Ensure the same add-on you edited is available on the Add-on Store with the status "update available".
 1. Select multiple add-ons using `shift` and `ctrl`.
@@ -172,7 +171,8 @@ For example: "Clock".
 1. Confirm the up-to-date add-ons are listed in the installed add-ons tab of the Add-ons Store.
 
 ### Automatic update notifications
-1. Repeatedly [create updatable add-ons](#simulate-creating-an-updatable-add-on-from-the-add-on-store).
+
+1. Repeatedly [create updatable add-ons](#simulate-creating-an-updatable-add-on).
 1. Start NVDA
 1. Ensure Automatic update notifications are enabled in the Add-on Store panel
 1. Trigger the update notification manually, or alternatively wait for the notification to occur
@@ -191,6 +191,7 @@ For example: "Clock".
     - Press "Open Add-on Store": Ensure NVDA opens to the Updatable tab in the Add-on Store
 
 ### Automatic updating
+
 Full automatic updating is not currently supported.
 
 ## Other add-on actions
@@ -260,3 +261,12 @@ Typically, this requires a contributor creating 3 different versions of the same
 | Downgrade to a different but compatible API version | X.2 | X.1 | Add-ons which remain incompatible are listed as incompatible on upgrading. Preserves state of enabled incompatible add-ons |
 | Upgrade to an API breaking version | X.1 | (X+1).1 | All incompatible add-ons are listed as incompatible on upgrading, overridden compatibility is reset. |
 | Downgrade to an API breaking version | (X+1).1 | X.1 | Add-ons which remain incompatible listed as incompatible on upgrading. Preserves state of enabled incompatible add-ons. Add-ons which are now compatible are re-enabled. |
+
+## Miscellaneous
+
+## Editing User Configuration
+
+Where you can find your NVDA user configuration folder:
+- For installed copies: `%APPDATA%\nvda`
+- For source copies: `source\userConfig`
+- Inside a portable copy directory: `userConfig`

--- a/tests/manual/createUpdatableAddons.ps1
+++ b/tests/manual/createUpdatableAddons.ps1
@@ -1,0 +1,40 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2024 NV Access Limited
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+
+param(
+	[string]$addonName = "clock",
+	[string]$configFolder = "$env:APPDATA\nvda\userConfig",
+	[string]$newVersionMajor = "0",
+	[string]$newVersionMinor = "0"
+)
+
+# Define paths to the JSON metadata and manifest file
+$jsonPath = Join-Path -Path $configFolder -ChildPath "\addons\$addonName.json"
+$manifestPath = Join-Path -Path $configFolder -ChildPath "\addons\$addonName\manifest.ini"
+
+# Function to update JSON metadata
+function Update-JsonMetadata {
+	if (Test-Path $jsonPath) {
+		(Get-Content $jsonPath) -replace '"addonVersionName": "[\d+\.]+"', "`"addonVersionName`": `"$newVersionMajor.$newVersionMinor`"" | Set-Content $jsonPath
+		(Get-Content $jsonPath) -replace '"addonVersionNumber": {[^}]+}', "`"addonVersionNumber`": {`"major`": $newVersionMajor, `"minor`": $newVersionMinor, `"patch`": 0}" | Set-Content $jsonPath
+		Write-Host "Updated JSON metadata at $jsonPath"
+	} else {
+		Write-Host "JSON metadata file not found at $jsonPath"
+	}
+}
+
+# Function to update manifest file
+function Update-Manifest {
+	if (Test-Path $manifestPath) {
+		(Get-Content $manifestPath) -replace '^version = [\d+\.]+', "version = $newVersionMajor.$newVersionMinor" | Set-Content $manifestPath
+		Write-Host "Updated manifest file at $manifestPath"
+	} else {
+		Write-Host "Manifest file not found at $manifestPath"
+	}
+}
+
+# Execute updates
+Update-JsonMetadata
+Update-Manifest

--- a/tests/unit/test_util/test_schedule.py
+++ b/tests/unit/test_util/test_schedule.py
@@ -39,32 +39,32 @@ class ScheduleThreadTests(unittest.TestCase):
 
 		expectedResult = [0, 0, 0]
 		self.assertEqual(scheduledVals, expectedResult)
-		for index in range(3):
+		for jobIndex in range(3):
 			# Simulate a forced job run
 			startTime = NVDAState.getStartTime()
-			currentJob = ScheduleThread.scheduledJobs[index]
+			currentJob = ScheduleThread.scheduledJobs[jobIndex]
 
 			# Ensure that the job is scheduled to run at the expected time
-			expectedSecsOffsetMin = index * ScheduleThread.DAILY_JOB_MINUTE_OFFSET * 60
-			expectedSecsOffsetMax = (index + 1) * ScheduleThread.DAILY_JOB_MINUTE_OFFSET * 60
+			expectedSecsOffsetMin = jobIndex * ScheduleThread.DAILY_JOB_MINUTE_OFFSET * 60
+			expectedSecsOffsetMax = (jobIndex + 1) * ScheduleThread.DAILY_JOB_MINUTE_OFFSET * 60
 			nextRun = currentJob.next_run.timestamp()
 			actualSecsOffset = nextRun - startTime
 			self.assertLessEqual(
 				actualSecsOffset,
 				expectedSecsOffsetMax,
-				f"Job {index} did not scheduled as expected. Job: {currentJob}"
+				f"Job {jobIndex} did not scheduled as expected. Job: {currentJob}"
 			)
 			self.assertGreaterEqual(
 				actualSecsOffset,
 				expectedSecsOffsetMin,
-				f"Job {index} did not scheduled as expected. Job: {currentJob}"
+				f"Job {jobIndex} did not scheduled as expected. Job: {currentJob}"
 			)
 
 			# Ensure the job runs as expected
 			currentJob.run()
-			expectedResult[index] += 1
+			expectedResult[jobIndex] += 1
 			self.assertEqual(
 				scheduledVals,
 				expectedResult,
-				f"Job {index} did not run as expected. Scheduled jobs: {ScheduleThread.scheduledJobs}"
+				f"Job {jobIndex} did not run as expected. Scheduled jobs: {ScheduleThread.scheduledJobs}"
 			)

--- a/tests/unit/test_util/test_schedule.py
+++ b/tests/unit/test_util/test_schedule.py
@@ -1,0 +1,70 @@
+# A part of NonVisual Desktop Access (NVDA)
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+# Copyright (C) 2024 NV Access Limited.
+
+from datetime import datetime
+import unittest
+from unittest.mock import MagicMock
+
+import NVDAState
+from utils.schedule import ScheduleThread, initialize, terminate
+
+
+class ScheduleThreadTests(unittest.TestCase):
+	def setUp(self):
+		self.oldNVDAStateGetStartTime = NVDAState.getStartTime
+		NVDAState.getStartTime = MagicMock(return_value=datetime.now().timestamp())
+		initialize()
+
+	def tearDown(self):
+		terminate()
+		NVDAState.getStartTime = self.oldNVDAStateGetStartTime
+
+	def test_scheduleDailyJobAtStartUp(self):
+		scheduledVals = [0, 0, 0]
+
+		def incrementA(scheduledVals: list):
+			scheduledVals[0] += 1
+
+		def incrementB(scheduledVals: list):
+			scheduledVals[1] += 1
+
+		def incrementC(scheduledVals: list):
+			scheduledVals[2] += 1
+
+		ScheduleThread.scheduleDailyJobAtStartUp(incrementA, scheduledVals)
+		ScheduleThread.scheduleDailyJobAtStartUp(incrementB, scheduledVals)
+		ScheduleThread.scheduleDailyJobAtStartUp(incrementC, scheduledVals)
+
+		expectedResult = [0, 0, 0]
+		self.assertEqual(scheduledVals, expectedResult)
+		for index in range(3):
+			# Simulate a forced job run
+			startTime = NVDAState.getStartTime()
+			currentJob = ScheduleThread.scheduledJobs[index]
+
+			# Ensure that the job is scheduled to run at the expected time
+			expectedSecsOffsetMin = index * ScheduleThread.DAILY_JOB_MINUTE_OFFSET * 60
+			expectedSecsOffsetMax = (index + 1) * ScheduleThread.DAILY_JOB_MINUTE_OFFSET * 60
+			nextRun = currentJob.next_run.timestamp()
+			actualSecsOffset = nextRun - startTime
+			self.assertLessEqual(
+				actualSecsOffset,
+				expectedSecsOffsetMax,
+				f"Job {index} did not scheduled as expected. Job: {currentJob}"
+			)
+			self.assertGreaterEqual(
+				actualSecsOffset,
+				expectedSecsOffsetMin,
+				f"Job {index} did not scheduled as expected. Job: {currentJob}"
+			)
+
+			# Ensure the job runs as expected
+			currentJob.run()
+			expectedResult[index] += 1
+			self.assertEqual(
+				scheduledVals,
+				expectedResult,
+				f"Job {index} did not run as expected. Scheduled jobs: {ScheduleThread.scheduledJobs}"
+			)

--- a/tests/unit/test_util/test_schedule.py
+++ b/tests/unit/test_util/test_schedule.py
@@ -7,8 +7,16 @@ from datetime import datetime
 import unittest
 from unittest.mock import MagicMock
 
+import schedule
+
 import NVDAState
-from utils.schedule import ScheduleThread, initialize, terminate
+from utils.schedule import (
+	JobClashError,
+	ScheduleThread,
+	ThreadTarget,
+	initialize,
+	terminate,
+)
 
 
 class ScheduleThreadTests(unittest.TestCase):
@@ -33,9 +41,12 @@ class ScheduleThreadTests(unittest.TestCase):
 		def incrementC(scheduledVals: list):
 			scheduledVals[2] += 1
 
-		ScheduleThread.scheduleDailyJobAtStartUp(incrementA, scheduledVals)
-		ScheduleThread.scheduleDailyJobAtStartUp(incrementB, scheduledVals)
-		ScheduleThread.scheduleDailyJobAtStartUp(incrementC, scheduledVals)
+		ScheduleThread.scheduleDailyJobAtStartUp(incrementA, ThreadTarget.CUSTOM, scheduledVals)
+		ScheduleThread.scheduleDailyJobAtStartUp(incrementB, ThreadTarget.CUSTOM, scheduledVals)
+		ScheduleThread.scheduleDailyJobAtStartUp(incrementC, ThreadTarget.CUSTOM, scheduledVals)
+		# Sanity checks (have failed in development)
+		self.assertEqual(len(ScheduleThread.scheduledJobs), 3)
+		self.assertEqual(ScheduleThread.scheduledDailyJobCount, 3)
 
 		expectedResult = [0, 0, 0]
 		self.assertEqual(scheduledVals, expectedResult)
@@ -68,3 +79,60 @@ class ScheduleThreadTests(unittest.TestCase):
 				expectedResult,
 				f"Job {jobIndex} did not run as expected. Scheduled jobs: {ScheduleThread.scheduledJobs}"
 			)
+
+	def test_scheduleJob(self):
+		def jobFunc():
+			# Job function implementation
+			pass
+
+		cronTime = "12:00"  # Example cron time
+		jobSchedule = schedule.every().day.at(cronTime)
+
+		# Call the scheduleJob method
+		ScheduleThread.scheduleJob(jobFunc, jobSchedule, ThreadTarget.GUI)
+
+		# Assert that the job is scheduled correctly
+		self.assertEqual(len(ScheduleThread.scheduledJobs), 1)
+		scheduledJob = ScheduleThread.scheduledJobs[0]
+		self.assertEqual(f"{scheduledJob.at_time.hour:02d}:{scheduledJob.at_time.minute:02d}", cronTime)
+
+	def test_scheduleJob_jobClash(self):
+		def jobFunc():
+			# Job function implementation
+			pass
+
+		cronTime = "12:00"  # Example cron time
+		jobSchedule = schedule.every().day.at(cronTime)
+
+		# Call the scheduleJob method
+		ScheduleThread.scheduleJob(jobFunc, jobSchedule, ThreadTarget.GUI)
+
+		with self.assertRaises(JobClashError):
+			# Call the scheduleJob method with the same cron time
+			ScheduleThread.scheduleJob(jobFunc, jobSchedule, ThreadTarget.GUI)
+
+	def test_calculateDailyTimeOffset(self):
+		todayAtMidnight = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
+		NVDAState.getStartTime = MagicMock(return_value=todayAtMidnight.timestamp())
+		# Call the _calculateDailyTimeOffset method
+		offset = ScheduleThread._calculateDailyTimeOffset()
+		# Assert that the offset is calculated correctly
+		self.assertEqual(offset, f"00:{ScheduleThread.DAILY_JOB_MINUTE_OFFSET:02d}")
+		
+		ScheduleThread.scheduledDailyJobCount = 1
+		offset = ScheduleThread._calculateDailyTimeOffset()
+		self.assertEqual(offset, f"00:{ScheduleThread.DAILY_JOB_MINUTE_OFFSET * 2:02d}")
+
+		# Test the case where the start time is 11:59 to ensure the hour offset is calculated correctly
+		NVDAState.getStartTime = MagicMock(return_value=todayAtMidnight.replace(hour=11, minute=59).timestamp())
+		ScheduleThread.scheduledDailyJobCount = 0
+		offset = ScheduleThread._calculateDailyTimeOffset()
+		expectedMinOffset = (ScheduleThread.DAILY_JOB_MINUTE_OFFSET + 59) % 60
+		self.assertEqual(offset, f"12:{expectedMinOffset:02d}")
+
+		# Test the case where the start time is 23:59 to ensure the day and hour offset is calculated correctly
+		NVDAState.getStartTime = MagicMock(return_value=todayAtMidnight.replace(hour=23, minute=59).timestamp())
+		ScheduleThread.scheduledDailyJobCount = 0
+		offset = ScheduleThread._calculateDailyTimeOffset()
+		expectedMinOffset = (ScheduleThread.DAILY_JOB_MINUTE_OFFSET + 59) % 60
+		self.assertEqual(offset, f"00:{expectedMinOffset:02d}")

--- a/tests/unit/test_util/test_schedule.py
+++ b/tests/unit/test_util/test_schedule.py
@@ -45,14 +45,14 @@ class ScheduleThreadTests(unittest.TestCase):
 		ScheduleThread.scheduleDailyJobAtStartUp(incrementB, ThreadTarget.CUSTOM, scheduledVals)
 		ScheduleThread.scheduleDailyJobAtStartUp(incrementC, ThreadTarget.CUSTOM, scheduledVals)
 		# Sanity checks (have failed in development)
-		self.assertEqual(len(ScheduleThread.scheduledJobs), 3)
+		self.assertEqual(len(schedule.jobs), 3)
 		self.assertEqual(ScheduleThread.scheduledDailyJobCount, 3)
 
 		expectedResult = [0, 0, 0]
 		self.assertEqual(scheduledVals, expectedResult)
 		for jobIndex in range(3):
 			startTime = NVDAState.getStartTime()
-			currentJob = ScheduleThread.scheduledJobs[jobIndex]
+			currentJob = schedule.jobs[jobIndex]
 
 			# Ensure that the job is scheduled to run at the expected time
 			expectedSecsOffsetMin = jobIndex * ScheduleThread.DAILY_JOB_MINUTE_OFFSET * 60
@@ -76,7 +76,7 @@ class ScheduleThreadTests(unittest.TestCase):
 			self.assertEqual(
 				scheduledVals,
 				expectedResult,
-				f"Job {jobIndex} did not run as expected. Scheduled jobs: {ScheduleThread.scheduledJobs}"
+				f"Job {jobIndex} did not run as expected. Scheduled jobs: {schedule.jobs}"
 			)
 
 	def test_scheduleJob(self):
@@ -91,8 +91,8 @@ class ScheduleThreadTests(unittest.TestCase):
 		ScheduleThread.scheduleJob(jobFunc, jobSchedule, ThreadTarget.GUI)
 
 		# Assert that the job is scheduled correctly
-		self.assertEqual(len(ScheduleThread.scheduledJobs), 1)
-		scheduledJob = ScheduleThread.scheduledJobs[0]
+		self.assertEqual(len(schedule.jobs), 1)
+		scheduledJob = schedule.jobs[0]
 		self.assertEqual(f"{scheduledJob.at_time.hour:02d}:{scheduledJob.at_time.minute:02d}", cronTime)
 
 	def test_scheduleJob_jobClash(self):

--- a/tests/unit/test_util/test_schedule.py
+++ b/tests/unit/test_util/test_schedule.py
@@ -51,7 +51,6 @@ class ScheduleThreadTests(unittest.TestCase):
 		expectedResult = [0, 0, 0]
 		self.assertEqual(scheduledVals, expectedResult)
 		for jobIndex in range(3):
-			# Simulate a forced job run
 			startTime = NVDAState.getStartTime()
 			currentJob = ScheduleThread.scheduledJobs[jobIndex]
 
@@ -63,12 +62,12 @@ class ScheduleThreadTests(unittest.TestCase):
 			self.assertLessEqual(
 				actualSecsOffset,
 				expectedSecsOffsetMax,
-				f"Job {jobIndex} did not scheduled as expected. Job: {currentJob}"
+				f"Job {jobIndex} was not scheduled as expected. Job: {currentJob}"
 			)
 			self.assertGreaterEqual(
 				actualSecsOffset,
 				expectedSecsOffsetMin,
-				f"Job {jobIndex} did not scheduled as expected. Job: {currentJob}"
+				f"Job {jobIndex} was not scheduled as expected. Job: {currentJob}"
 			)
 
 			# Ensure the job runs as expected

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -19,6 +19,10 @@ Unicode CLDR has been updated.
   * This can be useful when reading characters that are unknown to a particular speech synthesizer or braille table and which have a compatible alternative, like the bold and italic characters commonly uses on social media.
   * It also allows reading of equations in the Microsoft Word equation editor. (#4631)
   * You can enable this functionality for both speech and braille in their respective settings categories in the NVDA Settings dialog.
+* By default, after NVDA startup, the Add-on Store will notify you if any add-on updates are available. (#15035)
+  * This can be disabled in the "Add-on Store" section of settings.
+  * The notification checks daily for add-on updates.
+  * Only updates within the same channel will be checked (e.g. installed beta add-ons will only notify for updates to beta add-ons).
 
 ### Changes
 
@@ -59,6 +63,9 @@ It is especially useful to read the error location markers in tracebacks. (#1632
 * When a `gainFocus` event is queued with an object that has a valid `focusRedirect` property, the object pointed to by the `focusRedirect` property is now held by `eventHandler.lastQueuedFocusObject`, rather than the originally queued object. (#15843)
 * NVDA will log its executable architecture (x86) at startup. (#16432, @josephsl)
 * `wx.CallAfter`, which is wrapped in `monkeyPatches/wxMonkeyPatches.py`, now includes proper `functools.wraps` indication. (#16520, @XLTechie)
+* There is a new module for scheduling tasks, using the pip module `schedule`.
+You can use `utils.schedule.ScheduleThread.scheduleDailyJobAtStartUp` to automatically schedule a job that happens after NVDA starts, and every 24 hours after that.
+Jobs are scheduled with a delay to avoid conflicts. (#16636)
 
 #### Deprecations
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -5,7 +5,8 @@
 This release adds support for Unicode Normalization to speech and braille output.
 This can be useful when reading characters that are unknown to a particular speech synthesizer or braille table and which have a compatible alternative, like the bold and italic characters commonly uses on social media.
 It also allows reading of equations in the Microsoft Word equation editor.
-You can enable this functionality for both speech and braille in their respective settings categories in the NVDA Settings dialog.
+
+The Add-on Store will now notify you if any add-on updates are available on NVDA start up.
 
 There are several bug fixes, particularly for the Windows 11 Emoji Panel and Clipboard history.
 For web browsers, there are fixes for reporting error messages, figures, captions, table labels and checkbox/radio button menu items.

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -19,10 +19,10 @@ Unicode CLDR has been updated.
   * This can be useful when reading characters that are unknown to a particular speech synthesizer or braille table and which have a compatible alternative, like the bold and italic characters commonly uses on social media.
   * It also allows reading of equations in the Microsoft Word equation editor. (#4631)
   * You can enable this functionality for both speech and braille in their respective settings categories in the NVDA Settings dialog.
-* By default, after NVDA startup, the Add-on Store will notify you if any add-on updates are available. (#15035)
-  * This can be disabled in the "Add-on Store" section of settings.
-  * The notification checks daily for add-on updates.
-  * Only updates within the same channel will be checked (e.g. installed beta add-ons will only notify for updates to beta add-ons).
+* By default, after NVDA startup, you will be notified if any add-on updates are available. (#15035)
+  * This can be disabled in the "Add-on Store" category of settings.
+  * NVDA checks daily for add-on updates.
+  * Only updates within the same channel will be checked (e.g. installed beta add-ons will only notify for updates in the beta channel).
 
 ### Changes
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -64,9 +64,9 @@ It is especially useful to read the error location markers in tracebacks. (#1632
 * NVDA will log its executable architecture (x86) at startup. (#16432, @josephsl)
 * `wx.CallAfter`, which is wrapped in `monkeyPatches/wxMonkeyPatches.py`, now includes proper `functools.wraps` indication. (#16520, @XLTechie)
 * There is a new module for scheduling tasks `utils.schedule`, using the pip module `schedule`. (#16636)
-  * You can use `ScheduleThread.scheduleDailyJobAtStartUp` to automatically schedule a job that happens after NVDA starts, and every 24 hours after that.
+  * You can use `scheduleThread.scheduleDailyJobAtStartUp` to automatically schedule a job that happens after NVDA starts, and every 24 hours after that.
   Jobs are scheduled with a delay to avoid conflicts.
-  * `ScheduleThread.scheduleDailyJob` and `scheduleJob` can be used to schedule jobs at custom times, where a `JobClashError` will be raised on a known job scheduling clash.
+  * `scheduleThread.scheduleDailyJob` and `scheduleJob` can be used to schedule jobs at custom times, where a `JobClashError` will be raised on a known job scheduling clash.
 
 #### Deprecations
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -1,12 +1,11 @@
 # What's New in NVDA
 
 ## 2024.3
+The Add-on Store will now notify you if any add-on updates are available on NVDA start up.
 
 This release adds support for Unicode Normalization to speech and braille output.
 This can be useful when reading characters that are unknown to a particular speech synthesizer or braille table and which have a compatible alternative, like the bold and italic characters commonly uses on social media.
 It also allows reading of equations in the Microsoft Word equation editor.
-
-The Add-on Store will now notify you if any add-on updates are available on NVDA start up.
 
 There are several bug fixes, particularly for the Windows 11 Emoji Panel and Clipboard history.
 For web browsers, there are fixes for reporting error messages, figures, captions, table labels and checkbox/radio button menu items.
@@ -64,9 +63,10 @@ It is especially useful to read the error location markers in tracebacks. (#1632
 * When a `gainFocus` event is queued with an object that has a valid `focusRedirect` property, the object pointed to by the `focusRedirect` property is now held by `eventHandler.lastQueuedFocusObject`, rather than the originally queued object. (#15843)
 * NVDA will log its executable architecture (x86) at startup. (#16432, @josephsl)
 * `wx.CallAfter`, which is wrapped in `monkeyPatches/wxMonkeyPatches.py`, now includes proper `functools.wraps` indication. (#16520, @XLTechie)
-* There is a new module for scheduling tasks, using the pip module `schedule`.
-You can use `utils.schedule.ScheduleThread.scheduleDailyJobAtStartUp` to automatically schedule a job that happens after NVDA starts, and every 24 hours after that.
-Jobs are scheduled with a delay to avoid conflicts. (#16636)
+* There is a new module for scheduling tasks `utils.schedule`, using the pip module `schedule`. (#16636)
+  * You can use `ScheduleThread.scheduleDailyJobAtStartUp` to automatically schedule a job that happens after NVDA starts, and every 24 hours after that.
+  Jobs are scheduled with a delay to avoid conflicts.
+  * `ScheduleThread.scheduleDailyJob` and `scheduleJob` can be used to schedule jobs at custom times, where a `JobClashError` will be raised on a known job scheduling clash.
 
 #### Deprecations
 

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -352,6 +352,9 @@ The status of the add-on will be listed as "Update available".
 The list will display the currently installed version and the available version.
 Press `enter` on the add-on to open the actions list; choose "Update".
 
+By default, after NVDA startup, the Add-on Store will notify you if any add-on updates are available.
+To learn more about and configure this behaviour, refer to ["Update Notifications"](#AutomaticAddonUpdates).
+
 ### Community {#Community}
 
 NVDA has a vibrant user community.
@@ -2890,6 +2893,27 @@ This style works best when working with documents which use block paragraphs.
 Note that this paragraph style cannot be used in Microsoft Word or Microsoft Outlook, unless you are using UIA to access Microsoft Word controls.
 
 You may toggle through the available paragraph styles from anywhere by assigning a key in the [Input Gestures dialog](#InputGestures).
+
+#### Add-on Store Settings {#AddonStoreSettings}
+
+This category allows you to adjust the behaviour of the Add-on Store.
+
+##### Update Notifications {#AutomaticAddonUpdates}
+
+By default, after NVDA startup, the Add-on Store will notify you if any add-on updates are available.
+This check is performed every 24 hours.
+Notifications will only occur for add-ons with updates available within the same channel.
+For example, for installed beta add-ons, you will only be notified of updates within the beta channel.
+
+| . {.hideHeaderRow} |.|
+|---|---|
+|Options |Notify (Default), Disabled |
+|Default |Notify |
+
+|Option |Behaviour |
+|---|---|
+|Enabled |Notify when updates are available to add-ons within the same channel |
+|Disabled |Do not automatically check for updates to add-ons |
 
 #### Windows OCR Settings {#Win10OcrSettings}
 

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -352,7 +352,7 @@ The status of the add-on will be listed as "Update available".
 The list will display the currently installed version and the available version.
 Press `enter` on the add-on to open the actions list; choose "Update".
 
-By default, after NVDA startup, the Add-on Store will notify you if any add-on updates are available.
+By default, after NVDA startup, you will be notified if any add-on updates are available.
 To learn more about and configure this behaviour, refer to ["Update Notifications"](#AutomaticAddonUpdates).
 
 ### Community {#Community}
@@ -2900,7 +2900,7 @@ This category allows you to adjust the behaviour of the Add-on Store.
 
 ##### Update Notifications {#AutomaticAddonUpdates}
 
-By default, after NVDA startup, the Add-on Store will notify you if any add-on updates are available.
+When this option is set to "Notify", the Add-on Store will notify you after NVDA startup if any add-on updates are available.
 This check is performed every 24 hours.
 Notifications will only occur for add-ons with updates available within the same channel.
 For example, for installed beta add-ons, you will only be notified of updates within the beta channel.
@@ -3500,7 +3500,7 @@ If NVDA is installed and running on your system, you can also open an add-on fil
 When an add-on is being installed from an external source, NVDA will ask you to confirm the installation.
 Once the add-on is installed, NVDA must be restarted for the add-on to start running, although you may postpone restarting NVDA if you have other add-ons to install or update.
 
-By default, after NVDA startup, the Add-on Store will notify you if any add-on updates are available.
+By default, after NVDA startup, you will be notified if any add-on updates are available.
 To learn more about and configure this behaviour, refer to ["Update Notifications"](#AutomaticAddonUpdates).
 
 #### Removing Add-ons {#AddonStoreRemoving}

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -3500,6 +3500,9 @@ If NVDA is installed and running on your system, you can also open an add-on fil
 When an add-on is being installed from an external source, NVDA will ask you to confirm the installation.
 Once the add-on is installed, NVDA must be restarted for the add-on to start running, although you may postpone restarting NVDA if you have other add-ons to install or update.
 
+By default, after NVDA startup, the Add-on Store will notify you if any add-on updates are available.
+To learn more about and configure this behaviour, refer to ["Update Notifications"](#AutomaticAddonUpdates).
+
 #### Removing Add-ons {#AddonStoreRemoving}
 
 To remove an add-on, select the add-on from the list and use the Remove action.


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Closes #15035

### Summary of the issue:
Users would like a push notification on NVDA start-up letting them know if add-ons have available updates

### Description of user facing changes
When starting NVDA, a dialog will appear notifying users of updatable add-ons if there are available updates.
This will only notify users if the available update is in the same channel as the installed add-on.
There is an "update all" button on the dialog and a list of add-ons with updates available.
There is also an "Open Add-on Store" button to open the add-on store to the updatable add-ons tab.

A setting to disable this. This is a combobox so that in future users can decide between:
- notify on updates (default)
- automatic update (See #3208)
- disabled

### Description of development approach
Created a scheduling module to schedule tasks on NVDA start up, using the schedule pip module.
This is so we can have conflict free scheduling. e.g. so NVDA's  update notification won't clash with the add-on update notification.
Uses their suggested code to run a background thread for task scheduling: https://schedule.readthedocs.io/en/stable/background-execution.html

Changed much of the Add-on Store downloading code to be classmethods. This allows us to use it from the message dialog without creating a store instance.

### Testing strategy:
**Manual testing**
See the manual test plan for the add-on store.

**Unit testing**
Unit testing to smoke test handling the daily job at startup

### Known issues with pull request:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced automatic update notifications for add-ons.
  - Added a daily job to check for updatable add-ons.

- **Enhancements**
  - Updated Add-on Store to support updating multiple add-ons at once.
  - Improved Add-on Store dialog to open to a specific tab based on installed add-ons.

- **Documentation**
  - Updated manual with instructions for simulating add-on updates and testing automatic update notifications.

- **Tests**
  - Added unit tests for scheduling daily jobs and handling job clashes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->