### PR TITLE
Fix braille next line command for documents of Notepad++

### DIFF
--- a/source/NVDAObjects/window/scintilla.py
+++ b/source/NVDAObjects/window/scintilla.py
@@ -319,7 +319,7 @@ class ScintillaTextInfo(textInfos.offsets.OffsetsTextInfo):
 		in Notepad++ documents.
 		https://github.com/nvaccess/nvda/issues/17430
 		"""
-		if end:
+		if end and self.obj.makeTextInfo(textInfos.POSITION_SELECTION).isCollapsed:
 			self.expand(textInfos.UNIT_LINE)
 		super().collapse(end=end)
 

--- a/source/NVDAObjects/window/scintilla.py
+++ b/source/NVDAObjects/window/scintilla.py
@@ -314,7 +314,7 @@ class ScintillaTextInfo(textInfos.offsets.OffsetsTextInfo):
 		return [start, end]
 
 	def collapse(self, end=False):
-		"""Before collapsing to end, TextInfo is expanded to line.
+		"""Before collapsing to end, if no text is selected, TextInfo is expanded to line.
 		This fixes a bug where next braille line command didn't move the cursor to the last empty line
 		in Notepad++ documents.
 		https://github.com/nvaccess/nvda/issues/17430

--- a/source/NVDAObjects/window/scintilla.py
+++ b/source/NVDAObjects/window/scintilla.py
@@ -314,6 +314,11 @@ class ScintillaTextInfo(textInfos.offsets.OffsetsTextInfo):
 		return [start, end]
 
 	def collapse(self, end=False):
+		"""Before collapsing to end, TextInfo is expanded to line.
+		This fixes a bug where next braille line command didn't move the cursor to the last empty line
+		in Notepad++ documents.
+		https://github.com/nvaccess/nvda/issues/17430
+		"""
 		if end:
 			self.expand(textInfos.UNIT_LINE)
 		super().collapse(end=end)

--- a/source/NVDAObjects/window/scintilla.py
+++ b/source/NVDAObjects/window/scintilla.py
@@ -313,7 +313,7 @@ class ScintillaTextInfo(textInfos.offsets.OffsetsTextInfo):
 				tempOffset -= 1
 		return [start, end]
 
-	def collapse(self, end=False):
+	def collapse(self, end: bool = False):
 		"""Before collapsing to end, if no text is selected, TextInfo is expanded to line.
 		This fixes a bug where next braille line command didn't move the cursor to the last empty line
 		in Notepad++ documents.

--- a/source/NVDAObjects/window/scintilla.py
+++ b/source/NVDAObjects/window/scintilla.py
@@ -313,6 +313,11 @@ class ScintillaTextInfo(textInfos.offsets.OffsetsTextInfo):
 				tempOffset -= 1
 		return [start, end]
 
