### PR TITLE
Do not erase a modified line when moving in the Python console history

### DIFF
--- a/source/pythonConsole.py
+++ b/source/pythonConsole.py
@@ -522,7 +522,7 @@ class ConsoleUI(
 				self.inputCtrl.ChangeValue(suffix)
 				break
 
-	def onInputTextChange(self, evt):
+	def onInputTextChange(self, evt: wx.CommandEvent):
 		self.inputTextModified = True
 		evt.Skip()
 

--- a/source/pythonConsole.py
+++ b/source/pythonConsole.py
@@ -313,6 +313,8 @@ class ConsoleUI(
 		self.inputCtrl.SetFont(font)
 		self.inputCtrl.Bind(wx.EVT_CHAR, self.onInputChar)
 		self.inputCtrl.Bind(wx.EVT_TEXT_PASTE, self.onInputPaste)
+		self.inputCtrl.Bind(wx.EVT_TEXT, self.onInputTextChange)
+		self.inputTextModified = False
 		inputSizer.Add(self.inputCtrl, proportion=1, flag=wx.EXPAND)
 		mainSizer.Add(inputSizer, proportion=1, flag=wx.EXPAND)
 		self.SetSizer(mainSizer)
@@ -374,6 +376,9 @@ class ConsoleUI(
 			self.outputPositions.append(self.outputCtrl.GetInsertionPoint())
 
 	def historyMove(self, movement):
+		if self.inputTextModified:
+			self.inputHistoryPos = len(self.inputHistory) - 1
+			self.inputHistory[self.inputHistoryPos] = self.inputCtrl.GetValue()
 		newIndex = self.inputHistoryPos + movement
 		if not (0 <= newIndex < len(self.inputHistory)):
 			# No more lines in this direction.
@@ -381,6 +386,7 @@ class ConsoleUI(
 		self.inputHistoryPos = newIndex
 		self.inputCtrl.ChangeValue(self.inputHistory[newIndex])
 		self.inputCtrl.SetInsertionPointEnd()
+		self.inputTextModified = False
 		return True
 
 	RE_COMPLETE_UNIT = re.compile(r"[\w.]*$")
@@ -515,6 +521,10 @@ class ConsoleUI(
 				# reading of output errors.
 				self.inputCtrl.ChangeValue(suffix)
 				break
+
+	def onInputTextChange(self, evt):
+		self.inputTextModified = True
+		evt.Skip()
 
 	def onOutputKeyDown(self, evt):
 		key = evt.GetKeyCode()

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -28,6 +28,7 @@ Unicode CLDR has been updated.
 * The fallback braille input table is now equal to the fallback output table, which is Unified English Braille Code grade 1. (#9863, @JulienCochuyt, @LeonarddeR)
 * NVDA will now report figures with no accessible children, but with a label or description. (#14514)
 * When reading by line in browse mode, "caption" is no longer reported on each line of a long figure or table caption. (#14874)
+* In the Python console, the last unexecuted command will no longer be lost when moving in the input history. (#16653, @CyrilleB79)
 
 ### Bug Fixes
 * Windows 11 fixes:


### PR DESCRIPTION
### Link to issue number:
Closes #16653
### Summary of the issue:
Unexecuted commands are lost when moving in the python console history.
### Description of user facing changes
If a command has been written or modified in the console but not executed, it will not be lost. In case the modified command is not the last in the history, the original history item will not be overriden (as it was before #15794), but it will be copied in last position in the history so that it can be edited.

### Description of development approach
Tracked text modification with an appropriate event to react accordingly.
### Testing strategy:
Manual tests.
### Known issues with pull request:
As soon as you modify an item in the history, you lose your position in the history and turn back to last item.
Though it is preferred to avoid overwriting items in the history.
### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
