### PR TITLE
Disable caret at end of line detection in Chromium

### DIFF
--- a/source/NVDAObjects/IAccessible/chromium.py
+++ b/source/NVDAObjects/IAccessible/chromium.py
@@ -166,6 +166,25 @@ class Figure(ia2Web.Ia2Web):
 		return controlTypes.Role.FIGURE
 
 
+class EditorTextInfo(ia2Web.MozillaCompoundTextInfo):
+	"""The TextInfo for edit areas such as edit fields and documents in Chromium."""
+
+	def _isCaretAtEndOfLine(self, caretObj: IAccessible) -> bool:
+		# Detecting if the caret is at the end of the line in Chromium is not currently possible
+		# as Chromium's IAccessibleText::textAtOffset with IA2_OFFSET_CARET returns the first character of the next line,
+		# which is what we are trying to avoid in the first place.
+		# #17039: In some scenarios such as in large files in VS Code,
+		# this call is extreamly costly for no actual bennifit right now,
+		# so we are disabling it for Chromium.
+		return False
+
+
+class Editor(ia2Web.Editor):
+	"""The NVDAObject for edit areas such as edit fields and documents in Chromium."""
+
+	TextInfo = EditorTextInfo
+
+
 def findExtraOverlayClasses(obj, clsList):
 	"""Determine the most appropriate class(es) for Chromium objects.
 	This works similarly to L{NVDAObjects.NVDAObject.findOverlayClasses} except that it never calls any other findOverlayClasses method.
@@ -188,3 +207,5 @@ def findExtraOverlayClasses(obj, clsList):
 		clsList,
 		documentClass=Document,
 	)
+	if ia2Web.Editor in clsList:
+		clsList.insert(0, Editor)

--- a/source/appModules/code.py
+++ b/source/appModules/code.py
@@ -7,22 +7,8 @@
 
 import appModuleHandler
 import controlTypes
-from NVDAObjects.IAccessible.ia2Web import Editor
 from NVDAObjects.IAccessible.chromium import Document
-from NVDAObjects.IAccessible.ia2TextMozilla import MozillaCompoundTextInfo
 from NVDAObjects import NVDAObject, NVDAObjectTextInfo
-
-
-class VSCodeEditorTextInfo(MozillaCompoundTextInfo):
-	def _isCaretAtEndOfLine(self, caretObj) -> bool:
-		# #17039: IAccessibleText::textAtOffset with IA2_OFFSET_CARET is way too costly in VSCode.
-		# And doesn't actually work correctly in Chromium yet anyway.
-		# So it is best not to try detecting for now.
-		return False
-
-
-class VSCodeEditor(Editor):
-	TextInfo = VSCodeEditorTextInfo
 
 
 class VSCodeDocument(Document):
@@ -31,8 +17,6 @@ class VSCodeDocument(Document):
 	Therefore, forcefully block tree interceptor creation.
 	"""
 
-	textInfo = VSCodeEditorTextInfo
-
 	_get_treeInterceptorClass = NVDAObject._get_treeInterceptorClass
 
 
@@ -40,8 +24,6 @@ class AppModule(appModuleHandler.AppModule):
 	def chooseNVDAObjectOverlayClasses(self, obj, clsList):
 		if Document in clsList and obj.IA2Attributes.get("tag") == "#document":
 			clsList.insert(0, VSCodeDocument)
-		elif Editor in clsList:
-			clsList.insert(0, VSCodeEditor)
 
 	def event_NVDAObject_init(self, obj: NVDAObject):
 		# This is a specific fix for Visual Studio Code,


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
More broadly fixes #17039

### Summary of the issue:
In PR #16745, code was added to detect the caret at end of lines in Mozilla-compatible edit areas, so as to not report the next line when on the final insertion point of the line before.
Although this works great in Firefox and other Gecko-based apps, it does not work at all in Chromium due to Chromium not correctly 
implementing IAccessibleText::textAtOffset with IA2_OFFSET_CARET.
More importantly, this is a very costly check in VS code, which has a noticeable performance hit when arrowing up and down large files (issue #17039), for no gain.
PR #17051 successfully fixed the performance hit in VS code by disabling caret at end of line detection just for VS Code. But it was pointed out that there are several VS Code variants including VS Code.dev which require this also.
 
### Description of user facing changes
NVDA is no longer as sluggish when arrowing up and down large fles in VS code and otherChromium-based applications.

### Description of development approach
* Remoe the VSCodeditor and VSCodeEditorTextInfo classes from the VS ode appModule introduced in pr #17051.
* Add Editor and EditorTextInfo classes to NVDAObjects.IAccessible.chromium which are used in Chromium where ever NVDAObject.IAccessible.ia2Web.Editor is used. These classes disable caret at end of line detection  for any chromium edit area.

### Testing strategy:
Retested steps in #17039, ensuring that the performance hit is stll gone in VS Code.


### Known issues with pull request:
None known.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced enhanced accessibility features for text areas in Chromium-based applications.
	- Added support for better text editing capabilities with new `Editor` and `EditorTextInfo` classes.

- **Bug Fixes**
	- Removed unnecessary caret detection methods to improve performance and accuracy in Chromium and VSCode environments.

- **Refactor**
	- Streamlined code by eliminating outdated classes and methods associated with text handling in Visual Studio Code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
