### PR TITLE
Remove generic anchor names from the User Guide

### DIFF
--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -3556,7 +3556,7 @@ To toggle the braille viewer from anywhere, please assign a custom gesture using
 The NVDA Python console, found under Tools in the NVDA menu, is a development tool which is useful for debugging, general inspection of NVDA internals or inspection of the accessibility hierarchy of an application.
 For more information, please see the [NVDA Developer Guide](https://www.nvaccess.org/files/nvda/documentation/developerGuide.html).
 
-### Add-on Store {#toc314}
+### Add-on Store {#AddonStoreMenuItem}
 
 This will open the [NVDA Add-on Store](#AddonsManager).
 For more information, read the in-depth section: [Add-ons and the Add-on Store](#AddonsManager).
@@ -4005,7 +4005,7 @@ The following extra devices are also supported (and do not require any special d
 Following are the key assignments for  the Brailliant BI/B and BrailleNote touch displays with NVDA.
 Please see the display's documentation for descriptions of where these keys can be found.
 
-#### Key assignments for All models {#toc334}
+#### Key assignments for All models {#HumanWareBrailliantKeyAssignmentForAllModels}
 
 <!-- KC:beginInclude -->
 
@@ -4034,7 +4034,7 @@ Please see the display's documentation for descriptions of where these keys can 
 
 <!-- KC:endInclude -->
 
-#### Key assignments for Brailliant BI 32, BI 40 and B 80 {#toc335}
+#### Key assignments for Brailliant BI 32, BI 40 and B 80 {#HumanWareBrailliantKeyAssignmentForBI32BI40AndB80}
 
 <!-- KC:beginInclude -->
 
@@ -4046,7 +4046,7 @@ Please see the display's documentation for descriptions of where these keys can 
 
 <!-- KC:endInclude -->
 
-#### Key assignments for Brailliant BI 14 {#toc336}
+#### Key assignments for Brailliant BI 14 {#HumanWareBrailliantKeyAssignmentForBI14}
 
 <!-- KC:beginInclude -->
 

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -1706,7 +1706,7 @@ The settings categories found in the NVDA Settings dialog will be outlined below
 
 <!-- KC:setting -->
 
-##### Open General settings {#toc110}
+##### Open General settings {#OpenGeneralSettings}
 
 Key: `NVDA+control+g`
 
@@ -1802,7 +1802,7 @@ You can also manually install the pending update from the Exit NVDA dialog (if e
 
 <!-- KC:setting -->
 
-##### Open Speech settings {#toc123}
+##### Open Speech settings {#OpenSpeechSettings}
 
 Key: `NVDA+control+v`
 
@@ -1945,7 +1945,7 @@ Note that it is necessary to check at least two modes.
 
 <!-- KC:setting -->
 
-##### Open Select Synthesizer dialog {#toc144}
+##### Open Select Synthesizer dialog {#OpenSelectSynthesizer}
 
 Key: `NVDA+control+s`
 
@@ -2177,7 +2177,7 @@ To toggle show selection from anywhere, please assign a custom gesture using the
 
 <!-- KC:setting -->
 
-##### Open Select Braille Display dialog {#toc168}
+##### Open Select Braille Display dialog {#OpenSelectBrailleDisplay}
 
 Key: `NVDA+control+a`
 
@@ -2229,7 +2229,7 @@ Therefore it is recommended to only connect one Braille Display of a given type 
 
 <!-- KC:setting -->
 
-##### Open Audio settings {#toc173}
+##### Open Audio settings {#OpenAudioSettings}
 
 Key: `NVDA+control+u`
 
@@ -2372,7 +2372,7 @@ For the supported settings per provider, please refer to the documentation for t
 
 <!-- KC:setting -->
 
-##### Open Keyboard settings {#toc188}
+##### Open Keyboard settings {#OpenKeyboardSettings}
 
 Key: `NVDA+control+k`
 
@@ -2449,7 +2449,7 @@ This option is on by default, though certain users may wish to turn this off, su
 
 <!-- KC:setting -->
 
-##### Open Mouse settings {#toc201}
+##### Open Mouse settings {#OpenMouseSettings}
 
 Key: `NVDA+control+m`
 
@@ -2552,7 +2552,7 @@ To toggle simple review mode from anywhere, please assign a custom gesture using
 
 <!-- KC:setting -->
 
-##### Open Object Presentation settings {#toc218}
+##### Open Object Presentation settings {#OpenObjectPresentationSettings}
 
 Key: `NVDA+control+o`
 
@@ -2667,7 +2667,7 @@ This option is on by default.
 
 <!-- KC:setting -->
 
-##### Open Browse Mode settings {#toc236}
+##### Open Browse Mode settings {#OpenBrowseModeSettings}
 
 Key: `NVDA+control+b`
 
@@ -2759,7 +2759,7 @@ Enabling this option may improve support for some websites at the cost of perfor
 
 <!-- KC:setting -->
 
-##### Open Document Formatting settings {#toc250}
+##### Open Document Formatting settings {#OpenDocumentFormattingSettings}
 
 Key: `NVDA+control+d`
 

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -540,7 +540,7 @@ You can also keep your finger on the screen and move it around to read other con
 When NVDA commands are described later in this user guide, they may list a touch gesture which can be used to activate that command with the touchscreen.
 Following are some instructions on how to perform the various touch gestures.
 
-##### Taps {#toc45}
+##### Taps {#Taps}
 
 Tap the screen quickly with one or more fingers.
 
@@ -552,7 +552,7 @@ Tapping twice will result in a double-tap.
 Tapping 3 times will result in a triple-tap and so on.
 Of course, these multi-tap gestures also recognize how many fingers were used, so it's possible to have gestures like a 2-finger triple-tap, a 4-finger tap, etc.
 
-##### Flicks {#toc46}
+##### Flicks {#Flicks}
 
 Quickly swipe your finger across the screen.
 


### PR DESCRIPTION
### Link to issue number:
Discussion in #16655

### Summary of the issue:
Some paragraphs in the User Guide have inexplicit anchors names such as `#toc45`. In case they need to be referenced in the future, in the User Guide, in NVDA's GUI (context help) or in an external source, it would be desirable to have a more explicit name. Moreover, the auto-generated anchor names (`#tocNNN`) have probably changed various times in the past due to the evolution of the structure of the user guide.

Until NVDA 2024.1 (included), the base document for the User Guide was the t2t file and these anchors were "floating", depending on the evolution of the document. E.g. the paragraph "Open General settings" has anchor `#toc109` in NVDA 2024.1 but `#toc110` in NVDA 2024.2beta3.

### Description of user facing changes
Replace auto-generated anchors `#tocNNN` by explicit anchor names.

### Description of development approach
#### Commit 8891a1e3c9416337cb6d07afb653f09474ab19d5
Renamed the anchors of the "open settings" paragraphs.
Note: These paragraphs were added in NVDA 2024.1 but their anchor names differ between 2024.1 and 2024.2beta3 due to changes in the User Guide structure.

#### Commit 9d726d626487f23aaae6d17257894b36b1b862e7
Renamed the 4 other anchors that have changed between NVDA 2024.1 and NVDA 2024.2beta3.
Note: These anchor names have changed due to changes in the User Guide structure.

#### Commit ce8591f615dd98d443b536b8ff3418d005d441f9
Rename the two remaining anchors whose name has not changed between 2024.1 and 2024.2beta3.
Note: These anchors were first present in NVDA 2024.1; before, they were not present since they correspond to level 5 heading (or level 4) which were not listed in the table of contents of the t2t file.

### Testing strategy:
Manual check with the links of the table of contents.

### Known issues with pull request:

* This PR requires to extend the translation freeze period or to accept that anchors do not reach translations for 2024.2.
* This PR changes the anchors of two headings ("Taps" and "Flicks") in commit ce8591f615dd98d443b536b8ff3418d005d441f9. It's not a big problem since this anchor was only present since 2024.1 and it applies to minor paragraphs.
* This PR changes the anchors for 14 other headings. It's not a big problem because:
  * they have already been changed between 2024.1 and 2024.2beta3
  * 10 of these headings have only been added in 2024.1
  * the name of the 4 other anchors has already changed various times in the past due to the evolution of the structure of the User Guide

As alternatives we can:
1. Close this PR and keep the `#tocNNN` anchor names for the existing ones; but ensure not to add new ones in the future.
2. Rebase this PR on master to target 2024.3. But this will lead to more anchor name changes. E.g. `#toc109` in 2024.1 will becomes `#toc110` in 2024.2 and then `#OpenGeneralSettings` in 2024.3, instead of directly `#OpenGeneralSettings` in 2024.2. It is to avoid this extra name change that this PR has been opened against beta.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
