### PR TITLE
Fix `exc_info` parameter for `log.exception`

### DIFF
--- a/source/logHandler.py
+++ b/source/logHandler.py
@@ -279,7 +279,7 @@ class Logger(logging.Logger):
 			return
 		self._log(log.IO, msg, args, **kwargs)
 
-	def exception(self, msg: str = "", exc_info: Literal[True] | _excInfo_t = True, **kwargs):
+	def exception(self, msg: str = "", exc_info: Literal[True] | _excInfo_t | BaseException = True, **kwargs):
 		"""Log an exception at an appropriate level.
 		Normally, it will be logged at level "ERROR".
 		However, certain exceptions which aren't considered errors (or aren't errors that we can fix) are expected and will therefore be logged at a lower level.
@@ -288,8 +288,11 @@ class Logger(logging.Logger):
 
 		if exc_info is True:
 			exc_info = sys.exc_info()
+		if isinstance(exc_info, tuple):
+			exc = exc_info[1]
+		else:
+			exc = exc_info
 
-		exc = exc_info[1]
 		if (
 			(
 				isinstance(exc, WindowsError)


### PR DESCRIPTION
### Link to issue number:
None
### Summary of the issue:
According to its type hints and its code, `log.exception` can accept either `True` or a tuple as returned by `sys.exc_info()` as `exc_info` parameter.
However, at least one function in NVDA expect it to also accept an exception instance: see `log.exception` call in `_getCurrentSessionInfoEx` in `winAPI\sessionTracking.py`.
Forcing an exception in the try block of this function unproperly raises:
`TypeError: 'RuntimeError' object is not subscriptable`

Also according to my tests, `logHandler.log._log` seems to accept for `exc_info` parameter: `True`, an exception instance or an exception tuple (in the format returned by `sys.exc_info()`), so it would make sense to be consistent with it.

At last, according to Python doc of [logging](https://docs.python.org/3.11/library/logging.html) module, logging function can accept an exception instance as `exc_info` parameter from Python 3.5 onward:
> Changed in version 3.5: The exc_info parameter can now accept exception instances.

### Description of user facing changes
`_getCurrentSessionInfoEx` can now also accept an exception instance as `exc_info` parameter.
### Description of development approach
Modified the function's code and signature.
### Testing strategy:

* In the try block of `_getCurrentSessionInfoEx` in `winAPI\sessionTracking.py`, raise a fake exception and check that it is correctly raised without triggering the previous `TypeError`.
* In Python console, manually test the 3 possible types for `exc_info` parameter.

### Known issues with pull request:
None
### Code Review Checklist:


- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
	- Enhanced logging flexibility by allowing a broader range of exception types to be passed to the logging method.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
