### PR TITLE
Add ability to report the document layout in Microsoft Word

### DIFF
--- a/source/appModules/winword.py
+++ b/source/appModules/winword.py
@@ -18,7 +18,9 @@ from utils.displayString import DisplayStringIntEnum
 
 
 class ViewType(DisplayStringIntEnum):
-	"""Enumeration containing the possible view types in Word documents."""
+	"""Enumeration containing the possible view types in Word documents:.
+	https://learn.microsoft.com/en-us/office/vba/api/word.wdviewtype
+	"""
 
 	DRAFT = 1
 	OUTLINE = 2

--- a/source/appModules/winword.py
+++ b/source/appModules/winword.py
@@ -30,6 +30,7 @@ class AppModule(appModuleHandler.AppModule):
 		# Translators: Message presented in input help mode to describe a command in Microsoft Word documents.
 		description=_("Reports the window title and document layout"),
 		gesture="kb:NVDA+t",
+		speakOnDemand=True,
 	)
 	def script_title(self, gesture):
 		title = api.getForegroundObject().name

--- a/source/appModules/winword.py
+++ b/source/appModules/winword.py
@@ -28,7 +28,7 @@ class AppModule(appModuleHandler.AppModule):
 	@script(
 		category=globalCommands.SCRCAT_FOCUS,
 		description=_(
-			# Translators: Input help mode message for report title bar command.
+			# Translators: Input help mode message for report title bar command in Microsoft Word.
 			"In Microsoft Word, reports the title and the layout of the current document. If pressed twice, spells this information. If pressed three times, copies it to the clipboard"
 		),
 		gesture="kb:NVDA+t",

--- a/source/appModules/winword.py
+++ b/source/appModules/winword.py
@@ -41,6 +41,7 @@ class ViewTypes(DisplayStringIntEnum):
 			ViewTypes.READ: _("Read mode"),
 		}
 
+
 class AppModule(appModuleHandler.AppModule):
 	def chooseNVDAObjectOverlayClasses(self, obj, clsList):
 		if UIAWordDocument in clsList or IAccessibleWordDocument in clsList:
@@ -48,7 +49,6 @@ class AppModule(appModuleHandler.AppModule):
 
 
 class WinwordWordDocument(WordDocument):
-
 	def _get_description(self) -> str:
 		curView = self.WinwordWindowObject.view.Type
 		return ViewTypes(curView).displayString

--- a/source/appModules/winword.py
+++ b/source/appModules/winword.py
@@ -29,7 +29,7 @@ class AppModule(appModuleHandler.AppModule):
 		category=globalCommands.SCRCAT_FOCUS,
 		description=_(
 			# Translators: Input help mode message for report title bar command in Microsoft Word.
-			"In Microsoft Word, reports the title and the layout of the current document. If pressed twice, spells this information. If pressed three times, copies it to the clipboard"
+			"In Microsoft Word, reports the title and the layout of the current document. If pressed twice, spells this information. If pressed three times, copies it to the clipboard",
 		),
 		gesture="kb:NVDA+t",
 		speakOnDemand=True,

--- a/source/appModules/winword.py
+++ b/source/appModules/winword.py
@@ -29,7 +29,7 @@ class AppModule(appModuleHandler.AppModule):
 		category=globalCommands.SCRCAT_FOCUS,
 		# Translators: Message presented in input help mode to describe a command in Microsoft Word documents.
 		description=_(
-			"In Microsoft Word, reports the title and the layout of the current document. If pressed twice, spells this information. If pressed three times, copies it to the clipboard"
+			"In Microsoft Word, reports the title and the layout of the current document. If pressed twice, spells this information. If pressed three times, copies it to the clipboard",
 		),
 		gesture="kb:NVDA+t",
 		speakOnDemand=True,

--- a/source/appModules/winword.py
+++ b/source/appModules/winword.py
@@ -41,6 +41,7 @@ class ViewType(DisplayStringIntEnum):
 			ViewType.READ: _("Read mode"),
 		}
 
+
 class AppModule(appModuleHandler.AppModule):
 	def chooseNVDAObjectOverlayClasses(self, obj, clsList):
 		if UIAWordDocument in clsList or IAccessibleWordDocument in clsList:
@@ -48,7 +49,6 @@ class AppModule(appModuleHandler.AppModule):
 
 
 class WinwordWordDocument(WordDocument):
-
 	def _get_description(self) -> str:
 		try:
 			curView = self.WinwordWindowObject.view.Type

