### PR TITLE
add github action to assign milestone automatically

### DIFF
--- a/.github/workflows/assign-milestone-on-close.yml
+++ b/.github/workflows/assign-milestone-on-close.yml
@@ -1,0 +1,41 @@
+name: Assign Milestone on Close
+
+env:
+  MILESTONE_ID: 1
+
+on:
+  issues:
+    types: [closed]
+  pull_request:
+    types: [closed]
+
+jobs:
+  assign-milestone:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if milestone is set
+        id: check-milestone
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const issueOrPr = context.payload.issue || context.payload.pull_request;
+            if (!issueOrPr.milestone) {
+              core.setOutput('milestoneNotSet', 'true');
+            } else {
+              core.setOutput('milestoneNotSet', 'false');
+            }
+
+      - name: Assign default milestone
+        if: steps.check-milestone.outputs.milestoneNotSet == 'true'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const issueOrPrNumber = (context.payload.issue || context.payload.pull_request).number;
+            const repository = context.repo;
+            await github.rest.issues.update({
+              ...repository,
+              issue_number: issueOrPrNumber,
+              milestone: process.env.MILESTONE_ID
+            });

--- a/.github/workflows/assign-milestone-on-close.yml
+++ b/.github/workflows/assign-milestone-on-close.yml
@@ -1,7 +1,7 @@
 name: Assign Milestone on Close
 
 env:
-  MILESTONE_ID: 1
+  MILESTONE_ID: 80  # 2024.4
 
 on:
   issues:

--- a/.github/workflows/assign-milestone-on-close.yml
+++ b/.github/workflows/assign-milestone-on-close.yml
@@ -1,7 +1,7 @@
 name: Assign Milestone on Close
 
 env:
-  MILESTONE_ID: 80  # 2024.4
+  MILESTONE_ID: ${{ secrets.MILESTONE_ID }}
 
 on:
   issues:

--- a/.github/workflows/assign-milestone-on-close.yml
+++ b/.github/workflows/assign-milestone-on-close.yml
@@ -1,7 +1,7 @@
 name: Assign Milestone on Close
 
 env:
-  MILESTONE_ID: ${{ secrets.MILESTONE_ID }}
+  MILESTONE_ID: ${{ vars.MILESTONE_ID }}
 
 on:
   issues:


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
None

### Summary of the issue:
NV Access has a server side script to automatically assign milestones to closed issues and PRs. This script has been malfunctioning for some time meaning we are not tracking which release issues are closed in.


### Description of user facing changes

### Description of development approach
Used copilot to generate a github action to assign milestones.

### Testing strategy
Manual testing
- Succesful milestone update:
  - https://github.com/nvaccess/nvda-test/issues/3
  - https://github.com/nvaccess/nvda-test/actions/runs/10211627120/job/28253321745
- Retaining previous milestone value if already set
  - https://github.com/nvaccess/nvda-test/issues/1
  - https://github.com/nvaccess/nvda-test/actions/runs/10211649094/job/28253382737

### Known issues with pull request:
- [ ] Need to update internal release docs to ensure the milestone id is updated when starting the release cycle:  https://github.com/nvaccess/Internal-issue-tracking/pull/538
- [x] need to tear out dead automilestone script from server - https://github.com/nvaccess/nvaccessServer/issues/57

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced an automated workflow that assigns a default milestone to closed issues and pull requests for improved project management and organization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
