### PR TITLE
Revert "Fix reading the last empty line of a text in apps using Java Access Bridge"

### DIFF
--- a/source/NVDAObjects/JAB/__init__.py
+++ b/source/NVDAObjects/JAB/__init__.py
@@ -184,11 +184,8 @@ class JABTextInfo(textInfos.offsets.OffsetsTextInfo):
 		if end == -1 and offset > 0:
 			# #1892: JAB returns -1 for the end insertion position
 			# instead of returning the offsets for the last line.
-			# Try one character back, unless we're on a new line.
-			if self.obj.jabContext.getAccessibleTextRange(offset - 1, offset - 1) != "\n":
-				(start, end) = self.obj.jabContext.getAccessibleTextLineBounds(offset - 1)
-			else:
-				(start, end) = (offset, offset)
+			# Try one character back.
+			(start, end) = self.obj.jabContext.getAccessibleTextLineBounds(offset - 1)
 		# Java gives end as the last character, not one past the last character
 		end = end + 1
 		return (start, end)

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -61,6 +61,7 @@ There have also been a number of fixes, including to mouse tracking in Firefox, 
 * It is now possible to interact with Data validation dropdown lists in Microsoft Excel 365. (#15138)
 * NVDA is no longer as sluggish when arrowing up and down through large files in VS Code. (#17039)
 * NVDA no longer becomes unresponsive after holding down an arrow key for a long time while in browse mode, particularly in Microsoft Word and Microsoft Outlook. (#16812)
+* NVDA no longer reads the last line when the cursor is on the second-last line of a multiline edit control in Java applications. (#17027)
 
 ### Changes for Developers
 


### PR DESCRIPTION
### Reverts PR
Reverts #16568 

### Issues fixed
<!-- Issues that will be closed by reverting, i.e. the issues introduced via the PR getting reverted  -->
Partial fix for #17027 

### Issues reopened
<!-- Issues that will be re-opened by reverting, i.e. the issues that were fixed via the PR getting reverted  -->
Reopens #9376 

### Reason for revert
The changes introduced a bug whereby if the final line was not blank, it would be read in place of the second-last line.

### Can this PR be reimplemented? If so, what is required for the next attempt
The changes introduced are desirable if the case of erroneously reporting the last line instead of the second-last line can be resolved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved NVDA screen reader accuracy for reading the last line of text in Java applications when the cursor is on the second-last line.
- **Bug Fixes**
	- Enhanced control flow for determining line offsets, potentially improving performance and clarity in text reading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->