### PR TITLE
`markdownTranslate.py`: Make `prettyPathString` more robust

### DIFF
--- a/user_docs/markdownTranslate.py
+++ b/user_docs/markdownTranslate.py
@@ -32,7 +32,10 @@ re_translationID = re.compile(r"^(.*)\$\(ID:([0-9a-f-]+)\)(.*)$")
 
 
 def prettyPathString(path: str) -> str:
-	return os.path.relpath(path, os.getcwd())
+	cwd = os.getcwd()
+	if os.path.normcase(os.path.splitdrive(path)[0]) != os.path.normcase(os.path.splitdrive(cwd)[0]):
+		return path
+	return os.path.relpath(path, cwd)
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:

None.

### Summary of the issue:

`markdownTranslate.prettyPathString` was using `os.path.relpath` without preventing or catching errors raised by that method. This was causing unit tests to fail for users whose development takes place on a separate drive to their Windows user account folder, as `ntpath.relpath` raises `ValueError` when the drives differ.

### Description of user facing changes

None.

### Description of developer facing changes

Unit tests now run properly when the NVDA repo and developer's user directory are on different drives. This may also fix translation for users with such setups, though I'm not sure if this was broken for them.

### Description of development approach

Added a check to see if the drives of the given path and the CWD differ, and if so, return the given path unchanged. Otherwise, calculate and return the relative path.

### Testing strategy:

Ran unittests to ensure they now pass.

### Known issues with pull request:

Arguably this could have been done with a try/except block, but I think this way will only capture exactly this error, while allowing other errors to propagate, which is desirable.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [ ] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
