### PR TITLE
soffice: Use SymphonyText only for objects with specific roles

### DIFF
--- a/source/appModules/soffice.py
+++ b/source/appModules/soffice.py
@@ -605,9 +605,12 @@ class AppModule(appModuleHandler.AppModule):
 				hasattr(obj, "IAccessibleTable2Object") or hasattr(obj, "IAccessibleTableObject")
 			):
 				clsList.insert(0, SymphonyTable)
-			elif hasattr(obj, "IAccessibleTextObject"):
+			elif hasattr(obj, "IAccessibleTextObject") and role in {
+				controlTypes.Role.EDITABLETEXT,
+				controlTypes.Role.HEADING,
+			}:
 				clsList.insert(0, SymphonyText)
-			if role == controlTypes.Role.PARAGRAPH:
+			if role in {controlTypes.Role.BLOCKQUOTE, controlTypes.Role.PARAGRAPH}:
 				clsList.insert(0, SymphonyParagraph)
 
 	def event_NVDAObject_init(self, obj):

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -46,6 +46,7 @@ In order to use this feature, the application volume adjuster needs to be enable
 * NVDA is able to read the popup submenu items on Thunderbird search results page. (#4708, @thgcode)
 * The COM Registration Fixing Tool no longer reports success on failure. (#12355, @XLTechie)
 * When using the Microsoft Pinyin Input Method for Chinese and enabling the Pinyin compatibility option to use the previous version, typing in LibreOffice Writer (and potentially other applications) while an IME popup is showing no longer triggers an error. (#17198, @michaelweghorn)
+* In LibreOffice, the current checkbox state (checked/unchecked) is now also reported in braille, not just speech. (#17218, @michaelweghorn)
 
 ### Changes for Developers
 


### PR DESCRIPTION
 ### Link to issue number:

Fixes #17218

 ### Summary of the issue:

When a checkbox in LibreOffice receives focus, the current state (checked/unchecked) of the checkbox was not reported in braille, while it was in speech.

This is due to the NVDA's braille logic using a concept of multiple "focus regions"/potential strings to display, and reporting only the one that's considered the most relevant on the braille display.
If an object is considered to have "useful text", that text is given a higher priority than the default logic for checkboxes (see `braille.getFocusRegions`).
While the latter does include the checkbox state, the former doesn't. An object is (among others) considered to have useful text if it is an `EditableText` instance (see `NVDAObjectHasUsefulText`).

So far, the `SymphonyText` overlay class was used for objects implementing the `IAccessibleText` interface in the LibreOffice app module, regardless of their role, which meant that the overlay class would also be used for checkboxes. As `SymphonyText` subclasses `EditableText`,
the text/label of the checkbox was reported on the braille display, which doesn't include the checkbox state.

 ### Description of user facing changes

In LibreOffice, the current checkbox state (checked/unchecked) is now also reported in braille, not just speech.

 ### Description of development approach

Limit the use of the `SymphonyText` overlay class to objects with corresponding roles:
`EDITABLETEXT` and `HEADING`

For objects with a `PARAGRAPH` role, `SymphonyParagraph` already gets used.

This prevents overriding the default logic for reporting objects, including that for checkboxes.

While at it, also add `BLOCKQUOTE` to the set of
roles for which to use `SymphonyParagraph`, as the block quote role is used for paragraphs in Writer using the
"Block Quotation" paragraph style since LibreOffice commit
https://git.libreoffice.org/core/commit/b7d2a9c824aca1a4dfd1b857a3620e73ade6bc0d .

 ### Testing strategy:

Follow the steps described in issue #17218
and verify that the status of the checkboxes
is reported in braille now (can be seen with
NVDA's integrated Braille Viewer).

 ### Known issues with pull request:

None.

Note: Should this change have any unwanted side-effects, it might be necessary to extend the now explicit set of roles used to determine whether or not to use the SymphonyText overlay class.

 ### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary