### PR TITLE
ia2TextMozilla: expose name as content for any non-contenteditable within a contenteditable. Required to report addresses in outlook.com / Modern Outlook To/CC/BCC fields.

### DIFF
--- a/source/NVDAObjects/IAccessible/ia2TextMozilla.py
+++ b/source/NVDAObjects/IAccessible/ia2TextMozilla.py
@@ -24,7 +24,6 @@ from . import IA2TextTextInfo, IAccessible
 from compoundDocuments import CompoundTextInfo
 import locationHelper
 from logHandler import log
-import controlTypes
 
 
 class FakeEmbeddingTextInfo(offsets.OffsetsTextInfo):

--- a/source/NVDAObjects/IAccessible/ia2TextMozilla.py
+++ b/source/NVDAObjects/IAccessible/ia2TextMozilla.py
@@ -24,6 +24,7 @@ from . import IA2TextTextInfo, IAccessible
 from compoundDocuments import CompoundTextInfo
 import locationHelper
 from logHandler import log
+import controlTypes
 
 
 class FakeEmbeddingTextInfo(offsets.OffsetsTextInfo):
@@ -80,6 +81,16 @@ class MozillaCompoundTextInfo(CompoundTextInfo):
 		uniqueID = obj.IA2UniqueID
 		if uniqueID is not None:
 			controlField["uniqueID"] = uniqueID
+		# #16631: Outlook.com /modern Outlook represent addresses in To/CC/BCC fields as labelled buttons.
+		# These buttons are non-contenteditable within a parent contenteditable.
+		# Ensure their label (name) is reported as the content
+		# as the caret cannot move through them.
+		if (
+			controlTypes.state.State.EDITABLE not in obj.states
+			and obj.parent
+			and controlTypes.state.State.EDITABLE in obj.parent.states
+		):
+			controlField['content'] = obj.name
 		return controlField
 
 	def _isCaretAtEndOfLine(self, caretObj: IAccessible) -> bool:

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -81,6 +81,7 @@ A warning message will inform you if you try writing to a non-empty directory. (
 * Speech is no longer silent after disconnecting from and reconnecting to a Remote Desktop session. (#16722, @jcsteh)
 * Support added for text review commands for an object's name in Visual Studio Code. (#16248, @Cary-Rowen)
 * Playing NVDA sounds no longer fails on a mono audio device. (#16770, @jcsteh)
+* NVDA will report addresses when arrowing through To/CC/BCC fields in outlook.com / Modern Outlook. (#16856)
 
 ### Changes for Developers
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Fixes #16631

### Summary of the issue:
In outlook.com or Modern Outlook (Monarch) app, when arrowing through the To/CC/BCC fields, NVDA only reports button graphic for email addresses, and does not report the actual name/ address. 
This is because NVDA knows it is in a contenteditable / editable text field, and assumes that all the content can be moved through by character, and therefore does not include meta info such as name on ancestor elements. 
However, in this case, the addresses are actually on-contenteditable buttons within the contenteditable, which means that each button only takes up one character stop, and its content does not contain the name / address.

### Description of user facing changes
NVDA now reports addresses when arrowing through To/CC/BCC fields in outlook.com / the Modern Outlook app.

### Description of development approach
In ia2TextMozilla compound textInfo: conrolFields or objects that are non-contenteditable (don't have the editable state) are within a contenteditable (do have the editable state), have their 'content' key set to the object's name. Which forces NVDA to report the name as the content.

### Testing strategy:
In outlook.com / Modern Outlook, created a new email message. Focused on the To field and inserted several email addresses. Then arrowed between them with the left and right arrow keys, ensuring that the addresses were reported.

### Known issues with pull request:
Reporting of these addresses is still quite verbose. E.g. "button available Michael Curran mick@nvaccess.org graphic available"
And then arrowing onto another one:
"out of graphic out of button button available Gerald Hartig gerald@nvaccess.org"

Perhaps outlook.com / Modern Outlook could hide the inner graphic from the accessibility tree. And or, NVDA could somehow for non-contenteditable fields, generate a control field that does not require reporting out of at the end. E.g. like a checkbox or separator.
But at very least, this pr is a necessary improvement as before the addresses were not being reported at all.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of specific control types for better compatibility with Outlook.com.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
