### PR TITLE
Reformat build guide and add note about building serially when debugging the build process

### DIFF
--- a/projectDocs/dev/buildingNVDA.md
+++ b/projectDocs/dev/buildingNVDA.md
@@ -40,6 +40,8 @@ A binary build of NVDA can be run on a system without Python and all of NVDA's o
 
 Binary archives and bundles can be created using scons from the root of the NVDA source distribution. To build any of the following, open a command prompt and change to that directory.
 
+### Building without Archiving
+
 To make a non-archived binary build (equivalent to an extracted portable archive), type:
 
 ```cmd

--- a/projectDocs/dev/buildingNVDA.md
+++ b/projectDocs/dev/buildingNVDA.md
@@ -20,10 +20,16 @@ scons source user_docs
 
 While simply testing or committing changes, it may be faster usually just doing `scons source` as user documentation will change each time the revision number changes.
 
-You can speed up scons calls by appending the `--all-cores` or `-j N` (where `N` is the number of cores to use) parameter to the call, however note that this can cause errors, and output will be scrambled:
+You can speed up scons calls by appending the following CLI parameters:
+
+- `-j N`, where `N` is the number of cores to use while building
+- `--all-cores` to use all cores.
+
+However note that building across cores can cause errors, and output will be scrambled.
 
 ```cmd
 scons source --all-cores
+scons checkPot -j 1
 ```
 
 If you are experiencing errors building NVDA with threading enabled, please force a serial build with the `-j 1` parameter.

--- a/projectDocs/dev/buildingNVDA.md
+++ b/projectDocs/dev/buildingNVDA.md
@@ -1,7 +1,9 @@
 # Building NVDA
+
 Before building NVDA, [create your developer environment](./createDevEnvironment.md).
 
 ## Preparing the Source Tree
+
 Before you can run the NVDA source code, you must prepare the source tree.
 You do this by opening a command prompt, changing to the root of the NVDA source distribution and typing:
 
@@ -25,6 +27,7 @@ scons source --all-cores
 ```
 
 ## Running the Source Code
+
 It is possible to run NVDA directly from source without having to build the full binary package and launcher.
 To launch NVDA from source, using `cmd.exe`, execute `runnvda.bat` in the root of the repository.
 
@@ -32,6 +35,7 @@ To view help on the arguments that NVDA will accept, use the `-h` or `--help` op
 These arguments are also documented in the [user guide](https://www.nvaccess.org/files/nvda/documentation/userGuide.html#CommandLineOptions).
 
 ## Building NVDA
+
 A binary build of NVDA can be run on a system without Python and all of NVDA's other dependencies installed (as we do for snapshots and releases).
 
 Binary archives and bundles can be created using scons from the root of the NVDA source distribution. To build any of the following, open a command prompt and change to that directory.
@@ -55,9 +59,11 @@ scons launcher
 The archive will be placed in the output directory.
 
 ### Building developer documentation
+
 Refer to [building developer documentation](./buildingDevDocumentation.md).
 
 ### Generate debug symbols archive
+
 To generate an archive of debug symbols for the various dll/exe binaries, type:
 
 ```cmd
@@ -67,6 +73,7 @@ scons symbolsArchive
 The archive will be placed in the output directory.
 
 ### Generate translation template
+
 To generate a gettext translation template (for translators), type:
 
 ```cmd
@@ -74,13 +81,14 @@ scons pot
 ```
 
 ### Customising the build
+
 Optionally, the build can be customised by providing variables on the command line.
 This is useful when [creating a self signed build](./selfSignedBuild.md).
 
 * version: The version of this build.
 * release: Whether this is a release version.
-	* This enables various C++ compiler optimizations such as /O2 and whole-program optimization.
-	* It also instructs Python to generate optimized byte code.
+  * This enables various C++ compiler optimizations such as /O2 and whole-program optimization.
+  * It also instructs Python to generate optimized byte code.
 * publisher: The publisher of this build.
 * certFile: The certificate file with which to sign executables. The certificate must be in pfx format and contain the private key.
 * certPassword: The password for the private key in the signing certificate. If omitted, no password will be assumed.

--- a/projectDocs/dev/buildingNVDA.md
+++ b/projectDocs/dev/buildingNVDA.md
@@ -34,7 +34,7 @@ To launch NVDA from source, using `cmd.exe`, execute `runnvda.bat` in the root o
 To view help on the arguments that NVDA will accept, use the `-h` or `--help` option.
 These arguments are also documented in the [user guide](https://www.nvaccess.org/files/nvda/documentation/userGuide.html#CommandLineOptions).
 
-## Building NVDA
+## Making Binary Builds
 
 A binary build of NVDA can be run on a system without Python and all of NVDA's other dependencies installed (as we do for snapshots and releases).
 

--- a/projectDocs/dev/buildingNVDA.md
+++ b/projectDocs/dev/buildingNVDA.md
@@ -20,11 +20,14 @@ scons source user_docs
 
 While simply testing or committing changes, it may be faster usually just doing `scons source` as user documentation will change each time the revision number changes.
 
-You can speed up scons calls by appending the `--all-cores` parameter to the call, however note that output will be scrambled:
+You can speed up scons calls by appending the `--all-cores` or `-j N` (where `N` is the number of cores to use) parameter to the call, however note that this can cause errors, and output will be scrambled:
 
 ```cmd
 scons source --all-cores
 ```
+
+If you are experiencing errors building NVDA with threading enabled, please force a serial build with the `-j 1` parameter.
+This will make tracking down the issue much easier, and may even resolve it.
 
 ## Running the Source Code
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:

None.

### Summary of the issue:

The build guide currently suggests that developers use the `--all-cores` parameter to SCons to speed up their builds, noting that this will scramble the output. However, it does not mention that in some cases this may break building altogether.

### Description of user facing changes

None. Developer change only.

### Description of development approach

Updated `projectDocs/dev/buildingNVDA.md`:

* Fixed a bunch of linting issues, including having blanks around headings, using 2 spaces for list indents, and not having duplicate headings.
* Added a heading for building NVDA without archiving it.
* Noted that the `-j N` option can be used instead of the `--all-cores` option.
* Noted that using a parallel build may break the build system.
* Noted that when experiencing problems with the build system, make sure to run it serially to make finding the source of the issue easier.

### Testing strategy:

Read over what I had written. Ran it through a spell checker and Markdown linter.

### Known issues with pull request:

None.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Enhanced clarity and detail in the NVDA build process documentation.
	- Updated section titles for better understanding, including renaming "Building NVDA" to "Making Binary Builds."
	- Added a new subsection for creating non-archived binary builds.
	- Expanded instructions for optimizing `scons` calls with the `-j N` option.
	- Included cautionary notes and recommendations for users encountering build errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
