### PR TITLE
    PowerPoint: Report link destination

### DIFF
--- a/source/NVDAObjects/__init__.py
+++ b/source/NVDAObjects/__init__.py
@@ -1648,6 +1648,5 @@ class NVDAObject(
 		return ti.getLinkTypeInDocument(self.value)
 
 	def _get_linkData(self) -> "_LinkData | None":
-		"""If the object has an associated link, returns the link's data (target and text).
-		"""
+		"""If the object has an associated link, returns the link's data (target and text)."""
 		raise NotImplementedError

--- a/source/NVDAObjects/__init__.py
+++ b/source/NVDAObjects/__init__.py
@@ -1647,6 +1647,7 @@ class NVDAObject(
 			return None
 		return ti.getLinkTypeInDocument(self.value)
 
+	linkData: "_LinkData | None"
 	def _get_linkData(self) -> "_LinkData | None":
 		"""If the object has an associated link, returns the link's data (target and text)."""
 		raise NotImplementedError

--- a/source/NVDAObjects/__init__.py
+++ b/source/NVDAObjects/__init__.py
@@ -47,7 +47,7 @@ import aria
 from winAPI.sessionTracking import isLockScreenModeActive
 
 if TYPE_CHECKING:
-	from textInfos import _LinkData
+	from utils.urlUtils import _LinkData
 
 
 class NVDAObjectTextInfo(textInfos.offsets.OffsetsTextInfo):

--- a/source/NVDAObjects/__init__.py
+++ b/source/NVDAObjects/__init__.py
@@ -1648,6 +1648,7 @@ class NVDAObject(
 		return ti.getLinkTypeInDocument(self.value)
 
 	linkData: "_LinkData | None"
+
 	def _get_linkData(self) -> "_LinkData | None":
 		"""If the object has an associated link, returns the link's data (target and text)."""
 		raise NotImplementedError

--- a/source/NVDAObjects/__init__.py
+++ b/source/NVDAObjects/__init__.py
@@ -13,6 +13,7 @@ import typing
 from typing import (
 	Dict,
 	Optional,
+	TYPE_CHECKING,
 )
 import weakref
 import textUtils
@@ -44,6 +45,9 @@ import brailleInput
 import locationHelper
 import aria
 from winAPI.sessionTracking import isLockScreenModeActive
+
+if TYPE_CHECKING:
+	from textInfos import _LinkData
 
 
 class NVDAObjectTextInfo(textInfos.offsets.OffsetsTextInfo):
@@ -1642,3 +1646,8 @@ class NVDAObject(
 		if not isinstance(ti, BrowseModeDocumentTreeInterceptor):
 			return None
 		return ti.getLinkTypeInDocument(self.value)
+
+	def _get_linkData(self) -> "_LinkData | None":
+		"""If the object has an associated link, returns the link's data (target and text).
+		"""
+		raise NotImplementedError

--- a/source/NVDAObjects/window/excel.py
+++ b/source/NVDAObjects/window/excel.py
@@ -29,6 +29,7 @@ from tableUtils import HeaderCellTracker
 import config
 from config.configFlags import ReportCellBorders
 import textInfos
+from textInfos import _LinkData
 import colors
 import eventHandler
 import api
@@ -1368,21 +1369,6 @@ class ExcelCellTextInfo(NVDAObjectTextInfo):
 	def _get_locationText(self):
 		return self.obj.getCellPosition()
 
-	def _getLinkDataAtCaretPosition(self) -> textInfos._Link | None:
-		links = self.obj.excelCellObject.Hyperlinks
-		if links.count == 0:
-			return None
-		link = links(1)
-		if link.Type == MsoHyperlink.RANGE:
-			text = link.TextToDisplay
-		else:
-			log.debugWarning(f"No text to display for link type {link.Type}")
-			text = None
-		return textInfos._Link(
-			displayText=text,
-			destination=link.Address,
-		)
-
 
 NVCELLINFOFLAG_ADDRESS = 0x1
 NVCELLINFOFLAG_TEXT = 0x2
@@ -1709,6 +1695,21 @@ class ExcelCell(ExcelBase):
 		if controlTypes.State.LINKED in self.states:
 			return controlTypes.Role.LINK
 		return controlTypes.Role.TABLECELL
+
+	def _get_linkData(self) -> _LinkData | None:
+		links = self.excelCellObject.Hyperlinks
+		if links.count == 0:
+			return None
+		link = links(1)
+		if link.Type == MsoHyperlink.RANGE:
+			text = link.TextToDisplay
+		else:
+			log.debugWarning(f"No text to display for link type {link.Type}")
+			text = None
+		return _LinkData(
+			displayText=text,
+			destination=link.Address,
+		)
 
 	TextInfo = ExcelCellTextInfo
 

--- a/source/NVDAObjects/window/excel.py
+++ b/source/NVDAObjects/window/excel.py
@@ -29,7 +29,7 @@ from tableUtils import HeaderCellTracker
 import config
 from config.configFlags import ReportCellBorders
 import textInfos
-from textInfos import _LinkData
+from utils.urlUtils import _LinkData
 import colors
 import eventHandler
 import api

--- a/source/NVDAObjects/window/winword.py
+++ b/source/NVDAObjects/window/winword.py
@@ -47,7 +47,7 @@ import locationHelper
 from enum import IntEnum
 import documentBase
 from utils.displayString import DisplayStringIntEnum
-from textInfos import _LinkData
+from utils.urlUtils import _LinkData
 
 if TYPE_CHECKING:
 	import inputCore

--- a/source/NVDAObjects/window/winword.py
+++ b/source/NVDAObjects/window/winword.py
@@ -46,6 +46,7 @@ import locationHelper
 from enum import IntEnum
 import documentBase
 from utils.displayString import DisplayStringIntEnum
+from textInfos import _LinkData
 
 if TYPE_CHECKING:
 	import inputCore
@@ -866,7 +867,7 @@ class WordDocumentTextInfo(textInfos.TextInfo):
 			return shapes[1]
 		return None
 
-	def _getLinkDataAtCaretPosition(self) -> textInfos._Link | None:
+	def _getLinkDataAtCaretPosition(self) -> _LinkData | None:
 		link = self._getLinkAtCaretPosition()
 		if not link:
 			return None
@@ -879,7 +880,7 @@ class WordDocumentTextInfo(textInfos.TextInfo):
 			case _:
 				log.debugWarning(f"No text to display for link type {link.Type}")
 				text = None
-		return textInfos._Link(
+		return _LinkData(
 			displayText=text,
 			destination=link.Address,
 		)

--- a/source/appModules/powerpnt.py
+++ b/source/appModules/powerpnt.py
@@ -1201,7 +1201,7 @@ class TextFrameTextInfo(textInfos.offsets.OffsetsTextInfo):
 		formatField = textInfos.FormatField()
 		curRun = None
 		if calculateOffsets:
-			curRun, startOffset, endOffset = _getCurrentRun(self)
+			curRun, startOffset, endOffset = self._getCurrentRun(self)
 		if not curRun:
 			curRun = self.obj.ppObject.textRange.characters(offset + 1)
 			startOffset, endOffset = offset, self._endOffset

--- a/source/appModules/powerpnt.py
+++ b/source/appModules/powerpnt.py
@@ -1008,7 +1008,6 @@ class Shape(PpObject):
 				destination=mouseClickSetting.Hyperlink.Address,
 			)
 			return None
-		
 
 	__gestures = {
 		"kb:leftArrow": "moveHorizontal",
@@ -1178,7 +1177,7 @@ class TextFrameTextInfo(textInfos.offsets.OffsetsTextInfo):
 
 	def _getCurrentRun(
 		self,
-		offset: int
+		offset: int,
 	) -> tuple[comtypes.client.lazybind.Dispatch | None, int, int]:
 		runs = self.obj.ppObject.textRange.runs()
 		for run in runs:

--- a/source/appModules/powerpnt.py
+++ b/source/appModules/powerpnt.py
@@ -42,7 +42,7 @@ from logHandler import log
 import scriptHandler
 from locationHelper import RectLTRB
 from NVDAObjects.window._msOfficeChart import OfficeChart
-from textInfos import _LinkData
+from utils.urlUtils import _LinkData
 
 # Translators: The name of a category of NVDA commands.
 SCRCAT_POWERPOINT = _("PowerPoint")

--- a/source/appModules/powerpnt.py
+++ b/source/appModules/powerpnt.py
@@ -27,6 +27,7 @@ import msoAutoShapeTypes
 from treeInterceptorHandler import DocumentTreeInterceptor
 from NVDAObjects import NVDAObjectTextInfo
 from displayModel import DisplayModelTextInfo, EditableTextDisplayModelTextInfo
+import textInfos
 import textInfos.offsets
 import eventHandler
 import appModuleHandler
@@ -41,6 +42,7 @@ from logHandler import log
 import scriptHandler
 from locationHelper import RectLTRB
 from NVDAObjects.window._msOfficeChart import OfficeChart
+from textInfos import _LinkData
 
 # Translators: The name of a category of NVDA commands.
 SCRCAT_POWERPOINT = _("PowerPoint")
@@ -994,6 +996,20 @@ class Shape(PpObject):
 		except:  # noqa: E722
 			raise LookupError("Couldn't get MathML from MathType")
 
+	def _get_linkData(self) -> _LinkData | None:
+		mouseClickSetting = self.ppObject.ActionSettings(ppMouseClick)
+		if mouseClickSetting.action == ppActionHyperlink:
+			if self.value:
+				text = f"{self.roleText} {self.value}"
+			else:
+				text = self.roleText
+			return _LinkData(
+				displayText=text,
+				destination=mouseClickSetting.Hyperlink.Address,
+			)
+			return None
+		
+
 	__gestures = {
 		"kb:leftArrow": "moveHorizontal",
 		"kb:rightArrow": "moveHorizontal",
@@ -1160,6 +1176,23 @@ class TextFrameTextInfo(textInfos.offsets.OffsetsTextInfo):
 		bottom = self.obj.documentWindow.ppObjectModel.pointsToScreenPixelsY(rangeTop + rangeHeight)
 		return RectLTRB(left, top, right, bottom)
 
+	def _getCurrentRun(
+		self,
+		offset: int
+	) -> tuple[comtypes.client.lazybind.Dispatch | None, int, int]:
+		runs = self.obj.ppObject.textRange.runs()
+		for run in runs:
+			start = run.start - 1
+			end = start + run.length
+			if start <= offset < end:
+				startOffset = start
+				endOffset = end
+				curRun = run
+				break
+		else:
+			curRun, startOffset, endOffset = None, 0, 0
+		return curRun, startOffset, endOffset
+
 	def _getFormatFieldAndOffsets(
 		self,
 		offset: int,
@@ -1169,15 +1202,7 @@ class TextFrameTextInfo(textInfos.offsets.OffsetsTextInfo):
 		formatField = textInfos.FormatField()
 		curRun = None
 		if calculateOffsets:
-			runs = self.obj.ppObject.textRange.runs()
-			for run in runs:
-				start = run.start - 1
-				end = start + run.length
-				if start <= offset < end:
-					startOffset = start
-					endOffset = end
-					curRun = run
-					break
+			curRun, startOffset, endOffset = _getCurrentRun(self)
 		if not curRun:
 			curRun = self.obj.ppObject.textRange.characters(offset + 1)
 			startOffset, endOffset = offset, self._endOffset
@@ -1212,6 +1237,17 @@ class TextFrameTextInfo(textInfos.offsets.OffsetsTextInfo):
 		if formatConfig["reportLinks"] and curRun.actionSettings(ppMouseClick).action == ppActionHyperlink:
 			formatField["link"] = True
 		return formatField, (startOffset, endOffset)
+
+	def _getLinkDataAtCaretPosition(self) -> _LinkData | None:
+		offset = self._getCaretOffset()
+		curRun, _startOffset, _endOffset = self._getCurrentRun(offset)
+		mouseClickSetting = curRun.actionSettings(ppMouseClick)
+		if mouseClickSetting.action == ppActionHyperlink:
+			return textInfos._LinkData(
+				displayText=mouseClickSetting.Hyperlink.TextToDisplay,
+				destination=mouseClickSetting.Hyperlink.Address,
+			)
+		return None
 
 	def _setCaretOffset(self, offset: int) -> None:
 		return self._setSelectionOffsets(offset, offset)

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -4280,19 +4280,19 @@ class GlobalCommands(ScriptableObject):
 		positioned on a link, or an element with an included link such as a graphic.
 		:param forceBrowseable: skips the press once check, and displays the browseableMessage version.
 		"""
+		focus = api.getFocusObject()
 		try:
 			ti: textInfos.TextInfo = api.getCaretPosition()
 			link = ti._getLinkDataAtCaretPosition()
 		except RuntimeError:
-			obj = api.getFocusObject()
 			try:
-				link = obj.linkData
+				link = focus.linkData
 			except NotImplementedError:
 				link = None
 		presses = scriptHandler.getLastScriptRepeatCount()
 		if link:
 			if link.destination is None:
-				# Translators: Informs the user that the link has no destination
+				# Translators: Reported when using the command to report the destination of a link.
 				ui.message(_("Link has no apparent destination"))
 				return
 			if (
@@ -4317,8 +4317,11 @@ class GlobalCommands(ScriptableObject):
 				ui.message(link.destination)  # Speak the link
 			else:  # Some other number of presses
 				return  # Do nothing
+		elif focus.role == controlTypes.Role.LINK or controlTypes.State.LINKED in focus.states:
+			# Translators: Reported when using the command to report the destination of a link.
+			ui.message(_("Unable to get the destination of this link."))
 		else:
-			# Translators: Tell user that the command has been run on something that is not a link
+			# Translators: Reported when using the command to report the destination of a link.
 			ui.message(_("Not a link."))
 
 	@script(

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -4282,10 +4282,13 @@ class GlobalCommands(ScriptableObject):
 		"""
 		try:
 			ti: textInfos.TextInfo = api.getCaretPosition()
+			link = ti._getLinkDataAtCaretPosition()
 		except RuntimeError:
-			log.debugWarning("Unable to get the caret position.", exc_info=True)
-			ti: textInfos.TextInfo = api.getFocusObject().makeTextInfo(textInfos.POSITION_FIRST)
-		link = ti._getLinkDataAtCaretPosition()
+			obj = api.getFocusObject()
+			try:
+				link = obj.linkData
+			except NotImplementedError:
+				link = None
 		presses = scriptHandler.getLastScriptRepeatCount()
 		if link:
 			if link.destination is None:

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -4307,11 +4307,9 @@ class GlobalCommands(ScriptableObject):
 					link.destination,
 					# Translators: Informs the user that the window contains the destination of the
 					# link with given title
-					title=_("Destination of: {name}").format(
-						name=text,
-						closeButton=True,
-						copyButton=True,
-					),
+					title=_("Destination of: {name}").format(name=text),
+					closeButton=True,
+					copyButton=True,
 				)
 			elif presses == 0:  # One press
 				ui.message(link.destination)  # Speak the link

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -4283,12 +4283,13 @@ class GlobalCommands(ScriptableObject):
 		focus = api.getFocusObject()
 		try:
 			ti: textInfos.TextInfo = api.getCaretPosition()
-			link = ti._getLinkDataAtCaretPosition()
 		except RuntimeError:
 			try:
 				link = focus.linkData
 			except NotImplementedError:
 				link = None
+		else:
+			link = ti._getLinkDataAtCaretPosition()
 		presses = scriptHandler.getLastScriptRepeatCount()
 		if link:
 			if link.destination is None:

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -4292,7 +4292,7 @@ class GlobalCommands(ScriptableObject):
 			link = ti._getLinkDataAtCaretPosition()
 		presses = scriptHandler.getLastScriptRepeatCount()
 		if link:
-			if link.destination is None:
+			if not link.destination:  # May be None or ""
 				# Translators: Reported when using the command to report the destination of a link.
 				ui.message(_("Link has no apparent destination"))
 				return

--- a/source/textInfos/__init__.py
+++ b/source/textInfos/__init__.py
@@ -340,8 +340,8 @@ def _logBadSequenceTypes(sequence: SpeechSequence, shouldRaise: bool = True):
 
 
 @dataclass
-class _Link:
-	"""Class to store information on a link in text."""
+class _LinkData:
+	"""Class to store information on a link."""
 
 	displayText: str | None
 	destination: str
@@ -713,7 +713,7 @@ class TextInfo(baseObject.AutoPropertyObject):
 		mouseHandler.doPrimaryClick()
 		winUser.setCursorPos(oldX, oldY)
 
-	def _getLinkDataAtCaretPosition(self) -> _Link | None:
+	def _getLinkDataAtCaretPosition(self) -> _LinkData | None:
 		self.expand(UNIT_CHARACTER)
 		obj: NVDAObjects.NVDAObject = self.NVDAObjectAtStart
 		if obj.role == controlTypes.role.Role.GRAPHIC and (
@@ -726,7 +726,7 @@ class TextInfo(baseObject.AutoPropertyObject):
 			obj.role == controlTypes.role.Role.LINK  # If it's a link, or
 			or controlTypes.state.State.LINKED in obj.states  # if it isn't a link but contains one
 		):
-			return _Link(
+			return _LinkData(
 				displayText=obj.name,
 				destination=obj.value,
 			)
@@ -783,7 +783,7 @@ class TextInfo(baseObject.AutoPropertyObject):
 			exactly 1 character.
 			A good illustration of this is in Microsoft Word with UIA enabled always,
 			the first character of a bullet list item would be represented by three pythonic codepoint characters:
-			* Bullet character "•"
+			* Bullet character "Ã¢â‚¬Â¢"
 			* Tab character \t
 			* And the first character of of list item per se.
 

--- a/source/textInfos/__init__.py
+++ b/source/textInfos/__init__.py
@@ -11,7 +11,6 @@ A default implementation, L{NVDAObjects.NVDAObjectTextInfo}, is used to enable t
 
 from abc import abstractmethod
 from enum import Enum
-from dataclasses import dataclass
 import weakref
 import re
 import typing
@@ -31,6 +30,7 @@ import controlTypes
 from controlTypes import OutputReason
 import locationHelper
 from logHandler import log
+from utils.urlUtils import _LinkData
 
 if typing.TYPE_CHECKING:
 	import documentBase  # noqa: F401 used for type checking only
@@ -337,14 +337,6 @@ def _logBadSequenceTypes(sequence: SpeechSequence, shouldRaise: bool = True):
 	import speech.types
 
 	return speech.types.logBadSequenceTypes(sequence, raiseExceptionOnError=shouldRaise)
-
-
-@dataclass
-class _LinkData:
-	"""Class to store information on a link."""
-
-	displayText: str | None
-	destination: str
 
 
 class TextInfo(baseObject.AutoPropertyObject):
@@ -783,7 +775,7 @@ class TextInfo(baseObject.AutoPropertyObject):
 			exactly 1 character.
 			A good illustration of this is in Microsoft Word with UIA enabled always,
 			the first character of a bullet list item would be represented by three pythonic codepoint characters:
-			* Bullet character "Ã¢â‚¬Â¢"
+			* Bullet character "•"
 			* Tab character \t
 			* And the first character of of list item per se.
 

--- a/source/treeInterceptorHandler.py
+++ b/source/treeInterceptorHandler.py
@@ -24,7 +24,7 @@ import extensionPoints
 
 if TYPE_CHECKING:
 	import NVDAObjects
-	from  textInfos import _LinkData
+	from textInfos import _LinkData
 
 post_browseModeStateChange = extensionPoints.Action()
 """

--- a/source/treeInterceptorHandler.py
+++ b/source/treeInterceptorHandler.py
@@ -24,7 +24,7 @@ import extensionPoints
 
 if TYPE_CHECKING:
 	import NVDAObjects
-	from textInfos import _LinkData
+	from utils.urlUtils import _LinkData
 
 post_browseModeStateChange = extensionPoints.Action()
 """

--- a/source/treeInterceptorHandler.py
+++ b/source/treeInterceptorHandler.py
@@ -24,6 +24,7 @@ import extensionPoints
 
 if TYPE_CHECKING:
 	import NVDAObjects
+	from  textInfos import _LinkData
 
 post_browseModeStateChange = extensionPoints.Action()
 """
@@ -228,7 +229,7 @@ class RootProxyTextInfo(textInfos.TextInfo):
 	def activate(self):
 		return self.innerTextInfo.activate()
 
-	def _getLinkDataAtCaretPosition(self) -> textInfos._Link | None:
+	def _getLinkDataAtCaretPosition(self) -> "_LinkData | None":
 		return self.innerTextInfo._getLinkDataAtCaretPosition()
 
 	def compareEndPoints(self, other, which):

--- a/source/utils/urlUtils.py
+++ b/source/utils/urlUtils.py
@@ -58,5 +58,6 @@ def isSamePageURL(targetURLOnPage: str, rootURL: str) -> bool:
 @dataclass
 class _LinkData:
 	"""Class to store information on a link."""
+
 	displayText: str | None
 	destination: str

--- a/source/utils/urlUtils.py
+++ b/source/utils/urlUtils.py
@@ -5,6 +5,7 @@
 
 import controlTypes
 from urllib.parse import ParseResult, urlparse, urlunparse
+from dataclasses import dataclass
 from logHandler import log
 
 
@@ -52,3 +53,10 @@ def isSamePageURL(targetURLOnPage: str, rootURL: str) -> bool:
 	return targetURLOnPageWithoutFragments == rootURLWithoutFragments and not any(
 		char in parsedTargetURLOnPage.fragment for char in fragmentInvalidChars
 	)
+
+
+@dataclass
+class _LinkData:
+	"""Class to store information on a link."""
+	displayText: str | None
+	destination: str

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -63,7 +63,7 @@ Specifically, MathML inside of span and other elements that have the attribute `
 * When spelling, unicode normalization now works more appropriately:
   * After reporting a normalized character, NVDA no longer incorrectly reports subsequent characters as normalized. (#17286, @LeonarddeR)
   * Composite characters (such as é) are now reported correctly. (#17295, @LeonarddeR)
-* The command to Report the destination URL of a link now works as expected when using the legacy object model in Microsoft Word, Outlook and Excel. (#17292, #17362, @CyrilleB79)
+* The command to Report the destination URL of a link now works as expected when using the legacy object model in Microsoft Word, Outlook, Excel and PowerPoint. (#17292, #17362, #17435, @CyrilleB79)
 * NVDA will no longer announce Windows 11 clipboard history entries when closing the window while items are present. (#17308, @josephsl)
 * If the plugins are reloaded while a browseable message is opened, NVDA will no longer fail to report subsequent focus moves. (#17323, @CyrilleB79)
 * When using applications such as Skype, Discord, Signal and Phone Link for audio communication, NVDA speech and sounds no longer decrease in volume. (#17349, @jcsteh)


### PR DESCRIPTION
### Link to issue number:
None
### Summary of the issue:
When in PowerPoint, NVDA+K does not work to report a link.

### Description of user facing changes
* In PowerPoint slides (edition mode), pressing NVDA+K will now report the link destination. This works in text areas as well as on shapes / charts / images that are links.
* Also 2 small fixes:
  * Restored the Copy and Close buttons of the browseable message of NVDA+K that were removed by mistake in #17292
  * In Windows UI, e.g. settings, pressing NVDA+K on a link does not report anymore that there is no link; it rather reports that the destination cannot be reported.

### Description of development approach
* Use PowerPoint object model
* Changed the global strategy to retrieve a link: first try from text infos; if not supported, try from the focused object.

### Testing strategy:
* Tested PowerPoint link reporting in text area, on shapes and images
* Re-tested link reporting in browsers (Chrome, FF and `ui.browseableMessage`), in Word / Outlook with/without UIA (text and images), in Excel.

### Known issues with pull request:
* NVDA+K doesn't still work in the slideshow; by the way, the presence of links is not reported either in slideshow.
* There are other situations where link is not reported by NVDA+K on the web or elsewhere (WordPad, Adobe Reader) but this PR does not degrade any experience.

### Code Review Checklist:


- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
