### PR TITLE
Make Python console opening more robust

### DIFF
--- a/source/pythonConsole.py
+++ b/source/pythonConsole.py
@@ -7,6 +7,7 @@
 """Provides an interactive Python console which can be run from within NVDA.
 To use, call L{initialize} to create a singleton instance of the console GUI. This can then be accessed externally as L{consoleUI}.
 """
+
 import watchdog
 import builtins
 import os

--- a/source/pythonConsole.py
+++ b/source/pythonConsole.py
@@ -4,32 +4,30 @@
 # See the file COPYING for more details.
 # Copyright (C) 2008-2024 NV Access Limited, Leonard de Ruijter, Julien Cochuyt, Cyrille Bougot
 
-import watchdog
-
 """Provides an interactive Python console which can be run from within NVDA.
 To use, call L{initialize} to create a singleton instance of the console GUI. This can then be accessed externally as L{consoleUI}.
 """
-
-import builtins  # noqa: E402
-import os  # noqa: E402
-from typing import Sequence  # noqa: E402
-import code  # noqa: E402
-import codeop  # noqa: E402
-import sys  # noqa: E402
-import pydoc  # noqa: E402
-import re  # noqa: E402
-import itertools  # noqa: E402
-import rlcompleter  # noqa: E402
-import wx  # noqa: E402
-from baseObject import AutoPropertyObject  # noqa: E402
-import speech  # noqa: E402
-import queueHandler  # noqa: E402
-import api  # noqa: E402
-import gui  # noqa: E402
-from logHandler import log  # noqa: E402
-import braille  # noqa: E402
-import gui.contextHelp  # noqa: E402
-import textInfos  # noqa: E402
+import watchdog
+import builtins
+import os
+from typing import Sequence
+import code
+import codeop
+import sys
+import pydoc
+import re
+import itertools
+import rlcompleter
+import wx
+from baseObject import AutoPropertyObject
+import speech
+import queueHandler
+import api
+import gui
+from logHandler import log
+import braille
+import gui.contextHelp
+import textInfos
 
 
 class HelpCommand(object):

--- a/source/pythonConsole.py
+++ b/source/pythonConsole.py
@@ -29,7 +29,7 @@ import gui  # noqa: E402
 from logHandler import log  # noqa: E402
 import braille  # noqa: E402
 import gui.contextHelp  # noqa: E402
-import textInfos
+import textInfos  # noqa: E402
 
 
 class HelpCommand(object):

