### PR TITLE
Remove add-on update warning when launcher is running

### DIFF
--- a/source/gui/addonStoreGui/controls/messageDialogs.py
+++ b/source/gui/addonStoreGui/controls/messageDialogs.py
@@ -19,7 +19,6 @@ from addonStore.dataManager import addonDataManager
 from addonStore.models.status import AvailableAddonStatus
 import config
 from config.configFlags import AddonsAutomaticUpdate
-import globalVars
 import gui
 from gui import nvdaControls
 from gui.addonGui import ConfirmAddonInstallDialog, ErrorAddonInstallDialog, promptUserForRestart
@@ -33,6 +32,7 @@ from gui.guiHelper import (
 )
 from gui.message import DisplayableError, displayDialogAsModal, messageBox
 from logHandler import log
+import NVDAState
 import ui
 import windowUtils
 
@@ -547,7 +547,7 @@ class UpdatableAddonsDialog(
 	@classmethod
 	def _checkForUpdatableAddons(cls):
 		if (
-			globalVars.appArgs.secure
+			not NVDAState.shouldWriteToDisk()
 			or (AddonsAutomaticUpdate.DISABLED == config.conf["addonStore"]["automaticUpdates"])
 		):
 			log.debug("automatic add-on updates are disabled")


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Fixes #16783

### Summary of the issue:
The update notification for add-ons occurs on the NVDA installer.
This should not happen, it should only run where NVDA should write to disk (e.g. manage the state of add-ons).
This excludes secure mode and the launcher environment.

### Description of user facing changes
Add-on update notifications should not occur on the launcher any more

### Description of development approach
Check `NVDAState.shouldWriteToDisk` rather than `globalVars.appArgs.secure`.

### Testing strategy:
Tested STR of #16783

### Known issues with pull request:

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced the logic for automatic addon updates based on disk write permissions and update settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
