### PR TITLE
CursorManager._caretMovementScriptHelper: return early if another script is waiting.

### DIFF
--- a/source/cursorManager.py
+++ b/source/cursorManager.py
@@ -18,7 +18,7 @@ from gui import guiHelper
 import gui.contextHelp
 from speech import sayAll
 import review
-from scriptHandler import willSayAllResume, script
+from scriptHandler import willSayAllResume, script, isScriptWaiting
 import textInfos
 import speech
 import config
@@ -145,6 +145,10 @@ class CursorManager(documentBase.TextContainerObject, baseObject.ScriptableObjec
 		extraDetail=False,
 		handleSymbols=False,
 	):
+		if isScriptWaiting():
+			# Moving / reporting is quite costly, so we don't want to do it if there are more scripts waiting.
+			# Otherwise, NVDA could become unusable while it processes many backed up scripts.
+			return
 		oldInfo = self.makeTextInfo(posConstant)
 		info = oldInfo.copy()
 		info.collapse(end=self.isTextSelectionAnchoredAtStart)

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -43,7 +43,7 @@ The available options are:
   * It is now possible to use braille display routing keys to move the text cursor. (#9101)
   * It is now possible to use the review cursor selection commands to select text.
 * Updating NVDA while add-on updates are pending no longer results in the add-on being removed. (#16837)
-* NVDA no longer becomes unresponsive after holding down an arrow key for a long time while in browse mode, particularly in Microsoft Word. (#16812)
+* NVDA no longer becomes unresponsive after holding down an arrow key for a long time while in browse mode, particularly in Microsoft Word and Microsoft Outlook. (#16812)
 
 ### Changes for Developers
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -43,6 +43,7 @@ The available options are:
   * It is now possible to use braille display routing keys to move the text cursor. (#9101)
   * It is now possible to use the review cursor selection commands to select text.
 * Updating NVDA while add-on updates are pending no longer results in the add-on being removed. (#16837)
+* NVDA no longer becomes unresponsive if holding down an arrow key for a long time while in NVDA browse mode, in particular Microsoft word. (#16812)
 
 ### Changes for Developers
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -43,7 +43,7 @@ The available options are:
   * It is now possible to use braille display routing keys to move the text cursor. (#9101)
   * It is now possible to use the review cursor selection commands to select text.
 * Updating NVDA while add-on updates are pending no longer results in the add-on being removed. (#16837)
-* NVDA no longer becomes unresponsive if holding down an arrow key for a long time while in NVDA browse mode, in particular Microsoft word. (#16812)
+* NVDA no longer becomes unresponsive after holding down an arrow key for a long time while in browse mode, particularly in Microsoft Word. (#16812)
 
 ### Changes for Developers
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Fixes #16812

### Summary of the issue:
If holding down an arrow key in NvDA browse mode, such as in Microsoft Word, NVDA can become unresponsive if holding down the key for a long period of time. This is because moving in browse mode can be very costly, and scripts become backed up.

### Description of user facing changes
NVDA no longer becomes unresponsive if holding down an arrow key for a long time while in NVDA browse mode, in particular in Microsoft word.

### Description of development approach
CursorManager._caretMovementScriptHelper: return early if another script is waiting. There is no point doing something costly when another script is going to happen anyway.

### Testing strategy:
with both UIA enabled and disabled for MS Word:
* Opened a large document in Microsoft Word. 
* Switched to browse mode with NVDA+space.
* Held down down arrow for at least 5 seconds. Ensured that NvDA had moved down several lines and that it started to report the line straight away, rather than becoming unresponsive.
  
### Known issues with pull request:
None known.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved keyboard navigation in NVDA to prevent unresponsiveness during extended key presses in browse mode.
	- Added support for braille display routing keys and new cursor selection commands.
- **Bug Fixes**
	- Resolved an issue where updating NVDA while pending add-on updates would remove the add-on, ensuring a smoother update process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
