### PR TITLE
Fix popup menu item reading on Thunderbird

### DIFF
--- a/source/appModules/thunderbird.py
+++ b/source/appModules/thunderbird.py
@@ -16,6 +16,21 @@ from typing import Callable
 
 
 class AppModule(appModuleHandler.AppModule):
+	def _isPopupMenuItem(self, obj):
+		attributes = getattr(obj, "IA2Attributes", None)
+
+		if attributes and "class" in attributes:
+			tag = attributes["tag"]
+			classes = attributes["class"].split()
+			return tag == "div" and "popup-menuitem" in classes
+
+		return False
+
+	def event_NVDAObject_init(self, obj):
+		if obj.role == controlTypes.Role.SECTION and not obj.name and self._isPopupMenuItem(obj):
+			obj.role = controlTypes.Role.MENUITEM
+			obj.name = obj.IAccessibleObject.accChild(1).accName(0)
+
 	def event_gainFocus(self, obj, nextHandler):
 		if (
 			obj.role == controlTypes.Role.DOCUMENT

--- a/source/appModules/thunderbird.py
+++ b/source/appModules/thunderbird.py
@@ -16,7 +16,7 @@ from typing import Callable
 
 
 class AppModule(appModuleHandler.AppModule):
-	def _isPopupMenuItem(self, obj):
+	def _isPopupMenuItem(self, obj: NVDAObject):
 		attributes = getattr(obj, "IA2Attributes", None)
 
 		if attributes and "class" in attributes:
@@ -26,7 +26,7 @@ class AppModule(appModuleHandler.AppModule):
 
 		return False
 
-	def event_NVDAObject_init(self, obj):
+	def event_NVDAObject_init(self, obj: NVDAObject):
 		if obj.role == controlTypes.Role.SECTION and not obj.name and self._isPopupMenuItem(obj):
 			obj.role = controlTypes.Role.MENUITEM
 			obj.name = obj.IAccessibleObject.accChild(1).accName(0)

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -29,7 +29,7 @@ In order to use this feature, the application volume adjuster needs to be enable
 * Improvements when editing in Microsoft PowerPoint:
   * Caret reporting no longer breaks when text contains wide characters, such as emoji. (#17006 , @LeonarddeR)
   * Character location reporting is now accurate (e.g. when pressing `NVDA+Delete`. (#9941, @LeonarddeR)
-* NVDA is able to read the popu submenu items on Thunderbird find HTML page. (#4708, @thgcode)
+* NVDA is able to read the popup submenu items on Thunderbird search results page. (#4708, @thgcode)
 
 ### Changes for Developers
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -29,6 +29,7 @@ In order to use this feature, the application volume adjuster needs to be enable
 * Improvements when editing in Microsoft PowerPoint:
   * Caret reporting no longer breaks when text contains wide characters, such as emoji. (#17006 , @LeonarddeR)
   * Character location reporting is now accurate (e.g. when pressing `NVDA+Delete`. (#9941, @LeonarddeR)
+* NVDA is able to read the popu submenu items on Thunderbird find HTML page. (#4708, @thgcode)
 
 ### Changes for Developers
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
closes #4708 .

### Summary of the issue:
When the user finds text on Thunderbird by pressing CONTROL+K, searching the text and activating one of the links, NVDA speaks only "section".

### Description of user facing changes
NVDA will speak the popup menu item name correctly.

### Description of development approach
Added a check if the object 's name is empty, and is of the "div" tag and has a class of "popup-menuitem", NVDA replaces its name with the name of its child.

### Testing strategy:
Performed manual tests with Thunderbird 128.2.0 and 102.6.0.

### Known issues with pull request:
None.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [ ] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [ ] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [ ] API is compatible with existing add-ons.
- [ ] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
