### PR TITLE
Improve ruff lint rules, indented functions and scons inbuilts

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,14 @@ repos:
     - id: end-of-file-fixer
     - id: trailing-whitespace
 
+- repo: https://github.com/asottile/add-trailing-comma
+  rev: v3.1.0
+  hooks:
+  # Ruff preserves indent/new-line formatting of function arguments, list items, and similar iterables,
+  # if a trailing comma is added.
+  # This adds a trailing comma to args/iterable items in case it wass missed.
+  - id: add-trailing-comma
+
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Matches Ruff version in requirements.
   rev: v0.5.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
   hooks:
   # Ruff preserves indent/new-line formatting of function arguments, list items, and similar iterables,
   # if a trailing comma is added.
-  # This adds a trailing comma to args/iterable items in case it wass missed.
+  # This adds a trailing comma to args/iterable items in case it was missed.
   - id: add-trailing-comma
 
 - repo: https://github.com/astral-sh/ruff-pre-commit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ exclude = [
 [tool.ruff.format]
 indent-style = "tab"
 line-ending = "lf"
+skip-magic-trailing-comma = true
 
 [tool.ruff.lint.mccabe]
 max-complexity = 15
@@ -52,6 +53,12 @@ ignore = [
 	"W191",
 ]
 logger-objects = ["logHandler.log"]
+
+[tool.ruff.lint.per-file-ignores]
+# sconscripts contains many inbuilt functions not recognised by the lint,
+# so ignore F821.
+"sconstruct" = ["F821"]
+"*sconscript" = ["F821"]
 
 [tool.licensecheck]
 using = "requirements:requirements.txt"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,9 +42,6 @@ exclude = [
 [tool.ruff.format]
 indent-style = "tab"
 line-ending = "lf"
-# Preserve indentation of items separated by commas and newlines,
-# rather than wrapping to a single line.
-skip-magic-trailing-comma = true
 
 [tool.ruff.lint.mccabe]
 max-complexity = 15

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,8 @@ exclude = [
 [tool.ruff.format]
 indent-style = "tab"
 line-ending = "lf"
+# Preserve indentation of items separated by commas and newlines,
+# rather than wrapping to a single line.
 skip-magic-trailing-comma = true
 
 [tool.ruff.lint.mccabe]


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Closes https://github.com/nvaccess/nvda/issues/11905
Follow up to https://github.com/nvaccess/nvda/pull/16767

### Summary of the issue:

scons files have a lot of inbuilt functions that the linter doesn't recognize.  See also #11905

Ruff preserves indent/new-line formatting of function arguments, list items, and similar iterables, if a trailing comma is added.
Much of NVDA is missing these trailing commas causing the lint to collapse them.

### Description of user facing changes

### Description of development approach
A lint rule has been added to ignore F821 errors in scons files.

A pre-commit hook is added, which adds a trailing comma to python in case it was missed.

### Testing strategy:
Tested running ruff commands on the code base

### Known issues with pull request:
N/A

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [ ] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [ ] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [ ] API is compatible with existing add-ons.
- [ ] Security precautions taken.

<!-- Please keep the following -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated project configuration for enhanced linting and formatting, including new rules and ignores for specific file types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
