### PR TITLE
Ensure that when character normalization results in a character with symbol definition, the symbol replacement is spoken

### DIFF
--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -467,7 +467,9 @@ def _getSpellingSpeechWithoutCharMode(
 				speakCharAs = symbol
 			elif not isNormalized and unicodeNormalization:
 				if (normalized := unicodeNormalize(speakCharAs)) != speakCharAs:
-					speakCharAs = " ".join(normalized)
+					speakCharAs = " ".join(
+						characterProcessing.processSpeechSymbol(locale, normChar) for normChar in normalized
+					)
 					isNormalized = True
 		if config.conf['speech']['autoLanguageSwitching']:
 			yield LangChangeCommand(locale)

--- a/tests/unit/test_speech.py
+++ b/tests/unit/test_speech.py
@@ -10,6 +10,7 @@ import typing
 import unittest
 
 import config
+from characterProcessing import processSpeechSymbol
 from speech import (
 	_getSpellingCharAddCapNotification,
 	_getSpellingSpeechAddCharMode,
@@ -466,6 +467,58 @@ class Test_getSpellingSpeechWithoutCharMode(unittest.TestCase):
 		output = _getSpellingSpeechWithoutCharMode(
 			text='É',
 			locale=None,
+			useCharacterDescriptions=False,
+			sayCapForCapitals=False,
+			capPitchChange=0,
+			beepForCapitals=False,
+			unicodeNormalization=True,
+			reportNormalizedForCharacterNavigation=True,
+		)
+		self.assertEqual(repr(list(output)), expected)
+
+	def test_normalizedInSymbolDict_normalizeOff(self):
+		expected = repr([
+			'·',
+			EndUtteranceCommand(),
+		])
+		output = _getSpellingSpeechWithoutCharMode(
+			text='·',
+			locale="en",
+			useCharacterDescriptions=False,
+			sayCapForCapitals=False,
+			capPitchChange=0,
+			beepForCapitals=False,
+			unicodeNormalization=False,
+			reportNormalizedForCharacterNavigation=False,
+		)
+		self.assertEqual(repr(list(output)), expected)
+
+	def test_normalizedInSymbolDict_normalizeOnDontReport(self):
+		expected = repr([
+			processSpeechSymbol("en", "·"),
+			EndUtteranceCommand(),
+		])
+		output = _getSpellingSpeechWithoutCharMode(
+			text='·',
+			locale="en",
+			useCharacterDescriptions=False,
+			sayCapForCapitals=False,
+			capPitchChange=0,
+			beepForCapitals=False,
+			unicodeNormalization=True,
+			reportNormalizedForCharacterNavigation=False,
+		)
+		self.assertEqual(repr(list(output)), expected)
+
+	def test_normalizedInSymbolDict_normalizeOnReport(self):
+		expected = repr([
+			processSpeechSymbol("en", "·"),
+			' normalized',
+			EndUtteranceCommand(),
+		])
+		output = _getSpellingSpeechWithoutCharMode(
+			text='·',
+			locale="en",
 			useCharacterDescriptions=False,
 			sayCapForCapitals=False,
 			capPitchChange=0,


### PR DESCRIPTION
### Link to issue number:
Fixup for #16622 

### Summary of the issue:
When unicode normalization of a character (e.g. `·`) resulted into a character that had a symbol definition (e.g. `·`, middle dot), the symbol definition wasn't applied to the normalization. This resulted in NVDA speaking nothing or only the word `normalized`.

### Description of user facing changes
NVDA will now properly speak the `·` character (Greek Ano Teleia) as `middle dot` when normalizing. This also applies to other characters where normalization results in a character that's part of the symbol dictionary.

### Description of development approach
When normalizing a character, ensure it is thrown through `characterProcessing.processSpeechSymbol`.

### Testing strategy:
- Tested speaking of the Greek Ano Teleia as middle dot normalized when navigating across it with left/right arrow and normalization was on.
- Validated unit tests

### Known issues with pull request:
None known

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
	- Enhanced code readability with consistent spacing and improved formatting in method definitions.
	- Standardized use of double quotes for string literals across multiple files.
	- Consolidated multi-line conditions and method calls into single lines for clarity.
- **Bug Fixes**
	- Improved processing logic for character handling in speech functions, resulting in more accurate speech output.
- **Tests**
	- Added new test cases for the `_getSpellingSpeechWithoutCharMode` function to validate the normalization feature under various conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
