### PR TITLE
MozillaCompoundTextInfo: Add special handling for the insertion point at the end of a line.

### DIFF
--- a/source/NVDAObjects/IAccessible/ia2TextMozilla.py
+++ b/source/NVDAObjects/IAccessible/ia2TextMozilla.py
@@ -430,7 +430,12 @@ class MozillaCompoundTextInfo(CompoundTextInfo):
 	def getTextWithFields(self, formatConfig: Optional[Dict] = None) -> textInfos.TextInfo.TextWithFieldsT:
 		return self._getText(True, formatConfig)
 
-	def _adjustIfEndOfLine(self, expandTi, unit, obj):
+	def _adjustIfEndOfLine(
+			self,
+			expandTi: offsets.OffsetsTextInfo,
+			unit: str,
+			obj: IAccessible
+	) -> None:
 		if (
 			self._isEndOfLineInsertionPoint and unit != textInfos.UNIT_CHARACTER
 			and obj is self._startObj and expandTi._startOffset > 0

--- a/source/NVDAObjects/IAccessible/ia2TextMozilla.py
+++ b/source/NVDAObjects/IAccessible/ia2TextMozilla.py
@@ -84,6 +84,13 @@ class MozillaCompoundTextInfo(CompoundTextInfo):
 
 	def __init__(self, obj, position):
 		super(MozillaCompoundTextInfo, self).__init__(obj, position)
+		# #3156: The position when the caret is at the end of a wrapped line (e.g.
+		# when you press the end key) has the same offset as the start of the next
+		# line. We need to handle this specially so that the correct units are
+		# retrieved when at this position. This gets set to True if appropriate when
+		# handling POSITION_CARET or a copy below. It must be reset to False whenever
+		# this TextInfo is adjusted.
+		self._isEndOfLineInsertionPoint = False
 		if isinstance(position, NVDAObject):
 			try:
 				self._start, self._startObj = self._findContentDescendant(position, textInfos.POSITION_FIRST)
@@ -106,6 +113,7 @@ class MozillaCompoundTextInfo(CompoundTextInfo):
 			else:
 				self._end = position._end.copy()
 			self._endObj = position._endObj
+			self._isEndOfLineInsertionPoint = position._isEndOfLineInsertionPoint
 		elif position in (textInfos.POSITION_FIRST, textInfos.POSITION_LAST):
 			self._start, self._startObj = self._findContentDescendant(obj, position)
 			self._end = self._start
@@ -120,6 +128,19 @@ class MozillaCompoundTextInfo(CompoundTextInfo):
 				caretTi, caretObj = self._findContentDescendant(obj, textInfos.POSITION_CARET)
 			except LookupError:
 				raise RuntimeError("No caret")
+			# #3156: Even though the insertion point at the end of a line might have
+			# the same offset as the start of the next, some implementations
+			# support IA2_TEXT_OFFSET_CARET to take this into account. Use this to
+			# determine whether we are at this position.
+			try:
+				start, end, text = caretObj.IAccessibleTextObject.textAtOffset(
+					IA2.IA2_TEXT_OFFSET_CARET, IA2.IA2_TEXT_BOUNDARY_CHAR
+				)
+				# If the offsets are the same, this means no character, which means this is
+				# the insertion point at the end of a line.
+				self._isEndOfLineInsertionPoint = start == end
+			except COMError:
+				pass
 			if caretObj is not obj and caretObj.IA2Attributes.get("display") == "inline" and caretTi.compareEndPoints(self._makeRawTextInfo(caretObj, textInfos.POSITION_ALL), "startToEnd") == 0:
 				# The caret is at the end of an inline object.
 				# This will report "blank", but we want to report the character just after the caret.
@@ -415,6 +436,15 @@ class MozillaCompoundTextInfo(CompoundTextInfo):
 				expandTi = self._makeRawTextInfo(obj, unit)
 			else:
 				expandTi = baseTi.copy()
+				if (
+					self._isEndOfLineInsertionPoint and unit != textInfos.UNIT_CHARACTER
+					and obj is self._startObj and expandTi._startOffset > 0
+				):
+					# #3156: This is the insertion point at the end of a line. If we use
+					# this offset, we'll get the unit at the start of the next line.
+					# Subtract 1 so that we get the unit on the current line.
+					expandTi._startOffset -= 1
+					expandTi._endOffset -= 1
 				expandTi.expand(unit)
 				if expandTi.isCollapsed:
 					# This shouldn't happen, but can due to server implementation bugs; e.g. MozillaBug:1149415.
@@ -528,6 +558,11 @@ class MozillaCompoundTextInfo(CompoundTextInfo):
 		if unit in ( textInfos.UNIT_CHARACTER, textInfos.UNIT_OFFSET):
 			self._end = self._start
 			self._endObj = self._startObj
+			if self._isEndOfLineInsertionPoint:
+				# #3156: Report no character rather than the character at the start of the
+				# next line.
+				self._start._endOffset = self._start._startOffset
+				return
 			self._start.expand(unit)
 			return
 
@@ -540,6 +575,7 @@ class MozillaCompoundTextInfo(CompoundTextInfo):
 		self._startObj = startObj
 		self._end = end
 		self._endObj = endObj
+		self._isEndOfLineInsertionPoint = False
 
 	def _findNextContent(self, origin, moveBack=False, limitToInline=False):
 		if isinstance(origin, textInfos.TextInfo):
@@ -658,6 +694,7 @@ class MozillaCompoundTextInfo(CompoundTextInfo):
 		if not endPoint or endPoint == "end":
 			self._end = moveTi
 			self._endObj = moveObj
+		self._isEndOfLineInsertionPoint = False
 		self._normalizeStartAndEnd()
 		return direction - remainingMovement
 
@@ -690,7 +727,15 @@ class MozillaCompoundTextInfo(CompoundTextInfo):
 
 		if selfObj == otherObj:
 			# Same object, so just compare the two TextInfos normally.
-			return selfTi.compareEndPoints(otherTi, which)
+			result = selfTi.compareEndPoints(otherTi, which)
+			if result == 0:
+				# #3156: If one of the TextInfos is at the insertion point at the end of
+				# a line but the other isn't, these are actually different positions.
+				if self._isEndOfLineInsertionPoint and not other._isEndOfLineInsertionPoint:
+					return -1
+				elif other._isEndOfLineInsertionPoint and not self._isEndOfLineInsertionPoint:
+					return 1
+			return result
 
 		# Different objects, so we have to compare ancestors.
 		selfAncs = self._getAncestors(selfTi, selfObj)
@@ -740,3 +785,7 @@ class MozillaCompoundTextInfo(CompoundTextInfo):
 				# while the ti for self._endObj might contain text that is after the current range.
 				ti = copy._end
 		return rects
+
+	def setEndPoint(self, other, which):
+		super().setEndPoint(other, which)
+		self._isEndOfLineInsertionPoint = False

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -68,6 +68,7 @@ Unicode CLDR has also been updated.
 * When navigating with the cursor keys in text boxes in applications which use UI Automation, NVDA no longer sometimes reports the wrong character, word, etc. (#16711, @jcsteh)
 * When pasting into the Windows 10/11 Calculator, NVDA now correctly reports the full number pasted. (#16573, @TristanBurchett)
 * Support added for text review commands for an object's name in Visual Studio Code. (#16248, @Cary-Rowen)
+* In Mozilla Firefox, NVDA now correctly reports the current character, word and line when the cursor is at the insertion point at the end of a line. (#3156, @jcsteh)
 
 ### Changes for Developers
 


### PR DESCRIPTION
### Link to issue number:
Fixes #3156. Strictly speaking, that issue covers other problems as well, but this addresses the issue for which it was originally opened. Other issues should be (re)opened for any remaining problems.

### Summary of the issue:
When editing text, there is an insertion point at the end of a line. This is where you are positioned when you press the end key. Firefox also allows you to reach this position with the left/right arrow keys. When text wraps across multiple lines, lines other than the last have this insertion point, but it does not have its own IAccessible2 offset, since it doesn't actually exist in the text. Instead, the caret offset reported is the same offset as the start of the next line.

This is problematic for NVDA because when the user is at this position, NVDA reports the character at the start of the next line. Worse, it reports the next word and line instead of the current word and line.

### Description of user facing changes
In Mozilla Firefox, NVDA now correctly reports the current character, word and line when the cursor is at the insertion point at the end of a line.

### Description of development approach
IAccessible2 provides IA2_TEXT_OFFSET_CARET to deal with this. While somewhat awkward, the idea is that you pass this special offset to IAccessibleText functions so that they know you care about the caret and can handle it specially if the caret is at the end of line insertion point. For example, asking for the character at the caret might report (3, 3, None), where 3 is the caret offset. In contrast, if the caret was at the start of the next line, it might report (3, 4, 'c'). Similarly, asking for the line at the caret when at the end of the line might report (0, 3, 'ab ') instead of (3, 6, 'cd ') at the start of the next.

Unfortunately, making NVDA use IA2_TEXT_OFFSET_CARET when fetching units is tricky. IA2TextTextInfo would need to keep track of the fact that it was constructed for the caret and pass IA2_TEXT_OFFSET_CARET if so. But this means that when the caret moves, the TextInfo moves too, which breaks detaching the review cursor from the caret, etc.

Instead, a flag `_isEndOfLineInsertionPoint` has been added to MozillaCompoundTextInfo. This is set by querying the character at IA2_TEXT_OFFSET_CARET when constructing with POSITION_CARET. This allows us to implement special behaviour when this is True: we expand to no character, we expand to the current word/line instead of the next word/line, etc. If the TextInfo is copied, this flag is copied too. If the TextInfo is mutated in any way, the flag is set to False. This allows us to represent this position (even across copies) without being attached to the current position of the caret.

Some of this could theoretically be done in IA2TextTextInfo, but that would have meant plumbing (and coupling) this special casing through both classes. I'm not aware of any other implementation which supports IA2_TEXT_OFFSET_CARET that doesn't use MozillaCompoundTextInfo.

Note that although Chromium supports IA2_TEXT_OFFSET_CARET, it doesn't special case the insertion point at the end of a line. Thus, although this works fine in Chromium, there is no benefit there, though Chromium could choose to implement this to gain that benefit.

### Testing strategy:
Test case:
`data:text/html,<textarea cols="2">ab cd</textarea>`

In Firefox:

1. Open the test case and focus the textarea.
2. Press end.
    - Incorrect result before this PR: "c"
    - Correct result after this PR: "blank"
3. Press read current line.
    - Incorrect result before this PR: "cd"
    - Correct result after this PR: "ab"
4. Press right arrow.
    - Observe: "c"
5. Press read current line.
    - Observe: "cd"

In Google Chrome:

1. Open the test case and focus the textarea.
2. Press end.
    - Incorrect result (before and after this PR): "c"
3. Press read current line.
    - Correct result (before and after this PR): "ab"
    - Note that Chromium does this by returning the current line for the real offset if the caret is positioned at the insertion point at the end of a line. However, this causes other problems; e.g. you are unable to move the review cursor to the next line if the caret is at this position.

### Known issues with pull request:
None.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - NVDA in Mozilla Firefox now accurately reports the current character, word, and line when the cursor is at the end of a wrapped line.

- **Documentation**
  - Updated user documentation to reflect the new enhancement in text reporting for Mozilla Firefox.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
