### PR TITLE
Handle "number of Braille cells" usage in HID Braille standard

### DIFF
--- a/source/brailleDisplayDrivers/hidBrailleStandard.py
+++ b/source/brailleDisplayDrivers/hidBrailleStandard.py
@@ -199,7 +199,10 @@ class HidBrailleDriver(braille.BrailleDisplayDriver):
 		for dataItem in report.getDataItems():
 			if dataItem.DataIndex in self._inputButtonCapsByDataIndex and dataItem.u1.On:
 				keys.append(dataItem.DataIndex)
-			elif self._numberOfCellsValueCaps and dataItem.DataIndex == self._numberOfCellsValueCaps.u1.NotRange.DataIndex:
+			elif (
+				self._numberOfCellsValueCaps
+				and dataItem.DataIndex == self._numberOfCellsValueCaps.u1.NotRange.DataIndex
+			):
 				self.numCells = dataItem.u1.RawValue
 		if len(keys) > len(self._keysDown):
 			# Press. This begins a new key combination.

--- a/source/brailleDisplayDrivers/hidBrailleStandard.py
+++ b/source/brailleDisplayDrivers/hidBrailleStandard.py
@@ -141,7 +141,7 @@ class HidBrailleDriver(braille.BrailleDisplayDriver):
 				return valueCaps
 		return None
 
-	def _findNumberOfCellsValueCaps(self) -> Optional[hidpi.HIDP_VALUE_CAPS]:
+	def _findNumberOfCellsValueCaps(self) -> hidpi.HIDP_VALUE_CAPS | None:
 		for valueCaps in self._dev.inputValueCaps:
 			if (
 				valueCaps.LinkUsagePage == HID_USAGE_PAGE_BRAILLE


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
None applies
### Summary of the issue:
Standard HID Braille displays can inform the screen reader about the number of available Braille cells. For instance, an 80 cells Braille display can decide to use 20 cells for internal purposes and leave 60 cells for use by the screen reader. The device communicates this to the host by setting a certain HID usage to the number of available cells. The screen reader should still send as many cells as determined by the report descriptor, but all cells in excess of the number given in the "number of Braille cells" usage will be ignored by the device.
### Description of user facing changes
The number of Braille cells assumed by NVDA will match the one given by the device in its "number of Braille cells" usage.
### Description of development approach
The HID driver was modified to scan the report descriptor for the usage in question. If found, it will subsequently be honored.
### Testing strategy:
Tested with a Help Tech Activator device which implements the usage.
### Known issues with pull request:
None
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [ ] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved responsiveness of Braille display by dynamically adjusting the number of cells according to input data.
	- Enhanced the display method to ensure consistent output report length.

- **Bug Fixes**
	- Improved handling of Braille display capabilities for more accurate device representation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
