### PR TITLE
Add new extension points for keyboard input and speech pause

### DIFF
--- a/projectDocs/dev/developerGuide/developerGuide.md
+++ b/projectDocs/dev/developerGuide/developerGuide.md
@@ -1361,6 +1361,7 @@ For examples of how to define and use new extension points, please see the code 
 
 | Type |Extension Point |Description|
 |---|---|---|
+|`Decider` |`decide_handleRawKey` |Notifies when a raw keyboard event is received, before any NVDA processing, allowing other code to decide if it should be handled.|
 |`Decider` |`decide_executeGesture` |Notifies when a gesture is about to be executed, allowing other code to decide if it should be.|
 
 ### logHandler {#logHandlerExtPts}
@@ -1382,6 +1383,7 @@ For examples of how to define and use new extension points, please see the code 
 |`Action` |`speechCanceled` |Triggered when speech is canceled.|
 |`Action` |`pre_speechCanceled` |Triggered before speech is canceled.|
 |`Action` |`pre_speech` |Triggered before NVDA handles prepared speech.|
+|`Action` |`speechPaused` |Triggered when speech is paused or resumed.|
 |`Filter` |`filter_speechSequence` |Allows components or add-ons to filter speech sequence before it passes to the synth driver.|
 
 ### synthDriverHandler {#synthDriverHandlerExtPts}

--- a/projectDocs/dev/developerGuide/developerGuide.md
+++ b/projectDocs/dev/developerGuide/developerGuide.md
@@ -1383,7 +1383,7 @@ For examples of how to define and use new extension points, please see the code 
 |`Action` |`speechCanceled` |Triggered when speech is canceled.|
 |`Action` |`pre_speechCanceled` |Triggered before speech is canceled.|
 |`Action` |`pre_speech` |Triggered before NVDA handles prepared speech.|
-|`Action` |`speechPaused` |Triggered when speech is paused or resumed.|
+|`Action` |`post_speechPaused` |Triggered when speech is paused or resumed.|
 |`Filter` |`filter_speechSequence` |Allows components or add-ons to filter speech sequence before it passes to the synth driver.|
 
 ### synthDriverHandler {#synthDriverHandlerExtPts}

--- a/source/inputCore.py
+++ b/source/inputCore.py
@@ -456,16 +456,16 @@ decide_handleRawKey = extensionPoints.Decider()
 """
 Notifies when a raw keyboard event is received, before any NVDA processing.
 Handlers can decide whether the key should be processed by NVDA and/or passed to the OS.
-@param vkCode: The virtual key code
-@type vkCode: int
-@param scanCode: The scan code
-@type scanCode: int
-@param extended: Whether this is an extended key
-@type extended: bool
-@param pressed: Whether this is a key press or release
-@type pressed: bool
-@return: True to allow normal processing, False to block the key
-@rtype: bool
+:param vkCode: The virtual key code
+:type vkCode: int
+:param scanCode: The scan code
+:type scanCode: int
+:param extended: Whether this is an extended key
+:type extended: bool
+:param pressed: Whether this is a key press or release
+:type pressed: bool
+:return: True to allow normal processing, False to block the key
+:rtype: bool
 """
 
 decide_executeGesture = extensionPoints.Decider()

--- a/source/inputCore.py
+++ b/source/inputCore.py
@@ -457,10 +457,15 @@ decide_handleRawKey = extensionPoints.Decider()
 Notifies when a raw keyboard event is received, before any NVDA processing.
 Handlers can decide whether the key should be processed by NVDA and/or passed to the OS.
 @param vkCode: The virtual key code
+@type vkCode: int
 @param scanCode: The scan code
+@type scanCode: int
 @param extended: Whether this is an extended key
+@type extended: bool
 @param pressed: Whether this is a key press or release
+@type pressed: bool
 @return: True to allow normal processing, False to block the key
+@rtype: bool
 """
 
 decide_executeGesture = extensionPoints.Decider()

--- a/source/inputCore.py
+++ b/source/inputCore.py
@@ -452,6 +452,17 @@ class GlobalGestureMap:
 		return NotImplemented
 
 
+decide_handleRawKey = extensionPoints.Decider()
+"""
+Notifies when a raw keyboard event is received, before any NVDA processing.
+Handlers can decide whether the key should be processed by NVDA and/or passed to the OS.
+@param vkCode: The virtual key code
+@param scanCode: The scan code
+@param extended: Whether this is an extended key
+@param pressed: Whether this is a key press or release
+@return: True to allow normal processing, False to block the key
+"""
+
 decide_executeGesture = extensionPoints.Decider()
 """
 Notifies when a gesture is about to be executed,