--- a/source/appModules/winword.py
+++ b/source/appModules/winword.py
@@ -27,8 +27,8 @@ class AppModule(appModuleHandler.AppModule):
 
 	@script(
 		category=globalCommands.SCRCAT_FOCUS,
-		# Translators: Message presented in input help mode to describe a command in Microsoft Word documents.
 		description=_(
+			# Translators: Input help mode message for report title bar command.
 			"In Microsoft Word, reports the title and the layout of the current document. If pressed twice, spells this information. If pressed three times, copies it to the clipboard"
 		),
 		gesture="kb:NVDA+t",

--- a/source/appModules/winword.py
+++ b/source/appModules/winword.py
@@ -28,7 +28,9 @@ class AppModule(appModuleHandler.AppModule):
 	@script(
 		category=globalCommands.SCRCAT_FOCUS,
 		# Translators: Message presented in input help mode to describe a command in Microsoft Word documents.
-		description=_("Reports the window title and document layout"),
+		description=_(
+			"In Microsoft Word, reports the title and the layout of the current document. If pressed twice, spells this information. If pressed three times, copies it to the clipboard"
+		),
 		gesture="kb:NVDA+t",
 		speakOnDemand=True,
 	)

--- a/source/appModules/winword.py
+++ b/source/appModules/winword.py
@@ -54,7 +54,7 @@ class WinwordWordDocument(WordDocument):
 	def _get_description(self) -> str:
 		try:
 			curView = self.WinwordWindowObject.view.Type
-			return f"{ViewType(curView).displayString} super()._get_description()"
+			return f"{ViewType(curView).displayString} {super()._get_description()}"
 		except AttributeError:
 			return super()._get_description()
 

--- a/source/appModules/winword.py
+++ b/source/appModules/winword.py
@@ -17,7 +17,7 @@ from NVDAObjects.window.winword import WordDocument
 from utils.displayString import DisplayStringIntEnum
 
 
-class ViewTypes(DisplayStringIntEnum):
+class ViewType(DisplayStringIntEnum):
 	"""Enumeration containing the possible view types in Word documents."""
 
 	DRAFT = 1
@@ -30,15 +30,15 @@ class ViewTypes(DisplayStringIntEnum):
 	def _displayStringLabels(self):
 		return {
 			# Translators: One of the view types in Word documents.
-			ViewTypes.DRAFT: _("DRAFT"),
+			ViewType.DRAFT: _("DRAFT"),
 			# Translators: One of the view types in Word documents.
-			ViewTypes.OUTLINE: _("Outline"),
+			ViewType.OUTLINE: _("Outline"),
 			# Translators: One of the view types in Word documents.
-			ViewTypes.PRINT: _("Print layout"),
+			ViewType.PRINT: _("Print layout"),
 			# Translators: One of the view types in Word documents.
-			ViewTypes.WEB: _("Web layout"),
+			ViewType.WEB: _("Web layout"),
 			# Translators: One of the view types in Word documents.
-			ViewTypes.READ: _("Read mode"),
+			ViewType.READ: _("Read mode"),
 		}
 
 class AppModule(appModuleHandler.AppModule):
@@ -51,7 +51,7 @@ class WinwordWordDocument(WordDocument):
 
 	def _get_description(self) -> str:
 		curView = self.WinwordWindowObject.view.Type
-		return ViewTypes(curView).displayString
+		return ViewType(curView).displayString
 
 	@script(gesture="kb:control+shift+e")
 	def script_toggleChangeTracking(self, gesture):

--- a/source/appModules/winword.py
+++ b/source/appModules/winword.py
@@ -49,6 +49,7 @@ class AppModule(appModuleHandler.AppModule):
 		else:
 			api.copyToClip(title, notify=True)
 
+
 class WinwordWordDocument(WordDocument):
 	@script(gesture="kb:control+shift+e")
 	def script_toggleChangeTracking(self, gesture):

--- a/source/appModules/winword.py
+++ b/source/appModules/winword.py
@@ -54,7 +54,7 @@ class WinwordWordDocument(WordDocument):
 	def _get_description(self) -> str:
 		try:
 			curView = self.WinwordWindowObject.view.Type
-			return ViewType(curView).displayString
+			return f"{ViewType(curView).displayString} super()._get_description()"
 		except AttributeError:
 			return super()._get_description()
 

--- a/source/appModules/winword.py
+++ b/source/appModules/winword.py
@@ -8,7 +8,10 @@ Word and Outlook share a lot of code and components. This app module gathers the
 Microsoft Word only.
 """
 
+import api
 import appModuleHandler
+import controlTypes
+import globalCommands
 from scriptHandler import script
 import ui
 from NVDAObjects.IAccessible.winword import WordDocument as IAccessibleWordDocument
@@ -20,6 +23,28 @@ class AppModule(appModuleHandler.AppModule):
 	def chooseNVDAObjectOverlayClasses(self, obj, clsList):
 		if UIAWordDocument in clsList or IAccessibleWordDocument in clsList:
 			clsList.insert(0, WinwordWordDocument)
+
+	@script(
+		category=globalCommands.SCRCAT_FOCUS,
+		# Translators: Message presented in input help mode to describe a command in Microsoft Word documents.
+		description=_("Reports the window title and document layout"),
+		gesture="kb:NVDA+t",
+	)
+	def script_title(self, gesture):
+		title = api.getForegroundObject().name
+		statusBar = api.getStatusBar()
+		if statusBar is None:
+			ui.message(title)
+			return
+		documentLayout = None
+		for child in statusBar.children:
+			if controlTypes.state.State.PRESSED in child.states:
+				documentLayout = child.name
+				break
+		if documentLayout is None:
+			ui.message(title)
+		else:
+			ui.message(f"{title} - {documentLayout}")
 
 
 class WinwordWordDocument(WordDocument):

--- a/source/appModules/winword.py
+++ b/source/appModules/winword.py
@@ -50,8 +50,11 @@ class AppModule(appModuleHandler.AppModule):
 class WinwordWordDocument(WordDocument):
 
 	def _get_description(self) -> str:
-		curView = self.WinwordWindowObject.view.Type
-		return ViewType(curView).displayString
+		try:
+			curView = self.WinwordWindowObject.view.Type
+			return ViewType(curView).displayString
+		except AttributeError:
+			return super()._get_description()
 
 	@script(gesture="kb:control+shift+e")
 	def script_toggleChangeTracking(self, gesture):

--- a/source/appModules/winword.py
+++ b/source/appModules/winword.py
@@ -32,13 +32,13 @@ class AppModule(appModuleHandler.AppModule):
 		gesture="kb:NVDA+t",
 	)
 	def script_title(self, gesture):
-		foregroundWindowName = api.getForegroundObject().name
-		title = foregroundWindowName
+		title = api.getForegroundObject().name
 		statusBar = api.getStatusBar()
 		if statusBar is not None:
 			for child in statusBar.children:
 				if controlTypes.state.State.PRESSED in child.states:
 					documentLayout = child.name
+					foregroundWindowName = title
 					title = f"{foregroundWindowName} - {documentLayout}"
 					break
 		repeatCount = getLastScriptRepeatCount()

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -35,6 +35,7 @@ To use this feature, "allow NVDA to control the volume of other applications" mu
   * It will now show a message to the user, including the error, in the rare event of a Windows error while attempting COM re-registrations.
 * In Word and Outlook the result of more font formatting shortcuts is now reported. (#10271, @CyrilleB79)
 * Default input and output braille tables will now be determined based on the NVDA language. (#16390, #290, @nvdaes)
+* In Microsoft Word, when using the `report title` command, the document layout will be announced if possible (#15088, @nvdaes)
 
 ### Bug Fixes
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -35,7 +35,7 @@ To use this feature, "allow NVDA to control the volume of other applications" mu
   * It will now show a message to the user, including the error, in the rare event of a Windows error while attempting COM re-registrations.
 * In Word and Outlook the result of more font formatting shortcuts is now reported. (#10271, @CyrilleB79)
 * Default input and output braille tables will now be determined based on the NVDA language. (#16390, #290, @nvdaes)
-* In Microsoft Word, when using the `report title` command, the document layout will be announced if possible (#15088, @nvdaes)
+* In Microsoft Word, when using the `report title bar` command, the document layout will be announced if this information is available on the status bar (#15088, @nvdaes)
 
 ### Bug Fixes
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -35,7 +35,7 @@ To use this feature, "allow NVDA to control the volume of other applications" mu
   * It will now show a message to the user, including the error, in the rare event of a Windows error while attempting COM re-registrations.
 * In Word and Outlook the result of more font formatting shortcuts is now reported. (#10271, @CyrilleB79)
 * Default input and output braille tables will now be determined based on the NVDA language. (#16390, #290, @nvdaes)
-* In Microsoft Word, when using the `report title bar` command, the document layout will be announced if this information is available on the status bar (#15088, @nvdaes)
+* In Microsoft Word, when using the `report focus` command, the document layout will be announced if this information is available and reporting object descriptions is enabled (#15088, @nvdaes)
 
 ### Bug Fixes
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Fixes #15088
### Summary of the issue:
Knowing the document layout in Microsoft Word may be important, for example, to figure out why a table is not read properly when navigating with NVDA, and in other situations.
### Description of user facing changes
WinwordWindowObject.view.Type is used to add the document layout to the document description. It can be announced when the document is focused, and when pressing NVDA+tab.
### Description of development approach
In the WinWord app module, a script has been created, using `api.getStatusBar()` to search for the status bar. If it can be found, and one of the bar status children has the PRESSED state, its name Will be added to the title, assuming that it correspond to the document layout.
### Testing strategy:
Tested manually, in Word documents, with the ribbon active and inactive, and with a dialog opened to check that the title without the document layout is reported when the status bar is not found.
### Known issues with pull request:
None.
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
