### PR TITLE
When handling caret movement, fetch the new caret info after checking for a pending caret event.

### DIFF
--- a/source/editableText.py
+++ b/source/editableText.py
@@ -85,27 +85,34 @@ class EditableText(TextContainerObject,ScriptableObject):
 			if eventHandler.isPendingEvents("gainFocus"):
 				log.debug("Focus event. Elapsed %g sec" % elapsed)
 				return (True,None)
+			# Caret events are unreliable in some controls.
+			# Only use them if we consider them safe to rely on for a particular control,
+			# and only if they arrive within C{_useEvents_maxTimeoutSec} seconds
+			# after causing the event to occur.
+			if (
+				elapsed <= self._useEvents_maxTimeoutSec
+				and self.caretMovementDetectionUsesEvents
+				and (eventHandler.isPendingEvents("caret") or eventHandler.isPendingEvents("textChange"))
+			):
+				log.debug(
+					"Caret move detected using event. Elapsed %g sec, retries %d"
+					% (elapsed, retries)
+				)
+				# We must fetch the caret here rather than above the isPendingEvents check
+				# to avoid a race condition where an event is queued from a background
+				# thread just after we query the caret. In that case, the caret info we
+				# retrieved might be stale.
+				try:
+					newInfo = self.makeTextInfo(textInfos.POSITION_CARET)
+				except (RuntimeError, NotImplementedError):
+					newInfo = None
+				return (True, newInfo)
 			# If the focus changes after this point, fetching the caret may fail,
 			# but we still want to stay in this loop.
 			try:
 				newInfo = self.makeTextInfo(textInfos.POSITION_CARET)
 			except (RuntimeError,NotImplementedError):
 				newInfo = None
-			else:
-				# Caret events are unreliable in some controls.
-				# Only use them if we consider them safe to rely on for a particular control,
-				# and only if they arrive within C{_useEvents_maxTimeoutSec} seconds
-				# after causing the event to occur.
-				if (
-					elapsed <= self._useEvents_maxTimeoutSec
-					and self.caretMovementDetectionUsesEvents
-					and (eventHandler.isPendingEvents("caret") or eventHandler.isPendingEvents("textChange"))
-				):
-					log.debug(
-						"Caret move detected using event. Elapsed %g sec, retries %d"
-						% (elapsed, retries)
-					)
-					return (True,newInfo)
 			# Try to detect with bookmarks.
 			newBookmark = None
 			if newInfo:

--- a/source/editableText.py
+++ b/source/editableText.py
@@ -111,7 +111,7 @@ class EditableText(TextContainerObject,ScriptableObject):
 			# but we still want to stay in this loop.
 			try:
 				newInfo = self.makeTextInfo(textInfos.POSITION_CARET)
-			except (RuntimeError,NotImplementedError):
+			except (RuntimeError, NotImplementedError):
 				newInfo = None
 			# Try to detect with bookmarks.
 			newBookmark = None

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -59,6 +59,7 @@ Unicode CLDR has also been updated.
 * NVDA will correctly announce selection changes when editing a cell's text in Microsoft Excel. (#15843)
 * In applications using Java Access Bridge, NVDA will now correctly read the last blank line of a text instead of repeating the previous line. (#9376, @dmitrii-drobotov)
 * In LibreOffice Writer (version 24.8 and newer), when toggling text formatting (bold, italic, underline, subscript/superscript, alignment) using the corresponding keyboard shortcut, NVDA announces the new formatting attribute (e.g. "Bold on", "Bold off"). (#4248, @michaelweghorn)
+* When navigating with the cursor keys in text boxes in applications which use UI Automation, NVDA no longer sometimes reports the wrong character, word, etc. (#16711, @jcsteh)
 
 ### Changes for Developers
 


### PR DESCRIPTION
### Link to issue number:
None.

### Summary of the issue:
In Firefox's in-progress UIA implementation, moving with the cursor keys in editable text boxes sometimes reports the character at the old position of the caret instead of the new position of the caret. For example, on the line:
abcdef
with the cursor positioned on "a", pressing right arrow several times might read a, b, c instead of b, c, d.
I don't anticipate that NVDA will ever move to using UIA in Firefox. Nevertheless, this is an NVDA bug which might impact other things.

### Description of user facing changes
When navigating with the cursor keys in text boxes in applications which use UI Automation, NVDA no longer sometimes reports the wrong character, word, etc.

### Description of development approach
Previously, `EditableText._hasCaretMoved` fetched the caret before checking for a pending caret event. It then returned this fetched caret. The following race condition could occur:

1. In NVDA's main thread, NVDA queries the caret. The caret hasn't updated yet in the app, so this is the old position.
2. The app fires a caret event.
3. NVDA receives this caret event on a background UIA thread and queues it.
4. Back in NVDA's main thread, NVDA checks for a pending caret event. That check passes because of 3).
5. NVDA returns the old caret info retrieved in 1).

This can't happen with other APIs because they all queue events on the main thread, which can't be preempted during `_hasCaretMoved`. However, UIA queues events from a background thread.

### Testing strategy:
I tested caret navigation in various apps: normal Firefox, Edge, Windows Run dialog, Notepad++, Windows Settings, Windows Start Menu. Everything worked as expected.
I tested caret navigation in Firefox's in-progress UIA implementation. After this change, everything worked as expected.

### Known issues with pull request:
None.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved caret movement detection to prevent NVDA from reporting incorrect characters or words when navigating with cursor keys in text boxes using UI Automation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
