### PR TITLE
Honour multi keypress timeout for NVDA key

### DIFF
--- a/source/keyboardHandler.py
+++ b/source/keyboardHandler.py
@@ -203,7 +203,7 @@ def internal_keyDownEvent(vkCode, scanCode, extended, injected):
 			or (
 				keyCode == lastNVDAModifier
 				and lastNVDAModifierReleaseTime
-				and time.time() - lastNVDAModifierReleaseTime < config.conf["keyboard"]["multiPressTimeout"]
+				and time.time() - lastNVDAModifierReleaseTime < config.conf["keyboard"]["multiPressTimeout"] / 1000
 			)
 		):
 			# The user wants the key to serve its normal function instead of acting as an NVDA modifier key.

--- a/source/keyboardHandler.py
+++ b/source/keyboardHandler.py
@@ -203,7 +203,8 @@ def internal_keyDownEvent(vkCode, scanCode, extended, injected):
 			or (
 				keyCode == lastNVDAModifier
 				and lastNVDAModifierReleaseTime
-				and time.time() - lastNVDAModifierReleaseTime < config.conf["keyboard"]["multiPressTimeout"] / 1000
+				and time.time() - lastNVDAModifierReleaseTime
+				< config.conf["keyboard"]["multiPressTimeout"] / 1000
 			)
 		):
 			# The user wants the key to serve its normal function instead of acting as an NVDA modifier key.

--- a/source/keyboardHandler.py
+++ b/source/keyboardHandler.py
@@ -203,8 +203,10 @@ def internal_keyDownEvent(vkCode, scanCode, extended, injected):
 			or (
 				keyCode == lastNVDAModifier
 				and lastNVDAModifierReleaseTime
-				and time.time() - lastNVDAModifierReleaseTime
-				< config.conf["keyboard"]["multiPressTimeout"] / 1000
+				and (
+					time.time() - lastNVDAModifierReleaseTime
+					< config.conf["keyboard"]["multiPressTimeout"] / 1000
+				)
 			)
 		):
 			# The user wants the key to serve its normal function instead of acting as an NVDA modifier key.

--- a/source/keyboardHandler.py
+++ b/source/keyboardHandler.py
@@ -2,7 +2,7 @@
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-# Copyright (C) 2006-2023 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Babbage B.V., Cyrille Bougot
+# Copyright (C) 2006-2024 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Babbage B.V., Cyrille Bougot
 
 """Keyboard support"""
 
@@ -203,7 +203,7 @@ def internal_keyDownEvent(vkCode, scanCode, extended, injected):
 			or (
 				keyCode == lastNVDAModifier
 				and lastNVDAModifierReleaseTime
-				and time.time() - lastNVDAModifierReleaseTime < 0.5
+				and time.time() - lastNVDAModifierReleaseTime < config.conf["keyboard"]["multiPressTimeout"]
 			)
 		):
 			# The user wants the key to serve its normal function instead of acting as an NVDA modifier key.


### PR DESCRIPTION
### Link to issue number:
Fix-up of #12049.

### Summary of the issue:
When implementing multi keypress timeout in #12049, the timeout for double press of NVDA key (to execute native function) was not honoured.

### Description of user facing changes
Multiple key press timeout will now be honoured also for double press of NVDA key.

### Description of development approach
Replace the hard-coded value 0.5 with the config value.

### Testing strategy:
Manual tests:
Increased the delay to 3000 ms and:
* checked that double NVDA press on `insert` or `capslock` honour the native key function is executed
* checked that 2 presses with more than 3000 ms between the presses do not execute the native key's function

### Known issues with pull request:
Opened against beta since the PR being fixed up is part of this release cycle. But it may be too late to have a test period...

If you do not wish to introduce change at this stage, #12049 can remain in the release though, and I'll rebase on master.

### Code Review Checklist:


- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced flexibility in keyboard input handling by allowing configurable timeout for modifier key presses.

- **Chores**
	- Updated copyright notice to reflect the year 2024.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
