### PR TITLE
Add automatic language switching support for SAPI5 voices

### DIFF
--- a/source/synthDrivers/sapi5.py
+++ b/source/synthDrivers/sapi5.py
@@ -340,7 +340,11 @@ class SynthDriver(SynthDriver):
 					if item.text:
 						textList.append(item.text)
 			elif isinstance(item, LangChangeCommand):
-				lcid = languageHandler.localeNameToWindowsLCID(item.lang) if item.lang else languageHandler.LCID_NONE
+				lcid = (
+					languageHandler.localeNameToWindowsLCID(item.lang)
+					if item.lang
+					else languageHandler.LCID_NONE
+				)
 				if lcid is languageHandler.LCID_NONE:
 					try:
 						del tags["lang"]

--- a/source/synthDrivers/sapi5.py
+++ b/source/synthDrivers/sapi5.py
@@ -340,17 +340,15 @@ class SynthDriver(SynthDriver):
 					if item.text:
 						textList.append(item.text)
 			elif isinstance(item, LangChangeCommand):
-				lcid = languageHandler.LCID_NONE
-				if item.lang:
-					lcid = languageHandler.localeNameToWindowsLCID(item.lang)
-				if lcid == languageHandler.LCID_NONE:
+				lcid = languageHandler.localeNameToWindowsLCID(item.lang) if item.lang else languageHandler.LCID_NONE
+				if lcid is languageHandler.LCID_NONE:
 					try:
 						del tags["lang"]
 					except KeyError:
 						pass
 				else:
 					tags["lang"] = {"langid": "%x" % lcid}
-					tagsChanged[0] = True
+				tagsChanged[0] = True
 			elif isinstance(item, SpeechCommand):
 				log.debugWarning("Unsupported speech command: %s" % item)
 			else:

--- a/source/synthDrivers/sapi5.py
+++ b/source/synthDrivers/sapi5.py
@@ -17,6 +17,7 @@ import config
 import nvwave
 from logHandler import log
 import weakref
+import languageHandler
 
 from speech.commands import (
 	IndexCommand,
@@ -338,6 +339,18 @@ class SynthDriver(SynthDriver):
 					log.debugWarning("Couldn't convert character in IPA string: %s" % item.ipa)
 					if item.text:
 						textList.append(item.text)
+			elif isinstance(item, LangChangeCommand):
+				lcid = languageHandler.LCID_NONE
+				if item.lang:
+					lcid = languageHandler.localeNameToWindowsLCID(item.lang)
+				if lcid == languageHandler.LCID_NONE:
+					try:
+						del tags["lang"]
+					except KeyError:
+						pass
+				else:
+					tags["lang"] = {"langid": "%x" % lcid}
+					tagsChanged[0] = True
 			elif isinstance(item, SpeechCommand):
 				log.debugWarning("Unsupported speech command: %s" % item)
 			else:

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -16,7 +16,7 @@ In order to use this feature, the application volume adjuster needs to be enable
 * Added an action in the Add-on Store to retry the installation if the download/installation of an add-on fails. (#17090, @hwf1324)
 * It is now possible to specify a mirror URL to use for the Add-on Store. (#14974)
 * When decreasing or increasing the font size in LibreOffice Writer using the corresponding keyboard shortcuts, NVDA announces the new font size. (#6915, @michaelweghorn)
-* Automatic language switching is now supported when using Microsoft Speech API version 5 (SAPI5) voices. (#17146, @gexgd0419)
+* Automatic language switching is now supported when using Microsoft Speech API version 5 (SAPI5) and Microsoft Speech Platform voices. (#17146, @gexgd0419)
 
 ### Changes
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -16,6 +16,7 @@ In order to use this feature, the application volume adjuster needs to be enable
 * Added an action in the Add-on Store to retry the installation if the download/installation of an add-on fails. (#17090, @hwf1324)
 * It is now possible to specify a mirror URL to use for the Add-on Store. (#14974)
 * When decreasing or increasing the font size in LibreOffice Writer using the corresponding keyboard shortcuts, NVDA announces the new font size. (#6915, @michaelweghorn)
+* Automatic language switching is now supported when using Microsoft Speech API version 5 (SAPI5) voices. (#17146, @gexgd0419)
 
 ### Changes
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Fixes #17146

### Summary of the issue:
Automatic language switching does not work for SAPI 5 voices, because the SAPI5 synth driver does not support `LangChangeCommand`. This is a simple fix that uses the SAPI5 [`<lang>`](https://learn.microsoft.com/en-us/previous-versions/windows/desktop/ms717077(v=vs.85)#lang) tags to make the SAPI5 framework switch to a voice in the specified language.

### Description of user facing changes
Automatic language switching is enabled by default, so users who have SAPI5 voices in multiple languages may notice the voice switching after this change. As Microsoft Speech Platform voices use the same implementation, they will be affected as well.

### Description of development approach
The SAPI5 [`<lang>`](https://learn.microsoft.com/en-us/previous-versions/windows/desktop/ms717077(v=vs.85)#lang) tag requires a language ID in hexadecimal, without the `0x` prefix (e.g. 409 for English US), so here `languageHandler` is imported to do the language-to-LCID conversion. The text will be wrapped in a `<lang langid="409">...</lang>` XML tag, or if there's no valid corresponding LCID, the `<lang>` tag is removed to restore the original voice.

### Testing strategy:
- Have some SAPI5 voices in different languages installed. 
- Select an SAPI5 voice, and enable Automatic language switching.
- Use an HTML with language attributes to test it. For example:
``` html
<html><body>
<p lang="zh-CN">This should be spoken with a Chinese voice.</p>
<p lang="en">This should be spoken with an English voice.</p>
</body></html>
```

I only tested it with some built-in SAPI5 voices, such as "Microsoft Huihui Desktop" and "Microsoft Zira Desktop". As there are many SAPI5 voices and Microsoft Speech Platform voices, more tests should be done.

### Known issues with pull request:
SAPI5 voice switching may not be as fast as the OneCore voices.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered: (no UI change)
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons. (API not changed)
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
