### PR TITLE
Update liblouis to 3.31

### DIFF
--- a/projectDocs/dev/createDevEnvironment.md
+++ b/projectDocs/dev/createDevEnvironment.md
@@ -80,7 +80,7 @@ For reference, the following run time dependencies are included in Git submodule
 * [eSpeak NG](https://github.com/espeak-ng/espeak-ng), version 1.52-dev commit `961454ffaa894d981526f4d424daef1d3bc4175f`
 * [Sonic](https://github.com/waywardgeek/sonic), commit `8694c596378c24e340c09ff2cd47c065494233f1`
 * [IAccessible2](https://wiki.linuxfoundation.org/accessibility/iaccessible2/start), commit `3d8c7f0b833453f761ded6b12d8be431507bfe0b`
-* [liblouis](http://www.liblouis.io/), version 3.30.0
+* [liblouis](http://www.liblouis.io/), version 3.31.0
 * [Unicode Common Locale Data Repository (CLDR)](http://cldr.unicode.org/), version 45.0
 * NVDA images and sounds
 * [Adobe Acrobat accessibility interface, version XI](https://download.macromedia.com/pub/developer/acrobat/AcrobatAccess.zip)

--- a/source/brailleTables.py
+++ b/source/brailleTables.py
@@ -359,7 +359,10 @@ addTable("ga-g2.ctb", _("Irish grade 2"), contracted=True)
 addTable("gu-in-g1.utb", _("Gujarati grade 1"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
-addTable("grc-international-en.utb", _("Greek international braille"))
+addTable("grc-international-en.utb", _("Greek international braille (2-cell accented letters)"))
+# Translators: The name of a braille table displayed in the
+# braille settings dialog.
+addTable("grc-international-en-composed.utb", _("Greek international braille (single-cell accented letters)"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("grc-international-es.utb", _("Spanish for Greek text"))
@@ -626,7 +629,10 @@ addTable("te-in-g1.utb", _("Telugu grade 1"))
 addTable("th-comp8-backward.utb", _("Thai 8 dot computer braille"), output=False)
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
-addTable("th-g0.utb", _("Thai 6 dot"), input=False)
+addTable("th-g0.utb", _("Thai grade 0"), input=False)
+# Translators: The name of a braille table displayed in the
+# braille settings dialog.
+addTable("th-g1.utb", _("Thai grade 1"), input=False, contracted=True)
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("tr.ctb", _("Turkish grade 1"))

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -20,6 +20,8 @@ NVDA is no longer unstable after restarting NVDA during an automatic Braille Blu
 
 eSpeak NG has been updated, adding support for the Faroese and Xextan languages.
 
+LibLouis has been updated, adding new Braille tables for Thai and Greek international braille with single-cell accented letters.
+
 There have also been a number of fixes, including to mouse tracking in Firefox, and the on-demand speech mode.
 
 ### New Features
@@ -41,7 +43,7 @@ There have also been a number of fixes, including to mouse tracking in Firefox, 
 
 * The `-c`/`--config-path` and `--disable-addons` command line options are now respected when launching an update from within NVDA. (#16937)
 * Component updates:
-  * Updated LibLouis braille translator to [3.31.0](https://github.com/liblouis/liblouis/releases/tag/v3.31.0). (#????, @LeonarddeR)
+  * Updated LibLouis braille translator to [3.31.0](https://github.com/liblouis/liblouis/releases/tag/v3.31.0). (#17080, @LeonarddeR)
     * New braille tables:
       * Thai grade 1
       * Greek international braille (single-cell accented letters)

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -40,8 +40,16 @@ There have also been a number of fixes, including to mouse tracking in Firefox, 
 ### Changes
 
 * The `-c`/`--config-path` and `--disable-addons` command line options are now respected when launching an update from within NVDA. (#16937)
-* eSpeak NG has been updated to 1.52-dev commit `961454ff`. (#16775)
-  * Added new languages Faroese and Xextan.
+* Component updates:
+  * Updated LibLouis braille translator to [3.31.0](https://github.com/liblouis/liblouis/releases/tag/v3.31.0). (#????, @LeonarddeR)
+    * New braille tables:
+      * Thai grade 1
+      * Greek international braille (single-cell accented letters)
+    * Renamed tables:
+      * "Thai 6 dot" was renamed to "Thai grade 0" for consistency reasons.
+      * The existing "Greek international braille" table was renamed to "Greek international braille (2-cell accented letters)" to clarify the distinction between the two Greek systems.
+  * eSpeak NG has been updated to 1.52-dev commit `961454ff`. (#16775)
+    * Added new languages Faroese and Xextan.
 * When using a multi-line braille display via the standard HID braille driver, all lines of cells will be used. (#16993, @alexmoon)
 
 ### Bug Fixes

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -44,7 +44,7 @@ There have also been a number of fixes, including to mouse tracking in Firefox, 
 * The `-c`/`--config-path` and `--disable-addons` command line options are now respected when launching an update from within NVDA. (#16937)
 * Component updates:
   * Updated LibLouis Braille translator to [3.31.0](https://github.com/liblouis/liblouis/releases/tag/v3.31.0). (#17080, @LeonarddeR, @codeofdusk)
-    * Fixed back-translation of numbers in Spanish Braille.
+    * Fixed translation of numbers in Spanish Braille.
     * New Braille tables:
       * Thai grade 1
       * Greek international Braille (single-cell accented letters)

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -43,10 +43,11 @@ There have also been a number of fixes, including to mouse tracking in Firefox, 
 
 * The `-c`/`--config-path` and `--disable-addons` command line options are now respected when launching an update from within NVDA. (#16937)
 * Component updates:
-  * Updated LibLouis braille translator to [3.31.0](https://github.com/liblouis/liblouis/releases/tag/v3.31.0). (#17080, @LeonarddeR)
-    * New braille tables:
+  * Updated LibLouis Braille translator to [3.31.0](https://github.com/liblouis/liblouis/releases/tag/v3.31.0). (#17080, @LeonarddeR, @codeofdusk)
+    * Fixed back-translation of numbers in Spanish Braille.
+    * New Braille tables:
       * Thai grade 1
-      * Greek international braille (single-cell accented letters)
+      * Greek international Braille (single-cell accented letters)
     * Renamed tables:
       * "Thai 6 dot" was renamed to "Thai grade 0" for consistency reasons.
       * The existing "Greek international braille" table was renamed to "Greek international braille (2-cell accented letters)" to clarify the distinction between the two Greek systems.


### PR DESCRIPTION
## Preliminary note

Liblouis 3.31 is to be released on the 2nd of September

### Link to issue number:
None

### Summary of the issue:

Liblouis 3.31 is to be released soon. AMong new tables, this release contains a bug fix for Spanish causing digits to be presented incorrectly, see https://github.com/liblouis/liblouis/pull/1624. CC @jmdaweb. Hence this pr is filed against beta.In my humble opinion, we are still early enough in the beta cycle to warrant this update.

### Description of user facing changes
Update to Liblouis 3.31, adding new tables as mentioned in the changelog.

### Description of development approach
Update the submodule, added and updated definitions in `brailleTables.py`

### Testing strategy:
Running NVDA< ensured that the new and changed tables work.

### Known issues with pull request:
None known

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Upgraded LibLouis Braille translator to version 3.31.0, adding new Braille tables for Thai grade 1 and Greek international Braille with single-cell accented letters.
	- Updated eSpeak NG component to version 1.52-dev, now supporting Faroese and Xextan languages.
	- Enhanced command line options for better user experience during updates.

- **Bug Fixes**
	- Resolved a bug related to back-translation of numbers in Spanish Braille.

- **Documentation**
	- Updated documentation to reflect changes in Braille table names and versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
