### PR TITLE
Enable caret event detection for IA2Web

### DIFF
--- a/source/IAccessibleHandler/__init__.py
+++ b/source/IAccessibleHandler/__init__.py
@@ -643,7 +643,7 @@ def processGenericWinEvent(eventID, window, objectID, childID):
 		elif isinstance(focus.IAccessibleObject, IA2.IAccessible2):
 			if isMSAADebugLoggingEnabled():
 				log.debug(
-					f"Ignoring MSAA caret event on focused IAccessible2 object"
+					"Ignoring MSAA caret event on focused IAccessible2 object"
 					f"winEvent {getWinEventLogInfo(window, objectID, childID)}",
 				)
 			return False

--- a/source/IAccessibleHandler/__init__.py
+++ b/source/IAccessibleHandler/__init__.py
@@ -640,6 +640,13 @@ def processGenericWinEvent(eventID, window, objectID, childID):
 						f"winEvent {getWinEventLogInfo(window, objectID, childID)}",
 					)
 				return False
+		elif isinstance(focus.IAccessibleObject, IA2.IAccessible2):
+			if isMSAADebugLoggingEnabled():
+				log.debug(
+					f"Ignoring MSAA caret event on focused IAccessible2 object"
+					f"winEvent {getWinEventLogInfo(window, objectID, childID)}",
+				)
+			return False
 		if isMSAADebugLoggingEnabled():
 			log.debug(
 				"handling winEvent as caret event on focus. "

--- a/source/NVDAObjects/IAccessible/ia2Web.py
+++ b/source/NVDAObjects/IAccessible/ia2Web.py
@@ -101,7 +101,6 @@ class IA2WebAnnotation(AnnotationOrigin):
 
 class Ia2Web(IAccessible):
 	IAccessibleTableUsesTableCellIndexAttrib = True
-	caretMovementDetectionUsesEvents = False
 
 	def isDescendantOf(self, obj: "NVDAObjects.NVDAObject") -> bool:
 		if obj.windowHandle != self.windowHandle:

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -9,7 +9,7 @@
 ### Bug Fixes
 
 * NVDA once again relies on events for caret movement in several cases, rather than only on manual querying of the caret position.
-  * UIA for XAML and WPF text controls; (#16817, @LeonarddeR)
+  * UIA for XAML and WPF text controls. (#16817, @LeonarddeR)
   * IAccessible2 for browsers such as Firefox and Chromium based browsers. (#11545, #16815, @LeonarddeR)
 
 ### Changes for Developers

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -8,7 +8,9 @@
 
 ### Bug Fixes
 
-* NVDA once again relies on UIA events for caret movement in XAML and WPF text controls, rather than only on manual querying of the caret position. (#16817, @LeonarddeR)
+* NVDA once again relies on events for caret movement in several cases, rather than only on manual querying of the caret position.
+  * UIA for XAML and WPF text controls; (#16817, @LeonarddeR)
+  * IAccessible2 for browsers such as Firefox and Chromium based browsers. (#11545, #16815, @LeonarddeR)
 
 ### Changes for Developers
 


### PR DESCRIPTION
CC @jcsteh 

### Link to issue number:
Fixes #11545 

### Summary of the issue:
We do not rely on caret events for IA2.

### Description of user facing changes
Possibly slightly faster caret navigation in Firefox and Chrome.

### Description of development approach
1. No longer ignore caret events for IA2Web objects
2. Ignore the location change and show events for IA2, rather, rely on IA2_EVENT_TEXT_CARET_MOVED

### Testing strategy:
Verified that IA2_EVENT_TEXT_CARET_MOVED is fired for:
- [x] Firefox
- [x] Chrome
- [x] LibreOffice

### Known issues with pull request:
None known

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of caret events for IAccessible2 objects to enhance accessibility features.

- **Documentation**
  - Updated documentation to reflect the reliance on events for caret movement in various scenarios, including UIA for XAML and WPF text controls, and IAccessible2 for browsers like Firefox and Chromium.

- **Refactor**
  - Removed the `caretMovementDetectionUsesEvents` attribute from the `Ia2Web` class to streamline code related to caret movement detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
