### PR TITLE
Follow-up of #16359 - Make incompatibility messages more explicit

### DIFF
--- a/source/addonStore/models/version.py
+++ b/source/addonStore/models/version.py
@@ -122,7 +122,7 @@ class SupportsVersionCheck(Protocol):
 				# The addon relies on older, removed features of NVDA, an updated add-on is required.
 				# The placeholder will be replaced with Year.Major.Minor (e.g. 2019.1).
 				"An updated version of this add-on is required. "
-				"This add-on was last tested with {lastTestedNVDAVersion}. "
+				"This add-on was last tested with NVDA {lastTestedNVDAVersion}. "
 				"NVDA requires this add-on to be tested with NVDA {nvdaVersion} or higher. "
 				"You can enable this add-on at your own risk. "
 				).format(

--- a/source/gui/addonStoreGui/controls/messageDialogs.py
+++ b/source/gui/addonStoreGui/controls/messageDialogs.py
@@ -165,7 +165,7 @@ def _shouldInstallWhenAddonTooOldDialog(
 	name=addon.displayName,
 	version=addon.addonVersionName,
 	lastTestedNVDAVersion=addonAPIVersion.formatForGUI(addon.lastTestedNVDAVersion),
-	NVDAVersion=addonAPIVersion.formatForGUI(addonAPIVersion.CURRENT)
+	nvdaVersion=addonAPIVersion.formatForGUI(addonAPIVersion.BACK_COMPAT_TO),
 	)
 	dlg = ErrorAddonInstallDialogWithYesNoButtons(
 		parent=parent,
@@ -198,7 +198,7 @@ def _shouldEnableWhenAddonTooOldDialog(
 	name=addon.displayName,
 	version=addon.addonVersionName,
 	lastTestedNVDAVersion=addonAPIVersion.formatForGUI(addon.lastTestedNVDAVersion),
-	NVDAVersion=addonAPIVersion.formatForGUI(addonAPIVersion.CURRENT)
+	nvdaVersion=addonAPIVersion.formatForGUI(addonAPIVersion.BACK_COMPAT_TO),
 	)
 	dlg = ErrorAddonInstallDialogWithYesNoButtons(
 		parent=parent,

--- a/source/gui/addonStoreGui/controls/messageDialogs.py
+++ b/source/gui/addonStoreGui/controls/messageDialogs.py
@@ -157,8 +157,8 @@ def _shouldInstallWhenAddonTooOldDialog(
 		# because the add-on is too old for the running version of NVDA.
 		"Warning: add-on is incompatible: {name} {version}. "
 		"Check for an updated version of this add-on if possible. "
-		"The last tested NVDA version for this add-on is {lastTestedNVDAVersion}, "
-		"your current NVDA version is {NVDAVersion}. "
+		"This add-on was last tested with NVDA {lastTestedNVDAVersion}. "
+		"NVDA requires this add-on to be tested with NVDA {nvdaVersion} or higher. "
 		"Installation may cause unstable behavior in NVDA.\n"
 		"Proceed with installation anyway? "
 		).format(
@@ -190,8 +190,8 @@ def _shouldEnableWhenAddonTooOldDialog(
 		# because the add-on is too old for the running version of NVDA.
 		"Warning: add-on is incompatible: {name} {version}. "
 		"Check for an updated version of this add-on if possible. "
-		"The last tested NVDA version for this add-on is {lastTestedNVDAVersion}, "
-		"your current NVDA version is {NVDAVersion}. "
+		"This add-on was last tested with NVDA {lastTestedNVDAVersion}. "
+		"NVDA requires this add-on to be tested with NVDA {nvdaVersion} or higher. "
 		"Enabling may cause unstable behavior in NVDA.\n"
 		"Proceed with enabling anyway? "
 		).format(


### PR DESCRIPTION
### Link to issue number:
Follow-up of #16359

### Summary of the issue:
In #16359, an add-on incompatibility message has been made more explicit. Two other similar message need to be made clearer too.

### Description of user facing changes
* Modify the original message adding a missing "NVDA" word
* Rephrased the two other similar incompatibility messages the same way.
### Description of development approach
N/A
### Testing strategy:
Checked the 3 messages in add-on store:
* in other details field for an incompatible add-on
* when installing an incompatible add-on
* when enabling an incompatible add-on

### Known issues with pull request:
None
### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Enhanced clarity of messages regarding add-on compatibility with NVDA versions.
  - Updated messages now specify both the last tested NVDA version and the required NVDA version for installation and enabling of add-ons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
