### PR TITLE
Support IAccessible2 labelled-by relation

### DIFF
--- a/source/IAccessibleHandler/types.py
+++ b/source/IAccessibleHandler/types.py
@@ -29,3 +29,4 @@ class RelationType(str, enum.Enum):
 	CONTROLLER_FOR = "controllerFor"
 	ERROR = "error"
 	ERROR_FOR = "errorFor"
+	LABELLED_BY = "labelledBy"

--- a/source/NVDAObjects/IAccessible/__init__.py
+++ b/source/NVDAObjects/IAccessible/__init__.py
@@ -10,7 +10,6 @@ from typing import (
 	Optional,
 	Tuple,
 	Union,
-	List,
 )
 
 from comtypes.automation import IEnumVARIANT, VARIANT
@@ -1948,7 +1947,7 @@ class IAccessible(Window):
 		# due to caching of baseObject.AutoPropertyObject, do not attempt to return a generator.
 		return tuple(detailsRelsGen)
 
-	def _get_controllerFor(self) -> List[NVDAObject]:
+	def _get_controllerFor(self) -> typing.List[NVDAObject]:
 		control = self._getIA2RelationFirstTarget(IAccessibleHandler.RelationType.CONTROLLER_FOR)
 		if control:
 			return [control]

--- a/source/NVDAObjects/IAccessible/__init__.py
+++ b/source/NVDAObjects/IAccessible/__init__.py
@@ -1163,12 +1163,19 @@ class IAccessible(Window):
 		return True
 
 	def _get_labeledBy(self):
+		label = self._getIA2RelationFirstTarget(IAccessibleHandler.RelationType.LABELLED_BY)
+		if label:
+			return label
+
 		try:
