### PR TITLE
Remove reference to windows 7 in self-signed build docs

### DIFF
--- a/projectDocs/dev/selfSignedBuild.md
+++ b/projectDocs/dev/selfSignedBuild.md
@@ -75,7 +75,7 @@ Thumbprint                                Subject
 On any supported version of Windows, you can manage certifications through the "Certificate Manager".
 
 Importing A Windows 11 certificate via PowerShell may fail on older versions of Windows.
-For Windows 10, simply open the certificate file and go through the installation dialog.
+On Windows 10, open the certificate file and go through the installation dialog.
 Install it to "Local Machine", in the store: "Trusted Root Certification Authorities".
 
 ### Using the certificate

--- a/projectDocs/dev/selfSignedBuild.md
+++ b/projectDocs/dev/selfSignedBuild.md
@@ -70,8 +70,13 @@ Thumbprint                                Subject
 148CB69869B802A36B3D8D801BA8D9D0F3C1484F  CN=Test NVDA Build, O=NV Access Dev, C=US
 ```
 
-For Windows 7, you will need to use an alternative method.
+#### Note for older versions of Windows
+
 On any supported version of Windows, you can manage certifications through the "Certificate Manager".
+
+Importing A Windows 11 certificate via PowerShell may fail on older versions of Windows.
+For Windows 10, simply open the certificate file and go through the installation dialog.
+Install it to "Local Machine", in the store: "Trusted Root Certification Authorities".
 
 ### Using the certificate
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:

### Summary of the issue:
The self signed build docs reference Windows 7. Windows 7 is no longer supported in NVDA.

### Description of user facing changes
None
### Description of development approach
Update docs to remove reference to windows 7 in self-signed build docs
