### PR TITLE
Report the result of word switch case formatting command

### DIFF
--- a/source/NVDAObjects/window/winword.py
+++ b/source/NVDAObjects/window/winword.py
@@ -295,9 +295,9 @@ class WdCharacterCase(DisplayStringIntEnum):
 			# Translators: a Microsoft Word character case type
 			WdCharacterCase.NO_CASE: _("No case"),
 			# Translators: a Microsoft Word character case type
-			WdCharacterCase.LOWER_CASE: _("lowercase"),
+			WdCharacterCase.LOWER_CASE: _("Lowercase"),
 			# Translators: a Microsoft Word character case type
-			WdCharacterCase.UPPER_CASE: _("UUPPERCASE"),
+			WdCharacterCase.UPPER_CASE: _("Uppercase"),
 			# Translators: a Microsoft Word character case type
 			WdCharacterCase.TITLE_WORD: _("Each word capitalized"),
 			# Translators: a Microsoft Word character case type
@@ -305,7 +305,7 @@ class WdCharacterCase(DisplayStringIntEnum):
 			# Translators: a Microsoft Word character case type
 			WdCharacterCase.MIXED_CASE: _("Mixed case"),
 			# Translators: a Microsoft Word character case type
-			WdCharacterCase.HALF_WIDTH: _("Half width:"),
+			WdCharacterCase.HALF_WIDTH: _("Half width"),
 			# Translators: a Microsoft Word character case type
 			WdCharacterCase.FULL_WIDTH: _("Full width"),
 			# Translators: a Microsoft Word character case type

--- a/source/NVDAObjects/window/winword.py
+++ b/source/NVDAObjects/window/winword.py
@@ -1752,7 +1752,9 @@ class WordDocument(Window):
 			# We cannot fetch the Word object model, so we therefore cannot report the format change.
 			# The object model may be unavailable because this is a pure UIA implementation such as Windows 10 Mail,
 			# or its within Windows Defender Application Guard.
-			not self.WinwordSelectionObject or scriptHandler.isScriptWaiting()
+			not self.WinwordSelectionObject 
+			# Or we do not want to apply the delay due in case of multipe repetition of the script.
+			or scriptHandler.isScriptWaiting()
 		):
 			# Just let the gesture through and don't report anything.
 			return gesture.send()

--- a/source/NVDAObjects/window/winword.py
+++ b/source/NVDAObjects/window/winword.py
@@ -295,9 +295,9 @@ class WdCharacterCase(DisplayStringIntEnum):
 			# Translators: a Microsoft Word character case type
 			WdCharacterCase.NO_CASE: _("No case"),
 			# Translators: a Microsoft Word character case type
-			WdCharacterCase.LOWER_CASE: _("Lowercase"),
+			WdCharacterCase.LOWER_CASE: _("lowercase"),
 			# Translators: a Microsoft Word character case type
-			WdCharacterCase.UPPER_CASE: _("Uppercase"),
+			WdCharacterCase.UPPER_CASE: _("UUPPERCASE"),
 			# Translators: a Microsoft Word character case type
 			WdCharacterCase.TITLE_WORD: _("Each word capitalized"),
 			# Translators: a Microsoft Word character case type

--- a/source/NVDAObjects/window/winword.py
+++ b/source/NVDAObjects/window/winword.py
@@ -1747,7 +1747,7 @@ class WordDocument(Window):
 			ui.message(_("Caps off"))
 
 	@script(gesture="kb:shift+f3")
-	def script_changeCase(self, gesture):
+	def script_changeCase(self, gesture: "inputCore.InputGesture"):
 		if (
 			# We cannot fetch the Word object model, so we therefore cannot report the format change.
 			# The object model may be unavailable because this is a pure UIA implementation such as Windows 10 Mail,

--- a/source/NVDAObjects/window/winword.py
+++ b/source/NVDAObjects/window/winword.py
@@ -1752,7 +1752,7 @@ class WordDocument(Window):
 			# We cannot fetch the Word object model, so we therefore cannot report the format change.
 			# The object model may be unavailable because this is a pure UIA implementation such as Windows 10 Mail,
 			# or its within Windows Defender Application Guard.
-			not self.WinwordSelectionObject 
+			not self.WinwordSelectionObject
 			# Or we do not want to apply the delay due in case of multipe repetition of the script.
 			or scriptHandler.isScriptWaiting()
 		):

