### PR TITLE
Fix translatable string issue in Albatross driver

### DIFF
--- a/source/brailleDisplayDrivers/albatross/driver.py
+++ b/source/brailleDisplayDrivers/albatross/driver.py
@@ -484,9 +484,9 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 							# for a braille display driver
 							"To use Albatross with NVDA: "
 							"change number of status cells in Albatross internal menu at most "
-							f"to {MAX_STATUS_CELLS_ALLOWED}, and if needed, restart Albatross "
+							"to {maxCells}, and if needed, restart Albatross "
 							"and NVDA.",
-						),
+						).format(maxCells=MAX_STATUS_CELLS_ALLOWED),
 					)
 					self._disableConnection()
 					return False

--- a/source/brailleDisplayDrivers/albatross/driver.py
+++ b/source/brailleDisplayDrivers/albatross/driver.py
@@ -482,10 +482,8 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 						_(
 							# Translators: A message when number of status cells must be changed
 							# for a braille display driver
-							"To use Albatross with NVDA: "
-							"change number of status cells in Albatross internal menu at most "
-							"to {maxCells}, and if needed, restart Albatross "
-							"and NVDA.",
+							"To use an Albatross with NVDA, change the number of status cells in the Albatross's internal menu "
+							"to at most {maxCells}, and restart the Albatross and NVDA if needed.",
 						).format(maxCells=MAX_STATUS_CELLS_ALLOWED),
 					)
 					self._disableConnection()


### PR DESCRIPTION
### Link to issue number:
None
### Summary of the issue:

In Albatross driver, a string consisting in the concatenation of normal strings (`"..."`) and an f-string) is passed to the `_` translation function.
As a consequence:
* Only a part of the concatenated string appears in the `.pot` file instead of the full concatenation
* In any case, f-strings cannot be used for translatable messages since the formatting should be applied only after the gettext function has been called

Thus, this message was not translated.


### Description of user facing changes
The message of the Albatross driver is now translated.

### Description of development approach
Do not use f-string. Instead used `.format` function, applied to the translated string.

Also checked that no other occurrence of translated f-string is found in NVDA: In Git bash:
* Concatenate the content of all files in one single file:
`find source -name '*.py' -type f -exec cat {} \; > /c/users/Cyrille/out.txt`
* Open `out.txt` in my editor
* Look for any translatable message that contains f-strings
`((?<!_)_|ngettext)\s*\(( *\r\n)?(\s*[#"'][^\n]+\n)*[\s\t]*f['"]`

Note: This regexp has some limitations. It only looks for the use of `_` function as well as `ngettext` function; it does not check `pgettext`/`npgettext` usage. Moreover, for `ngettext`, it only checks the singular form. Though, it should already help capture the majority of cases.

### Testing strategy:

- [x] Check in the `.pot` file that we have the full message
- [ ] Test on a real device: not done (but the fix is quite simple so this test may not be necessary)

### Known issues with pull request:
None

### Code Review Checklist:


- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

Cc @burmancomp 

<!-- Please keep the following -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved clarity of configuration messages for the Albatross braille display driver when used with NVDA.
- **Bug Fixes**
	- Updated string formatting for better user understanding regarding the maximum number of status cells allowed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
