### PR TITLE
Portable copy safe creation fixups

### DIFF
--- a/source/core.py
+++ b/source/core.py
@@ -806,12 +806,15 @@ def main():
 		)
 	elif globalVars.appArgs.portablePath and (globalVars.appArgs.createPortable or globalVars.appArgs.createPortableSilent):
 		import gui.installerGui
+		isUpdate = gui.installerGui._nvdaExistsInDir(globalVars.appArgs.portablePath)
+		# If we are updating, we don't want to warn for non-empty directory.
+		warnForNonEmptyDirectory = not isUpdate and not globalVars.appArgs.createPortableSilent
 		wx.CallAfter(
 			gui.installerGui.doCreatePortable,
 			portableDirectory=globalVars.appArgs.portablePath,
 			silent=globalVars.appArgs.createPortableSilent,
 			startAfterCreate=not globalVars.appArgs.createPortableSilent,
-			warnForNonEmptyDirectory=not globalVars.appArgs.createPortableSilent,
+			warnForNonEmptyDirectory=warnForNonEmptyDirectory,
 		)
 	elif not globalVars.appArgs.minimal:
 		try:

--- a/source/gui/installerGui.py
+++ b/source/gui/installerGui.py
@@ -341,46 +341,48 @@ def showInstallGui():
 	gui.mainFrame.postPopup()
 
 
+def _nvdaExistsInDir(directory: str) -> bool:
+	return os.path.exists(os.path.join(directory, "nvda.exe"))
+
+
 def _warnAndConfirmForNonEmptyDirectory(portableDirectory: str) -> bool:
 	"""
 	Display a warning message if the specified directory is not empty.
 	:param portableDirectory: The directory to check.
 	:return: True if the user wants to continue, False if the user wants to cancel.
 	"""
-	if os.path.exists(portableDirectory):
-		dirContents = os.listdir(portableDirectory)
-	else:
-		dirContents = []
-	if len(dirContents) > 0:
-		if "nvda.exe" in dirContents:
-			if wx.NO == gui.messageBox(
-				_(
-					# Translators: The message displayed when the user has specified a destination directory
-					# that already has a portable copy in the Create Portable NVDA dialog.
-					f"A portable copy already exists in the directory '{portableDirectory}'. "
-					"Do you want to update it?"
-				),
-				# Translators: The title of a dialog presented when the user has specified a destination directory
-				# that already has a portable copy in the Create Portable NVDA dialog.
-				_("Portable Copy Exists"),
-				wx.YES_NO | wx.ICON_QUESTION
-			):
-				return False
-		elif wx.NO == gui.messageBox(
+	if not os.path.exists(portableDirectory):
+		# The directory does not exist, so we can proceed.
+		return True
+	if not any(os.scandir(portableDirectory)):
+		# The directory is empty, so we can proceed.
+		return True
+	if _nvdaExistsInDir(portableDirectory):
+		return wx.YES == gui.messageBox(
 			_(
 				# Translators: The message displayed when the user has specified a destination directory
-				# that already exists in the Create Portable NVDA dialog.
-				f"The specified directory '{portableDirectory}' is not empty. "
-				"Proceeding will delete and replace existing files in the directory. "
-				"Do you want to overwrite the contents of this folder? "
-			),
+				# that already has a portable copy in the Create Portable NVDA dialog.
+				"A portable copy already exists in the directory '{portableDirectory}'. "
+				"Do you want to update it?"
+			).format(portableDirectory=portableDirectory),
 			# Translators: The title of a dialog presented when the user has specified a destination directory
-			# that already exists in the Create Portable NVDA dialog.
-			_("Directory Exists"),
+			# that already has a portable copy in the Create Portable NVDA dialog.
+			_("Portable Copy Exists"),
 			wx.YES_NO | wx.ICON_QUESTION
-		):
-			return False
-	return True
+		)
+	return wx.YES == gui.messageBox(
+		_(
+			# Translators: The message displayed when the user has specified a destination directory
+			# that already exists in the Create Portable NVDA dialog.
+			"The specified directory '{portableDirectory}' is not empty. "
+			"Proceeding will delete and replace existing files in the directory. "
+			"Do you want to overwrite the contents of this folder? "
+		).format(portableDirectory=portableDirectory),
+		# Translators: The title of a dialog presented when the user has specified a destination directory
+		# that already exists in the Create Portable NVDA dialog.
+		_("Directory Exists"),
+		wx.YES_NO | wx.ICON_QUESTION
+	)
 
 
 def _getUniqueNewPortableDirectory(basePath: str) -> str:


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Fixup of #16686 
Fixes #16847 

### Summary of the issue:
When updating a portable copy either from the auto-update check UX, or through the portable copy CLI, a warning is shown to confirm if a user wants to update and overwrite the portable copy.
This is not ideal UX, as the update check UX should assume the user wants to update, same with the portable copy CLI.

Additionally, some translator strings in #16686 were not formatted correctly

### Description of user facing changes
Warnings are no longer shown when updating a portable copy via the auto-update UX or via CLI.
Warnings are still shown when overwriting any other directory via CLI.

Messages in warning dialogs are now translatable correctly

### Description of development approach
Fix format of translation strings

check if an update is being performed when creating a portable copy via CLI, do not warn in that case.
The portable copy auto-update UX uses the CLI to perform the update.

### Testing strategy:

- [x] Re-test steps in #16686
  - Ensure warnings still occur when updating a portable copy through the menu of an NVDA copy or the launcher dialog
- [x] Test STR in #16847

### Known issues with pull request:

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new variable to handle updates in portable installations.
  - Added checks for existing NVDA installations in specified directories.
  
- **Bug Fixes**
  - Improved logic for warning and confirmation dialogs related to non-empty directories during installations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
