### PR TITLE
fix up changes

### DIFF
--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -5,9 +5,12 @@
 ### Important notes
 
 ### New Features
+
 * In Mozilla Firefox, NVDA will report the highlighted text when a URL containing a text fragment is visited. (#16910, @jcsteh)
 
 ### Bug Fixes
+
+* Native support for the Dot Pad tactile graphics device from Dot Inc as a multiline braille display. (#17007)
 
 ### Changes for Developers
 
@@ -59,9 +62,6 @@ There have also been a number of fixes, including to mouse tracking in Firefox, 
 * The comment command in Microsoft Word and notes command in Microsoft Excel can now be pressed twice to show the comment or note in a browsable message. (#16800, #16878, @Cary-Rowen)
 * NVDA can now be configured to report font attributes in speech and braille separately. (#16755)
 * The timeout to perform a multiple keypress is now configurable; this may be especially useful for people with dexterity impairment. (#11929, @CyrilleB79)
-* When performing a braille cursor routing action, NVDA can now automatically speak the character at the cursor. (#8072, @LeonarddeR)
-  * This option is disabled by default. You can enable "Speak character when routing cursor in text" in NVDA's braille settings.
-* Native support for the Dot Pad tactile graphics device from Dot Inc as a multiline braille display. (#17007)
 
 ### Changes
 


### PR DESCRIPTION
Fixup changes from #17007

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced NVDA support for Mozilla Firefox allows reporting of highlighted text when accessing URLs with text fragments.
	- Added native support for the Dot Pad tactile graphics device as a multiline braille display.

- **Bug Fixes**
	- Improved interaction in Microsoft Word and Excel with the ability to browse comments and notes easily.
	- NVDA now reports font attributes in speech and braille separately.
	- Configurable timeout for multiple keypresses to assist users with dexterity impairments.

- **Documentation**
	- Updated documentation to reflect new features and improvements, ensuring clarity for users. 
	- Removed the feature related to automatic speaking of characters during braille cursor routing based on user feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->