### PR TITLE
Project documentation: mention Windows 11 SDK 10.0.26100 as the latest release

### DIFF
--- a/projectDocs/dev/createDevEnvironment.md
+++ b/projectDocs/dev/createDevEnvironment.md
@@ -66,7 +66,7 @@ To replicate the production build environment, use the 3.11.x minor version of P
 		* Desktop development with C++.
 			* Once selected, ensure "C++ Clang tools for Windows" is included under the optional grouping.
 	* On the Individual components tab, ensure the following items are selected:
-		* Windows 11 SDK (10.0.22621.0)
+		* Windows 11 SDK (10.0.26100.0)
 		* MSVC v143 - VS 2022 C++ ARM64/ARM64EC build tools
 		* MSVC v143 - VS 2022 C++ x64/x86 build tools
 		* C++ ATL for v143 build tools (x86 & x64)


### PR DESCRIPTION

### Link to issue number:
Closes #17377 

### Summary of the issue:
The latest Windows 11 SDK is listed as build 22621.

### Description of user facing changes
None

### Description of development approach
Update Windows 11 SDK build to 10.0.26100 (24H2).

### Testing strategy:
Building: make sure NVDA is built with Windows 11 SDK 10.0.26100 (it's been done on Appveyor for some time).

### Known issues with pull request:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
