### PR TITLE
Update robot framework to 7.1.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -48,6 +48,6 @@ pre-commit==3.7.1
 licensecheck==2024.2
 
 # Requirements for system tests
-robotframework==6.1.1
+robotframework==7.1.1
 robotremoteserver==1.1.1
 robotframework-screencaplibrary==1.6.0

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -70,6 +70,7 @@ Add-ons will need to be re-tested and have their manifest updated.
   * Updated wxPython to 4.2.2. (#17181, @dpy013)
   * Updated SCons to 4.8.1. (#17254)
   * Updated sphinx to 8.1.2 and sphinx-rtd-theme to 3.0.1. (#17284, @josephsl)
+  * Updated robotframework to 7.1.1. (#17329, @josephsl)
 * `ui.browseableMessage` may now be called with options to present a button for copying to clipboard, and/or a button for closing the window. (#17018, @XLTechie)
 * Several additions to identify link types (#16994, @LeonarddeR, @nvdaes)
   * A new `utils.urlUtils` module with different functions to determine link types

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -70,7 +70,7 @@ Add-ons will need to be re-tested and have their manifest updated.
   * Updated wxPython to 4.2.2. (#17181, @dpy013)
   * Updated SCons to 4.8.1. (#17254)
   * Updated sphinx to 8.1.2 and sphinx-rtd-theme to 3.0.1. (#17284, @josephsl)
-  * Updated robotframework to 7.1.1. (#17329, @josephsl)
+  * Updated Robot Framework to 7.1.1. (#17329, @josephsl)
 * `ui.browseableMessage` may now be called with options to present a button for copying to clipboard, and/or a button for closing the window. (#17018, @XLTechie)
 * Several additions to identify link types (#16994, @LeonarddeR, @nvdaes)
   * A new `utils.urlUtils` module with different functions to determine link types


### PR DESCRIPTION

### Link to issue number:
Closes #17329 

### Summary of the issue:
NVDA is using an outdated version of robot framework (6.1.1).

### Description of user facing changes
None

### Description of development approach
Updated robot framework to 7.1.1, ensuring that system tests continue to work (pass/fail).

### Testing strategy:
Manual and system tests:

* Manual: updated robot framework to 7.1.1 and ensure that this is picked up from PyPI
* System tests: make sure system tests do work after updating robot framework (system tests do run).
* 
### Known issues with pull request:
Some system tests may fail, but that might not be related to robot framework dependency updates.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
