### PR TITLE
Provide speech symbols file name path on creation

### DIFF
--- a/source/buildVersion.py
+++ b/source/buildVersion.py
@@ -65,7 +65,7 @@ def formatVersionForGUI(year, major, minor):
 name = "NVDA"
 version_year = 2024
 version_major = 4
-version_minor = 0
+version_minor = 1
 version_build = 0  # Should not be set manually. Set in 'sconscript' provided by 'appVeyor.yml'
 version = _formatDevVersionString()
 publisher = "unknown"

--- a/source/characterProcessing.py
+++ b/source/characterProcessing.py
@@ -237,11 +237,11 @@ class SpeechSymbols:
 	This is all handled by L{SpeechSymbolProcessor}.
 	"""
 
-	def __init__(self):
+	def __init__(self, filename: str | None = None):
 		"""Constructor."""
 		self.complexSymbols = collections.OrderedDict()
 		self.symbols = collections.OrderedDict()
-		self.fileName = None
+		self.fileName = filename
 
 	def load(self, fileName: str, allowComplexSymbols: bool = True) -> None:
 		"""Load symbol information from a file.
@@ -826,7 +826,7 @@ class SymbolDictionaryDefinition:
 
 	def _initSymbols(self, locale: str) -> SpeechSymbols:
 		raiseOnError = self.source != _SymbolDefinitionSource.USER
-		symbols = SpeechSymbols()
+		symbols = SpeechSymbols(self.path.format(locale=locale))
 		if locale not in self.availableLocales:
 			msg = f"No {self.name!r} data for locale {locale!r}"
 			if raiseOnError:

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -1,5 +1,14 @@
 # What's New in NVDA
 
+## 2024.4.1
+
+This patch release includes a fix for Outlook on certain Windows 10 systems.
+It also includes a fix for saving speech symbol dictionaries.
+
+### Bug fixes
+
+* Fixed bug where speech dictionaries were not saved and the dialog would not be closed. (#17345)
+
 ## 2024.4
 
 This release includes a number of improvements in Microsoft Office, braille, and document formatting.

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -2,7 +2,6 @@
 
 ## 2024.4.1
 
-This patch release includes a fix for Outlook on certain Windows 10 systems.
 It also includes a fix for saving speech symbol dictionaries.
 
 ### Bug fixes

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -7,7 +7,7 @@ It also includes a fix for saving speech symbol dictionaries.
 
 ### Bug fixes
 
-* Fixed bug where speech dictionaries were not saved and the dialog would not be closed. (#17344)
+* Fixed bug where speech symbols dictionaries were not saved and the dialog would not be closed. (#17344)
 
 ## 2024.4
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -7,7 +7,7 @@ It also includes a fix for saving speech symbol dictionaries.
 
 ### Bug fixes
 
-* Fixed bug where speech dictionaries were not saved and the dialog would not be closed. (#17345)
+* Fixed bug where speech dictionaries were not saved and the dialog would not be closed. (#17344)
 
 ## 2024.4
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Fixes #17344

### Summary of the issue:

The `SpeechSymbols` only sets the filename to write to when the dictionary is loaded.
Before 826ef91, dictionary files were always loaded before they were saved.
Afterwards, dictionaries are saved without being loaded.
When trying to save dictionary files the following error occurs, due to no file name being set

```py
Speaking [LangChangeCommand ('en_US'), 'pressed']
ERROR - unhandled exception (17:00:20.842) - MainThread (9964):
Traceback (most recent call last):
  File "gui\settingsDialogs.pyc", line 5350, in onOk
  File "characterProcessing.pyc", line 364, in save
ValueError: No file name
```

### Description of user facing changes

Users can now save the speech dictionary dialog.
Add-ons which use custom speech dictionaries are also saved correctly now.

### Description of development approach

Create optional parameter to set filename path for speech dictionaries.

### Testing strategy:

Manual testing issue described in #17345
Manually testing Perky Duck add-on which uses a custom speech dictionary

### Known issues with pull request:

None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced support for new braille displays with automatic detection.
	- Enhanced support for Microsoft Office applications, including better formatting and table reporting.
	- Added functionality for reading and interacting with mathematical content in web browsers and Office.
	- Implemented automatic language switching based on document language.
	- Launched a new "Add-on Store" for managing NVDA add-ons.

- **Improvements**
	- Significant enhancements to web browsing support, including a new "browse mode."
	- Improved stability and performance with numerous bug fixes.

- **Version Update**
	- Minor version updated from 0 to 1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
