### PR TITLE
Create a new folder by default when making a portable copy, warn for non-empty directories

### DIFF
--- a/source/core.py
+++ b/source/core.py
@@ -806,8 +806,13 @@ def main():
 		)
 	elif globalVars.appArgs.portablePath and (globalVars.appArgs.createPortable or globalVars.appArgs.createPortableSilent):
 		import gui.installerGui
-		wx.CallAfter(gui.installerGui.doCreatePortable,portableDirectory=globalVars.appArgs.portablePath,
-			silent=globalVars.appArgs.createPortableSilent,startAfterCreate=not globalVars.appArgs.createPortableSilent)
+		wx.CallAfter(
+			gui.installerGui.doCreatePortable,
+			portableDirectory=globalVars.appArgs.portablePath,
+			silent=globalVars.appArgs.createPortableSilent,
+			startAfterCreate=not globalVars.appArgs.createPortableSilent,
+			warnForNonEmptyDirectory=not globalVars.appArgs.createPortableSilent,
+		)
 	elif not globalVars.appArgs.minimal:
 		try:
 			# Translators: This is shown on a braille display (if one is connected) when NVDA starts.

--- a/source/gui/installerGui.py
+++ b/source/gui/installerGui.py
@@ -436,10 +436,19 @@ class PortableCreaterDialog(
 		# needed. The OS's idea of the current drive is used, as in os.getcwd(). (#14681)
 		expandedPortableDirectory = os.path.abspath(expandedPortableDirectory)
 		if self.newFolderCheckBox.Value:
-			expandedPortableDirectory = os.path.join(expandedPortableDirectory, "NVDA")
+			newPortableDirectory = os.path.join(expandedPortableDirectory, "NVDA")
+			i = 1
+			while os.path.exists(newPortableDirectory):
+				newPortableDirectory = os.path.join(expandedPortableDirectory, f"NVDA_{i}")
+				i += 1
+			expandedPortableDirectory = newPortableDirectory
 
-		if os.path.exists(expandedPortableDirectory) and len(os.listdir(expandedPortableDirectory)) > 0:
-			if "nvda.exe" in os.listdir(expandedPortableDirectory):
+		if os.path.exists(expandedPortableDirectory):
+			dirContents = os.listdir(expandedPortableDirectory)
+		else:
+			dirContents = []
+		if len(dirContents) > 0:
+			if "nvda.exe" in dirContents:
 				if wx.NO == gui.messageBox(
 					# Translators: The message displayed when the user has specified a destination directory
 					# that already has a portable copy in the Create Portable NVDA dialog.

--- a/source/gui/installerGui.py
+++ b/source/gui/installerGui.py
@@ -367,12 +367,17 @@ class PortableCreaterDialog(
 		browseText = _("Browse...")
 		# Translators: The title of the dialog presented when browsing for the
 		# destination directory when creating a portable copy of NVDA.
-		dirDialogTitle = _("Select portable  directory")
+		dirDialogTitle = _("Select portable directory")
 		directoryPathHelper = guiHelper.PathSelectionHelper(groupBox, browseText, dirDialogTitle)
 		directoryEntryControl = groupHelper.addItem(directoryPathHelper)
 		self.portableDirectoryEdit = directoryEntryControl.pathControl
 		if globalVars.appArgs.portablePath:
 			self.portableDirectoryEdit.Value = globalVars.appArgs.portablePath
+
+		# Translators: The label of a checkbox option in the Create Portable NVDA dialog.
+		newFolderText = _("Create a &new folder for the portable copy")
+		self.newFolderCheckBox = sHelper.addItem(wx.CheckBox(self, label=newFolderText))
+		self.newFolderCheckBox.Value = True
 
 		# Translators: The label of a checkbox option in the Create Portable NVDA dialog.
 		copyConfText = _("Copy current &user configuration")
@@ -430,6 +435,32 @@ class PortableCreaterDialog(
 		# components to that path to make it absolute from other contexts, by adding a drive letter/share path if
 		# needed. The OS's idea of the current drive is used, as in os.getcwd(). (#14681)
 		expandedPortableDirectory = os.path.abspath(expandedPortableDirectory)
+		if self.newFolderCheckBox.Value:
+			expandedPortableDirectory = os.path.join(expandedPortableDirectory, "NVDA")
+
+		if os.path.exists(expandedPortableDirectory) and len(os.listdir(expandedPortableDirectory)) > 0:
+			if "nvda.exe" in os.listdir(expandedPortableDirectory):
+				if wx.NO == gui.messageBox(
+					# Translators: The message displayed when the user has specified a destination directory
+					# that already has a portable copy in the Create Portable NVDA dialog.
+					_("A portable copy already exists in this directory. Do you want to update it?"),
+					# Translators: The title of a dialog presented when the user has specified a destination directory
+					# that already has a portable copy in the Create Portable NVDA dialog.
+					_("Portable Copy Exists"),
+					wx.YES_NO | wx.ICON_QUESTION
+				):
+					return
+			elif wx.NO == gui.messageBox(
+				# Translators: The message displayed when the user has specified a destination directory
+				# that already exists in the Create Portable NVDA dialog.
+				_("The specified directory is not empty. Do you want to overwrite the contents of this folder?"),
+				# Translators: The title of a dialog presented when the user has specified a destination directory
+				# that already exists in the Create Portable NVDA dialog.
+				_("Directory Exists"),
+				wx.YES_NO | wx.ICON_QUESTION
+			):
+				return
+
 		self.Hide()
 		doCreatePortable(
 			expandedPortableDirectory,

--- a/source/gui/installerGui.py
+++ b/source/gui/installerGui.py
@@ -341,7 +341,7 @@ def showInstallGui():
 	gui.mainFrame.postPopup()
 
 
-def _warnForNonEmptyDirectory(portableDirectory: str) -> bool:
+def _warnAndConfirmForNonEmptyDirectory(portableDirectory: str) -> bool:
 	"""
 	Display a warning message if the specified directory is not empty.
 	:param portableDirectory: The directory to check.
@@ -354,9 +354,12 @@ def _warnForNonEmptyDirectory(portableDirectory: str) -> bool:
 	if len(dirContents) > 0:
 		if "nvda.exe" in dirContents:
 			if wx.NO == gui.messageBox(
-				# Translators: The message displayed when the user has specified a destination directory
-				# that already has a portable copy in the Create Portable NVDA dialog.
-				_("A portable copy already exists in this directory. Do you want to update it?"),
+				_(
+					# Translators: The message displayed when the user has specified a destination directory
+					# that already has a portable copy in the Create Portable NVDA dialog.
+					f"A portable copy already exists in the directory '{portableDirectory}'. "
+					"Do you want to update it?"
+				),
 				# Translators: The title of a dialog presented when the user has specified a destination directory
 				# that already has a portable copy in the Create Portable NVDA dialog.
 				_("Portable Copy Exists"),
@@ -367,7 +370,7 @@ def _warnForNonEmptyDirectory(portableDirectory: str) -> bool:
 			_(
 				# Translators: The message displayed when the user has specified a destination directory
 				# that already exists in the Create Portable NVDA dialog.
-				"The specified directory is not empty. "
+				f"The specified directory '{portableDirectory}' is not empty. "
 				"Proceeding will delete and replace existing files in the directory. "
 				"Do you want to overwrite the contents of this folder? "
 			),
@@ -493,7 +496,7 @@ class PortableCreaterDialog(
 			expandedPortableDirectory = _getUniqueNewPortableDirectory(expandedPortableDirectory)
 
 		# Warn here so that users can update the directory
-		if not _warnForNonEmptyDirectory(expandedPortableDirectory):
+		if not _warnAndConfirmForNonEmptyDirectory(expandedPortableDirectory):
 			return
 
 		self.Hide()
@@ -525,7 +528,7 @@ def doCreatePortable(
 	:param startAfterCreate: Whether to start the new portable copy after creation.
 	:param warnForNonEmptyDirectory: Whether to warn if the destination directory is not empty.
 	"""
-	if warnForNonEmptyDirectory and not _warnForNonEmptyDirectory(portableDirectory):
+	if warnForNonEmptyDirectory and not _warnAndConfirmForNonEmptyDirectory(portableDirectory):
 		# Translators: The message displayed when the user cancels the creation of a portable copy of NVDA.
 		ui.message(_("Portable copy creation cancelled."))
 		return

--- a/source/gui/installerGui.py
+++ b/source/gui/installerGui.py
@@ -492,6 +492,7 @@ class PortableCreaterDialog(
 		if self.newFolderCheckBox.Value:
 			expandedPortableDirectory = _getUniqueNewPortableDirectory(expandedPortableDirectory)
 
+		# Warn here so that users can update the directory
 		if not _warnForNonEmptyDirectory(expandedPortableDirectory):
 			return
 

--- a/source/nvda.pyw
+++ b/source/nvda.pyw
@@ -191,8 +191,23 @@ parser.add_argument('--no-sr-flag',action="store_false",dest='changeScreenReader
 installGroup = parser.add_mutually_exclusive_group()
 installGroup.add_argument('--install',action="store_true",dest='install',default=False,help="Installs NVDA (starting the new copy after installation)")
 installGroup.add_argument('--install-silent',action="store_true",dest='installSilent',default=False,help="Installs NVDA silently (does not start the new copy after installation).")
-installGroup.add_argument('--create-portable',action="store_true",dest='createPortable',default=False,help="Creates a portable copy of NVDA (starting the new copy after installation)")
-installGroup.add_argument('--create-portable-silent',action="store_true",dest='createPortableSilent',default=False,help="Creates a portable copy of NVDA silently (does not start the new copy after installation).")
+installGroup.add_argument(
+	"--create-portable",
+	action="store_true",
+	dest="createPortable",
+	default=False,
+	help="Creates a portable copy of NVDA (starting the new copy after installation). "
+	"Requires `--portable-path` to be specified. "
+)
+installGroup.add_argument(
+	"--create-portable-silent",
+	action="store_true",
+	dest="createPortableSilent",
+	default=False,
+	help="Creates a portable copy of NVDA silently (does not start the new copy after installation). "
+	"Note this will suppresses warnings when overwriting non-empty directories. "
+	"Requires --portable-path to be specified. "
+)
 parser.add_argument('--portable-path',dest='portablePath',default=None,type=str,help="The path where a portable copy will be created")
 parser.add_argument('--launcher',action="store_true",dest='launcher',default=False,help="Started from the launcher")
 parser.add_argument('--enable-start-on-logon',metavar="True|False",type=stringToBool,dest='enableStartOnLogon',default=None,

--- a/source/nvda.pyw
+++ b/source/nvda.pyw
@@ -196,7 +196,7 @@ installGroup.add_argument(
 	action="store_true",
 	dest="createPortable",
 	default=False,
-	help="Creates a portable copy of NVDA (starting the new copy after installation).\n"
+	help="Creates a portable copy of NVDA (and starts the new copy).\n"
 	"Requires `--portable-path` to be specified.\n"
 )
 installGroup.add_argument(
@@ -204,8 +204,8 @@ installGroup.add_argument(
 	action="store_true",
 	dest="createPortableSilent",
 	default=False,
-	help="Creates a portable copy of NVDA silently (does not start the new copy after installation).\n"
-	"Note this will suppresses warnings when overwriting non-empty directories.\n"
+	help="Creates a portable copy of NVDA (without starting the new copy).\n"
+	"This option suppresses warnings when writing to non-empty directories and may overwrite files without warning.\n"
 	"Requires --portable-path to be specified.\n"
 )
 parser.add_argument('--portable-path',dest='portablePath',default=None,type=str,help="The path where a portable copy will be created")

--- a/source/nvda.pyw
+++ b/source/nvda.pyw
@@ -196,17 +196,17 @@ installGroup.add_argument(
 	action="store_true",
 	dest="createPortable",
 	default=False,
-	help="Creates a portable copy of NVDA (starting the new copy after installation). "
-	"Requires `--portable-path` to be specified. "
+	help="Creates a portable copy of NVDA (starting the new copy after installation).\n"
+	"Requires `--portable-path` to be specified.\n"
 )
 installGroup.add_argument(
 	"--create-portable-silent",
 	action="store_true",
 	dest="createPortableSilent",
 	default=False,
-	help="Creates a portable copy of NVDA silently (does not start the new copy after installation). "
-	"Note this will suppresses warnings when overwriting non-empty directories. "
-	"Requires --portable-path to be specified. "
+	help="Creates a portable copy of NVDA silently (does not start the new copy after installation).\n"
+	"Note this will suppresses warnings when overwriting non-empty directories.\n"
+	"Requires --portable-path to be specified.\n"
 )
 parser.add_argument('--portable-path',dest='portablePath',default=None,type=str,help="The path where a portable copy will be created")
 parser.add_argument('--launcher',action="store_true",dest='launcher',default=False,help="Started from the launcher")

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -36,7 +36,7 @@ Unicode CLDR has been updated.
 * NVDA will now report figures with no accessible children, but with a label or description. (#14514)
 * When reading by line in browse mode, "caption" is no longer reported on each line of a long figure or table caption. (#14874)
 * In the Python console, the last unexecuted command will no longer be lost when moving in the input history. (#16653, @CyrilleB79)
-* By default, a new folder will be created when making a portable copy. (#16684)
+* By default, a new folder will be created when making a portable copy. Warnings have been added when writing to a non-empty directory. (#16684)
 
 ### Bug Fixes
 * Windows 11 fixes:

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -36,6 +36,7 @@ Unicode CLDR has been updated.
 * NVDA will now report figures with no accessible children, but with a label or description. (#14514)
 * When reading by line in browse mode, "caption" is no longer reported on each line of a long figure or table caption. (#14874)
 * In the Python console, the last unexecuted command will no longer be lost when moving in the input history. (#16653, @CyrilleB79)
+* By default, a new folder will be created when making a portable copy. (#16684)
 
 ### Bug Fixes
 * Windows 11 fixes:

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -5083,7 +5083,7 @@ Following are the command line options for NVDA:
 |None |`--enable-start-on-logon=True|False` |When installing, enable NVDA's [Use NVDA during Windows sign-in](#StartAtWindowsLogon)|
 |None |`--copy-portable-config` |When installing, copy the portable configuration from the provided path (`--config-path`, `-c`) to the current user account|
 |None |`--create-portable` |Creates a portable copy of NVDA (starting the newly created copy). Requires `--portable-path` to be specified|
-|None |`--create-portable-silent` |Creates a portable copy of NVDA (does not start the newly installed copy). Note this will suppress warnings when writing to non-empty directories. Requires `--portable-path` to be specified|
+|None |`--create-portable-silent` |Creates a portable copy of NVDA without starting the newly installed copy. Note: This option suppresses warnings when writing to non-empty directories and requires `--portable-path` to be specified.
 |None |`--portable-path=PORTABLEPATH` |The path where a portable copy will be created|
 
 ### System Wide Parameters {#SystemWideParameters}

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -442,10 +442,15 @@ This option is only available when installing from a portable copy, not when ins
 If creating a portable copy directly from the NVDA download package, press the Create Portable Copy button.
 If you have already closed this dialog or you are running an installed copy of NVDA, choose the Create Portable copy menu item found under Tools in the NVDA menu.
 
-The Dialog that appears allows you to choose where the portable copy should be created.
+The dialog that appears allows you to choose where the portable copy should be created.
 This can be a directory on your hard drive or a location on a USB thumb drive or other portable media.
-There is also an option to choose whether NVDA should copy the logged on user's current NVDA configuration for use  with the newly created portable copy.
+By default, a new directory is created for the portable copy.
+You can also choose to use an existing directory, this will overwrite files in the directory.
+If the existing directory is a portable copy of NVDA, that copy will be updated.
+
+There is also an option to choose whether NVDA should copy the logged on user's current NVDA configuration for use with the newly created portable copy.
 This option is only available when creating a portable copy from an installed copy, not when creating from the download package.
+
 Pressing Continue will create the portable copy.
 Once creation is complete, a message will appear telling you it was successful.
 Press OK to dismiss this dialog.
@@ -3650,14 +3655,10 @@ For more information, read the in-depth section: [Add-ons and the Add-on Store](
 ### Create portable copy {#CreatePortableCopy}
 
 This will open a dialog which allows you to create a portable copy of NVDA out of the installed version.
-Either way, when running a portable copy of NVDA, in the extra tool sub menu the menu item will be called "install NVDA on this PC" instead of "create portable copy).
 
 The dialog to create a portable copy of NVDA or to install NVDA on this PC will prompt you to choose a folder path in which NVDA should create the portable copy or in which NVDA should be installed.
 
-In this dialog you can enable or disable the following:
-
-* Copy current user configuration (this includes the files in %appdata%\roaming\NVDA or in the user configuration of your portable copy and also includes add-ons and other modules)
-* Start the new portable copy after creation or start NVDA after installation (starts NVDA automatically after the portable copy creation or the installation)
+Follow the directions in [Creating a portable copy](#CreatingAPortableCopy) for more information.
 
 ### Run COM registration fixing tool... {#RunCOMRegistrationFixingTool}
 

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -5083,7 +5083,7 @@ Following are the command line options for NVDA:
 |None |`--enable-start-on-logon=True|False` |When installing, enable NVDA's [Use NVDA during Windows sign-in](#StartAtWindowsLogon)|
 |None |`--copy-portable-config` |When installing, copy the portable configuration from the provided path (`--config-path`, `-c`) to the current user account|
 |None |`--create-portable` |Creates a portable copy of NVDA (starting the newly created copy). Requires `--portable-path` to be specified|
-|None |`--create-portable-silent` |Creates a portable copy of NVDA (does not start the newly installed copy). Requires `--portable-path` to be specified|
+|None |`--create-portable-silent` |Creates a portable copy of NVDA (does not start the newly installed copy). Note this will suppress warnings when writing to non-empty directories. Requires `--portable-path` to be specified|
 |None |`--portable-path=PORTABLEPATH` |The path where a portable copy will be created|
 
 ### System Wide Parameters {#SystemWideParameters}

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -5082,8 +5082,8 @@ Following are the command line options for NVDA:
 |None |`--install-silent` |Silently installs NVDA (does not start the newly installed copy)|
 |None |`--enable-start-on-logon=True|False` |When installing, enable NVDA's [Use NVDA during Windows sign-in](#StartAtWindowsLogon)|
 |None |`--copy-portable-config` |When installing, copy the portable configuration from the provided path (`--config-path`, `-c`) to the current user account|
-|None |`--create-portable` |Creates a portable copy of NVDA (starting the newly created copy). Requires `--portable-path` to be specified|
-|None |`--create-portable-silent` |Creates a portable copy of NVDA without starting the newly installed copy. Note: This option suppresses warnings when writing to non-empty directories and requires `--portable-path` to be specified.
+|None |`--create-portable` |Creates a portable copy of NVDA (and starts the new copy). Requires `--portable-path` to be specified|
+|None |`--create-portable-silent` |Creates a portable copy of NVDA  (without starting the new copy). Requires `--portable-path` to be specified. This option suppresses warnings when writing to non-empty directories and may overwrite files without warning.|
 |None |`--portable-path=PORTABLEPATH` |The path where a portable copy will be created|
 
 ### System Wide Parameters {#SystemWideParameters}

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -449,6 +449,7 @@ You can also choose to use an existing directory, this will overwrite files in t
 If the existing directory is a portable copy of NVDA, that copy will be updated.
 
 There is also an option to choose whether NVDA should copy the logged on user's current NVDA configuration for use with the newly created portable copy.
+This also includes add-ons.
 This option is only available when creating a portable copy from an installed copy, not when creating from the download package.
 
 Pressing Continue will create the portable copy.


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Fixes #16443

### Summary of the issue:
When creating a portable copy, NVDA overwrites the contents of the folder. This may delete files like dlls.
This caused https://github.com/nvaccess/nvda/issues/16514 to be reported, as this can be quite destructive and unexpected.

Typical behaviour for writing to a directory like this involves creating a new folder to write the contents to.
However, portable copies can also be upgraded, so it is important to be able to support writing to existing portable copy directories.

### Description of user facing changes

When creating a portable copy, a new checkbox has been added to create a new folder for the portable copy, which is checked by default.
If this box is unchecked, a warning dialog will appear if the directory is non-empty.
The directory contains `nvda.exe` we assume its a portable copy directory, and confirm the user wishes to upgrade the portable copy.
The directory is otherwise non-empty, a general warning dialog is opened warning the user that the contents of the folder will be overwritten.

### Description of development approach

Added GUI elements to the create portable copy dialog

### Testing strategy:

Manual testing

- Tested a new folder is created when the checkbox is ticked
- Tested a new folder named NVDA_1, NVDA_2, etc is created if the proposed new folder "NVDA" exists
- Tested a new folder is not created when the checkbox is not ticked
- Tested writing to an existing portable copy creates a warning before writing to disk
- Tested writing to a non-empty directory creates a warning before writing to disk
- Tested with `--create-portable-silent`: no warning should appear
- Tested from cli with `--create-portable`: warnings should appear for non-empty, and upgrades

### Known issues with pull request:

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a checkbox option to create a new folder for portable copies in the installation dialog.
  - Introduced warnings for non-empty directories when creating portable copies.
  - Updated command line options with detailed descriptions and requirements for creating portable copies.

- **Documentation**
  - Enhanced user documentation with notes on new folder creation and warnings for non-empty directories during portable copy creation.
  - Updated help messages for `--create-portable` and `--create-portable-silent` command line options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->