### PR TITLE
start 2024.4 dev cycle

### DIFF
--- a/source/buildVersion.py
+++ b/source/buildVersion.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2006-2023 NV Access Limited
+# Copyright (C) 2006-2024 NV Access Limited
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -11,9 +11,9 @@ Any localizable version information should be placed in the versionInfo module, 
 This module exists separately so that it can be imported for version checks before localization is initialized.
 """
 
+
 def _updateVersionFromVCS():
-	"""Update the version from version control system metadata if possible.
-	"""
+	"""Update the version from version control system metadata if possible."""
 	global version
 	# The root of the Git working tree will be the parent of this module's directory.
 	gitDir = os.path.join(os.path.dirname(os.path.dirname(__file__)), ".git")
@@ -28,9 +28,7 @@ def _updateVersionFromVCS():
 		ref = head[5:]
 		with open(os.path.join(gitDir, ref), "r") as f:
 			commit = f.read().rstrip()
-		version = "source-%s-%s" % (
-			os.path.basename(ref),
-			commit[:7])
+		version = f"source-{os.path.basename(ref)}-{commit[:7]}"
 	except:  # noqa: E722
 		pass
 
@@ -66,12 +64,12 @@ def formatVersionForGUI(year, major, minor):
 # Version information for NVDA
 name = "NVDA"
 version_year = 2024
-version_major = 3
+version_major = 4
 version_minor = 0
 version_build = 0  # Should not be set manually. Set in 'sconscript' provided by 'appVeyor.yml'
-version=_formatDevVersionString()
-publisher="unknown"
-updateVersionType=None
+version = _formatDevVersionString()
+publisher = "unknown"
+updateVersionType = None
 try:
 	from _buildVersion import version, publisher, updateVersionType, version_build  # noqa: F401
 except ImportError:

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -1,5 +1,19 @@
 # What's New in NVDA
 
+## 2024.4
+
+### Important notes
+
+### New Features
+
+### Bug Fixes
+
+### Changes for Developers
+
+Please refer to [the developer guide](https://www.nvaccess.org/files/nvda/documentation/developerGuide.html#API) for information on NVDA's API deprecation and removal process.
+
+#### Deprecations
+
 ## 2024.3
 
 The Add-on Store will now notify you if any add-on updates are available on NVDA startup.


### PR DESCRIPTION
Start the dev cycle for the 2024.4 release.
This won't be a compatibility breaking release.

Complete:
- [x] New section in the change log.
- [x] Update NVDA version in `master`
- [x] Update [`nvdaAPIVersions.json` to include the next version](https://github.com/nvaccess/addon-datastore-transform)
  - Re-run the last "Transform NVDA addons to views" on [addon-datastore](https://github.com/nvaccess/addon-datastore/actions/workflows/transformDataToViews.yml) to regenerate projections (views) for the add-on datastore API.

On merge:
- [x] Update auto milestone ID

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated to version 4.0 of the software, reflecting the latest major release.

- **Documentation**
  - Added a new section for version `2024.4` in the user documentation, detailing important updates and developer notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->