### PR TITLE
Revert disabling handling of caret notifications for UIA

### DIFF
--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -21,12 +21,12 @@ import time
 import numbers
 import colors
 import languageHandler
+import NVDAState
 import UIAHandler
 import UIAHandler.customProps
 import UIAHandler.customAnnotations
 import controlTypes
 from controlTypes import TextPosition, TextAlign
-import inputCore
 import config
 import speech
 import api
@@ -2482,27 +2482,13 @@ class UIA(Window):
 			ui.message(dropTargetEffect)
 
 
-class InaccurateTextChangeEventEmittingEditableText(EditableTextBase, UIA):
-	# XAML and WPF fire UIA textSelectionChange events before the caret position change is reflected
-	# in the related UIA text pattern.
-	# This means that, apart from deleting text, NVDA cannot rely on textSelectionChange (caret) events
-	# in XAML or WPF to detect if the caret has moved, as it occurs too early.
-	caretMovementDetectionUsesEvents = False
+if NVDAState._allowDeprecatedAPI():
 
-	def _backspaceScriptHelper(self, unit: str, gesture: inputCore.InputGesture):
-		"""As UIA text range objects from XAML or WPF don't mutate with backspace,
-		comparing a text range copied from before backspace with a text range fetched after backspace
-		isn't reliable, as the ranges compare equal.
-		Therefore, we must always rely on events for caret change detection in this case.
-		"""
-		self.caretMovementDetectionUsesEvents = True
-		try:
-			super()._backspaceScriptHelper(unit, gesture)
-		finally:
-			self.caretMovementDetectionUsesEvents = False
+	class InaccurateTextChangeEventEmittingEditableText(EditableTextBase, UIA):
+		"""InaccurateTextChangeEventEmittingEditableText is deprecated without a replacement."""
 
 
-class XamlEditableText(InaccurateTextChangeEventEmittingEditableText):
+class XamlEditableText(EditableTextBase, UIA):
 	"""An UIA element with editable text exposed by the XAML framework."""
 
 	...
@@ -2687,7 +2673,7 @@ class ToolTip(ToolTip, UIA):
 	event_UIA_toolTipOpened = ToolTip.event_show
 
 
-class WpfTextView(InaccurateTextChangeEventEmittingEditableText):
+class WpfTextView(EditableTextBase, UIA):
 	"""WpfTextView fires name state changes once a second,
 	plus when IUIAutomationTextRange::GetAttributeValue is called.
 	This causes major lag when using this control with Braille in NVDA. (#2759)

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -8,6 +8,8 @@
 
 ### Bug Fixes
 
+* NVDA once again relies on UIA events for caret movement in XAML and WPF text controls, rather than only on manual querying of the caret position. (#16817, @LeonarddeR)
+
 ### Changes for Developers
 
 Please refer to [the developer guide](https://www.nvaccess.org/files/nvda/documentation/developerGuide.html#API) for information on NVDA's API deprecation and removal process.
@@ -15,6 +17,8 @@ Please refer to [the developer guide](https://www.nvaccess.org/files/nvda/docume
 * Added a `.editorconfig` file to NVDA's repository in order for several IDEs to pick up basic NVDA code style rules by default. (#16795, @LeonarddeR)
 
 #### Deprecations
+
+* `NVDAObjects.UIA.InaccurateTextChangeEventEmittingEditableText` is deprecated with no replacement. (#16817, @LeonarddeR)
 
 ## 2024.3
 


### PR DESCRIPTION
### Link to issue number:
Partially reverts #14888, #15838

### Summary of the issue:
In #14888, `XamlEditableText` was added to ensure that UIA events wouldn't be used to determine caret changes, as the hypothesis was that they were fired too early. In https://github.com/nvaccess/nvda/pull/15838, I expanded this workaround for WPF (Visual Studio) text controls.
It turns out @jcsteh found the actual cause of these issues and fixed them in #16711, allowing us to rely on events again.

### Description of user facing changes
None, though caret movement would possibly be detected a little bit faster in XAML and WPF controls.

### Description of development approach
Mostly reverts.

### Testing strategy:
- [x] Tested that caret movement works reliably in WhatsApp Desktop (UWP)
- [x] Tested that caret movement works reliably in the search field in the Windows 11 start menu
- [x] Tested that caret movement works reliably in Visual Studio text controls

### Known issues with pull request:
None known

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed issue with NVDA's caret movement in XAML and WPF text controls by reverting to UIA events.
  
- **Deprecations**
  - Deprecated `NVDAObjects.UIA.InaccurateTextChangeEventEmittingEditableText` with no replacement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
