### PR TITLE
Fix remote ops to again allow access to the Windows Mail message area

### DIFF
--- a/source/UIAHandler/_remoteOps/remoteTypes/__init__.py
+++ b/source/UIAHandler/_remoteOps/remoteTypes/__init__.py
@@ -15,6 +15,7 @@ from typing import (
 	TypeVar,
 	cast
 )
+from types import NoneType
 import ctypes
 from ctypes import (
 	_SimpleCData,
@@ -716,6 +717,8 @@ class RemoteGuid(RemoteBaseObject[GUID]):
 def getRemoteTypeForLocalType(LocalType: Type[object]) -> Type[RemoteBaseObject]:
 	if issubclass(LocalType, enum.IntEnum):
 		return RemoteIntEnum
+	elif issubclass(LocalType, NoneType):
+		return RemoteNull
 	elif issubclass(LocalType, bool):
 		return RemoteBool
 	elif issubclass(LocalType, int):


### PR DESCRIPTION
### Link to issue number:
Fixes #16689

### Summary of the issue:
The user can no longer read the Windows Mail message area with the arrow keys.
This is due to the fact that this implementation of the MS Word control does not support custom attribute values, but more importantly because code to fetch custom attribute values in NVDA via remote ops is not fail-safe enough.
 In this case, the remote ops function was raising a NoReturnException as the function was not returning a value on common errors.

### Description of user facing changes
The user can again read messages in Windows Mail.

### Description of development approach
* Rewrote the remote ops msWord_getCustomAttributeValue function to be more readable and return early on any error. this avoids deeply nested if statements, and ensures that all code paths return a value. This also required the following extra change:
    * UIA remote ops can now marshal the `None` object as a `RemoteNull` object. This `None` can now be returned from a remote ops function via `RemoteAPI.Return`.
 
### Testing strategy:
* Opened a message in windows Mail and tried to read/navigate the message using the arrow keys.
* Opened a document in Microsoft Word, turned on Report line numbers in NVDA, and arrowed up and down the document, confirming that line numbers were still announced (line numbers being a custom attribute value).

### Known issues with pull request:
None known.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced support for handling `NoneType` in remote operations.
- **Refactor**
  - Improved logic for checking and handling extended text range patterns and custom attribute values, resulting in more efficient and clear code execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
