### PR TITLE
merge lint docs

### DIFF
--- a/projectDocs/dev/codingStandards.md
+++ b/projectDocs/dev/codingStandards.md
@@ -96,7 +96,7 @@ self.copySettingsButton = wx.Button(
   - Anything imported into a (sub)module can also be imported from that submodule.
   - As a result, removing unused imports may break compatibility, and should be done in compatibility breaking releases (see `deprecations.md`).
 * Unused imports will give a lint warning. These can be handled the following ways:
-  - If these imports are inteded to be imported from other modules, they can be done included in a definition for `__all__`. This will override and define the symbols imported when performing a star import, eg `from module import *`.
+  - If these imports are intended to be imported from other modules, they can be included in a definition for `__all__`. This will override and define the symbols imported when performing a star import, eg `from module import *`.
   - Otherwise, with a comment like `# noqa: <explanation>`.
 
 ### Considering future backwards compatibility

--- a/projectDocs/dev/codingStandards.md
+++ b/projectDocs/dev/codingStandards.md
@@ -1,6 +1,6 @@
 ## Code Style
 
-Python code style is enforced with the Ruff linter, see [linting](./lint.md) for more information.
+Python code style is enforced with the Ruff linter, see [linting](../testing/automated.md#linting-your-changes) for more information.
 
 ### Encoding
 
@@ -95,7 +95,7 @@ self.copySettingsButton = wx.Button(
 * Unused imports should be removed where possible.
   - Anything imported into a (sub)module can also be imported from that submodule.
   - As a result, removing unused imports may break compatibility, and should be done in compatibility breaking releases (see `deprecations.md`).
-* Unused imports will give a lint warning. These can be handled the following ways: 
+* Unused imports will give a lint warning. These can be handled the following ways:
   - If these imports are inteded to be imported from other modules, they can be done included in a definition for `__all__`. This will override and define the symbols imported when performing a star import, eg `from module import *`.
   - Otherwise, with a comment like `# noqa: <explanation>`.
 

--- a/projectDocs/dev/lint.md
+++ b/projectDocs/dev/lint.md
@@ -1,9 +1,0 @@
-# Linting
-
-## Lint overview
-
-Our linting process involves running [Ruff](https://docs.astral.sh/ruff) to pick up linting issues and auto-apply fixes where possible.
-
-## Lint integration
-
-For faster lint results, or greater integration with your tools you may want to set up Ruff with your IDE.

--- a/projectDocs/testing/automated.md
+++ b/projectDocs/testing/automated.md
@@ -31,15 +31,15 @@ scons checkPot
 
 ### Linting your changes
 
-In order to ensure your changes comply with NVDA's coding style you can run the Ruff linter locally.
-`runlint.bat` will use Ruff to lint and where possible, fix the code you have written.
+Our linting process involves running [Ruff](https://docs.astral.sh/ruff) to pick up Python linting issues and auto-apply fixes where possible.
+
+To run the linter locally:
 
 ```cmd
 runlint.bat
 ```
 
-To be warned about linting errors faster, you may wish to integrate Ruff with other development tools you are using.
-For more details, see the [linting docs](../dev/lint.md).
+To be warned about linting errors faster, you may wish to integrate Ruff with your IDE or other development tools you are using.
 
 ### Unit Tests
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Fixup of #16751 

### Summary of the issue:
The documentation for linting was fragmented.
It was not clear why a `lint.md` file was created as part of #16751 and related changes..
It was probably a  result from migrating the [Flake8 wiki](https://github.com/nvaccess/nvda/wiki/LintWithFlake8) to the document, and then whittling it down to the point where it became useless.
information on how to actually run the linter was missing from it

### Description of development approach
removes `lint.md` change references to the automated testing doc



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated coding standards documentation to include Ruff linter for Python code style enforcement.
  - Clarified handling of lint warnings related to unused imports.
  - Revised instructions on linting processes and integration with development tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->