### PR TITLE
Document incompatibility of Code Factory synthesizers with 'Use spelling functionality'

### DIFF
--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -1972,6 +1972,7 @@ Most synthesizers do support it.
 
 This option should generally be enabled.
 However, some Microsoft Speech API synthesizers do not implement this correctly and behave strangely when it is enabled.
+Synthesizers from Code Factory, both the add-on and the SAPI application, do not implement it correctly either and cause unwanted spelling of the spoken text (e.g. in NVDA menu or dialogs).
 If you are having problems with the pronunciation of individual characters, try disabling this option.
 
 ##### Delayed descriptions for characters on cursor movement {#delayedCharacterDescriptions}


### PR DESCRIPTION
Against beta given the change is small.

### Link to issue number:
Many threads on NVDA mailing list, the last ones being:
* [NVDA Vocalizer expressive spelling](https://nvda.groups.io/g/nvda/topic/106474246#msg118764)
* [To stop NVDA from spelling when not wanted, uncheck the setting "Use spelling functionality if ](https://nvda.groups.io/g/nvda/topic/106867570#msg119120)
* [NVDA 2024-1 and Code Factory Vocaliser pronunciation problem](https://nvda.groups.io/g/nvda/topic/106987424#msg119212)

But there are much more of them.

### Summary of the issue:
Code Factory synthesizers (NVDA add-on and SAPI one) are not compatible with "Use spelling functionality" setting. This needs to be documented. It's worth noting that the add-on is being discontinued, so there will never be a compatible version.

### Description of user facing changes
See User Guide.
### Description of development approach
I just mention Code Factory, not Vocalizer nor Eloquence, to avoid confusion with the other Vocalizer synthesizer from Tiflotecnia.

### Testing strategy:
Check generated User Guide.
### Known issues with pull request:
The User Guide may be out-dated if Code Factory updates the SAPI synthesizer to be compatible. In this case we may update the User Guide again.
### Code Review Checklist:


- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated user guide to inform users about synthesizers from Code Factory incorrectly implementing a feature, which may cause unwanted spelling of spoken text. Advised users to disable the option if they encounter pronunciation issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
