### PR TITLE
English user guide: remove stest string for forcing rebuild

### DIFF
--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -7,7 +7,6 @@
 
 
 ## Introduction {#Introduction}
-Crowdin Test string 1
 
 Welcome to NVDA!
 


### PR DESCRIPTION
Second of two janitorial PRs for xliff support:
After merging the Crowdin stuff, I realise I need to make two more commits to beta. One to add a temporary string to the user guide, and one then to remove it. This will cause userguide.xliff to be re-built.
1. I should have merged beta into xliff one more time before I merged the pr, to catch the poedit change to the user guide. But also
2. userGuide.xliff currently lists a commit in its file header that no longer exists as the pr was a squash merge (as we always do).
Bumping userGuide.md with an added line, and then a removed line will fix this.
Any future changes to userGuide.md in beta will be handled as expected by the Github action


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Removed a redundant line from the user guide, streamlining the introduction while maintaining the overall content and welcoming message for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->