### PR TITLE
Update Add-on Store mirror to use new UX

### DIFF
--- a/source/gui/_SetURLDialog.py
+++ b/source/gui/_SetURLDialog.py
@@ -75,13 +75,13 @@ class _SetURLDialog(SettingsDialog):
 			wx.TextCtrl,
 			size=(250, -1),
 		)
-		self.bindHelpEvent("UpdateMirrorURL", urlControl)
+		self.bindHelpEvent("SetURLTextbox", urlControl)
 		self._testButton = testButton = wx.Button(
 			self,
 			# Translators: A button in a dialog which allows the user to test a URL that they have entered.
 			label=_("&Test..."),
 		)
-		self.bindHelpEvent("UpdateMirrorTest", testButton)
+		self.bindHelpEvent("SetURLTest", testButton)
 		urlControlsSizerHelper = guiHelper.BoxSizerHelper(self, sizer=urlControl.GetContainingSizer())
 		urlControlsSizerHelper.addItem(testButton)
 		testButton.Bind(wx.EVT_BUTTON, self._onTest)

--- a/source/gui/_SetURLDialog.py
+++ b/source/gui/_SetURLDialog.py
@@ -181,25 +181,22 @@ class _SetURLDialog(SettingsDialog):
 	def _failure(self, error: Exception):
 		"""Notify the user that testing their URL failed."""
 		if isinstance(error, _ValidationError):
