### PR TITLE
UIA handler/notification event handling: fetch native window handle if present in runtime ID

### DIFF
--- a/source/UIAHandler/__init__.py
+++ b/source/UIAHandler/__init__.py
@@ -1069,7 +1069,7 @@ class UIAHandler(COMObject):
 					)
 					return
 		try:
-			obj = NVDAObjects.UIA.UIA(UIAElement=sender)
+			obj = NVDAObjects.UIA.UIA(windowHandle=window, UIAElement=sender)
 		except Exception:
 			if _isDebug():
 				log.debugWarning(

--- a/source/UIAHandler/__init__.py
+++ b/source/UIAHandler/__init__.py
@@ -1037,8 +1037,10 @@ class UIAHandler(COMObject):
 			return
 		import NVDAObjects.UIA
 
-		# #16871: some elements do not report native window handle when in fact
-		# native window handle is shown via runtime ID.
+		# #16871: some elements do not report native window handle.
+		# Sometimes native window handle is reported by runtime ID (typically a tuple of four items)
+		# but runtime ID tuple might be empty or may have different lengths sometimes.
+		# Therefore, handle runtime ID tuple of four elements.
 		# This is seen when handling Windows 11 Voice Access notifications.
 		if not (window := self.getNearestWindowHandle(sender)):
 			if _isDebug():
@@ -1048,8 +1050,8 @@ class UIAHandler(COMObject):
 					f"displayString={displayString} "
 					f"activityId={activityId}"
 				)
-			if any(runtimeID := sender.getRuntimeID()):
-				# Second item in runtime ID array is native window handle.
+			if len(runtimeID := sender.getRuntimeID()) == 4:
+				# Second item in four element runtime ID array is native window handle.
 				window = runtimeID[1]
 				if _isDebug():
 					log.debugWarning(

--- a/source/UIAHandler/__init__.py
+++ b/source/UIAHandler/__init__.py
@@ -1037,6 +1037,37 @@ class UIAHandler(COMObject):
 			return
 		import NVDAObjects.UIA
 
+		# #16871: some elements do not report native window handle when in fact
+		# native window handle is shown via runtime ID.
+		# This is seen when handling Windows 11 Voice Access notifications.
+		if not (window := self.getNearestWindowHandle(sender)):
+			if _isDebug():
+				log.debugWarning(
+					"HandleNotificationEvent: native window handle not found, consulting runtime ID: "
+					f"NotificationProcessing={NotificationProcessing} "
+					f"displayString={displayString} "
+					f"activityId={activityId}"
+				)
+			if any(runtimeID := sender.getRuntimeID()):
+				# Second item in runtime ID array is native window handle.
+				window = runtimeID[1]
+				if _isDebug():
+					log.debugWarning(
+						f"HandleNotificationEvent: native window handle is {window}: "
+						f"NotificationProcessing={NotificationProcessing} "
+						f"displayString={displayString} "
+						f"activityId={activityId}"
+					)
+			else:
+				# No runtime ID (tuple is empty).
+				if _isDebug():
+					log.debugWarning(
+						"HandleNotificationEvent: native window handle not found in runtime ID: "
+						f"NotificationProcessing={NotificationProcessing} "
+						f"displayString={displayString} "
+						f"activityId={activityId}"
+					)
+					return
 		try:
 			obj = NVDAObjects.UIA.UIA(UIAElement=sender)
 		except Exception:

--- a/source/UIAHandler/__init__.py
+++ b/source/UIAHandler/__init__.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2008-2023 NV Access Limited, Joseph Lee, Babbage B.V., Leonard de Ruijter, Bill Dengler
+# Copyright (C) 2008-2024 NV Access Limited, Joseph Lee, Babbage B.V., Leonard de Ruijter, Bill Dengler
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 

--- a/source/UIAHandler/__init__.py
+++ b/source/UIAHandler/__init__.py
@@ -1019,7 +1019,7 @@ class UIAHandler(COMObject):
 		NotificationKind: int,
 		NotificationProcessing: int,
 		displayString: str,
-		activityId: str
+		activityId: str,
 	) -> None:
 		if _isDebug():
 			log.debug(

--- a/source/UIAHandler/__init__.py
+++ b/source/UIAHandler/__init__.py
@@ -1015,12 +1015,12 @@ class UIAHandler(COMObject):
 
 	def IUIAutomationNotificationEventHandler_HandleNotificationEvent(
 		self,
-		sender,
-		NotificationKind,
-		NotificationProcessing,
-		displayString,
-		activityId,
-	):
+		sender: UIA.IUIAutomationElement,
+		NotificationKind: int,
+		NotificationProcessing: int,
+		displayString: str,
+		activityId: str
+	) -> None:
 		if _isDebug():
 			log.debug(
 				"handleNotificationEvent called "

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -18,6 +18,7 @@
 * NVDA once again relies on events for caret movement in several cases, rather than only on manual querying of the caret position.
   * UIA for XAML and WPF text controls. (#16817, @LeonarddeR)
   * IAccessible2 for browsers such as Firefox and Chromium based browsers. (#11545, #16815, @LeonarddeR)
+* NVDA can announce more UIA notifications in apps such as Windows 11 Voice Access. (#16871, @josephsl)
 
 
 ### Changes for Developers


### PR DESCRIPTION

### Link to issue number:
Closes #16871

### Summary of the issue:
NVDA does not handle UIA notification events for elements with native window handle despite shown in runtime ID.

### Description of user facing changes
NVDA will announce UIA notifications in more apps such as Windows 11 Voice Access.

### Description of development approach
Updated UIA handler/notification event handler:

* Added type hints for event arguments.
* If UIAHandler.handler.getNearestWindowHandle method returns None (for the sender), look at the sender's (element's) runtime ID tuple, returning early if the tuple is empty.
* Pass in the just obtained native window handle to UIA NVDA object constructor.

### Testing strategy:
Manual testing (see #16862 for details):

1. Run Voice Access (Windows 11 2022 Update).
2. After confugiring the microphone, press Space on "microphone active/sleep" button.
3. Observe NVDA's UIA notificatoin event handler (should announce changed mic state).

Note that the test build must be installed or run with admin rights.

### Known issues with pull request:
In some cases runtime ID is empty, and for that case, there's nothing NVDA can do. The native window handle check is done early for performance - if UIA NVDA object constructor does not see a window handle, the constructor will call UIAHandler.handler.getNearestWindowHandle method to obtain a window handle. Also, while more UIA notifications are announced, it may need some tweaks such as making sure the window handle is indeed a native window handle, and at least runtime ID tuple check is performed in this PR; these should be dealt with on a ase-by-case basis (as issues arise).

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for NVDA to announce additional UIA notifications in applications, such as Windows 11 Voice Access.
  - Expanded NVDA's utilization of events for caret movement across XAML, WPF text controls, and major browsers, ensuring more consistent and responsive feedback for text cursor positioning.

- **Documentation**
  - Updated documentation to reflect the new enhancements and changes to caret movement handling and UIA notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
