### PR TITLE
Prevent additional attempts at closing HID braille connections

### DIFF
--- a/source/hwIo/hid.py
+++ b/source/hwIo/hid.py
@@ -320,6 +320,7 @@ class Hid(IoBase):
 
 	def close(self):
 		if self._isClosed:
+			log.debug("Attempted to close an already closed device.")
 			return
 		super(Hid, self).close()
 		winKernel.closeHandle(self._file)

--- a/source/hwIo/hid.py
+++ b/source/hwIo/hid.py
@@ -18,7 +18,7 @@ from .ioThread import IoThread
 from serial.win32 import FILE_FLAG_OVERLAPPED, INVALID_HANDLE_VALUE, CreateFile
 import winKernel
 from logHandler import log
-from .base import IoBase, _isDebug
+from .base import 	IoBase, _isDebug
 import hidpi
 
 
@@ -180,6 +180,7 @@ class Hid(IoBase):
 		self._writeSize = caps.OutputReportByteLength
 		self._readSize = caps.InputReportByteLength
 		# Reading any less than caps.InputReportByteLength is an error.
+		self._isClosed = False
 		super().__init__(
 			handle,
 			onReceive,
@@ -318,7 +319,10 @@ class Hid(IoBase):
 			raise ctypes.WinError()
 
 	def close(self):
+		if self._isClosed:
+			pass
 		super(Hid, self).close()
 		winKernel.closeHandle(self._file)
 		self._file = None
 		hidDll.HidD_FreePreparsedData(self._pd)
+		self._isClosed = True

--- a/source/hwIo/hid.py
+++ b/source/hwIo/hid.py
@@ -320,7 +320,7 @@ class Hid(IoBase):
 
 	def close(self):
 		if self._isClosed:
-			pass
+			return
 		super(Hid, self).close()
 		winKernel.closeHandle(self._file)
 		self._file = None

--- a/source/hwIo/hid.py
+++ b/source/hwIo/hid.py
@@ -18,7 +18,7 @@ from .ioThread import IoThread
 from serial.win32 import FILE_FLAG_OVERLAPPED, INVALID_HANDLE_VALUE, CreateFile
 import winKernel
 from logHandler import log
-from .base import 	IoBase, _isDebug
+from .base import IoBase, _isDebug
 import hidpi
 
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Fixes https://github.com/nvaccess/nvda/issues/16218
### Summary of the issue:
NVDA could silently crash when a Braille HID device was disconnected/closed.
### Description of user facing changes
No more crashes under the above conditions.
### Description of development approach
Introduced a flag that tracks if the close() method has already been called, and don't perform the operation again.
### Testing strategy:
Tried to reproduce the crash.
### Known issues with pull request:
None.
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [ ] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of HID device closing to prevent errors.
  - Added an internal check to ensure the HID device is not closed multiple times.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
