### PR TITLE
IA2TextTextInfo.expand: Correctly add the text start offset when adjusting for embedded objects during mouse navigation.

### DIFF
--- a/source/NVDAObjects/IAccessible/__init__.py
+++ b/source/NVDAObjects/IAccessible/__init__.py
@@ -248,18 +248,19 @@ class IA2TextTextInfo(textInfos.offsets.OffsetsTextInfo):
 			# over "before" would just read "before", mousing over "link" would read
 			# "link" and mousing over "after" would just read "after".
 			text = self._getTextRange(self._startOffset, self._endOffset)
+			textStart = self._startOffset
 			if not text:
 				return
 			# Make our origin relative to the start of the text we just retrieved.
 			relativeOrigin = origin - self._startOffset
 			try:
 				# Shrink the start to the nearest embedded object before our origin.
-				self._startOffset = text.rindex(textUtils.OBJ_REPLACEMENT_CHAR, 0, relativeOrigin)
+				self._startOffset = textStart + text.rindex(textUtils.OBJ_REPLACEMENT_CHAR, 0, relativeOrigin)
 			except ValueError:
 				pass
 			try:
 				# Shrink the end to the nearest embedded object after our origin.
-				self._endOffset = text.index(textUtils.OBJ_REPLACEMENT_CHAR, relativeOrigin)
+				self._endOffset = textStart + text.index(textUtils.OBJ_REPLACEMENT_CHAR, relativeOrigin)
 			except ValueError:
 				pass
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -20,6 +20,7 @@
 * When accessing Microsoft Word without UI Automation, NVDA no longer outputs garbage characters in braille in table headers defined with the set row and column header commands. (#7212)
 * The Seika Notetaker driver now correctly generates braille input for space, backspace and dots with space/backspace gestures. (#16642, @school510587)
 * In on-demand speech mode, NVDA does not talk anymore when a message is opened in Outlook, when a new page is loaded in a browser or during the slideshow in PowerPoint. (#16825, @CyrilleB79)
+* In Mozilla Firefox, moving the mouse over text before or after a link now reliably reports the text. (#15990, @jcsteh)
 
 
 ### Changes for Developers


### PR DESCRIPTION
### Link to issue number:
Fixes #15990.

### Summary of the issue:
In Firefox, when a paragraph, line, etc. contains links (or other elements), moving the mouse over text before or after the link sometimes doesn't report the text correctly. I attempted to fix this in #14755, and while my fix did work in some cases, it seems it wasn't quite complete.

### Description of user facing changes
In Mozilla Firefox, moving the mouse over text before or after a link now reliably reports the text.

### Description of development approach
To search for embedded objects, `IA2TextTextInfo.expand` fetches the text between the expanded start and end offsets. Previously, when adjusting the offsets if an embedded object was found, the code didn't add the offset from the start of the object to the start of the retrieved text. Now it does.

### Testing strategy:
Verified that the reported failures in https://github.com/nvaccess/nvda/issues/15990#issue-2061094062 and https://github.com/nvaccess/nvda/issues/16902#issue-2427425678 work as expected with this change.
Also verified with this distilled test case:
`data:text/html,<p>ab<br>bcd <a href="/">efg</a> hij`
Before this change, with mouse reading unit set to paragraph, moving the mouse to b only reported "b" and moving the mouse to h reported "cd hij". After this change, moving the mouse to b reports "bcd" and moving the mouse to h reports "hij", as expected.

### Known issues with pull request:
None.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced text reporting for links in Mozilla Firefox, ensuring consistent and accurate text feedback when hovering the mouse over links.
  
- **Bug Fixes**
	- Improved accuracy of text range offsets in the `expand` method, refining the detection of embedded objects within text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
