### PR TITLE
WasapiWavePlayer.feed: Log exceptions but don't raise them.

### DIFF
--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -65,6 +65,7 @@ Unicode CLDR has also been updated.
 * In LibreOffice Writer (version 24.8 and newer), when toggling text formatting (bold, italic, underline, subscript/superscript, alignment) using the corresponding keyboard shortcut, NVDA announces the new formatting attribute (e.g. "Bold on", "Bold off"). (#4248, @michaelweghorn)
 * When navigating with the cursor keys in text boxes in applications which use UI Automation, NVDA no longer sometimes reports the wrong character, word, etc. (#16711, @jcsteh)
 * When pasting into the Windows 10/11 Calculator, NVDA now correctly reports the full number pasted. (#16573, @TristanBurchett)
+* Speech is no longer silent after disconnecting from and reconnecting to a Remote Desktop session. (#16722, @jcsteh)
 
 ### Changes for Developers
 


### PR DESCRIPTION
### Link to issue number:
Fixes #16722.

### Summary of the issue:
When a client disconnects from a Remote Desktop session without exiting NVDA on the server, WASAPI can throw ERROR_TOO_MANY_FILES, which is not a WASAPI error code and thus not expected by the C++ code. E_NOTFOUND is also possible, probably thrown by IMMDeviceEnumerator::GetDefaultAudioEndpoint. WasapiWavePlayer.feed raises an exception, which breaks the oneCore driver because it isn't expecting exceptions. Speech is broken henceforth.

### Description of user facing changes
Speech is no longer silent after disconnecting from and reconnecting to a Remote Desktop session.

### Description of development approach
I changed WasapiWavePlayer.feed to log exceptions and return without raising them.

I could have tweaked the C++ code to handle ERROR_TOO_MANY_FILES and E_NOTFOUND as well as the codes it already handles (AUDCLNT_E_DEVICE_INVALIDATED and AUDCLNT_E_NOT_INITIALIZED). However, I figured it was best to make this code more resilient in general by catching exceptions, especially given that WinmmWavePlayer.feed also catches exceptions.

### Testing strategy:
I'm not set up to test this myself. However, @WestonThayer (the original reporter) verified that this fixes the problem in https://github.com/nvaccess/nvda/pull/16738#issuecomment-2189848398.

### Known issues with pull request:
None.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Speech remains active after disconnecting from and reconnecting to a Remote Desktop session.

- **Bug Fixes**
  - Improved error handling in the audio feed function to enhance stability and provide better logging for potential issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