-			(pacc, accChild) = IAccessibleHandler.accNavigate(
+			ret = IAccessibleHandler.accNavigate(
 				self.IAccessibleObject,
 				self.IAccessibleChildID,
 				IAccessibleHandler.NAVRELATION_LABELLED_BY,
 			)
+			if not ret:
+				return None
+			(pacc, accChild) = ret
 			obj = IAccessible(IAccessibleObject=pacc, IAccessibleChildID=accChild)
 			return obj
 		except COMError:

--- a/source/NVDAObjects/IAccessible/__init__.py
+++ b/source/NVDAObjects/IAccessible/__init__.py
@@ -1161,7 +1161,7 @@ class IAccessible(Window):
 			return False
 		return True
 
-	def _get_labeledBy(self) -> "IAccessible" | None:
+	def _get_labeledBy(self) -> "IAccessible | None":
 		label = self._getIA2RelationFirstTarget(IAccessibleHandler.RelationType.LABELLED_BY)
 		if label:
 			return label

--- a/source/NVDAObjects/IAccessible/__init__.py
+++ b/source/NVDAObjects/IAccessible/__init__.py
@@ -3,10 +3,6 @@
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
-# required for Python < 3.14 for IAccessible return type annotation
-# within IAccessible class itself, see https://peps.python.org/pep-0563/
-# and and https://peps.python.org/pep-0649/
-from __future__ import annotations
 
 import typing
 from typing import (
@@ -1166,7 +1162,7 @@ class IAccessible(Window):
 			return False
 		return True
 
-	def _get_labeledBy(self) -> IAccessible | None:
+	def _get_labeledBy(self) -> "IAccessible" | None:
 		label = self._getIA2RelationFirstTarget(IAccessibleHandler.RelationType.LABELLED_BY)
 		if label:
 			return label

--- a/source/NVDAObjects/IAccessible/__init__.py
+++ b/source/NVDAObjects/IAccessible/__init__.py
@@ -3,6 +3,7 @@
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
+from __future__ import annotations
 import typing
 from typing import (
 	Generator,
@@ -1162,7 +1163,7 @@ class IAccessible(Window):
 			return False
 		return True
 
-	def _get_labeledBy(self):
+	def _get_labeledBy(self) -> IAccessible | None:
 		label = self._getIA2RelationFirstTarget(IAccessibleHandler.RelationType.LABELLED_BY)
 		if label:
 			return label

--- a/source/NVDAObjects/IAccessible/__init__.py
+++ b/source/NVDAObjects/IAccessible/__init__.py
@@ -3,7 +3,6 @@
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
-
 import typing
 from typing import (
 	Generator,

--- a/source/NVDAObjects/IAccessible/__init__.py
+++ b/source/NVDAObjects/IAccessible/__init__.py
@@ -3,7 +3,11 @@
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
+# required for Python < 3.14 for IAccessible return type annotation
+# within IAccessible class itself, see https://peps.python.org/pep-0563/
+# and and https://peps.python.org/pep-0649/
 from __future__ import annotations
+
 import typing
 from typing import (
 	Generator,

--- a/source/NVDAObjects/IAccessible/__init__.py
+++ b/source/NVDAObjects/IAccessible/__init__.py
@@ -1947,7 +1947,7 @@ class IAccessible(Window):
 		# due to caching of baseObject.AutoPropertyObject, do not attempt to return a generator.
 		return tuple(detailsRelsGen)
 
-	def _get_controllerFor(self) -> typing.List[NVDAObject]:
+	def _get_controllerFor(self) -> list[NVDAObject]:
 		control = self._getIA2RelationFirstTarget(IAccessibleHandler.RelationType.CONTROLLER_FOR)
 		if control:
 			return [control]

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -70,6 +70,7 @@ Specifically, MathML inside of span and other elements that have the attribute `
 * Opening the NVDA Python Console will no longer fail in case an error occurs while retrieving snapshot variables. (#17391, @CyrilleB79)
 * In Notepad and other UIA documents on Windows 11, if the last line is empty, the `braille next line command` will move the cursor to the last line.
 In any document, if the cursor is on the last line, it will be moved to the end when using this command. (#17251, @nvdaes)
+* In NVDA's Python console, retrieving the "labeledBy" property now works for objects in applications implementing the "labelled-by" IAccessible2 relation and no longer triggers an error. (#17436, @michaelweghorn)
 
 ### Changes for Developers
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -99,7 +99,7 @@ Add-ons will need to be re-tested and have their manifest updated.
 * Removed the requirement to indent function parameter lists by two tabs from NVDA's Coding Standards, to be compatible with modern automatic linting. (#17126, @XLTechie)
 * Added the [VS Code workspace configuration for NVDA](https://nvaccess.org/nvaccess/vscode-nvda) as a git submodule. (#17003)
 * In the `brailleTables` module, a `getDefaultTableForCurrentLang` function has been added (#17222, @nvdaes)
-* Retrieving the "labeledBy" property now works for objects in applications implementing the "labelled-by" IAccessible2 relation and no longer triggers an error. (#17436, @michaelweghorn)
+* Retrieving the `labeledBy` property now works for objects in applications implementing the `labelled-by` IAccessible2 relation and no longer triggers an error. (#17436, @michaelweghorn)
 
 #### API Breaking Changes
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -70,7 +70,6 @@ Specifically, MathML inside of span and other elements that have the attribute `
 * Opening the NVDA Python Console will no longer fail in case an error occurs while retrieving snapshot variables. (#17391, @CyrilleB79)
 * In Notepad and other UIA documents on Windows 11, if the last line is empty, the `braille next line command` will move the cursor to the last line.
 In any document, if the cursor is on the last line, it will be moved to the end when using this command. (#17251, @nvdaes)
-* In NVDA's Python console, retrieving the "labeledBy" property now works for objects in applications implementing the "labelled-by" IAccessible2 relation and no longer triggers an error. (#17436, @michaelweghorn)
 
 ### Changes for Developers
 
@@ -100,6 +99,7 @@ Add-ons will need to be re-tested and have their manifest updated.
 * Removed the requirement to indent function parameter lists by two tabs from NVDA's Coding Standards, to be compatible with modern automatic linting. (#17126, @XLTechie)
 * Added the [VS Code workspace configuration for NVDA](https://nvaccess.org/nvaccess/vscode-nvda) as a git submodule. (#17003)
 * In the `brailleTables` module, a `getDefaultTableForCurrentLang` function has been added (#17222, @nvdaes)
+* Retrieving the "labeledBy" property now works for objects in applications implementing the "labelled-by" IAccessible2 relation and no longer triggers an error. (#17436, @michaelweghorn)
 
 #### API Breaking Changes
 


### PR DESCRIPTION
### Link to issue number:

Fixes #17436

### Summary of the issue:

IAccessible2 has an IA2_RELATION_LABELLED_BY relation type, see https://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/group__grp_relations.html#ga7bbace7ffb57476b75d621af2e27d1ff . However, that one was not taken into account by NVDA's "labeledBy" property for objects. This could could be seen for example with LibreOffice that implements handling of that IAccessible2 relation.

Additionally, a `None` return value from
IAccessibleHandler.accNavigate wasn't handled
in `IAccessible._get_labeledBy`, triggering an error, e.g.:

    >>> focus.labeledBy
    Traceback (most recent call last):
      File "<console>", line 1, in <module>
      File "C:\tools\cygwin\home\user\development\git\nvda\source\baseObject.py", line 59, in __get__
        return instance._getPropertyViaCache(self.fget)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "C:\tools\cygwin\home\user\development\git\nvda\source\baseObject.py", line 167, in _getPropertyViaCache
        val = getterMethod(self)
              ^^^^^^^^^^^^^^^^^^
      File "C:\tools\cygwin\home\user\development\git\nvda\source\NVDAObjects\IAccessible\__init__.py", line 1167, in _get_labeledBy
        (pacc, accChild) = IAccessibleHandler.accNavigate(
        ^^^^^^^^^^^^^^^^
    TypeError: cannot unpack non-iterable NoneType object

### Description of user facing changes

None, unless they're using the Python console or addons making use of the property.

### Description of development approach

* Extend `IAccessibleHandler.RelationType` with the `LABELLED_BY` relation as defined in the IAccessible2 spec.
* Use this relation in `IAccessible._get_labeledBy` before falling back to trying a custom Mozilla/Gecko specific NAVRELATION.
* Add handling for the case where `IAccessibleHandler.accNavigate` for the custom Mozilla/Geck approach returns `None` to fix the error triggered otherwise when no relation is set.

### Testing strategy:

1. start NVDA
2. Start LibreOffice Writer
3. open the options dialog: "Tools" -> "Options", go to the "User Data" page
4. move focus to the "Company" text edit
5. open NVDA's Python console (Ctrl+Insert+Z)
6. print the object that the currently focused edit is labelled by, and it's accessible name and role:

    >>> focus.labeledBy
    <NVDAObjects.IAccessible.IAccessible object at 0x0BC55A70>
    >>> focus.labeledBy.name
    'Company:'
    >>> focus.labeledBy.role
    <Role.STATICTEXT: 7>

### Known issues with pull request:

None

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
