### PR TITLE
Use UIA caret events in Windows Terminal

### DIFF
--- a/source/NVDAObjects/UIA/winConsoleUIA.py
+++ b/source/NVDAObjects/UIA/winConsoleUIA.py
@@ -450,7 +450,7 @@ class _DiffBasedWinTerminalUIA(EnhancedTermTypedCharSupport):
 		"Block notification events when diffing to prevent double reporting."
 		log.debugWarning(f"Notification event blocked to avoid double-report: {kwargs}")
 
-	def _get_caretMovementDetectionUsesEvents(self):
+	def _get_caretMovementDetectionUsesEvents(self) -> bool:
 		"Windows Terminal has a good implementation of caret move detection."
 		return True
 

--- a/source/NVDAObjects/UIA/winConsoleUIA.py
+++ b/source/NVDAObjects/UIA/winConsoleUIA.py
@@ -450,6 +450,10 @@ class _DiffBasedWinTerminalUIA(EnhancedTermTypedCharSupport):
 		"Block notification events when diffing to prevent double reporting."
 		log.debugWarning(f"Notification event blocked to avoid double-report: {kwargs}")
 
+	def _get_caretMovementDetectionUsesEvents(self):
+		"Windows Terminal has a good implementation of caret move detection."
+		return True
+
 
 class _NotificationsBasedWinTerminalUIA(UIA):
 	"""

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -12,12 +12,12 @@
 
 ### Bug Fixes
 
-* NVDA once again relies on UIA events for caret movement in XAML and WPF text controls, rather than only on manual querying of the caret position. (#16817, @LeonarddeR)
-* The Seika Notetaker driver now correctly generates braille input for space, backspace and dots with space/backspace gestures. (#16642, @school510587)
-* In on-demand speech mode, NVDA does not talk anymore when a message is opened in Outlook, when a new page is loaded in a browser or during the slideshow in PowerPoint. (#16825, @CyrilleB79)
 * NVDA once again relies on events for caret movement in several cases, rather than only on manual querying of the caret position.
   * UIA for XAML and WPF text controls. (#16817, @LeonarddeR)
   * IAccessible2 for browsers such as Firefox and Chromium based browsers. (#11545, #16815, @LeonarddeR)
+  * UIA in Windows Terminal. (#16873, @codeofdusk)
+* The Seika Notetaker driver now correctly generates braille input for space, backspace and dots with space/backspace gestures. (#16642, @school510587)
+* In on-demand speech mode, NVDA does not talk anymore when a message is opened in Outlook, when a new page is loaded in a browser or during the slideshow in PowerPoint. (#16825, @CyrilleB79)
 
 
 ### Changes for Developers


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Follow-up of #16711, #16817.

### Summary of the issue:
UIA caret events in Windows Terminal were unreliable before #16711. In particular, when rapidly pressing backspace, sometimes the last character of the prompt would be erroneously read.

### Description of how this pull request fixes the issue:
Re-enable caret events in Windows Terminal specifically. Note that caret events are still broken in this way in Conhost and are therefore left disabled.

### Testing strategy:
Active daily use of an NVDA build containing this change, much of which is in Windows Terminal. Alpha testing.

### Known issues with pull request:
None known

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Enhanced caret movement detection for better performance in various scenarios.
  - Improved support using UIA for XAML and WPF text controls.
  - Enhanced browser support using IAccessible2.

- **Bug Fixes**
  - Fixed issues with the Seika Notetaker driver handling braille input gestures correctly.
  - Refined behavior of NVDA's on-demand speech mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->