### PR TITLE
Start dev cycle for 2025.1

### DIFF
--- a/source/addonAPIVersion.py
+++ b/source/addonAPIVersion.py
@@ -24,7 +24,7 @@ CURRENT: AddonApiVersionT = (
 	buildVersion.version_minor,
 )
 
-BACK_COMPAT_TO: AddonApiVersionT = (2024, 1, 0)
+BACK_COMPAT_TO: AddonApiVersionT = (2025, 1, 0)
 """
 As BACK_COMPAT_TO is incremented, the changed / removed parts / or reasoning should be added below.
 These only serve to act as a reminder, the changelog should be consulted for a comprehensive listing.

--- a/source/addonAPIVersion.py
+++ b/source/addonAPIVersion.py
@@ -30,6 +30,7 @@ As BACK_COMPAT_TO is incremented, the changed / removed parts / or reasoning sho
 These only serve to act as a reminder, the changelog should be consulted for a comprehensive listing.
 EG: (x, y, z): Large changes to speech.py
 ---
+(2025, 1, 0): HTML passed to browsableMessage is now sanitised, and various changes to the settings schema
 (2024, 1, 0): upgrade to python 3.11
 (2023, 1, 0): speech as str was dropped in favor of only SpeechCommand, and security changes.
 (2022, 1, 0): various constants moved to enums, notably a controlTypes refactor.

--- a/source/buildVersion.py
+++ b/source/buildVersion.py
@@ -63,8 +63,8 @@ def formatVersionForGUI(year, major, minor):
 
 # Version information for NVDA
 name = "NVDA"
-version_year = 2024
-version_major = 4
+version_year = 2025
+version_major = 1
 version_minor = 0
 version_build = 0  # Should not be set manually. Set in 'sconscript' provided by 'appVeyor.yml'
 version = _formatDevVersionString()

--- a/source/versionInfo.py
+++ b/source/versionInfo.py
@@ -14,7 +14,7 @@ from buildVersion import *  # noqa: F403
 longName = _("NonVisual Desktop Access")
 description = _("A free and open source screen reader for Microsoft Windows")
 url = "https://www.nvaccess.org"
-copyrightYears = "2006-2024"
+copyrightYears = "2006-2025"
 copyright = _("Copyright (C) {years} NVDA Contributors").format(
 	years=copyrightYears,
 )

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -18,7 +18,7 @@ Add-ons will need to be re-tested and have their manifest updated.
 #### API Breaking Changes
 
 These are breaking API changes.
-Please open a GitHub issue if your Add-on has an issue with updating to the new API.
+Please open a GitHub issue if your add-on has an issue with updating to the new API.
 
 #### Deprecations
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -1,5 +1,27 @@
 # What's New in NVDA
 
+## 2025.1
+
+### Important notes
+
+### New Features
+
+### Bug Fixes
+
+### Changes for Developers
+
+Please refer to [the developer guide](https://www.nvaccess.org/files/nvda/documentation/developerGuide.html#API) for information on NVDA's API deprecation and removal process.
+
+* Note: this is an Add-on API compatibility breaking release.
+Add-ons will need to be re-tested and have their manifest updated.
+
+#### API Breaking Changes
+
+These are breaking API changes.
+Please open a GitHub issue if your Add-on has an issue with updating to the new API.
+
+#### Deprecations
+
 ## 2024.4
 
 ### Important notes


### PR DESCRIPTION
Start the dev cycle for the 2025.1 release.
This will be a compatibility breaking release.

Complete:
- [x] New section in the change log.
- [x] Update NVDA version in `master`
- [x] Bump the add-on API compatibility in `master`
- [x] Update [`nvdaAPIVersions.json` to include the next version](https://github.com/nvaccess/addon-datastore-transform) nvaccess/addon-datastore-transform#26
  - Re-run the last "Transform NVDA addons to views" on [addon-datastore](https://github.com/nvaccess/addon-datastore/actions/workflows/transformDataToViews.yml) to regenerate projections (views) for the add-on datastore API.

On merge:
- [x] [Update auto milestone ID](https://github.com/nvaccess/nvda/settings/variables/actions)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated to version 2025.1, introducing significant breaking changes to the Add-on API.
	- Enhanced documentation for developers outlining new features, bug fixes, and necessary actions regarding API changes.
  
- **Bug Fixes**
	- Resolved issues related to backward compatibility and API interactions.
  
- **Chores**
	- Updated copyright year to 2025 in the version information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->