### PR TITLE
Update auto milestone action to only apply to completed issues and merged PRs

### DIFF
--- a/.github/workflows/assign-milestone-on-close.yml
+++ b/.github/workflows/assign-milestone-on-close.yml
@@ -1,7 +1,7 @@
 name: Assign Milestone on Close
 
 env:
-  MILESTONE_ID: 1
+  MILESTONE_ID: ${{ vars.MILESTONE_ID }}
 
 on:
   issues:

--- a/.github/workflows/assign-milestone-on-close.yml
+++ b/.github/workflows/assign-milestone-on-close.yml
@@ -1,7 +1,7 @@
 name: Assign Milestone on Close
 
 env:
-  MILESTONE_ID: ${{ vars.MILESTONE_ID }}
+  MILESTONE_ID: 1
 
 on:
   issues:
@@ -30,8 +30,21 @@ jobs:
               core.setOutput('milestoneNotSet', 'false');
             }
 
+      - name: Check completed or merged
+        id: check-done
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            if ((context.payload.issue && context.payload.issue.state_reason === "completed")
+                || (context.payload.pull_request && context.payload.pull_request.merged === true)) {
+              core.setOutput('isDone', 'true');
+            } else {
+              core.setOutput('isDone', 'false');
+            }
+
       - name: Assign default milestone
-        if: steps.check-milestone.outputs.milestoneNotSet == 'true'
+        if: steps.check-milestone.outputs.milestoneNotSet == 'true' && steps.check-done.outputs.isDone == 'true'
         uses: actions/github-script@v7
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:

None

### Summary of the issue:

The current auto milestone script currently applies milestones to all closed issues and pull requests, even when the issues are invalid or pull requests not merged.

### Description of user facing changes

None. Purely a DX improvement.

### Description of developer facing changes

- If an issue is closed as completed, the default milestone will be applied if the issue does not yet have a milestone.
- If an issue is closed as not planned, no milestone will be auto-applied.
- If a pull request is merged and closed, the default milestone will be applied if the PR does not yet have a milestone.
- If a pull request is closed without merging, no milestone will be auto-applied.

### Description of development approach

Added a step to the auto milestone script that checks the close reason of the issue, or merge status of the PR. If the issue is closed as complete or PR closed and merged, the `isDone` output is set to `'true'`, otherwise it is set to `'false'`. Updated the "Assign default milestone" step's `if` condition to require `isDone` to be `'true'`.

### Testing strategy:

Tested in my own fork of NVDA. Created a number of issues and PRs, with the following results:

- Good issue, no milestone, closed as complete: milestone applied automatically.
- Good issue, milestone already set, closed as complete: milestone unchanged.
- Bad issue, closed as not planned: milestone not applied.
- Good PR, closed and merged: milestone applied automatically.
- Bad PR, closed without merging: milestone not applied.
- PR linked to issue, closed and merged: milestone applied automatically to issue and PR.

### Known issues with pull request:

None.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new job step to enhance milestone assignment logic for issues and pull requests.
- **Improvements**
	- Improved accuracy of milestone assignments by ensuring they only occur for completed or merged tasks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
