### PR TITLE
soffice: Report keyboard-triggered paragraph style change

### DIFF
--- a/source/appModules/soffice.py
+++ b/source/appModules/soffice.py
@@ -48,7 +48,7 @@ class SymphonyUtils:
 		return False
 
 	@staticmethod
-	def get_id(obj: NVDAObject) -> Optional[str]:
+	def get_id(obj: NVDAObject) -> str | None:
 		"""Get value of the "id" object attribute, if set."""
 		if not hasattr(obj, "IA2Attributes"):
 			return None

--- a/source/appModules/soffice.py
+++ b/source/appModules/soffice.py
@@ -455,10 +455,10 @@ class SymphonyDocument(CompoundDocument):
 	TextInfo = SymphonyDocumentTextInfo
 
 	# variables used for handling announcements resulting from gestures
-	GESTURE_ANNOUNCEMENT_TIMEOUT = 2.0  # Seconds
-	announceFormattingGestureChange = False
-	formattingGestureObjectIds = []
-	lastFormattingGestureEventTime = 0
+	GESTURE_ANNOUNCEMENT_TIMEOUT: float = 2.0  # Seconds
+	announceFormattingGestureChange: bool = False
+	formattingGestureObjectIds: list[str] = []
+	lastFormattingGestureEventTime: float = 0
 
 	@staticmethod
 	def isFormattingChangeAnnouncementEnabled(obj: NVDAObject) -> bool:

--- a/source/appModules/soffice.py
+++ b/source/appModules/soffice.py
@@ -28,6 +28,7 @@ import speech
 import api
 import braille
 import inputCore
+import keyboardHandler
 import languageHandler
 import ui
 import vision
@@ -45,6 +46,12 @@ class SymphonyUtils:
 				return True
 			parent = parent.parent
 		return False
+
+	def get_id(obj: NVDAObject) -> Optional[str]:
+		"""Get value of the "id" object attribute, if set."""
+		if not hasattr(obj, "IA2Attributes"):
+			return None
+		return obj.IA2Attributes.get("id")
 
 
 class SymphonyTextInfo(IA2TextTextInfo):
@@ -252,7 +259,7 @@ class SymphonyText(IAccessible, EditableText):
 	def event_valueChange(self) -> None:
 		# announce new value to indicate formatting change if registered gesture
 		# triggered the change in toolbar item's value/text
-		if SymphonyDocument.isFormattingChangeAnnouncementEnabled() and SymphonyUtils.is_toolbar_item(self):
+		if SymphonyDocument.isFormattingChangeAnnouncementEnabled(self):
 			message = self.IAccessibleTextObject.text(0, -1)
 			ui.message(message)
 			# disable announcement until next registered keypress enables it again
@@ -380,7 +387,7 @@ class SymphonyButton(IAccessible):
 	def event_stateChange(self) -> None:
 		# announce new state of toggled toolbar button to indicate formatting change
 		# if registered gesture resulted in button state change
-		if SymphonyDocument.isFormattingChangeAnnouncementEnabled() and SymphonyUtils.is_toolbar_item(self):
+		if SymphonyDocument.isFormattingChangeAnnouncementEnabled(self):
 			states = self.states
 			enabled = controlTypes.State.PRESSED in states or controlTypes.State.CHECKED in states
 			# button's accessible name is the font attribute, e.g. "Bold", "Italic"
@@ -449,13 +456,36 @@ class SymphonyDocument(CompoundDocument):
 	# variables used for handling announcements resulting from gestures
 	GESTURE_ANNOUNCEMENT_TIMEOUT = 2.0
 	announceFormattingGestureChange = False
+	formattingGestureObjectIds = []
 	lastFormattingGestureEventTime = 0
 
 	@staticmethod
-	def isFormattingChangeAnnouncementEnabled() -> bool:
-		return SymphonyDocument.announceFormattingGestureChange and time.time() < (
+	def isFormattingChangeAnnouncementEnabled(obj: NVDAObject) -> bool:
+		if not SymphonyDocument.announceFormattingGestureChange:
+			return False
+
+		# don't announce if too much time has passed since last gesture
+		if time.time() > (
 			SymphonyDocument.lastFormattingGestureEventTime + SymphonyDocument.GESTURE_ANNOUNCEMENT_TIMEOUT
-		)
+		):
+			return False
+
+		# only toolbar items are of interest
+		if not SymphonyUtils.is_toolbar_item(obj):
+			return False
+
+		# If announcement is restricted to objects with specific IDs, check whether
+		# object or its parent has an ID that matches.
+		# (For editable comboboxes, the value change event is triggered for the edit
+		# that's a child of the combobox which has the corresponding ID.)
+		if (
+			SymphonyDocument.formattingGestureObjectIds
+			and (SymphonyUtils.get_id(obj) not in SymphonyDocument.formattingGestureObjectIds)
+			and (SymphonyUtils.get_id(obj.parent) not in SymphonyDocument.formattingGestureObjectIds)
+		):
+			return False
+
+		return True
 
 	# override base class implementation because that one assumes
 	# that the text retrieved from the text info for the text unit
