### PR TITLE
Normalize path of crash dump

### DIFF
--- a/source/watchdog.py
+++ b/source/watchdog.py
@@ -250,7 +250,7 @@ def _crashHandler(exceptionInfo):
 	ctypes.pythonapi.PyThreadState_SetAsyncExc(threadId, None)
 
 	# Write a minidump.
-	dumpPath = os.path.join(globalVars.appArgs.logFileName, "..", "nvda_crash.dmp")
+	dumpPath = os.path.join(os.path.dirname(globalVars.appArgs.logFileName), "nvda_crash.dmp")
 	try:
 		# Though we aren't using pythonic functions to write to the dump file,
 		# open it in binary mode as opening it in text mode (the default) doesn't make sense.

--- a/tests/system/libraries/NvdaLib.py
+++ b/tests/system/libraries/NvdaLib.py
@@ -21,6 +21,7 @@ from os.path import (
 	expandvars as _expandvars,
 	exists as _exists,
 	splitext as _splitext,
+	dirname as _dirname,
 )
 import tempfile as _tempFile
 from typing import (
@@ -385,7 +386,7 @@ class NvdaLib:
 		"""
 		Checks if a crash.dmp exits and returns the crash dmp path if so
 		"""
-		crashPath = overridePath or _pJoin(_locations.profileDir, "nvda_crash.dmp")
+		crashPath = overridePath or _pJoin(_dirname(_locations.logPath), "nvda_crash.dmp")
 		try:
 			opSys.file_should_not_exist(crashPath)
 		except Exception:

--- a/tests/system/libraries/NvdaLib.py
+++ b/tests/system/libraries/NvdaLib.py
@@ -385,7 +385,7 @@ class NvdaLib:
 		"""
 		Checks if a crash.dmp exits and returns the crash dmp path if so
 		"""
-		crashPath = overridePath or _pJoin(_locations.logPath, "..", "nvda_crash.dmp")
+		crashPath = overridePath or _pJoin(_locations.profileDir, "nvda_crash.dmp")
 		try:
 			opSys.file_should_not_exist(crashPath)
 		except Exception:


### PR DESCRIPTION

### Link to issue number:
None
### Summary of the issue:
When a crash dump is created, the following is logged:
```
CRITICAL - watchdog._crashHandler (14:32:14.383) - MainThread (15656):
NVDA crashed! Minidump written to C:\Users\Cyrille\Documents\DevP\GIT\nvda\source\nvda.log\..\nvda_crash.dmp
```

Although it causes no functional issue, the path is not normalized (presence of `..` in the path). It is a bit confusing when reading this in the log.

### Description of user facing changes
The message being logged shows a normalized path.
### Description of development approach
Get the directory of the log file and join with the dumpfile file name.
### Testing strategy:
Manual test:
Force a crash as follows:
* In the `settingsdialog.py` file, in `MultiCategorySettingsDialog.onCategoryChange` method, add the following line:
  `globalVars.dbg = evt`
* (Re)start NVDA from source
* In the Python console, type `import globalVars` and press `Enter`
* Then in the console, type `globalVars.dbg.` and press tab

Check that the path is normalized in the log and that the crash dump file is still being generated.

### Known issues with pull request:
None
### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced stability by updating the crash dump file path calculation.
  - Improved accuracy in locating crash dump files in system tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->