### PR TITLE
Fix braille breakage when activating say all with a config profile enabled

### DIFF
--- a/source/braille.py
+++ b/source/braille.py
@@ -3130,7 +3130,9 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 		):
 			self._detector._limitToDevices = bdDetect.getBrailleDisplayDriversEnabledForDetection()
 
-		self._tether = config.conf["braille"]["tetherTo"]
+		configuredTether = config.conf["braille"]["tetherTo"]
+		if configuredTether != TetherTo.AUTO.value:
+			self._tether = configuredTether
 		tableName = config.conf["braille"]["translationTable"]
 		# #6140: Migrate to new table names as smoothly as possible.
 		newTableName = brailleTables.RENAMED_TABLES.get(tableName)

--- a/source/braille.py
+++ b/source/braille.py
@@ -3130,8 +3130,7 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 		):
 			self._detector._limitToDevices = bdDetect.getBrailleDisplayDriversEnabledForDetection()
 
-		configuredTether = config.conf["braille"]["tetherTo"]
-		if configuredTether != TetherTo.AUTO.value:
+		if (configuredTether := config.conf["braille"]["tetherTo"]) != TetherTo.AUTO.value:
 			self._tether = configuredTether
 		tableName = config.conf["braille"]["translationTable"]
 		# #6140: Migrate to new table names as smoothly as possible.

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -30,6 +30,7 @@ In order to use this feature, the application volume adjuster needs to be enable
 * Improvements when editing in Microsoft PowerPoint:
   * Caret reporting no longer breaks when text contains wide characters, such as emoji. (#17006 , @LeonarddeR)
   * Character location reporting is now accurate (e.g. when pressing `NVDA+Delete`. (#9941, @LeonarddeR)
+* Braille is no longer dysfunctional when activating 'say all' with an associated configuration profile. (#17163, @LeonarddeR)
 
 ### Changes for Developers
 


### PR DESCRIPTION
### Link to issue number:
Fixed #17163 

### Summary of the issue:
When you have a config profile attached to say all and activate a config profile, braille is broken until you move out and into the document control.

### Description of user facing changes
Braille follows along properly.

### Description of development approach
The problem was that in the braille handler, `self._tether` was set to `auto` when it was configured to auto. However `self._tether` should only contain the internal tether state, `focus` or `review`. Therefore if it is configured as `auto`, do not override the internal tether state of the braille handler.

### Testing strategy:
Tested str from #17163 

### Known issues with pull request:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
