### PR TITLE
Upgrading Markdown and nh3 to the latest version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,13 @@
 # NVDA's build system is SCons
-SCons==4.7.0
+SCons==4.5.2
 
 # NVDA's runtime dependencies
-comtypes==1.4.4
+comtypes==1.2.0
 pyserial==3.5
 ./miscDeps/python/wxPython-4.2.2a1-cp311-cp311-win32.whl
 git+https://github.com/DiffSK/configobj@e2ba4457c4651fa54f8d59d8dcdd3da950e956b8#egg=configobj
-requests==2.32.3
-schedule==1.2.2
+requests==2.32.0
+schedule==1.2.1
 # Pillow is an implicit dependency and requires zlib and jpeg by default, but we don't need it
 Pillow==10.3.0 -C "zlib=disable" -C "jpeg=disable"
 
@@ -15,7 +15,7 @@ Pillow==10.3.0 -C "zlib=disable" -C "jpeg=disable"
 fast-diff-match-patch==2.1.0
 
 # typing_extensions are required for specifying default value for `TypeVar`, which is not yet possible with any released version of Python (see PEP 696)
-typing-extensions==4.12.2
+typing-extensions==4.9.0
 
 # pycaw is a Core Audio Windows Library used for sound split
 pycaw==20240210
@@ -35,8 +35,8 @@ mdx-gh-links==0.4
 nh3==0.2.17
 
 # For building developer documentation
-sphinx==7.3.7
-sphinx_rtd_theme==2.0.0
+sphinx==7.2.6
+sphinx_rtd_theme==1.3.0
 
 # Requirements for automated linting
 flake8 ~= 4.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,13 @@
 # NVDA's build system is SCons
-SCons==4.5.2
+SCons==4.7.0
 
 # NVDA's runtime dependencies
-comtypes==1.2.0
+comtypes==1.4.4
 pyserial==3.5
 ./miscDeps/python/wxPython-4.2.2a1-cp311-cp311-win32.whl
 git+https://github.com/DiffSK/configobj@e2ba4457c4651fa54f8d59d8dcdd3da950e956b8#egg=configobj
-requests==2.32.0
-schedule==1.2.1
+requests==2.32.3
+schedule==1.2.2
 # Pillow is an implicit dependency and requires zlib and jpeg by default, but we don't need it
 Pillow==10.3.0 -C "zlib=disable" -C "jpeg=disable"
 
@@ -15,7 +15,7 @@ Pillow==10.3.0 -C "zlib=disable" -C "jpeg=disable"
 fast-diff-match-patch==2.1.0
 
 # typing_extensions are required for specifying default value for `TypeVar`, which is not yet possible with any released version of Python (see PEP 696)
-typing-extensions==4.9.0
+typing-extensions==4.12.2
 
 # pycaw is a Core Audio Windows Library used for sound split
 pycaw==20240210
@@ -27,16 +27,16 @@ git+https://github.com/py2exe/py2exe@4e7b2b2c60face592e67cb1bc935172a20fa371d#eg
 unittest-xml-reporting==3.2.0
 
 # Building user documentation
-Markdown==3.5.1
+Markdown==3.6
 mdx_truly_sane_lists==1.3
 markdown-link-attr-modifier==0.2.1
 mdx-gh-links==0.4
 # Sanitize HTML documentation output to prevent XSS from translators
-nh3==0.2.15
+nh3==0.2.17
 
 # For building developer documentation
-sphinx==7.2.6
-sphinx_rtd_theme==1.3.0
+sphinx==7.3.7
+sphinx_rtd_theme==2.0.0
 
 # Requirements for automated linting
 flake8 ~= 4.0.1


### PR DESCRIPTION

### Link to issue number:
none
### Summary of the issue:
The following packages have been updated:
[Markdown==3.5.1 to Markdown==3.6](https://github.com/Python-Markdown/markdown/releases/tag/3.6)
[nh3==0.2.15 to nh3==0.2.17](https://github.com/messense/nh3/releases/tag/v0.2.17)
### Description of development approach
Testing needs to be done with care and is recommended for review in 2024.4.
### Testing strategy:
Need to test if the appveyor compilation completes successfully

### Known issues with pull request:
Not yet.
### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated various dependencies to ensure compatibility and enhance security:
    - SCons updated to 4.7.0
    - comtypes updated to 1.4.4
    - requests updated to 2.32.3
    - schedule updated to 1.2.2
    - typing-extensions updated to 4.12.2
    - Pillow specification changes
    - Markdown updated to 3.6
    - nh3 updated to 0.2.17
    - sphinx updated to 7.3.7
    - sphinx_rtd_theme updated to 2.0.0
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
