### PR TITLE
soffice: Announce keyboard triggered "double underline" toggling

### DIFF
--- a/source/appModules/soffice.py
+++ b/source/appModules/soffice.py
@@ -538,6 +538,8 @@ class SymphonyDocument(CompoundDocument):
 			"kb:control+5",
 			# bold
 			"kb:control+b",
+			# double underline
+			"kb:control+d",
 			# italic
 			"kb:control+i",
 			# underline

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -18,6 +18,7 @@ In order to use this feature, the application volume adjuster needs to be enable
 * The add-ons lists in the Add-on Store can be sorted by columns. (#15277, @nvdaes)
 * When decreasing or increasing the font size in LibreOffice Writer using the corresponding keyboard shortcuts, NVDA announces the new font size. (#6915, @michaelweghorn)
 * When applying the "Body Text" or a heading paragraph style using the corresponding keyboard shortcut in LibreOffice Writer 25.2 or newer, NVDA announces the new paragraph style. (#6915, @michaelweghorn)
+* When toggling double underline in LibreOffice Writer using the corresponding keyboard shortcut, NVDA announces the new state ("double underline on"/"double underline off"). (#6915, @michaelweghorn)
 * Automatic language switching is now supported when using Microsoft Speech API version 5 (SAPI5) and Microsoft Speech Platform voices. (#17146, @gexgd0419)
 
 ### Changes


### PR DESCRIPTION
 ### Link to issue number:

Implements one aspect from feature requests in #6915

 ### Summary of the issue:

Commit 46a343685247ed7d1adfb737716590ec4be456a0
("soffice: Report keyboard-triggered formatting toggles in Writer (#16413)") implemented announcement of keyboard-triggered formatting changes in LibreOffice Writer, including the one to toggle underline. (When English keyboard layout and UI, the shortcut is Ctrl+B.)

Issue #6915 (among others) requests announcement also for "toggle double underline", which is done via the Ctrl+D keyboard shortcut for an English UI.

 ### Description of user facing changes

When toggling double underline in LibreOffice Writer using the corresponding keyboard shortcut, NVDA announces the new state ("double underline on"/"double underline off"). (#6915, @michaelweghorn)

 ### Description of development approach

Add Ctrl+D to the list gestures handled by the existing gesture handler.

 ### Testing strategy:

1. start NVDA
2. start LibreOffice Writer (with English UI and keyboard layout)
3. Press Ctrl+D to enable double underline
4. Verify that NVDA announces "double underline on"
5. Press Ctrl+D to disable double underline again
6. Verify that NVDA announces "double underline off"
7. Press Ctrl+U to enable (normal/single) underline
8. Verify that NVDA announces "underline on"
9. Press Ctrl+D to enable double underline
10. Verify that NVDA announces "double underline on"

 ### Known issues with pull request:

None.

 ### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
