### PR TITLE
Use OffsetConverter for OffsetTextInfo find

### DIFF
--- a/source/textInfos/offsets.py
+++ b/source/textInfos/offsets.py
@@ -667,7 +667,7 @@ class OffsetsTextInfo(textInfos.TextInfo):
 			return False
 		converter = textUtils.getOffsetConverter(self.encoding)(inText)
 		if reverse:
-			offset = self._startOffset- converter.strToEncodedOffsets(m.end())
+			offset = self._startOffset - converter.strToEncodedOffsets(m.end())
 		else:
 			offset = self._startOffset + 1 + converter.strToEncodedOffsets(m.start())
 		self._startOffset=self._endOffset=offset

--- a/source/textInfos/offsets.py
+++ b/source/textInfos/offsets.py
@@ -665,10 +665,11 @@ class OffsetsTextInfo(textInfos.TextInfo):
 		m=re.search(re.escape(text),inText,(0 if caseSensitive else re.IGNORECASE)|re.UNICODE)
 		if not m:
 			return False
+		converter = textUtils.getOffsetConverter(self.encoding)(inText)
 		if reverse:
-			offset=self._startOffset-m.end()
+			offset = self._startOffset- converter.strToEncodedOffsets(m.end())
 		else:
-			offset=self._startOffset+1+m.start()
+			offset = self._startOffset + 1 + converter.strToEncodedOffsets(m.start())
 		self._startOffset=self._endOffset=offset
 		return True
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -39,6 +39,7 @@ Unicode CLDR has been updated.
   * Error messages referenced with `aria-errormessage` are now reported in Google Chrome and Mozilla Firefox. (#8318)
   * If present, NVDA will now use `aria-labelledby` to provide accessible names for tables in Mozilla Firefox. (#5183)
   * NVDA will correctly announce radio and checkbox menuitems when first entering submenus in Google Chrome and Mozilla Firefox. (#14550)
+  * NVDA's browse mode find functionality is now more accurate when the page contains emojis. (#16317, @LeonarddeR)
 * NVDA will announce correctly the autocomplete suggestions in Eclipse and other Eclipse-based environments on Windows 11. (#16416, @thgcode)
 * Improved reliability of automatic text readout, particularly in terminal applications. (#15850, #16027, @Danstiv)
 * NVDA will correctly announce selection changes when editing a cell's text in Microsoft Excel. (#15843)


### PR DESCRIPTION
### Link to issue number:
Fixes #16317

### Summary of the issue:
Find in browse mode (Virtual Buffers) can be inaccurate when a python character spans two character offsets in the underlying TextInfo, such as when emojis come in to play.

### Description of user facing changes
Find functionality is now accurate when a page contains emoji characters and similar.

### Description of development approach
Use an OffsetConverter to correct offsets.

### Testing strategy:
Tested test case as provided by @CyrilleB79 in https://github.com/nvaccess/nvda/issues/16317#issuecomment-2003259194

### Known issues with pull request:
None known

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
