### PR TITLE
Encourage deferring triage to NV access for features and product decisions

### DIFF
--- a/projectDocs/issues/triage.md
+++ b/projectDocs/issues/triage.md
@@ -144,7 +144,7 @@ New features and enhancements should be [well defined](#new-features-1) before a
 Once a bug has clear steps to reproduce and is well documented, the `triaged` label can be applied.
 A `triaged` issue should also have a [priority label](#priority).
 
-Community members should avoid adding a `triaged` label to feature requests or other product decisions, deferring to NV Access.
+Community members should avoid adding a `triaged` label to feature requests or other decisions potentially involving significant or controversial changes to NVDA features or functionality, which may require community input or approval from NV Access.
 The label should also be avoided for other issues that are controversial, or the priority is unclear, such as bug fixes with an unclear solution.
 For changes where a product decision from NV Access is required before applying the `triaged` label, the label `blocked/needs-product-decision` should be used.
 

--- a/projectDocs/issues/triage.md
+++ b/projectDocs/issues/triage.md
@@ -145,7 +145,7 @@ Once a bug has clear steps to reproduce and is well documented, the `triaged` la
 A `triaged` issue should also have a [priority label](#priority).
 
 Community members should avoid adding a `triaged` label to feature requests or other decisions potentially involving significant or controversial changes to NVDA features or functionality, which may require community input or approval from NV Access.
-The label should also be avoided for other issues that are controversial, or the priority is unclear, such as bug fixes with an unclear solution.
+The label should also be avoided for other issues that are controversial, or where the priority is unclear, such as bug fixes with an unclear solution.
 For changes where a product decision from NV Access is required before applying the `triaged` label, the label `blocked/needs-product-decision` should be used.
 Community members should apply the `triaged` where an issue is:
 

--- a/projectDocs/issues/triage.md
+++ b/projectDocs/issues/triage.md
@@ -143,10 +143,10 @@ An issue is triaged if it is ready to be worked on.
 New features and enhancements should be [well defined](#new-features-1) before applying the `triaged` label.
 Once a bug has clear steps to reproduce and is well documented, the `triaged` label can be applied.
 A `triaged` issue should also have a [priority label](#priority).
-Generally these labels are provided by NV Access only, particularly for issues that are controversial, or priority is unclear.
 
-For controversial changes, a product decision from NV Access may be required before applying the `triaged` label.
-This can be indicated with adding the label `blocked/needs-product-decision`.
+Community members should avoid adding a `triaged` label to feature requests or other product decisions, deferring to NV Access.
+The label should also be avoided for other issues that are controversial, or the priority is unclear, such as bug fixes with an unclear solution.
+For changes where a product decision from NV Access is required before applying the `triaged` label, the label `blocked/needs-product-decision` should be used.
 
 If an issue has been checked by NV Access, and needs further triage, the `needs-triage` label will be applied.
 Please notify NV Access when you believe the issue is ready for the `triaged` label.

--- a/projectDocs/issues/triage.md
+++ b/projectDocs/issues/triage.md
@@ -147,7 +147,7 @@ A `triaged` issue should also have a [priority label](#priority).
 Community members should avoid adding a `triaged` label to feature requests or other decisions potentially involving significant or controversial changes to NVDA features or functionality, which may require community input or approval from NV Access.
 The label should also be avoided for other issues that are controversial, or where the priority is unclear, such as bug fixes with an unclear solution.
 For changes where a product decision from NV Access is required before applying the `triaged` label, the label `blocked/needs-product-decision` should be used.
-Community members should apply the `triaged` where an issue is:
+Community members should apply the `triaged` label where an issue is:
 
 * A well formed bug report following the issue template
 * Which can easily be understood
@@ -158,7 +158,7 @@ Community members should apply the `triaged` where an issue is:
 
 If an issue has been checked by NV Access, and needs further triage, the `needs-triage` label will be applied.
 Please notify NV Access when you believe the issue is ready for the `triaged` label.
-You can do this by tagging @nvaccess/developers or mailing info@nvaccess.org.
+You can do this by tagging @nvaccess/developers or emailing info@nvaccess.org.
 
 A `triaged` issue that requires a complex fix may require advice from NV Access, such as a project plan, before implementation is started.
 

--- a/projectDocs/issues/triage.md
+++ b/projectDocs/issues/triage.md
@@ -157,7 +157,7 @@ Community members should apply the `triaged` label where an issue is a well form
 
 If an issue has been checked by NV Access, and needs further triage, the `needs-triage` label will be applied.
 Please notify NV Access when you believe the issue is ready for the `triaged` label.
-You can do this by tagging @nvaccess/developers or emailing info@nvaccess.org.
+You can do this by tagging `@nvaccess/developers` or emailing <info@nvaccess.org>.
 
 A `triaged` issue that requires a complex fix may require advice from NV Access, such as a project plan, before implementation is started.
 

--- a/projectDocs/issues/triage.md
+++ b/projectDocs/issues/triage.md
@@ -144,13 +144,12 @@ New features and enhancements should be [well defined](#new-features-1) before a
 Once a bug has clear steps to reproduce and is well documented, the `triaged` label can be applied.
 A `triaged` issue should also have a [priority label](#priority).
 
-Community members should avoid adding a `triaged` label to feature requests or other decisions potentially involving significant or controversial changes to NVDA features or functionality, which may require community input or approval from NV Access.
+Community members should avoid adding a `triaged` label to feature requests or decisions potentially involving significant or controversial changes to NVDA features or functionality, which may require community input or approval from NV Access.
 The label should also be avoided for other issues that are controversial, or where the priority is unclear, such as bug fixes with an unclear solution.
 For changes where a product decision from NV Access is required before applying the `triaged` label, the label `blocked/needs-product-decision` should be used.
-Community members should apply the `triaged` label where an issue is:
+Community members should apply the `triaged` label where an issue is a well formed bug report following the issue template, and has the following characteristics:
 
-* A well formed bug report following the issue template
-* Which can easily be understood
+* Can easily be understood
 * Isn't missing any important debug information
 * Can clearly be reproduced
 * Can clearly be prioritised

--- a/projectDocs/issues/triage.md
+++ b/projectDocs/issues/triage.md
@@ -158,6 +158,7 @@ Community members should apply the `triaged` where an issue is:
 
 If an issue has been checked by NV Access, and needs further triage, the `needs-triage` label will be applied.
 Please notify NV Access when you believe the issue is ready for the `triaged` label.
+You can do this by tagging @nvaccess/developers or mailing info@nvaccess.org.
 
 A `triaged` issue that requires a complex fix may require advice from NV Access, such as a project plan, before implementation is started.
 

--- a/projectDocs/issues/triage.md
+++ b/projectDocs/issues/triage.md
@@ -147,6 +147,14 @@ A `triaged` issue should also have a [priority label](#priority).
 Community members should avoid adding a `triaged` label to feature requests or other decisions potentially involving significant or controversial changes to NVDA features or functionality, which may require community input or approval from NV Access.
 The label should also be avoided for other issues that are controversial, or the priority is unclear, such as bug fixes with an unclear solution.
 For changes where a product decision from NV Access is required before applying the `triaged` label, the label `blocked/needs-product-decision` should be used.
+Community members should apply the `triaged` where an issue is:
+
+* A well formed bug report following the issue template
+* Which can easily be understood
+* Isn't missing any important debug information
+* Can clearly be reproduced
+* Can clearly be prioritised
+* Doesn't require a controversial solution
 
 If an issue has been checked by NV Access, and needs further triage, the `needs-triage` label will be applied.
 Please notify NV Access when you believe the issue is ready for the `triaged` label.


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
None

### Summary of the issue:
It is unclear which scenarios are okay for community members to apply a "triaged" label.
Generally NV Access prefers it if any product decisions or feature requests are left to NV Access to add this label.
