### PR TITLE
Make CLI help dialog visually readable

### DIFF
--- a/source/nvda.pyw
+++ b/source/nvda.pyw
@@ -84,8 +84,8 @@ class _WideParserHelpFormatter(argparse.RawTextHelpFormatter):
 			self,
 			prog: str,
 			indent_increment: int = 2,
-			max_help_position: int = 30,
-			width: int = 100
+			max_help_position: int = 50,
+			width: int = 1000
 	):
 		"""
 		A custom formatter for argparse help messages that uses a wider width.

--- a/source/nvda.pyw
+++ b/source/nvda.pyw
@@ -214,7 +214,8 @@ parser.add_argument(
 	dest="debugLogging",
 	default=False,
 	help="Enable debug level logging just for this run.\n"
-	"This setting will override any other log level (--loglevel, -l) argument given, as well as no logging option."
+	"This setting will override any other log level (--loglevel, -l) argument given, "
+	"as well as no logging option."
 )
 parser.add_argument(
 	"--no-logging",
@@ -222,7 +223,8 @@ parser.add_argument(
 	dest="noLogging",
 	default=False,
 	help="Disable logging completely for this run.\n"
-	"This setting can be overwritten with other log level (--loglevel, -l) switch or if debug logging is specified."
+	"This setting can be overwritten with other log level (--loglevel, -l) "
+	"switch or if debug logging is specified."
 )
 parser.add_argument('--no-sr-flag',action="store_false",dest='changeScreenReaderFlag',default=True,help="Don't change the global system screen reader flag")
 installGroup = parser.add_mutually_exclusive_group()

--- a/source/nvda.pyw
+++ b/source/nvda.pyw
@@ -13,7 +13,7 @@ import logging
 import sys
 import os
 
-import typing
+from typing import IO
 
 import globalVars
 import ctypes
@@ -78,19 +78,42 @@ else:
 	# #8362: error 15700 (not a package) error is returned if this is not a Windows Store package.
 	config.isAppX=(GetCurrentPackageFullName(ctypes.byref(bufLen),None)!=15700)
 
+
+class _WideParserHelpFormatter(argparse.RawTextHelpFormatter):
+	def __init__(
+			self,
+			prog: str,
+			indent_increment: int = 2,
+			max_help_position: int = 30,
+			width: int = 100
+	):
+		"""
+		A custom formatter for argparse help messages that uses a wider width.
+		:param prog: The program name.
+		:param indent_increment: The number of spaces to indent for each level of nesting.
+		:param max_help_position: The maximum starting column of the help text.
+		:param width: The width of the help text.
+		"""
+
+		super().__init__(prog, indent_increment, max_help_position, width)
+
+
 class NoConsoleOptionParser(argparse.ArgumentParser):
-	"""A commandline option parser that shows its messages using dialogs,  as this pyw file has no dos console window associated with it"""
+	"""
+	A commandline option parser that shows its messages using dialogs,
+	as this pyw file has no dos console window associated with it.
+	"""
 
-	def print_help(self, file=None):
+	def print_help(self, file: IO[str] | None = None):
 		"""Shows help in a standard Windows message dialog"""
-		winUser.MessageBox(0, self.format_help(), u"Help", 0)
+		winUser.MessageBox(0, self.format_help(), "Help", 0)
 
-	def error(self, message):
+	def error(self, message: str):
 		"""Shows an error in a standard Windows message dialog, and then exits NVDA"""
 		out = ""
 		out = self.format_usage()
-		out += "\nerror: %s" % message
-		winUser.MessageBox(0, out, u"Error", 0)
+		out += f"\nerror: {message}"
+		winUser.MessageBox(0, out, "Error", 0)
 		sys.exit(2)
 
 
@@ -129,8 +152,8 @@ def stringToLang(value: str) -> str:
 	)
 
 
-#Process option arguments
-parser=NoConsoleOptionParser()
+# Process option arguments
+parser = NoConsoleOptionParser(formatter_class=_WideParserHelpFormatter)
 quitGroup = parser.add_mutually_exclusive_group()
 quitGroup.add_argument('-q','--quit',action="store_true",dest='quit',default=False,help="Quit already running copy of NVDA")
 parser.add_argument('-k','--check-running',action="store_true",dest='check_running',default=False,help="Report whether NVDA is running via the exit code; 0 if running, 1 if not running")
@@ -139,9 +162,9 @@ parser.add_argument(
 	"--log-file",
 	dest="logFileName",
 	type=str,
-	help="The file to which log messages should be written. "
-	"Default destination is \"%%TEMP%%\\nvda.log\". "
-	"Logging is always disabled if secure mode is enabled. "
+	help="The file to which log messages should be written.\n"
+	"Default destination is \"%%TEMP%%\\nvda.log\".\n"
+	"Logging is always disabled if secure mode is enabled.\n"
 )
 parser.add_argument(
 	'-l',
@@ -150,9 +173,9 @@ parser.add_argument(
 	type=int,
 	default=0,  # 0 means unspecified in command line.
 	choices=[10, 12, 15, 20, 100],
-	help="The lowest level of message logged (debug 10, input/output 12, debugwarning 15, info 20, off 100). "
-	"Default value is 20 (info) or the user configured setting. "
-	"Logging is always disabled if secure mode is enabled. "
+	help="The lowest level of message logged (debug 10, input/output 12, debugwarning 15, info 20, off 100).\n"
+	"Default value is 20 (info) or the user configured setting.\n"
+	"Logging is always disabled if secure mode is enabled.\n"
 )
 parser.add_argument(
 	"-c",
@@ -160,8 +183,8 @@ parser.add_argument(
 	dest="configPath",
 	default=None,
 	type=str,
-	help="The path where all settings for NVDA are stored. "
-	"The default value is forced if secure mode is enabled. "
+	help="The path where all settings for NVDA are stored.\n"
+	"The default value is forced if secure mode is enabled.\n"
 )
 parser.add_argument(
 	'--lang',
@@ -169,8 +192,8 @@ parser.add_argument(
 	default="en",
 	type=stringToLang,
 	help=(
-		"Override the configured NVDA language."
-		" Set to \"Windows\" for current user default, \"en\" for English, etc."
+		"Override the configured NVDA language.\n"
+		"Set to \"Windows\" for current user default, \"en\" for English, etc."
 	)
 )
 parser.add_argument('-m','--minimal',action="store_true",dest='minimal',default=False,help="No sounds, no interface, no start message etc")
@@ -185,8 +208,22 @@ parser.add_argument(
 	help="Starts NVDA in secure mode",
 )
 parser.add_argument('--disable-addons',action="store_true",dest='disableAddons',default=False,help="Disable all add-ons")
-parser.add_argument('--debug-logging',action="store_true",dest='debugLogging',default=False,help="Enable debug level logging just for this run. This setting will override any other log level (--loglevel, -l) argument given, as well as no logging option.")
-parser.add_argument('--no-logging',action="store_true",dest='noLogging',default=False,help="Disable logging completely for this run. This setting can be overwritten with other log level (--loglevel, -l) switch or if debug logging is specified.")
+parser.add_argument(
+	"--debug-logging",
+	action="store_true",
+	dest="debugLogging",
+	default=False,
+	help="Enable debug level logging just for this run.\n"
+	"This setting will override any other log level (--loglevel, -l) argument given, as well as no logging option."
+)
+parser.add_argument(
+	"--no-logging",
+	action="store_true",
+	dest="noLogging",
+	default=False,
+	help="Disable logging completely for this run.\n"
+	"This setting can be overwritten with other log level (--loglevel, -l) switch or if debug logging is specified."
+)
 parser.add_argument('--no-sr-flag',action="store_false",dest='changeScreenReaderFlag',default=True,help="Don't change the global system screen reader flag")
 installGroup = parser.add_mutually_exclusive_group()
 installGroup.add_argument('--install',action="store_true",dest='install',default=False,help="Installs NVDA (starting the new copy after installation)")
@@ -299,7 +336,7 @@ desktopName = _getDesktopName()
 _log.info(f"DesktopName: {desktopName}")
 
 
-def _acquireMutex(_desktopName: str) -> typing.Optional[wintypes.HANDLE]:
+def _acquireMutex(_desktopName: str) -> wintypes.HANDLE | None:
 	# From MS docs; "Multiple processes can have handles of the same mutex object"
 	# > Two or more processes can call CreateMutex to create the same named mutex.
 	# > The first process actually creates the mutex, and subsequent processes with sufficient access rights

--- a/source/nvda.pyw
+++ b/source/nvda.pyw
@@ -113,7 +113,7 @@ class NoConsoleOptionParser(argparse.ArgumentParser):
 		out = ""
 		out = self.format_usage()
 		out += f"\nerror: {message}"
-		winUser.MessageBox(0, out, "Error", 0)
+		winUser.MessageBox(0, out, "Command-line Argument Error", winUser.MB_ICONERROR)
 		sys.exit(2)
 
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
None

### Summary of the issue:
When using the CLI command `nvda.exe --help`, a dialog window opens with visual clipping for smaller screens.
![image](https://github.com/nvaccess/nvda/assets/7090342/88aa0390-7ffc-4272-9867-d9b4ee0d5c99)


### Description of user facing changes
Make the dialog wider and more legible.
![image](https://github.com/nvaccess/nvda/assets/7090342/fb30af3d-637a-4f57-805a-76fe5ccf0c1a)


### Description of development approach
Created a custom formatter to widen the default dialog for CLI help.

### Testing strategy:
`runnvda.bat --help`

### Known issues with pull request:
This still will result in clipping, particulary with larger text environment. We can consider shortening the text to improve this, or making custom help on a command level (this is a complex solution).
An alternative would be to find a way to pipe the text out to the console of whatever is running --help.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Introduced a custom help formatter for better readability of command-line help messages.

- **Improvements**
  - Enhanced type annotations for improved code clarity and error checking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
