### PR TITLE
Fix what's new

### DIFF
--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -8,9 +8,9 @@
 
 * Commands to adjust the volume of other applications besides NVDA have been added.
 To use this feature, "allow NVDA to control the volume of other applications" must be enabled in the audio settings panel. (#16052, @mltony, @codeofdusk)
-    * `NVDA+alt+pageUp`: Increase the volume of all other applications.
-    * `NVDA+alt+pageDown`: Decrease the volume of all other applications.
-    * `NVDA+alt+delete`: Mute the volume of all other applications.
+  * `NVDA+alt+pageUp`: Increase the volume of all other applications.
+  * `NVDA+alt+pageDown`: Decrease the volume of all other applications.
+  * `NVDA+alt+delete`: Mute the volume of all other applications.
 * When editing in Microsoft PowerPoint text boxes, you can now move per sentence with `alt+upArrow`/`alt+downArrow`. (#17015, @LeonarddeR)
 * In Mozilla Firefox, NVDA will report the highlighted text when a URL containing a text fragment is visited. (#16910, @jcsteh)
 * NVDA can now report when a link destination points to the current page. (#141, @LeonarddeR, @nvdaes)


### PR DESCRIPTION
In #17271, I updated the what's new entry for application volume control, but what's new isn't displaying the sublist correctly with four-space indents. Outdent for consistent and correct parsing.