### PR TITLE
Revert "Use UIA caret events in Windows Terminal (#16873)"

### DIFF
--- a/source/NVDAObjects/UIA/winConsoleUIA.py
+++ b/source/NVDAObjects/UIA/winConsoleUIA.py
@@ -450,10 +450,6 @@ class _DiffBasedWinTerminalUIA(EnhancedTermTypedCharSupport):
 		"Block notification events when diffing to prevent double reporting."
 		log.debugWarning(f"Notification event blocked to avoid double-report: {kwargs}")
 
-	def _get_caretMovementDetectionUsesEvents(self) -> bool:
-		"Windows Terminal has a good implementation of caret move detection."
-		return True
-
 
 class _NotificationsBasedWinTerminalUIA(UIA):
 	"""

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -27,10 +27,12 @@ The available options are:
 
 ### Bug Fixes
 
+* NVDA once again relies on UIA events for caret movement in XAML and WPF text controls, rather than only on manual querying of the caret position. (#16817, @LeonarddeR)
+* The Seika Notetaker driver now correctly generates braille input for space, backspace and dots with space/backspace gestures. (#16642, @school510587)
+* In on-demand speech mode, NVDA does not talk anymore when a message is opened in Outlook, when a new page is loaded in a browser or during the slideshow in PowerPoint. (#16825, @CyrilleB79)
 * NVDA once again relies on events for caret movement in several cases, rather than only on manual querying of the caret position.
   * UIA for XAML and WPF text controls. (#16817, @LeonarddeR)
   * IAccessible2 for browsers such as Firefox and Chromium based browsers. (#11545, #16815, @LeonarddeR)
-  * UIA in Windows Terminal. (#16873, @codeofdusk)
 * When accessing Microsoft Word without UI Automation, NVDA no longer outputs garbage characters in braille in table headers defined with the set row and column header commands. (#7212)
 * The Seika Notetaker driver now correctly generates braille input for space, backspace and dots with space/backspace gestures. (#16642, @school510587)
 * Braille cursor routing is now much more reliable when a line contains one or more Unicode variation selectors or decomposed characters. (#10960, @mltony, @LeonarddeR)


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Reverts #16873.

### Summary of the issue:
* When backspacing beyond the leftmost character of a line in Windows Terminal, the last character of the prompt is erroneously read in some environments.
* Some caret tracking issues (especially when connected to remote systems) are more apparent.

### Description of how this pull request fixes the issue:
Revert the new behaviour until it can be fixed upstream or a workaround can be found.

### Testing strategy:
Verified restoration of previous behaviour and that caret tracking works as before.

### Known issues with pull request:
Please include in 2024.4.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Reinstated reliance on UIA events for caret movement in XAML and WPF text controls, improving caret tracking accuracy.
	- Updated Seika Notetaker driver for better braille input handling.

- **Bug Fixes**
	- Adjusted on-demand speech mode to reduce interruptions during specific actions.
	- Fixed garbage character output in braille when accessing Microsoft Word without UI Automation.
	- Improved braille cursor routing for better navigation with Unicode characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->