### PR TITLE
Enable/disable the 'Report normalized' checkbox when opening the speech panel

### DIFF
--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -1614,6 +1614,9 @@ class VoiceSettingsPanel(AutoSettingsMixin, SettingsPanel):
 		self.reportNormalizedForCharacterNavigationCheckBox.SetValue(
 			config.conf["speech"]["reportNormalizedForCharacterNavigation"]
 		)
+		self.reportNormalizedForCharacterNavigationCheckBox.Enable(
+			bool(self.unicodeNormalizationCombo._getControlCurrentFlag())
+		)
 
 		includeCLDRText = _(
 			# Translators: This is the label for a checkbox in the


### PR DESCRIPTION
### Link to issue number:
Fix-up of #16521.
### Summary of the issue:
When opening the speech settings panel, the checkbox "Report 'Normalized' when navigating by character" is enabled, no matter the value of the "Unicode normalization" combo-box.

### Description of user facing changes
When opening the speech settings panel, the checkbox "Report 'Normalized' when navigating by character" will be enabled or disabled (greyed out), depending on the value of the "Unicode normalization" combo-box, as it is already the case when the selection of this combo-box is modified.

### Description of development approach
As done for "Ignore blank lines for line indentation reporting" checkbox in Document formatting settings, explicitly call the `.Enable` method when the panel is initialized.

### Testing strategy:
Manual testing.
### Known issues with pull request:
None
### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enabled the "Report Normalized for Character Navigation" checkbox based on Unicode normalization settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
