### PR TITLE
sconstruct: correctly detect the language of xliff files when trying to skip English

### DIFF
--- a/sconstruct
+++ b/sconstruct
@@ -335,7 +335,7 @@ numberedHeadingsStyle = os.path.join(userDocsDir.path, "numberedHeadings.css")
 
 # Create Non-english md files in user_docs from localized xliff and English skel files
 for xliffFile in env.Glob(os.path.join(userDocsDir.path, "*", "*.xliff")):
-	lang = os.path.basename(xliffFile.path).split(".")[0]
+	lang = os.path.split(os.path.dirname(xliffFile.path))[-1]
 	if lang == "en":
 		continue
 	mdFile = os.path.splitext(xliffFile.path)[0] + ".md"


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
None.

### Summary of the issue:
The NVDA build system creates html from markdown files. For any language other than English, these markdown files should be themselves generated from xliff files.
However, a rather strange and incorrect line of code caused this to also happen for English, as the line was not correctly detecting the language.
 
### Description of user facing changes
English user documentation in alpha builds should be based on the very latest markdown files, rather than the last beta from the previous release.

### Description of development approach
Fix the questionable line.

### Testing strategy:
* Ensure English userGuide.xliff is newer than userguide.md.
* Build English userGuide.html
* Ensure this does not cause userguide.md to be re-generated from userGuide.xliff.
* [ ] Check the English what's new artifact to ensure it has an entry for 2025.1.

### Known issues with pull request:
None known.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved language detection for localized files by extracting language information from the directory path, enhancing localization accuracy.
  
- **Bug Fixes**
	- Addressed potential issues with language identification that could arise from changes in directory structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
