### PR TITLE
Added descriptive text to more of the settings panels

### DIFF
--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -2419,6 +2419,11 @@ class ObjectPresentationPanel(SettingsPanel):
 class BrowseModePanel(SettingsPanel):
 	# Translators: This is the label for the browse mode settings panel.
 	title = _("Browse Mode")
+	panelDescription = _(
+		# Translators: This is descriptive text shown at the top of the Browse Mode settings panel.
+		"Configure behaviors when reading complex documents, including web pages, messages in Outlook or Thunderbird, or "
+		"files in the MS Office browse mode."
+	)
 	helpId = "BrowseModeSettings"
 
 	def makeSettings(self, settingsSizer):

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -2123,6 +2123,10 @@ class MouseSettingsPanel(SettingsPanel):
 class ReviewCursorPanel(SettingsPanel):
 	# Translators: This is the label for the review cursor settings panel.
 	title = _("Review Cursor")
+	panelDescription = _(
+		# Translators: This is descriptive text shown at the top of the Review Cursor settings panel.
+		"Configure NVDA's review cursor behavior."
+	)
 	helpId = "ReviewCursorSettings"
 
 	def makeSettings(self, settingsSizer):

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -3196,11 +3196,6 @@ class AudioPanel(SettingsPanel):
 class AddonStorePanel(SettingsPanel):
 	# Translators: This is the label for the addon navigation settings panel.
 	title = _("Add-on Store")
-	panelDescription = _(
-		# Translators: This is descriptive text shown at the top of the Add-on Store settings panel.
-		"Adjust certain aspects of the Add-on Store, including whether you want to be notified "
-		"when your add-ons have updates available.",
-	)
 	helpId = "AddonStoreSettings"
 
 	def makeSettings(self, settingsSizer: wx.BoxSizer) -> None:

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -2161,6 +2161,11 @@ class ReviewCursorPanel(SettingsPanel):
 class InputCompositionPanel(SettingsPanel):
 	# Translators: This is the label for the Input Composition settings panel.
 	title = _("Input Composition")
+	panelDescription = _(
+		# Translators: This is descriptive text shown at the top of the Input Composition settings panel.
+		"Configure how NVDA reports the input of Asian characters, "
+		"such as when using IME or Text Service input methods."
+	)
 	helpId = "InputCompositionSettings"
 
 	def makeSettings(self, settingsSizer):

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -2942,6 +2942,10 @@ class DocumentFormattingPanel(SettingsPanel):
 class DocumentNavigationPanel(SettingsPanel):
 	# Translators: This is the label for the document navigation settings panel.
 	title = _("Document Navigation")
+	panelDescription = _(
+		# Translators: This is descriptive text shown at the top of the Document Navigation settings panel.
+		"Configure certain specifics of how you can move through documents."
+	)
 	helpId = "DocumentNavigation"
 
 	def makeSettings(self, settingsSizer: wx.BoxSizer) -> None:

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -2421,8 +2421,7 @@ class BrowseModePanel(SettingsPanel):
 	title = _("Browse Mode")
 	panelDescription = _(
 		# Translators: This is descriptive text shown at the top of the Browse Mode settings panel.
-		"Configure behaviors when reading complex documents, including web pages, messages in Outlook or Thunderbird, or "
-		"files in the MS Office browse mode.",
+		"Configure how NVDA behaves when reading complex documents, such as web pages and emails.",
 	)
 	helpId = "BrowseModeSettings"
 

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -2125,7 +2125,7 @@ class ReviewCursorPanel(SettingsPanel):
 	title = _("Review Cursor")
 	panelDescription = _(
 		# Translators: This is descriptive text shown at the top of the Review Cursor settings panel.
-		"Configure NVDA's review cursor behavior."
+		"Configure NVDA's review cursor behavior.",
 	)
 	helpId = "ReviewCursorSettings"
 
@@ -2168,7 +2168,7 @@ class InputCompositionPanel(SettingsPanel):
 	panelDescription = _(
 		# Translators: This is descriptive text shown at the top of the Input Composition settings panel.
 		"Configure how NVDA reports the input of Asian characters, "
-		"such as when using IME or Text Service input methods."
+		"such as when using IME or Text Service input methods.",
 	)
 	helpId = "InputCompositionSettings"
 
@@ -2422,7 +2422,7 @@ class BrowseModePanel(SettingsPanel):
 	panelDescription = _(
 		# Translators: This is descriptive text shown at the top of the Browse Mode settings panel.
 		"Configure behaviors when reading complex documents, including web pages, messages in Outlook or Thunderbird, or "
-		"files in the MS Office browse mode."
+		"files in the MS Office browse mode.",
 	)
 	helpId = "BrowseModeSettings"
 
@@ -2944,7 +2944,7 @@ class DocumentNavigationPanel(SettingsPanel):
 	title = _("Document Navigation")
 	panelDescription = _(
 		# Translators: This is descriptive text shown at the top of the Document Navigation settings panel.
-		"Configure certain specifics of how you can move through documents."
+		"Configure certain specifics of how you can move through documents.",
 	)
 	helpId = "DocumentNavigation"
 
