### PR TITLE
Upgrade nh3 from 0.2.17 to 0.2.18

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ mdx_truly_sane_lists==1.3
 markdown-link-attr-modifier==0.2.1
 mdx-gh-links==0.4
 # Sanitize HTML documentation output to prevent XSS from translators
-nh3==0.2.17
+nh3==0.2.18
 
 # For building developer documentation
 sphinx==7.2.6

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -51,6 +51,7 @@ Please refer to [the developer guide](https://www.nvaccess.org/files/nvda/docume
   * Updated py2exe to 0.13.0.2 (#16907, @dpy013)
   * Updated setuptools to 72.0 (#16907, @dpy013)
   * Updated Ruff to 0.5.6. (#16868, @LeonarddeR)
+  * Updated nh3 0.2.17 to 0.2.18 (#17020, @dpy013)
 * Added a `.editorconfig` file to NVDA's repository in order for several IDEs to pick up basic NVDA code style rules by default. (#16795, @LeonarddeR)
 * Added support for custom speech symbol dictionaries. (#16739, #16823, @LeonarddeR)
   * Dictionaries can be provided in locale specific folders in an add-on package, e.g. `locale\en`.


### PR DESCRIPTION
### Update Details
nh3 0.2.18 mainly updates the following dependencies:
* Bump pyo3 from 0.21.0 to 0.21.1 
* Bump pyo3 from 0.21.1 to 0.21.2
* Bump pyo3 from 0.21.2 to 0.22.0
View the [changelog](https://github.com/messense/nh3/releases/tag/v0.2.18) from here

### Link to issue number:
none
### Summary of the issue:
nh3 0.2.18 This is a dependency update version with no functional changes.
### Description of user facing changes
No user changes
### Description of development approach
Updated requirements.txt to use latest nh3 0.2.18
### Testing strategy:
has been compiled and tested using the local environment.
You need to use appveyor to compile the test.
### Known issues with pull request:
none
### Code Review Checklist:


- [ ] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [ ] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [ ] API is compatible with existing add-ons.
- [ ] Security precautions taken.

<!-- Please keep the following -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated the `nh3` package version to improve performance and potential bug fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
