### PR TITLE
Improve fetching of document layout information in word

### DIFF
--- a/source/appModules/winword.py
+++ b/source/appModules/winword.py
@@ -55,7 +55,7 @@ class WinwordWordDocument(WordDocument):
 		try:
 			curView = self.WinwordWindowObject.view.Type
 			description = super().description
-			if isinstance(super()._get_description(), str):
+			if isinstance(super()._get_description(), str) and (description := description.strip()):
 				return f"{ViewType(curView).displayString} {description}".strip()
 			return curView.displayString
 		except AttributeError:

--- a/source/appModules/winword.py
+++ b/source/appModules/winword.py
@@ -57,7 +57,7 @@ class WinwordWordDocument(WordDocument):
 			description = super().description
 			if isinstance(description, str) and not description.isspace():
 				return f"{ViewType(curView).displayString} {description}"
-			return curView.displayString
+			return ViewType(curView).displayString
 		except AttributeError:
 			return super()._get_description()
 

--- a/source/appModules/winword.py
+++ b/source/appModules/winword.py
@@ -56,7 +56,7 @@ class WinwordWordDocument(WordDocument):
 			curView = self.WinwordWindowObject.view.Type
 			description = super().description
 			if isinstance(super()._get_description(), str):
-				return f"{ViewType(curView).displayString} {super()._get_description()}".strip()
+				return f"{ViewType(curView).displayString} {description}".strip()
 			return curView.displayString
 		except AttributeError:
 			return super()._get_description()

--- a/source/appModules/winword.py
+++ b/source/appModules/winword.py
@@ -54,7 +54,9 @@ class WinwordWordDocument(WordDocument):
 	def _get_description(self) -> str:
 		try:
 			curView = self.WinwordWindowObject.view.Type
-			return f"{ViewType(curView).displayString} {super()._get_description()}"
+			if isinstance(super()._get_description(), str):
+				return f"{ViewType(curView).displayString} {super()._get_description()}".strip()
+			return curView.displayString
 		except AttributeError:
 			return super()._get_description()
 

--- a/source/appModules/winword.py
+++ b/source/appModules/winword.py
@@ -55,8 +55,8 @@ class WinwordWordDocument(WordDocument):
 		try:
 			curView = self.WinwordWindowObject.view.Type
 			description = super().description
-			if isinstance(super()._get_description(), str) and (description := description.strip()):
-				return f"{ViewType(curView).displayString} {description}".strip()
+			if isinstance(description, str) and not description.isspace():
+				return f"{ViewType(curView).displayString} {description}"
 			return curView.displayString
 		except AttributeError:
 			return super()._get_description()

--- a/source/appModules/winword.py
+++ b/source/appModules/winword.py
@@ -54,6 +54,7 @@ class WinwordWordDocument(WordDocument):
 	def _get_description(self) -> str:
 		try:
 			curView = self.WinwordWindowObject.view.Type
+			description = super().description
 			if isinstance(super()._get_description(), str):
 				return f"{ViewType(curView).displayString} {super()._get_description()}".strip()
 			return curView.displayString


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Fixes PR #17324
### Summary of the issue:
If the Word document description is None, None is reported after the document layout.
### Description of user facing changes
The document layout Will be reported without garbage information like None.
### Description of development approach
Check if the description is an instance of str, and if it's not just blank characters. In this case, prepend the document layout. Otherwise, just use the document layout as the description.
### Testing strategy:
Tested manually in a Word version where the description is blank, and in another computer where it'sNone.
### Known issues with pull request:
None
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
