### PR TITLE
fix up translation comment checks after Ruff format

### DIFF
--- a/source/NVDAObjects/IAccessible/winword.py
+++ b/source/NVDAObjects/IAccessible/winword.py
@@ -255,16 +255,16 @@ class WordDocument(IAccessible, EditableTextWithoutAutoSelectDetection, winWordW
 			return
 		if scriptCount == 0:
 			if self.setAsHeaderCell(cell, isColumnHeader=True, isRowHeader=False):
-				# Translators: a message reported in the SetColumnHeader script for Microsoft Word.
 				ui.message(
+					# Translators: a message reported in the SetColumnHeader script for Microsoft Word.
 					_("Set row {rowNumber} column {columnNumber} as start of column headers").format(
 						rowNumber=cell.rowIndex,
 						columnNumber=cell.columnIndex,
 					),
 				)
 			else:
-				# Translators: a message reported in the SetColumnHeader script for Microsoft Word.
 				ui.message(
+					# Translators: a message reported in the SetColumnHeader script for Microsoft Word.
 					_("Already set row {rowNumber} column {columnNumber} as start of column headers").format(
 						rowNumber=cell.rowIndex,
 						columnNumber=cell.columnIndex,
@@ -272,17 +272,17 @@ class WordDocument(IAccessible, EditableTextWithoutAutoSelectDetection, winWordW
 				)
 		elif scriptCount == 1:
 			if self.forgetHeaderCell(cell, isColumnHeader=True, isRowHeader=False):
-				# Translators: a message reported in the SetColumnHeader script for Microsoft Word.
 				ui.message(
-					_("Removed row {rowNumber} column {columnNumber}  from column headers").format(
+					# Translators: a message reported in the SetColumnHeader script for Microsoft Word.
+					_("Removed row {rowNumber} column {columnNumber} from column headers").format(
 						rowNumber=cell.rowIndex,
 						columnNumber=cell.columnIndex,
 					),
 				)
 			else:
-				# Translators: a message reported in the SetColumnHeader script for Microsoft Word.
 				ui.message(
-					_("Cannot find row {rowNumber} column {columnNumber}  in column headers").format(
+					# Translators: a message reported in the SetColumnHeader script for Microsoft Word.
+					_("Cannot find row {rowNumber} column {columnNumber} in column headers").format(
 						rowNumber=cell.rowIndex,
 						columnNumber=cell.columnIndex,
 					),
@@ -307,16 +307,16 @@ class WordDocument(IAccessible, EditableTextWithoutAutoSelectDetection, winWordW
 			return
 		if scriptCount == 0:
 			if self.setAsHeaderCell(cell, isColumnHeader=False, isRowHeader=True):
-				# Translators: a message reported in the SetRowHeader script for Microsoft Word.
 				ui.message(
+					# Translators: a message reported in the SetRowHeader script for Microsoft Word.
 					_("Set row {rowNumber} column {columnNumber} as start of row headers").format(
 						rowNumber=cell.rowIndex,
 						columnNumber=cell.columnIndex,
 					),
 				)
 			else:
-				# Translators: a message reported in the SetRowHeader script for Microsoft Word.
 				ui.message(
+					# Translators: a message reported in the SetRowHeader script for Microsoft Word.
 					_("Already set row {rowNumber} column {columnNumber} as start of row headers").format(
 						rowNumber=cell.rowIndex,
 						columnNumber=cell.columnIndex,
@@ -324,17 +324,17 @@ class WordDocument(IAccessible, EditableTextWithoutAutoSelectDetection, winWordW
 				)
 		elif scriptCount == 1:
 			if self.forgetHeaderCell(cell, isColumnHeader=False, isRowHeader=True):
-				# Translators: a message reported in the SetRowHeader script for Microsoft Word.
 				ui.message(
-					_("Removed row {rowNumber} column {columnNumber}  from row headers").format(
+					# Translators: a message reported in the SetRowHeader script for Microsoft Word.
+					_("Removed row {rowNumber} column {columnNumber} from row headers").format(
 						rowNumber=cell.rowIndex,
 						columnNumber=cell.columnIndex,
 					),
 				)
 			else:
-				# Translators: a message reported in the SetRowHeader script for Microsoft Word.
 				ui.message(
-					_("Cannot find row {rowNumber} column {columnNumber}  in row headers").format(
+					# Translators: a message reported in the SetRowHeader script for Microsoft Word.
+					_("Cannot find row {rowNumber} column {columnNumber} in row headers").format(
 						rowNumber=cell.rowIndex,
 						columnNumber=cell.columnIndex,
 					),

--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -2723,11 +2723,8 @@ class SuggestionsList(UIA):
 		# Item count must be the last one spoken.
 		suggestionsCount: int = self.childCount
 		suggestionsMessage = (
-			# Translators: part of the suggestions count message for one suggestion.
-			_("1 suggestion")
-			# Translators: part of the suggestions count message (for example: 2 suggestions).
-			if suggestionsCount == 1
-			else _("{} suggestions").format(suggestionsCount)
+			# Translators: message from to note the number of suggestions
+			ngettext("{} suggestion", "{} suggestions", suggestionsCount).format(suggestionsCount)
 		)
 		ui.message(suggestionsMessage)
 

--- a/source/NVDAObjects/__init__.py
+++ b/source/NVDAObjects/__init__.py
@@ -642,9 +642,16 @@ class NVDAObject(
 		percentFromTop = (float(top - deskTop) / deskHeight) * 100
 		percentWidth = (float(width) / deskWidth) * 100
 		percentHeight = (float(height) / deskHeight) * 100
-		# Translators: Reports navigator object's dimensions (example output: object edges positioned 20 per cent from left edge of screen, 10 per cent from top edge of screen, width is 40 per cent of screen, height is 50 per cent of screen).
 		return _(
-			"Object edges positioned {left:.1f} per cent from left edge of screen, {top:.1f} per cent from top edge of screen, width is {width:.1f} per cent of screen, height is {height:.1f} per cent of screen",
+			# Translators: Reports navigator object's dimensions.
+			# Example output: Object edges positioned 20 per cent from left edge of screen,
+			# 10 per cent from top edge of screen,
+			# width is 40 per cent of screen,
+			# height is 50 per cent of screen.
+			"Object edges positioned {left:.1f} percent from left edge of screen, "
+			"{top:.1f} percent from top edge of screen, "
+			"width is {width:.1f} percent of screen, "
+			"height is {height:.1f} percent of screen",
 		).format(left=percentFromLeft, top=percentFromTop, width=percentWidth, height=percentHeight)
 
 	#: Typing information for auto-property: _get_parent

--- a/source/NVDAObjects/behaviors.py
+++ b/source/NVDAObjects/behaviors.py
@@ -642,8 +642,8 @@ class CandidateItem(NVDAObject):
 					if description.startswith("(") and description.endswith(")"):
 						describedSymbols.append(description[1:-1])
 					else:
-						# Translators: a message announcing a candidate's character and description.
 						describedSymbols.append(
+							# Translators: a message announcing a candidate's character and description.
 							_("{symbol} as in {description}").format(symbol=symbol, description=description),
 						)
 				else:

--- a/source/NVDAObjects/window/_msOfficeChart.py
+++ b/source/NVDAObjects/window/_msOfficeChart.py
@@ -433,7 +433,8 @@ class OfficeChartElementBase(Window):
 		if self.elementID == xlSeries:
 			if self.arg2 == -1:
 				ui.message(
-					_("Series color: {colorName} ").format(
+					# Translators: Message to be spoken to report Series Color
+					_("Series color: {colorName}").format(
 						colorName=colors.RGB.fromCOLORREF(
 							int(self.officeChartObject.SeriesCollection(self.arg1).Interior.Color),
 						).name,
@@ -786,8 +787,8 @@ class OfficeChartElementSeries(OfficeChartElementList):
 
 	def script_reportColor(self, gesture):
 		if self.officeChartObject.ChartType in (xlPie, xlPieExploded, xlPieOfPie):
-			# Translators: Message to be spoken to report Slice Color in Pie Chart
 			ui.message(
+				# Translators: Message to be spoken to report Slice Color in Pie Chart
 				_("Slice color: {colorName} ").format(
 					colorName=colors.RGB.fromCOLORREF(
 						int(
@@ -799,9 +800,9 @@ class OfficeChartElementSeries(OfficeChartElementList):
 				),
 			)
 		else:
-			# Translators: Message to be spoken to report Series Color
 			ui.message(
-				_("Series color: {colorName} ").format(
+				# Translators: Message to be spoken to report Series Color
+				_("Series color: {colorName}").format(
 					colorName=colors.RGB.fromCOLORREF(
 						int(self.officeChartObject.SeriesCollection(self.seriesIndex).Interior.Color),
 					).name,
@@ -911,9 +912,9 @@ class OfficeChartElementPoint(OfficeChartElementBase):
 
 				if self.officeChartObject.ChartType in (xlPie, xlPieExploded, xlPieOfPie):
 					total = math.fsum(self.officeChartObject.SeriesCollection(arg1).Values)
-					# Translators: Details about a slice of a pie chart.
-					# For example, this might report "fraction 25.25 percent slice 1 of 5"
 					output += _(
+						# Translators: Details about a slice of a pie chart.
+						# For example, this might report "fraction 25.25 percent slice 1 of 5"
 						" fraction {fractionValue:.2f} Percent slice {pointIndex} of {pointCount}",
 					).format(
 						fractionValue=self.officeChartObject.SeriesCollection(arg1).Values[arg2 - 1]
@@ -1069,8 +1070,8 @@ class OfficeChartElementTrendline(OfficeChartElementBase):
 			label = re.sub(r"([a-zA-Z]+)([-]*[04-9][0-9]*)", r"\1 to the power \2", label)
 			# Translators: Substitute - by minus in trendline equations.
 			label = label.replace("-", _(" minus "))
-			# Translators: This message gives trendline type and name for selected series
 			output = _(
+				# Translators: This message gives trendline type and name for selected series
 				"{seriesName} trendline type: {trendlineType}, name: {trendlineName}, label: {trendlineLabel} ",
 			).format(
 				seriesName=self.officeChartObject.SeriesCollection(self.seriesIndex).Name,
@@ -1125,9 +1126,10 @@ class OfficeChartElementChartArea(OfficeChartElementBase):
 
 	def _getChartElementText(self, ElementID, arg1, arg2, reportExtraInfo=False):
 		if reportExtraInfo:
-			# Translators: Details about the chart area in a Microsoft Office chart.
 			return _(
-				"Chart area, height: {chartAreaHeight}, width: {chartAreaWidth}, top: {chartAreaTop}, left: {chartAreaLeft}",
+				# Translators: Details about the chart area in a Microsoft Office chart.
+				"Chart area, height: {chartAreaHeight}, "
+				"width: {chartAreaWidth}, top: {chartAreaTop}, left: {chartAreaLeft}",
 			).format(
 				chartAreaHeight=self.officeChartObject.ChartArea.Height,
 				chartAreaWidth=self.officeChartObject.ChartArea.Width,
@@ -1155,9 +1157,12 @@ class OfficeChartElementPlotArea(OfficeChartElementBase):
 	def _getChartElementText(self, ElementID, arg1, arg2, reportExtraInfo=False):
 		if reportExtraInfo:
 			# useing {:.0f} to remove fractions
-			# Translators: Details about the plot area of a Microsoft Office chart.
 			return _(
-				"Plot area, inside height: {plotAreaInsideHeight:.0f}, inside width: {plotAreaInsideWidth:.0f}, inside top: {plotAreaInsideTop:.0f}, inside left: {plotAreaInsideLeft:.0f}",
+				# Translators: Details about the plot area of a Microsoft Office chart.
+				"Plot area, inside height: {plotAreaInsideHeight:.0f}, "
+				"inside width: {plotAreaInsideWidth:.0f}, "
+				"inside top: {plotAreaInsideTop:.0f}, "
+				"inside left: {plotAreaInsideLeft:.0f}",
 			).format(
 				plotAreaInsideHeight=self.officeChartObject.PlotArea.InsideHeight,
 				plotAreaInsideWidth=self.officeChartObject.PlotArea.InsideWidth,

--- a/source/NVDAObjects/window/excel.py
+++ b/source/NVDAObjects/window/excel.py
@@ -1621,18 +1621,18 @@ class ExcelCell(ExcelBase):
 				# Translators: a message reported in the SetColumnHeader script for Excel.
 				ui.message(_("Set {address} as start of column headers").format(address=self.cellCoordsText))
 			else:
-				# Translators: a message reported in the SetColumnHeader script for Excel.
 				ui.message(
+					# Translators: a message reported in the SetColumnHeader script for Excel.
 					_("Already set {address} as start of column headers").format(address=self.cellCoordsText),
 				)
 		elif scriptCount == 1:
 			if self.parent.forgetHeaderCell(self, isColumnHeader=True, isRowHeader=False):
 				# Translators: a message reported in the SetColumnHeader script for Excel.
-				ui.message(_("Removed {address}    from column headers").format(address=self.cellCoordsText))
+				ui.message(_("Removed {address} from column headers").format(address=self.cellCoordsText))
 			else:
-				# Translators: a message reported in the SetColumnHeader script for Excel.
 				ui.message(
-					_("Cannot find {address}    in column headers").format(address=self.cellCoordsText),
+					# Translators: a message reported in the SetColumnHeader script for Excel.
+					_("Cannot find {address} in column headers").format(address=self.cellCoordsText),
 				)
 
 	@script(
@@ -1652,8 +1652,8 @@ class ExcelCell(ExcelBase):
 				# Translators: a message reported in the SetRowHeader script for Excel.
 				ui.message(_("Set {address} as start of row headers").format(address=self.cellCoordsText))
 			else:
-				# Translators: a message reported in the SetRowHeader script for Excel.
 				ui.message(
+					# Translators: a message reported in the SetRowHeader script for Excel.
 					_("Already set {address} as start of row headers").format(address=self.cellCoordsText),
 				)
 		elif scriptCount == 1:

--- a/source/NVDAObjects/window/excelCellBorder.py
+++ b/source/NVDAObjects/window/excelCellBorder.py
@@ -158,8 +158,8 @@ def getCellBorderStyleDescription(bordersObj, reportBorderColor=False):
 		del d[xlDiagonalUp]
 		del d[xlDiagonalDown]
 	for pos, desc in d.items():
-		# Translators: border styles in Microsoft Excel.
 		s.append(
+			# Translators: border styles in Microsoft Excel.
 			_("{desc} {position}").format(
 				desc=desc,
 				position=bordersIndexLabels.get(pos),

--- a/source/NVDAObjects/window/winword.py
+++ b/source/NVDAObjects/window/winword.py
@@ -1665,8 +1665,8 @@ class WordDocument(Window):
 			lambda: self.WinwordSelectionObject.paragraphFormat.outlineLevel,
 		)
 		style = self.WinwordSelectionObject.style.nameLocal
-		# Translators: the message when the outline level / style is changed in Microsoft word
 		ui.message(
+			# Translators: the message when the outline level / style is changed in Microsoft word
 			_("{styleName} style, outline level {outlineLevel}").format(styleName=style, outlineLevel=val),
 		)
 

--- a/source/addonStore/models/status.py
+++ b/source/addonStore/models/status.py
@@ -110,16 +110,16 @@ class AvailableAddonStatus(DisplayStringEnum):
 			self.PENDING_DISABLE: pgettext("addonStore", "Disabled, pending restart"),
 			# Translators: Status for addons shown in the add-on store dialog
 			self.DISABLED: pgettext("addonStore", "Disabled"),
-			# Translators: Status for addons shown in the add-on store dialog
 			self.PENDING_INCOMPATIBLE_DISABLED: pgettext(
 				"addonStore",
+				# Translators: Status for addons shown in the add-on store dialog
 				"Disabled (incompatible), pending restart",
 			),
 			# Translators: Status for addons shown in the add-on store dialog
 			self.INCOMPATIBLE_DISABLED: pgettext("addonStore", "Disabled (incompatible)"),
-			# Translators: Status for addons shown in the add-on store dialog
 			self.PENDING_INCOMPATIBLE_ENABLED: pgettext(
 				"addonStore",
+				# Translators: Status for addons shown in the add-on store dialog
 				"Enabled (incompatible), pending restart",
 			),
 			# Translators: Status for addons shown in the add-on store dialog

--- a/source/appModules/foobar2000.py
+++ b/source/appModules/foobar2000.py
@@ -166,8 +166,8 @@ class AppModule(appModuleHandler.AppModule):
 		if parsedElapsedTime is not None and parsedTotalTime is not None:
 			remainingTime = parsedTotalTime - parsedElapsedTime
 			remainingTimeFormatted = TimeOutputFormat.parseTimeDeltaToFormatted(remainingTime)
-			# Translators: Reported remaining time in Foobar2000
 			ui.message(
+				# Translators: Reported remaining time in Foobar2000
 				_("{remainingTimeFormatted} remaining").format(remainingTimeFormatted=remainingTimeFormatted),
 			)
 		else:

--- a/source/brailleDisplayDrivers/freedomScientific.py
+++ b/source/brailleDisplayDrivers/freedomScientific.py
@@ -180,15 +180,16 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver, ScriptableObject):
 	timeout = 0.2
 
 	wizWheelActions = [
-		# Translators: The name of a key on a braille display, that scrolls the display
-		# to show previous/next part of a long line.
 		(
+			# Translators: The name of a key on a braille display, that scrolls the display
+			# to show previous/next part of a long line.
 			_("display scroll"),
 			("globalCommands", "GlobalCommands", "braille_scrollBack"),
 			("globalCommands", "GlobalCommands", "braille_scrollForward"),
 		),
-		# Translators: The name of a key on a braille display, that scrolls the display to show the next/previous line.
 		(
+			# Translators: The name of a key on a braille display,
+			# that scrolls the display to show the next/previous line.
 			_("line scroll"),
 			("globalCommands", "GlobalCommands", "braille_previousLine"),
 			("globalCommands", "GlobalCommands", "braille_nextLine"),

--- a/source/brailleInput.py
+++ b/source/brailleInput.py
@@ -278,8 +278,8 @@ class BrailleInputHandler(AutoPropertyObject):
 		for modifier in added:
 			speech.speakMessage(keyLabels.getKeyCombinationLabel(modifier))
 		for modifier in removed:
-			# Translators: Reported when a braille input modifier is released.
 			speech.speakMessage(
+				# Translators: Reported when a braille input modifier is released.
 				_("{modifier} released").format(
 					modifier=keyLabels.getKeyCombinationLabel(modifier),
 				),

--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -457,9 +457,11 @@ class BrowseModeTreeInterceptor(treeInterceptorHandler.TreeInterceptor):
 			# Translators: Reported when single letter navigation in browse mode is turned on.
 			ui.message(_("Single letter navigation on"))
 
-	# Translators: the description for the toggleSingleLetterNavigation command in browse mode.
 	script_toggleSingleLetterNav.__doc__ = _(
-		"Toggles single letter navigation on and off. When on, single letter keys in browse mode jump to various kinds of elements on the page. When off, these keys are passed to the application",
+		# Translators: the description for the toggleSingleLetterNavigation command in browse mode.
+		"Toggles single letter navigation on and off. "
+		"When on, single letter keys in browse mode jump to various kinds of elements on the page. "
+		"When off, these keys are passed to the application",
 	)
 
 	def _get_ElementsListDialog(self):
@@ -1297,11 +1299,11 @@ class ElementsListDialog(
 		mainSizer = wx.BoxSizer(wx.VERTICAL)
 		contentsSizer = wx.BoxSizer(wx.VERTICAL)
 
-		# Translators: The label of a group of radio buttons to select the type of element
-		# in the browse mode Elements List dialog.
 		child = wx.RadioBox(
 			self,
 			wx.ID_ANY,
+			# Translators: The label of a group of radio buttons to select the type of element
+			# in the browse mode Elements List dialog.
 			label=_("Type:"),
 			choices=tuple(et[1] for et in self.ELEMENT_TYPES),
 		)
@@ -2302,8 +2304,8 @@ class BrowseModeDocumentTreeInterceptor(
 			speech.speakTextInfo(container, reason=OutputReason.FOCUS)
 
 	script_moveToStartOfContainer.resumeSayAllMode = sayAll.CURSOR.CARET
-	# Translators: Description for the Move to start of container command in browse mode.
 	script_moveToStartOfContainer.__doc__ = _(
+		# Translators: Description for the Move to start of container command in browse mode.
 		"Moves to the start of the container element, such as a list or table",
 	)
 
@@ -2330,9 +2332,9 @@ class BrowseModeDocumentTreeInterceptor(
 			speech.speakTextInfo(container, reason=OutputReason.FOCUS)
 
 	script_movePastEndOfContainer.resumeSayAllMode = sayAll.CURSOR.CARET
-	# Translators: Description for the Move past end of container command in browse mode.
 	script_movePastEndOfContainer.__doc__ = _(
-		"Moves past the end  of the container element, such as a list or table",
+		# Translators: Description for the Move past end of container command in browse mode.
+		"Moves past the end of the container element, such as a list or table",
 	)
 
 	NOT_LINK_BLOCK_MIN_LEN = 30

--- a/source/config/configFlags.py
+++ b/source/config/configFlags.py
@@ -142,10 +142,10 @@ class ReportLineIndentation(DisplayStringIntEnum):
 			# Translators: A choice in a combo box in the document formatting dialog to report indentation
 			# with tones.
 			ReportLineIndentation.TONES: pgettext("line indentation setting", "Tones"),
-			# Translators: A choice in a combo box in the document formatting dialog to report indentation with both
-			# Speech and tones.
 			ReportLineIndentation.SPEECH_AND_TONES: pgettext(
 				"line indentation setting",
+				# Translators: A choice in a combo box in the document formatting dialog to report indentation with both
+				# Speech and tones.
 				"Both Speech and Tones",
 			),
 		}

--- a/source/core.py
+++ b/source/core.py
@@ -155,8 +155,8 @@ def doStartupDialogs():
 		import wx
 
 		gui.messageBox(
-			# Translators: A message informing the user that there are errors in the configuration file.
 			_(
+				# Translators: A message informing the user that there are errors in the configuration file.
 				"Your configuration file contains errors. "
 				"Your configuration has been reset to factory defaults.\n"
 				"More details about the errors can be found in the log file.",

--- a/source/documentBase.py
+++ b/source/documentBase.py
@@ -573,8 +573,8 @@ class DocumentWithTableNavigation(TextContainerObject, ScriptableObject):
 			config.conf["documentFormatting"]["includeLayoutTables"] = True
 		ui.message(state)
 
-	# Translators: Input help mode message for include layout tables command.
 	script_toggleIncludeLayoutTables.__doc__ = _(
+		# Translators: Input help mode message for include layout tables command.
 		"Toggles on and off the inclusion of layout tables in browse mode",
 	)
 

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -351,8 +351,8 @@ class GlobalCommands(ScriptableObject):
 				braille.handler.message(selectMessage)
 
 	@script(
-		# Translators: Input help mode message for report date and time command.
 		description=_(
+			# Translators: Input help mode message for report date and time command.
 			"If pressed once, reports the current time. If pressed twice, reports the current date",
 		),
 		category=SCRCAT_SYSTEM,
@@ -1177,8 +1177,8 @@ class GlobalCommands(ScriptableObject):
 		mouseHandler.executeMouseMoveEvent(x, y)
 
 	@script(
-		# Translators: Input help mode message for move navigator object to mouse command.
 		description=_(
+			# Translators: Input help mode message for move navigator object to mouse command.
 			"Sets the navigator object to the current object under the mouse pointer and speaks it",
 		),
 		category=SCRCAT_MOUSE,
@@ -1658,8 +1658,8 @@ class GlobalCommands(ScriptableObject):
 		ui.message(_("No action"))
 
 	@script(
-		# Translators: Input help mode message for move review cursor to top line command.
 		description=_(
+			# Translators: Input help mode message for move review cursor to top line command.
 			"Moves the review cursor to the top line of the current navigator object and speaks it",
 		),
 		category=SCRCAT_TEXTREVIEW,
@@ -1683,8 +1683,8 @@ class GlobalCommands(ScriptableObject):
 			return
 
 	@script(
-		# Translators: Input help mode message for move review cursor to previous line command.
 		description=_(
+			# Translators: Input help mode message for move review cursor to previous line command.
 			"Moves the review cursor to the previous line of the current navigator object and speaks it",
 		),
 		resumeSayAllMode=sayAll.CURSOR.REVIEW,
@@ -1745,8 +1745,8 @@ class GlobalCommands(ScriptableObject):
 			speech.spellTextInfo(info, useCharacterDescriptions=scriptCount > 1)
 
 	@script(
-		# Translators: Input help mode message for move review cursor to next line command.
 		description=_(
+			# Translators: Input help mode message for move review cursor to next line command.
 			"Moves the review cursor to the next line of the current navigator object and speaks it",
 		),
 		resumeSayAllMode=sayAll.CURSOR.REVIEW,
@@ -1784,8 +1784,8 @@ class GlobalCommands(ScriptableObject):
 			)
 
 	@script(
-		# Translators: Input help mode message for move review cursor to previous page command.
 		description=_(
+			# Translators: Input help mode message for move review cursor to previous page command.
 			"Moves the review cursor to the previous page of the current navigator object and speaks it",
 		),
 		resumeSayAllMode=sayAll.CURSOR.REVIEW,
@@ -1818,8 +1818,8 @@ class GlobalCommands(ScriptableObject):
 			speech.speakTextInfo(info, unit=textInfos.UNIT_PAGE, reason=controlTypes.OutputReason.CARET)
 
 	@script(
-		# Translators: Input help mode message for move review cursor to next page command.
 		description=_(
+			# Translators: Input help mode message for move review cursor to next page command.
 			"Moves the review cursor to the next page of the current navigator object and speaks it",
 		),
 		resumeSayAllMode=sayAll.CURSOR.REVIEW,
@@ -1857,8 +1857,8 @@ class GlobalCommands(ScriptableObject):
 			speech.speakTextInfo(newPage, unit=textInfos.UNIT_PAGE, reason=controlTypes.OutputReason.CARET)
 
 	@script(
-		# Translators: Input help mode message for move review cursor to bottom line command.
 		description=_(
+			# Translators: Input help mode message for move review cursor to bottom line command.
 			"Moves the review cursor to the bottom line of the current navigator object and speaks it",
 		),
 		category=SCRCAT_TEXTREVIEW,
@@ -1882,8 +1882,8 @@ class GlobalCommands(ScriptableObject):
 			return
 
 	@script(
-		# Translators: Input help mode message for move review cursor to previous word command.
 		description=_(
+			# Translators: Input help mode message for move review cursor to previous word command.
 			"Moves the review cursor to the previous word of the current navigator object and speaks it",
 		),
 		category=SCRCAT_TEXTREVIEW,
@@ -1944,8 +1944,8 @@ class GlobalCommands(ScriptableObject):
 			speech.spellTextInfo(info, useCharacterDescriptions=scriptCount > 1)
 
 	@script(
-		# Translators: Input help mode message for move review cursor to next word command.
 		description=_(
+			# Translators: Input help mode message for move review cursor to next word command.
 			"Moves the review cursor to the next word of the current navigator object and speaks it",
 		),
 		category=SCRCAT_TEXTREVIEW,
@@ -2172,9 +2172,10 @@ class GlobalCommands(ScriptableObject):
 		return curLanguage
 
 	@script(
-		# Translators: Input help mode message for Review Current Symbol command.
 		description=_(
-			"Reports the symbol where the review cursor is positioned. Pressed twice, shows the symbol and the text used to speak it in browse mode",
+			# Translators: Input help mode message for Review Current Symbol command.
+			"Reports the symbol where the review cursor is positioned. "
+			"Pressed twice, shows the symbol and the text used to speak it in browse mode",
 		),
 		category=SCRCAT_TEXTREVIEW,
 		speakOnDemand=True,
@@ -3088,8 +3089,8 @@ class GlobalCommands(ScriptableObject):
 		ui.message(state)
 
 	@script(
-		# Translators: Input help mode message for toggle auto focus focusable elements command.
 		description=_(
+			# Translators: Input help mode message for toggle auto focus focusable elements command.
 			"Toggles on and off automatic movement of the system focus due to browse mode commands",
 		),
 		category=inputCore.SCRCAT_BROWSEMODE,
@@ -3990,8 +3991,8 @@ class GlobalCommands(ScriptableObject):
 		brailleInput.handler.toggleModifier("alt")
 
 	@script(
-		# Translators: Input help mode message for a braille command.
 		description=_(
+			# Translators: Input help mode message for a braille command.
 			"Virtually toggles the left windows key to emulate a keyboard shortcut with braille input",
 		),
 		category=inputCore.SCRCAT_KBEMU,

--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -203,10 +203,11 @@ class MainFrame(wx.Frame):
 
 	def onRevertToDefaultConfigurationCommand(self, evt):
 		queueHandler.queueFunction(queueHandler.eventQueue, core.resetConfiguration, factoryDefaults=True)
-		# Translators: Reported when configuration has been restored to defaults by using restore configuration to factory defaults item in NVDA menu.
 		queueHandler.queueFunction(
 			queueHandler.eventQueue,
 			ui.message,
+			# Translators: Reported when configuration has been restored to defaults,
+			# by using restore configuration to factory defaults item in NVDA menu.
 			_("Configuration restored to factory defaults"),
 		)
 
@@ -220,9 +221,11 @@ class MainFrame(wx.Frame):
 			# Translators: Reported when current configuration has been saved.
 			queueHandler.queueFunction(queueHandler.eventQueue, ui.message, _("Configuration saved"))
 		except PermissionError:
-			# Translators: Message shown when current configuration cannot be saved such as when running NVDA from a CD.
 			messageBox(
+				# Translators: Message shown when current configuration cannot be saved,
+				# such as when running NVDA from a CD.
 				_("Could not save configuration - probably read only file system"),
+				# Translators: the title of an error message dialog
 				_("Error"),
 				wx.OK | wx.ICON_ERROR,
 			)
@@ -235,10 +238,11 @@ class MainFrame(wx.Frame):
 		except SettingsDialog.MultiInstanceErrorWithDialog as errorWithDialog:
 			errorWithDialog.dialog.SetFocus()
 		except MultiCategorySettingsDialog.CategoryUnavailableError:
-			# Translators: Message shown when trying to open an unavailable category of a multi category settings dialog
-			# (example: when trying to open touch interaction settings on an unsupported system).
 			messageBox(
+				# Translators: Message shown when trying to open an unavailable category of a multi category settings dialog.
+				# Example: when trying to open touch interaction settings on an unsupported system.
 				_("The settings panel you tried to open is unavailable on this system."),
+				# Translators: the title of an error message dialog
 				_("Error"),
 				style=wx.OK | wx.ICON_ERROR,
 			)
@@ -482,9 +486,13 @@ class MainFrame(wx.Frame):
 	def onRunCOMRegistrationFixesCommand(self, evt):
 		if (
 			messageBox(
-				# Translators: A message to warn the user when starting the COM Registration Fixing tool
 				_(
-					"You are about to run the COM Registration Fixing tool. This tool will try to fix common system problems that stop NVDA from being able to access content in many programs including Firefox and Internet Explorer. This tool must make changes to the System registry and therefore requires administrative access. Are you sure you wish to proceed?",
+					# Translators: A message to warn the user when starting the COM Registration Fixing tool
+					"You are about to run the COM Registration Fixing tool. "
+					"This tool will try to fix common system problems that stop NVDA from being able to access content "
+					"in many programs including Firefox and Internet Explorer. "
+					"This tool must make changes to the System registry and therefore requires administrative access. "
+					"Are you sure you wish to proceed?",
 				),
 				# Translators: The title of the warning dialog displayed when launching the COM Registration Fixing tool
 				_("Warning"),
@@ -561,9 +569,9 @@ class SysTrayIcon(wx.adv.TaskBarIcon):
 			item = menu_tools.Append(wx.ID_ANY, _("View &log"))
 			self.Bind(wx.EVT_MENU, frame.onViewLogCommand, item)
 
-			# Translators: The label for the menu item to toggle Speech Viewer.
 			item = self.menu_tools_toggleSpeechViewer = menu_tools.AppendCheckItem(
 				wx.ID_ANY,
+				# Translators: The label for the menu item to toggle Speech Viewer.
 				_("&Speech viewer"),
 			)
 			item.Check(speechViewer.isActive)
@@ -623,7 +631,13 @@ class SysTrayIcon(wx.adv.TaskBarIcon):
 		self._appendPendingUpdateSection(frame)
 
 		self.menu.AppendSeparator()
-		item = self.menu.Append(wx.ID_EXIT, _("E&xit"), _("Exit NVDA"))
+		item = self.menu.Append(
+			wx.ID_EXIT,
+			# Translators: The label for the menu item to exit NVDA
+			_("E&xit"),
+			# Translators: The help string for the menu item to exit NVDA
+			_("Exit NVDA"),
+		)
 		self.Bind(wx.EVT_MENU, frame.onExitCommand, item)
 
 		self.Bind(wx.adv.EVT_TASKBAR_LEFT_DOWN, self.onActivate)

--- a/source/gui/addonStoreGui/controls/messageDialogs.py
+++ b/source/gui/addonStoreGui/controls/messageDialogs.py
@@ -415,10 +415,10 @@ class UpdatableAddonsDialog(
 		self.openStoreButton = bHelper.addButton(self, wx.ID_CLOSE, label=openStoreLabel)
 		self.openStoreButton.Bind(wx.EVT_BUTTON, self.onOpenStoreButton)
 
-		# Translators: The label of a button in a dialog
 		self.updateAllButton = bHelper.addButton(
 			self,
 			wx.ID_CLOSE,
+			# Translators: The label of a button in a dialog
 			label=pgettext("addonStore", "&Update all"),
 		)
 		self.updateAllButton.Bind(wx.EVT_BUTTON, self.onUpdateAllButton)

--- a/source/gui/configProfiles.py
+++ b/source/gui/configProfiles.py
@@ -175,9 +175,10 @@ class ProfilesDialog(
 			config.conf.manualActivateProfile(profile)
 		except:  # noqa: E722
 			log.debugWarning("", exc_info=True)
-			# Translators: An error displayed when activating a configuration profile fails.
 			gui.messageBox(
+				# Translators: An error displayed when activating a configuration profile fails.
 				_("Error activating profile."),
+				# Translators: the title of an error message dialog
 				_("Error"),
 				wx.OK | wx.ICON_ERROR,
 				self,
@@ -209,9 +210,10 @@ class ProfilesDialog(
 			config.conf.deleteProfile(name)
 		except:  # noqa: E722
 			log.debugWarning("", exc_info=True)
-			# Translators: An error displayed when deleting a configuration profile fails.
 			gui.messageBox(
+				# Translators: An error displayed when deleting a configuration profile fails.
 				_("Error deleting profile."),
+				# Translators: the title of an error message dialog
 				_("Error"),
 				wx.OK | wx.ICON_ERROR,
 				self,
@@ -326,9 +328,10 @@ class ProfilesDialog(
 			config.conf.saveProfileTriggers()
 		except:  # noqa: E722
 			log.debugWarning("", exc_info=True)
-			# Translators: An error displayed when saving configuration profile triggers fails.
 			gui.messageBox(
+				# Translators: An error displayed when saving configuration profile triggers fails.
 				_("Error saving configuration profile triggers - probably read only file system."),
+				# Translators: the title of an error message dialog
 				_("Error"),
 				wx.OK | wx.ICON_ERROR,
 				parent=parentWindow,
@@ -486,9 +489,9 @@ class NewProfileDialog(
 		if (
 			spec in confTrigs
 			and gui.messageBox(
-				# Translators: The confirmation prompt presented when creating a new configuration profile
-				# and the selected trigger is already associated.
 				_(
+					# Translators: The confirmation prompt presented when creating a new configuration profile
+					# and the selected trigger is already associated.
 					"This trigger is already associated with another profile. "
 					"If you continue, it will be removed from that profile and associated with this one.\n"
 					"Are you sure you want to continue?",
@@ -518,9 +521,11 @@ class NewProfileDialog(
 		try:
 			config.conf.createProfile(name)
 		except ValueError:
-			# Translators: An error displayed when the user attempts to create a configuration profile which already exists.
 			gui.messageBox(
+				# Translators: An error displayed when the user attempts to create
+				# a configuration profile which already exists.
 				_("That profile already exists. Please choose a different name."),
+				# Translators: Title of an error message.
 				_("Error"),
 				wx.OK | wx.ICON_ERROR,
 				self,
@@ -528,9 +533,10 @@ class NewProfileDialog(
 			return
 		except:  # noqa: E722
 			log.debugWarning("", exc_info=True)
-			# Translators: An error displayed when creating a configuration profile fails.
 			gui.messageBox(
+				# Translators: An error displayed when creating a configuration profile fails.
 				_("Error creating profile - probably read only file system."),
+				# Translators: Title of an error message.
 				_("Error"),
 				wx.OK | wx.ICON_ERROR,
 				self,
@@ -545,9 +551,9 @@ class NewProfileDialog(
 		if manualEdit:
 			if (
 				gui.messageBox(
-					# Translators: The prompt asking the user whether they wish to
-					# manually activate a configuration profile that has just been created.
 					_(
+						# Translators: The prompt asking the user whether they wish to
+						# manually activate a configuration profile that has just been created.
 						"To edit this profile, you will need to manually activate it. "
 						"Once you have finished editing, you will need to manually deactivate it to resume normal usage.\n"
 						"Do you wish to manually activate it now?",

--- a/source/gui/installerGui.py
+++ b/source/gui/installerGui.py
@@ -84,9 +84,11 @@ def doInstall(
 	progressDialog.done()
 	del progressDialog
 	if isinstance(res, installer.RetriableFailure):
-		# Translators: a message dialog asking to retry or cancel when NVDA install fails
 		message = _(
-			"The installation is unable to remove or overwrite a file. Another copy of NVDA may be running on another logged-on user account. Please make sure all installed copies of NVDA are shut down and try the installation again.",
+			# Translators: a message dialog asking to retry or cancel when NVDA install fails
+			"The installation is unable to remove or overwrite a file. "
+			"Another copy of NVDA may be running on another logged-on user account. "
+			"Please make sure all installed copies of NVDA are shut down and try the installation again.",
 		)
 		# Translators: the title of a retry cancel dialog when NVDA installation fails
 		title = _("File in Use")
@@ -101,8 +103,8 @@ def doInstall(
 			)
 	if res != 0:
 		log.error("Installation failed: %s" % res)
-		# Translators: The message displayed when an error occurs during installation of NVDA.
 		gui.messageBox(
+			# Translators: The message displayed when an error occurs during installation of NVDA.
 			_("The installation of NVDA failed. Please check the Log Viewer for more information."),
 			# Translators: The title of a dialog presented when an error occurs.
 			_("Error"),
@@ -117,9 +119,9 @@ def doInstall(
 			# Translators: The message displayed when NVDA has been successfully updated.
 			else _("Successfully updated your installation of NVDA. ")
 		)
-		# Translators: The message displayed to the user after NVDA is installed
-		# and the installed copy is about to be started.
 		gui.messageBox(
+			# Translators: The message displayed to the user after NVDA is installed
+			# and the installed copy is about to be started.
 			msg + _("Please press OK to start the installed copy."),
 			# Translators: The title of a dialog presented to indicate a successful operation.
 			_("Success"),
@@ -183,13 +185,13 @@ class InstallerDialog(
 		# Translators: An informational message in the Install NVDA dialog.
 		msg = _("To install NVDA to your hard drive, please press the Continue button.")
 		if self.isUpdate:
-			# Translators: An informational message in the Install NVDA dialog.
 			msg += " " + _(
+				# Translators: An informational message in the Install NVDA dialog.
 				"A previous copy of NVDA has been found on your system. This copy will be updated.",
 			)
 			if not os.path.isdir(installer.defaultInstallPath):
-				# Translators: a message in the installer telling the user NVDA is now located in a different place.
 				msg += " " + _(
+					# Translators: a message in the installer telling the user NVDA is now located in a different place.
 					"The installation path for NVDA has changed. it will now  be installed in {path}",
 				).format(path=installer.defaultInstallPath)
 		if shouldAskAboutAddons:
@@ -430,8 +432,8 @@ class PortableCreaterDialog(
 		mainSizer = self.mainSizer = wx.BoxSizer(wx.VERTICAL)
 		sHelper = guiHelper.BoxSizerHelper(self, orientation=wx.VERTICAL)
 
-		# Translators: An informational message displayed in the Create Portable NVDA dialog.
 		dialogCaption = _(
+			# Translators: An informational message displayed in the Create Portable NVDA dialog.
 			"To create a portable copy of NVDA, please select the path and other options and then press Continue",
 		)
 		sHelper.addItem(wx.StaticText(self, label=dialogCaption))

--- a/source/gui/logViewer.py
+++ b/source/gui/logViewer.py
@@ -54,6 +54,7 @@ class LogViewer(
 		item = menu.Append(wx.ID_SAVEAS, _("Save &as...	Ctrl+S"))
 		self.Bind(wx.EVT_MENU, self.onSaveAsCommand, item)
 		menu.AppendSeparator()
+		# Translators: The label for a menu item in NVDA log viewer to exit.
 		item = menu.Append(wx.ID_EXIT, _("E&xit"))
 		self.Bind(wx.EVT_MENU, self.onClose, item)
 		# Translators: The title of a menu in NVDA Log Viewer.
@@ -90,8 +91,8 @@ class LogViewer(
 		self.Destroy()
 
 	def onSaveAsCommand(self, evt):
-		# Translators: Label of a menu item in NVDA Log Viewer.
 		filename = wx.FileSelector(
+			# Translators: Label of a menu item in NVDA Log Viewer.
 			_("Save As"),
 			default_filename="nvda.log",
 			flags=wx.FD_SAVE | wx.FD_OVERWRITE_PROMPT,
@@ -104,9 +105,10 @@ class LogViewer(
 			with open(filename, "w", encoding="UTF-8") as f:
 				f.write(self.outputCtrl.GetValue())
 		except (IOError, OSError) as e:
-			# Translators: Dialog text presented when NVDA cannot save a log file.
 			gui.messageBox(
+				# Translators: Dialog text presented when NVDA cannot save a log file.
 				_("Error saving log: %s") % e.strerror,
+				# Translators: the title of an error message dialog
 				_("Error"),
 				style=wx.OK | wx.ICON_ERROR,
 				parent=self,

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -849,9 +849,9 @@ class GeneralSettingsPanel(SettingsPanel):
 		settingsSizerHelper.addItem(self.askToExitCheckBox)
 		self.bindHelpEvent("GeneralSettingsShowExitOptions", self.askToExitCheckBox)
 
-		# Translators: The label for a setting in general settings to play sounds when NVDA starts or exits.
 		self.playStartAndExitSoundsCheckBox = wx.CheckBox(
 			self,
+			# Translators: The label for a setting in general settings to play sounds when NVDA starts or exits.
 			label=_("&Play sounds when starting or exiting NVDA"),
 		)
 		self.bindHelpEvent("GeneralSettingsPlaySounds", self.playStartAndExitSoundsCheckBox)
@@ -919,9 +919,10 @@ class GeneralSettingsPanel(SettingsPanel):
 			self.copySettingsButton.Disable()
 		settingsSizerHelper.addItem(self.copySettingsButton)
 		if updateCheck:
-			# Translators: The label of a checkbox in general settings to toggle automatic checking for updated versions of NVDA (if not checked, user must check for updates manually).
 			item = self.autoCheckForUpdatesCheckBox = wx.CheckBox(
 				self,
+				# Translators: The label of a checkbox in general settings to toggle automatic checking for updated versions of NVDA.
+				# If not checked, user must check for updates manually.
 				label=_("Automatically check for &updates to NVDA"),
 			)
 			self.bindHelpEvent("GeneralSettingsCheckForUpdates", self.autoCheckForUpdatesCheckBox)
@@ -930,10 +931,10 @@ class GeneralSettingsPanel(SettingsPanel):
 				item.Disable()
 			settingsSizerHelper.addItem(item)
 
-			# Translators: The label of a checkbox in general settings to toggle startup notifications
-			# for a pending NVDA update.
 			item = self.notifyForPendingUpdateCheckBox = wx.CheckBox(
 				self,
+				# Translators: The label of a checkbox in general settings to toggle startup notifications
+				# for a pending NVDA update.
 				label=_("Notify for &pending update on startup"),
 			)
 			self.bindHelpEvent("GeneralSettingsNotifyPendingUpdates", self.notifyForPendingUpdateCheckBox)
@@ -982,9 +983,10 @@ class GeneralSettingsPanel(SettingsPanel):
 				break
 			except installer.RetriableFailure:
 				log.debugWarning("Error when copying settings to system config", exc_info=True)
-				# Translators: a message dialog asking to retry or cancel when copying settings  fails
 				message = _(
-					"Unable to copy a file. Perhaps it is currently being used by another process or you have run out of disc space on the drive you are copying to.",
+					# Translators: a message dialog asking to retry or cancel when copying settings  fails
+					"Unable to copy a file. "
+					"Perhaps it is currently being used by another process or you have run out of disc space on the drive you are copying to.",
 				)
 				# Translators: the title of a retry cancel dialog when copying settings  fails
 				title = _("Error Copying")
@@ -1002,9 +1004,10 @@ class GeneralSettingsPanel(SettingsPanel):
 			# Translators: The message displayed when errors were found while trying to copy current configuration to system settings.
 			gui.messageBox(_("Error copying NVDA user settings"), _("Error"), wx.OK | wx.ICON_ERROR, self)
 		else:
-			# Translators: The message displayed when copying configuration to system settings was successful.
 			gui.messageBox(
+				# Translators: The message displayed when copying configuration to system settings was successful.
 				_("Successfully copied NVDA user settings"),
+				# Translators: The message title displayed when copying configuration to system settings was successful.
 				_("Success"),
 				wx.OK | wx.ICON_INFORMATION,
 				self,
@@ -1059,8 +1062,8 @@ class LanguageRestartDialog(
 		super(LanguageRestartDialog, self).__init__(parent, title=_("Language Configuration Change"))
 		mainSizer = wx.BoxSizer(wx.VERTICAL)
 		sHelper = guiHelper.BoxSizerHelper(self, orientation=wx.VERTICAL)
-		# Translators: The message displayed after NVDA interface language has been changed.
 		sHelper.addItem(
+			# Translators: The message displayed after NVDA interface language has been changed.
 			wx.StaticText(self, label=_("NVDA must be restarted for the new language to take effect.")),
 		)
 
@@ -2137,11 +2140,11 @@ class InputCompositionPanel(SettingsPanel):
 	helpId = "InputCompositionSettings"
 
 	def makeSettings(self, settingsSizer):
-		# Translators: This is the label for a checkbox in the
-		# Input composition settings panel.
 		self.autoReportAllCandidatesCheckBox = wx.CheckBox(
 			self,
 			wx.ID_ANY,
+			# Translators: This is the label for a checkbox in the
+			# Input composition settings panel.
 			label=_("Automatically report all available &candidates"),
 		)
 		self.bindHelpEvent("InputCompositionReportAllCandidates", self.autoReportAllCandidatesCheckBox)
@@ -2149,11 +2152,11 @@ class InputCompositionPanel(SettingsPanel):
 			config.conf["inputComposition"]["autoReportAllCandidates"],
 		)
 		settingsSizer.Add(self.autoReportAllCandidatesCheckBox, border=10, flag=wx.BOTTOM)
-		# Translators: This is the label for a checkbox in the
-		# Input composition settings panel.
 		self.announceSelectedCandidateCheckBox = wx.CheckBox(
 			self,
 			wx.ID_ANY,
+			# Translators: This is the label for a checkbox in the
+			# Input composition settings panel.
 			label=_("Announce &selected candidate"),
 		)
 		self.bindHelpEvent(
@@ -2164,11 +2167,11 @@ class InputCompositionPanel(SettingsPanel):
 			config.conf["inputComposition"]["announceSelectedCandidate"],
 		)
 		settingsSizer.Add(self.announceSelectedCandidateCheckBox, border=10, flag=wx.BOTTOM)
-		# Translators: This is the label for a checkbox in the
-		# Input composition settings panel.
 		self.candidateIncludesShortCharacterDescriptionCheckBox = wx.CheckBox(
 			self,
 			wx.ID_ANY,
+			# Translators: This is the label for a checkbox in the
+			# Input composition settings panel.
 			label=_("Always include short character &description when announcing candidates"),
 		)
 		self.bindHelpEvent(
@@ -2179,11 +2182,11 @@ class InputCompositionPanel(SettingsPanel):
 			config.conf["inputComposition"]["alwaysIncludeShortCharacterDescriptionInCandidateName"],
 		)
 		settingsSizer.Add(self.candidateIncludesShortCharacterDescriptionCheckBox, border=10, flag=wx.BOTTOM)
-		# Translators: This is the label for a checkbox in the
-		# Input composition settings panel.
 		self.reportReadingStringChangesCheckBox = wx.CheckBox(
 			self,
 			wx.ID_ANY,
+			# Translators: This is the label for a checkbox in the
+			# Input composition settings panel.
 			label=_("Report changes to the &reading string"),
 		)
 		self.bindHelpEvent(
@@ -2194,11 +2197,11 @@ class InputCompositionPanel(SettingsPanel):
 			config.conf["inputComposition"]["reportReadingStringChanges"],
 		)
 		settingsSizer.Add(self.reportReadingStringChangesCheckBox, border=10, flag=wx.BOTTOM)
-		# Translators: This is the label for a checkbox in the
-		# Input composition settings panel.
 		self.reportCompositionStringChangesCheckBox = wx.CheckBox(
 			self,
 			wx.ID_ANY,
+			# Translators: This is the label for a checkbox in the
+			# Input composition settings panel.
 			label=_("Report changes to the &composition string"),
 		)
 		self.bindHelpEvent(
@@ -3229,10 +3232,10 @@ class AdvancedPanelControls(
 		UIAGroup = guiHelper.BoxSizerHelper(self, sizer=UIASizer)
 		sHelper.addItem(UIAGroup)
 
-		# Translators: This is the label for a combo box for selecting the
-		# means of registering for UI Automation events in the advanced settings panel.
-		# Choices are automatic, selective, and global.
 		selectiveUIAEventRegistrationComboText = _(
+			# Translators: This is the label for a combo box for selecting the
+			# means of registering for UI Automation events in the advanced settings panel.
+			# Choices are automatic, selective, and global.
 			"Regi&stration for UI Automation events and property changes:",
 		)
 		selectiveUIAEventRegistrationChoices = [
@@ -5207,9 +5210,11 @@ class SpeechSymbolsDialog(SettingsDialog):
 		self.filter()
 		for index, symbol in enumerate(self.symbols):
 			if identifier == symbol.identifier:
-				# Translators: An error reported in the Symbol Pronunciation dialog when adding a symbol that is already present.
 				gui.messageBox(
+					# Translators: An error reported in the Symbol Pronunciation dialog
+					# when adding a symbol that is already present.
 					_('Symbol "%s" is already present.') % identifier,
+					# Translators: title of an error message
 					_("Error"),
 					wx.OK | wx.ICON_ERROR,
 				)

--- a/source/gui/startupDialogs.py
+++ b/source/gui/startupDialogs.py
@@ -208,6 +208,7 @@ class LauncherDialog(
 		sizer.Add(ctrl)
 		ctrl.Bind(wx.EVT_BUTTON, self.onContinueRunning)
 		self.actionButtons.append(ctrl)
+		# Translators: The label for a button to exit the NVDA launcher.
 		sizer.Add(wx.Button(self, label=_("E&xit"), id=wx.ID_CANCEL))
 		# If we bind this on the button, it fails to trigger when the dialog is closed.
 		self.Bind(wx.EVT_BUTTON, self.onExit, id=wx.ID_CANCEL)

--- a/source/msoAutoShapeTypes.py
+++ b/source/msoAutoShapeTypes.py
@@ -496,10 +496,10 @@ msoAutoShapeTypeToRoleText = {
 	# Translators: a shape name from Microsoft Office.
 	# See MSOAutoShapeType enumeration from https://msdn.microsoft.com/en-us/library/office/ff862770.aspx?f=255&MSPPError=-2147217396
 	msoShapeLineCallout1AccentBar: pgettext("shape", "Callout with horizontal accent bar"),
-	# Translators: a shape name from Microsoft Office.
-	# See MSOAutoShapeType enumeration from https://msdn.microsoft.com/en-us/library/office/ff862770.aspx?f=255&MSPPError=-2147217396
 	msoShapeLineCallout1BorderandAccentBar: pgettext(
 		"shape",
+		# Translators: a shape name from Microsoft Office.
+		# See MSOAutoShapeType enumeration from https://msdn.microsoft.com/en-us/library/office/ff862770.aspx?f=255&MSPPError=-2147217396
 		"Callout with border and horizontal accent bar",
 	),
 	# Translators: a shape name from Microsoft Office.
@@ -511,10 +511,10 @@ msoAutoShapeTypeToRoleText = {
 	# Translators: a shape name from Microsoft Office.
 	# See MSOAutoShapeType enumeration from https://msdn.microsoft.com/en-us/library/office/ff862770.aspx?f=255&MSPPError=-2147217396
 	msoShapeLineCallout2AccentBar: pgettext("shape", "Callout with diagonal callout line and accent bar"),
-	# Translators: a shape name from Microsoft Office.
-	# See MSOAutoShapeType enumeration from https://msdn.microsoft.com/en-us/library/office/ff862770.aspx?f=255&MSPPError=-2147217396
 	msoShapeLineCallout2BorderandAccentBar: pgettext(
 		"shape",
+		# Translators: a shape name from Microsoft Office.
+		# See MSOAutoShapeType enumeration from https://msdn.microsoft.com/en-us/library/office/ff862770.aspx?f=255&MSPPError=-2147217396
 		"Callout with border, diagonal straight line and accent bar",
 	),
 	# Translators: a shape name from Microsoft Office.
@@ -526,10 +526,10 @@ msoAutoShapeTypeToRoleText = {
 	# Translators: a shape name from Microsoft Office.
 	# See MSOAutoShapeType enumeration from https://msdn.microsoft.com/en-us/library/office/ff862770.aspx?f=255&MSPPError=-2147217396
 	msoShapeLineCallout3AccentBar: pgettext("shape", "Callout with angled callout line and accent bar"),
-	# Translators: a shape name from Microsoft Office.
-	# See MSOAutoShapeType enumeration from https://msdn.microsoft.com/en-us/library/office/ff862770.aspx?f=255&MSPPError=-2147217396
 	msoShapeLineCallout3BorderandAccentBar: pgettext(
 		"shape",
+		# Translators: a shape name from Microsoft Office.
+		# See MSOAutoShapeType enumeration from https://msdn.microsoft.com/en-us/library/office/ff862770.aspx?f=255&MSPPError=-2147217396
 		"Callout with border, angled callout line, and accent bar",
 	),
 	# Translators: a shape name from Microsoft Office.
@@ -538,22 +538,22 @@ msoAutoShapeTypeToRoleText = {
 	# Translators: a shape name from Microsoft Office.
 	# See MSOAutoShapeType enumeration from https://msdn.microsoft.com/en-us/library/office/ff862770.aspx?f=255&MSPPError=-2147217396
 	msoShapeLineCallout4: pgettext("shape", "Callout with callout line segments forming a U-shape"),
-	# Translators: a shape name from Microsoft Office.
-	# See MSOAutoShapeType enumeration from https://msdn.microsoft.com/en-us/library/office/ff862770.aspx?f=255&MSPPError=-2147217396
 	msoShapeLineCallout4AccentBar: pgettext(
 		"shape",
+		# Translators: a shape name from Microsoft Office.
+		# See MSOAutoShapeType enumeration from https://msdn.microsoft.com/en-us/library/office/ff862770.aspx?f=255&MSPPError=-2147217396
 		"Callout with accent bar and callout line segments forming a U-shape",
 	),
-	# Translators: a shape name from Microsoft Office.
-	# See MSOAutoShapeType enumeration from https://msdn.microsoft.com/en-us/library/office/ff862770.aspx?f=255&MSPPError=-2147217396
 	msoShapeLineCallout4BorderandAccentBar: pgettext(
 		"shape",
+		# Translators: a shape name from Microsoft Office.
+		# See MSOAutoShapeType enumeration from https://msdn.microsoft.com/en-us/library/office/ff862770.aspx?f=255&MSPPError=-2147217396
 		"Callout with border, accent bar, and callout line segments forming a U-shape",
 	),
-	# Translators: a shape name from Microsoft Office.
-	# See MSOAutoShapeType enumeration from https://msdn.microsoft.com/en-us/library/office/ff862770.aspx?f=255&MSPPError=-2147217396
 	msoShapeLineCallout4NoBorder: pgettext(
 		"shape",
+		# Translators: a shape name from Microsoft Office.
+		# See MSOAutoShapeType enumeration from https://msdn.microsoft.com/en-us/library/office/ff862770.aspx?f=255&MSPPError=-2147217396
 		"Callout with no border and callout line segments forming a U-shape",
 	),
 	# Translators: a shape name from Microsoft Office.

--- a/source/nvda_slave.pyw
+++ b/source/nvda_slave.pyw
@@ -109,8 +109,9 @@ def main():
 
 				winUser.MessageBox(
 					0,
-					# Translators: the message that is shown when the user tries to install an add-on from windows explorer and NVDA is not running.
 					_(
+						# Translators: the message that is shown when the user tries to install an add-on
+						# from windows explorer and NVDA is not running.
 						"Cannot install NVDA add-on from {path}.\n"
 						"You must be running NVDA to be able to install add-ons."
 					).format(path=addonPath),

--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -2319,8 +2319,8 @@ def getControlFieldSpeech(  # noqa: C901
 		# #7652: containerContainsText variable is set here, but the actual generation of all other output is
 		# handled further down in the general cases section.
 		# This ensures that properties such as name, states and level etc still get reported appropriately.
-		# Translators: Number of items in a list (example output: list with 5 items).
 		containerContainsText = (
+			# Translators: Number of items in a list (example output: list with 5 items).
 			ngettext("with %s item", "with %s items", childControlCount) % childControlCount
 		)
 	elif fieldType == "start_addedToControlFieldStack" and role == controlTypes.Role.TABLE and tableID:
@@ -2661,10 +2661,10 @@ def getFormatFieldSpeech(  # noqa: C901
 			# {color2} will be replaced with the second background color.
 			bgColorText = _("{color1} to {color2}").format(color1=bgColorText, color2=bg2Name)
 		if color and backgroundColor and color != oldColor and bgColorChanged:
-			# Translators: Reported when both the text and background colors change.
-			# {color} will be replaced with the text color.
-			# {backgroundColor} will be replaced with the background color.
 			textList.append(
+				# Translators: Reported when both the text and background colors change.
+				# {color} will be replaced with the text color.
+				# {backgroundColor} will be replaced with the background color.
 				_("{color} on {backgroundColor}").format(
 					color=color.name if isinstance(color, colors.RGB) else color,
 					backgroundColor=bgColorText,
@@ -2701,8 +2701,8 @@ def getFormatFieldSpeech(  # noqa: C901
 		revision = attrs.get("revision-insertion")
 		oldRevision = attrsCache.get("revision-insertion") if attrsCache is not None else None
 		if (revision or oldRevision is not None) and revision != oldRevision:
-			# Translators: Reported when text is marked as having been inserted
 			text = (
+				# Translators: Reported when text is marked as having been inserted
 				_("inserted")
 				if revision
 				# Translators: Reported when text is no longer marked as having been inserted.
@@ -2712,8 +2712,8 @@ def getFormatFieldSpeech(  # noqa: C901
 		revision = attrs.get("revision-deletion")
 		oldRevision = attrsCache.get("revision-deletion") if attrsCache is not None else None
 		if (revision or oldRevision is not None) and revision != oldRevision:
-			# Translators: Reported when text is marked as having been deleted
 			text = (
+				# Translators: Reported when text is marked as having been deleted
 				_("deleted")
 				if revision
 				# Translators: Reported when text is no longer marked as having been  deleted.
@@ -2735,8 +2735,8 @@ def getFormatFieldSpeech(  # noqa: C901
 		marked = attrs.get("marked")
 		oldMarked = attrsCache.get("marked") if attrsCache is not None else None
 		if (marked or oldMarked is not None) and marked != oldMarked:
-			# Translators: Reported when text is marked
 			text = (
+				# Translators: Reported when text is marked
 				_("marked")
 				if marked
 				# Translators: Reported when text is no longer marked
@@ -2761,8 +2761,8 @@ def getFormatFieldSpeech(  # noqa: C901
 		strong = attrs.get("strong")
 		oldStrong = attrsCache.get("strong") if attrsCache is not None else None
 		if (strong or oldStrong is not None) and strong != oldStrong:
-			# Translators: Reported when text is marked as strong (e.g. bold)
 			text = (
+				# Translators: Reported when text is marked as strong (e.g. bold)
 				_("strong")
 				if strong
 				# Translators: Reported when text is no longer marked as strong (e.g. bold)
@@ -2773,8 +2773,8 @@ def getFormatFieldSpeech(  # noqa: C901
 		emphasised = attrs.get("emphasised")
 		oldEmphasised = attrsCache.get("emphasised") if attrsCache is not None else None
 		if (emphasised or oldEmphasised is not None) and emphasised != oldEmphasised:
-			# Translators: Reported when text is marked as emphasised
 			text = (
+				# Translators: Reported when text is marked as emphasised
 				_("emphasised")
 				if emphasised
 				# Translators: Reported when text is no longer marked as emphasised
@@ -2808,9 +2808,9 @@ def getFormatFieldSpeech(  # noqa: C901
 		oldStrikethrough = attrsCache.get("strikethrough") if attrsCache is not None else None
 		if (strikethrough or oldStrikethrough is not None) and strikethrough != oldStrikethrough:
 			if strikethrough:
-				# Translators: Reported when text is formatted with double strikethrough.
-				# See http://en.wikipedia.org/wiki/Strikethrough
 				text = (
+					# Translators: Reported when text is formatted with double strikethrough.
+					# See http://en.wikipedia.org/wiki/Strikethrough
 					_("double strikethrough")
 					if strikethrough == "double"
 					# Translators: Reported when text is formatted with strikethrough.
@@ -2825,8 +2825,8 @@ def getFormatFieldSpeech(  # noqa: C901
 		underline = attrs.get("underline")
 		oldUnderline = attrsCache.get("underline") if attrsCache is not None else None
 		if (underline or oldUnderline is not None) and underline != oldUnderline:
-			# Translators: Reported when text is underlined.
 			text = (
+				# Translators: Reported when text is underlined.
 				_("underlined")
 				if underline
 				# Translators: Reported when text is not underlined.

--- a/source/updateCheck.py
+++ b/source/updateCheck.py
@@ -648,8 +648,8 @@ class UpdateDownloader(garbageHandler.TrackedObject):
 		# Use a timer because timers aren't re-entrant.
 		self._guiExecTimer = gui.NonReEntrantTimer(self._guiExecNotify)
 		gui.mainFrame.prePopup()
-		# Translators: The title of the dialog displayed while downloading an NVDA update.
 		self._progressDialog = wx.ProgressDialog(
+			# Translators: The title of the dialog displayed while downloading an NVDA update.
 			_("Downloading Update"),
 			# Translators: The progress message indicating that a connection is being established.
 			_("Connecting"),

--- a/source/winAPI/_powerTracking.py
+++ b/source/winAPI/_powerTracking.py
@@ -242,9 +242,9 @@ def _getBatteryInformation(systemPowerStatus: SystemPowerStatus) -> List[str]:
 			"{minutes:d} minutes",
 			nMinutes,
 		).format(minutes=nMinutes)
-		# Translators: This is the main string for the estimated remaining runtime of the laptop battery.
-		# E.g. hourText is replaced by "1 hour" and minuteText by "34 minutes".
 		text.append(
+			# Translators: This is the main string for the estimated remaining runtime of the laptop battery.
+			# E.g. hourText is replaced by "1 hour" and minuteText by "34 minutes".
 			_("{hourText} and {minuteText} remaining").format(hourText=hourText, minuteText=minuteText),
 		)
 	return text

--- a/tests/checkPot.py
+++ b/tests/checkPot.py
@@ -55,7 +55,6 @@ EXPECTED_MESSAGES_WITHOUT_COMMENTS = {
 	"Display",
 	"left",
 	"right",
-	"E&xit",
 	"Error renaming profile.",
 	"Use this profile for:",
 	"This change requires administrator privileges.",


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Follow up to #16803 

### Summary of the issue:
Ruff formatting python code in #16803 caused our translation comments to lose association with translation strings
This causes our scons check to fail.

### Description of user facing changes
None
### Description of development approach
Move translation comments to reassociated them.

### Testing strategy:

### Known issues with pull request:

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [ ] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [ ] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [ ] API is compatible with existing add-ons.
- [ ] Security precautions taken.

<!-- Please keep the following -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an "Exit" button to the NVDA launcher dialog.

- **Enhancements**
  - Improved message clarity and detail for various actions in Microsoft Word and Excel.
  - Refined messages related to chart elements in Microsoft Office.
  - Updated descriptions of shapes in the Microsoft Office suite for better clarity.
  - Enhanced message formatting for braille displays and braille input.

- **Bug Fixes**
  - Corrected message display in Microsoft Word when changing style and outline level.

- **Documentation**
  - Updated and added comments for translator clarity across multiple modules.
  - Improved documentation strings for various functions for better readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