@@ -493,6 +523,18 @@ class SymphonyDocument(CompoundDocument):
 
 	@script(
 		gestures=[
+			# paragraph style: Body Text
+			"kb:control+0",
+			# paragraph style: Heading 1
+			"kb:control+1",
+			# paragraph style: Heading 2
+			"kb:control+2",
+			# paragraph style: Heading 3
+			"kb:control+3",
+			# paragraph style: Heading 4
+			"kb:control+4",
+			# paragraph style: Heading 5
+			"kb:control+5",
 			# bold
 			"kb:control+b",
 			# italic
@@ -524,6 +566,21 @@ class SymphonyDocument(CompoundDocument):
 		:func:`SymphonyText.event_valueChange`.
 		"""
 		SymphonyDocument.announceFormattingGestureChange = True
+
+		# changing paragraph style can imply more related formatting changes (e.g. font size, bold,...);
+		# restrict announcement to the paragraph style combobox via its ID
+		if isinstance(gesture, keyboardHandler.KeyboardInputGesture) and gesture.displayName in [
+			"ctrl+0",
+			"ctrl+1",
+			"ctrl+2",
+			"ctrl+3",
+			"ctrl+4",
+			"ctrl+5",
+		]:
+			SymphonyDocument.formattingGestureObjectIds = ["applystyle"]
+		else:
+			SymphonyDocument.formattingGestureObjectIds = []
+
 		SymphonyDocument.lastFormattingGestureEventTime = time.time()
 		# send gesture
 		gesture.send()

--- a/source/appModules/soffice.py
+++ b/source/appModules/soffice.py
@@ -455,7 +455,7 @@ class SymphonyDocument(CompoundDocument):
 	TextInfo = SymphonyDocumentTextInfo
 
 	# variables used for handling announcements resulting from gestures
-	GESTURE_ANNOUNCEMENT_TIMEOUT = 2.0
+	GESTURE_ANNOUNCEMENT_TIMEOUT = 2.0  # Seconds
 	announceFormattingGestureChange = False
 	formattingGestureObjectIds = []
 	lastFormattingGestureEventTime = 0

--- a/source/appModules/soffice.py
+++ b/source/appModules/soffice.py
@@ -47,6 +47,7 @@ class SymphonyUtils:
 			parent = parent.parent
 		return False
 
+	@staticmethod
 	def get_id(obj: NVDAObject) -> Optional[str]:
 		"""Get value of the "id" object attribute, if set."""
 		if not hasattr(obj, "IA2Attributes"):

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -16,6 +16,7 @@ In order to use this feature, the application volume adjuster needs to be enable
 * Added an action in the Add-on Store to retry the installation if the download/installation of an add-on fails. (#17090, @hwf1324)
 * It is now possible to specify a mirror URL to use for the Add-on Store. (#14974)
 * When decreasing or increasing the font size in LibreOffice Writer using the corresponding keyboard shortcuts, NVDA announces the new font size. (#6915, @michaelweghorn)
+* When applying the "Body Text" or a heading paragraph style using the corresponding keyboard shortcut in LibreOffice Writer 25.2 or newer, NVDA announces the new paragraph style. (#6915, @michaelweghorn)
 
 ### Changes
 


### PR DESCRIPTION
### Link to issue number:

Partially implements feature requests from #6915

### Summary of the issue:

Commit 20bdb39e6f83ef87726817cb1bad31fa7b0f73cb
("soffice: Report keyboard-triggered font size change (#17147)") implemented announcement of the new value of the font size combobox in Writer's formatting toolbar when it is changed via keyboard shortcut. Issue #6915 requests announcement of further attributes, including the announcement of the current paragraph style when applying "Heading 1",..., "Heading 5" styles via the Ctrl+1,..., Ctrl+5 keyboard shortcuts.

### Description of user facing changes

When applying the "Body Text" or a heading paragraph style using the corresponding keyboard shortcut in LibreOffice Writer 25.2 or newer, NVDA announces the new paragraph style.

### Description of development approach

Extend the solution from the above-mentioned
commit 20bdb39e6f83ef87726817cb1bad31fa7b0f73cb.
Other than the simpler case of the font size combo box, changing the paragraph style can imply more related formatting changes (e.g. font size, bold,...).
To avoid triggering the announcement of these implicit formatting changes, but rather announce the new paragraph style to confirm that the user-triggered action had the expected result, introduce a way to reliably identify the paragraph style combobox in the formatting toolbar:

1) Add an "id" object attribute to the IAccessible2 object attribute specification:

> This identifier remains the same across different sessions of
> the same application, regardless of the UI language.

IAccessible2 commit: https://github.com/LinuxA11y/IAccessible2/commit/2b8c2c79417bad4b464761a142fab45ffde8bfa8

2) In LibreOffice, set the "id" attribute to the ID already used in the UI file format (GtkBuilder XML files): https://git.libreoffice.org/core/commit/21b29f25660db973fa1480de77e6a69d76a5de53

3) In NVDA, extend the logic for announcing gesture-triggered formatting changes to allow specifying a specific ID of the UI element(s) of interest. If one is set, don't announce changes in other UI elements for that gesture.
Set the ID to the one that the paragraph style combobox in Writer's formatting toolbar has ("applystyle").
Let NVDA handle the Ctrl+0, Ctrl+1, Ctrl+2, Ctrl+3, Ctrl+4 and Ctrl+5 gestures to announce the new paragraph style ("Body Text" for Ctrl+0, corresponding heading for Ctrl+1 through Ctrl+5).

### Testing strategy:

1. start NVDA
2. start current development version of LibreOffice Writer (with English UI and keyboard layout)
3. Press Ctrl+1 to apply paragraph Style "Heading 1"
4. Verify that NVDA announces the new paragraph style by name, i.e. says "Heading 1"
5. Repeat steps 3 and 4 with Ctrl+2, Ctrl+3, Ctrl+4, Ctrl+5 to verify that the other heading levels are also announced correctly.
6. Press Ctrl+0 to apply paragraph style "Body Text" and verify that NVDA announces the new paragraph style by name, i.e. says "Body Text"
8. Retest that the other supported keyboard gestures as implemented in commits 46a343685247ed7d1adfb737716590ec4be456a0 and 20bdb39e6f83ef87726817cb1bad31fa7b0f73cb are still announced as expected.

### Known issues with pull request:

None, but note that a current LibreOffice development version (to become LibreOffice 25.2) is required for the feature to actually work.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
