### PR TITLE
Fix link URL reporting in Excel cells

### DIFF
--- a/source/NVDAObjects/window/_msOffice.py
+++ b/source/NVDAObjects/window/_msOffice.py
@@ -10,6 +10,7 @@ class MsoHyperlink(IntEnum):
 	"""Enumeration of hyperlink types in the Microsoft Office object model.
 	See https://learn.microsoft.com/en-us/office/vba/api/office.msohyperlinktype
 	"""
+
 	RANGE = 0
 	SHAPE = 1
 	INLINE_SHAPE = 2

--- a/source/NVDAObjects/window/_msOffice.py
+++ b/source/NVDAObjects/window/_msOffice.py
@@ -1,0 +1,13 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2024 NV Access Limited, Cyrille Bougot
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+
+from enum import IntEnum
+
+
+class MsoHyperlink(IntEnum):
+	# See https://learn.microsoft.com/en-us/office/vba/api/office.msohyperlinktype
+	RANGE = 0
+	SHAPE = 1
+	INLINE_SHAPE = 2

--- a/source/NVDAObjects/window/_msOffice.py
+++ b/source/NVDAObjects/window/_msOffice.py
@@ -7,7 +7,9 @@ from enum import IntEnum
 
 
 class MsoHyperlink(IntEnum):
-	# See https://learn.microsoft.com/en-us/office/vba/api/office.msohyperlinktype
+	"""Enumeration of hyperlink types in the Microsoft Office object model.
+	See https://learn.microsoft.com/en-us/office/vba/api/office.msohyperlinktype
+	"""
 	RANGE = 0
 	SHAPE = 1
 	INLINE_SHAPE = 2

--- a/source/NVDAObjects/window/excel.py
+++ b/source/NVDAObjects/window/excel.py
@@ -51,6 +51,7 @@ import vision
 from utils.displayString import DisplayStringIntEnum
 import NVDAState
 from globalCommands import SCRCAT_SYSTEMCARET
+from ._msOffice import MsoHyperlink
 
 excel2010VersionMajor = 14
 
@@ -1366,6 +1367,21 @@ class ExcelCellTextInfo(NVDAObjectTextInfo):
 
 	def _get_locationText(self):
 		return self.obj.getCellPosition()
+
+	def _getLinkDataAtCaretPosition(self) -> textInfos._Link | None:
+		links = self.obj.excelCellObject.Hyperlinks
+		if links.count == 0:
+			return None
+		link = links(1)
+		if link.Type == MsoHyperlink.RANGE:
+			text = link.TextToDisplay
+		else:
+			log.debugWarning(f"No text to display for link type {link.Type}")
+			text = None
+		return textInfos._Link(
+			displayText=text,
+			destination=link.Address,
+		)
 
 
 NVCELLINFOFLAG_ADDRESS = 0x1

--- a/source/NVDAObjects/window/winword.py
+++ b/source/NVDAObjects/window/winword.py
@@ -41,6 +41,7 @@ import browseMode
 from . import Window
 from ..behaviors import EditableTextWithoutAutoSelectDetection
 from . import _msOfficeChart
+from ._msOffice import MsoHyperlink
 import locationHelper
 from enum import IntEnum
 import documentBase
@@ -80,13 +81,6 @@ wdStartOfRangeRowNumber = 13
 wdMaximumNumberOfRows = 15
 wdStartOfRangeColumnNumber = 16
 wdMaximumNumberOfColumns = 18
-
-
-class MsoHyperlink(IntEnum):
-	# See https://learn.microsoft.com/en-us/office/vba/api/office.msohyperlinktype
-	RANGE = 0
-	SHAPE = 1
-	INLINE_SHAPE = 2
 
 
 class WdUnderline(DisplayStringIntEnum):

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -58,7 +58,7 @@ To use this feature, "allow NVDA to control the volume of other applications" mu
 * When spelling, unicode normalization now works more appropriately:
   * After reporting a normalized character, NVDA no longer incorrectly reports subsequent characters as normalized. (#17286, @LeonarddeR)
   * Composite characters (such as é) are now reported correctly. (#17295, @LeonarddeR)
-* In Word or Outlook when using legacy object model and in Excel, the command to report the destination URL of a link now works as expected. (#17292, #17362, @CyrilleB79)
+* The command to Report the destination URL of a link now works as expected when using the legacy object model in Microsoft Word, Outlook and Excel. (#17292, #17362, @CyrilleB79)
 
 ### Changes for Developers
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -58,7 +58,7 @@ To use this feature, "allow NVDA to control the volume of other applications" mu
 * When spelling, unicode normalization now works more appropriately:
   * After reporting a normalized character, NVDA no longer incorrectly reports subsequent characters as normalized. (#17286, @LeonarddeR)
   * Composite characters (such as é) are now reported correctly. (#17295, @LeonarddeR)
-* In Word or Outlook, when using legacy object model, the command to report the destination URL of a link does not report any longer "Not a link" when there is one to report. (#17292, @CyrilleB79)
+* In Word or Outlook when using legacy object model and in Excel, the command to report the destination URL of a link now works as expected. (#17292, #17362, @CyrilleB79)
 
 ### Changes for Developers
 


### PR DESCRIPTION
### Link to issue number:
None
### Summary of the issue:
In Excel, when a cell contains a link, using the report link command (`NVDA+k`) reports "Blank" instead of the URL.

### Description of user facing changes
When using `NVDA+K` in an Excel cell, the correct URL is now reported (with simple or double press).

### Description of development approach
* Use Excel object model to get the URL of the link.
* Put the `MsoHyperlink` enumeration in a separate file since it is now used by both Word and Excel.

### Testing strategy:
Manual tests:
* Confirmed that link reporting in Excel (single or double press), as well as in Word (legacy) is working correctly.
* Confirmed that trying to report the URL of a link where there is no link behaves as expected.
### Known issues with pull request:
None
### Code Review Checklist:


- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
