### PR TITLE
Fixed a bug where NVDA sometimes was unable to reset the configuration to factory defaults when using the NVDA+control+r command

### DIFF
--- a/source/inputCore.py
+++ b/source/inputCore.py
@@ -531,16 +531,23 @@ class InputManager(baseObject.AutoPropertyObject):
 		if speechEffect == gesture.SPEECHEFFECT_CANCEL:
 			# Import late to avoid circular import.
 			import braille
+			if braille.handler:
+				@braille.handler.suppressClearBrailleRegions(script)
+				def suppressCancelSpeech():
+					speech.cancelSpeech()
 
-			@braille.handler.suppressClearBrailleRegions(script)
-			def suppressCancelSpeech():
-				speech.cancelSpeech()
+				queueHandler.queueFunction(
+					queueHandler.eventQueue,
+					suppressCancelSpeech,
+					_immediate=immediate,
+				)
+			else:
+				queueHandler.queueFunction(
+					queueHandler.eventQueue,
+					speech.cancelSpeech,
+					_immediate=immediate,
+				)
 
-			queueHandler.queueFunction(
-				queueHandler.eventQueue,
-				suppressCancelSpeech,
-				_immediate=immediate,
-			)
 		elif speechEffect in (gesture.SPEECHEFFECT_PAUSE, gesture.SPEECHEFFECT_RESUME):
 			queueHandler.queueFunction(queueHandler.eventQueue, speech.pauseSpeech, speechEffect == gesture.SPEECHEFFECT_PAUSE)
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -73,6 +73,7 @@ A warning message will inform you if you try writing to a non-empty directory. (
   * In Mozilla Firefox, NVDA now correctly reports the current character, word and line when the cursor is at the insertion point at the end of a line. (#3156, @jcsteh)
 * NVDA will announce correctly the autocomplete suggestions in Eclipse and other Eclipse-based environments on Windows 11. (#16416, @thgcode)
 * Improved reliability of automatic text readout, particularly in terminal applications. (#15850, #16027, @Danstiv)
+* It is once again possible to reset the configuration to factory defaults reliably. (#16755, @Emil-18)
 * NVDA will correctly announce selection changes when editing a cell's text in Microsoft Excel. (#15843)
 * In applications using Java Access Bridge, NVDA will now correctly read the last blank line of a text instead of repeating the previous line. (#9376, @dmitrii-drobotov)
 * In LibreOffice Writer (version 24.8 and newer), when toggling text formatting (bold, italic, underline, subscript/superscript, alignment) using the corresponding keyboard shortcut, NVDA announces the new formatting attribute (e.g. "Bold on", "Bold off"). (#4248, @michaelweghorn)


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
fixes #16896
### Summary of the issue:
Sometimes, when pressing the NVDA+control+r command three times, NVDA wouldn't reset the configuration to factory defaults, but instead produce the following error
ERROR - keyboardHandler.internal_keyDownEvent (10:14:40.187) - winInputHook (13232):
internal_keyDownEvent
Traceback (most recent call last):
  File "keyboardHandler.pyc", line 245, in internal_keyDownEvent
  File "inputCore.pyc", line 535, in executeGesture
AttributeError: 'NoneType' object has no attribute 'suppressClearBrailleRegions'
### Description of user facing changes
The user will reliably be able to reset the configuration to factory defaults with the NVDA+control+r command
### Description of development approach
the suppressCancelSpeech function is only defined and called if braille.handler is not None, otherwise, speech.cancelSpeech is called
### Testing strategy:
Tested by resetting the configuration to factory defaults and restoring the configuration multiple times by using NVDA+control+r. Everything worked as expected for me.
@CyrilleB79 Could you check if it works for you as well?
### Known issues with pull request:
None
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a reliable method for users to reset their configuration to factory defaults, enhancing usability.
  
- **Bug Fixes**
	- Improved speech cancellation handling in gesture recognition, ensuring a more robust response depending on the availability of the `braille.handler`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
