### PR TITLE
UpdateBuilding user documentation module: Update markdown to nh3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,12 +27,12 @@ git+https://github.com/py2exe/py2exe@4e7b2b2c60face592e67cb1bc935172a20fa371d#eg
 unittest-xml-reporting==3.2.0
 
 # Building user documentation
-Markdown==3.5.1
+Markdown==3.6.0
 mdx_truly_sane_lists==1.3
 markdown-link-attr-modifier==0.2.1
 mdx-gh-links==0.4
 # Sanitize HTML documentation output to prevent XSS from translators
-nh3==0.2.15
+nh3==0.2.17
 
 # For building developer documentation
 sphinx==7.2.6

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -37,6 +37,7 @@ Unicode CLDR has also been updated.
   * Updated LibLouis Braille translator to [3.30.0](https://github.com/liblouis/liblouis/releases/tag/v3.30.0). (#16652, @codeofdusk)
     * New Braille tables for Cyrillic Serbian, Yiddish, several ancient languages (Biblical Hebrew, Akkadian, Syriac, and Ugaritic), and transliterated Cuneiform text.
   * Updated NSIS 3.09 to 3.10 (#16674, @dpy013)
+  * Updated python markdown and nh3 to latest(#16725, @dpy013)
 * The fallback braille input table is now equal to the fallback output table, which is Unified English Braille Code grade 1. (#9863, @JulienCochuyt, @LeonarddeR)
 * NVDA will now report figures with no accessible children, but with a label or description. (#14514)
 * When reading by line in browse mode, "caption" is no longer reported on each line of a long figure or table caption. (#14874)

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -37,7 +37,8 @@ Unicode CLDR has also been updated.
   * Updated LibLouis Braille translator to [3.30.0](https://github.com/liblouis/liblouis/releases/tag/v3.30.0). (#16652, @codeofdusk)
     * New Braille tables for Cyrillic Serbian, Yiddish, several ancient languages (Biblical Hebrew, Akkadian, Syriac, and Ugaritic), and transliterated Cuneiform text.
   * Updated NSIS 3.09 to 3.10 (#16674, @dpy013)
-  * Updated python markdown and nh3 to latest(#16725, @dpy013)
+  * Updated python markdown 3.5.1 to 3.6(#16725, @dpy013)
+  * Updated nh3 0.2.15 to 0.2.17(#16725, @dpy013)
 * The fallback braille input table is now equal to the fallback output table, which is Unified English Braille Code grade 1. (#9863, @JulienCochuyt, @LeonarddeR)
 * NVDA will now report figures with no accessible children, but with a label or description. (#14514)
 * When reading by line in browse mode, "caption" is no longer reported on each line of a long figure or table caption. (#14874)


### PR DESCRIPTION

### Link to issue number:
Follow up to https://github.com/nvaccess/nvda/pull/16724
### Summary of the issue:
[markdown 3.5.1 to 3.6](https://github.com/Python-Markdown/markdown/releases/tag/3.6)
Updating python markdown to get the latest security updates
[modifications](https://github.com/messense/nh3/pull/35)
### Description of user facing changes
none
### Description of development approach
Updated markdown and nh3 versions of requirements.txt file
### Testing strategy:
Careful review of the generated documentation is required
### Known issues with pull request:
Not found at the moment
### Code Review Checklist:


- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated dependencies to improve security and stability:
    - Markdown updated from `3.5.1` to `3.6.0`.
    - nh3 updated from `0.2.15` to `0.2.17`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
