### PR TITLE
Revert "Create a smaller review team for general code reviews"

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -40,7 +40,7 @@
 # Start of NVDA config
 
 # By default auto request review from NV Access developer team.
-* @nvaccess/nvda-code-reviews
+* @nvaccess/developers
 
 # For changes to the userGuide auto request review from userDocs team
 /user_docs/en/userGuide.md @nvaccess/userDocs
@@ -48,8 +48,8 @@
 
 # For various project documentation, require appropriate teams
 /projectDocs/community/ @nvaccess/userDocs
-/projectDocs/testing/ @nvaccess/userDocs @nvaccess/nvda-code-reviews
-/projectDocs/issues/ @nvaccess/userDocs @nvaccess/nvda-code-reviews
+/projectDocs/testing/ @nvaccess/userDocs @nvaccess/developers
+/projectDocs/issues/ @nvaccess/userDocs @nvaccess/developers
 /readme.md @nvaccess/userDocs @nvaccess/developers
 security.md @nvaccess/userDocs @nvaccess/developers
 CODE_OF_CONDUCT.md @nvaccess/userDocs @nvaccess/developers


### PR DESCRIPTION

### Reverts PR
Reverts #16975 

### Issues fixed
None

### Issues reopened
None
### Reason for revert
The issue which prompted the PR can be fixed through the GitHub UX:

https://github.com/orgs/nvaccess/teams/developers/edit/review_assignment

### Can this PR be reimplemented? If so, what is required for the next attempt
yes, through the GitHub UX instead

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated team responsibilities for code reviews and documentation, streamlining the review process.
	- Adjusted CODEOWNERS file for project documentation paths to reflect the new team designation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->