### PR TITLE
Remove "or later" from copying.txt

### DIFF
--- a/copying.txt
+++ b/copying.txt
@@ -1,6 +1,6 @@
 # NVDA License
 
-NVDA is available under the GNU General Public License version 2 or later, with two special exceptions.
+NVDA is available under the GNU General Public License version 2, with two special exceptions.
 The exceptions are outlined in the sections "Non-GPL Components in Plugins and Drivers" and "Microsoft Distributable Code".
 NVDA also includes and uses components which are made available under different free and open source licenses.
 Information about how to obtain and build the code for yourself is available at http://community.nvda-project.org/wiki/AccessingAndRunningSourceCode
@@ -304,12 +304,12 @@ DAMAGES.
 
 ## Non-GPL Components in Plugins and Drivers
 
-Plugins and drivers, including those provided by third parties, are considered derivative works of NVDA and must therefore be licensed under the terms of the GNU General Public License version 2 or later.
+Plugins and drivers, including those provided by third parties, are considered derivative works of NVDA and must therefore be licensed under the terms of the GNU General Public License version 2.
 As a special exception, an NVDA plugin or driver (as defined in the NVDA Developer Guide) may use components under other licenses provided that:
-a) Any such component does not prevent the NVDA plugin or driver from being licensed under the terms of the GNU General Public License version 2 or later; and
+a) Any such component does not prevent the NVDA plugin or driver from being licensed under the terms of the GNU General Public License version 2; and
 b) Any such component does not directly use and is not directly used by any portion of NVDA outside of that plugin or driver.
 For example, a speech synthesizer driver may use a speech synthesiser under a proprietary license.
-In contrast, in a plugin providing support for an application, the code which implements any interface provided by NVDA must be licensed under the GNU General Public License version 2 or later.
+In contrast, in a plugin providing support for an application, the code which implements any interface provided by NVDA must be licensed under the GNU General Public License version 2.
 
 
 ## Microsoft Distributable Code
@@ -319,7 +319,7 @@ This applies to the following files:
 - Microsoft.VC*.manifest
 - msvc*.dll
 
-As a special exception to the GNU General Public License version 2 or later, these components may be included with binary distributions of NVDA without being subject to the terms of that license.
+As a special exception to the GNU General Public License version 2, these components may be included with binary distributions of NVDA without being subject to the terms of that license.
 
 Microsoft Distributable Code is covered by the following terms:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ maintainers = [
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: End Users/Desktop",
-    "License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)",
+    "License :: OSI Approved :: GNU General Public License v2",
     "Operating System :: Microsoft :: Windows",
     "Programming Language :: Python :: 3",
     "Topic :: Accessibility",


### PR DESCRIPTION
### Link to issue number:
Revert https://github.com/nvaccess/nvda/pull/16830

### Summary of the issue:
Inadvertently merged PR before licence clarification was fully addressed 

### Description of user facing changes
Revert "GPL-2 or later" to "GPL-2"


<!-- Please keep the following -->
@coderabbitai summary
