### PR TITLE
Revert "ia2TextMozilla: expose name as content for any non-contenteditable within a contenteditable. Required to report addresses in outlook.com / Modern Outlook To/CC/BCC fields."

### DIFF
--- a/source/NVDAObjects/IAccessible/ia2TextMozilla.py
+++ b/source/NVDAObjects/IAccessible/ia2TextMozilla.py
@@ -80,16 +80,6 @@ class MozillaCompoundTextInfo(CompoundTextInfo):
 		uniqueID = obj.IA2UniqueID
 		if uniqueID is not None:
 			controlField["uniqueID"] = uniqueID
-		# #16631: Outlook.com /modern Outlook represent addresses in To/CC/BCC fields as labelled buttons.
-		# These buttons are non-contenteditable within a parent contenteditable.
-		# Ensure their label (name) is reported as the content
-		# as the caret cannot move through them.
-		if (
-			controlTypes.state.State.EDITABLE not in obj.states
-			and obj.parent
-			and controlTypes.state.State.EDITABLE in obj.parent.states
-		):
-			controlField['content'] = obj.name
 		return controlField
 
 	def _isCaretAtEndOfLine(self, caretObj: IAccessible) -> bool:

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -81,7 +81,6 @@ A warning message will inform you if you try writing to a non-empty directory. (
 * Speech is no longer silent after disconnecting from and reconnecting to a Remote Desktop session. (#16722, @jcsteh)
 * Support added for text review commands for an object's name in Visual Studio Code. (#16248, @Cary-Rowen)
 * Playing NVDA sounds no longer fails on a mono audio device. (#16770, @jcsteh)
-* NVDA will report addresses when arrowing through To/CC/BCC fields in outlook.com / Modern Outlook. (#16856)
 * NVDA now handles add-on installation failures more gracefully. (#16704)
 
 ### Changes for Developers


### PR DESCRIPTION
Reverts nvaccess/nvda#16856
There were valid system tests that failed with the merging of pr #16856 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Removed logic that caused NVDA to report addresses in To/CC/BCC fields as labelled buttons in Outlook.com/Modern Outlook. This improves the accuracy and reliability of content reporting in these fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->