### PR TITLE
Avoid crash in Chrome, issue 41487612

### DIFF
--- a/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.cpp
+++ b/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.cpp
@@ -1515,6 +1515,7 @@ GeckoVBufBackend_t::~GeckoVBufBackend_t() {
 	// However in the unlikely case terminate can't run,
 	// it will be deleted along with the backend, but in an RPC thread!
 	// Therefore in this case deliberately leak the COM object, which is better than a crash. 
+	nhAssert(!rootDocAcc);
 	if(this->rootDocAcc) {
 		this->rootDocAcc.Detach();
 	}

--- a/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.cpp
+++ b/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.cpp
@@ -1479,7 +1479,7 @@ void GeckoVBufBackend_t::renderThread_terminate() {
 	// The backend holds a reference to the root accessible of the document.
 	// This must be specifically released here, in the UI thread where it was created.
 	// See https://issues.chromium.org/issues/41487612
-	if(this->rootDocAcc) {
+	if (this->rootDocAcc) {
 		this->rootDocAcc.Release();
 	}
 }
@@ -1513,11 +1513,11 @@ GeckoVBufBackend_t::~GeckoVBufBackend_t() {
 	// See https://issues.chromium.org/issues/41487612
 	// In most cases this will be released in renderThread_terminate.
 	// However in the unlikely case terminate can't run,
-	// We must detach and leak the COM pointer here,
-	// Otherwise it  would be automatically  deleted along with the backend which would cause a crash,
+	// we must detach and leak the COM pointer here.
+	// Otherwise it would be automatically deleted along with the backend which would cause a crash,
 	// as the COM object would be released from within an RPC worker thread.
 	nhAssert(!rootDocAcc);
-	if(this->rootDocAcc) {
+	if (this->rootDocAcc) {
 		this->rootDocAcc.Detach();
 	}
 }

--- a/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.cpp
+++ b/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.cpp
@@ -1513,8 +1513,9 @@ GeckoVBufBackend_t::~GeckoVBufBackend_t() {
 	// See https://issues.chromium.org/issues/41487612
 	// In most cases this will be released in renderThread_terminate.
 	// However in the unlikely case terminate can't run,
-	// it will be deleted along with the backend, but in an RPC thread!
-	// Therefore in this case deliberately leak the COM object, which is better than a crash. 
+	// We must detach and leak the COM pointer here,
+	// Otherwise it  would be automatically  deleted along with the backend which would cause a crash,
+	// as the COM object would be released from within an RPC worker thread.
 	nhAssert(!rootDocAcc);
 	if(this->rootDocAcc) {
 		this->rootDocAcc.Detach();

--- a/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.cpp
+++ b/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.cpp
@@ -1476,6 +1476,12 @@ void GeckoVBufBackend_t::renderThread_initialize() {
 void GeckoVBufBackend_t::renderThread_terminate() {
 	unregisterWinEventHook(renderThread_winEventProcHook);
 	VBufBackend_t::renderThread_terminate();
+	// The backend holds a reference to the root accessible of the document.
+	// This must be specifically released here, in the UI thread where it was created.
+	// See https://issues.chromium.org/issues/41487612
+	if(this->rootDocAcc) {
+		this->rootDocAcc.Release();
+	}
 }
 
 void GeckoVBufBackend_t::render(VBufStorage_buffer_t* buffer, int docHandle, int ID, VBufStorage_controlFieldNode_t* oldNode) {
@@ -1502,6 +1508,16 @@ GeckoVBufBackend_t::GeckoVBufBackend_t(int docHandle, int ID): VBufBackend_t(doc
 }
 
 GeckoVBufBackend_t::~GeckoVBufBackend_t() {
+	// The backend holds a reference to the root accessible of the document.
+	// This must be specifically released in the UI thread where it was created.
+	// See https://issues.chromium.org/issues/41487612
+	// In most cases this will be released in renderThread_terminate.
+	// However in the unlikely case terminate can't run,
+	// it will be deleted along with the backend, but in an RPC thread!
+	// Therefore in this case deliberately leak the COM object, which is better than a crash. 
+	if(this->rootDocAcc) {
+		this->rootDocAcc.Detach();
+	}
 }
 
 VBufBackend_t* GeckoVBufBackend_t_createInstance(int docHandle, int ID) {

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -71,6 +71,7 @@ A warning message will inform you if you try writing to a non-empty directory. (
   * NVDA will correctly announce radio and checkbox menu items when first entering sub-menus in Google Chrome and Mozilla Firefox. (#14550)
   * NVDA's browse mode find functionality is now more accurate when the page contains emojis. (#16317, @LeonarddeR)
   * In Mozilla Firefox, NVDA now correctly reports the current character, word and line when the cursor is at the insertion point at the end of a line. (#3156, @jcsteh)
+  * No longer cause Google Chrome to crash when closing a document or exiting Chrome. (#16893)
 * NVDA will announce correctly the autocomplete suggestions in Eclipse and other Eclipse-based environments on Windows 11. (#16416, @thgcode)
 * Improved reliability of automatic text readout, particularly in terminal applications. (#15850, #16027, @Danstiv)
 * NVDA will correctly announce selection changes when editing a cell's text in Microsoft Excel. (#15843)
@@ -83,7 +84,6 @@ A warning message will inform you if you try writing to a non-empty directory. (
 * Playing NVDA sounds no longer fails on a mono audio device. (#16770, @jcsteh)
 * NVDA will report addresses when arrowing through To/CC/BCC fields in outlook.com / Modern Outlook. (#16856)
 * NVDA now handles add-on installation failures more gracefully. (#16704)
-* No longer cause Google Chrome to crash when closing a document or exiting Chrome. (#16893)
 
 ### Changes for Developers
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -83,6 +83,7 @@ A warning message will inform you if you try writing to a non-empty directory. (
 * Playing NVDA sounds no longer fails on a mono audio device. (#16770, @jcsteh)
 * NVDA will report addresses when arrowing through To/CC/BCC fields in outlook.com / Modern Outlook. (#16856)
 * NVDA now handles add-on installation failures more gracefully. (#16704)
+* No longer cause Google Chrome to crash when closing a document or exiting Chrome. (#16893)
 
 ### Changes for Developers
 


### PR DESCRIPTION
### Link to issue number:
Fixes Chrome issue [41487612](https://issues.chromium.org/issues/41487612)
Fixes Chrome crash introduced in NVDA pr #14647

### Summary of the issue:
Google has detected crashes in Chrome when users are running NVDA.
Exact steps to reproduce are not known, but it is when an NVDA virtual buffer is destroyed. Could be on Chrome exit, NVDA exit, or closing a Chrome window.
Chrome issue: https://issues.chromium.org/issues/41487612
It shows that a COM object tries to be released from an RPC worker thread by NVDA's in-process code, which causes Chrome to crash.

NVDA pr #14647 introduced code to hold a reference to the document root accessible on the virtual buffer, so that NVDA could check if the document had died. However, it is this COM object that is automatically released when the virtual buffer id destroyed from an RPC worker thread. 
The COM object should really however be released when the virtual buffer is terminated in the correct UI thread, before destruction.

### Description of user facing changes
No longer cause Google Chrome to crash when closing a document or exiting Chrome.

### Description of development approach
* VBufBackend_gecko_ia2::renderThread_terminate: correctly release the document root accessible.
* VBufBackend_gecko_ia2's destructor: in the very unlikely case where the VBufBackend_gecko_ia2::renderThread_terminate has not been called, detach the document root accessible, leaking it rather than inappropriately releasing it on the wrong thread.
 
### Testing strategy:
* With Firefox and Google Chrome with NvDA running, open and close many documents, and exit the browser many times, ensuring that no crash occurs.

### Known issues with pull request:
In the very unlikely case that the virtual buffer cannot be terminated in the UI thread correctly (Perhaps that thread has been terminated, or the browser is exiting such that wm_destroy messages are not being sent), the document root accessible will be leaked I.e. never released. This may hold memory or other resources. However, the original behaviour of calling release from the wrong thread was much worse as it could crash the browser entirely.
 
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved memory management and resource cleanup to prevent potential memory leaks.
	- Enhanced stability of the backend by ensuring proper handling of critical resources during termination and destruction phases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
