### PR TITLE
Fix failing browsable messages

### DIFF
--- a/source/comInterfaces_sconscript
+++ b/source/comInterfaces_sconscript
@@ -90,6 +90,7 @@ comtypes.client.gen_dir = Dir("comInterfaces").abspath
 COM_INTERFACES = {
 	"IAccessible2Lib.py": "typelibs/ia2.tlb",
 	"ISimpleDOM.py": "typelibs/ISimpleDOMNode.tlb",
+	"Scripting.py": ("{420B2830-E718-11CF-893D-00A0C9054228}", 1, 0),  # Used for browseable messages
 	"MathPlayer.py": "typelibs/mathPlayerDLL.tlb",
 	"Accessibility.py": ("{1EA4DBF0-3C3B-11CF-810C-00AA00389B71}", 1, 0),
 	"tom.py": ("{8CC497C9-A1DF-11CE-8098-00AA0047BE5D}", 1, 0),

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -29,6 +29,7 @@ The available options are:
 * In on-demand speech mode, NVDA does not talk anymore when a message is opened in Outlook, when a new page is loaded in a browser or during the slideshow in PowerPoint. (#16825, @CyrilleB79)
 * In Mozilla Firefox, moving the mouse over text before or after a link now reliably reports the text. (#15990, @jcsteh)
 * NVDA no longer throws an error when panning the braille display forward in some empty edit controls. (#16927)
+* NVDA no longer occasionally fails to open browsable messages (such as pressing NVDA+f twice). (#16806, @LeonarddeR)
 * NVDA is no longer unstable after restarting NVDA during an automatic Braille Bluetooth scan. (#16933)
 
 ### Changes for Developers

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -29,7 +29,7 @@ The available options are:
 * In on-demand speech mode, NVDA does not talk anymore when a message is opened in Outlook, when a new page is loaded in a browser or during the slideshow in PowerPoint. (#16825, @CyrilleB79)
 * In Mozilla Firefox, moving the mouse over text before or after a link now reliably reports the text. (#15990, @jcsteh)
 * NVDA no longer throws an error when panning the braille display forward in some empty edit controls. (#16927)
-* NVDA no longer occasionally fails to open browsable messages (such as pressing NVDA+f twice). (#16806, @LeonarddeR)
+* NVDA no longer occasionally fails to open browsable messages (such as pressing `NVDA+f` twice). (#16806, @LeonarddeR)
 * NVDA is no longer unstable after restarting NVDA during an automatic Braille Bluetooth scan. (#16933)
 
 ### Changes for Developers


### PR DESCRIPTION
cc @CyrilleB79 

### Link to issue number:
Fixes #16806 

### Summary of the issue:
Opening browsable messages can sometimes fail. The underlying issue is that this requires a COM Interface wrapper that is not bundled with NVDA. It will therefore be created on the fly and stored in `%temp%\comtypes_cache\nvda-311`

### Description of user facing changes
No crashes, no creation of these modules in temp folder.

### Description of development approach
Added the interface definition to `comInterfaces_sconscript`

### Testing strategy:
* Run from source. Ensure that `.venv\Lib\site-packages\comtypes\gen` won't be populated with `Scripting.py` and `_420B2830_E718_11CF_893D_00A0C9054228_0_1_0.py`
* Run a portable copy. Ensure that `%temp%\comtypes_cache\nvda-311` won't be populated with `Scripting.py` and `_420B2830_E718_11CF_893D_00A0C9054228_0_1_0.py`

### Known issues with pull request:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for the `Scripting.py` interface, enhancing COM interaction capabilities.
  
- **Bug Fixes**
  - Resolved an issue where NVDA occasionally failed to open browsable messages when the NVDA+f command was pressed twice, improving reliability and user experience. 

- **Documentation**
  - Updated changelog to reflect recent improvements and fixes in NVDA.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
