### PR TITLE
Remove code to support out-of-process iframes in Firefox which is no longer necessary.

### DIFF
--- a/source/virtualBuffers/gecko_ia2.py
+++ b/source/virtualBuffers/gecko_ia2.py
@@ -9,7 +9,6 @@ from typing import (
 	Optional,
 )
 import typing
-import weakref
 from ctypes import byref
 from . import VirtualBuffer, VirtualBufferTextInfo, VBufStorage_findMatch_word, VBufStorage_findMatch_notEmpty
 import treeInterceptorHandler
@@ -264,86 +263,11 @@ class Gecko_ia2_TextInfo(VirtualBufferTextInfo):
 class Gecko_ia2(VirtualBuffer):
 
 	TextInfo=Gecko_ia2_TextInfo
-	#: Maps NVDAObjects to a list of iframes/frames in that object's ancestry,
-	#: ordered from deepest to shallowest. The key is held as a weak reference so
-	#: that the cache for an object is cleaned up when that object dies. Each
-	#: frame/iframe in the lists is a tuple of (IAccessible2_2, uniqueId). This
-	#: cache is used across instances.
-	_framesCache = weakref.WeakKeyDictionary()
 	_nativeAppSelectionModeSupported = True
 
 	def __init__(self,rootNVDAObject):
 		super(Gecko_ia2,self).__init__(rootNVDAObject,backendName="gecko_ia2")
 		self._initialScrollObj = None
-
-	@staticmethod
-	def _getEmbedderFrame(acc):
-		"""Get the iframe/frame (if any) which contains the given object.
-		For example, if acc is a button inside an iframe, this will return the iframe.
-		"""
-		try:
-			# 1. Get the containing document.
-			if not isinstance(acc, IA2.IAccessible2_2):
-				# IAccessible NVDAObjects currently fetch IA2, but we need IA2_2 for relationTargetsOfType.
-				# (Out-of-process, for a single relation, this is cheaper than IA2::relations.)
-				acc = acc.QueryInterface(IA2.IAccessible2_2)
-			targets, count = acc.relationTargetsOfType(
-				IAccessibleHandler.RelationType.CONTAINING_DOCUMENT,
-				1  # max relations to fetch
-			)
-			if count == 0:
-				return None
-			doc = targets[0].QueryInterface(IA2.IAccessible2_2)
-			# 2. Get its parent (the embedder); e.g. iframe.
-			embedder = doc.accParent
-			if not embedder:
-				return None
-			embedder = embedder.QueryInterface(IA2.IAccessible2_2)
-			# 3. Make sure this is an iframe/frame.
-			attribs = embedder.attributes
-			if "tag:browser;" in attribs:
-				# This is a top level browser, not an iframe/frame.
-				return None
-			return embedder
-		except COMError:
-			return None
-
-	@classmethod
-	def _iterIdsToTryWithAccChild(cls, obj):
-		"""Return the child ids we should try with accChild in order to determine
-		whether this object is a descendant of a particular document.
-		"""
-		# 1. Try the object itself.
-		acc = obj.IAccessibleObject
-		accId = obj.IA2UniqueID
-		yield accId
-		# 2. If this fails, this might be because the object is in an
-		# out-of-process frame, in which case the embedder document won't know
-		# about it. Try embedder frames.
-		# 2.1. Try cached frames. We cache because walking frames is expensive,
-		# and when trying to work out what TreeInterceptor this object belongs to,
-		# we'll need to query these frames for each TreeInterceptor.
-		cache = cls._framesCache.setdefault(obj, [])
-		for acc, accId in cache:
-			if not acc:
-				# All frames were cached in a previous run. There are no more.
-				return
-			yield accId
-		# 2.2. Walk remaining ancestor embedder frames, filling the cache as we go.
-		while True:
-			acc = cls._getEmbedderFrame(acc)
-			if not acc:
-				# No more. Signal this in the cache.
-				cache.append((None, None))
-				return
-			try:
-				accId = acc.uniqueID
-			except COMError:
-				# Dead object.
-				cache.append((None, None))
-				return
-			cache.append((acc, accId))
-			yield accId
 
 	def __contains__(self,obj):
 		if (
@@ -355,19 +279,13 @@ class Gecko_ia2(VirtualBuffer):
 			or not winUser.isDescendantWindow(self.rootNVDAObject.windowHandle, obj.windowHandle)
 		):
 			return False
