### PR TITLE
appveyor: try to show downloads and notifications directly in GitHubP…

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -104,3 +104,12 @@ on_finish:
  - ps: |
      "FINISH_END, $(Get-Date -Format 'o')"| Out-File ../timing.csv -Append
  - ps: appveyor\scripts\logCiTiming.ps1
+
+notifications:
+ - provider: GitHubPullRequest
+   on_build_status_changed: false
+   template: |-
+    {{#passed}}Build succeeded!{{/passed}}{{#failed}}Build failed!{{/failed}} [Build {{&projectName}} {{buildVersion}} {{status}}]({{buildUrl}}) (commit {{commitUrl}} by @{{&commitAuthorUsername}})
+    {{#passed}}Downloads:{{#jobs}}
+    <details>
+    <summary>{{name}}</summary>


### PR DESCRIPTION

### Link to issue number:
none
### Summary of the issue:
[Code reference from](https://github.com/jcsteh/osara/blob/e47571a624c987fa586e2e8552b0651434c3bfdb/appveyor.yml)
### Description of user facing changes
No user changes, this feature is limited to PR contributors only
### Description of development approach
Added a [notifications](https://www.appveyor.com/docs/notifications/) category in the appveyor.yml file
### Testing strategy:
Need to test the compilation build with appveyor and issue a notification
### Known issues with pull request:
Not found at the moment
### Code Review Checklist:

- [ ] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [ ] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [ ] API is compatible with existing add-ons.
- [ ] Security precautions taken.

<!-- Please keep the following -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added GitHub pull request notifications for build status updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
This pr mainly implements that
When after compiling the pr, the compiled build can be downloaded directly within the pull request.
Instead of using a second browser [open](https://ci.appveyor.com/project/nvaccess/nvda)
to download.