### PR TITLE
HID braille display driver: handle case where a display has no input values in its HID descriptor

### DIFF
--- a/source/hwIo/hid.py
+++ b/source/hwIo/hid.py
@@ -203,6 +203,8 @@ class Hid(IoBase):
 			return self._inputButtonCaps
 		valueCapsList = (hidpi.HIDP_VALUE_CAPS * self.caps.NumberInputButtonCaps)()
 		numValueCaps = ctypes.c_long(self.caps.NumberInputButtonCaps)
+		if numValueCaps.value == 0:
+			return valueCapsList
 		check_HidP_status(
 			hidDll.HidP_GetButtonCaps,
 			hidpi.HIDP_REPORT_TYPE.INPUT,
@@ -219,6 +221,8 @@ class Hid(IoBase):
 			return self._inputValueCaps
 		valueCapsList = (hidpi.HIDP_VALUE_CAPS * self.caps.NumberInputValueCaps)()
 		numValueCaps = ctypes.c_long(self.caps.NumberInputValueCaps)
+		if numValueCaps.value == 0:
+			return valueCapsList
 		check_HidP_status(
 			hidDll.HidP_GetValueCaps,
 			hidpi.HIDP_REPORT_TYPE.INPUT,
@@ -235,6 +239,8 @@ class Hid(IoBase):
 			return self._outputValueCaps
 		valueCapsList = (hidpi.HIDP_VALUE_CAPS * self.caps.NumberOutputValueCaps)()
 		numValueCaps = ctypes.c_long(self.caps.NumberOutputValueCaps)
+		if numValueCaps.value == 0:
+			return valueCapsList
 		check_HidP_status(
 			hidDll.HidP_GetValueCaps,
 			hidpi.HIDP_REPORT_TYPE.OUTPUT,

--- a/source/hwIo/hid.py
+++ b/source/hwIo/hid.py
@@ -198,7 +198,7 @@ class Hid(IoBase):
 		return self._caps
 
 	@property
-	def inputButtonCaps(self):
+	def inputButtonCaps(self) -> ctypes.Array[hidpi.HIDP_VALUE_CAPS]:
 		if hasattr(self, "_inputButtonCaps"):
 			return self._inputButtonCaps
 		valueCapsList = (hidpi.HIDP_VALUE_CAPS * self.caps.NumberInputButtonCaps)()
@@ -216,7 +216,7 @@ class Hid(IoBase):
 		return self._inputButtonCaps
 
 	@property
-	def inputValueCaps(self):
+	def inputValueCaps(self) -> ctypes.Array[hidpi.HIDP_VALUE_CAPS]:
 		if hasattr(self, "_inputValueCaps"):
 			return self._inputValueCaps
 		valueCapsList = (hidpi.HIDP_VALUE_CAPS * self.caps.NumberInputValueCaps)()
@@ -234,7 +234,7 @@ class Hid(IoBase):
 		return self._inputValueCaps
 
 	@property
-	def outputValueCaps(self):
+	def outputValueCaps(self) -> ctypes.Array[hidpi.HIDP_VALUE_CAPS]:
 		if hasattr(self, "_outputValueCaps"):
 			return self._outputValueCaps
 		valueCapsList = (hidpi.HIDP_VALUE_CAPS * self.caps.NumberOutputValueCaps)()


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
None.

### Summary of the issue:
In PR #16916, NVDA asks the HID braille display for its configurable number of cells. However, with the merging of that pr, trying to use some HID braille displays fails and causes the following traceback:
```
Traceback (most recent call last):
  File "braille.py", line 2514, in setDisplayByName
    self._setDisplay(newDisplayClass, isFallback=isFallback, detected=detected)
  File "braille.py", line 2584, in _setDisplay
    newDisplay = self._switchDisplay(oldDisplay, newDisplayClass, **kwargs)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "braille.py", line 2554, in _switchDisplay
    extensionPoints.callWithSupportedKwargs(newDisplay.__init__, **kwargs)
  File "extensionPoints\util.py", line 216, in callWithSupportedKwargs
    return func(*boundArguments.args, **boundArguments.kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "brailleDisplayDrivers\hidBrailleStandard.py", line 110, in __init__
    self._numberOfCellsValueCaps = self._findNumberOfCellsValueCaps()
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "brailleDisplayDrivers\hidBrailleStandard.py", line 145, in _findNumberOfCellsValueCaps
    for valueCaps in self._dev.inputValueCaps:
                     ^^^^^^^^^^^^^^^^^^^^^^^^
  File "hwIo\hid.py", line 222, in inputValueCaps
    check_HidP_status(
  File "hwIo\hid.py", line 40, in check_HidP_status
    raise HidPError(func.__name__, str(code))
hwIo.hid.HidPError: ('HidP_GetValueCaps', '3222339588')
```

this is due to the fact that some HID braille displays have no input values (number of cells property for example) in their HID descriptor.
Although pr #16916 handled this correctly at its own level, the underlying `hwIo.hid.Hid` `inputValueCaps` property did not check if the number of input value caps on the descriptor was 0 before trying to fetch them.
 
### Description of user facing changes
None known as this driver is still rare and the only place I've seen it is a device with custom firmware.

### Description of development approach
For the `inputButtonCaps`, `inputValueCaps` and `outputValueCaps` properties on `hwIo.hid.Hid`, if the number of value caps in the descriptor is 0, return the unfilled 0-length array, rather than trying to fetch 0 caps (which HidP_GetButtonCaps and friends) does not like.
These 0-length arrays can still be treated as iterators, which will be empty.
 
### Testing strategy:
Set NVDA to use the problematic braille display with the Standard HID braille display driver. Ensured that NVDA could display braille.

### Known issues with pull request:
None known.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
