### PR TITLE
Do not complete add-on installation or removal from the launcher

### DIFF
--- a/source/addonHandler/__init__.py
+++ b/source/addonHandler/__init__.py
@@ -337,7 +337,7 @@ def _getAvailableAddonsFromPath(
 	log.debug("Listing add-ons from %s", path)
 	for p in os.listdir(path):
 		if p.endswith(DELETEDIR_SUFFIX):
-			if isFirstLoad:
+			if isFirstLoad and NVDAState.shouldWriteToDisk():
 				removeFailedDeletion(os.path.join(path, p))
 			continue
 		addon_path = os.path.join(path, p)
@@ -351,6 +351,7 @@ def _getAvailableAddonsFromPath(
 					name = a.manifest["name"]
 					if (
 						isFirstLoad
+						and NVDAState.shouldWriteToDisk()
 						and name in state[AddonStateCategory.PENDING_REMOVE]
 						and not a.path.endswith(ADDON_PENDINGINSTALL_SUFFIX)
 					):
@@ -360,9 +361,13 @@ def _getAvailableAddonsFromPath(
 						except RuntimeError:
 							log.exception(f"Failed to remove {name} add-on")
 							_failedPendingRemovals.add(name)
-					if isFirstLoad and (
-						name in state[AddonStateCategory.PENDING_INSTALL]
-						or a.path.endswith(ADDON_PENDINGINSTALL_SUFFIX)
+					if (
+						isFirstLoad
+						and NVDAState.shouldWriteToDisk()
+						and (
+							name in state[AddonStateCategory.PENDING_INSTALL]
+							or a.path.endswith(ADDON_PENDINGINSTALL_SUFFIX)
+						)
 					):
 						newPath = a.completeInstall()
 						if newPath:

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -42,6 +42,7 @@ The available options are:
 * Improvements in Microsoft PowerPoint: (#17004)
   * It is now possible to use braille display routing keys to move the text cursor. (#9101)
   * It is now possible to use the review cursor selection commands to select text.
+* Updating NVDA while NVDA updates are pending no longer results in the add-on being removed. (#16837)
 
 ### Changes for Developers
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -42,7 +42,7 @@ The available options are:
 * Improvements in Microsoft PowerPoint: (#17004)
   * It is now possible to use braille display routing keys to move the text cursor. (#9101)
   * It is now possible to use the review cursor selection commands to select text.
-* Updating NVDA while NVDA updates are pending no longer results in the add-on being removed. (#16837)
+* Updating NVDA while add-on updates are pending no longer results in the add-on being removed. (#16837)
 
 ### Changes for Developers
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:

Fixes #16837 

### Summary of the issue:

As reported by @CyrilleB79, if one were to update an add-on from the add-on store, then accept an NVDA update before restarting to complete the add-on update, the update will completely clobber the add-on. Upon further investigation, this is because the launcher erroneously attempts to complete add-on installation/removal, but an error is thrown (because it shouldn't be touching the file system) part way through, so it cannot complete successfully.

### Description of user facing changes

If add-ons are pending installation/removal when an update is started, the installation will not affect this, and the installation/removal will proceed when the updated copy of NVDA starts.

### Description of development approach

Added checks for `NVDAState.shouldWriteToDisk()` to sections of `addonHandler._getAvailableAddonsFromPath` that alter the filesystem.

### Testing strategy:

Spoofed an old add-on. Updated via the store. Triggered NVDA to update. Ensured the add-on was updated when the new version started.

### Known issues with pull request:

The launcher will log an error about add-ons not being found, but all add-ons still seem to work properly.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved add-on handling during updates, ensuring users can update NVDA without losing installed add-ons.
  
- **Bug Fixes**
	- Fixed an issue preventing proper removal of failed deletions and processing of pending installations, enhancing data integrity during add-on management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
