### PR TITLE
Keep the message window around until all remaining threads complete.

### DIFF
--- a/source/core.py
+++ b/source/core.py
@@ -1084,10 +1084,21 @@ def main():
 			pass
 	# We cannot terminate nvwave until after we perform nvwave.playWaveFile
 	_terminate(nvwave)
-	# #5189: Destroy the message window as late as possible
+	_terminate(NVDAHelper)
+	# Log and join any remaining non-daemon threads here,
+	# before releasing our mutex and exiting.
+	# In a perfect world there should be none.
+	# If we don't do this, the NvDA process may stay alive after the mutex is released,
+	# which would cause issues for rpc / nvdaHelper.
+	# See issue #16933.
+	for thr in threading.enumerate():
+		if not thr.daemon and thr is not threading.current_thread():
+			log.info(f"Waiting on {thr}...")
+			thr.join()
+			log.info(f"Thread {thr.name} complete")
+	# #5189: Destroy the message window as the very last action
 	# so new instances of NVDA can find this one even if it freezes during exit.
 	messageWindow.destroy()
-	_terminate(NVDAHelper)
 	log.debug("core done")
 
 

--- a/source/nvda.pyw
+++ b/source/nvda.pyw
@@ -13,7 +13,6 @@ It sets up logging, and then starts the core.
 import logging
 import sys
 import os
-import threading
 
 from typing import IO
 
@@ -533,18 +532,6 @@ finally:
 		easeOfAccess.notify(2)
 	if globalVars.appArgs.changeScreenReaderFlag:
 		winUser.setSystemScreenReaderFlag(False)
-
-	# Log and join any remaining non-daemon threads here,
-	# before releasing our mutex and exiting.
-	# In a perfect world there should be none.
-	# If we don't do this, the NvDA process may stay alive after the mutex is released,
-	# which would cause issues for rpc / nvdaHelper.
-	# See issue #16933.
-	for thr in threading.enumerate():
-		if not thr.daemon and thr is not threading.current_thread():
-			log.info(f"Waiting on {thr}...")
-			thr.join()
-			log.info(f"Thread {thr.name} complete")
 
 	# From MS docs; "Multiple processes can have handles of the same mutex object"
 	# > Use the CloseHandle function to close the handle.


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Improves fix for #16933
Improves upon pr #16934

### Summary of the issue:
In PR #16934, it was ensured that NVDA's mutex would not be released until all remaining non-daemon threads were joined and completed. Otherwise, the NVDA process may stay around because of remaining background threads, such as the Braille auto detector worker thread.
However, the joining of the threads was done after NVDA's message window was destroyed, therefore making it impossible for a new instance of NVDA to locate and kill off the old NVDA if it truly was taking way too long.
 
### Description of user facing changes
An old NvDA has more chance of being killed off if it is taking too long to exit when a new copy of NVDA is trying to start.

### Description of development approach
Move the joining of the non-daemon threads out of nvda.pyw, and into the bottom of core.main. Also ensure that destroying the message window is the very last action taken. So the ordering of the end of core.main is now:
* terminate all subsystems
* Join threads
 * destroy the message window.

### Testing strategy:
Reproduced steps in #16933.
Temporarily added a time.sleep(10) after joining the threads, and ensured that a new copy of NVDA could successfully kill off the old copy.

### Known issues with pull request:
None known.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced shutdown process for the NVDA application, improving thread management and cleanup.
  - Adjusted sequence of operations for a more robust exit behavior.

- **Bug Fixes**
  - Addressed potential issues with the NVDA process remaining active after shutdown due to non-daemon threads.

- **Chores**
  - Simplified the application's shutdown logic by removing unnecessary threading checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
