### PR TITLE
Remove outputting md files to AppVeyor artifacts

### DIFF
--- a/sconstruct
+++ b/sconstruct
@@ -412,22 +412,10 @@ outputHeadingStylesFile = env.Command(
 	Copy("$TARGET", "$SOURCE")
 )
 changesFile=env.Command(outputDir.File("%s_changes.html" % outFilePrefix),userDocsDir.File('en/changes.html'),Copy('$TARGET','$SOURCE'))
-changesMDFile = env.Command(
-	outputDir.File("changes.md"),
-	userDocsDir.File('en/changes.md'),
-	Copy('$TARGET', '$SOURCE')
-)
-env.Depends(changesFile, changesMDFile)
 env.Depends(changesFile, outputStylesFile)
 env.Alias('changes',changesFile)
 
 userGuideFile=env.Command(outputDir.File("userGuide.html"),userDocsDir.File('en/userGuide.html'),Copy('$TARGET','$SOURCE'))
-userGuideMDFile = env.Command(
-	outputDir.File("userGuide.md"),
-	userDocsDir.File('en/userGuide.md'),
-	Copy('$TARGET', '$SOURCE')
-)
-env.Depends(userGuideFile, userGuideMDFile)
 env.Depends(userGuideFile, outputStylesFile)
 env.Alias('userGuide', userGuideFile)
 

--- a/user_docs/keyCommandsDoc.py
+++ b/user_docs/keyCommandsDoc.py
@@ -37,9 +37,6 @@ class Command(StrEnum):
 	SETTING = "setting"
 	SETTINGS_SECTION = "settingsSection"
 
-	def t2tRegex(self) -> re.Pattern:
-		return re.compile(rf"%kc:({self.value}.*)")
-
 
 class Regex(Enum):
 	COMMAND = re.compile(r"^<!-- KC:(?P<cmd>[^:\s]+)(?:: (?P<arg>.*))? -->$")
@@ -120,7 +117,7 @@ class KeyCommandsPreprocessor(Preprocessor):
 		if cmd == Command.TITLE.value:
 			if self._kcSect > Section.HEADER:
 				raise KeyCommandsError(f"{self._lineNum}, title command is not valid here")
-			# Write the title and two blank lines to complete the txt2tags header section.
+			# Write the title and two blank lines to complete the header section.
 			self._kcLines.append("# " + arg + LINE_END * 2)
 			# Add table of contents marker
 			self._kcLines.append("[TOC]" + LINE_END * 2)
@@ -139,7 +136,10 @@ class KeyCommandsPreprocessor(Preprocessor):
 
 		elif cmd == Command.SETTINGS_SECTION.value:
 			# The argument is the table header row for the settings section.
-			# Replace t2t header syntax with markdown syntax.
+			# Replace legacy t2t header syntax with markdown syntax.
+			# TODO: when migrating all userGuide translations to po files,
+			# update the base userGuide to replace the legacy syntax with markdown syntax
+			# and remove this.
 			self._settingsHeaderRow = arg.replace("||", "|")
 			# There are name and description columns.
 			# Each of the remaining columns provides keystrokes for one layout.

--- a/user_docs/styles.css
+++ b/user_docs/styles.css
@@ -60,19 +60,11 @@ pre {
   border-left: 2px solid #69c;
 }
 
-/* 
-Definition styling.
-https://txt2tags.org/markup.html
-In t2t, definition lists are defined as follows:
+/*
+Definition list
 
-: Definition list
-  A list with terms
-: Start term with colon
-  And its definition follows
-:
+Note these are not exposed correctly in NVDA: #3858
 */
-
-/* Definition list */
 dl {
   display: grid;
   grid-template-columns: auto;


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
None

### Summary of the issue:
Previously, markdown files were built as an intermittent step between converting text2tags content to HTML.
During this period, it was useful for builds to upload their markdown files as AppVeyor artifacts in the builds system.
We have now removed the t2t content in favour of a markdown source of truth, meaning that the artifact uploaded should be the same as the contents in the PR.

### Description of user facing changes
Remove userGuide and changes markdown files from build artifacts

### Description of development approach
Remove userGuide and changes markdown files from build artifacts

Also removed other deprecated code and updated remaining references to t2t

### Testing strategy:
Test build results

### Known issues with pull request:

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Addressed an issue related to NVDA compatibility in the documentation styles.

- **Documentation**
  - Updated comments for clarity and future migration notes in the user documentation.
  - Simplified and consolidated styling for definition lists in the user documentation.

- **Refactor**
  - Removed obsolete command dependencies to streamline build processes.
  - Improved handling of `TITLE` and `SETTINGS_SECTION` commands for better readability and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
