### PR TITLE
fix no speech when role="math" on a non-math element

### DIFF
--- a/source/NVDAObjects/IAccessible/ia2Web.py
+++ b/source/NVDAObjects/IAccessible/ia2Web.py
@@ -346,7 +346,7 @@ class Math(Ia2Web):
 			if self.IA2Attributes.get("tag") != "math":
 				# Could be a <span> (etc) that has role = math -- check the child
 				# If there is a single <math> child, recurse on the assumption that is what was the intended math
-				mathObjs: list[NVDAObject] = [
+				mathObjs: list["NVDAObjects.NVDAObject"] = [
 					child for child in self.children if child.IA2Attributes.get("tag") == "math"
 				]
 				if len(mathObjs) == 1:

--- a/source/NVDAObjects/IAccessible/ia2Web.py
+++ b/source/NVDAObjects/IAccessible/ia2Web.py
@@ -346,7 +346,9 @@ class Math(Ia2Web):
 			if self.IA2Attributes.get("tag") != "math":
 				# Could be a <span> (etc) that has role = math -- check the child
 				# If there is a single <math> child, recurse on the assumption that is what was the intended math
-				mathObjs: str | None = [child for child in self.children if child.IA2Attributes.get("tag") == 'math']
+				mathObjs: str | None = [
+					child for child in self.children if child.IA2Attributes.get("tag") == "math"
+				]
 				if len(mathObjs) == 1:
 					return mathObjs[0].mathMl
 				# This isn't MathML

--- a/source/NVDAObjects/IAccessible/ia2Web.py
+++ b/source/NVDAObjects/IAccessible/ia2Web.py
@@ -346,7 +346,7 @@ class Math(Ia2Web):
 			if self.IA2Attributes.get("tag") != "math":
 				# Could be a <span> (etc) that has role = math -- check the child
 				# If there is a single <math> child, recurse on the assumption that is what was the intended math
-				mathObjs: str | None = [
+				mathObjs: list[NVDAObject] = [
 					child for child in self.children if child.IA2Attributes.get("tag") == "math"
 				]
 				if len(mathObjs) == 1:

--- a/source/NVDAObjects/IAccessible/ia2Web.py
+++ b/source/NVDAObjects/IAccessible/ia2Web.py
@@ -344,7 +344,12 @@ class Math(Ia2Web):
 					attr = mathPres.insertLanguageIntoMath(attr, self.language)
 				return attr
 			if self.IA2Attributes.get("tag") != "math":
-				# This isn't MathML.
+				# Could be a <span> (etc) that has role = math -- check the child
+				# If there is a single <math> child, recurse on the assumption that is what was the intended math
+				mathObjs: str | None = [child for child in self.children if child.IA2Attributes.get("tag") == 'math']
+				if len(mathObjs) == 1:
+					return mathObjs[0].mathMl
+				# This isn't MathML
 				raise LookupError
 			if self.language:
 				attrs = ' xml:lang="%s"' % self.language

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -41,6 +41,7 @@ To use this feature, "allow NVDA to control the volume of other applications" mu
 
 ### Bug Fixes
 
+* MathML inside of span and other elements that have the attribute `role="math"` is now spoken/brailled
 * Native support for the Dot Pad tactile graphics device from Dot Inc as a multiline braille display. (#17007)
 * Improvements when editing in Microsoft PowerPoint:
   * Caret reporting no longer breaks when text contains wide characters, such as emoji. (#17006 , @LeonarddeR)

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -41,7 +41,8 @@ To use this feature, "allow NVDA to control the volume of other applications" mu
 
 ### Bug Fixes
 
-* MathML inside of span and other elements that have the attribute `role="math"` is now spoken/brailled
+* Math reading has been fixed for some web elements.
+Specifically, MathML inside of span and other elements that have the attribute `role="math"`. (#15058)
 * Native support for the Dot Pad tactile graphics device from Dot Inc as a multiline braille display. (#17007)
 * Improvements when editing in Microsoft PowerPoint:
   * Caret reporting no longer breaks when text contains wide characters, such as emoji. (#17006 , @LeonarddeR)


### PR DESCRIPTION
### Link to issue number:
This fixes #15058.

### Summary of the issue:
When someone has something like
```
            <span role="math">
                <math>
                    <msqrt>
                        <mn>4</mn>
                    </msqrt>
                </math>
            </span>
```
The math is not spoken (nothing is spoken). 

This construct happens in real life math (see #15058 for more details).

### Description of user facing changes
Web content such as the above will now be spoken as if the `span` (or other elements) are not present. This is what should have always happened.


### Description of development approach
The fix (which is a bit of a hueristic) is to look inside the `span` (or other element with `role="math"` and see if exactly one of the children is `math`. If so, then we recursively call the code to get the MathML for it.

If there isn't exactly one math element, we fall through and raise a LookupError (which is what happened before adding this check).

### Testing strategy:

### Known issues with pull request:
It only deals with one scenario where `role="math"` occurs. If there are multiple `math` children or if the math is not MathML, nothing is done. Potentially there are better things that might be done (such as speaking the leaf content) rather than being silent.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
