### PR TITLE
Add an --all-cores command line option to scons

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,13 +48,13 @@ repos:
   hooks:
     - id: scons-source
       name: build c/c++ files
-      entry: cmd.exe /c "scons source -j 0"
+      entry: cmd.exe /c "scons source --all-cores"
       language: system
       pass_filenames: false
       types_or: [c, c++]
     - id: checkPot
       name: translation string check
-      entry: cmd.exe /c "scons checkPot -j 0"
+      entry: cmd.exe /c "scons checkPot --all-cores"
       language: system
       pass_filenames: false
       types: [python]

--- a/projectDocs/dev/buildingNVDA.md
+++ b/projectDocs/dev/buildingNVDA.md
@@ -18,6 +18,12 @@ scons source user_docs
 
 While simply testing or committing changes, it may be faster usually just doing `scons source` as user documentation will change each time the revision number changes.
 
+You can speed up scons calls by appending the `--all-cores` parameter to the call, however note that output will be scrambled:
+
+```cmd
+scons source --all-cores
+```
+
 ## Running the Source Code
 It is possible to run NVDA directly from source without having to build the full binary package and launcher.
 To launch NVDA from source, using `cmd.exe`, execute `runnvda.bat` in the root of the repository.

--- a/sconstruct
+++ b/sconstruct
@@ -159,18 +159,23 @@ env = Environment(
 # speed up subsequent runs by checking timestamps of targets and dependencies, and only using md5 if timestamps differ.
 env.Decider("MD5-timestamp")
 
+AddOption(
+	"--all-cores",
+	action="store_true",
+	dest="all_cores",
+	default=False,
+	help="always use the maximum number of available processor cores",
+)
 # Warn to run the build on multiple threads so it runs faster
-numJobs = env.GetOption("num_jobs")
 numCores = multiprocessing.cpu_count()
-if numJobs == 0:
-	numJobs = numCores
-	env.SetOption("num_jobs", numJobs)
-if numJobs < numCores:
+if (allCores := GetOption("all_cores")):
+	SetOption("num_jobs", numCores)
+if (numJobs := GetOption("num_jobs")) < numCores:
 	print(
 		f"Warning: Building with {numJobs} concurrent job{'s' if numJobs != 1 else ''} "
 		f"while {numCores} CPU threads are available. "
 		f"Running SCONS with the parameter '-j{numCores}' may lead to a faster build. "
-		"Running SCONS with parameter '-j0' will automatically pick all available cores. "
+		"Running SCONS with parameter '--all-cores' will automatically pick all available cores. "
 	)
 else:
 	print(f"Building with {numJobs} concurrent jobs")

--- a/sconstruct
+++ b/sconstruct
@@ -171,12 +171,16 @@ numCores = multiprocessing.cpu_count()
 if (allCores := GetOption("all_cores")):
 	SetOption("num_jobs", numCores)
 if (numJobs := GetOption("num_jobs")) < numCores:
-	print(
-		f"Warning: Building with {numJobs} concurrent job{'s' if numJobs != 1 else ''} "
+	msg = "Warning: "
+	if allCores:
+		msg += "Providing both the '--all-cores' and '-j'/'--num-jobs' parameters is not supported. "
+	msg += (
+		f"Building with {numJobs} concurrent job{'s' if numJobs != 1 else ''} "
 		f"while {numCores} CPU threads are available. "
 		f"Running SCONS with the parameter '-j{numCores}' may lead to a faster build. "
-		"Running SCONS with parameter '--all-cores' will automatically pick all available cores. "
+		"Running SCONS with parameter '--all-cores' will automatically pick all available cores."
 	)
+	print(msg)
 else:
 	print(f"Building with {numJobs} concurrent jobs")
 

--- a/sconstruct
+++ b/sconstruct
@@ -164,7 +164,7 @@ AddOption(
 	action="store_true",
 	dest="all_cores",
 	default=False,
-	help="always use the maximum number of available processor cores",
+	help="Use the maximum number of available processor cores",
 )
 # Warn to run the build on multiple threads so it runs faster
 numCores = multiprocessing.cpu_count()

--- a/sconstruct
+++ b/sconstruct
@@ -168,7 +168,7 @@ AddOption(
 )
 # Warn to run the build on multiple threads so it runs faster
 numCores = multiprocessing.cpu_count()
-if (allCores := GetOption("all_cores")):
+if allCores := GetOption("all_cores"):
 	SetOption("num_jobs", numCores)
 if (numJobs := GetOption("num_jobs")) < numCores:
 	msg = "Warning: "

--- a/sconstruct
+++ b/sconstruct
@@ -178,7 +178,7 @@ if (numJobs := GetOption("num_jobs")) < numCores:
 		f"Building with {numJobs} concurrent job{'s' if numJobs != 1 else ''} "
 		f"while {numCores} CPU threads are available. "
 		f"Running SCONS with the parameter '-j{numCores}' may lead to a faster build. "
-		"Running SCONS with parameter '--all-cores' will automatically pick all available cores."
+		"Running SCONS with parameter '--all-cores' will automatically pick all available cores. "
 	)
 	print(msg)
 else:

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -45,7 +45,7 @@ Please refer to [the developer guide](https://www.nvaccess.org/files/nvda/docume
   * Dictionary metadata can be added to an optional `symbolDictionaries` section in the add-on manifest.
   * Please consult the [Custom speech symbol dictionaries section in the developer guide](https://www.nvaccess.org/files/nvda/documentation/developerGuide.html#AddonSymbolDictionaries) for more details.
 * It is now possible to redirect objects retrieved from on-screen coordinates, by using the `NVDAObject.objectFromPointRedirect` method. (#16788, @Emil-18)
-* Running SCons with the parameter `-j0` will automatically pick the maximum number of available CPU cores. (#16868, @LeonarddeR)
+* Running SCons with the parameter `--all-cores` will automatically pick the maximum number of available CPU cores. (#16868, @LeonarddeR)
 
 #### Deprecations
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -45,7 +45,7 @@ Please refer to [the developer guide](https://www.nvaccess.org/files/nvda/docume
   * Dictionary metadata can be added to an optional `symbolDictionaries` section in the add-on manifest.
   * Please consult the [Custom speech symbol dictionaries section in the developer guide](https://www.nvaccess.org/files/nvda/documentation/developerGuide.html#AddonSymbolDictionaries) for more details.
 * It is now possible to redirect objects retrieved from on-screen coordinates, by using the `NVDAObject.objectFromPointRedirect` method. (#16788, @Emil-18)
-* Running SCons with the parameter `--all-cores` will automatically pick the maximum number of available CPU cores. (#16868, @LeonarddeR)
+* Running SCons with the parameter `--all-cores` will automatically pick the maximum number of available CPU cores. (#16943, #16868, @LeonarddeR)
 
 #### Deprecations
 


### PR DESCRIPTION
### Link to issue number:
Fixup for #16868

### Summary of the issue:
As part of #16868, i intended to implement support to pass a number of 0 cores to scons (e.g. `scons source -j0`) to automatically pick all available cores. It turns out that you cant override an option with `SetOption` when set on the command line.

### Description of user facing changes
None, build system related.

### Description of development approach
Added an `--all-cores` parameter that will pick all available cores.

### Testing strategy:
Ensured that the build was marvelously faster when using the `--all-cores` parameter.

### Known issues with pull request:
None known

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a command-line option `--all-cores` for the build process, allowing users to utilize all available CPU cores for improved performance.
	- Updated documentation to guide users on using the `--all-cores` option in the `scons` build tool.

- **Bug Fixes**
	- Improved documentation clarity by changing command parameters from `-j0` to `--all-cores`. 

- **Documentation**
	- Enhanced user guidance on optimizing build performance with the new `--all-cores` parameter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
