### PR TITLE
Feat/create disable dictionaries command line switch

### DIFF
--- a/source/globalVars.py
+++ b/source/globalVars.py
@@ -58,6 +58,7 @@ class DefaultAppArgs(argparse.Namespace):
 	 - SecureMode and SecureScreens
 	"""
 	disableAddons: bool = False
+	disableDictionaries: bool = False
 	debugLogging: bool = False
 	noLogging: bool = False
 	changeScreenReaderFlag: bool = True

--- a/source/gui/speechDict.py
+++ b/source/gui/speechDict.py
@@ -240,12 +240,19 @@ class DictionaryDialog(
 	def postInit(self):
 		self.dictList.SetFocus()
 
+	def ReEnableDictionaryProcessing(self):
+		if globalVars.appArgs.disableDictionaries is False:
+			globalVars.speechDictionaryProcessing = True
+		else:
+			log.warning("dictionaries processing is disabled")
+
 	def onCancel(self, evt):
-		globalVars.speechDictionaryProcessing = True
+		self.ReEnableDictionaryProcessing()
 		super(DictionaryDialog, self).onCancel(evt)
 
 	def onOk(self, evt):
-		globalVars.speechDictionaryProcessing = True
+		self.ReEnableDictionaryProcessing()
+
 		if self.tempSpeechDict != self.speechDict:
 			del self.speechDict[:]
 			self.speechDict.extend(self.tempSpeechDict)

--- a/source/nvda.pyw
+++ b/source/nvda.pyw
@@ -221,6 +221,13 @@ parser.add_argument(
 	"--disable-addons", action="store_true", dest="disableAddons", default=False, help="Disable all add-ons"
 )
 parser.add_argument(
+	"--disable-dictionaries",
+	action="store_true",
+	dest="disableDictionaries",
+	default=False,
+	help="Disable dictionary processing for all dictionaries",
+)
+parser.add_argument(
 	"--debug-logging",
 	action="store_true",
 	dest="debugLogging",
@@ -332,6 +339,10 @@ for name in pathAppArgs:
 	if isinstance(origVal, str):
 		newVal = os.path.abspath(origVal)
 		setattr(globalVars.appArgs, name, newVal)
+
+if globalVars.appArgs.disableDictionaries is True:
+	log.debug("Dictionaries processing is disabled.")
+	globalVars.speechDictionaryProcessing = False
 
 
 def terminateRunningNVDA(window):

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -5236,6 +5236,7 @@ Following are the command line options for NVDA:
 |`-m` |`--minimal` |No sounds, no interface, no start message, etc.|
 |`-s` |`--secure` |Starts NVDA in [Secure Mode](#SecureMode)|
 |None |`--disable-addons` |Add-ons will have no effect|
+|None |`--disable-dictionaries` |Dictionaries will not be used|
 |None |`--debug-logging` |Enable debug level logging just for this run. This setting will override any other log level ( `--loglevel`, `-l`) argument given, including no logging option.|
 |None |`--no-logging` |Disable logging altogether while using NVDA. This setting can be overridden if a log level (`--loglevel`, `-l`) is specified from command line or if debug logging is turned on.|
 |None |`--no-sr-flag` |Don't change the global system screen reader flag|


### PR DESCRIPTION
### Link to issue number: https://github.com/nvaccess/nvda/issues/17129

### Summary of the issue:

Allows a command switch to completely disable dictionaries processing

### Description of user facing changes

When called with --disable-dictionaries, no dictionary processing will occur.

### Description of development approach

* nvda.pyw
    * added the --disable-dictionaries as a valid option
    * if this option was enabled, set globalVars.speechDictionaryProcessing to false. This is already used to stop processing dictionaries when the dictionary dialogs are opened.
* globalVars.py: created disableDictionaries as false in the defaultAppArgs
* gui\speechDict.py: prevented the onOk and onCancel methods of speechDict class to enable globalVars.speechDictionaryProcessing in case globalVars.appArgs.disableDictionaries is true (when disable dictionaries option was passed to NVDA in cli)

### Testing strategy:

1. Run nvda from source
2. If the default dictionaries has no entries, create one and test to check it works.
3. Perform runnvda.bat --disable-dictionaries
4. Check that the dictionary entry is not in use (ex: the original text is used)
5. Open the dictionary dialogs. Change the entry, add new entries. Test them and confirm they are not used after hitting ok in the dictionaries dialog.

Please notice that dictionary addons might bypass this command line. We have no way of controlling this behavior, other than asking for dictionaries related addons to take the globalApps.speechDictionaryProcessing var in consideration, optionally using global.appArgs.disableDictionaries  as a hint to process or not dictionaris.

### Known issues with pull request:

No known issues.

### Code Review Checklist:



- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [ ] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
