### PR TITLE
Fixes an issue where using the display speech output braille mode while no braille display is connected causes zero division errors

### DIFF
--- a/source/braille.py
+++ b/source/braille.py
@@ -2452,7 +2452,7 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 	_showSpeechInBrailleRegions: list[TextRegion] = []
 
 	def _showSpeechInBraille(self, speechSequence: "SpeechSequence"):
-		if config.conf["braille"]["mode"] == BrailleMode.FOLLOW_CURSORS.value:
+		if config.conf["braille"]["mode"] == BrailleMode.FOLLOW_CURSORS.value or not self.enabled:
 			return
 		_showSpeechInBrailleRegions = self._showSpeechInBrailleRegions
 		regionsText = "".join([i.rawText for i in _showSpeechInBrailleRegions])

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -44,6 +44,7 @@ In order to use this feature, the application volume adjuster needs to be enable
   * Braille is no longer dysfunctional when activating 'say all' with an associated configuration profile. (#17163, @LeonarddeR)
   * Fixed an issue where certain settings were explicitly saved to the active configuration profile even when the value of that setting was equal to the value in the base configuration. (#17157, @leonarddeR)
 * NVDA is able to read the popup submenu items on Thunderbird search results page. (#4708, @thgcode)
+* NVDA should no longer play error sounds or spam the log file when using the display speech output braille mode while no braille display is connected. (#17092, @Emil-18)
 * The COM Registration Fixing Tool no longer reports success on failure. (#12355, @XLTechie)
 * When using the Microsoft Pinyin Input Method for Chinese and enabling the Pinyin compatibility option to use the previous version, typing in LibreOffice Writer (and potentially other applications) while an IME popup is showing no longer triggers an error. (#17198, @michaelweghorn)
 * In LibreOffice, the current checkbox state (checked/unchecked) is now also reported in braille, not just speech. (#17218, @michaelweghorn)


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
fixes #17092
### Summary of the issue:
When using the display speech output braille mode with no braille display connected and the braille viewer closed, zero division errors are thrown
### Description of user facing changes
The user can have braille mode set to display speech output at all times, without NVDA spamming the log file
### Description of development approach
Made the showSpeechInBraille function return without doing anything if the braille.handler object is not enabled
### Testing strategy:
I am unable to test it, because when I run NVDA from source it crashes. @josephsl Could you confirm that this works?
### Known issues with pull request:
None
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
