### PR TITLE
Fix  access to the message area for Windows Mail

### DIFF
--- a/source/appModules/hxmail.py
+++ b/source/appModules/hxmail.py
@@ -9,16 +9,23 @@ import controlTypes
 import appModuleHandler
 from comtypes import COMError
 import UIAHandler
-from NVDAObjects.UIA.wordDocument import WordDocument
+from NVDAObjects.UIA.wordDocument import WordDocument, WordDocumentTextInfo
 
 class MailWordDocumentTreeInterceptor(WordDocument.treeInterceptorClass):
 
 	def _get_isAlive(self):
 		return super(MailWordDocumentTreeInterceptor,self).isAlive and self.rootNVDAObject.shouldCreateTreeInterceptor
 
+class MailWordDocumentTextInfo(WordDocumentTextInfo):
+	# Windows Mail doesn't seem to support MS Word custom attributes, so call the base '_getFormatFieldAtRange'
+	def _getFormatFieldAtRange(self, textRange, formatConfig, ignoreMixedValues=False):
+		return super(WordDocumentTextInfo, self)._getFormatFieldAtRange(textRange, formatConfig, ignoreMixedValues=ignoreMixedValues)
+
 class MailWordDocument(WordDocument):
 
+	TextInfo=MailWordDocumentTextInfo
 	treeInterceptorClass=MailWordDocumentTreeInterceptor
+
 	def _get_shouldCreateTreeInterceptor(self):
 		# Newer versions of Mail (Windows 11+) correctly set the readonly state for emails
 		if controlTypes.State.READONLY in self.states:


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
fixes #16689 

### Summary of the issue:
When using Windows Mail, arrow key navigation in the message reading and writing area triggers an error sound and fails to read content. This issue occurs both when reading a message and when replying to a message.

### Description of user facing changes
Reading a message and navigating between lines works correctly.

### Description of development approach
modify the Windows Mail App Module file to create a custom MailWordDocumentTextInfo class that inherits from WordDocumentTextInfo. This new class overrides the _getFormatFieldAtRange method to use the base implementation, as Windows Mail doesn't support MS Word custom attributes.
The MailWordDocument class is updated to use the new MailWordDocumentTextInfo class for its TextInfo property.

### Testing strategy:
1. Tested message reading:
- Opened a message and navigated content with arrow keys successfully
- Verified no errors were logged 
2. Tested message composition:
- Replied to a message and typed some text
- Navigated the typed text with arrow keys
- Verified no errors were logged.

### Known issues with pull request:
None.

### Changelog entry:
Regression in beta, 2024.2 did not have this issue.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved email document handling by introducing a specialized class for better format field extraction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
