### PR TITLE
Fix regression: make BASE_ONLY_SECTIONS no longer a frozen set

### DIFF
--- a/source/config/__init__.py
+++ b/source/config/__init__.py
@@ -504,15 +504,18 @@ class ConfigManager(object):
 	Changed settings are written to the most recently activated profile.
 	"""
 
-	#: Sections that only apply to the base configuration;
-	#: i.e. they cannot be overridden in profiles.
-	BASE_ONLY_SECTIONS = frozenset({
+	BASE_ONLY_SECTIONS = {
 		"general",
 		"update",
 		"upgrade",
 		"development",
 		"addonStore",
-	})
+	}
+	"""
+	Sections that only apply to the base configuration;
+	i.e. they cannot be overridden in profiles.
+	Note this set may be extended by add-ons.
+	"""
 
 	def __init__(self):
 		self.spec = confspec


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Fixes #16684

### Summary of the issue:
In #16636 / d7facd1, config.ConfigManager.BASE_ONLY_SECTIONS underwent a mutation from a set to a frozenset.
Thhis modification hinders extensions from easily expanding this set.

There are perfectly legit scenarios where an extension’s settings should not be overridden by profiles. Take webAccess, for instance: accessolutions/WebAccessForNVDA@4251aae/addon/globalPlugins/webAccess/config.py

### Description of user facing changes
None

### Description of development approach
Undo change in #16636

### Testing strategy:

### Known issues with pull request:

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Enhanced documentation for the `ConfigManager` class to clarify the purpose of `BASE_ONLY_SECTIONS`.

- **Refactor**
  - Updated `BASE_ONLY_SECTIONS` from a `frozenset` to a dictionary for better structure and readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