--- a/source/pythonConsole.py
+++ b/source/pythonConsole.py
@@ -255,6 +255,7 @@ class PythonConsole(code.InteractiveConsole, AutoPropertyObject):
 		Typically, used before the NVDA python console is opened, after which, calls
 		to the 'api' module will refer to this new focus.
 		"""
+
 		def _getCaretPos() -> textInfos.TextInfo | None:
 			try:
 				return api.getCaretPosition()

--- a/source/pythonConsole.py
+++ b/source/pythonConsole.py
@@ -264,7 +264,7 @@ class PythonConsole(code.InteractiveConsole, AutoPropertyObject):
 				return None
 
 		self._namespaceSnapshotVarsGetters = {
-			"focus": (lambda: api.getFocusObject()),
+			"focus": api.getFocusObject),
 			# Copy the focus ancestor list, as it gets mutated once it is replaced in api.setFocusObject.
 			"focusAnc": (lambda: list(api.getFocusAncestors())),
 			"fdl": (lambda: api.getFocusDifferenceLevel()),

--- a/source/pythonConsole.py
+++ b/source/pythonConsole.py
@@ -264,16 +264,16 @@ class PythonConsole(code.InteractiveConsole, AutoPropertyObject):
 				return None
 
 		self._namespaceSnapshotVarsGetters = {
-			"focus": api.getFocusObject),
+			"focus": api.getFocusObject,
 			# Copy the focus ancestor list, as it gets mutated once it is replaced in api.setFocusObject.
 			"focusAnc": (lambda: list(api.getFocusAncestors())),
-			"fdl": (lambda: api.getFocusDifferenceLevel()),
-			"fg": (lambda: api.getForegroundObject()),
-			"nav": (lambda: api.getNavigatorObject()),
-			"caretObj": (lambda: api.getCaretObject()),
+			"fdl": api.getFocusDifferenceLevel,
+			"fg": api.getForegroundObject,
+			"nav": api.getNavigatorObject,
+			"caretObj": api.getCaretObject,
 			"caretPos": _getCaretPos,
-			"review": (lambda: api.getReviewPosition()),
-			"mouse": (lambda: api.getMouseObject()),
+			"review": api.getReviewPosition,
+			"mouse": api.getMouseObject,
 			"brlRegions": (lambda: braille.handler.buffer.regions),
 		}
 		self._namespaceSnapshotVars = {}

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -64,7 +64,7 @@ To use this feature, "allow NVDA to control the volume of other applications" mu
 * NVDA will no longer announce Windows 11 clipboard history entries when closing the window while items are present. (#17308, @josephsl)
 * If the plugins are reloaded while a browseable message is opened, NVDA will no longer fail to report subsequent focus moves. (#17323, @CyrilleB79)
 * When using applications such as Skype, Discord, Signal and Phone Link for audio communication, NVDA speech and sounds no longer decrease in volume. (#17349, @jcsteh)
-* Opening the Python console will no longer fail in case an error occurs while retrieving snapshot variables.
+* Opening the NVDA Python Console will no longer fail in case an error occurs while retrieving snapshot variables.
 
 ### Changes for Developers
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -63,6 +63,7 @@ To use this feature, "allow NVDA to control the volume of other applications" mu
 * The command to Report the destination URL of a link now works as expected when using the legacy object model in Microsoft Word, Outlook and Excel. (#17292, #17362, @CyrilleB79)
 * NVDA will no longer announce Windows 11 clipboard history entries when closing the window while items are present. (#17308, @josephsl)
 * If the plugins are reloaded while a browseable message is opened, NVDA will no longer fail to report subsequent focus moves. (#17323, @CyrilleB79)
+* Opening the Python console will no longer fail in case an error occurs while retrieving snapshot variables.
 
 ### Changes for Developers
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -64,7 +64,7 @@ To use this feature, "allow NVDA to control the volume of other applications" mu
 * NVDA will no longer announce Windows 11 clipboard history entries when closing the window while items are present. (#17308, @josephsl)
 * If the plugins are reloaded while a browseable message is opened, NVDA will no longer fail to report subsequent focus moves. (#17323, @CyrilleB79)
 * When using applications such as Skype, Discord, Signal and Phone Link for audio communication, NVDA speech and sounds no longer decrease in volume. (#17349, @jcsteh)
-* Opening the NVDA Python Console will no longer fail in case an error occurs while retrieving snapshot variables.
+* Opening the NVDA Python Console will no longer fail in case an error occurs while retrieving snapshot variables. (#17391, @CyrilleB79)
 
 ### Changes for Developers
 


### PR DESCRIPTION
### Link to issue number:
Closes #17391
### Summary of the issue:
When opening Python console with `NVDA+control+Z`, NVDA initialize snapshot variables. If an error occurs during the initialization of these variables, the console cannot open.

### Description of user facing changes
The Python console will not fail to open anymore in case an error occurs while retrieving snapshot variables. If an exception occurs while retrieving a snapshot variable, this variable is set to `None`.

Note: I have imagined to display an error dialog if one or more variable cannot be retrieved successfully, but:
* I have not been able to implement one. My trial lead to a not vocalized dialog, probably because run from the main thread instead of wx one.
* I also wonder if there are side effect having a dialog here.
So I'd like to discuss this point before choosing investigating how to implement this design if you agree.

### Description of development approach
For each snapshot variable, catch any exception that can occur during its retrieval and initialize the variable to `None` if retrieval has failed. Also log the corresponding error.

Note: I have added one more `#noqa E402`. I am tempted to remove all of them but have not done so because I do not know why they have been added in the first place.

### Testing strategy:
Manual test:
Steps of #17391.

### Known issues with pull request:
None

### Code Review Checklist:


- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
