### PR TITLE
Work around broken Data validation dropdown lists in Microsoft Excel

### DIFF
--- a/source/appModules/excel.py
+++ b/source/appModules/excel.py
@@ -110,11 +110,6 @@ class AppModule(appModuleHandler.AppModule):
 			# Therefore treat this window as native UIA.
 			return True
 		windowClass = winUser.getClassName(hwnd)
-		if windowClass == "SysListView32":
-			import tones
-
-			tones.beep(550, 50)
-			return True
 		versionMajor = int(self.productVersion.split(".")[0])
 		if versionMajor >= 16 and windowClass == "RICHEDIT60W" and winVersion.getWinVer() >= winVersion.WIN10:
 			# RICHEDIT60W In Excel 2016+ on Windows 10+

--- a/source/appModules/excel.py
+++ b/source/appModules/excel.py
@@ -58,6 +58,7 @@ class Excel6_WhenUIAEnabled(IAccessible):
 
 	shouldAllowIAccessibleFocusEvent = False
 
+
 class BrokenDataValidationSysListView32(UIA):
 	"""
 	#15138: Broken data validation SysListView32 control in Excel.
@@ -70,16 +71,16 @@ class BrokenDataValidationSysListView32(UIA):
 
 	@classmethod
 	def windowMatches(cls, hwnd: int) -> bool:
-		""" Identifies if the given window is a broken data validation SysListView32 control. """
-		if winUser.getClassName(hwnd) == 'SysListView32':
+		"""Identifies if the given window is a broken data validation SysListView32 control."""
+		if winUser.getClassName(hwnd) == "SysListView32":
 			parentHwnd = winUser.getAncestor(hwnd, winUser.GA_PARENT)
-			if winUser.getClassName(parentHwnd) == '__XLACOOUTER':
+			if winUser.getClassName(parentHwnd) == "__XLACOOUTER":
 				return True
 		return False
 
 	@classmethod
 	def matchesNVDAObject(cls, obj: NVDAObject) -> bool:
-		""" Identifies if the given NVDAObject is a broken data validation SysListView32 control. """
+		"""Identifies if the given NVDAObject is a broken data validation SysListView32 control."""
 		if isinstance(obj, UIA) and obj.UIAIsWindowElement and cls.windowMatches(obj.windowHandle):
 			return True
 		return False
@@ -88,20 +89,19 @@ class BrokenDataValidationSysListView32(UIA):
 		return api.getDesktopObject()
 
 	def _correctFocus(self):
-			eventHandler.queueEvent("gainFocus", NVDAObject.objectWithFocus())
+		eventHandler.queueEvent("gainFocus", NVDAObject.objectWithFocus())
 
 	@script(
 		gestures=["kb:enter", "kb:space", "kb:escape"],
 		canPropagate=True,
 	)
 	def script_close(self, gesture):
-		""" Correct focus when the user presses Enter, Space or Escape. """
+		"""Correct focus when the user presses Enter, Space or Escape."""
 		gesture.send()
 		core.callLater(100, self._correctFocus)
 
 
 class AppModule(appModuleHandler.AppModule):
-
 	def isGoodUIAWindow(self, hwnd: int) -> bool:
 		if BrokenDataValidationSysListView32.windowMatches(hwnd):
 			# #15138: Broken data validation SysListView32 control in Excel.
@@ -111,7 +111,9 @@ class AppModule(appModuleHandler.AppModule):
 			return True
 		windowClass = winUser.getClassName(hwnd)
 		if windowClass == "SysListView32":
-			import tones; tones.beep(550, 50)
+			import tones
+
+			tones.beep(550, 50)
 			return True
 		versionMajor = int(self.productVersion.split(".")[0])
 		if versionMajor >= 16 and windowClass == "RICHEDIT60W" and winVersion.getWinVer() >= winVersion.WIN10:

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -43,6 +43,7 @@ The available options are:
   * It is now possible to use braille display routing keys to move the text cursor. (#9101)
   * It is now possible to use the review cursor selection commands to select text.
 * Updating NVDA while add-on updates are pending no longer results in the add-on being removed. (#16837)
+* It is possible to interact with Data validation dropdown lists in Microsoft Excel 2016 and above. (#15138)
 
 ### Changes for Developers
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -43,7 +43,7 @@ The available options are:
   * It is now possible to use braille display routing keys to move the text cursor. (#9101)
   * It is now possible to use the review cursor selection commands to select text.
 * Updating NVDA while add-on updates are pending no longer results in the add-on being removed. (#16837)
-* It is possible to interact with Data validation dropdown lists in Microsoft Excel 365. (#15138)
+* It is now possible to interact with Data validation dropdown lists in Microsoft Excel 365. (#15138)
 
 ### Changes for Developers
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -43,7 +43,7 @@ The available options are:
   * It is now possible to use braille display routing keys to move the text cursor. (#9101)
   * It is now possible to use the review cursor selection commands to select text.
 * Updating NVDA while add-on updates are pending no longer results in the add-on being removed. (#16837)
-* It is possible to interact with Data validation dropdown lists in Microsoft Excel 2016 and above. (#15138)
+* It is possible to interact with Data validation dropdown lists in Microsoft Excel 365. (#15138)
 
 ### Changes for Developers
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Fixes #15138

### Summary of the issue:
If a cell in Microsoft Excel has a data validation type of list, NvDA does not report anything when it is opened and or when selecting a value.
Note that this is specifically talking about the list shown when the cell has data validation set. The dropdown list shown when auto completing from values in higher cells does report okay.

#### Technical info
* The list is a SysListView32 control.
* It has a native UIA implementation.
* NvDA generally does not trust UIA implementations for SysListView32 as they have been somewhat limited.
* Therefore NVDA falls back to MSAA for the list.
* Although UIA core is proxying the UIA events to MSAA events, the UIA implementation seems to be incomplete as AccessibleObjectFromEvent is always returning E_FAIL for any focus win event fired by the control.
* Even if NvDA is told to specifically use UIA for this control, there is a loop in the control's parent chain, causing a never ending focus ancestry.

### Description of user facing changes
It is now possible tin teract with data validation dropdown lists in Excel. this includes reporting the focused / selected item as you move up and down the list, and reporting focus back on the sheet when the list is closed with enter, space or escape.
  
### Description of development approach
* Excel appModule's isGoodUIAWindow treats this SysListView32 window as native UIA.
* The parent property on this NvDAObject has been overridden to return the desktop, skipping the loop between SysListView32 and __XLACOOUTER windows.
* AScript on this NvDAObject bound to enter, space and escape, corrects NvDA's focus back to the sheet.
 
### Testing strategy:
In Excel 365:
* Opened a new blank sheet in Excel
* On a1, went to the Data Validation dialog, chose a type of 'list' and added 'red, blue, green' as the source.
* when focused back on a1, pressed alt+downArrow. Confirmed that NVDA reported "list red 1 of 3".
* Moved focus / selection up and down the list with the arrow keys. Confirming that the correct item was reported.
* Closed the list with enter, space and escape, and confirmed that NvDA reported focus move back to the sheet, specifically cell a1. For enter and space, confirmed that the value of the cell changed.
 Further testing from other people on other versions of Excel would be very welcome.

### Known issues with pull request:
None known.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced enhanced accessibility for data validation dropdowns in Excel, improving user interaction with Microsoft Excel 2016 and later.
- **Bug Fixes**
	- Addressed focus issues with the SysListView32 control, ensuring better focus behavior when interacting with data validation elements.
- **Documentation**
	- Added reference to issue #15138 for transparency on accessibility enhancements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
