### PR TITLE
Enable cursor movement with braille display routing keys in PowerPoint

### DIFF
--- a/source/appModules/powerpnt.py
+++ b/source/appModules/powerpnt.py
@@ -1129,7 +1129,7 @@ class TextFrameTextInfo(textInfos.offsets.OffsetsTextInfo):
 		return formatField, (startOffset, endOffset)
 
 	def _setCaretOffset(self, offset: int):
-		if not 0 <= offset <= (maxLength := self.storyLength):
+		if not 0 <= offset <= (maxLength := self._getStoryLength()):
 			log.debugWarning(f"Got out of range {offset=} (min 0, max {maxLength}. Clamping.", stack_inf=True)
 			offset = max(0, min(offset, maxLength))
 		# Use the TextRange.select method to move the text caret to a 0-length TextRange.

--- a/source/appModules/powerpnt.py
+++ b/source/appModules/powerpnt.py
@@ -1128,6 +1128,14 @@ class TextFrameTextInfo(textInfos.offsets.OffsetsTextInfo):
 			formatField["link"] = True
 		return formatField, (startOffset, endOffset)
 
+	def _setCaretOffset(self, offset: int):
+		if not 0 <= offset <= (maxLength := self.storyLength):
+			log.debugWarning(f"Got out of range {offset=} (min 0, max {maxLength}. Clamping.", stack_inf=True)
+			offset = max(0, min(offset, maxLength))
+		# Use the TextRange.select method to move the text caret to a 0-length TextRange.
+		# The TextRange.characters method is 1-indexed.
+		self.obj.ppObject.textRange.characters(offset + 1, 0).select()
+
 
 class Table(Shape):
 	"""Represents the table shape in Powerpoint. Provides row and column counts."""

--- a/source/appModules/powerpnt.py
+++ b/source/appModules/powerpnt.py
@@ -1136,6 +1136,25 @@ class TextFrameTextInfo(textInfos.offsets.OffsetsTextInfo):
 		# The TextRange.characters method is 1-indexed.
 		self.obj.ppObject.textRange.characters(offset + 1, 0).select()
 
+	def _setSelectionOffsets(self, start: int, end: int):
+		if not start < end:
+			log.debug(f"start must be less than end. Got {start=}, {end=}.", stack_info=True)
+			return
+		maxLength = self._getStoryLength()
+		# Having start = maxLength does not make sense, as there will be no selection if this is the case.
+		if not 0 <= start < maxLength:
+			log.debugWarning(
+				f"Got out of range {start=} (min 0, max {maxLength - 1}. Clamping.",
+				stack_info=True,
+			)
+			start = max(0, min(start, maxLength - 1))
+		# Having end = 0 does not make sense, as there will be no selection if this is the case.
+		if not 0 < end <= maxLength:
+			log.debugWarning(f"Got out of range {end=} (min 1, max {maxLength}. Clamping.", stack_info=True)
+			end = max(1, min(end, maxLength))
+		# The TextRange.characters method is 1-indexed.
+		self.obj.ppObject.textRange.characters(start + 1, end - start).select()
+
 
 class Table(Shape):
 	"""Represents the table shape in Powerpoint. Provides row and column counts."""

--- a/source/appModules/powerpnt.py
+++ b/source/appModules/powerpnt.py
@@ -1129,7 +1129,7 @@ class TextFrameTextInfo(textInfos.offsets.OffsetsTextInfo):
 		return formatField, (startOffset, endOffset)
 
 	def _setCaretOffset(self, offset: int):
