### PR TITLE
Fix up order for feature descriptions in the user guide standards

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -44,6 +44,7 @@
 
 # For changes to the userGuide auto request review from userDocs team
 /user_docs/en/userGuide.md @nvaccess/userDocs
+/projectDocs/dev/userGuideStandards.md @nvaccess/userDocs
 
 # For various project documentation, require appropriate teams
 /projectDocs/community/ @nvaccess/userDocs

--- a/projectDocs/dev/userGuideStandards.md
+++ b/projectDocs/dev/userGuideStandards.md
@@ -21,20 +21,20 @@ Once the anchor is set it cannot be updated, while settings may move categories.
 ```md
 ==== The name of a feature ====[FeatureDescriptionAnchor]
 
+Brief summary of the feature.
+This setting allows the feature of using functionality in a certain situation to be controlled in some way.
+If necessary, a description of a common use case that is supported by each option.
 
 | . {.hideHeaderRow} |.|
 |---|---|
-|Options |Default (Enabled), Disabled, Enabled|
-|Default |Enabled|
+|Options |Default (Enabled), Disabled, Enabled |
+|Default |Enabled |
 |Toggle command |`NVDA+shift+e` |
 
 |Option |Behaviour |
 |---|---|
 |Enabled |behaviour of enabled |
 |Disabled |behaviour of disabled |
-
-This setting allows the feature of using functionality in a certain situation to be controlled in some way.
-If necessary, a description of a common use case that is supported by each option.
 ```
 
 ## Generation of Key Commands


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
None

### Summary of the issue:
As discussed in https://github.com/nvaccess/nvda/pull/16490 and https://github.com/nvaccess/nvda/pull/15902#issuecomment-1867321541 that feature descriptions should come before settings tables for features in the user guide.
This is because a basic description is more common than detailed tables in reference manuals

### Description of user facing changes
Fixes up order for feature descriptions in the user guide standards
