### PR TITLE
Update the documentation of the snapshot variables in the Python Console

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,7 @@ source/louis
 dlldata.c
 *.pdb
 .sconsign.dblite
-user_docs/*/*.md.sub
+*.md.sub
 user_docs/*/*.html
 user_docs/*/*.css
 extras/controllerClient/x86/nvdaController.h

--- a/projectDocs/dev/developerGuide/developerGuide.md
+++ b/projectDocs/dev/developerGuide/developerGuide.md
@@ -1248,6 +1248,9 @@ These variables are:
 * fdl: Focus difference level; i.e. the level at which the ancestors for the current and previous focus differ
 * fg: The current foreground object
 * nav: The current navigator object
+* caretObj: The object which contains the caret (focus or tree interceptor if any)
+* caretPos: A text info at the position of the caret
+* review: The current TextInfo instance representing the user's review position
 * mouse: The current mouse object
 * brlRegions: The braille regions from the active braille buffer
 

--- a/projectDocs/dev/developerGuide/developerGuide.md
+++ b/projectDocs/dev/developerGuide/developerGuide.md
@@ -1248,9 +1248,9 @@ These variables are:
 * fdl: Focus difference level; i.e. the level at which the ancestors for the current and previous focus differ
 * fg: The current foreground object
 * nav: The current navigator object
-* caretObj: The object which contains the caret (focus or tree interceptor if any)
-* caretPos: A text info at the position of the caret
-* review: The current TextInfo instance representing the user's review position
+* `caretObj`: The object which contains the caret (focus or tree interceptor if any)
+* `caretPos`: A text info at the position of the caret
+* `review`: The current `TextInfo` instance representing the user's review position
 * mouse: The current mouse object
 * brlRegions: The braille regions from the active braille buffer
 

--- a/projectDocs/dev/developerGuide/developerGuide.md
+++ b/projectDocs/dev/developerGuide/developerGuide.md
@@ -1243,16 +1243,16 @@ See: pythonConsole.PythonConsole.initNamespace
 Whenever NVDA+control+z is pressed, certain variables available in the console will be assigned according to the current state of NVDA.
 These variables are:
 
-* focus: The current focus object
-* focusAnc: The ancestors of the current focus object
-* fdl: Focus difference level; i.e. the level at which the ancestors for the current and previous focus differ
-* fg: The current foreground object
-* nav: The current navigator object
+* `focus`: The current focus object
+* `focusAnc`: The ancestors of the current focus object
+* `fdl`: Focus difference level; i.e. the level at which the ancestors for the current and previous focus differ
+* `fg`: The current foreground object
+* `nav`: The current navigator object
 * `caretObj`: The object which contains the caret (focus or tree interceptor if any)
 * `caretPos`: A text info at the position of the caret
 * `review`: The current `TextInfo` instance representing the user's review position
-* mouse: The current mouse object
-* brlRegions: The braille regions from the active braille buffer
+* `mouse`: The current mouse object
+* `brlRegions`: The braille regions from the active braille buffer
 
 ### Tab completion {#pythonConsoleTab}
 


### PR DESCRIPTION
### Link to issue number:
None
### Summary of the issue:
In the Developer's Guide, the [Snapshot Variables](https://www.nvaccess.org/files/nvda/documentation/developerGuide.html#PythonConsoleSnapshotVariables) paragraph is not up-to-date: three more snapshot variables are created when opening the console with `NVDA+control+z`, but are not documented: `caretObj`, `caretPos` and `review`.

### Description of user facing changes
Updated the paragraph with these three variables.

### Description of development approach
I have based the description on the docstring of the functions that are called to create these variables;

While at it, I have noticed that the `.md.sub` generated while compiling the dev guide was not ignored by Git, so I have added it to the `.gitignore` file.

### Testing strategy:
Check that the dev guide is correctly generated.
### Known issues with pull request:
None
### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
