### PR TITLE
Only warn about add-on compatibility when updating to an incompatible API

### DIFF
--- a/source/updateCheck.py
+++ b/source/updateCheck.py
@@ -61,6 +61,7 @@ from addonStore.models.version import (  # noqa: E402
 	getAddonCompatibilityMessage,
 	getAddonCompatibilityConfirmationMessage,
 )
+import addonAPIVersion
 from logHandler import log, isPathExternalToNVDA
 import config
 import winKernel
@@ -452,7 +453,7 @@ class UpdateResultDialog(
 
 			self.apiVersion = pendingUpdateDetails[2]
 			self.backCompatTo = pendingUpdateDetails[3]
-			showAddonCompat = any(
+			showAddonCompat = (self.backCompatTo[0] > addonAPIVersion.BACK_COMPAT_TO[0]) and any(
 				getIncompatibleAddons(
 					currentAPIVersion=self.apiVersion,
 					backCompatToAPIVersion=self.backCompatTo,

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -40,6 +40,7 @@ To use this feature, "allow NVDA to control the volume of other applications" mu
 * In Word and Outlook the result of more font formatting shortcuts is now reported. (#10271, @CyrilleB79)
 * Default input and output braille tables can now be determined based on the NVDA language. (#17306, #16390, #290, @nvdaes)
 * In Microsoft Word, when using the "report focus" command, the document layout will be announced if this information is available and reporting object descriptions is enabled. (#15088, @nvdaes)
+* NVDA will now only warn about add-on incompatibility when updating to a version which has an incompatible add-on API to the currently installed copy. (#17071)
 
 ### Bug Fixes
 


### PR DESCRIPTION
### Link to issue number:

Closes #17071

### Summary of the issue:

NVDA complains about incompatible updates whenever it is updated with add-ons installed that are incompatible with the updated API version. This is particularly annoying for beta and alpha u8sers.

### Description of user facing changes

The add-on incompatibility message is now only presented when updating to a version with an incompatible API to that of the installed copy. That is, when the update will cause `addonAPIVersion.BACK_COMPAT_TO[0]` to increase.

### Description of development approach

Make increasing the add-on API backcompat's year a precondition of showing the warning in `updateCheck.py`.

### Testing strategy:

Created two builds of NVDA, both with their version spoofed to 2024.4, and update version type to alpha.
In the first, set `addonAPIVersion.BACK_COMPAT_TO` to `(2024.1.0)`, and the other to `(2025.1.0)`.
Installed an add-on that is incompatible with the 2025 API in both copies.
Ensured that updating the first copy caused the add-on incompatibility message to appear, and updating the second copy did not.

### Known issues with pull request:

None.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
