### PR TITLE
Update our documentation on updating eSpeak-NG

### DIFF
--- a/include/espeak.md
+++ b/include/espeak.md
@@ -3,15 +3,18 @@
 The submodule contained in the `espeak` directory is a cross platform open source speech synthesizer.
 
 ## Building
+
 NVDA has a custom build of eSpeak because not all components are required.
 
 ### Background
+
 The main authority on build requirements should be [`include/espeak/Makefile.am`](./espeak/Makefile.am).
 The `*.vcxproj` files in [`include/espeak/src/windows/`](./espeak/src/windows/) can also be considered,
 however these are not always kept up to date.
 
 We don't use the auto make files or the visual studio files, we maintain our own method of building eSpeak.
 Modifications will need to be made in [`nvdaHelper/espeak`](../nvdaHelper/espeak)
+
 * `sconscript` for the build process.
 * `config.h` to set the eSpeak-ng version that NVDA outputs to the log file.
 
@@ -36,15 +39,16 @@ Modifications will need to be made in [`nvdaHelper/espeak`](../nvdaHelper/espeak
 1. Update our record of the version number and build.
    1. Change back to the NVDA repo root
    1. Update the `/DPACKAGE_VERSION` in [`nvdaHelper/espeak/sconscript`](../nvdaHelper/espeak/sconscript)
-      - The preprocessor definition is used to supply these definitions instead of [`nvdaHelper/espeak/config.h`](../nvdaHelper/espeak/config.h)
-      - [`nvdaHelper/espeak/config.h`](../nvdaHelper/espeak/config.h) must exist (despite being empty) since a "config.h" is included within eSpeak.
-      - Compare to eSpeak source config: [`include/espeak/src/windows/config.h`](./espeak/src/windows/config.h).
-      - Diff `src/windows/config.h` with the previous commit.
+      *-* The preprocessor definition is used to supply these definitions instead of [`nvdaHelper/espeak/config.h`](../nvdaHelper/espeak/config.h)
+      *-* [`nvdaHelper/espeak/config.h`](../nvdaHelper/espeak/config.h) must exist (despite being empty) since a "config.h" is included within eSpeak.
+      *-* Compare to eSpeak source config: [`include/espeak/src/windows/config.h`](./espeak/src/windows/config.h).
+      *-* Diff `src/windows/config.h` with the previous commit.
    1. Update NVDA's [dev environment documentation](../projectDocs/dev/createDevEnvironment.md#git-submodules) and [changelog](../user_docs/en/changes.md) with eSpeak version and commit.
    1. Build NVDA: `scons source`
-      - Expected warnings from eSpeak compilation:
-         - On the first build after changes, all languages may show this warning.
+      * Expected warnings from eSpeak compilation:
+         * On the first build after changes, all languages may show this warning.
          Our build intentionally compiles using the `phonemetable`.
+
          ```log
          espeak_compileDict_buildAction(["include\espeak\espeak-ng-data\uz_dict"], ["include\espeak\dictsource\uz_list", "include\espeak\dictsource\uz_rules"])
          Can't read dictionary file: 'C:\Users\sean\projects\nvda\include\espeak/espeak-ng-data\uz_dict'
@@ -54,6 +58,7 @@ Modifications will need to be made in [`nvdaHelper/espeak`](../nvdaHelper/espeak
          Compiling: 'C:\Users\sean\projects\nvda\include\espeak\dictsource/uz_rules'
                35 rules, 26 groups (0)
          ```
+
 1. Run NVDA (set eSpeak-ng as the synthesizer) and test.
 1. Ensure that the log file contains the new version number for eSpeak-NG
 
@@ -68,11 +73,13 @@ If the build fails, take note of the error, compare the diff of the `Makefile.am
 any changes in our `sconscript` file.
 
 ### Known issues
+
 Due to problems with emoji support (causing crashes), emoji dictionary files are being excluded
 from the build, they are deleted prior to compiling the dictionaries in the
 [`nvdaHelper/espeak/sconscript`](../nvdaHelper/espeak/sconscript) file.
 
 ## Manually testing eSpeak-ng
+
 If you wish to test eSpeak-ng directly, perhaps to create steps to reproduce when raising an issue for the eSpeak-ng project, consider feeding SSML directly to the executable provided by the project.
 
 The [eSpeak docs](https://github.com/espeak-ng/espeak-ng/blob/master/docs/index.md) are worth reading.
@@ -80,18 +87,20 @@ They describe the various [(eSpeak-ng) command line arguments](https://github.co
 However, historically the Windows build for espeak-ng hasn't been well maintained, with periods of build failures.
 It is also different from the build approach within NVDA.
 
-
-1. Install an (x86) release: https://github.com/espeak-ng/espeak-ng/releases
+1. Install an (x86) release: <https://github.com/espeak-ng/espeak-ng/releases>
    `espeak.exe` is in `C:/Program Files (x86)/espeak-ng/`
    Adding it to your path temporarily will make the following easier.
 1. Write out [some SSML](https://github.com/espeak-ng/espeak-ng/blob/master/docs/markup.md) that demonstrates the problem.
+
    ```sh
    $ cat /c/work/test-espeak-ssml.txt
    <prosody pitch="+100">I am now speaking at an extra high pitch.</prosody>
    <break time="1s"/>
    <prosody pitch="1">I am now speaking at the default pitch.</prosody>
    ```
+
 1. Feed the SSML into `espeak-ng.exe`
+
    ```sh
    $ cat /c/work/test-espeak-ssml.txt | ./espeak-ng.exe --stdin -m
    ```

--- a/include/espeak.md
+++ b/include/espeak.md
@@ -13,10 +13,7 @@ The `*.vcxproj` files in [`include/espeak/src/windows/`](./espeak/src/windows/) 
 however these are not always kept up to date.
 
 We don't use the auto make files or the visual studio files, we maintain our own method of building eSpeak.
-Modifications will need to be made in [`nvdaHelper/espeak`](../nvdaHelper/espeak)
-
-* `sconscript` for the build process.
-* `config.h` to set the eSpeak-ng version that NVDA outputs to the log file.
+Modifications will need to be made in [`nvdaHelper/espeak/sconscript`](../nvdaHelper/espeak)
 
 ### Updating the version used by NVDA
 

--- a/include/espeak.md
+++ b/include/espeak.md
@@ -40,7 +40,7 @@ Modifications will need to be made in [`nvdaHelper/espeak`](../nvdaHelper/espeak
       - [`nvdaHelper/espeak/config.h`](../nvdaHelper/espeak/config.h) must exist (despite being empty) since a "config.h" is included within eSpeak.
       - Compare to eSpeak source config: [`include/espeak/src/windows/config.h`](./espeak/src/windows/config.h).
       - Diff `src/windows/config.h` with the previous commit.
-   1. Update NVDA [documentation](../projectDocs/dev/createDevEnvironment.md#git-submodules) and [changelog](../user_docs/en/changes.md) with eSpeak version and commit.
+   1. Update NVDA's [dev environment documentation](../projectDocs/dev/createDevEnvironment.md#git-submodules) and [changelog](../user_docs/en/changes.md) with eSpeak version and commit.
    1. Build NVDA: `scons source`
       - Expected warnings from eSpeak compilation:
          - On the first build after changes, all languages may show this warning.


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:

None

### Summary of the issue:

The docs on updating eSpeak-NG were slightly unclear, and had a couple of outdated things in them.

### Description of user facing changes

None.

### Description of development approach

Updated the eSpeak docs:

* Made it more obvious that as well as updating `user_docs/en/changes.md`, you also need to update `projectDocs/dev/createDevEnvironment.md` (this was already included, but it was not particularly obvious to me).
* Removed old references to the eSpeak version being in `nvdaHelper/espeak/config.h`, as it is now in `nvdaHelper/espeak/sconstruct`.
* Fixed up markdown formatting problems.

### Testing strategy:

### Known issues with pull request:

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Improved formatting and organization of the eSpeak speech synthesizer documentation for better clarity.
  - Emphasized the need to update the `/DPACKAGE_VERSION` in the `sconscript`.
  - Refined the known issues section to clarify limitations regarding emoji dictionary files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
