### PR TITLE
Support multi-line braille displays in HidBrailleDriver

### DIFF
--- a/source/brailleDisplayDrivers/hidBrailleStandard.py
+++ b/source/brailleDisplayDrivers/hidBrailleStandard.py
@@ -109,7 +109,7 @@ class HidBrailleDriver(braille.BrailleDisplayDriver):
 			cellValueCaps = self._findCellValueCaps()
 			if len(cellValueCaps) > 0:
 				if any(x.ReportCount != cellValueCaps[0].ReportCount for x in cellValueCaps):
-					log.warn("Found multi-line display with an irregular shape, ignoring.")
+					log.warning("Found multi-line display with an irregular shape, ignoring.")
 					self._dev.close()
 					continue
 				self.numRows = len(cellValueCaps)
@@ -122,9 +122,9 @@ class HidBrailleDriver(braille.BrailleDisplayDriver):
 					log.warn("The number of braille cells usage is not supported on multi-line displays")
 				# A display responded.
 				log.info(
-					"Found display with {rows}x{cells} cells connected via {type} ({port})".format(
+					"Found display with {rows} rows, {cols} cols connected via {type} ({port})".format(
 						rows=self.numRows,
-						cells=self.numCols,
+						cols=self.numCols,
 						type=portType,
 						port=port,
 					),
@@ -138,7 +138,7 @@ class HidBrailleDriver(braille.BrailleDisplayDriver):
 		self._keysDown = set()
 		self._ignoreKeyReleases = False
 
-	def _findCellValueCaps(self) -> List[hidpi.HIDP_VALUE_CAPS]:
+	def _findCellValueCaps(self) -> list[hidpi.HIDP_VALUE_CAPS]:
 		return [
 			valueCaps
 			for valueCaps in self._dev.outputValueCaps
@@ -250,9 +250,9 @@ class HidBrailleDriver(braille.BrailleDisplayDriver):
 				HID_USAGE_PAGE_BRAILLE,
 				valueCap.LinkCollection,
 				valueCap.u1.NotRange.Usage,
-				cellBytes[: valueCap.ReportCount],
+				cellBytes[:valueCap.ReportCount],
 			)
-			cellBytes = cellBytes[valueCap.ReportCount :]
+			cellBytes = cellBytes[valueCap.ReportCount:]
 		self._dev.write(report.data)
 
 	gestureMap = inputCore.GlobalGestureMap(

--- a/source/brailleDisplayDrivers/hidBrailleStandard.py
+++ b/source/brailleDisplayDrivers/hidBrailleStandard.py
@@ -119,7 +119,7 @@ class HidBrailleDriver(braille.BrailleDisplayDriver):
 				if self.numRows == 1:
 					self._numberOfCellsValueCaps = self._findNumberOfCellsValueCaps()
 				elif self._findNumberOfCellsValueCaps():
-					log.warn("The number of braille cells usage is not supported on multi-line displays")
+					log.warning("The number of braille cells usage is not supported on multi-line displays")
 				# A display responded.
 				log.info(
 					"Found display with {rows} rows, {cols} cols connected via {type} ({port})".format(

--- a/source/brailleDisplayDrivers/hidBrailleStandard.py
+++ b/source/brailleDisplayDrivers/hidBrailleStandard.py
@@ -119,7 +119,7 @@ class HidBrailleDriver(braille.BrailleDisplayDriver):
 				if self.numRows == 1:
 					self._numberOfCellsValueCaps = self._findNumberOfCellsValueCaps()
 				elif self._findNumberOfCellsValueCaps():
-					log.warning("The number of braille cells usage is not supported on multi-line displays")
+					log.warning("Reserved braille cells are not supported on multi-line displays")
 				# A display responded.
 				log.info(
 					"Found display with {rows} rows, {cols} cols connected via {type} ({port})".format(
@@ -250,9 +250,9 @@ class HidBrailleDriver(braille.BrailleDisplayDriver):
 				HID_USAGE_PAGE_BRAILLE,
 				valueCap.LinkCollection,
 				valueCap.u1.NotRange.Usage,
-				cellBytes[:valueCap.ReportCount],
+				cellBytes[: valueCap.ReportCount],
 			)
-			cellBytes = cellBytes[valueCap.ReportCount:]
+			cellBytes = cellBytes[valueCap.ReportCount :]
 		self._dev.write(report.data)
 
 	gestureMap = inputCore.GlobalGestureMap(

--- a/source/brailleDisplayDrivers/hidBrailleStandard.py
+++ b/source/brailleDisplayDrivers/hidBrailleStandard.py
@@ -4,7 +4,7 @@
 # Copyright (C) 2021 NV Access Limited
 
 from dataclasses import dataclass
-from typing import List, Optional
+from typing import List
 import enum
 import braille
 import inputCore
@@ -139,16 +139,20 @@ class HidBrailleDriver(braille.BrailleDisplayDriver):
 		self._ignoreKeyReleases = False
 
 	def _findCellValueCaps(self) -> List[hidpi.HIDP_VALUE_CAPS]:
-		return [valueCaps for valueCaps in self._dev.outputValueCaps if (
-			valueCaps.LinkUsagePage == HID_USAGE_PAGE_BRAILLE
-			and valueCaps.LinkUsage == BraillePageUsageID.BRAILLE_ROW
-			and valueCaps.u1.NotRange.Usage
-			in (
-				BraillePageUsageID.EIGHT_DOT_BRAILLE_CELL,
-				BraillePageUsageID.SIX_DOT_BRAILLE_CELL,
+		return [
+			valueCaps
+			for valueCaps in self._dev.outputValueCaps
+			if (
+				valueCaps.LinkUsagePage == HID_USAGE_PAGE_BRAILLE
+				and valueCaps.LinkUsage == BraillePageUsageID.BRAILLE_ROW
+				and valueCaps.u1.NotRange.Usage
+				in (
+					BraillePageUsageID.EIGHT_DOT_BRAILLE_CELL,
+					BraillePageUsageID.SIX_DOT_BRAILLE_CELL,
+				)
+				and valueCaps.ReportCount > 0
 			)
-			and valueCaps.ReportCount > 0
-		)]
+		]
 
 	def _findNumberOfCellsValueCaps(self) -> hidpi.HIDP_VALUE_CAPS | None:
 		for valueCaps in self._dev.inputValueCaps:
@@ -246,9 +250,9 @@ class HidBrailleDriver(braille.BrailleDisplayDriver):
 				HID_USAGE_PAGE_BRAILLE,
 				valueCap.LinkCollection,
 				valueCap.u1.NotRange.Usage,
-				cellBytes[:valueCap.ReportCount],
+				cellBytes[: valueCap.ReportCount],
 			)
-			cellBytes = cellBytes[valueCap.ReportCount:]
+			cellBytes = cellBytes[valueCap.ReportCount :]
 		self._dev.write(report.data)
 
 	gestureMap = inputCore.GlobalGestureMap(

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -23,6 +23,7 @@ The available options are:
 * The `-c`/`--config-path` and `--disable-addons` command line options are now respected when launching an update from within NVDA. (#16937)
 * eSpeak NG has been updated to 1.52-dev commit `961454ff`. (#16775)
   * Added new languages Faroese and Xextan.
+* When using a multi-line braille display via the Standard HID braille driver, all lines of cells will be used. (#16993, @alexmoon)
 
 ### Bug Fixes
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -23,7 +23,7 @@ The available options are:
 * The `-c`/`--config-path` and `--disable-addons` command line options are now respected when launching an update from within NVDA. (#16937)
 * eSpeak NG has been updated to 1.52-dev commit `961454ff`. (#16775)
   * Added new languages Faroese and Xextan.
-* When using a multi-line braille display via the Standard HID braille driver, all lines of cells will be used. (#16993, @alexmoon)
+* When using a multi-line braille display via the standard HID braille driver, all lines of cells will be used. (#16993, @alexmoon)
 
 ### Bug Fixes
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:

Closes #16993

### Summary of the issue:

Multi-line braille displays using the HID standard driver only support the first line of cells.

### Description of user facing changes

Users with multi-line braille displays that connect using the `HidBrailleDriver` will now be able to use all cells of their display.

### Description of development approach

`HidBrailleDriver._cellValueCaps` is now a list of all braille cell controls in the device. `numRows` is set to the length of that list and `numCols` is set to the `ReportCount` of each element of the list. In `display`, the `cells` are split across the elements of `_cellValueCaps`.

### Testing strategy:

Tested against Tactile Engineering's Cadence tablet. Manual testing only due to required hardware interactions.

### Known issues with pull request:

- Multi-line braille displays with an irregular shape (i.e. not all braille rows are the same length) are not supported. I'm not aware of any actual hardware that would be affected by this.
- Multi-line braille displays will ignore "Number of Braille Cells" controls. This is because those controls will operate per-row and in general will give the usable display area an irregular shape. I'm not aware of any multi-line HID standard braille displays that use the "Number of Braille Cells" control.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced functionality for multi-line braille displays, allowing full utilization of display lines with the Standard HID braille driver.
	- Improved accessibility for users relying on braille output.

- **Improvements**
	- Respect for command line options during updates.
	- Updated eSpeak NG library to support additional languages.

- **Bug Fixes**
	- Enhanced detection and management of connected braille display devices for better performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
