### PR TITLE
turn off auto reviews from coderabbit

### DIFF
--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -13,7 +13,7 @@ reviews:
   auto_review:
     enabled: false
     auto_incremental_review: false
-    drafts: false
+    drafts: true
     base_branches:
       - master
       - beta

--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -11,7 +11,7 @@ reviews:
   collapse_walkthrough: false
   poem: false
   auto_review:
-    enabled: true
+    enabled: false
     auto_incremental_review: false
     drafts: false
     base_branches:

--- a/projectDocs/dev/contributing.md
+++ b/projectDocs/dev/contributing.md
@@ -73,12 +73,13 @@ If you are new to the project, or looking for some way to help take a look at:
 	- When the PR is approved it will be merged, and the change will be active in the next alpha build.
 	- If issues are raised with your PR, it may be marked as a draft.
 	Please mark it as ready for review when you have addressed the review comments.
-	- CodeRabbit AI will review your code.
+	- CodeRabbit AI can review your code.
+	  - To request a review from CodeRabbit, comment `@coderabbitai review`
+	  - CodeRabbit reviews may be automatically or manually requested by reviewers
 	  - Please participate in the review process, the AI can respond to review comments, questions and feedback.
 	  - Some comments may not be helpful due to the nature of AI, and some might be useful.
 	  Please indicate comments which you intend to ignore and why.
 	  For large numbers of unhelpful comments, please mark them as resolved or comment `@coderabbitai resolve` to resolve all comments.
-	  - To request another review from CodeRabbit, comment `@coderabbitai review`
 1. Feedback from alpha users
 	- After a PR is merged, watch for feedback from alpha users / testers.
 	You may have to follow up to address bugs or missed use-cases.


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Closes #17112 

### Summary of the issue:
CodeRabbit reviews are generally unhelpful for most PRs.
An initial review when a PR is marked as ready is usually not useful, the timing for when an AI review becomes useful is better left to the contributor or human reviewers.

Instead, a manually workflow seems much more desired.

### Description of user facing changes
Disable CodeRabbit review comments happening automatically on PRs.
PR summaries will still be added, and reviews/discussion is still available from manual prompts
Update docs.

