### PR TITLE
Unique anonymous ID statistics tracking

### DIFF
--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -6,7 +6,6 @@
 # See the file COPYING for more details.
 
 from io import StringIO
-from uuid import uuid4
 from configobj import ConfigObj
 from . import configDefaults
 
@@ -29,7 +28,7 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 	loggingLevel = string(default="INFO")
 	showWelcomeDialogAtStartup = boolean(default=true)
 	# Unique ID per copy of NVDA.
-	id = string(default="{uuid4()}")
+	id = string(default="")
 
 # Speech settings
 [speech]

--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -27,8 +27,6 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 	#possible log levels are DEBUG, IO, DEBUGWARNING, INFO
 	loggingLevel = string(default="INFO")
 	showWelcomeDialogAtStartup = boolean(default=true)
-	# Unique ID per copy of NVDA.
-	id = string(default="")
 
 # Speech settings
 [speech]

--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -6,6 +6,7 @@
 # See the file COPYING for more details.
 
 from io import StringIO
+from uuid import uuid4
 from configobj import ConfigObj
 from . import configDefaults
 
@@ -27,6 +28,8 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 	#possible log levels are DEBUG, IO, DEBUGWARNING, INFO
 	loggingLevel = string(default="INFO")
 	showWelcomeDialogAtStartup = boolean(default=true)
+	# Unique ID per copy of NVDA.
+	id = string(default="{uuid4()}")
 
 # Speech settings
 [speech]

--- a/source/core.py
+++ b/source/core.py
@@ -14,7 +14,6 @@ from typing import (
 	List,
 	Optional,
 )
-from uuid import uuid4
 import comtypes
 import sys
 import winVersion
@@ -639,10 +638,6 @@ def main():
 	log.debug("loading config")
 	import config
 	config.initialize()
-	if not config.conf["general"]["id"]:
-		config.conf["general"]["id"] = uuid4().hex
-		config.conf.save()
-	log.debug(f"NVDA user ID {config.conf['general']['id']}")
 	if config.conf['development']['enableScratchpadDir']:
 		log.info("Developer Scratchpad mode enabled")
 	if languageHandler.isLanguageForced():
@@ -912,6 +907,7 @@ def main():
 	else:
 		log.debug("initializing updateCheck")
 		updateCheck.initialize()
+		log.debug(f"NVDA user ID {updateCheck.state['id']}")
 
 	from winAPI import sessionTracking
 	sessionTracking.initialize()

--- a/source/core.py
+++ b/source/core.py
@@ -638,6 +638,7 @@ def main():
 	log.debug("loading config")
 	import config
 	config.initialize()
+	log.debug(f"NVDA user ID {config.conf['general']['id']}")
 	if config.conf['development']['enableScratchpadDir']:
 		log.info("Developer Scratchpad mode enabled")
 	if languageHandler.isLanguageForced():

--- a/source/core.py
+++ b/source/core.py
@@ -14,6 +14,7 @@ from typing import (
 	List,
 	Optional,
 )
+from uuid import uuid4
 import comtypes
 import sys
 import winVersion
@@ -638,6 +639,9 @@ def main():
 	log.debug("loading config")
 	import config
 	config.initialize()
+	if not config.conf["general"]["id"]:
+		config.conf["general"]["id"] = uuid4().hex
+		config.conf.save()
 	log.debug(f"NVDA user ID {config.conf['general']['id']}")
 	if config.conf['development']['enableScratchpadDir']:
 		log.info("Developer Scratchpad mode enabled")

--- a/source/updateCheck.py
+++ b/source/updateCheck.py
@@ -6,7 +6,7 @@
 """Update checking functionality.
 @note: This module may raise C{RuntimeError} on import if update checking for this build is not supported.
 """