+	def collapse(self, end=False):
+		if end:
+			self.expand(textInfos.UNIT_LINE)
+		super().collapse(end=end)
+
 
 # The Scintilla NVDA object, inherists the generic MSAA NVDA object
 class Scintilla(EditableTextWithAutoSelectDetection, Window):

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -116,7 +116,7 @@ As the NVDA update check URL is now configurable directly within NVDA, no replac
   * `SymphonyDocument.script_toggleTextAttribute` to `SymphonyDocument.script_changeTextFormatting`
 * The `space` keyword argument for `brailleDisplayDrivers.seikantk.InputGesture` now expects an `int` rather than a `bool`. (#17047, @school510587)
 * The `[upgrade]` configuration section including `[upgrade][newLaptopKeyboardLayout]` has been removed. (#17191)
-* in `NVDAObjects.window.scintilla.ScintillaTextInfo`, the `collapse` method is overriden to expand to line if the `end` parameter is set to `True` (#17431, @nvdaes)
+* in `NVDAObjects.window.scintilla.ScintillaTextInfo`, if no text is selected, the `collapse` method is overriden to expand to line if the `end` parameter is set to `True` (#17431, @nvdaes)
 
 #### Deprecations
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -68,7 +68,7 @@ Specifically, MathML inside of span and other elements that have the attribute `
 * If the plugins are reloaded while a browseable message is opened, NVDA will no longer fail to report subsequent focus moves. (#17323, @CyrilleB79)
 * When using applications such as Skype, Discord, Signal and Phone Link for audio communication, NVDA speech and sounds no longer decrease in volume. (#17349, @jcsteh)
 * Opening the NVDA Python Console will no longer fail in case an error occurs while retrieving snapshot variables. (#17391, @CyrilleB79)
-* In Notepad and other UIA documents, and Notepad++ on Windows 11, if the last line is empty, the `braille next line command` will move the cursor to the last line.
+* In Notepad and other UIA documents, and Notepad++ documents on Windows 11, if the last line is empty, the `braille next line command` will move the cursor to the last line.
 In any document, if the cursor is on the last line, it will be moved to the end when using this command. (#17251, #17430, @nvdaes)
 
 ### Changes for Developers
@@ -116,7 +116,7 @@ As the NVDA update check URL is now configurable directly within NVDA, no replac
   * `SymphonyDocument.script_toggleTextAttribute` to `SymphonyDocument.script_changeTextFormatting`
 * The `space` keyword argument for `brailleDisplayDrivers.seikantk.InputGesture` now expects an `int` rather than a `bool`. (#17047, @school510587)
 * The `[upgrade]` configuration section including `[upgrade][newLaptopKeyboardLayout]` has been removed. (#17191)
-* in `NVDAObjects.window.scintilla.ScintillaTextInfo`, if no text is selected, the `collapse` method is overriden to expand to line if the `end` parameter is set to `True` (#17431, @nvdaes)
+* In `NVDAObjects.window.scintilla.ScintillaTextInfo`, if no text is selected, the `collapse` method is overriden to expand to line if the `end` parameter is set to `True` (#17431, @nvdaes)
 
 #### Deprecations
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -68,8 +68,8 @@ Specifically, MathML inside of span and other elements that have the attribute `
 * If the plugins are reloaded while a browseable message is opened, NVDA will no longer fail to report subsequent focus moves. (#17323, @CyrilleB79)
 * When using applications such as Skype, Discord, Signal and Phone Link for audio communication, NVDA speech and sounds no longer decrease in volume. (#17349, @jcsteh)
 * Opening the NVDA Python Console will no longer fail in case an error occurs while retrieving snapshot variables. (#17391, @CyrilleB79)
-* In Notepad and other UIA documents on Windows 11, if the last line is empty, the `braille next line command` will move the cursor to the last line.
-In any document, if the cursor is on the last line, it will be moved to the end when using this command. (#17251, @nvdaes)
+* In Notepad and other UIA documents, and Notepad++ on Windows 11, if the last line is empty, the `braille next line command` will move the cursor to the last line.
+In any document, if the cursor is on the last line, it will be moved to the end when using this command. (#17251, #17430, @nvdaes)
 
 ### Changes for Developers
 
@@ -116,6 +116,7 @@ As the NVDA update check URL is now configurable directly within NVDA, no replac
   * `SymphonyDocument.script_toggleTextAttribute` to `SymphonyDocument.script_changeTextFormatting`
 * The `space` keyword argument for `brailleDisplayDrivers.seikantk.InputGesture` now expects an `int` rather than a `bool`. (#17047, @school510587)
 * The `[upgrade]` configuration section including `[upgrade][newLaptopKeyboardLayout]` has been removed. (#17191)
+* in `NVDAObjects.window.scintilla.ScintillaTextInfo`, the `collapse` method is overriden to expand to line if the `end` parameter is set to `True` (#17431, @nvdaes)
 
 #### Deprecations
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -69,7 +69,8 @@ Specifically, MathML inside of span and other elements that have the attribute `
 * When using applications such as Skype, Discord, Signal and Phone Link for audio communication, NVDA speech and sounds no longer decrease in volume. (#17349, @jcsteh)
 * Opening the NVDA Python Console will no longer fail in case an error occurs while retrieving snapshot variables. (#17391, @CyrilleB79)
 * In Notepad and other UIA documents, and Notepad++ on Windows 11, if the last line is empty, the `braille next line command` will move the cursor to the last line.
-In any document, if the cursor is on the last line, it will be moved to the end when using this command. (#17251, #17430, @nvdaes)
+  In any document, if the cursor is on the last line, it will be moved to the end when using this command.
+  (#17251, #17430, @nvdaes)
 
 ### Changes for Developers
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -68,7 +68,7 @@ Specifically, MathML inside of span and other elements that have the attribute `
 * If the plugins are reloaded while a browseable message is opened, NVDA will no longer fail to report subsequent focus moves. (#17323, @CyrilleB79)
 * When using applications such as Skype, Discord, Signal and Phone Link for audio communication, NVDA speech and sounds no longer decrease in volume. (#17349, @jcsteh)
 * Opening the NVDA Python Console will no longer fail in case an error occurs while retrieving snapshot variables. (#17391, @CyrilleB79)
-* In Notepad and other UIA documents, and Notepad++ documents on Windows 11, if the last line is empty, the `braille next line command` will move the cursor to the last line.
+* In Notepad and other UIA documents, and Notepad++ documents on Windows 11, if the last line is empty, the "braille next line command" will move the cursor to the last line.
 In any document, if the cursor is on the last line, it will be moved to the end when using this command.
 (#17251, #17430, @nvdaes)
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Fixes #17430 
### Summary of the issue:
Next braille line command doesn't work in Notepad++ documents when the last line is empty.
### Description of user facing changes
Next braille line command works as expected in Notepad++ documents.
### Description of development approach
The collapse method is overriden for Scintilla textInfo, so that textInfo is expanded to line before collapsing to end. In this way the cursor is properly moved to the end of the document when running the braille next line command.
### Testing strategy:
Tested manually in portable Notepad++ on Windows 11.
### Known issues with pull request:
None. Should be tested in different versions of Notepad++ and Windows.
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes for NVDA 2024.1

- **New Features**
	- Support for the new HID Braille specification for automatic detection of multiple Braille displays.
	- Introduced "on-demand" speech mode, allowing users to control when speech is spoken.
	- Added "Native Selection" mode for Mozilla Firefox for improved text selection.
	- Add-on Store now alerts users of available updates at startup.
	- Support for Unicode normalization in speech and braille output.

- **Bug Fixes**
	- Resolved cursor movement issues in Notepad++ documents with new text handling features.

- **Improvements**
	- Enhanced performance and stability, especially in Microsoft Office applications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
