### PR TITLE
Fix bug to move braille to next line in UIA documents

### DIFF
--- a/source/braille.py
+++ b/source/braille.py
@@ -1646,6 +1646,7 @@ class TextInfoRegion(Region):
 
 	def nextLine(self):
 		dest = self._readingInfo.copy()
+		shouldCollapseToEnd = False
 		moved = dest.move(self._getReadingUnit(), 1)
 		if not moved:
 			if self.allowPageTurns and isinstance(dest.obj, textInfos.DocumentWithPageTurns):
@@ -1656,8 +1657,8 @@ class TextInfoRegion(Region):
 				else:
 					dest = dest.obj.makeTextInfo(textInfos.POSITION_FIRST)
 			else:  # no page turn support
-				return
-		dest.collapse()
+				shouldCollapseToEnd = True
+		dest.collapse(shouldCollapseToEnd)
 		self._setCursor(dest)
 		_speakOnNavigatingByUnit(dest, self._getReadingUnit())
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -67,6 +67,7 @@ Specifically, MathML inside of span and other elements that have the attribute `
 * If the plugins are reloaded while a browseable message is opened, NVDA will no longer fail to report subsequent focus moves. (#17323, @CyrilleB79)
 * When using applications such as Skype, Discord, Signal and Phone Link for audio communication, NVDA speech and sounds no longer decrease in volume. (#17349, @jcsteh)
 * Opening the NVDA Python Console will no longer fail in case an error occurs while retrieving snapshot variables. (#17391, @CyrilleB79)
+* In Notepad and other UIA documents on Windows 11, if the last line is empty, the `braille next line command` will move the cursor to the last line. In any document, if the cursor is in the last line, it will be moved to the end when using this command (#17251, @nvdaes)
 
 ### Changes for Developers
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -67,7 +67,8 @@ Specifically, MathML inside of span and other elements that have the attribute `
 * If the plugins are reloaded while a browseable message is opened, NVDA will no longer fail to report subsequent focus moves. (#17323, @CyrilleB79)
 * When using applications such as Skype, Discord, Signal and Phone Link for audio communication, NVDA speech and sounds no longer decrease in volume. (#17349, @jcsteh)
 * Opening the NVDA Python Console will no longer fail in case an error occurs while retrieving snapshot variables. (#17391, @CyrilleB79)
-* In Notepad and other UIA documents on Windows 11, if the last line is empty, the `braille next line command` will move the cursor to the last line. In any document, if the cursor is in the last line, it will be moved to the end when using this command (#17251, @nvdaes)
+* In Notepad and other UIA documents on Windows 11, if the last line is empty, the `braille next line command` will move the cursor to the last line.
+In any document, if the cursor is in the last line, it will be moved to the end when using this command. (#17251, @nvdaes)
 
 ### Changes for Developers
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -68,7 +68,7 @@ Specifically, MathML inside of span and other elements that have the attribute `
 * When using applications such as Skype, Discord, Signal and Phone Link for audio communication, NVDA speech and sounds no longer decrease in volume. (#17349, @jcsteh)
 * Opening the NVDA Python Console will no longer fail in case an error occurs while retrieving snapshot variables. (#17391, @CyrilleB79)
 * In Notepad and other UIA documents on Windows 11, if the last line is empty, the `braille next line command` will move the cursor to the last line.
-In any document, if the cursor is in the last line, it will be moved to the end when using this command. (#17251, @nvdaes)
+In any document, if the cursor is on the last line, it will be moved to the end when using this command. (#17251, @nvdaes)
 
 ### Changes for Developers
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Fixes #17251
### Summary of the issue:
In some UIA documents which end with an empty line, braille cannot be moved to the last line.
### Description of user facing changes
Braille can be moved to the last line in all UIA documents.
If the braille move to next line command is run from the last line, the cursor will be moved to the last character. In this case, if the review cursor follows system cursor, the review cursor will also be moved.
### Description of development approach
A `shouldCollapseToEnd` variable has been added to the method to move braille to the next line, to determine if text info should be collapsed to end. When braille is not moved to the next line using other procedures, `shouldCollapseToEnd` is set to True and text info is collapsed to end.
### Testing strategy:
Tested manually in Notepad.
### Known issues with pull request:
None.
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
