### PR TITLE
Remove unneeded and unused TermControl2 class name

### DIFF
--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -1410,14 +1410,6 @@ class UIA(Window):
 				# TermControl represents an up-to-date version of the UWP (standard)
 				# Windows Terminal control.
 				"TermControl",
-				# TermControl2 was going to represent a
-				# terminal that supported UIA notifications (i.e. one where
-				# microsoft/terminal#12358 has been merged). However, the UIA class
-				# name was not changed in microsoft/terminal#12358 due to backward
-				# compat concerns raised by Freedom Scientific. However, a check for
-				# it is kept here just in case it should later become necessary to
-				# change it.
-				"TermControl2",
 				# WPFTermControl represents an embedded Windows Terminal control
 				# In .NET apps, such as LTS Visual Studio.
 				# WPFTermControl does not follow the same update cadence as TermControl

--- a/source/UIAHandler/__init__.py
+++ b/source/UIAHandler/__init__.py
@@ -129,7 +129,6 @@ textChangeUIAClassNames = (
 
 windowsTerminalUIAClassNames = (
 	"TermControl",
-	"TermControl2",
 	"WPFTermControl",
 )
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
microsoft/terminal#12358

### Summary of the issue:
For microsoft/terminal#12358, we discussed having a second `TermControl2` class name to distinguish terminals that do and don't support UIA notifications, but this was never implemented and there are no plans to do so.

### Description of how this pull request fixes the issue:
Remove unneeded constant

### Testing strategy:
Alpha testing

### Known issues with pull request:
None known

### Change log entry:
None needed

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
