### PR TITLE
Fix braille settings controls layout

### DIFF
--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -4450,7 +4450,7 @@ class BrailleSettingsSubPanel(AutoSettingsMixin, SettingsPanel):
 		# Translators: The label for a setting in braille settings to speak the character under the cursor when cursor routing in text.
 		speakOnRoutingText = _("Spea&k character when routing cursor in text")
 		self.speakOnRoutingCheckBox = followCursorGroupHelper.addItem(
-			wx.CheckBox(self, label=speakOnRoutingText),
+			wx.CheckBox(self.followCursorGroupBox, label=speakOnRoutingText),
 		)
 		self.bindHelpEvent("BrailleSpeakOnRouting", self.speakOnRoutingCheckBox)
 		self.speakOnRoutingCheckBox.Value = config.conf["braille"]["speakOnRouting"]


### PR DESCRIPTION
### Link to issue number:
Closes #17141
### Summary of the issue:

### Description of user facing changes
TBD
### Description of development approach

### Testing strategy:

### Known issues with pull request:

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [ ] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [ ] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [ ] API is compatible with existing add-ons.
- [ ] Security precautions taken.

<!-- Please keep the following -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Adjusted the layout of a checkbox in the settings dialog for improved grouping and organization within the GUI. 
	- Ensured the checkbox remains functionally intact while enhancing its contextual placement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
