### PR TITLE
Convert add-on submission time to seconds

### DIFF
--- a/source/addonStore/models/addon.py
+++ b/source/addonStore/models/addon.py
@@ -188,7 +188,8 @@ class _AddonStoreModel(_AddonGUIModel):
 	def publicationDate(self) -> str | None:
 		if self.submissionTime is None:
 			return None
-		return datetime.strftime(datetime.fromtimestamp(self.submissionTime), "%x")
+		# Convert `self.submissionTime` to seconds.
+		return datetime.strftime(datetime.fromtimestamp(self.submissionTime // 1000), "%x")
 
 
 class _AddonManifestModel(_AddonGUIModel):


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Part of #16681, fixup of PR 17091
### Summary of the issue:
Add-on `submissionTime` in json metadata files is in milliseconds, but it needs to be converted to seconds to be transformed in a `publicationDate`

### Description of user facing changes
None
### Description of development approach
Convert add-on submissionTime to seconds in `addonStore/models/addon.py`
### Testing strategy:
Tested manually: now Windows App Essentials 20240918.0.0 dev is shown properly with its publication date.
### Known issues with pull request:
None
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
