### PR TITLE
Windows 11 clipboard history: NVDA no longer announces history items when closing clipboard history interface

### DIFF
--- a/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
+++ b/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
@@ -436,11 +436,8 @@ class AppModule(appModuleHandler.AppModule):
 		# causing NVDA to report data item text such as clipboard history entries.
 		# Therefore, tell NVDA to veto this event at the object level, otherwise focus change handling breaks
 		# due to live region change event being queued.
-		if (
-			obj.role == controlTypes.Role.DATAITEM
-			and obj.parent.role in (
-				controlTypes.Role.TABLEROW,  # Clipboard history item
-				controlTypes.Role.LIST,  # Clipboard history item actions list
-			)
+		if obj.role == controlTypes.Role.DATAITEM and obj.parent.role in (
+			controlTypes.Role.TABLEROW,  # Clipboard history item
+			controlTypes.Role.LIST,  # Clipboard history item actions list
 		):
 			obj._shouldAllowUIALiveRegionChangeEvent = False

--- a/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
+++ b/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
@@ -430,3 +430,17 @@ class AppModule(appModuleHandler.AppModule):
 			elif obj.UIAAutomationId == "Windows.Shell.InputApp.FloatingSuggestionUI.DelegationTextBox":
 				clsList.remove(EditableTextWithAutoSelectDetection)
 				clsList.remove(XamlEditableText)
+
+	def event_NVDAObject_init(self, obj: NVDAObject) -> None:
+		# #17308: recent Windows 11 builds raise live region change event when clipboard history closes,
+		# causing NVDA to report data item text such as clipboard history entries.
+		# Therefore, tell NVDA to veto this event at the object level, otherwise focus change handling breaks
+		# due to live region change event being queued.
+		if (
+			obj.role == controlTypes.Role.DATAITEM
+			and obj.parent.role in (
+				controlTypes.Role.TABLEROW,  # Clipboard history item
+				controlTypes.Role.LIST,  # Clipboard history item actions list
+			)
+		):
+			obj._shouldAllowUIALiveRegionChangeEvent = False

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -60,6 +60,7 @@ To use this feature, "allow NVDA to control the volume of other applications" mu
   * After reporting a normalized character, NVDA no longer incorrectly reports subsequent characters as normalized. (#17286, @LeonarddeR)
   * Composite characters (such as é) are now reported correctly. (#17295, @LeonarddeR)
 * In Word or Outlook, when using legacy object model, the command to report the destination URL of a link does not report any longer "Not a link" when there is one to report. (#17292, @CyrilleB79)
+* NVDA will no longer announce Windows 11 clipboard history entries when closing the window while items are present. (#17308, @josephsl)
 
 ### Changes for Developers
 


### PR DESCRIPTION

### Link to issue number:
Closes #17308 

### Summary of the issue:
In Windows 11, NVDA announces clipboard history items when closing the interface while items are present.

### Description of user facing changes
NVDA will no longer announce clipboard items when closing Windows 11 clipboard history with items present.

### Description of development approach
Windows 11 input exprience interface fires UIA live region change event when closing clipboard history with items present. Therefore, veto this event at the object level (NVDA object init event) to prevent item announcement and to help gain focus event handler (no events should be pending).

### Testing strategy:
Manual testing (implemented in an add-on):

1. In Windows 11, copy several items to the clipboard, preferably text.
2. OPen clipboard history (Widows+V).
3. Close clipboard history WITHOUT clearing the list.

Expected: NVDA does not announce clipboard history items.

### Known issues with pull request:
The approach should be revisited if Microsoft fixes this issue or clipboard history UI/event processing changes. Since clipboard may contain sensitive information, fixing from NVDA side is warranted for now.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes for NVDA 2024.1

- **New Features**
	- Introduced support for the new HID Braille specification for enhanced Braille Display compatibility.
	- Added "on-demand" speech mode for more control over spoken feedback.
	- Implemented "Native Selection" mode for Mozilla Firefox, integrating text selection with Firefox's native capabilities.
	- Launched an Add-on Store for easy browsing, searching, and managing community add-ons.
	- Added support for Windows 10 on ARM64.

- **Bug Fixes**
	- Various improvements made for braille support, Microsoft Office integration, and web browsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
