### PR TITLE
VS Code is no longer as sluggish when arrowing up and down through large files

### DIFF
--- a/source/appModules/code.py
+++ b/source/appModules/code.py
@@ -7,8 +7,22 @@
 
 import appModuleHandler
 import controlTypes
+from NVDAObjects.IAccessible.ia2Web import Editor
 from NVDAObjects.IAccessible.chromium import Document
+from NVDAObjects.IAccessible.ia2TextMozilla import MozillaCompoundTextInfo
 from NVDAObjects import NVDAObject, NVDAObjectTextInfo
+
+
+class VSCodeEditorTextInfo(MozillaCompoundTextInfo):
+	def _isCaretAtEndOfLine(self, caretObj) -> bool:
+		# #17039: IAccessibleText::textAtOffset with IA2_OFFSET_CARET is way too costly in VSCode.
+		# And doesn't actually work correctly in Chromium yet anyway.
+		# So it is best not to try detecting for now.
+		return False
+
+
+class VSCodeEditor(Editor):
+	TextInfo = VSCodeEditorTextInfo
 
 
 class VSCodeDocument(Document):
@@ -17,6 +31,8 @@ class VSCodeDocument(Document):
 	Therefore, forcefully block tree interceptor creation.
 	"""
 
+	textInfo = VSCodeEditorTextInfo
+
 	_get_treeInterceptorClass = NVDAObject._get_treeInterceptorClass
 
 
@@ -24,6 +40,8 @@ class AppModule(appModuleHandler.AppModule):
 	def chooseNVDAObjectOverlayClasses(self, obj, clsList):
 		if Document in clsList and obj.IA2Attributes.get("tag") == "#document":
 			clsList.insert(0, VSCodeDocument)
+		elif Editor in clsList:
+			clsList.insert(0, VSCodeEditor)
 
 	def event_NVDAObject_init(self, obj: NVDAObject):
 		# This is a specific fix for Visual Studio Code,

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -43,6 +43,7 @@ The available options are:
   * It is now possible to use braille display routing keys to move the text cursor. (#9101)
   * It is now possible to use the review cursor selection commands to select text.
 * Updating NVDA while add-on updates are pending no longer results in the add-on being removed. (#16837)
+* NVDA is no longer as sluggish when arrowing up and down through large files in VS Code. (#17039)
 
 ### Changes for Developers
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Fixes #17039

### Summary of the issue:
With the introduction of pr #16745 which added better reporting of the caret at when at the end of a line, VS Code became quite slow when arrowing up and down through particular large files.
 `IAccessibleText::textAtOffset` with `IA2_OFFSET_CARET` is very costly in VS Code, and Chromium does not actually implement this correctly yet anyway.

### Description of user facing changes
NVDA is less sluggish when arrowing up and down through large files in VS Code.

### Description of development approach
VS code appModule: provide a new `VsCodeEditorTextInfo` which disables end-of-line caret detection by returning False in `_IsCaretAtEndOfLine`.

### Testing strategy:
Opened source/NVDAObjects/IAccessible/__init__.py in VS Code, and moved to line 1491, and arrowed down several line. Confirmed that the sluggishness was gone.

### Known issues with pull request:
None known.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved performance of NVDA when navigating large files in Visual Studio Code, reducing sluggishness when using arrow keys.
	- Enhanced text handling integration specifically for VSCode editors.

- **Bug Fixes**
	- Maintained functionality for braille display routing keys and review cursor selection commands, ensuring they operate as intended.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