@@ -3200,7 +3200,7 @@ class AddonStorePanel(SettingsPanel):
 	panelDescription = _(
 		# Translators: This is descriptive text shown at the top of the Add-on Store settings panel.
 		"Adjust certain aspects of the Add-on Store, including whether you want to be notified "
-		"when your add-ons have updates available."
+		"when your add-ons have updates available.",
 	)
 	helpId = "AddonStoreSettings"
 
@@ -3271,7 +3271,7 @@ class UwpOcrPanel(SettingsPanel):
 	title = _("Windows OCR")
 	panelDescription = _(
 		# Translators: This is descriptive text shown at the top of the Windows OCR settings panel.
-		"Configure some elements of the Windows optical character recognition feature which NVDA makes available."
+		"Configure some elements of the Windows optical character recognition feature which NVDA makes available.",
 	)
 	helpId = "Win10OcrSettings"
 

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -3269,6 +3269,10 @@ class TouchInteractionPanel(SettingsPanel):
 class UwpOcrPanel(SettingsPanel):
 	# Translators: The title of the Windows OCR panel.
 	title = _("Windows OCR")
+	panelDescription = _(
+		# Translators: This is descriptive text shown at the top of the Windows OCR settings panel.
+		"Configure some elements of the Windows optical character recognition feature which NVDA makes available."
+	)
 	helpId = "Win10OcrSettings"
 
 	def makeSettings(self, settingsSizer):

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -3265,7 +3265,7 @@ class UwpOcrPanel(SettingsPanel):
 	title = _("Windows OCR")
 	panelDescription = _(
 		# Translators: This is descriptive text shown at the top of the Windows OCR settings panel.
-		"Configure some elements of the Windows optical character recognition feature which NVDA makes available.",
+		"Configure NVDA's Windows optical character recognition support.",
 	)
 	helpId = "Win10OcrSettings"
 

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -3197,6 +3197,11 @@ class AudioPanel(SettingsPanel):
 class AddonStorePanel(SettingsPanel):
 	# Translators: This is the label for the addon navigation settings panel.
 	title = _("Add-on Store")
+	panelDescription = _(
+		# Translators: This is descriptive text shown at the top of the Add-on Store settings panel.
+		"Adjust certain aspects of the Add-on Store, including whether you want to be notified "
+		"when your add-ons have updates available."
+	)
 	helpId = "AddonStoreSettings"
 
 	def makeSettings(self, settingsSizer: wx.BoxSizer) -> None:

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -2943,7 +2943,7 @@ class DocumentNavigationPanel(SettingsPanel):
 	title = _("Document Navigation")
 	panelDescription = _(
 		# Translators: This is descriptive text shown at the top of the Document Navigation settings panel.
-		"Configure certain specifics of how you can move through documents.",
+		"Configure the behaviour of navigation commands in documents.",
 	)
 	helpId = "DocumentNavigation"
 

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -2125,7 +2125,7 @@ class ReviewCursorPanel(SettingsPanel):
 	title = _("Review Cursor")
 	panelDescription = _(
 		# Translators: This is descriptive text shown at the top of the Review Cursor settings panel.
-		"Configure NVDA's review cursor behavior.",
+		"Configure the review cursor, which allows reading the contents of the screen, current document or current object without moving the caret",
 	)
 	helpId = "ReviewCursorSettings"
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -30,7 +30,7 @@ In order to use this feature, the application volume adjuster needs to be enable
 * Improvements when editing in Microsoft PowerPoint:
   * Caret reporting no longer breaks when text contains wide characters, such as emoji. (#17006 , @LeonarddeR)
   * Character location reporting is now accurate (e.g. when pressing `NVDA+Delete`. (#9941, @LeonarddeR)
-* More of the NVDA settings dialogs start with descriptive text. (#pending, @XLTechie)
+* More of the NVDA settings dialogs now start with descriptive text. (#17160, @XLTechie)
 
 ### Changes for Developers
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -30,6 +30,7 @@ In order to use this feature, the application volume adjuster needs to be enable
 * Improvements when editing in Microsoft PowerPoint:
   * Caret reporting no longer breaks when text contains wide characters, such as emoji. (#17006 , @LeonarddeR)
   * Character location reporting is now accurate (e.g. when pressing `NVDA+Delete`. (#9941, @LeonarddeR)
+* More of the NVDA settings dialogs start with descriptive text. (#pending, @XLTechie)
 
 ### Changes for Developers
 


### PR DESCRIPTION

### Link to issue number:

Fixes #13568

### Summary of the issue:

Several settings panels were missing friendly introductory text.
While some have names that are so obvious they do not need introductory text (Speech, Braille, Keyboard, Mouse), others do need it (Input Composition, Browse Mode).

### Description of user facing changes

The following settings panels now have some introductory text.

* Input Composition
* Review Cursor
* browse mode
* Document Nav
* Add-on Store
* Windows OCR

### Description of development approach

Wrote, or mostly copied from the user guide with minor alterations, descriptions for the above listed settings panels.

### Testing strategy:

Built, made sure the modified panels spoke correctly.
Some with vision may want to check that they show up right.

### Known issues with pull request:

None, unless you count that i didn't label the more obvious panels.

### Code Review Checklist:

- [X] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [X] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [X] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [X] API is compatible with existing add-ons.
- [X] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