-import datetime
+from datetime import datetime
 from typing import (
 	Any,
 	Dict,
@@ -271,8 +271,8 @@ class UpdateChecker(garbageHandler.TrackedObject):
 
 	def _bg(self):
 		assert state is not None
-		lastCheckDate = datetime.datetime.fromtimestamp(state["lastCheck"])
-		nowDate = datetime.datetime.now()
+		lastCheckDate = datetime.fromtimestamp(state["lastCheck"])
+		nowDate = datetime.now()
 		if (lastCheckDate.year, lastCheckDate.month) != (nowDate.year, nowDate.month):
 			# reset unique ID once a month
 			state["id"] = uuid4().hex

--- a/source/updateCheck.py
+++ b/source/updateCheck.py
@@ -145,7 +145,8 @@ def checkForUpdate(auto: bool = False) -> Optional[Dict]:
 		brailleDisplayClass = braille.handler.display.__class__ if braille.handler else None
 		# Following are parameters sent purely for stats gathering.
 		#  If new parameters are added here, they must be documented in the userGuide for transparency.
-		extraParams={
+		extraParams = {
+			"id": config.conf["general"]["id"],
 			"language": languageHandler.getLanguage(),
 			"installed": config.isInstalledCopy(),
 			"synthDriver":getQualifiedDriverClassNameForStats(synthDriverClass) if synthDriverClass else None,

--- a/source/updateCheck.py
+++ b/source/updateCheck.py
@@ -138,6 +138,7 @@ def checkForUpdate(auto: bool = False) -> Optional[Dict]:
 		# Available values of PROCESSOR_ARCHITEW6432 found in:
 		# https://docs.microsoft.com/en-gb/windows/win32/winprog64/wow64-implementation-details
 		"x64": os.environ.get("PROCESSOR_ARCHITEW6432") == "AMD64",
+		"ARM": os.environ.get("PROCESSOR_ARCHITEW6432") == "ARM64",
 		"osArchitecture": os.environ.get("PROCESSOR_ARCHITEW6432"),
 	}
 	if auto and allowUsageStats:

--- a/source/updateCheck.py
+++ b/source/updateCheck.py
@@ -140,7 +140,6 @@ def checkForUpdate(auto: bool = False) -> Optional[Dict]:
 		# Available values of PROCESSOR_ARCHITEW6432 found in:
 		# https://docs.microsoft.com/en-gb/windows/win32/winprog64/wow64-implementation-details
 		"x64": os.environ.get("PROCESSOR_ARCHITEW6432") == "AMD64",
-		"ARM": os.environ.get("PROCESSOR_ARCHITEW6432") == "ARM64",
 		"osArchitecture": os.environ.get("PROCESSOR_ARCHITEW6432"),
 	}
 	if auto and allowUsageStats:

--- a/source/updateCheck.py
+++ b/source/updateCheck.py
@@ -820,9 +820,12 @@ def initialize():
 		state = {
 			"lastCheck": 0,
 			"dontRemindVersion": None,
-			"id": uuid4().hex,
 		}
 		_setStateToNone(state)
+
+	if "id" not in state:
+		# ID was introduced in 2024.3
+		state["id"] = uuid4().hex
 
 	# check the pending version against the current version
 	# and make sure that pendingUpdateFile and pendingUpdateVersion are part of the state dictionary.

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -41,7 +41,7 @@ Unicode CLDR has also been updated.
 * NVDA will now report figures with no accessible children, but with a label or description. (#14514)
 * When reading by line in browse mode, "caption" is no longer reported on each line of a long figure or table caption. (#14874)
 * In the Python console, the last unexecuted command will no longer be lost when moving in the input history. (#16653, @CyrilleB79)
-* A unique anonymous ID is now sent as part of NVDA usage statistics gathering. (#16266)
+* A unique anonymous ID is now sent as part of optional NVDA usage statistics gathering. (#16266)
 * By default, a new folder will be created when making a portable copy. Warnings have been added when writing to a non-empty directory. (#16684)
 
 ### Bug Fixes

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -41,6 +41,7 @@ Unicode CLDR has also been updated.
 * NVDA will now report figures with no accessible children, but with a label or description. (#14514)
 * When reading by line in browse mode, "caption" is no longer reported on each line of a long figure or table caption. (#14874)
 * In the Python console, the last unexecuted command will no longer be lost when moving in the input history. (#16653, @CyrilleB79)
+* A unique anonymous ID is now sent as part of NVDA usage statistics gathering. (#16266)
 
 ### Bug Fixes
 * Windows 11 fixes:

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -505,8 +505,7 @@ The third lets you control if this Welcome dialog should appear each time NVDA s
 
 #### Data usage statistics dialog {#UsageStatsDialog}
 
-Starting from NVDA 2018.3, the user is asked if they want to allow usage data to be sent to NV Access in order to help improve NVDA in the future.
-When starting NVDA for the first time, a dialog will appear which will ask you if you want to accept sending data to NV Access while using NVDA.
+When starting NVDA for the first time, a dialog will appear which will ask you if you want to accept sending data to NV Access while using NVDA, in order to help improve NVDA in the future.
 You can read more info about the data gathered by NV Access in the general settings section, [Allow NV Access to gather NVDA usage statistics](#GeneralSettingsGatherUsageStats).
 Note: pressing on "yes" or "no" will save this setting and the dialog will never appear again unless you reinstall NVDA.
 However, you can enable or disable the data gathering process manually in NVDA's general settings panel. For changing this setting manually, you can check or uncheck the checkbox called [Allow the NVDA project to gather NVDA usage statistics](#GeneralSettingsGatherUsageStats).
@@ -1798,10 +1797,11 @@ The following information is always sent:
 
 ##### Allow NV Access to gather NVDA usage statistics {#GeneralSettingsGatherUsageStats}
 
-If this is enabled, NV Access will use the information from update checks in order to track  the number of NVDA users including particular demographics such as Operating system and country of origin.
+If this is enabled, NV Access will use the information from update checks in order to track the number of NVDA users including particular demographics such as the operating system and country of origin.
 Note that although your IP address will be used to calculate your country during the update check, the IP address is never kept.
 Apart from the mandatory information required to check for updates, the following extra information is also currently sent:
 
+* A unique ID for the current NVDA user
 * NVDA interface language
 * Whether this copy of NVDA is portable or installed
 * Name of the current speech synthesizer in use (including the name of the add-on the driver comes from)

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -1807,7 +1807,7 @@ If this is enabled, NV Access will use the information from update checks in ord
 Note that although your IP address will be used to calculate your country during the update check, the IP address is never kept.
 Apart from the mandatory information required to check for updates, the following extra information is also currently sent:
 
-* A unique ID for the current NVDA user
+* A unique ID for the current NVDA user, this changes once a month
 * NVDA interface language
 * Whether this copy of NVDA is portable or installed
 * Name of the current speech synthesizer in use (including the name of the add-on the driver comes from)


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Closes #16266 

### Summary of the issue:
Right now NV access is unable to gauge monthly or weekly users, only daily users.
Each day NVDA performs an update check and optionally sends more usage data information.
We are unable to differentiate copies performing update checks, meaning we only know X users who checked for an update on a given day.

### Description of user facing changes
None

### Description of development approach
A unique ID is stored to user config when initializing the update check.
This creates a unique ID per user of NVDA, counting portable copies and each Windows user's profile of an installation.

When checking for update, NVDA now sends the unique ID if usage tracking is enabled.

### Testing strategy:
 - [x] Tested running NVDA from installed copy, ensured unique ID persisted. Set `lastCheckUpdate` time to trigger new unique ID.

### Known issues with pull request:

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a unique anonymous ID for improved NVDA usage statistics gathering.

- **Documentation**
  - Updated user guide to clarify data usage statistics dialog and user consent process.

- **Enhancements**
  - Improved update checking functionality with monthly unique ID updates.

- **Bug Fixes**
  - Refined NVDA behavior in the Python console for better performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
