### PR TITLE
Include NVDA-VSCode as a Submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,7 +43,6 @@ tests/system/settingsCache/*
 !tests/system/settingsCache/2020.4/*.txt
 source/locale/en/LC_MESSAGES/nvda.po
 source/locale/*/cldr.dic
-.vscode
 .vs
 .venv
 nvdaHelper/docs/

--- a/.gitmodules
+++ b/.gitmodules
@@ -38,6 +38,7 @@
 	url = https://github.com/nvaccess/nvda-cldr.git
 	branch = main-out
 	shallow = true
-[submodule ".vscode"]
+[submodule "vscode-nvda"]
 	path = .vscode
 	url = https://github.com/nvaccess/vscode-nvda.git
+	ignore=dirty

--- a/.gitmodules
+++ b/.gitmodules
@@ -41,4 +41,4 @@
 [submodule "vscode-nvda"]
 	path = .vscode
 	url = https://github.com/nvaccess/vscode-nvda.git
-	ignore=dirty
+	ignore = dirty

--- a/.gitmodules
+++ b/.gitmodules
@@ -38,3 +38,6 @@
 	url = https://github.com/nvaccess/nvda-cldr.git
 	branch = main-out
 	shallow = true
+[submodule ".vscode"]
+	path = .vscode
+	url = https://github.com/nvaccess/vscode-nvda.git

--- a/projectDocs/dev/createDevEnvironment.md
+++ b/projectDocs/dev/createDevEnvironment.md
@@ -62,18 +62,6 @@ To replicate the production build environment, use the 3.11.x minor version of P
 		* MSVC v143 - VS 2022 C++ x64/x86 build tools
 		* C++ ATL for v143 build tools (x86 & x64)
 		* C++ ATL for v143 build tools (ARM64/ARM64EC)
-* When you are using [Visual Studio Code](https://code.visualstudio.com/) as your integrated development environment of preference, you get the benefit of our [prepopulated workspace configuration](https://github.com/nvaccess/vscode-nvda/), which is included as a submodule.
-If you do not wish to use the pre-populated VS Code workspace configuration, you can unregister the `.vscode` submodule.
-
-	```sh
-	git submodule deinit .vscode
-	```
-
-	If you change your mind, you can re-enable it at any time.
-
-	```sh
-	git submodule init .vscode
-	```
 
 ### Git Submodules
 Some of the dependencies are contained in Git submodules.
@@ -81,7 +69,7 @@ If you didn't pass the `--recursive` option to git clone, you will need to run `
 Whenever a required submodule commit changes (e.g. after git pull), you will need to run `git submodule update`.
 If you aren't sure, run `git submodule update` after every git pull, merge or checkout.
 
-For reference, the following run time dependencies are included in Git submodules:
+#### Run time dependencies
 
 * [eSpeak NG](https://github.com/espeak-ng/espeak-ng), version 1.52-dev commit `961454ffaa894d981526f4d424daef1d3bc4175f`
 * [Sonic](https://github.com/waywardgeek/sonic), commit `8694c596378c24e340c09ff2cd47c065494233f1`
@@ -106,6 +94,21 @@ Additionally, the following build time dependencies are included in the miscDeps
 The following dependencies aren't needed by most people, and are not included in Git submodules:
 * To generate [developer documentation for nvdaHelper](#building-nvdahelper-developer-documentation): [Doxygen Windows installer](http://www.doxygen.nl/download.html), version 1.8.15:
 
+
+#### VS Code
+
+* If you use [Visual Studio Code](https://code.visualstudio.com/) as your integrated development environment, you get the benefit of our [prepopulated workspace configuration](https://github.com/nvaccess/vscode-nvda/), which is included as a submodule.
+  If you do not wish to use the pre-populated VS Code workspace configuration, you can unregister the `.vscode` submodule.
+
+  ```sh
+  git submodule deinit .vscode
+  ```
+
+  If you change your mind, you can re-enable it at any time.
+
+  ```sh
+  git submodule init .vscode
+  ```
 
 ### Python dependencies
 NVDA and its build system also depend on an extensive list of Python packages. They are all listed with their specific versions in the requirements.txt file in the root of this repository. However, the build system takes care of fetching these itself when needed. These packages will be installed into an isolated Python virtual environment within this repository, and will not affect your system-wide set of packages.

--- a/projectDocs/dev/createDevEnvironment.md
+++ b/projectDocs/dev/createDevEnvironment.md
@@ -62,11 +62,17 @@ To replicate the production build environment, use the 3.11.x minor version of P
 		* MSVC v143 - VS 2022 C++ x64/x86 build tools
 		* C++ ATL for v143 build tools (x86 & x64)
 		* C++ ATL for v143 build tools (ARM64/ARM64EC)
-* When you are using Visual Studio Code as your integrated development environment of preference, you can make use of our [prepopulated workspace configuration](https://github.com/nvaccess/vscode-nvda/) for [Visual Studio Code](https://code.visualstudio.com/).
-	While this VSCode project is not included as a submodule in the NVDA repository, you can easily check out the workspace configuration in your repository by executing the following from the root of the repository.
+* When you are using [Visual Studio Code](https://code.visualstudio.com/) as your integrated development environment of preference, you get the benefit of our [prepopulated workspace configuration](https://github.com/nvaccess/vscode-nvda/), which is included as a submodule.
+If you do not wish to use the pre-populated VS Code workspace configuration, you can unregister the `.vscode` submodule.
 
 	```sh
-	git clone https://github.com/nvaccess/vscode-nvda.git .vscode
+	git submodule deinit .vscode
+	```
+
+	If you change your mind, you can re-enable it at any time.
+
+	```sh
+	git submodule init .vscode
 	```
 
 ### Git Submodules

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -66,6 +66,7 @@ Add-ons will need to be re-tested and have their manifest updated.
   * A `toggleBooleanValue` helper function has been added to `globalCommands`.
   It can be used in scripts to report the result when a boolean is toggled in `config.conf`
 * Removed the requirement to indent function parameter lists by two tabs from NVDA's Coding Standards, to be compatible with modern automatic linting. (#17126, @XLTechie)
+* Added the [VS Code workspace configuration for NVDA](https://nvaccess.org/nvaccess/vscode-nvda) as a git submodule. (#17003)
 
 #### API Breaking Changes
 


### PR DESCRIPTION
### Link to issue number:

Closes #17003

### Summary of the issue:

The [nvda-vscode repository](https://github.com/nvaccess/vscode-nvda) exists to create a workspace configuration for VS Code  that contains some sensible defaults, and recommendations for extensions that make developing for NVDA to our standards easier. However, using this workspace configuration currently requires manually clone it.

### Description of user facing changes

None

### Description of developer-facing changes:

The `.vscode` directory for NVDA is now included as a submodule. This reduces friction for VS Code users, should have effectively no impact on users of other IDEs, and can be disabled by users who do not desire this behaviour.

### Description of development approach

Added nvaccess/vscode-nvda as a submodule. Set its `ignore` option to `dirty` so that users' changes to their project config don't cause the superproject to show as dirty. Updated the dev docs to note the change.

### Testing strategy:

Verified that `.gitmodules` has been updated.

### Known issues with pull request:

None.

### Note

This should be merged after merging nvaccess/vscode-nvda#17 and checking out the new head of nvaccess/vscode-nvda.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
