### PR TITLE
Handle error when creating TextInfo from alleged caret object

### DIFF
--- a/source/compoundDocuments.py
+++ b/source/compoundDocuments.py
@@ -545,8 +545,11 @@ class CompoundDocument(EditableText, DocumentTreeInterceptor):
 		self.detectPossibleSelectionChange()
 		braille.handler.handleCaretMove(self)
 		vision.handler.handleCaretMove(self)
-		caret = self.makeTextInfo(textInfos.POSITION_CARET)
-		review.handleCaretMove(caret)
+		try:
+			caret = self.makeTextInfo(textInfos.POSITION_CARET)
+			review.handleCaretMove(caret)
+		except NotImplementedError:
+			pass
 
 	def event_gainFocus(self, obj, nextHandler):
 		if not isinstance(obj, behaviors.EditableText):

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -19,6 +19,7 @@ In order to use this feature, the application volume adjuster needs to be enable
 * When decreasing or increasing the font size in LibreOffice Writer using the corresponding keyboard shortcuts, NVDA announces the new font size. (#6915, @michaelweghorn)
 * When applying the "Body Text" or a heading paragraph style using the corresponding keyboard shortcut in LibreOffice Writer 25.2 or newer, NVDA announces the new paragraph style. (#6915, @michaelweghorn)
 * When toggling double underline in LibreOffice Writer using the corresponding keyboard shortcut, NVDA announces the new state ("double underline on"/"double underline off"). (#6915, @michaelweghorn)
+* When using the Microsoft Pinyin Input Method for Chinese and enabling the Pinyin compatibility option to use the previous version, typing in LibreOffice (and potentially other applications) while an IME popup is showing no longer triggers an error. (#17198, @michaelweghorn)
 * Automatic language switching is now supported when using Microsoft Speech API version 5 (SAPI5) and Microsoft Speech Platform voices. (#17146, @gexgd0419)
 
 ### Changes

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -19,7 +19,6 @@ In order to use this feature, the application volume adjuster needs to be enable
 * When decreasing or increasing the font size in LibreOffice Writer using the corresponding keyboard shortcuts, NVDA announces the new font size. (#6915, @michaelweghorn)
 * When applying the "Body Text" or a heading paragraph style using the corresponding keyboard shortcut in LibreOffice Writer 25.2 or newer, NVDA announces the new paragraph style. (#6915, @michaelweghorn)
 * When toggling double underline in LibreOffice Writer using the corresponding keyboard shortcut, NVDA announces the new state ("double underline on"/"double underline off"). (#6915, @michaelweghorn)
-* When using the Microsoft Pinyin Input Method for Chinese and enabling the Pinyin compatibility option to use the previous version, typing in LibreOffice (and potentially other applications) while an IME popup is showing no longer triggers an error. (#17198, @michaelweghorn)
 * Automatic language switching is now supported when using Microsoft Speech API version 5 (SAPI5) and Microsoft Speech Platform voices. (#17146, @gexgd0419)
 
 ### Changes
@@ -45,6 +44,7 @@ In order to use this feature, the application volume adjuster needs to be enable
   * Fixed an issue where certain settings were explicitly saved to the active configuration profile even when the value of that setting was equal to the value in the base configuration. (#17157, @leonarddeR)
 * NVDA is able to read the popup submenu items on Thunderbird search results page. (#4708, @thgcode)
 * The COM Registration Fixing Tool no longer reports success on failure. (#12355, @XLTechie)
+* When using the Microsoft Pinyin Input Method for Chinese and enabling the Pinyin compatibility option to use the previous version, typing in LibreOffice Writer (and potentially other applications) while an IME popup is showing no longer triggers an error. (#17198, @michaelweghorn)
 
 ### Changes for Developers
 


### PR DESCRIPTION
 ### Link to issue number:

Partially fixes #17198

 ### Summary of the issue:

When using the Microsoft Pinyin Input Method for Chinese and enabling the Pinyin compatibility option to use the previous version, typing in LibreOffice (e.g. Writer or Calc) while an IME popup was showing triggered an error, with this traceback:

    ERROR - eventHandler.executeEvent (10:45:49.378) - MainThread (7416):
    error executing event: caret on <NVDAObjects.Dynamic_SymphonyParagraphSymphonyTextEditableTextWithAutoSelectDetectionIAccessible object at 0x0B918DF0> with extra args of {}
    Traceback (most recent call last):
      File "eventHandler.py", line 353, in executeEvent
        _EventExecuter(eventName, obj, kwargs)
      File "eventHandler.py", line 119, in __init__
        self.next()
      File "eventHandler.py", line 128, in next
        return func(*args, **self.kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "compoundDocuments.py", line 548, in event_caret
        caret = self.makeTextInfo(textInfos.POSITION_CARET)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "documentBase.py", line 76, in makeTextInfo
        return self.TextInfo(self, position)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "compoundDocuments.py", line 287, in __init__
        self._start = self._end = self._startObj.makeTextInfo(position)
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "documentBase.py", line 76, in makeTextInfo
        return self.TextInfo(self, position)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "textInfos\offsets.py", line 505, in __init__
        self._startOffset = self._endOffset = self._getCaretOffset()
                                              ^^^^^^^^^^^^^^^^^^^^^^
      File "textInfos\offsets.py", line 267, in _getCaretOffset
        raise NotImplementedError
    NotImplementedError

This was caused by the attempt to create a text info for an object from the IME popup that's not actually part of the LibreOffice accessibility tree, and that doesn't provide any means to get the current caret position.

This is due to `CompoundDocument._get_caretObject` returning the last queued focus object, which isn't necessarily the object that the caret change event has actually been sent for, and might be an object that doesn't support reporting of a caret positiion altogether.

 ### Description of user facing changes

When using the Microsoft Pinyin Input Method for Chinese and enabling the Pinyin compatibility option to use the previous version, typing in LibreOffice Writer (and potentially other applications) while an IME popup is showing no longer triggers an error.

 ### Description of development approach

Handle the NotImplementedError error that may get thrown in CompoundDocument.event_caret.

 ### Testing strategy:

1. set up the Microsoft Pinyin Input Method for Chinese and enable the Pinyin compatibility option as described in issue #17198
2. start LibreOffice Writer
3. start typing, e.g. just type "e" multiple times
4. Notice the IME popup showing without triggering an error

 ### Known issues with pull request:

None, but note that other than Writer, the case of using Calc still shows more issues, s. https://github.com/nvaccess/nvda/issues/17198#issuecomment-2370956581 , i.e. this is only a partial fix for the use case described in that ticket.

 ### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
