### PR TITLE
Update Pre-Commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,9 +23,12 @@ repos:
       exclude: source/comInterfaces/_944DE083_8FB8_45CF_BCB7_C477ACB2F897_0_1_0.py
     - id: check-case-conflict
     - id: check-merge-conflict
+    - id: debug-statements
     - id: trailing-whitespace
       types_or: [python, c, c++, batch, markdown]
     - id: end-of-file-fixer
+      types_or: [python, c, c++, batch, markdown]
+    - id: fix-byte-order-marker
       types_or: [python, c, c++, batch, markdown]
     - id: check-toml
     - id: check-yaml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,6 +33,24 @@ repos:
     - id: check-toml
     - id: check-yaml
     - id: check-xml
+    - id: check-vcs-permalinks
+    - id: name-tests-test
+      args: ["--unittest"]
+      # Exclude Python files under `tests/` that aren't unittest files.
+      # This is a Python verbose regular expression.
+      # See https://docs.python.org/3/library/re.html#re.VERBOSE
+      exclude: |
+        (?x)^tests/(
+          checkPot.py |  # Doesn't use unittest
+          system |  # Uses robot
+          unit/ (
+            # Test helpers
+            textProvider.py |
+            extensionPointTestHelpers.py |
+            objectProvider.py |
+            test_speechManager/speechManagerTestHarness.py
+          )
+        )
 
 - repo: https://github.com/asottile/add-trailing-comma
   rev: v3.1.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,6 +33,8 @@ repos:
     - id: check-merge-conflict
     # Checks Python files for debug statements, such as python's breakpoint function, or those inserted by some IDEs.
     - id: debug-statements
+      # File uses encoding not supported in Linux
+      exclude: source/comInterfaces/_944DE083_8FB8_45CF_BCB7_C477ACB2F897_0_1_0.py
     # Removes trailing whitespace.
     - id: trailing-whitespace
       types_or: [python, c, c++, batch, markdown]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,6 +27,9 @@ repos:
       types_or: [python, c, c++, batch, markdown]
     - id: end-of-file-fixer
       types_or: [python, c, c++, batch, markdown]
+    - id: check-toml
+    - id: check-yaml
+    - id: check-xml
 
 - repo: https://github.com/asottile/add-trailing-comma
   rev: v3.1.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
     - id: check-ast
       # File uses encoding not supported in Linux
       exclude: source/comInterfaces/_944DE083_8FB8_45CF_BCB7_C477ACB2F897_0_1_0.py
-    # Checks for filenames that will conflict on case insensative filesystems (most windows filesystems, most of the time)
+    # Checks for filenames that will conflict on case insensitive filesystems (the majority of Windows filesystems, most of the time)
     - id: check-case-conflict
     # Checks for artifacts from resolving merge conflicts.
     - id: check-merge-conflict

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,12 @@ repos:
     # Prevents commits to certain branches
     - id: no-commit-to-branch
       args: ["--branch", "master", "--branch", "beta", "--branch", "rc"]
+    # Checks that large files have not been added. Default cut-off for "large" files is 500kb.
+    - id: check-added-large-files
+      # POFiles and TTF fonts can't be made smaller
+      exclude_types: ["pofile", "ttf"]
+      # Same applies for NVDA dictionary (.dic) files and Spline Font Database (.SFD) files, but these aren't recognised by the Identify library.
+      exclude: "\\.(dic|sfd)$"
     # Checks python syntax
     - id: check-ast
       # File uses encoding not supported in Linux

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,19 +21,31 @@ repos:
     - id: check-ast
       # File uses encoding not supported in Linux
       exclude: source/comInterfaces/_944DE083_8FB8_45CF_BCB7_C477ACB2F897_0_1_0.py
+    # Checks for filenames that will conflict on case insensative filesystems (most windows filesystems, most of the time)
     - id: check-case-conflict
+    # Checks for artifacts from resolving merge conflicts.
     - id: check-merge-conflict
+    # Checks Python files for debug statements, such as python's breakpoint function, or those inserted by some IDEs.
     - id: debug-statements
+    # Removes trailing whitespace.
     - id: trailing-whitespace
       types_or: [python, c, c++, batch, markdown]
+    # Ensures all files end in 1 (and only 1) newline.
     - id: end-of-file-fixer
       types_or: [python, c, c++, batch, markdown]
+    # Removes the UTF-8 BOM from files that have it.
+    # See https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/codingStandards.md#encoding
     - id: fix-byte-order-marker
       types_or: [python, c, c++, batch, markdown]
+    # Validates TOML files.
     - id: check-toml
+    # Validates YAML files.
     - id: check-yaml
+    # Validates XML files.
     - id: check-xml
+    # Ensures that links to lines in files under version control point to a particular commit.
     - id: check-vcs-permalinks
+    # Checks that tests are named test_*.py.
     - id: name-tests-test
       args: ["--unittest"]
       # Exclude Python files under `tests/` that aren't unittest files.

--- a/test.txt
+++ b/test.txt
@@ -1,0 +1,1 @@
+Test link: https://github.com/pre-commit/pre-commit-hooks/blob/main/pre_commit_hooks/check_vcs_permalinks.py

--- a/test.txt
+++ b/test.txt
@@ -1,1 +1,0 @@
-Test link: https://github.com/pre-commit/pre-commit-hooks/blob/main/pre_commit_hooks/check_vcs_permalinks.py


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:

None

### Summary of the issue:

Continuing work on our pre-commit hooks, there are still several we don't use but could.

### Description of user facing changes

None.

### Description of development approach

Tested pre-commit hooks available at <https://github.com/pre-commit/pre-commit-hooks/>. Added those that work as expected and do not require major changes to our code base. Added:

- Automatic checking of yaml, toml and XML syntax
- Checks that no Python debug statements are included in commits
- Remove BOM on Python, C/C++ and Batch files, if present
- Ensure that unit test files are named according to unittest rules.
- Ensure that any include VCS links are permalinks.

### Testing strategy:

Ran the tests individually with `pre-commit run <hook-id> -a` and all together with `pre-commit run -a`.

### Known issues with pull request:

The following are good candidates for inclusion:

- [check-builtin-literals](https://github.com/pre-commit/pre-commit-hooks/?tab=readme-ov-file#check-builtin-literals): We have a lot of violations of this one
- [check-docstring-first](https://github.com/pre-commit/pre-commit-hooks/?tab=readme-ov-file#check-docstring-first): We have a lot of violations of this one
- [check-illegal-windows-names](https://github.com/pre-commit/pre-commit-hooks/?tab=readme-ov-file#check-illegal-windows-names): Not yet in a tagged version.
- [check-added-large-files](https://github.com/pre-commit/pre-commit-hooks/?tab=readme-ov-file#check-added-large-files): We have several files that are larger than the default limit of 500kb. It is not clear what our cut-off should be, and it doesn't seem as though we can have different sizes for different file types.
  - The biggest culprits seem to be translations, with the largest (Simplified Chinese (PRC)) character descriptions being 3.21MiB.
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced pre-commit hooks for improved code quality and style enforcement.
  - Added checks for various file types including TOML, YAML, XML, and VCS permalinks.

- **Improvements**
  - Modified existing test hook to enforce unittest standards, refining the validation process for Python files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
