### PR TITLE
QuickNav next menu command: adding more IA2 roles

### DIFF
--- a/source/virtualBuffers/gecko_ia2.py
+++ b/source/virtualBuffers/gecko_ia2.py
@@ -565,7 +565,10 @@ class Gecko_ia2(VirtualBuffer):
 			]
 		elif nodeType == "menuItem":
 			attrs = [
-				{"IAccessible::role": [oleacc.ROLE_SYSTEM_BUTTONMENU]}
+				{"IAccessible::role": [
+					oleacc.ROLE_SYSTEM_BUTTONMENU,
+					oleacc.ROLE_SYSTEM_MENUITEM,
+				]}
 			]
 		elif nodeType == "toggleButton":
 			attrs = [


### PR DESCRIPTION
### Link to issue number:
N/A
### Summary of the issue:
On some websites QuickNav command jump to next menu doesn't work. For  example in Jupyter:
https://jupyter.org/try-jupyter/notebooks/?path=notebooks/Intro.ipynb
### Description of user facing changes
QuickNav next menu command now works with Jupyter.
### Description of development approach
Added one more IA2 role to search for in next menu QuickNav command.
### Testing strategy:
Tested on Jupyter website - link above.
### Known issues with pull request:
N/A
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
