### PR TITLE
Add commands to move the review cursor to the first and last character of selected text

### DIFF
--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -374,6 +374,29 @@ class GlobalCommands(ScriptableObject):
 				speech.speakTextSelected(info.text)
 				braille.handler.message(selectMessage)
 
+	@staticmethod
+	def _getSelection() -> textInfos.TextInfo | None:
+		"""Gets the current selection, if any.
+		:return: The TextInfo corresponding to the current selection, or None if no selection is available.
+		"""
+		obj = api.getFocusObject()
+		treeInterceptor = obj.treeInterceptor
+		if (
+			isinstance(treeInterceptor, treeInterceptorHandler.DocumentTreeInterceptor)
+			and not treeInterceptor.passThrough
+		):
+			obj = treeInterceptor
+		try:
+			info = obj.makeTextInfo(textInfos.POSITION_SELECTION)
+		except (RuntimeError, NotImplementedError):
+			info = None
+		if not info or info.isCollapsed:
+			# Translators: The message reported when there is no selection
+			ui.message(_("No selection"))
+			return None
+		selection = info.copy()
+		return selection
+
 	@script(
 		description=_(
 			# Translators: Input help mode message for report date and time command.
@@ -2188,16 +2211,43 @@ class GlobalCommands(ScriptableObject):
 
 	@script(
 		description=_(
-			# Translators: Input help mode message for move review cursor to end of current line command.
-			"Moves the review cursor to the last character of the line "
-			"where it is situated in the current navigator object and speaks it",
+			# Translators: Input help mode message for move review cursor to start of selection command.
+			"Moves the review cursor to the first character of the selection, and speaks it"
 		),
 		category=SCRCAT_TEXTREVIEW,
-		gestures=("kb:shift+numpad3", "kb(laptop):NVDA+end"),
+		gesture="kb:NVDA+alt+home",
 	)
-	def script_review_endOfLine(self, gesture: inputCore.InputGesture):
-		info = api.getReviewPosition().copy()
-		info.expand(textInfos.UNIT_LINE)
+	def script_review_startOfSelection(self, gesture: inputCore.InputGesture):
+		info = self._getSelection()
+		if info is None:
+			return
+		info.collapse()
+
+		# This script is available on the lock screen via getSafeScripts, as such
+		# ensure the review position does not contain secure information
+		# before announcing this object
+		if api.setReviewPosition(info):
+			info.expand(textInfos.UNIT_CHARACTER)
+			speech.speakTextInfo(
+				info,
+				unit=textInfos.UNIT_CHARACTER,
+				reason=controlTypes.OutputReason.CARET,
+			)
+		else:
+			ui.reviewMessage(gui.blockAction.Context.WINDOWS_LOCKED.translatedMessage)
+
+	@script(
+		description=_(
+			# Translators: Input help mode message for move review cursor to end of selection command.
+			"Moves the review cursor to the last character of the selection, and speaks it"
+		),
+		category=SCRCAT_TEXTREVIEW,
+		gesture="kb:NVDA+alt+end",
+	)
+	def script_review_endOfSelection(self, gesture: inputCore.InputGesture):
+		info = self._getSelection()
+		if info is None:
+			return
 		info.collapse(end=True)
 		info.move(textInfos.UNIT_CHARACTER, -1)
 
@@ -2213,7 +2263,6 @@ class GlobalCommands(ScriptableObject):
 			)
 		else:
 			ui.reviewMessage(gui.blockAction.Context.WINDOWS_LOCKED.translatedMessage)
-			return
 
 	def _getCurrentLanguageForTextInfo(self, info):
 		curLanguage = None

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -2211,6 +2211,35 @@ class GlobalCommands(ScriptableObject):
 
 	@script(
 		description=_(
+			# Translators: Input help mode message for move review cursor to end of current line command.
+			"Moves the review cursor to the last character of the line "
+			"where it is situated in the current navigator object and speaks it",
+		),
+		category=SCRCAT_TEXTREVIEW,
+		gestures=("kb:shift+numpad3", "kb(laptop):NVDA+end"),
+	)
+	def script_review_endOfLine(self, gesture: inputCore.InputGesture):
+		info = api.getReviewPosition().copy()
+		info.expand(textInfos.UNIT_LINE)
+		info.collapse(end=True)
+		info.move(textInfos.UNIT_CHARACTER, -1)
+
+		# This script is available on the lock screen via getSafeScripts, as such
+		# ensure the review position does not contain secure information
+		# before announcing this object
+		if api.setReviewPosition(info):
+			info.expand(textInfos.UNIT_CHARACTER)
+			speech.speakTextInfo(
+				info,
+				unit=textInfos.UNIT_CHARACTER,
+				reason=controlTypes.OutputReason.CARET,
+			)
+		else:
+			ui.reviewMessage(gui.blockAction.Context.WINDOWS_LOCKED.translatedMessage)
+			return
+
+	@script(
+		description=_(
 			# Translators: Input help mode message for move review cursor to start of selection command.
 			"Moves the review cursor to the first character of the selection, and speaks it",
 		),

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -390,7 +390,7 @@ class GlobalCommands(ScriptableObject):
 			info = obj.makeTextInfo(textInfos.POSITION_SELECTION)
 		except (RuntimeError, NotImplementedError):
 			info = None
-		if not info or info.isCollapsed:
+		if info is None or info.isCollapsed:
 			# Translators: The message reported when there is no selection
 			ui.message(_("No selection"))
 			return None

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -123,6 +123,8 @@ SCRCAT_AUDIO = _("Audio")
 # Translators: Reported when there are no settings to configure in synth settings ring
 # (example: when there is no setting for language).
 NO_SETTINGS_MSG = _("No settings")
+# Translators: Reported when there is no selection
+NO_SELECTION_MESSAGE = _("No selection")
 
 
 def toggleBooleanValue(
@@ -388,14 +390,9 @@ class GlobalCommands(ScriptableObject):
 			obj = treeInterceptor
 		try:
 			info = obj.makeTextInfo(textInfos.POSITION_SELECTION)
+			return info.copy()
 		except (RuntimeError, NotImplementedError):
-			info = None
-		if info is None or info.isCollapsed:
-			# Translators: The message reported when there is no selection
-			ui.message(_("No selection"))
 			return None
-		selection = info.copy()
-		return selection
 
 	@script(
 		description=_(
@@ -2248,7 +2245,8 @@ class GlobalCommands(ScriptableObject):
 	)
 	def script_review_startOfSelection(self, gesture: inputCore.InputGesture):
 		info = self._getSelection()
-		if info is None:
+		if info is None or info.isCollapsed:
+			ui.message(NO_SELECTION_MESSAGE)
 			return
 		info.collapse()
 
@@ -2275,7 +2273,8 @@ class GlobalCommands(ScriptableObject):
 	)
 	def script_review_endOfSelection(self, gesture: inputCore.InputGesture):
 		info = self._getSelection()
-		if info is None:
+		if info is None or info.isCollapsed:
+			ui.message(NO_SELECTION_MESSAGE)
 			return
 		info.move(textInfos.UNIT_CHARACTER, -1, "end")
 		info.collapse(end=True)

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -2248,8 +2248,8 @@ class GlobalCommands(ScriptableObject):
 		info = self._getSelection()
 		if info is None:
 			return
+		info.move(textInfos.UNIT_CHARACTER, -1, "end")
 		info.collapse(end=True)
-		info.move(textInfos.UNIT_CHARACTER, -1)
 
 		# This script is available on the lock screen via getSafeScripts, as such
 		# ensure the review position does not contain secure information

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -2212,7 +2212,7 @@ class GlobalCommands(ScriptableObject):
 	@script(
 		description=_(
 			# Translators: Input help mode message for move review cursor to start of selection command.
-			"Moves the review cursor to the first character of the selection, and speaks it"
+			"Moves the review cursor to the first character of the selection, and speaks it",
 		),
 		category=SCRCAT_TEXTREVIEW,
 		gesture="kb:NVDA+alt+home",
@@ -2239,7 +2239,7 @@ class GlobalCommands(ScriptableObject):
 	@script(
 		description=_(
 			# Translators: Input help mode message for move review cursor to end of selection command.
-			"Moves the review cursor to the last character of the selection, and speaks it"
+			"Moves the review cursor to the last character of the selection, and speaks it",
 		),
 		category=SCRCAT_TEXTREVIEW,
 		gesture="kb:NVDA+alt+end",

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -41,7 +41,7 @@ To use this feature, "allow NVDA to control the volume of other applications" mu
 * Default input and output braille tables can now be determined based on the NVDA language. (#17306, #16390, #290, @nvdaes)
 * In Microsoft Word, when using the "report focus" command, the document layout will be announced if this information is available and reporting object descriptions is enabled. (#15088, @nvdaes)
 * NVDA will now only warn about add-on incompatibility when updating to a version which has an incompatible add-on API to the currently installed copy. (#17071)
-* Added commands to move the review cursor to the first and last character of the selected text, assigned to `NVDA+alt+home` and `NVDA+alt+end` (#17299, @nvdaes)
+* Added commands to move the review cursor to the first and last character of the selected text, assigned to `NVDA+alt+home` and `NVDA+alt+end`, respectively. (#17299, @nvdaes)
 
 ### Bug Fixes
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -41,6 +41,7 @@ To use this feature, "allow NVDA to control the volume of other applications" mu
 * Default input and output braille tables can now be determined based on the NVDA language. (#17306, #16390, #290, @nvdaes)
 * In Microsoft Word, when using the "report focus" command, the document layout will be announced if this information is available and reporting object descriptions is enabled. (#15088, @nvdaes)
 * NVDA will now only warn about add-on incompatibility when updating to a version which has an incompatible add-on API to the currently installed copy. (#17071)
+* Added commands to move the review cursor to the first and last character of the selected text, assigned to `NVDA+alt+home` and `NVDA+alt+end` (#17299, @nvdaes)
 
 ### Bug Fixes
 

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -843,6 +843,8 @@ The following commands are available for reviewing text:
 |Move to end of line in review |shift+numpad3 |NVDA+end |none |Moves the review cursor to the end of the current line of text|
 |Move to previous page in review |`NVDA+pageUp` |`NVDA+shift+pageUp` |none |Moves the review cursor to the previous page of text if supported by the application|
 |Move to next page in review |`NVDA+pageDown` |`NVDA+shift+pageDown` |none |Moves the review cursor to the next page of text if supported by the application|
+|Move to start of selection |NVDA+alt+home |NVDA+alt+home |none |Moves the review cursor to the first character of the selected text|
+|Move to end of selection |NVDA+alt+end |NVDA+alt+end |none |Moves the review cursor to the last character of the selected text|
 |Say all with review |numpadPlus |NVDA+shift+a |3-finger flick down (text mode) |Reads from the current position of the review cursor, moving it as it goes|
 |Select then Copy from review cursor |NVDA+f9 |NVDA+f9 |none |Starts the select then copy process from the current position of the review cursor. The actual action is not performed until you tell NVDA where the end of the text range is|
 |Select then Copy to review cursor |NVDA+f10 |NVDA+f10 |none |On the first press, text is selected from the position previously set as start marker up to and including the review cursor's current position. If the system caret can reach the text, it will be moved to the selected text. After pressing this key stroke a second time, the text will be copied to the Windows clipboard|

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -843,8 +843,8 @@ The following commands are available for reviewing text:
 |Move to end of line in review |shift+numpad3 |NVDA+end |none |Moves the review cursor to the end of the current line of text|
 |Move to previous page in review |`NVDA+pageUp` |`NVDA+shift+pageUp` |none |Moves the review cursor to the previous page of text if supported by the application|
 |Move to next page in review |`NVDA+pageDown` |`NVDA+shift+pageDown` |none |Moves the review cursor to the next page of text if supported by the application|
-|Move to start of selection |NVDA+alt+home |NVDA+alt+home |none |Moves the review cursor to the first character of the selected text|
-|Move to end of selection |NVDA+alt+end |NVDA+alt+end |none |Moves the review cursor to the last character of the selected text|
+|Move to start of selection in review |NVDA+alt+home |NVDA+alt+home |none |Moves the review cursor to the first character of the selected text|
+|Move to end of selection in review |NVDA+alt+end |NVDA+alt+end |none |Moves the review cursor to the last character of the selected text|
 |Say all with review |numpadPlus |NVDA+shift+a |3-finger flick down (text mode) |Reads from the current position of the review cursor, moving it as it goes|
 |Select then Copy from review cursor |NVDA+f9 |NVDA+f9 |none |Starts the select then copy process from the current position of the review cursor. The actual action is not performed until you tell NVDA where the end of the text range is|
 |Select then Copy to review cursor |NVDA+f10 |NVDA+f10 |none |On the first press, text is selected from the position previously set as start marker up to and including the review cursor's current position. If the system caret can reach the text, it will be moved to the selected text. After pressing this key stroke a second time, the text will be copied to the Windows clipboard|


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Fixes #17299
### Summary of the issue:
NVDA doesn't have commands to move the review cursor to start and end of selection, which may be useful to review the selected text.
### Description of user facing changes
`NVDA+alt+home` and `NVDA+alt+end` can be used to move the review cursor to the first and last carácter of selected text.
### Description of development approach
In globalCommands.py, GlobalCommands class, a staticmethod has been added to get the current selection. This is used to scripts added to move the review cursor to start and end of selection, similar to other scripts used to move the review cursor.
### Testing strategy:
Tested manually in a webpage and in Notepad.
### Known issues with pull request:
None.
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
