### PR TITLE
show all channels for updatable add-ons if a beta/dev add-on has been installed

### DIFF
--- a/source/gui/addonStoreGui/controls/storeDialog.py
+++ b/source/gui/addonStoreGui/controls/storeDialog.py
@@ -319,7 +319,7 @@ class AddonStoreDialog(SettingsDialog):
 			_StatusFilterKey.AVAILABLE,
 			_StatusFilterKey.UPDATE,
 		}:
-			if self._storeVM._filteredStatusKey ==_StatusFilterKey.UPDATE and (
+			if self._storeVM._filteredStatusKey == _StatusFilterKey.UPDATE and (
 				self._storeVM._installedAddons[Channel.DEV]
 				or self._storeVM._installedAddons[Channel.BETA]
 			):

--- a/source/gui/addonStoreGui/controls/storeDialog.py
+++ b/source/gui/addonStoreGui/controls/storeDialog.py
@@ -319,7 +319,13 @@ class AddonStoreDialog(SettingsDialog):
 			_StatusFilterKey.AVAILABLE,
 			_StatusFilterKey.UPDATE,
 		}:
-			self._storeVM._filterChannelKey = Channel.STABLE
+			if self._storeVM._filteredStatusKey ==_StatusFilterKey.UPDATE and (
+				self._storeVM._installedAddons[Channel.DEV]
+				or self._storeVM._installedAddons[Channel.BETA]
+			):
+				self._storeVM._filterChannelKey = Channel.ALL
+			else:
+				self._storeVM._filterChannelKey = Channel.STABLE
 			self.enabledFilterCtrl.Hide()
 			self.enabledFilterCtrl.Disable()
 			self.includeIncompatibleCtrl.Enable()


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
None

### Summary of the issue:
If a beta/dev add-on has been installed, updates for that add-on are not displayed by default when going to the updatable add-ons tab.
This is because the default channel view for updatable add-ons is always "Stable".
Instead, it would be helpful to show beta/dev add-ons if these have been installed previously.

### Description of user facing changes
If a beta/dev add-on has been installed, add-ons of all channels will show up by default in the updatable add-ons tab

### Description of development approach
Set the filter key depending on if beta/dev add-ons have been installed

### Testing strategy:
Manual testing by installing a beta add-on

### Known issues with pull request:
Note: this switches the default to all if any beta/dev add-on has been installed, not necessarily the one with updates available

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
