### PR TITLE
    Report the update of the selection when using Word selection extend / reduce commmands (`f8` or `shift+f8`)

### DIFF
--- a/source/NVDAObjects/window/winword.py
+++ b/source/NVDAObjects/window/winword.py
@@ -1975,6 +1975,8 @@ class WordDocument(Window):
 			self.bindGesture("kb:alt+shift+end", "caret_changeSelection")
 			self.bindGesture("kb:alt+shift+pageUp", "caret_changeSelection")
 			self.bindGesture("kb:alt+shift+pageDown", "caret_changeSelection")
+			self.bindGesture("kb:f8", "caret_changeSelection")
+			self.bindGesture("kb:shift+f8", "caret_changeSelection")
 
 	__gestures = {
 		"kb:control+pageUp": "caret_moveByLine",

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -26,6 +26,7 @@ To use this feature, "allow NVDA to control the volume of other applications" mu
 * When toggling double underline in LibreOffice Writer using the corresponding keyboard shortcut, NVDA announces the new state ("double underline on"/"double underline off"). (#6915, @michaelweghorn)
 * Automatic language switching is now supported when using Microsoft Speech API version 5 (SAPI5) and Microsoft Speech Platform voices. (#17146, @gexgd0419)
 * NVDA can now be configured to speak the current line or paragraph when navigating with braille navigation keys. (#17053, @nvdaes)
+* In Word, the selection update is now reported when using Word commands to extend or reduce the selection (`f8` or `shift+f8`). (#3293, @CyrilleB79)
 
 ### Changes
 


### PR DESCRIPTION
### Link to issue number:
Partially fixes #3293.

### Summary of the issue:
When using `f8` (extend selection) or `shift+f8` (reduce selection) in Word, the selection changes are not reported.

### Description of user facing changes
When using `f8` (extend selection) or `shift+f8` (reduce selection) in Word, the selection changes will now be reported.
If the selection is extended / reduced at both ends, two consecutive selection update messages are reported, as done for `control+a` (select all).

### Description of development approach
In `WordDocument.initOverlayClass`, bind `script_caret_changeSelection` to `f8` and `shift+f8`, as already done for other gestures such as `alt+shift+home` or `alt+shift+pageDown`.

### Testing strategy:
Manual test of `f8` and `shift+f8` in Word and Outlook, with and without UIA.
Test made on Windows 10, Word 2016 (Microsoft® Word 2016 MSO (Version 2410 Build 16.0.18129.20158) 32 bits).

### Known issues with pull request:
This PR only reports selection change when `f8`/`shift+f8` is pressed.

Though this PR does not fix the following issues:
* "extend selection" mode" enabled or disabled upon first press on `F8` or when pressing `escape` is not reported.
* While in "extend selection mode", pressing left/right arrows reports the first character of the selection, what is unuseful, before reporting the selection change;

Since these issues were pre-existing to this PR, my opinion is that this PR is already an improvement of the "extend selection mode" usage with respect to what was occurring before.

### Code Review Checklist:


- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
