### PR TITLE
When spelling by line, ensure that only normalized characters report as such

### DIFF
--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -25,6 +25,7 @@ import speechDictHandler
 import characterProcessing
 import languageHandler
 from textUtils import unicodeNormalize
+from textUtils.uniscribe import splitAtCharacterBoundaries
 from . import manager
 from .extensions import speechCanceled, pre_speechCanceled, pre_speech
 from .extensions import filter_speechSequence
@@ -462,7 +463,12 @@ def _getSpellingSpeechWithoutCharMode(
 			text = normalized
 			textIsNormalized = True
 	localeHasConjuncts = True if locale.split("_", 1)[0] in LANGS_WITH_CONJUNCT_CHARS else False
-	charDescList = getCharDescListFromText(text, locale) if localeHasConjuncts else text
+	if localeHasConjuncts:
+		charDescList = getCharDescListFromText(text, locale)
+	elif not textIsNormalized and unicodeNormalization:
+		charDescList = list(splitAtCharacterBoundaries(text))
+	else:
+		charDescList = text
 	for item in charDescList:
 		if localeHasConjuncts:
 			# item is a tuple containing character and its description

--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -418,11 +418,12 @@ def _getSpellingSpeechWithoutCharMode(
 	reportNormalizedForCharacterNavigation: bool = False,
 ) -> Generator[SequenceItemT, None, None]:
 	"""
-	Processes text when spoken by character.
+	Processes text when spelling by character.
 	This doesn't take care of character mode (Option "Use spelling functionality").
 	:param text: The text to speak.
-		This is usually one character or a string containing a decomposite character (or glyph)
-	:param locale: The locale used to generate character descrptions, if applicable.
+		This is usually one character or a string containing a decomposite character (or glyph),
+		however it can also be a word or line of text spoken by a spell command.
+	:param locale: The locale used to generate character descriptions, if applicable.
 	:param useCharacterDescriptions: Whether or not to use character descriptions,
 		e.g. speak "a" as "alpha".
 	:param sayCapForCapitals: Indicates if 'cap' should be reported
@@ -453,13 +454,13 @@ def _getSpellingSpeechWithoutCharMode(
 		text = text.rstrip()
 
 	textLength = len(text)
-	isNormalized = False
+	textIsNormalized = False
 	if unicodeNormalization and textLength > 1:
 		normalized = unicodeNormalize(text)
 		if len(normalized) == 1:
 			# Normalization of a composition
 			text = normalized
-			isNormalized = True
+			textIsNormalized = True
 	localeHasConjuncts = True if locale.split("_", 1)[0] in LANGS_WITH_CONJUNCT_CHARS else False
 	charDescList = getCharDescListFromText(text, locale) if localeHasConjuncts else text
 	for item in charDescList:
@@ -472,6 +473,7 @@ def _getSpellingSpeechWithoutCharMode(
 			speakCharAs = item
 			if useCharacterDescriptions:
 				charDesc = characterProcessing.getCharacterDescription(locale, speakCharAs.lower())
+		itemIsNormalized = textIsNormalized
 		uppercase = speakCharAs.isupper()
 		if useCharacterDescriptions and charDesc:
 			IDEOGRAPHIC_COMMA = "\u3001"
@@ -481,12 +483,12 @@ def _getSpellingSpeechWithoutCharMode(
 		else:
 			if (symbol := characterProcessing.processSpeechSymbol(locale, speakCharAs)) != speakCharAs:
 				speakCharAs = symbol
-			elif not isNormalized and unicodeNormalization:
+			elif not textIsNormalized and unicodeNormalization:
 				if (normalized := unicodeNormalize(speakCharAs)) != speakCharAs:
 					speakCharAs = " ".join(
 						characterProcessing.processSpeechSymbol(locale, normChar) for normChar in normalized
 					)
-					isNormalized = True
+					itemIsNormalized = True
 		if config.conf["speech"]["autoLanguageSwitching"]:
 			yield LangChangeCommand(locale)
 		yield from _getSpellingCharAddCapNotification(
@@ -494,7 +496,7 @@ def _getSpellingSpeechWithoutCharMode(
 			uppercase and sayCapForCapitals,
 			capPitchChange if uppercase else 0,
 			uppercase and beepForCapitals,
-			isNormalized and reportNormalizedForCharacterNavigation,
+			itemIsNormalized and reportNormalizedForCharacterNavigation,
 		)
 		yield EndUtteranceCommand()
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -47,6 +47,7 @@ In order to use this feature, the application volume adjuster needs to be enable
 * The COM Registration Fixing Tool no longer reports success on failure. (#12355, @XLTechie)
 * When using the Microsoft Pinyin Input Method for Chinese and enabling the Pinyin compatibility option to use the previous version, typing in LibreOffice Writer (and potentially other applications) while an IME popup is showing no longer triggers an error. (#17198, @michaelweghorn)
 * In LibreOffice, the current checkbox state (checked/unchecked) is now also reported in braille, not just speech. (#17218, @michaelweghorn)
+* Unicode normalization no longer incorrectly reports subsequent characters as normalized after reporting a normalized character. (#17286, @LeonarddeR)
 
 ### Changes for Developers
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -47,7 +47,7 @@ In order to use this feature, the application volume adjuster needs to be enable
 * The COM Registration Fixing Tool no longer reports success on failure. (#12355, @XLTechie)
 * When using the Microsoft Pinyin Input Method for Chinese and enabling the Pinyin compatibility option to use the previous version, typing in LibreOffice Writer (and potentially other applications) while an IME popup is showing no longer triggers an error. (#17198, @michaelweghorn)
 * In LibreOffice, the current checkbox state (checked/unchecked) is now also reported in braille, not just speech. (#17218, @michaelweghorn)
-* Unicode normalization no longer incorrectly reports subsequent characters as normalized after reporting a normalized character. (#17286, @LeonarddeR)
+* When spelling, unicode normalization no longer incorrectly reports subsequent characters as normalized after reporting a normalized character. (#17286, @LeonarddeR)
 
 ### Changes for Developers
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -47,7 +47,9 @@ In order to use this feature, the application volume adjuster needs to be enable
 * The COM Registration Fixing Tool no longer reports success on failure. (#12355, @XLTechie)
 * When using the Microsoft Pinyin Input Method for Chinese and enabling the Pinyin compatibility option to use the previous version, typing in LibreOffice Writer (and potentially other applications) while an IME popup is showing no longer triggers an error. (#17198, @michaelweghorn)
 * In LibreOffice, the current checkbox state (checked/unchecked) is now also reported in braille, not just speech. (#17218, @michaelweghorn)
-* When spelling, unicode normalization no longer incorrectly reports subsequent characters as normalized after reporting a normalized character. (#17286, @LeonarddeR)
+* When spelling, unicode normalization now works more appropriately:
+  * After reporting a normalized character, NVDA no longer incorrectly reports subsequent characters as normalized. (#17286, @LeonarddeR)
+  * Composite characters (such as é) are now reported correctly. (#17295, @LeonarddeR)
 
 ### Changes for Developers
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Fixes #17286

### Summary of the issue:
When spelling by line, when NVDA normalizes a character, it would incorrectly report all following characters as normalized.

### Description of user facing changes
The above issue is fixed.

### Description of development approach
There was an isNormalized boolean that would report all characters as normalized when set to True. I fixed this by creating a variable local to the loop that contains the per character normalization state.

### Testing strategy:
Tested str from 

### Known issues with pull request:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

@coderabbitai review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Support for new braille displays with automatic detection.
	- Enhanced support for Microsoft Office applications, improving formatting and navigation.
	- Major improvements in web browsing support, including faster rendering and ARIA landmark support.
	- Introduction of a new Add-ons Manager and configuration profiles.
	- Support for global plugins to extend NVDA's functionality.

- **Bug Fixes**
	- Improved stability and performance with fixes for crashes and freezes.

- **Documentation**
	- Updated comments and docstrings for clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->