### PR TITLE
Slightly rework shouldUseToUnicodeEx to avoid errors

### DIFF
--- a/source/keyboardHandler.py
+++ b/source/keyboardHandler.py
@@ -149,11 +149,14 @@ def shouldUseToUnicodeEx(focus: Optional["NVDAObject"] = None):
 		# This is only possible in Windows 10 1607 and above
 		and winVersion.getWinVer() >= winVersion.WIN10_1607
 		and (  # Either of
-			# We couldn't inject in-process, and its not a legacy console window without keyboard support.
+			# The focus is within a UWP app, where WM_CHAR never gets sent
+			focus.windowClassName.startswith("Windows.UI.Core")
+			# Or we couldn't inject in-process, and its not a legacy console window without keyboard support.
 			# console windows have their own specific typed character support.
-			(not focus.appModule.helperLocalBindingHandle and focus.windowClassName != "ConsoleWindowClass")
-			# or the focus is within a UWP app, where WM_CHAR never gets sent
-			or focus.windowClassName.startswith("Windows.UI.Core")
+			or (
+				not (focus.appModule and focus.appModule.helperLocalBindingHandle)
+				and focus.windowClassName != "ConsoleWindowClass"
+			)
 			# Or this is a console with keyboard support, where WM_CHAR messages are doubled
 			or isinstance(focus, KeyboardHandlerBasedTypedCharSupport)
 		)


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
`shouldUseToUnicodeEx` can sometimes result in none object has no property helperLocalBindingHandle error. This is hard to reproduce but I've seen it often in WhatsApp UWP.

### Description of user facing changes
None known.

### Description of development approach
1. When checking for `helperLocalBindingHandle`, ensure that `appModule` has a value.
2. While at it, reorder the checks, since in current era, UWP applications are much more common than during the initial implementation of this approach.

### Testing strategy:
Should be tested during daily use as it is hard to reproduce the underlying issue.

### Known issues with pull request:
None known

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
