### PR TITLE
WASAPI: Disable default communication ducking for all NVDA audio streams.

### DIFF
--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -63,6 +63,7 @@ To use this feature, "allow NVDA to control the volume of other applications" mu
 * The command to Report the destination URL of a link now works as expected when using the legacy object model in Microsoft Word, Outlook and Excel. (#17292, #17362, @CyrilleB79)
 * NVDA will no longer announce Windows 11 clipboard history entries when closing the window while items are present. (#17308, @josephsl)
 * If the plugins are reloaded while a browseable message is opened, NVDA will no longer fail to report subsequent focus moves. (#17323, @CyrilleB79)
+* When using applications such as Skype, Discord, Signal and Phone Link for audio communication, NVDA speech and sounds no longer decrease in volume. (#17349, @jcsteh)
 
 ### Changes for Developers
 


### PR DESCRIPTION
### Link to issue number:
Fixes #17349.

### Summary of the issue:
Windows has a concept of communication audio streams. When an app (Skype, Signal, Discord, Phone Link, etc.) opens a communication audio stream, by default, the volume of audio from non-communication apps is significantly reduced. This includes NVDA. This effectively makes NVDA unusable for speech users while on a call with such an application.

There is a setting to disable this for all audio streams on the system:  Sound Properties -> Communications -> WhenWindows detects communications activity: Do nothing. However:

1. This doesn't work properly, which seems to be a long standing [Windows](https://answers.microsoft.com/en-us/windows/forum/all/selection-for-when-windows-detects-communications/721594ca-281e-4ccf-9e9f-cf71b8d6d426) [bug](https://github.com/signalapp/Signal-Desktop/issues/5649).
2. Even if it did, I don't think we ever want NVDA's audio to be ducked by the system, regardless of this setting.

### Description of user facing changes
When using applications such as Skype, Discord, Signal and Phone Link for audio communication, NVDA speech and sounds no longer decrease in volume.

### Description of development approach
Windows allows this default ducking experience to be disabled for a WASAPI stream. This change calls the appropriate API methods in WasapiPlayer to opt out of this ducking.

### Testing strategy:
I tested this with Phone Link. Before this change, making a phone call would cause NVDA speech to severely decrease in volume. After this change, NVDA's volume remains untouched.

### Known issues with pull request:
None.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
