### PR TITLE
Fix config profiles quickly get polluted with untouched settings

### DIFF
--- a/source/config/__init__.py
+++ b/source/config/__init__.py
@@ -40,7 +40,6 @@ from .configFlags import OutputMode
 from .featureFlag import (
 	_transformSpec_AddFeatureFlagDefault,
 	_validateConfig_featureFlag,
-	FeatureFlag,
 )
 from typing import (
 	Any,
@@ -1146,7 +1145,7 @@ class AggregatedSection:
 			else:
 				# This is a setting.
 				if not checkValidity:
-					spec = None
+					return val  # Never cache unvalidated values
 				return self._cacheLeaf(key, spec, val)
 		subProfiles.reverse()
 
@@ -1291,13 +1290,10 @@ class AggregatedSection:
 		except KeyError:
 			pass
 		else:
-			if (
-				# Feature flags override __eq__.
-				# Check str comparison as this is what is written to the config.
-				# If the value is unchanged, do not update
-				# or mark the profile as dirty.
-				(isinstance(val, FeatureFlag) or isinstance(curVal, FeatureFlag)) and str(val) == str(curVal)
-			):
+			if self._isSection(val) or self._isSection(curVal):
+				# If value is a section, continue to update
+				pass
+			elif str(val) == str(curVal):
 				return
 
 		# Set this value in the most recently activated profile.

--- a/source/config/__init__.py
+++ b/source/config/__init__.py
@@ -1294,6 +1294,9 @@ class AggregatedSection:
 				# If value is a section, continue to update
 				pass
 			elif str(val) == str(curVal):
+				# Check str comparison as this is what is written to the config.
+				# If the value is unchanged, do not update
+				# or mark the profile as dirty.
 				return
 
 		# Set this value in the most recently activated profile.

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,7 +1,7 @@
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-# Copyright (C) 2022-2023 NV Access Limited, Cyrille Bougot
+# Copyright (C) 2022-2024 NV Access Limited, Cyrille Bougot, Leonard de Ruijter
 import enum
 import typing
 import unittest
@@ -884,3 +884,29 @@ class Config_AggregatedSection_setitem(unittest.TestCase):
 		self.assertIs(self.testSection["foo"], defaultFlag)
 		self.testSection["foo"] = valueOfDefaultFlag
 		self.assertIs(self.testSection["foo"], valueOfDefaultFlag)
+
+
+class Config_AggregatedSection_polution(unittest.TestCase):
+	"""Ënsure that config profiles don't get polluted with overridden values equal to the base config"""
+
+	def setUp(self):
+		manager = ConfigManager()
+		spec = configobj.ConfigObj({"someBool": "boolean(default=True)"})
+		self.baseConfig = configobj.ConfigObj({"someBool": True})
+		self.profile = configobj.ConfigObj()
+		self.testSection = AggregatedSection(
+			manager=manager,
+			path=(),
+			spec=spec,
+			profiles=[self.baseConfig, self.profile],
+		)
+
+	def test_updateToSameValue(self):
+		self.testSection["someBool"] = True
+		# Since we set someBool to its existing value, don't touch the profile.
+		self.assertEqual(self.profile, {})
+
+	def test_updateToDifferentValue(self):
+		self.testSection["someBool"] = False
+		# Since we set someBool to a different value, update the profile.
+		self.assertEqual(self.profile, {"someBool": False})

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -886,7 +886,7 @@ class Config_AggregatedSection_setitem(unittest.TestCase):
 		self.assertIs(self.testSection["foo"], valueOfDefaultFlag)
 
 
-class Config_AggregatedSection_polution(unittest.TestCase):
+class Config_AggregatedSection_pollution(unittest.TestCase):
 	"""Ënsure that config profiles don't get polluted with overridden values equal to the base config"""
 
 	def setUp(self):

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -30,6 +30,7 @@ In order to use this feature, the application volume adjuster needs to be enable
 * Improvements when editing in Microsoft PowerPoint:
   * Caret reporting no longer breaks when text contains wide characters, such as emoji. (#17006 , @LeonarddeR)
   * Character location reporting is now accurate (e.g. when pressing `NVDA+Delete`. (#9941, @LeonarddeR)
+* Fixed an issue where certain settings were explicitly saved to the active configuration profile even when the value of that setting was equal to the value in the base configuration. (#17157, @leonarddeR)
 
 ### Changes for Developers
 


### PR DESCRIPTION
### Link to issue number:
Fixes #17157 
Fixup of https://github.com/nvaccess/nvda/pull/14133
Partially reverts https://github.com/nvaccess/nvda/pull/15074

### Summary of the issue:
When saving configuration profiles, unchanged values are yet saved to a profile.

### Description of user facing changes
Configuration profiles should become less polluted after this change.

### Description of development approach
Restored the behavior of https://github.com/nvaccess/nvda/pull/14133, mostly reverting #15074. There was namely a False assumption in #15074.
@seanbudd wrote:
> This caused various issues including config values not being correctly converted to numbers from strings when validating.

In fact, the validation was not the problem here. Instead, when `__getitem__` was called with `checkValidity` set to False, the unvalidated value was yet saved in the cache. Therefore subsequent calls of `__getitem__` would always return the unvalidated cached value that would always be of the string type.

### Testing strategy:
- [x] Tested STR from #17157. Ensured that the braille and vision settings don't get polluted.
- [x] Tested str from #14133
- [x] Tested str from https://github.com/nvaccess/nvda/issues/14760 (cc @fernando-jose-silva)
- [x] Tested str from https://github.com/nvaccess/nvda/issues/14760#issuecomment-1491684838 (cc @CyrilleB79)

### Known issues with pull request:
None known

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved handling of configuration settings to prevent redundant storage of identical values in the active configuration profile.
  
- **Bug Fixes**
	- Resolved an issue that caused certain settings to be incorrectly saved, enhancing the integrity of the configuration management process. 

- **Documentation**
	- Updated user documentation to include notes on recent fixes related to configuration settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
