### PR TITLE
Do not attempt to move out of bounds in IAccessible edit controls

### DIFF
--- a/source/NVDAObjects/IAccessible/__init__.py
+++ b/source/NVDAObjects/IAccessible/__init__.py
@@ -274,7 +274,7 @@ class IA2TextTextInfo(textInfos.offsets.OffsetsTextInfo):
 			raise RuntimeError("no active caret in this object")
 		return offset
 
-	def _setCaretOffset(self, offset):
+	def _setCaretOffset(self, offset: int) -> None:
 		iaTextObject = self.obj.IAccessibleTextObject
 		if offset > (nCharacters := iaTextObject.nCharacters):
 			log.debugWarning(

--- a/source/NVDAObjects/IAccessible/__init__.py
+++ b/source/NVDAObjects/IAccessible/__init__.py
@@ -277,7 +277,10 @@ class IA2TextTextInfo(textInfos.offsets.OffsetsTextInfo):
 	def _setCaretOffset(self, offset):
 		iaTextObject = self.obj.IAccessibleTextObject
 		if offset > (nCharacters := iaTextObject.nCharacters):
-			log.debugWarning(f"{offset=} is greater than IAccessibleText::{nCharacters=}. Clamping to {nCharacters}.", stack_info=True)
+			log.debugWarning(
+				f"{offset=} is greater than IAccessibleText::{nCharacters=}. Clamping to {nCharacters}.",
+				stack_info=True,
+			)
 			offset = nCharacters
 		self.obj.IAccessibleTextObject.SetCaretOffset(offset)
 

--- a/source/NVDAObjects/IAccessible/__init__.py
+++ b/source/NVDAObjects/IAccessible/__init__.py
@@ -275,6 +275,10 @@ class IA2TextTextInfo(textInfos.offsets.OffsetsTextInfo):
 		return offset
 
 	def _setCaretOffset(self, offset):
+		iaTextObject = self.obj.IAccessibleTextObject
+		if offset > (nCharacters := iaTextObject.nCharacters):
+			log.debugWarning(f"{offset=} is greater than IAccessibleText::{nCharacters=}. Clamping to {nCharacters}.", stack_info=True)
+			offset = nCharacters
 		self.obj.IAccessibleTextObject.SetCaretOffset(offset)
 
 	def _getSelectionOffsets(self):

--- a/source/NVDAObjects/IAccessible/ia2TextMozilla.py
+++ b/source/NVDAObjects/IAccessible/ia2TextMozilla.py
@@ -687,6 +687,8 @@ class MozillaCompoundTextInfo(CompoundTextInfo):
 	def move(self, unit, direction, endPoint=None):
 		if direction == 0:
 			return 0
+		if self._makeRawTextInfo(self.obj, textInfos.POSITION_ALL)._getStoryLength() == 0:
+			return 0
 
 		if not endPoint or endPoint == "start":
 			moveTi = self._start

--- a/source/NVDAObjects/IAccessible/ia2TextMozilla.py
+++ b/source/NVDAObjects/IAccessible/ia2TextMozilla.py
@@ -684,7 +684,12 @@ class MozillaCompoundTextInfo(CompoundTextInfo):
 				pass
 		return ti, obj
 
-	def move(self, unit, direction, endPoint=None):
+	def move(
+		self,
+		unit: int,
+		direction: str,
+		endPoint: str | None = None,
+	) -> int:
 		if direction == 0:
 			return 0
 		if self._makeRawTextInfo(self.obj, textInfos.POSITION_ALL)._getStoryLength() == 0:

--- a/source/NVDAObjects/IAccessible/ia2TextMozilla.py
+++ b/source/NVDAObjects/IAccessible/ia2TextMozilla.py
@@ -686,13 +686,13 @@ class MozillaCompoundTextInfo(CompoundTextInfo):
 
 	def move(
 		self,
-		unit: int,
-		direction: str,
+		unit: str,
+		direction: int,
 		endPoint: str | None = None,
 	) -> int:
 		if direction == 0:
 			return 0
-		if self._makeRawTextInfo(self.obj, textInfos.POSITION_ALL)._getStoryLength() == 0:
+		if self.obj.IAccessibleTextObject.nCharacters == 0:
 			return 0
 
 		if not endPoint or endPoint == "start":

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -24,7 +24,7 @@ The available options are:
 * The Seika Notetaker driver now correctly generates braille input for space, backspace and dots with space/backspace gestures. (#16642, @school510587)
 * In on-demand speech mode, NVDA does not talk anymore when a message is opened in Outlook, when a new page is loaded in a browser or during the slideshow in PowerPoint. (#16825, @CyrilleB79)
 * In Mozilla Firefox, moving the mouse over text before or after a link now reliably reports the text. (#15990, @jcsteh)
-
+* NVDA no longer throws an error when panning the braille display forward in some empty edit controls. (#16927)
 
 ### Changes for Developers
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:

Closes #12885
Closes #16314

### Summary of the issue:

When panning the display at the end of some edit controls, NVDA generates an error as it attempts to move to an offset that is out of range.

### Description of user facing changes

The error is no longer encountered. This should not matter to most users, who would not have even known there was an error in the first place. As a result, I have not added a change log entry.

### Description of development approach

Updated `MozillaCompoundTextInfo.move` to return `0` if the underlying object's text length is `0`.
Added a check to `IA2TextTextInfo.setCaretOffset` to clamp `offset` to `IAccessibleText::nCharacters` and log a debug warning.

### Testing strategy:

Tested using the repro steps in the linked issues.

### Known issues with pull request:

None.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved caret positioning by ensuring the offset does not exceed available characters, enhancing reliability.
	- Added a safeguard in the `move` method to handle cases where there is no content, preventing unintended behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
