### PR TITLE
Fix audio panel layout

### DIFF
--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -3045,8 +3045,8 @@ class AudioPanel(SettingsPanel):
 			defaultVolume = config.conf.getConfigValidation(["audio", "applicationsSoundVolume"]).default
 			self.appSoundVolSlider.SetValue(defaultVolume)
 
-		# Translators: Mute other apps checkbox in settings
 		self.muteOtherAppsCheckBox: wx.CheckBox = sHelper.addItem(
+			# Translators: Mute other apps checkbox in settings
 			wx.CheckBox(self, label=_("Mute other apps"))
 		)
 		self.muteOtherAppsCheckBox.SetValue(config.conf["audio"]["applicationsSoundMuted"])

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -3046,7 +3046,7 @@ class AudioPanel(SettingsPanel):
 			self.appSoundVolSlider.SetValue(defaultVolume)
 
 		# Translators: Mute other apps checkbox in settings
-		self.muteOtherAppsCheckBox = wx.CheckBox(self, label=_("Mute other apps"))
+		self.muteOtherAppsCheckBox: wx.CheckBox = sHelper.addItem(wx.CheckBox(self, label=_("Mute other apps")))
 		self.muteOtherAppsCheckBox.SetValue(config.conf["audio"]["applicationsSoundMuted"])
 		self.bindHelpEvent("OtherAppMute", self.muteOtherAppsCheckBox)
 

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -3046,7 +3046,9 @@ class AudioPanel(SettingsPanel):
 			self.appSoundVolSlider.SetValue(defaultVolume)
 
 		# Translators: Mute other apps checkbox in settings
-		self.muteOtherAppsCheckBox: wx.CheckBox = sHelper.addItem(wx.CheckBox(self, label=_("Mute other apps")))
+		self.muteOtherAppsCheckBox: wx.CheckBox = sHelper.addItem(
+			wx.CheckBox(self, label=_("Mute other apps"))
+		)
 		self.muteOtherAppsCheckBox.SetValue(config.conf["audio"]["applicationsSoundMuted"])
 		self.bindHelpEvent("OtherAppMute", self.muteOtherAppsCheckBox)
 

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -3047,7 +3047,7 @@ class AudioPanel(SettingsPanel):
 
 		self.muteOtherAppsCheckBox: wx.CheckBox = sHelper.addItem(
 			# Translators: Mute other apps checkbox in settings
-			wx.CheckBox(self, label=_("Mute other apps"))
+			wx.CheckBox(self, label=_("Mute other apps")),
 		)
 		self.muteOtherAppsCheckBox.SetValue(config.conf["audio"]["applicationsSoundMuted"])
 		self.bindHelpEvent("OtherAppMute", self.muteOtherAppsCheckBox)


### PR DESCRIPTION
### Link to issue number:
Fixes #17182

### Summary of the issue:
In audio settings panel, the "Mute other apps" checkbox is misplaced: it appears at the top of the panel and hides its first control (output item).

### Description of user facing changes
The checkbox is now correctly positionned.

### Description of development approach
The checkbox has been added to the `BoxSizerHelper` so that it is positioned by it.

### Testing strategy:
Visual check
### Known issues with pull request:
None
### Code Review Checklist:


- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
