### PR TITLE
Improve auto-deprecation process

### DIFF
--- a/projectDocs/dev/deprecations.md
+++ b/projectDocs/dev/deprecations.md
@@ -28,7 +28,7 @@ def __getattr__(attrName: str) -> Any:
 
 ## Required API breaking changes
 
-In order to improve the NVDA API, changes that will break future compatibility may be implemented, as long they retain backwards compatibility until the `20XX.1` release.
+In order to improve the NVDA API, changes that will break future compatibility may be implemented, as long as they retain backwards compatibility until the `20XX.1` release.
 
 This can be done by using a version check to automate deprecation.
 For example, if you wish to replace usages of `deprecatedSymbolName` with `newSymbolName`.
@@ -36,7 +36,7 @@ When we begin work on `NEXT_YEAR`, we update `BACK_COMPAT_TO`, which introduces 
 At this stage, `deprecatedSymbolName` will no longer be part of the NVDA API and all internal usages must be removed prior.
 
 ```python
-from addonAPIversion import BACK_COMPAT_TO
+from addonAPIVersion import BACK_COMPAT_TO
 import NVDAState
 if BACK_COMPAT_TO < (NEXT_YEAR, 1, 0) and NVDAState._allowDeprecatedAPI():
 	deprecatedSymbolName = newSymbolName

--- a/projectDocs/dev/deprecations.md
+++ b/projectDocs/dev/deprecations.md
@@ -27,16 +27,18 @@ def __getattr__(attrName: str) -> Any:
 ```
 
 ## Required API breaking changes
+
 In order to improve the NVDA API, changes that will break future compatibility may be implemented, as long they retain backwards compatibility until the `20XX.1` release.
 
 This can be done by using a version check to automate deprecation.
 For example, if you wish to replace usages of `deprecatedSymbolName` with `newSymbolName`.
-When we begin work on `NEXT_YEAR`, `deprecatedSymbolName` will no longer be part of the NVDA API and all internal usages must be removed prior.
+When we begin work on `NEXT_YEAR`, we update `BACK_COMPAT_TO`, which introduces the add-on API breakage warning.
+At this stage, `deprecatedSymbolName` will no longer be part of the NVDA API and all internal usages must be removed prior.
 
 ```python
-from buildVersion import version_year
+from addonAPIversion import BACK_COMPAT_TO
 import NVDAState
-if version_year < NEXT_YEAR and NVDAState._allowDeprecatedAPI():
+if BACK_COMPAT_TO < (NEXT_YEAR, 1, 0) and NVDAState._allowDeprecatedAPI():
 	deprecatedSymbolName = newSymbolName
 ```
 

--- a/source/config/__init__.py
+++ b/source/config/__init__.py
@@ -50,9 +50,9 @@ from typing import (
 	Set,
 	Tuple,
 )
+from addonAPIVersion import BACK_COMPAT_TO
 import NVDAState
 from NVDAState import WritePaths
-from buildVersion import version_year
 
 #: True if NVDA is running as a Windows Store Desktop Bridge application
 isAppX = False
@@ -1308,7 +1308,7 @@ class AggregatedSection:
 		# Alias ["documentFormatting"]["reportFontAttributes"] and ["speech"]["includeCLDR"]
 		# for backwards compatibility.
 		# TODO: Comment out in 2025.1.
-		if version_year < 2025 and NVDAState._allowDeprecatedAPI():
+		if BACK_COMPAT_TO < (2025, 1, 0) and NVDAState._allowDeprecatedAPI():
 			self._linkDeprecatedValues(key, val)
 
 	def _linkDeprecatedValues(self, key: aggregatedSection._cacheKeyT, val: aggregatedSection._cacheValueT):

--- a/source/speech/commands.py
+++ b/source/speech/commands.py
@@ -80,7 +80,7 @@ class _CancellableSpeechCommand(SpeechCommand):
 	def __repr__(self):
 		return (
 			f"CancellableSpeech ("
-			f"{ 'cancelled' if self._checkIfCancelled() else 'still valid' }"
+			f"{ 'cancelled' if self._checkIfCancelled() else 'still valid'}"
 			f"{self._getFormattedDevInfo()}"
 			f")"
 		)


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
None

### Summary of the issue:
The current auto-deprecation process causes API breakages when we branch for the next release, e.g. the start of the 2025.1 release cycle.
When we upgrade `BACK_COMPAT_TO` add-ons begin to receive API breakage warnings. Generally we want to update `BACK_COMPAT_TO` before any API breaking changes.
Sometimes we may start the 2025.1 release cycle, updating `version_year` before we update `BACK_COMPAT_TO`.
This causes API deprecations to break before add-ons are declared as incompatible.

### Description of user facing changes
None

### Description of development approach
minor fix up to existing deprecation pending removal

### Testing strategy:
Test that the boolean for the existing deprecation works as expected by modifying BACK_COMPAT_TO

### Known issues with pull request:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated the NVDA API documentation to clarify breaking changes and deprecation handling, improving clarity on backward compatibility.
  
- **Chores**
	- Enhanced the logic determining deprecated values, transitioning from a static year-based check to a dynamic versioning approach.

- **Style**
	- Minor formatting adjustment in the `__repr__` method of the `CancellableSpeech` class for improved output presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