--- a/source/keyboardHandler.py
+++ b/source/keyboardHandler.py
@@ -165,6 +165,13 @@ def shouldUseToUnicodeEx(focus: Optional["NVDAObject"] = None):
 
 def internal_keyDownEvent(vkCode, scanCode, extended, injected):
 	"""Event called by winInputHook when it receives a keyDown."""
+	if not inputCore.decide_handleRawKey.decide(
+		vkCode=vkCode,
+		scanCode=scanCode,
+		extended=extended,
+		pressed=True,
+	):
+		return False
 	gestureExecuted = False
 	try:
 		global \
@@ -313,6 +320,13 @@ def internal_keyDownEvent(vkCode, scanCode, extended, injected):
 
 def internal_keyUpEvent(vkCode, scanCode, extended, injected):
 	"""Event called by winInputHook when it receives a keyUp."""
+	if not inputCore.decide_handleRawKey.decide(
+		vkCode=vkCode,
+		scanCode=scanCode,
+		extended=extended,
+		pressed=False,
+	):
+		return False
 	try:
 		global \
 			lastNVDAModifier, \

--- a/source/speech/__init__.py
+++ b/source/speech/__init__.py
@@ -63,7 +63,7 @@ from .speech import (
 	spellTextInfo,
 	splitTextIndentation,
 )
