### PR TITLE
Edge WebView2: add possibility to create app modules for apps hosting WebView2 interface

### DIFF
--- a/projectDocs/dev/developerGuide/developerGuide.md
+++ b/projectDocs/dev/developerGuide/developerGuide.md
@@ -472,12 +472,13 @@ As with other examples in this guide, remember to delete the created app module 
 
 ### App modules for hosted apps {#appModulesForHostedApps}
 
-Some executables host various apps inside.
-These include javaw.exe for running various Java programs and wwahost.exe for some apps in Windows 8 and later.
+Some executables host various apps inside or are employed by an app to display their interfaces.
+These include javaw.exe for running various Java programs, wwahost.exe for some apps in Windows 8 and later, and msedgewebview2.exe for displaying web-like interface on apps employing Edge WebView2 runtime.
 
-If an app runs inside a host executable, the name of the app module must be the name as defined by the host executable, which can be found through AppModule.appName property.
+If an app runs inside a host executable or employs a different app to display the interface, the name of the app module must be the name as defined by the host or the interface executable, which can be found through AppModule.appName property.
 For example, an app module for a Java app named "test" hosted inside javaw.exe must be named test.py.
 For apps hosted inside wwahost, not only must the app module name be the name of the loaded app, but the app module must subclass the app module class found in wwahost.
+By default, apps employing Edge WebView2 such as modern Outlook (olk.exe) are displayed as a webpage.
 
 ### Example 2: an app module for an app hosted by wwahost.exe {#example2}
 
@@ -503,6 +504,24 @@ As a built-in app module, wwahost can be imported from nvdaBuiltin.appModules.
 
 Another difference is how the app module class is defined.
 As wwahost app module provides necessary infrastructure for apps hosted inside, you just need to subclass the wwahost AppModule class.
+
+### Example 3: an app module for  an app employing Edge WebView2 (msedgewebview2.exe) {#example3}
+
+The following example is an app module employing Edge WebView2 runtime with browse mode disabled by default, using modern Outlook (olk.exe) as an example.
+
+    --- start ---
+    # msedgewebview2 example (modern Outlook/olk.py)
+    # Developer guide example 3
+    
+    import appModuleHandler
+    
+    class AppModule(appModuleHandler.AppModule):
+    
+    	disableBrowseModeByDefault: bool = True
+    
+    --- end ---
+
+Browse mode is disabled for this example because apps employing WebView2 display their interfaces as webpages. You can remove "disableBrowseModeByDefault" line if you would like to let users navigate the app using browse mode commands.
 
 ### Basics of a Global Plugin {#globalPluginBasics}
 

--- a/projectDocs/dev/developerGuide/developerGuide.md
+++ b/projectDocs/dev/developerGuide/developerGuide.md
@@ -475,7 +475,7 @@ As with other examples in this guide, remember to delete the created app module 
 Some executables host various apps inside or are employed by an app to display their interfaces.
 These include javaw.exe for running various Java programs, wwahost.exe for some apps in Windows 8 and later, and msedgewebview2.exe for displaying web-like interface on apps employing Edge WebView2 runtime.
 
-If an app runs inside a host executable or employs a different app to display the interface, the name of the app module must be the name as defined by the host or the interface executable, which can be found through AppModule.appName property.
+If an app runs inside a host executable or employs a different app to display the interface, the name of the app module must be the name as defined by the host or the interface executable, which can be found through the `AppModule.appName` property.
 For example, an app module for a Java app named "test" hosted inside javaw.exe must be named test.py.
 For apps hosted inside wwahost, not only must the app module name be the name of the loaded app, but the app module must subclass the app module class found in wwahost.
 By default, apps employing Edge WebView2 such as modern Outlook (olk.exe) are displayed as a webpage.
@@ -505,23 +505,21 @@ As a built-in app module, wwahost can be imported from nvdaBuiltin.appModules.
 Another difference is how the app module class is defined.
 As wwahost app module provides necessary infrastructure for apps hosted inside, you just need to subclass the wwahost AppModule class.
 
-### Example 3: an app module for  an app employing Edge WebView2 (msedgewebview2.exe) {#example3}
+### Example 3: an app module for an app employing Edge WebView2 (msedgewebview2.exe) {#example3}
 
 The following example is an app module employing Edge WebView2 runtime with browse mode disabled by default, using modern Outlook (olk.exe) as an example.
 
