### PR TITLE
Remove redundant NOQA flags

### DIFF
--- a/source/utils/schedule.py
+++ b/source/utils/schedule.py
@@ -184,7 +184,7 @@ class ScheduleThread(threading.Thread):
 					wx.CallAfter(task, *args, **kwargs)
 			case ThreadTarget.DAEMON:
 
-				def callJobOnThread(*args, **kwargs):  # noqa F811: lint bug with flake8 4.0.1 not recognizing case statement
+				def callJobOnThread(*args, **kwargs):
 					t = threading.Thread(
 						target=task,
 						args=args,
@@ -196,7 +196,7 @@ class ScheduleThread(threading.Thread):
 					t.run()
 			case ThreadTarget.CUSTOM:
 
-				def callJobOnThread(*args, **kwargs):  # noqa F811: lint bug with flake8 4.0.1 not recognizing case statement
+				def callJobOnThread(*args, **kwargs):
 					log.debug(f"Starting thread for job: {task.__name__} on custom thread")
 					task(*args, **kwargs)
 			case _:


### PR DESCRIPTION

<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->


### Summary of the issue:
before ruff, the flake8 version we used didn't support match/case statements. ruff does now

### Description of development approach
Remove redundant NOQA flags

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Removed unnecessary comments from the `callJobOnThread` function to improve code clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->