### PR TITLE
Fixed text for allow NVDA to control the volume of other apps

### DIFF
--- a/source/audio/appsVolume.py
+++ b/source/audio/appsVolume.py
@@ -164,13 +164,13 @@ def _toggleAppsVolumeState():
 	config.conf["audio"]["applicationsVolumeMode"] = state.name
 	_updateAppsVolumeImpl(volume / 100.0, muted, state)
 	if state == AppsVolumeAdjusterFlag.ENABLED:
-		# Translators: Reported as a result of the command to allow or disallow to control the volume of other
-		# applications
+		# Translators: Reported as a result of the command to toggle whether control of other applications' volume
+		# is enabled.
 		msg = _("Enabled control of other applications' volume")
 	else:
-		# Translators: Reported as a result of the command to allow or disallow to control the volume of other
-		# applications
-		msg = _("Disallowed to control the volume of other applications")
+		# Translators: Reported as a result of the command to toggle whether control of other applications' volume
+		# is enabled.
+		msg = _("Enabled control of other applications' volume")
 	ui.message(msg)
 
 

--- a/source/audio/appsVolume.py
+++ b/source/audio/appsVolume.py
@@ -170,7 +170,7 @@ def _toggleAppsVolumeState():
 	else:
 		# Translators: Reported as a result of the command to toggle whether control of other applications' volume
 		# is enabled.
-		msg = _("Disabled control of other applications' volume")
+		msg = _("Application volume control off")
 	ui.message(msg)
 
 

--- a/source/audio/appsVolume.py
+++ b/source/audio/appsVolume.py
@@ -166,7 +166,7 @@ def _toggleAppsVolumeState():
 	if state == AppsVolumeAdjusterFlag.ENABLED:
 		# Translators: Reported as a result of the command to toggle whether control of other applications' volume
 		# is enabled.
-		msg = _("Enabled control of other applications' volume")
+		msg = _("Application volume control on")
 	else:
 		# Translators: Reported as a result of the command to toggle whether control of other applications' volume
 		# is enabled.

--- a/source/audio/appsVolume.py
+++ b/source/audio/appsVolume.py
@@ -170,7 +170,7 @@ def _toggleAppsVolumeState():
 	else:
 		# Translators: Reported as a result of the command to toggle whether control of other applications' volume
 		# is enabled.
-		msg = _("Enabled control of other applications' volume")
+		msg = _("Disabled control of other applications' volume")
 	ui.message(msg)
 
 

--- a/source/audio/appsVolume.py
+++ b/source/audio/appsVolume.py
@@ -163,7 +163,15 @@ def _toggleAppsVolumeState():
 	state = _APPS_VOLUME_STATES_ORDER[index]
 	config.conf["audio"]["applicationsVolumeMode"] = state.name
 	_updateAppsVolumeImpl(volume / 100.0, muted, state)
-	ui.message(state.displayString)
+	if state == AppsVolumeAdjusterFlag.ENABLED:
+		# Translators: Reported as a result of the command to allow or disallow to control the volume of other
+		# applications
+		msg = _("Allowed to control the volume of other applications")
+	else:
+		# Translators: Reported as a result of the command to allow or disallow to control the volume of other
+		# applications
+		msg = _("Disallowed to control the volume of other applications")
+	ui.message(msg)
 
 
 def _toggleAppsVolumeMute():

--- a/source/audio/appsVolume.py
+++ b/source/audio/appsVolume.py
@@ -166,7 +166,7 @@ def _toggleAppsVolumeState():
 	if state == AppsVolumeAdjusterFlag.ENABLED:
 		# Translators: Reported as a result of the command to allow or disallow to control the volume of other
 		# applications
-		msg = _("Allowed to control the volume of other applications")
+		msg = _("Enabled control of other applications' volume")
 	else:
 		# Translators: Reported as a result of the command to allow or disallow to control the volume of other
 		# applications

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -4775,7 +4775,7 @@ class GlobalCommands(ScriptableObject):
 	@script(
 		description=_(
 			# Translators: Describes a command.
-			"Toggle whether control of other applications' volume is enabled.",
+			"Toggles application volume control on and off",
 		),
 		category=SCRCAT_AUDIO,
 	)

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -4775,10 +4775,9 @@ class GlobalCommands(ScriptableObject):
 	@script(
 		description=_(
 			# Translators: Describes a command.
-			"Toggles other applications volume adjuster status",
+			"Allow or disallow to control the volume of other applications",
 		),
 		category=SCRCAT_AUDIO,
-		gesture=None,
 	)
 	def script_toggleApplicationsVolumeAdjuster(self, gesture: "inputCore.InputGesture") -> None:
 		appsVolume._toggleAppsVolumeState()

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -4775,7 +4775,7 @@ class GlobalCommands(ScriptableObject):
 	@script(
 		description=_(
 			# Translators: Describes a command.
-			"Allow or disallow to control the volume of other applications",
+			"Toggle whether control of other applications' volume is enabled.",
 		),
 		category=SCRCAT_AUDIO,
 	)

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -2469,7 +2469,7 @@ This option is not available if you have started NVDA with [WASAPI disabled for 
 
 | . {.hideHeaderRow} |.|
 |---|---|
-|Options |No, Yes|
+|Options |Default (No), No, Yes|
 |Default |No|
 
 This combo box determines whether NVDA commands can be used to adjust the volume of other applications running on the system.


### PR DESCRIPTION
### Link to issue number:
Fixes #17303
### Summary of the issue:
Associated to the audio new option "Allow NVDA to control the volume of other applications" (ex Volume adjuster), there is a command (script) with no default bound gesture to toggle the value of this parameter. There are two issues with this script:
* Using it only reports "Yes" or "No", whereas other toggle scripts are usually more precise, e.g. the command "Toggles on and off the inclusion of layout tables in browse mode" reports "layout tables off" or "layout tables on".
* The input help or command name in the input gestures dialog still mentions volume adjuster, whereas the option in the audio settings and in the User Guide has been reworded.

### Description of user facing changes
* Reworded the command name / input help.
* Calling the command now reports something more explicit.

### Description of development approach
See code.
### Testing strategy:
Manual test.
### Known issues with pull request:
None
### Code Review Checklist:


- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
