### PR TITLE
Update codingStandards to remove instruction to double indent function parameters, and to note instructions for nameing scripts.

### DIFF
--- a/projectDocs/dev/codingStandards.md
+++ b/projectDocs/dev/codingStandards.md
@@ -24,8 +24,6 @@ Files can be checked out locally using CRLF if needed for Windows development us
   Don't use vertical alignment; e.g. lining up with the bracket on the previous line.
   - Be aware that this requires a new-line after an opening parenthesis/bracket/brace if you intend
     to split the statement over multiple lines.
-  - For the parameter list of function definitions, double indent, this differentiates the
-    parameters and the body of the function.
 
 ### Identifier Names
 * Use descriptive names
@@ -42,7 +40,9 @@ Files can be checked out locally using CRLF if needed for Windows development us
   - e.g. `BrailleHandler`.
 * Constants should be all upper case, separating words with underscores;
   - e.g. `LANGS_WITH_CONJUNCT_CHARS`.
-* Event handlers are prefixed with "event_", subsequent words in camel case.
+* Scripts (the targets of gestures) are prefixed with "script_", with subsequent words in camel case.
+  - E.g. `script_cycleAudioDuckingMode`.
+* Event handlers are prefixed with "event_", with subsequent words in camel case.
   Note, `object` and `action` are separated by underscores.
   - e.g.: `event_action` or `event_object_action`.
   - `object` refers to the class type that the `action` refers to.
@@ -57,7 +57,7 @@ Files can be checked out locally using CRLF if needed for Windows development us
     - Prefixed with `filter_` e.g. `filter_displaySize_preRefresh`
     - Should describe the filtering action and the data being returned
     - Should communicate if the filtering happens before or after some action
-* Enums should be formatted using the expected mix of above eg:
+* Enums should be formatted using the expected mix of above e.g.:
   ```python
   class ExampleGroupOfData(Enum):
       CONSTANT_VALUE_MEMBER = auto()
@@ -96,7 +96,7 @@ self.copySettingsButton = wx.Button(
   - Anything imported into a (sub)module can also be imported from that submodule.
   - As a result, removing unused imports may break compatibility, and should be done in compatibility breaking releases (see `deprecations.md`).
 * Unused imports will give a lint warning. These can be handled the following ways:
-  - If these imports are intended to be imported from other modules, they can be included in a definition for `__all__`. This will override and define the symbols imported when performing a star import, eg `from module import *`.
+  - If these imports are intended to be imported from other modules, they can be included in a definition for `__all__`. This will override and define the symbols imported when performing a star import, e.g. `from module import *`.
   - Otherwise, with a comment like `# noqa: <explanation>`.
 
 ### Considering future backwards compatibility

--- a/projectDocs/dev/codingStandards.md
+++ b/projectDocs/dev/codingStandards.md
@@ -21,7 +21,7 @@ Files can be checked out locally using CRLF if needed for Windows development us
 ### Indentation
 * Indentation must be done with tabs (one per level), not spaces.
 * When splitting a single statement over multiple lines, just indent one or more additional levels.
-  Don't use vertical alignment; e.g. lining up with the bracket on the previous line.
+  Don't use vertical alignment; i.e. lining up with the bracket on the previous line.
   - Be aware that this requires a new-line after an opening parenthesis/bracket/brace if you intend
     to split the statement over multiple lines.
 
@@ -30,21 +30,21 @@ Files can be checked out locally using CRLF if needed for Windows development us
   - name constants to avoid "magic numbers" and hint at intent or origin of the value.
     Consider, what does this represent?
 * Functions, variables, properties, etc. should use mixed case to separate words, starting with a lower case letter;
-  - e.g. `speakText`.
+  - E.g. `speakText`.
 * Boolean functions or variables
   - Use the positive form of the language.
     Avoid double negatives like `shouldNotDoSomething = False`
   - Start with a "question word" to hint at their boolean nature.
-  - e.g. `shouldX`, `isX`, `hasX`
+  - E.g. `shouldX`, `isX`, `hasX`
 * Classes should use mixed case to separate words, starting with an upper case letter;
-  - e.g. `BrailleHandler`.
+  - E.g. `BrailleHandler`.
 * Constants should be all upper case, separating words with underscores;
-  - e.g. `LANGS_WITH_CONJUNCT_CHARS`.
+  - E.g. `LANGS_WITH_CONJUNCT_CHARS`.
 * Scripts (the targets of gestures) are prefixed with "script_", with subsequent words in camel case.
   - E.g. `script_cycleAudioDuckingMode`.
 * Event handlers are prefixed with "event_", with subsequent words in camel case.
   Note, `object` and `action` are separated by underscores.
-  - e.g.: `event_action` or `event_object_action`.
+  - E.g.: `event_action` or `event_object_action`.
   - `object` refers to the class type that the `action` refers to.
   - Examples: `event_caret`, `event_appModule_gainFocus`
 * Extension points:
@@ -52,12 +52,12 @@ Files can be checked out locally using CRLF if needed for Windows development us
     - Prefixed with `pre_` or `post_` to specify that handlers are being notified before / after the
       action has taken place.
   * `Decider`
-    - Prefixed with `should_` to turn them into a question e.g. `should_doSomething`
+    - Prefixed with `should_` to turn them into a question, e.g. `should_doSomething`
   * `Filter`
-    - Prefixed with `filter_` e.g. `filter_displaySize_preRefresh`
+    - Prefixed with `filter_`, e.g. `filter_displaySize_preRefresh`
     - Should describe the filtering action and the data being returned
     - Should communicate if the filtering happens before or after some action
-* Enums should be formatted using the expected mix of above e.g.:
+* Enums should be formatted using the expected mix of the above, e.g.:
   ```python
   class ExampleGroupOfData(Enum):
       CONSTANT_VALUE_MEMBER = auto()

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -45,6 +45,7 @@ Add-ons will need to be re-tested and have their manifest updated.
   * `BrowseModeTreeInterceptor` object has a new `getLinkTypeInDocument` method which accepts an URL to check the link type of the object
   * A `toggleBooleanValue` helper function has been added to `globalCommands`.
   It can be used in scripts to report the result when a boolean is toggled in `config.conf`
+* Removed the requirement to indent function parameter lists by two tabs from NVDA's Coding Standards, to be compatible with modern automatic linting. (#17126, XLTechie)
 
 #### API Breaking Changes
 


### PR DESCRIPTION
### Link to issue number:

In-response-to https://github.com/nvaccess/nvda/pull/12355#discussion_r1746395171

### Summary of the issue:

Pre-commit-ci, on behalf of Ruff, does not approve of function parameter lists being double indented.
I.e. NVDA's coding standards said:

> For the parameter list of function definitions, double indent, this differentiates the parameters and the body of the function.

That resulted in, e.g.:

```py
def test(
		param1: str,
		param2: int,
		param3: bool = False,
) -> str:
	pass
```

Pushing a function definition like that to an NVDA PR, would result in Pre-commit-ci "fixing" it, to appear as:

```py
def test(
	param1: str,
	param2: int,
	param3: bool = False,
) -> str:
	pass
```

Sean suggested updating coding standards, which is presumably easier than trying to convince Ruff to do it our way.

### Description of user facing changes

None

### Description of development approach

* Updated coding standards.
* Also noticed that there was no instruction on how to format script names, but there was for events and various other entities. Added one to the relevant section.
* Changed a few "eg"s to "e.g."s, and made other slight grammar alterations.