-			message = _(
-				# Translators: Message shown to users when testing a given URL has failed because the response was invalid.
-				"The URL you have entered failed the connection test. The response received from the server was invalid. Check the URL is correct before trying again.",
+			tip = _(
+				# Translators: Tip shown to users when testing a given URL has failed because the response was invalid.
+				"The response from the server was not recognised. Check the URL is correct before trying again.",
 			)
 		elif isinstance(error, requests.HTTPError):
-			message = _(
-				# Translators: Message shown to users when testing a given URL has failed because the server returned an error.
-				"The URL you have entered failed the connection test. The server returned an error. Check that the URL is correct before trying again.",
-			)
+			# Translators: Tip shown to users when testing a given URL has failed because the server returned an error.
+			tip = _("The server returned an error. Check that the URL is correct before trying again.")
 		elif isinstance(error, requests.ConnectionError):
-			message = _(
-				# Translators: Message shown to users when testing a given URL has failed because of a network error.
-				"The URL you have entered failed the connection test. There was a network error. Check that you are connected to the internet and try again.",
-			)
+			# Translators: Tip shown to users when testing a given URL has failed because of a network error.
+			tip = _("There was a network error. Check that you are connected to the internet and try again.")
 		else:
-			message = _(
-				# Translators: Message shown to users when testing a given URL has failed for unknown reasons.
-				"The URL you have entered failed the connection test. Make sure you are connected to the internet and the URL is correct.",
-			)
+			# Translators: Tip shown to users when testing a given URL has failed for unknown reasons.
+			tip = _("Make sure you are connected to the internet and the URL is correct.")
+		# Translators: Message shown to users when testing a given URL has failed.
+		# {tip} will be replaced with a tip on how to resolve the issue.
+		message = _("The URL you have entered failed the connection test. {tip}").format(tip=tip)
 		wx.CallAfter(self._progressDialog.done)
 		self._progressDialog = None
 		self._testStatus = _SetURLDialog._URLTestStatus.FAILED

--- a/source/gui/_SetURLDialog.py
+++ b/source/gui/_SetURLDialog.py
@@ -180,18 +180,32 @@ class _SetURLDialog(SettingsDialog):
 
 	def _failure(self, error: Exception):
 		"""Notify the user that testing their URL failed."""
+		if isinstance(error, _ValidationError):
+			message = _(
+				# Translators: Message shown to users when testing a given URL has failed because the response was invalid.
+				"The URL you have entered failed the connection test. The response received from the server was invalid. Check the URL is correct before trying again.",
+			)
+		elif isinstance(error, requests.HTTPError):
+			message = _(
+				# Translators: Message shown to users when testing a given URL has failed because the server returned an error.
+				"The URL you have entered failed the connection test. The server returned an error. Check that the URL is correct before trying again.",
+			)
+		elif isinstance(error, requests.ConnectionError):
+			message = _(
+				# Translators: Message shown to users when testing a given URL has failed because of a network error.
+				"The URL you have entered failed the connection test. There was a network error. Check that you are connected to the internet and try again.",
+			)
+		else:
+			message = _(
+				# Translators: Message shown to users when testing a given URL has failed for unknown reasons.
+				"The URL you have entered failed the connection test. Make sure you are connected to the internet and the URL is correct.",
+			)
 		wx.CallAfter(self._progressDialog.done)
 		self._progressDialog = None
 		self._testStatus = _SetURLDialog._URLTestStatus.FAILED
 		wx.CallAfter(
 			gui.messageBox,
-			# Translators: Message displayed to users when testing a URL has failed due to validation errors.
-			_("The URL did not return a valid resource.")
-			if isinstance(error, _ValidationError)
-			else _(
-				# Translators: Message displayed to users when testing a URL has failed due to connection errors.
-				"Unable to connect to the given URL. Check that you are connected to the internet and the URL is correct.",
-			),
+			message,
 			# Translators: The title of a dialog presented when an error occurs.
 			"Error",
 			wx.OK | wx.ICON_ERROR,

--- a/source/gui/_SetURLDialog.py
+++ b/source/gui/_SetURLDialog.py
@@ -191,6 +191,16 @@ class _SetURLDialog(SettingsDialog):
 		elif isinstance(error, requests.ConnectionError):
 			# Translators: Tip shown to users when testing a given URL has failed because of a network error.
 			tip = _("There was a network error. Check that you are connected to the internet and try again.")
+		elif isinstance(
+			error,
+			(
+				requests.exceptions.InvalidURL,
+				requests.exceptions.MissingSchema,
+				requests.exceptions.InvalidSchema,
+			),
+		):
+			# Translators: Tip shown to users when testing a given URL has failed because the URL was invalid.
+			tip = _("The URL you have entered is not valid. Check that it is correct and try again.")
 		else:
 			# Translators: Tip shown to users when testing a given URL has failed for unknown reasons.
 			tip = _("Make sure you are connected to the internet and the URL is correct.")

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -3274,16 +3274,7 @@ class AddonStorePanel(SettingsPanel):
 		index = [x.value for x in AddonsAutomaticUpdate].index(config.conf["addonStore"]["automaticUpdates"])
 		self.automaticUpdatesComboBox.SetSelection(index)
 
-		# Translators: This is the label for a text box in the add-on store settings dialog.
-		self.addonMetadataMirrorLabelText = _("Server &mirror URL")
-		self.addonMetadataMirrorTextbox = sHelper.addLabeledControl(
-			self.addonMetadataMirrorLabelText,
-			wx.TextCtrl,
-		)
-		self.addonMetadataMirrorTextbox.SetValue(config.conf["addonStore"]["baseServerURL"])
-		self.bindHelpEvent("AddonStoreMetadataMirror", self.addonMetadataMirrorTextbox)
-
-		# Translators: The label for the update mirror on the General Settings panel.
+		# Translators: The label for the server  mirror on the Add-on store Settings panel.
 		mirrorBoxSizer = wx.StaticBoxSizer(wx.HORIZONTAL, self, label=_("Server mirror"))
 		mirrorBox = mirrorBoxSizer.GetStaticBox()
 		mirrorBoxSizerHelper = guiHelper.BoxSizerHelper(self, sizer=mirrorBoxSizer)

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -15,6 +15,7 @@ from enum import IntEnum
 from locale import strxfrm
 import re
 import typing
+import requests
 import wx
 from NVDAState import WritePaths
 
@@ -5520,3 +5521,14 @@ class SpeechSymbolsDialog(SettingsDialog):
 		self.filter(self.filterEdit.Value)
 		self._refreshVisibleItems()
 		evt.Skip()
+
+
+def _isResponseAddonStoreCacheHash(response: requests.Response) -> bool:
+	try:
+		# Attempt to parse the response as JSON
+		data = response.json()
+	except ValueError:
+		# Add-on Store cache hash is JSON, so this can't be it.
+		return False
+	# Add-on Store cache hash is a git commit hash as a string.
+	return isinstance(data, str) and bool(re.fullmatch("[0-9a-fA-F]{7,40}", data))

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -3274,8 +3274,8 @@ class AddonStorePanel(SettingsPanel):
 		index = [x.value for x in AddonsAutomaticUpdate].index(config.conf["addonStore"]["automaticUpdates"])
 		self.automaticUpdatesComboBox.SetSelection(index)
 
-		# Translators: The label for the server mirror on the Add-on Store Settings panel.
-		mirrorBoxSizer = wx.StaticBoxSizer(wx.HORIZONTAL, self, label=_("Server mirror"))
+		# Translators: The label for the mirror server on the Add-on Store Settings panel.
+		mirrorBoxSizer = wx.StaticBoxSizer(wx.HORIZONTAL, self, label=_("Mirror server"))
 		mirrorBox = mirrorBoxSizer.GetStaticBox()
 		mirrorBoxSizerHelper = guiHelper.BoxSizerHelper(self, sizer=mirrorBoxSizer)
 		sHelper.addItem(mirrorBoxSizerHelper)
@@ -3292,7 +3292,7 @@ class AddonStorePanel(SettingsPanel):
 			style=wx.TE_READONLY,
 		)
 		# Translators: This is the label for the button used to change the Add-on Store mirror URL,
-		# it appears in the context of the Server mirror group on the Add-on Store page of NVDA's settings.
+		# it appears in the context of the mirror server group on the Add-on Store page of NVDA's settings.
 		changeMirrorBtn = wx.Button(mirrorBox, label=_("Change..."))
 		mirrorBoxSizerHelper.addItem(
 			guiHelper.associateElements(
@@ -3311,8 +3311,8 @@ class AddonStorePanel(SettingsPanel):
 
 		changeMirror = _SetURLDialog(
 			self,
-			# Translators: Title of the dialog used to change the Add-on Store server mirror URL.
-			title=_("Set Add-on Store Server Mirror"),
+			# Translators: Title of the dialog used to change the Add-on Store mirror URL.
+			title=_("Set Add-on Store Mirror Server"),
 			configPath=("addonStore", "baseServerURL"),
 			helpId="SetURLDialog",
 			urlTransformer=lambda url: f"{url}/cacheHash.json",
@@ -5586,5 +5586,5 @@ def _isResponseAddonStoreCacheHash(response: requests.Response) -> bool:
 		# Add-on Store cache hash is JSON, so this can't be it.
 		return False
 	# While the NV Access Add-on Store cache hash is a git commit hash as a string, other implementations may use a different format.
-	# Therefor, we only check if the data is a non-empty string.
+	# Therefore, we only check if the data is a non-empty string.
 	return isinstance(data, str) and bool(data)

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -996,7 +996,7 @@ class GeneralSettingsPanel(SettingsPanel):
 			# Translators: Title of the dialog used to change NVDA's update server mirror URL.
 			title=_("Set NVDA Update Mirror"),
 			configPath=("update", "serverURL"),
-			helpId="SetUpdateMirror",
+			helpId="SetURLDialog",
 			urlTransformer=lambda url: f"{url}?versionType=stable",
 		)
 		ret = changeMirror.ShowModal()
@@ -3314,7 +3314,7 @@ class AddonStorePanel(SettingsPanel):
 			# Translators: Title of the dialog used to change the Add-on Store server mirror URL.
 			title=_("Set Add-on Store Server Mirror"),
 			configPath=("addonStore", "baseServerURL"),
-			helpId="SetUpdateMirror",
+			helpId="SetURLDialog",
 			urlTransformer=lambda url: f"{url}/cacheHash.json",
 			responseValidator=_isResponseAddonStoreCacheHash,
 		)

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -3274,7 +3274,7 @@ class AddonStorePanel(SettingsPanel):
 		index = [x.value for x in AddonsAutomaticUpdate].index(config.conf["addonStore"]["automaticUpdates"])
 		self.automaticUpdatesComboBox.SetSelection(index)
 
-		# Translators: The label for the server  mirror on the Add-on store Settings panel.
+		# Translators: The label for the server mirror on the Add-on Store Settings panel.
 		mirrorBoxSizer = wx.StaticBoxSizer(wx.HORIZONTAL, self, label=_("Server mirror"))
 		mirrorBox = mirrorBoxSizer.GetStaticBox()
 		mirrorBoxSizerHelper = guiHelper.BoxSizerHelper(self, sizer=mirrorBoxSizer)

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -5585,5 +5585,6 @@ def _isResponseAddonStoreCacheHash(response: requests.Response) -> bool:
 	except ValueError:
 		# Add-on Store cache hash is JSON, so this can't be it.
 		return False
-	# Add-on Store cache hash is a git commit hash as a string.
-	return isinstance(data, str) and bool(re.fullmatch("[0-9a-fA-F]{7,40}", data))
+	# While the NV Access Add-on Store cache hash is a git commit hash as a string, other implementations may use a different format.
+	# Therefor, we only check if the data is a non-empty string.
+	return isinstance(data, str) and bool(data)

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -1837,7 +1837,7 @@ These controls allow you to specify an alternative URL to use to check for updat
 This may be of use in locations where access to the NV Access NVDA update server is slow or unavailable.
 
 The read-only text box shows the current mirror URL.
-If no mirror is in use (i.e. the NV Access NVDA update server is being used), "No mirror" is displayed.
+If no mirror is in use (i.e. the NV Access update server is being used), "No mirror" is displayed.
 
 If you wish to change the update mirror, press the "Change..." button to open the [Set Update Mirror dialog](#SetURLDialog).
 
@@ -3088,7 +3088,7 @@ For example, for installed beta add-ons, you will only be notified of updates wi
 |Notify |Notify when updates are available to add-ons within the same channel |
 |Disabled |Do not automatically check for updates to add-ons |
 
-##### Server mirror {#AddonStoreMetadataMirror}
+##### Mirror server {#AddonStoreMetadataMirror}
 
 These controls allow you to specify an alternative URL to download Add-on Store data from.
 This may be of use in locations where access to the NV Access Add-on Store server is slow or unavailable.
@@ -3096,7 +3096,7 @@ This may be of use in locations where access to the NV Access Add-on Store serve
 The read-only text box shows the current mirror URL.
 If no mirror is in use (i.e. the NV Access Add-on Store server is being used), "No mirror" is displayed.
 
-If you wish to change the Add-on Store server mirror, press the "Change..." button to open the [Set Add-on Store Mirror dialog](#SetURLDialog).
+If you wish to change the Add-on Store mirror, press the "Change..." button to open the [Set Add-on Store Mirror dialog](#SetURLDialog).
 
 #### Windows OCR Settings {#Win10OcrSettings}
 
@@ -3121,7 +3121,7 @@ This dialog allows you to specify the URL of a mirror to use when [updating NVDA
 This may be of use in locations where access to the NV Access servers for these functions is slow or unavailable.
 
 * When setting the [NVDA update mirror](#UpdateMirror), the title of this dialog will be "Set NVDA Update Mirror".
-* When setting the [Add-on Store server mirror](#AddonStoreMetadataMirror), the title of this dialog will be "Set Add-on Store Server Mirror".
+* When setting the [Add-on Store mirror](#AddonStoreMetadataMirror), the title of this dialog will be "Set Add-on Store Mirror Server".
 
 ##### URL {#SetURLTextbox}
 

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -3107,12 +3107,34 @@ For example, for installed beta add-ons, you will only be notified of updates wi
 |Notify |Notify when updates are available to add-ons within the same channel |
 |Disabled |Do not automatically check for updates to add-ons |
 
-##### Server mirror URL {#AddonStoreMetadataMirror}
+##### Server mirror {#AddonStoreMetadataMirror}
 
-This option allows you to specify an alternative URL to download Add-on Store data from.
+These controls allow you to specify an alternative URL to download Add-on Store data from.
 This may be of use in locations where access to the NV Access Add-on Store server is slow or unavailable.
 
-Leave this blank to use the default NV Access Add-on Store server.
+The read-only text box shows the current mirror URL.
+If no mirror is in use (I.E. the NV Access NVDA Add-on Store server is being used), "No mirror" is displayed.
+
+If you wish to change the Add-on Store server mirror, press the "Change..." button to open the [Set Add-on Store Mirror dialog](#SetAddonStoreMirror).
+
+#### Set Add-on Store Server Mirror {#SetAddonStoreMirror}
+
+This dialog, which is accessed from the [Server mirror section of the Add-on Store page in NVDA's Settings dialog](#AddonStoreMetadataMirror), allows you to set a mirror to use when accessing the [Add-on Store](#AddonsManager).
+This may be of use in locations where access to the NV Access Add-on Store server is slow or unavailable.
+
+##### URL {#AddonStoreMirrorUrl}
+
+Enter the URL (web address) of the Add-on Store server mirror you wish to use here.
+Only HTTP and HTTPS URLs are supported.
+For your privacy, NV Access recommends using HTTPS URLs whenever possible.
+
+Leave this blank to use the NV Access Add-on Store server.
+
+##### Test... {#AddonStoreMirrorTest}
+
+Press this button to test the Add-on Store server URL you have entered.
+You must be connected to the internet for the test to succeed.
+It is recommended that you always test the URL before saving it.
 
 #### Windows OCR Settings {#Win10OcrSettings}
 

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -1837,7 +1837,7 @@ These controls allow you to specify an alternative URL to use to check for updat
 This may be of use in locations where access to the NV Access NVDA update server is slow or unavailable.
 
 The read-only text box shows the current mirror URL.
-If no mirror is in use (I.E. the NV Access NVDA update server is being used), "No mirror" is displayed.
+If no mirror is in use (i.e. the NV Access NVDA update server is being used), "No mirror" is displayed.
 
 If you wish to change the update mirror, press the "Change..." button to open the [Set Update Mirror dialog](#SetURLDialog).
 
@@ -3094,7 +3094,7 @@ These controls allow you to specify an alternative URL to download Add-on Store 
 This may be of use in locations where access to the NV Access Add-on Store server is slow or unavailable.
 
 The read-only text box shows the current mirror URL.
-If no mirror is in use (I.E. the NV Access NVDA Add-on Store server is being used), "No mirror" is displayed.
+If no mirror is in use (i.e. the NV Access Add-on Store server is being used), "No mirror" is displayed.
 
 If you wish to change the Add-on Store server mirror, press the "Change..." button to open the [Set Add-on Store Mirror dialog](#SetURLDialog).
 

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -1839,29 +1839,10 @@ This may be of use in locations where access to the NV Access NVDA update server
 The read-only text box shows the current mirror URL.
 If no mirror is in use (I.E. the NV Access NVDA update server is being used), "No mirror" is displayed.
 
-If you wish to change the update mirror, press the "Change..." button to open the [Set Update Mirror dialog](#SetUpdateMirror).
-
-#### Set Update Mirror {#SetUpdateMirror}
-
-This dialog, which is accessed from the [Update mirror section of the General page in NVDA's Settings dialog](#UpdateMirror), allows you to set a mirror to use when checking for NVDA updates.
-This may be of use in locations where access to the NV Access NVDA update server is slow or unavailable.
+If you wish to change the update mirror, press the "Change..." button to open the [Set Update Mirror dialog](#SetURLDialog).
 
 Please note that when using an update mirror, the operator of the mirror has access to all [information sent with update checks](#GeneralSettingsCheckForUpdates).
 Contact the operator of the update mirror for details of their data handling policies to ensure you are comfortable with the way your information will be handled before setting an update mirror.
-
-##### URL {#UpdateMirrorURL}
-
-Enter the URL (web address) of the update server mirror you wish to use here.
-Only HTTP and HTTPS URLs are supported.
-For your privacy, NV Access recommends using HTTPS URLs whenever possible.
-
-Leave this blank to use the NV Access NVDA update check server.
-
-##### Test... {#UpdateMirrorTest}
-
-Press this button to test the NVDA update server URL you have entered.
-You must be connected to the internet for the test to succeed.
-It is recommended that you always test the URL before saving it.
 
 #### Speech Settings {#SpeechSettings}
 
@@ -3115,26 +3096,7 @@ This may be of use in locations where access to the NV Access Add-on Store serve
 The read-only text box shows the current mirror URL.
 If no mirror is in use (I.E. the NV Access NVDA Add-on Store server is being used), "No mirror" is displayed.
 
-If you wish to change the Add-on Store server mirror, press the "Change..." button to open the [Set Add-on Store Mirror dialog](#SetAddonStoreMirror).
-
-#### Set Add-on Store Server Mirror {#SetAddonStoreMirror}
-
-This dialog, which is accessed from the [Server mirror section of the Add-on Store page in NVDA's Settings dialog](#AddonStoreMetadataMirror), allows you to set a mirror to use when accessing the [Add-on Store](#AddonsManager).
-This may be of use in locations where access to the NV Access Add-on Store server is slow or unavailable.
-
-##### URL {#AddonStoreMirrorUrl}
-
-Enter the URL (web address) of the Add-on Store server mirror you wish to use here.
-Only HTTP and HTTPS URLs are supported.
-For your privacy, NV Access recommends using HTTPS URLs whenever possible.
-
-Leave this blank to use the NV Access Add-on Store server.
-
-##### Test... {#AddonStoreMirrorTest}
-
-Press this button to test the Add-on Store server URL you have entered.
-You must be connected to the internet for the test to succeed.
-It is recommended that you always test the URL before saving it.
+If you wish to change the Add-on Store server mirror, press the "Change..." button to open the [Set Add-on Store Mirror dialog](#SetURLDialog).
 
 #### Windows OCR Settings {#Win10OcrSettings}
 
@@ -3152,6 +3114,28 @@ When this checkbox is enabled, NVDA will automatically refresh the recognized co
 This can be very useful when you want to monitor constantly changing content, such as when watching a video with subtitles.
 The refresh takes place every one and a half seconds.
 This option is disabled by default.
+
+#### Set Mirror Dialog {#SetURLDialog}
+
+This dialog allows you to specify the URL of a mirror to use when [updating NVDA](#GeneralSettingsCheckForUpdates) or [using the Add-on Store](#AddonsManager).
+This may be of use in locations where access to the NV Access servers for these functions is slow or unavailable.
+
+* When setting the [NVDA update mirror](#UpdateMirror), the title of this dialog will be "Set NVDA Update Mirror".
+* When setting the [Add-on Store server mirror](#AddonStoreMetadataMirror), the title of this dialog will be "Set Add-on Store Server Mirror".
+
+##### URL {#SetURLTextbox}
+
+Enter the URL (web address) of the mirror you wish to use here.
+Only HTTP and HTTPS URLs are supported.
+For your privacy, NV Access recommends using HTTPS URLs whenever possible.
+
+Leave this blank to use the default NV Access server.
+
+##### Test... {#SetURLTest}
+
+Press this button to test the mirror URL you have entered.
+You must be connected to the internet for the test to succeed.
+It is recommended that you always test the URL before saving it.
 
 #### Advanced Settings {#AdvancedSettings}
 


### PR DESCRIPTION
### Link to issue number:

Follow up to #17099

### Summary of the issue:

In PR #17099, the ability to set a mirror to use when accessing the Add-on Store was added.
PR #17151 built upon this, adding the ability to set a mirror for NVDA update checks.
However, it was decided that we needed a more robust way of checking the mirror URLs, and a means of protecting users from accidental changes to the URL.
These UX improvements were implemented for the NVDA update mirror, but not for the Add-on Store server mirror, so as to keep PRs single-issue.

### Description of user facing changes

The Add-on Store server mirror settings now use the same UI as the NVDA update check mirror.

### Description of development approach

- Added a `responseValidator` option to `_SetURLDialog`, which defaults to always returning `True`.
- Added a validator for `request.Response` objects to check if they're a valid Add-on Store cache hash (JSON comprising a single string of 7-40 hex digits ).
- Copied the implementation of NVDA update mirror to the Add-on Store page, using the cache hash validator as the `responseValidator` function.
- Made failure messages when setting a URL more descriptive.
- Updated user guide, including consolidating the description of the NVDA update check and Add-on Store server mirror dialogs into one.

### Testing strategy:

- Tested that using the new dialog sets the Add-on Store server mirror as expected.
- Ran through the NVDA update mirror process and Add-on Store server mirror process, checking that context help works on all controls.

### Known issues with pull request:

While not directly related to this issue, note that this work lays part of the groundwork for #17205.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
