### PR TITLE
Support IAccessible2 "mark" text attribute.

### DIFF
--- a/source/NVDAObjects/IAccessible/__init__.py
+++ b/source/NVDAObjects/IAccessible/__init__.py
@@ -180,6 +180,9 @@ def normalizeIA2TextFormatField(formatField):
 	fontSize = formatField.get("font-size")
 	if fontSize is not None:
 		formatField["font-size"] = FontSize.translateFromAttribute(fontSize)
+	mark = formatField.pop("mark", None)
+	if mark == "true":
+		formatField["marked"] = True
 
 
 class IA2TextTextInfo(textInfos.offsets.OffsetsTextInfo):

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -5,6 +5,7 @@
 ### Important notes
 
 ### New Features
+* In Mozilla Firefox, NVDA will report the highlighted text when a URL containing a text fragment is visited. (#16910, @jcsteh)
 
 ### Bug Fixes
 


### PR DESCRIPTION
### Link to issue number:
None.

### Summary of the issue:
Text fragments is a new web concept that allows you to link directly to a specified piece of arbitrary text on a page without needing a predefined id. For example:
https://www.jantrid.net/#:~:text=browsers%20were%20much%20simpler
As well as scrolling to the element containing the text, the browser will highlight the text. Because this could span a partial object, this can't be exposed using IA2_ROLE_MARK. Instead, similar to spelling errors, this is exposed using an IAccessible2 text attribute, specifically the new attribute mark:true.

This will also be used eventually to support CSS custom highlights.

### Description of user facing changes
In Mozilla Firefox, NVDA will report the highlighted text when a URL containing a text fragment is visited.

### Description of development approach
NVDA already supports the "marked" attribute on FormatFields. To be consistent with IA2_ROLE_MARK, it was decided to name the IA2 attribute "mark" instead of "marked". This PR simply maps the attribute appropriately in `normalizeIA2TextFormatField`.

### Testing strategy:
1. Opened this test case in Firefox Nightly (this isn't enabled in Firefox release yet):
    `data:text/html,<p>The first phrase.</p><p>The second <b>phrase.</b></p>#:~:text=second phrase`
2. Moved to the second line.
3. Verified that NVDA reported "The marked second phrase not marked."

### Known issues with pull request:
None with the PR itself.

I did notice that we report "highlighted" for `controlTypes.Role.MARKED_CONTENT`, but we report "marked" for the marked FormatField key, even though these are the same concept. I wonder whether the marked FormatField key should report "highlighted" instead.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced accessibility in Mozilla Firefox by enabling NVDA to report highlighted text when visiting URLs with text fragments.
- **Bug Fixes**
	- Improved processing of the `formatField` attribute, ensuring accurate handling of the `mark` key for better functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