-		for accId in self._iterIdsToTryWithAccChild(obj):
-			if accId == self.rootID:
-				return True
-			try:
-				self.rootNVDAObject.IAccessibleObject.accChild(accId)
-				# The object is definitely a descendant of the document.
-				break
-			except COMError:
-				pass
-		else:
-			# The object is definitely not a descendant of the document.
+		accId = obj.IA2UniqueID
+		if accId == self.rootID:
+			return True
+		try:
+			self.rootNVDAObject.IAccessibleObject.accChild(accId)
+		except COMError:
 			return False
-
 		return not self._isNVDAObjectInApplication(obj)
 
 	def _get_isAlive(self):
@@ -393,7 +311,15 @@ class Gecko_ia2(VirtualBuffer):
 		return not isDefunct
 
 	def getNVDAObjectFromIdentifier(self, docHandle, ID):
-		return NVDAObjects.IAccessible.getNVDAObjectFromEvent(docHandle, winUser.OBJID_CLIENT, ID)
+		try:
+			pacc=self.rootNVDAObject.IAccessibleObject.accChild(ID)
+		except COMError:
+			return None
+		return NVDAObjects.IAccessible.IAccessible(
+			windowHandle=docHandle,
+			IAccessibleObject=IAccessibleHandler.normalizeIAccessible(pacc),
+			IAccessibleChildID=0
+		)
 
 	def getIdentifierFromNVDAObject(self,obj):
 		docHandle=obj.windowHandle

--- a/source/virtualBuffers/gecko_ia2.py
+++ b/source/virtualBuffers/gecko_ia2.py
@@ -312,7 +312,7 @@ class Gecko_ia2(VirtualBuffer):
 
 	def getNVDAObjectFromIdentifier(self, docHandle, ID):
 		try:
-			pacc=self.rootNVDAObject.IAccessibleObject.accChild(ID)
+			pacc = self.rootNVDAObject.IAccessibleObject.accChild(ID)
 		except COMError:
 			return None
 		return NVDAObjects.IAccessible.IAccessible(

--- a/source/virtualBuffers/gecko_ia2.py
+++ b/source/virtualBuffers/gecko_ia2.py
@@ -320,7 +320,9 @@ class Gecko_ia2(VirtualBuffer):
 		return not isDefunct
 
 	def getNVDAObjectFromIdentifier(
-			self, docHandle: int, ID: int
+			self,
+			docHandle: int,
+			ID: int
 	) -> NVDAObjects.IAccessible.IAccessible:
 		try:
 			pacc = self.rootNVDAObject.IAccessibleObject.accChild(ID)


### PR DESCRIPTION
### Link to issue number:
Reverts #10707.

### Summary of the issue:
Firefox moved most iframes into different processes (AKA out-of-process iframes or project "Fission") in 2020. This necessitated some changes to NVDA because with Firefox's older multi-process architecture, objects in one process were unaware of objects in another. However, with the new "Cache the World" architecture released in Firefox 113 (just over a year ago in May 2023), this special handling is no longer necessary, since all objects are served from the parent process and the parent process is aware of all of them.

While removing this code likely doesn't have any discernible user benefit, I think it's worthwhile to remove unnecessary complexity.

There is no supported version of Firefox (even ESR) which depends on this code.

### Description of user facing changes
None. There might be a slight performance benefit, but I doubt this is perceivable.

### Description of development approach
Reverted #10707, adjusting for non-substantive changes that were made since #10707 was merged (code style, moved constants, etc.).

Note that this moves back to using accChild instead of getNVDAObjectFromEvent. At the time, there didn't appear to be a performance benefit to using accChild and using getNVDAObjectFromEvent made it easier to implement #10707. However, I have since then discovered (through Firefox profiling) that at least in-process, [AccessibleObjectFromWindow can be rather slow relative to direct COM calls](https://bugzilla.mozilla.org/show_bug.cgi?id=762769#c4). This probably isn't noticeable for NVDA's use case, especially given that we're doing this across processes, but any performance boost is probably worthwhile here.

I didn't add a change log entry because there is no user visible change here.

### Testing strategy:
Tested pages with and without iframes in both Firefox and Chrome. Everything worked as expected.

### Known issues with pull request:
None.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved internal logic and error handling for better performance and stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
