### PR TITLE
Fix `tests/manual/createUpdatableAddons.ps1`'s default config folder

### DIFF
--- a/tests/manual/createUpdatableAddons.ps1
+++ b/tests/manual/createUpdatableAddons.ps1
@@ -5,7 +5,7 @@
 
 param(
 	[string]$addonName = "clock",
-	[string]$configFolder = "$env:APPDATA\nvda\userConfig",
+	[string]$configFolder = "$env:APPDATA\nvda",
 	[string]$newVersionMajor = "0",
 	[string]$newVersionMinor = "0"
 )


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:

None

### Summary of the issue:

The `tests/manual/createUpdatableAddons.ps1` script exists to expedite testing the add-on store. It provides defaults for addon name, NVDA config directory and addon major and minor versions. However, the default value for the config directory of an installed copy of NVDA is set incorrectly.

### Description of user facing changes

None. This will only impact developers testing the add-on store.

### Description of development approach

Updated `configFolder` to remove the `userData` subdirectory, which is not used in installed copies of NVDA.

### Testing strategy:

Tested the script after the change to make sure it correctly updated the add-on store metadata and add-on manifest for the Clock add-on.

### Known issues with pull request:

None.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated the default configuration folder path for the script, allowing for broader access to configuration files.

- **Bug Fixes**
	- Adjusted the script's behavior to ensure compatibility with the new configuration path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