-		if not 0 <= offset <= (maxLength := self._getStoryLength()):
+		if not (0 <= offset <= (maxLength := self._getStoryLength())):
 			log.debugWarning(
 				f"Got out of range {offset=} (min 0, max {maxLength}. Clamping.",
 				stack_info=True,
@@ -1145,14 +1145,14 @@ class TextFrameTextInfo(textInfos.offsets.OffsetsTextInfo):
 			return
 		maxLength = self._getStoryLength()
 		# Having start = maxLength does not make sense, as there will be no selection if this is the case.
-		if not 0 <= start < maxLength:
+		if not (0 <= start < maxLength):
 			log.debugWarning(
 				f"Got out of range {start=} (min 0, max {maxLength - 1}. Clamping.",
 				stack_info=True,
 			)
 			start = max(0, min(start, maxLength - 1))
 		# Having end = 0 does not make sense, as there will be no selection if this is the case.
-		if not 0 < end <= maxLength:
+		if not (0 < end <= maxLength):
 			log.debugWarning(f"Got out of range {end=} (min 1, max {maxLength}. Clamping.", stack_info=True)
 			end = max(1, min(end, maxLength))
 		# The TextRange.characters method is 1-indexed.

--- a/source/appModules/powerpnt.py
+++ b/source/appModules/powerpnt.py
@@ -1130,7 +1130,10 @@ class TextFrameTextInfo(textInfos.offsets.OffsetsTextInfo):
 
 	def _setCaretOffset(self, offset: int):
 		if not 0 <= offset <= (maxLength := self._getStoryLength()):
-			log.debugWarning(f"Got out of range {offset=} (min 0, max {maxLength}. Clamping.", stack_inf=True)
+			log.debugWarning(
+				f"Got out of range {offset=} (min 0, max {maxLength}. Clamping.",
+				stack_info=True,
+			)
 			offset = max(0, min(offset, maxLength))
 		# Use the TextRange.select method to move the text caret to a 0-length TextRange.
 		# The TextRange.characters method is 1-indexed.

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -17,7 +17,9 @@ The available options are:
 * The timeout to perform a multiple keypress is now configurable; this may be especially useful for people with dexterity impairment. (#11929, @CyrilleB79)
 * When performing a braille cursor routing action, NVDA can now automatically speak the character at the cursor. (#8072, @LeonarddeR)
   * This option is disabled by default. You can enable "Speak character when routing cursor in text" in NVDA's braille settings.
-* It is now possible to use braille display routing keys to move the text cursor in Microsoft PowerPoint. (#9101)
+* Improvements in PowerPoint: (#17004)
+  * It is now possible to use braille display routing keys to move the text cursor in Microsoft PowerPoint. (#9101)
+  * It is now possible to use NVDA's review cursor selection commands to select text in Microsoft PowerPoint.
 
 ### Changes
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -17,6 +17,7 @@ The available options are:
 * The timeout to perform a multiple keypress is now configurable; this may be especially useful for people with dexterity impairment. (#11929, @CyrilleB79)
 * When performing a braille cursor routing action, NVDA can now automatically speak the character at the cursor. (#8072, @LeonarddeR)
   * This option is disabled by default. You can enable "Speak character when routing cursor in text" in NVDA's braille settings.
+* It is now possible to use braille display routing keys to move the text cursor in Microsoft PowerPoint. (#9101)
 
 ### Changes
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -17,9 +17,6 @@ The available options are:
 * The timeout to perform a multiple keypress is now configurable; this may be especially useful for people with dexterity impairment. (#11929, @CyrilleB79)
 * When performing a braille cursor routing action, NVDA can now automatically speak the character at the cursor. (#8072, @LeonarddeR)
   * This option is disabled by default. You can enable "Speak character when routing cursor in text" in NVDA's braille settings.
-* Improvements in PowerPoint: (#17004)
-  * It is now possible to use braille display routing keys to move the text cursor. (#9101)
-  * It is now possible to use the review cursor selection commands to select text.
 
 ### Changes
 
@@ -41,6 +38,9 @@ The available options are:
 * NVDA no longer throws an error when panning the braille display forward in some empty edit controls. (#16927)
 * NVDA no longer occasionally fails to open browsable messages (such as pressing `NVDA+f` twice). (#16806, @LeonarddeR)
 * NVDA is no longer unstable after restarting NVDA during an automatic Braille Bluetooth scan. (#16933)
+* Improvements in Microsoft PowerPoint: (#17004)
+  * It is now possible to use braille display routing keys to move the text cursor. (#9101)
+  * It is now possible to use the review cursor selection commands to select text.
 
 ### Changes for Developers
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -18,8 +18,8 @@ The available options are:
 * When performing a braille cursor routing action, NVDA can now automatically speak the character at the cursor. (#8072, @LeonarddeR)
   * This option is disabled by default. You can enable "Speak character when routing cursor in text" in NVDA's braille settings.
 * Improvements in PowerPoint: (#17004)
-  * It is now possible to use braille display routing keys to move the text cursor in Microsoft PowerPoint. (#9101)
-  * It is now possible to use NVDA's review cursor selection commands to select text in Microsoft PowerPoint.
+  * It is now possible to use braille display routing keys to move the text cursor. (#9101)
+  * It is now possible to use the review cursor selection commands to select text.
 
 ### Changes
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:

Closes #9101 

### Summary of the issue:

The routing keys on a braille display do not work to move the text insertion point in Microsoft PowerPoint.

### Description of user facing changes

The routing keys now move the cursor in PowerPoint.

### Description of development approach

Looked at `TextFrameTextInfo` to look at how access to PowerPoint text works. Used the Microsoft Powerpoint Object Model documentation to find the appropriate methods. Implemented a `_setCaretOffset` implementation on `TextFrameTextInfo`.

Sources:
- [PowerPoint Object Model](https://learn.microsoft.com/en-us/office/vba/api/overview/powerpoint/object-model)
- [PowerPoint `TextRange` object](https://learn.microsoft.com/en-us/office/vba/api/powerpoint.textrange) (of note are the [`TextRange.Characters`](https://learn.microsoft.com/en-us/office/vba/api/powerpoint.textrange.characters) and [`TextRange.Select`](https://learn.microsoft.com/en-us/office/vba/api/powerpoint.textrange.select) methods.
- [Helpful Stack Overflow thread](https://stackoverflow.com/questions/19535854/c-sharp-how-to-programatically-set-clear-selections-and-cursor-position-in-power)

### Testing strategy:

Manually tested with an old NV Access presentation.

### Known issues with pull request:

None.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced caret offset management for improved text manipulation in PowerPoint.
	- Added support for braille display routing keys to navigate text cursor in PowerPoint, enhancing accessibility options for users with dexterity impairments.
- **Documentation**
	- Updated documentation to include the new braille display functionality and its customization options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