-    --- start ---
-    # msedgewebview2 example (modern Outlook/olk.py)
-    # Developer guide example 3
-    
-    import appModuleHandler
-    
-    class AppModule(appModuleHandler.AppModule):
-    
-    	disableBrowseModeByDefault: bool = True
-    
-    --- end ---
+```py
+# msedgewebview2 example (modern Outlook/olk.py)
 
-Browse mode is disabled for this example because apps employing WebView2 display their interfaces as webpages. You can remove "disableBrowseModeByDefault" line if you would like to let users navigate the app using browse mode commands.
+import appModuleHandler
+
+class AppModule(appModuleHandler.AppModule):
+	disableBrowseModeByDefault: bool = True
+```
+
+Browse mode is disabled for this example because apps employing WebView2 display their interfaces as webpages.
+You can remove the "disableBrowseModeByDefault" line if you would like to let users navigate the app using browse mode commands.
 
 ### Basics of a Global Plugin {#globalPluginBasics}
 

--- a/source/appModules/msedgewebview2.py
+++ b/source/appModules/msedgewebview2.py
@@ -18,3 +18,9 @@ def getAppNameFromHost(processId: int) -> str:
 	if not (parent := proc.parentProcessId):
 		raise LookupError
 	return appModuleHandler.getAppNameFromProcessID(parent)
+
+
+def __getattr__(attrName: str) -> Any:
+	if attrName == "AppModule":
+		return appModuleHandler.AppModule
+	raise AttributeError(f"module {repr(__name__)} has no attribute {repr(attrName)}")

--- a/source/appModules/msedgewebview2.py
+++ b/source/appModules/msedgewebview2.py
@@ -1,0 +1,20 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2024 NV Access Limited, Joseph Lee
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+
+"""Support for apps employing Edge WebView2 runtime interface.
+"""
+
+from typing import Any
+import appModuleHandler
+
+
+def getAppNameFromHost(processId):
+	# #16705: some apps have launcher executables which launch msedgewebview2.exe to display the interface.
+	# In this case, the parent process will usually be the launcher.
+	proc = appModuleHandler.getWmiProcessInfo(processId)
+	# Unlikely but react to undefined parent process ID.
+	if not (parent := proc.parentProcessId):
+		raise LookupError
+	return appModuleHandler.getAppNameFromProcessID(parent)

--- a/source/appModules/msedgewebview2.py
+++ b/source/appModules/msedgewebview2.py
@@ -10,7 +10,7 @@ from typing import Any
 import appModuleHandler
 
 
-def getAppNameFromHost(processId):
+def getAppNameFromHost(processId: int) -> str:
 	# #16705: some apps have launcher executables which launch msedgewebview2.exe to display the interface.
 	# In this case, the parent process will usually be the launcher.
 	proc = appModuleHandler.getWmiProcessInfo(processId)

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -79,6 +79,7 @@ It is especially useful to read the error location markers in tracebacks. (#1632
   * You can use `scheduleThread.scheduleDailyJobAtStartUp` to automatically schedule a job that happens after NVDA starts, and every 24 hours after that.
   Jobs are scheduled with a delay to avoid conflicts.
   * `scheduleThread.scheduleDailyJob` and `scheduleJob` can be used to schedule jobs at custom times, where a `JobClashError` will be raised on a known job scheduling clash.
+* It is now possible to create app modules for apps hosting Edge WebView2 (msedgewebview2.exe) controls. (#16705, @josephsl)
 
 #### Deprecations
 


### PR DESCRIPTION
### Link to issue number:
Closes #16705 

### Summary of the issue:
Apps hosting Edge WebView2 show up as websites. However, in apps such as new Outlook (olk.exe), it is desirable to disable browse mode by default or offer custom commands and workarounds.

### Description of user facing changes
NVDA will recognize and work with app modules for apps hosting Edge WebView2 controls such as new Outlook.

### Description of development approach
Similar to wwahost and javaw, a new host app module (msedgewebview2) is created to fetch actual names of aps hosting the webview controls. The module borrows heavily from javaw app module except it is limited to fetching parent process information. Instead of importing appModuleHandler.AppModule, module-level __getattr__ is defined to return the default app module.

### Testing strategy:
Manual testing:

1. Download and install an app that embeds WebView2 controls such as new Outlook (olk) and LinkedIn, or if using Windows 11, launch Widgets (Windows+W).
2. Without the PR applied, generate develoepr info (NVDA+F1) and observe the appModule line (it will say "msedgewebview2" for app name).
3. With the PR applied, generate developer info, and observe that the parent process is now the app name ("olk" for new Outlook, for example).
4. Create an app module for one of the host apps such as olk.py for new Outlook.
5. Restart NVDA, switch to the app for te just-created app module, then generate developer info (app name and app module name will say the actual app name).

### Known issues with pull request:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for applications utilizing the Edge WebView2 runtime interface, enhancing app module creation capabilities.
  
- **Documentation**
  - Updated developer guide with additional details and examples for creating app modules for apps using Edge WebView2. Clarifications on naming conventions and subclassing were also included.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Thanks.