### PR TITLE
Remove old winTerminalUIA module attribute

### DIFF
--- a/source/NVDAObjects/UIA/winConsoleUIA.py
+++ b/source/NVDAObjects/UIA/winConsoleUIA.py
@@ -9,7 +9,6 @@ import config
 import controlTypes
 import ctypes
 import NVDAHelper
-import NVDAState
 import speech
 import textInfos
 import textUtils
@@ -19,10 +18,9 @@ from comtypes import COMError
 from diffHandler import prefer_difflib
 from logHandler import log
 from typing import (
-	Any,
 	Optional,
 )
-from UIAHandler.utils import _getConhostAPILevel, _shouldUseWindowsTerminalNotifications
+from UIAHandler.utils import _getConhostAPILevel
 from UIAHandler.constants import WinConsoleAPILevel
 from . import UIA, UIATextInfo
 from ..behaviors import EnhancedTermTypedCharSupport, KeyboardHandlerBasedTypedCharSupport

--- a/source/NVDAObjects/UIA/winConsoleUIA.py
+++ b/source/NVDAObjects/UIA/winConsoleUIA.py
@@ -481,18 +481,3 @@ class _NotificationsBasedWinTerminalUIA(UIA):
 		for line in displayString.splitlines():
 			if line and not line.isspace():  # Don't say "blank" during autoread
 				speech.speakText(line)
-
-
-def __getattr__(attrName: str) -> Any:
-	"""Module level `__getattr__` used to preserve backward compatibility."""
-	if attrName == "WinTerminalUIA" and NVDAState._allowDeprecatedAPI():
-		log.warning(
-			"WinTerminalUIA is deprecated. "
-			"Instead use _DiffBasedWinTerminalUIA or _NotificationsBasedWinTerminalUIA",
-		)
-		return (
-			_NotificationsBasedWinTerminalUIA
-			if _shouldUseWindowsTerminalNotifications()
-			else _DiffBasedWinTerminalUIA
-		)
-	raise AttributeError(f"module {repr(__name__)} has no attribute {repr(attrName)}")

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -40,6 +40,8 @@ Add-ons will need to be re-tested and have their manifest updated.
 These are breaking API changes.
 Please open a GitHub issue if your add-on has an issue with updating to the new API.
 
+* `NVDAObjects.UIA.winConsoleUIA.WinTerminalUIA` has been removed with no public replacement. (#14047, #16820, @codeofdusk)
+
 #### Deprecations
 
 * The `braille.filter_displaySize` extension point is deprecated.


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Fix-up of #14047.

### Summary of the issue:
Code to support a previously used `WinTerminalUIA` class name was added during a deprecation period, now over a year. See the deprecation note in 2023.1 developer changes.

### Description of how this pull request fixes the issue:
Remove the attribute. This code is unlikely to be used by add-ons.

### Testing strategy:
Verified functionality of terminal support.

### Known issues with pull request:
None known

### Change log entry:
In PR

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [ ] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed backward compatibility logic related to `WinTerminalUIA` deprecation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->