### PR TITLE
Only strip from right of string when processing for symbol pronunciation and normalization is enabled

### DIFF
--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -181,7 +181,9 @@ def processText(
 	text = RE_CONVERT_WHITESPACE.sub(" ", text)
 	if normalize:
 		text = unicodeNormalize(text)
-	return text.rstrip()
+		# keep leading space for normalization message
+		return text.rstrip()
+	return text.strip()
 
 
 def cancelSpeech():

--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -181,7 +181,7 @@ def processText(
 	text = RE_CONVERT_WHITESPACE.sub(" ", text)
 	if normalize:
 		text = unicodeNormalize(text)
-	return text.strip()
+	return text.rstrip()
 
 
 def cancelSpeech():

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -81,7 +81,6 @@ A warning message will inform you if you try writing to a non-empty directory. (
 * Support added for text review commands for an object's name in Visual Studio Code. (#16248, @Cary-Rowen)
 * In Mozilla Firefox, NVDA now correctly reports the current character, word and line when the cursor is at the insertion point at the end of a line. (#3156, @jcsteh)
 * Playing NVDA sounds no longer fails on a mono audio device. (#16770, @jcsteh)
-* Fixed a rare case with the OneCore synthesizer where NVDA would strip spaces from text, effectively resulting in malformed speech output. (#16772, @LeonarddeR)
 
 ### Changes for Developers
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -81,6 +81,7 @@ A warning message will inform you if you try writing to a non-empty directory. (
 * Support added for text review commands for an object's name in Visual Studio Code. (#16248, @Cary-Rowen)
 * In Mozilla Firefox, NVDA now correctly reports the current character, word and line when the cursor is at the insertion point at the end of a line. (#3156, @jcsteh)
 * Playing NVDA sounds no longer fails on a mono audio device. (#16770, @jcsteh)
+* Fixed a rare case with the OneCore synthesizer where NVDA would strip spaces from text, effectively resulting in malformed speech output. (#16772, @LeonarddeR)
 
 ### Changes for Developers
 


### PR DESCRIPTION
### Link to issue number:
Fixes #16772 

### Summary of the issue:
When reporting of normalized characters is enabled and OneCore is used, it does not pronounce the space that should be part of the speech sequence, so it announces `Cnormalized` rather than `c normalized`

### Description of user facing changes
Normalized characters are pronounced correctly, e.g. as `C normalized`

### Description of development approach
OneCore uses spelling functionality, which adds the character mode command to the speech sequence. This results in a sequence like `[CharacterModeCommand(True), "C", CharacterModeCommand(False), " normalized"]`.
Every distinct string in the sequence is passed through `ProcessText`, which strips spacing from the left and right of the string. This effectively results in a string of `Cnormalized` passed to the synthesizer. Therefore, I changed processText to only strip from the right of the string when normalization is enabled.
Note that this bug is not related to the normalization code as such, the normalization work just uncovers an existing bug, which is now only fixed in the case of normalization.

### Testing strategy:
Tested str from #16772 

### Known issues with pull request:
The underlying bug is still present when normalization is off. It would for example still apply if a translator translates the message for cap announcements: `cap %s` to something like `%s cap`. In that case, capital C would be announced as `Ccap` by OneCore.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved text processing by ensuring only trailing whitespaces are removed, preventing unintended removal of leading whitespaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
