### PR TITLE
MozillaCompoundTextInfo: Don't adjust for the end of a line at the end of an object.

### DIFF
--- a/source/NVDAObjects/IAccessible/ia2TextMozilla.py
+++ b/source/NVDAObjects/IAccessible/ia2TextMozilla.py
@@ -106,10 +106,12 @@ class MozillaCompoundTextInfo(CompoundTextInfo):
 			# means this is not the insertion point at the end of a line.
 			if start != end:
 				return False
-			# If there is a line feed before us, this is an empty line. We don't want
-			# to do any special adjustment in this case. Otherwise, we will report the
-			# previous line instead of the empty one.
-			if start > 0 and caretObj.IAccessibleTextObject.text(start - 1, start) == "\n":
+			# If this is the end of the object, it might be the end of a line, but it
+			# might just be the end of the object on a line containing multiple objects.
+			# It's also possible that this is an empty last line, in which case any
+			# adjustment would cause us to report the previous line instead of the empty
+			# one. Either way, we don't need the special end of line adjustment.
+			if start > 0 and start == caretObj.IAccessibleTextObject.nCharacters:
 				return False
 			return True
 		except COMError:


### PR DESCRIPTION
### Link to issue number:
Fixup of #16745.

### Summary of the issue:
In my work on #16745, I apparently neglected to consider the end of an inline object such as a link. In that case, adjusting for the line end caused NVDA to report blank when moving to the character after the link instead of reporting the actual character.

### Description of user facing changes
When editing text in Firefox, NVDA now reports the correct character instead of blank when pressing right arrow to move out of a link. This doesn't need a change log entry if we can get this into beta because the bug will not have shipped in release.

### Description of development approach
Return False in `_isCaretAtEndOfLine` if we're at the end of an object. While the end of an object could indeed be the end of a line, we don't need the special adjustment in this case and the adjustment causes problems if it isn't the end of a line.

This also means we can remove the change in #16763 because that was only ever a problem for a line feed at the end of an object anyway. This new fix covers both cases.

### Testing strategy:
Performed the tests described in #16745 and #16763. In addition, I tested the following in both Firefox and Chrome:

1. Opened this test case:
    `data:text/html,<div contenteditable>a<a href="/">b</a>c</div>`
2. Focused the editable.
3. Pressed right arrow.
    - Observe: NVDA reports "link, b"
4. Pressed right arrow.
    - Incorrect result in Firefox before this change: "blank"
    - Correct result in Firefox after this change (and result in Chrome before and after the change): "out of link, c"

### Known issues with pull request:
None.

### Code Review Checklist:
- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved logic for determining the caret's position at the end of a line or object, enhancing the overall text navigation experience.
  
- **Bug Fixes**
	- Fixed issues with caret position reporting, ensuring accurate identification when at the end of an empty line or text object.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