-from .extensions import speechCanceled, speechPaused
+from .extensions import speechCanceled, post_speechPaused
 from .priorities import Spri
 
 from .types import (
@@ -142,7 +142,7 @@ __all__ = [
 	"spellTextInfo",
 	"splitTextIndentation",
 	"speechCanceled",
-	"speechPaused",
+	"post_speechPaused",
 ]
 
 import synthDriverHandler

--- a/source/speech/__init__.py
+++ b/source/speech/__init__.py
@@ -63,7 +63,7 @@ from .speech import (
 	spellTextInfo,
 	splitTextIndentation,
 )
-from .extensions import speechCanceled
+from .extensions import speechCanceled, speechPaused
 from .priorities import Spri
 
 from .types import (
@@ -142,6 +142,7 @@ __all__ = [
 	"spellTextInfo",
 	"splitTextIndentation",
 	"speechCanceled",
+	"speechPaused",
 ]
 
 import synthDriverHandler

--- a/source/speech/extensions.py
+++ b/source/speech/extensions.py
@@ -26,8 +26,8 @@ post_speechPaused = Action()
 """
 Notifies when speech is paused.
 
-@param switch: True if speech is paused, False if speech is resumed.
-@type switch: bool
+:param switch: True if speech is paused, False if speech is resumed.
+:type switch: bool
 """
 
 pre_speech = Action()

--- a/source/speech/extensions.py
+++ b/source/speech/extensions.py
@@ -22,6 +22,14 @@ Notifies when speech is about to be canceled.
 Handlers are called without arguments.
 """
 
+speechPaused = Action()
+"""
+Notifies when speech is paused.
+
+@param switch: True if speech is paused, False if speech is resumed.
+@type switch: bool
+"""
+
 pre_speech = Action()
 """
 Notifies when code attempts to speak text.

--- a/source/speech/extensions.py
+++ b/source/speech/extensions.py
@@ -22,7 +22,7 @@ Notifies when speech is about to be canceled.
 Handlers are called without arguments.
 """
 
-speechPaused = Action()
+post_speechPaused = Action()
 """
 Notifies when speech is paused.
 

--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -27,7 +27,7 @@ import languageHandler
 from textUtils import unicodeNormalize
 from textUtils.uniscribe import splitAtCharacterBoundaries
 from . import manager
-from .extensions import speechCanceled, pre_speechCanceled, pre_speech
+from .extensions import speechCanceled, speechPaused, pre_speechCanceled, pre_speech
 from .extensions import filter_speechSequence
 from .commands import (
 	# Commands that are used in this file.
@@ -211,6 +211,7 @@ def cancelSpeech():
 
 def pauseSpeech(switch):
 	getSynth().pause(switch)
+	speechPaused.notify(switch=switch)
 	_speechState.isPaused = switch
 	_speechState.beenCanceled = False
 

--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -27,7 +27,7 @@ import languageHandler
 from textUtils import unicodeNormalize
 from textUtils.uniscribe import splitAtCharacterBoundaries
 from . import manager
-from .extensions import speechCanceled, speechPaused, pre_speechCanceled, pre_speech
+from .extensions import speechCanceled, post_speechPaused, pre_speechCanceled, pre_speech
 from .extensions import filter_speechSequence
 from .commands import (
 	# Commands that are used in this file.
@@ -211,7 +211,7 @@ def cancelSpeech():
 
 def pauseSpeech(switch):
 	getSynth().pause(switch)
-	speechPaused.notify(switch=switch)
+	post_speechPaused.notify(switch=switch)
 	_speechState.isPaused = switch
 	_speechState.beenCanceled = False
 

--- a/tests/unit/test_speech.py
+++ b/tests/unit/test_speech.py
@@ -18,7 +18,7 @@ from speech import (
 	cancelSpeech,
 	pauseSpeech,
 	speechCanceled,
-	speechPaused,
+	post_speechPaused,
 )
 from speech.commands import (
 	BeepCommand,
@@ -594,9 +594,9 @@ class SpeechExtensionPoints(unittest.TestCase):
 		):
 			cancelSpeech()
 
-	def test_speechPausedExtensionPoint(self):
-		with actionTester(self, speechPaused, switch=True):
+	def test_post_speechPausedExtensionPoint(self):
+		with actionTester(self, post_speechPaused, switch=True):
 			pauseSpeech(True)
 
-		with actionTester(self, speechPaused, switch=False):
+		with actionTester(self, post_speechPaused, switch=False):
 			pauseSpeech(False)

--- a/tests/unit/test_speech.py
+++ b/tests/unit/test_speech.py
@@ -16,7 +16,9 @@ from speech import (
 	_getSpellingSpeechAddCharMode,
 	_getSpellingSpeechWithoutCharMode,
 	cancelSpeech,
+	pauseSpeech,
 	speechCanceled,
+	speechPaused,
 )
 from speech.commands import (
 	BeepCommand,
@@ -591,3 +593,10 @@ class SpeechExtensionPoints(unittest.TestCase):
 			speechCanceled,
 		):
 			cancelSpeech()
+
+	def test_speechPausedExtensionPoint(self):
+		with actionTester(self, speechPaused, switch=True):
+			pauseSpeech(True)
+
+		with actionTester(self, speechPaused, switch=False):
+			pauseSpeech(False)

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -106,7 +106,7 @@ Add-ons will need to be re-tested and have their manifest updated.
 * Retrieving the `labeledBy` property now works for UIA elements supporting the corresponding `LabeledBy` UIA property. (#17442, @michaelweghorn)
 * Added the following extension points (#17428):
   * `inputCore.decide_handleRawKey`: called on each keypress
-  * `speech.extensions.post_speechPaused`: Called when speech is paused or unpaused
+  * `speech.extensions.post_speechPaused`: called when speech is paused or unpaused
 
 #### API Breaking Changes
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -104,10 +104,9 @@ Add-ons will need to be re-tested and have their manifest updated.
 * Added the [VS Code workspace configuration for NVDA](https://nvaccess.org/nvaccess/vscode-nvda) as a git submodule. (#17003)
 * In the `brailleTables` module, a `getDefaultTableForCurrentLang` function has been added (#17222, @nvdaes)
 * Retrieving the `labeledBy` property now works for UIA elements supporting the corresponding `LabeledBy` UIA property. (#17442, @michaelweghorn)
-* Added the following extension points:
-  * inputCore.decide_handleRawKey: called on each keypress
-  * speech.extensions.speechPaused: Called when speech is paused or unpaused
-pause)
+* Added the following extension points (#17428):
+  * `inputCore.decide_handleRawKey`: called on each keypress
+  * `speech.extensions.post_speechPaused`: Called when speech is paused or unpaused
 
 #### API Breaking Changes
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -104,7 +104,7 @@ Add-ons will need to be re-tested and have their manifest updated.
 * Added the [VS Code workspace configuration for NVDA](https://nvaccess.org/nvaccess/vscode-nvda) as a git submodule. (#17003)
 * In the `brailleTables` module, a `getDefaultTableForCurrentLang` function has been added (#17222, @nvdaes)
 * Retrieving the `labeledBy` property now works for UIA elements supporting the corresponding `LabeledBy` UIA property. (#17442, @michaelweghorn)
-* Added the following extension points (#17428):
+* Added the following extension points (#17428, @ctoth):
   * `inputCore.decide_handleRawKey`: called on each keypress
   * `speech.extensions.post_speechPaused`: called when speech is paused or unpaused
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -104,6 +104,10 @@ Add-ons will need to be re-tested and have their manifest updated.
 * Added the [VS Code workspace configuration for NVDA](https://nvaccess.org/nvaccess/vscode-nvda) as a git submodule. (#17003)
 * In the `brailleTables` module, a `getDefaultTableForCurrentLang` function has been added (#17222, @nvdaes)
 * Retrieving the `labeledBy` property now works for UIA elements supporting the corresponding `LabeledBy` UIA property. (#17442, @michaelweghorn)
+* Added the following extension points:
+  * inputCore.decide_handleRawKey: called on each keypress
+  * speech.extensions.speechPaused: Called when speech is paused or unpaused
+pause)
 
 #### API Breaking Changes
 


### PR DESCRIPTION
Add new extension points for raw keyboard events and speech pause state

This commit introduces two new extension points:

1. inputCore.decide_handleRawKey
- Called before any NVDA processing of raw keyboard events
- Allows add-ons to intercept and optionally block keyboard events
- Provides full context: vkCode, scanCode, extended flag, and press/release state
- Implemented in both keyDown and keyUp event handlers
- Returns True to allow normal processing, False to block the key

2. speech.extensions.speechPaused
- Notifies when speech is paused or resumed 
- Provides boolean 'switch' parameter (True=paused, False=resumed)
- Added corresponding unit tests to verify functionality
- Integrated into existing pauseSpeech() function

Technical Details:
- Added documentation for both extension points in developerGuide.md
- Updated speech/__init__.py to expose the new speechPaused extension point
- Added test case in test_speech.py to verify extension point behavior
- Maintains backwards compatibility with existing extensions

These additions enable add-ons to:
- Implement advanced keyboard interception/modification
- React to speech pause state changes

### Link to issue number:
N/A - New feature addition for extensibility

### Summary of the issue:
NVDA needed additional extension points to allow add-ons to:
1. Intercept and control raw keyboard events before NVDA processing
2. Monitor and react to speech pause state changes

### Description of user facing changes
- No direct user-facing changes
- Enables add-on developers to create more sophisticated keyboard handling and speech feedback features
- All changes are API-level additions that maintain backwards compatibility

### Description of development approach
1. Raw Keyboard Extension Point:
   - Added `decide_handleRawKey` extension point in inputCore.py
   - Integrated into both keyDown and keyUp event handlers in keyboardHandler.py
   - Full keyboard event context provided (vkCode, scanCode, extended, pressed)
   - Boolean return value controls event propagation

2. Speech Pause Extension Point:
   - Added `speechPaused` extension point in speech/extensions.py
   - Integrated into existing pauseSpeech() function
   - Provides pause state through boolean parameter

3. Documentation:
   - Added entries in developerGuide.md
   - Updated relevant module documentation
   - Added changelog entry

### Testing strategy:
1. Unit Tests:
   - Added test cases in test_speech.py for speechPaused extension point
   - Tests verify extension point notification on pause/resume
   - Tests ensure correct parameter passing

2. Manual Testing:
   - Verified keyboard extension point with test add-on
   - Confirmed speech pause notifications work as expected

### Known issues with pull request:
None identified - straightforward API additions with full test coverage

### Code Review Checklist:

- [x] Documentation:
  - Change log entry added in changes.md
  - Developer documentation updated in developerGuide.md
  - Technical documentation added in module docstrings
  - No GUI changes, so no context help needed

- [x] Testing:
  - Unit tests added for speechPaused
  - Manual testing performed with test add-on
  - System tests not required (API-level changes)

- [x] UX of all users considered:
  - No direct user impact
  - Enables better add-on support for all output methods
  - No localization impact (API only)

- [x] API is compatible with existing add-ons
  - New extension points are additive only
  - No breaking changes to existing APIs
  - Follows established extension point patterns

- [x] Security precautions taken:
  - Discussed raw keystroke decider security implications with NV Access.

@coderabbitai summary

