### PR TITLE
Fix punctuation/symbols dialog not saving

### DIFF
--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -5568,7 +5568,9 @@ class SpeechSymbolsDialog(SettingsDialog):
 				continue
 			self.symbolProcessor.updateSymbol(symbol)
 		try:
-			self.symbolProcessor.userSymbols.save()
+			self.symbolProcessor.userSymbols.save(
+				WritePaths.getSymbolsConfigFile(self.symbolProcessor.locale),
+			)
 		except IOError as e:
 			log.error("Error saving user symbols info: %s" % e)
 		characterProcessing._localeSpeechSymbolProcessors.invalidateLocaleData(self.symbolProcessor.locale)


### PR DESCRIPTION
### Link to issue number:

Fixes #17344

### Summary of the issue:

The punctuation/symbols dialog would not close when ok was pressed.

### Description of user facing changes

The dialog now closes as expected.

### Description of development approach

Explicitly pass in the name of the symbols file when attempting to save from the symbols dialog.

### Testing strategy:

Manually tested saving with a blank config and an existing config.

### Known issues with pull request:

Decision needs to be made as to whether this warrants a patch release.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
