### PR TITLE
Remove unit tests for linking code between `reportFontAttributes` and `fontAttributeReporting`

### DIFF
--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -835,47 +835,6 @@ class Config_upgradeProfileSteps_upgradeProfileFrom_11_to_12(unittest.TestCase):
 			profile["documentFormatting"]["fontAttributeReporting"]
 
 
-class Config_getitem_alias(unittest.TestCase):
-	def setUp(self):
-		self.config = ConfigManager()["documentFormatting"]
-
-	def test_set_reportFontAttributes_false(self):
-		config = self.config
-		config["reportFontAttributes"] = False
-		self.assertEqual(config["reportFontAttributes"], False)
-		self.assertEqual(config["fontAttributeReporting"], OutputMode.OFF)
-
-	def test_set_reportFontAttributes_true(self):
-		config = self.config
-		config["reportFontAttributes"] = True
-		self.assertEqual(config["reportFontAttributes"], True)
-		self.assertEqual(config["fontAttributeReporting"], OutputMode.SPEECH_AND_BRAILLE)
-
-	def test_set_fontAttributeReporting_off(self):
-		config = self.config
-		config["fontAttributeReporting"] = OutputMode.OFF
-		self.assertEqual(config["fontAttributeReporting"], OutputMode.OFF)
-		self.assertEqual(config["reportFontAttributes"], False)
-
-	def test_set_fontAttributeReporting_speech(self):
-		config = self.config
-		config["fontAttributeReporting"] = OutputMode.SPEECH
-		self.assertEqual(config["fontAttributeReporting"], OutputMode.SPEECH)
-		self.assertEqual(config["reportFontAttributes"], True)
-
-	def test_set_fontAttributeReporting_braille(self):
-		config = self.config
-		config["fontAttributeReporting"] = OutputMode.BRAILLE
-		self.assertEqual(config["fontAttributeReporting"], OutputMode.BRAILLE)
-		self.assertEqual(config["reportFontAttributes"], True)
-
-	def test_set_fontAttributeReporting_speechAndBraille(self):
-		config = self.config
-		config["fontAttributeReporting"] = OutputMode.SPEECH_AND_BRAILLE
-		self.assertEqual(config["fontAttributeReporting"], OutputMode.SPEECH_AND_BRAILLE)
-		self.assertEqual(config["reportFontAttributes"], True)
-
-
 class Config_AggregatedSection_getitem(unittest.TestCase):
 	def setUp(self):
 		manager = MagicMock(ConfigManager())


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:

Partial fix for #16802 

### Summary of the issue:

#16748 introduced new behaviour whereby NVDA can be configured to report font attributes in speech, braille, both or not at all. This required the implementation of a new configuration key, `documentFormatting.fontAttributeReporting`. To avoid a breaking change to the API, aliasing code was introduced to ensure that the new key and its deprecated counterpart were kept in sync. When the API version is updated, these tests will fail as this code will no-longer run. Therefore, these tests need to be removed.

### Description of user facing changes

None.

### Description of development approach

Deleted `tests.unit.test_config.Config_getitem_alias`.

### Testing strategy:

Ran unit tests to ensure they all ran, and verified that the total number of tests only reduced by 6 (as a sanity check that I hadn't accidentally deleted too much).

### Known issues with pull request:

#16802 calls for the complete removal of the linking code, however this has not been done in this PR.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Removed outdated test class that could lead to gaps in testing coverage for configuration management functionality.
- **Chores**
	- Adjusted testing strategy related to font attributes to enhance overall test integrity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