--- a/source/NVDAObjects/window/winword.py
+++ b/source/NVDAObjects/window/winword.py
@@ -1745,18 +1745,18 @@ class WordDocument(Window):
 		else:
 			# Translators: a message when toggling formatting to 'No capital' in Microsoft word
 			ui.message(_("Caps off"))
-	
+
 	@script(gesture="kb:shift+f3")
 	def script_changeCase(self, gesture):
 		if (
 			# We cannot fetch the Word object model, so we therefore cannot report the format change.
 			# The object model may be unavailable because this is a pure UIA implementation such as Windows 10 Mail,
 			# or its within Windows Defender Application Guard.
-			not self.WinwordSelectionObject
-			or scriptHandler.isScriptWaiting()
+			not self.WinwordSelectionObject or scriptHandler.isScriptWaiting()
 		):
 			# Just let the gesture through and don't report anything.
 			return gesture.send()
+
 		def action():
 			gesture.send()
 			# The object model for the "case" property is not fully reliable when using switch case command. During
@@ -1764,6 +1764,7 @@ class WordDocument(Window):
 			# Outlook. Thus we artificially add an empirical delay after the gesture has been send and before the
 			# first check.
 			time.sleep(0.15)
+
 		val = self._WaitForValueChangeForAction(
 			action=action,
 			fetcher=lambda: self.WinwordSelectionObject.Range.Case,

--- a/source/appModules/outlook.py
+++ b/source/appModules/outlook.py
@@ -735,6 +735,10 @@ class OutlookWordDocument(WordDocument, BaseOutlookWordDocument):
 		True  # This includes page sections, and page columns. None of which are appropriate for outlook.
 	)
 
+	__gestures = {
+		"kb:control+shift+a": "changeCase",
+	}
+
 
 class OutlookUIAWordDocument(UIAWordDocument, BaseOutlookWordDocument):
 	"""Forces browse mode to be used on the UI Automation Outlook message viewer if the message is being read)."""


### PR DESCRIPTION
### Link to issue number:
Fixes #10271 (last part)
Also could be considered a partial fix of #3293.

### Summary of the issue:
In Word / Outlook, nothing is reported when using the switch case command (`shift+f3` in both, `control+shift+a` in Outlook only). Since it is a toggle/cycle command, the user needs to have the result to be reported.

### Description of user facing changes
Using the switch case formatting command in Word or Outlook now reports its result, i.e. the type of case in which the selection has been formatted.

When possible, the message being reported illustrates its own casing, as in Word menus, e.g. "lower case", "UPPERCASE", "Each Word Capitalized"; this may be useful in braille. Exception, for "Mixed case", I have not done something such as "mIxEd cAsE" because it is not correctly understandable through speech.

### Description of development approach
* Used Word object model as for other Word formatting scripts.
* Introduced a delay (set empirically), since the property retrieved from the object model transitions through other values (no case or lower case) before reaching its definitive value.
* Bind gestures according to the ones existing in Word and Outlook.

Note: `shift+f3` performs case switch both in Word and Outlook, whereas `control+shift+A` does it only in Outlook. See "Notes about various capitalization shortcuts" in #17197 for more details.

### Testing strategy:
Manual test:
Test `shift+f3` and `control+shift+A` in the following conditions:
* In Word and in Outlook
* With or without UIA
* With various types of selection: no selection, piece of word selected, word selected, few words selected, sentence selected, all selected, only digits or punctuation selected, mix of letters and digits selected (e.g. "a0b1" between other words).

### Known issues with pull request:
None
### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
