### PR TITLE
Capture output when testing markdownTranslate

### DIFF
--- a/tests/unit/test_markdownTranslate.py
+++ b/tests/unit/test_markdownTranslate.py
@@ -31,7 +31,11 @@ class TestMarkdownTranslate(unittest.TestCase):
 	def runMarkdownTranslateCommand(self, description: str, args: list[str]):
 		failed = False
 		try:
-			subprocess.run([sys.executable, self.markdownTranslateScriptPath, *args], check=True)
+			subprocess.run(
+				[sys.executable, self.markdownTranslateScriptPath, *args],
+				check=True,
+				capture_output=True,
+			)
 		except subprocess.CalledProcessError:
 			failed = True
 		if failed:


### PR DESCRIPTION
### Link to issue number:

Fixes #17280

### Summary of the issue:

When running unit tests, a lot of output is generated by `test_markdownTranslate.py`, that is not useful most of the time.

### Description of user facing changes

None.

### Description of development approach

Add `capture_output=True` to `subprocess.run` calls when testing markdownTranslate.

### Testing strategy:

Ran unit tests.

### Known issues with pull request:

This may make some debug tasks slightly harder if problems occur. However, output should be present on exceptions raised by non-0 exits, and this change is extremely easy to comment out anyway.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
