### PR TITLE
Upgrade typing-extensions to 4.12.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,8 +14,8 @@ schedule==1.2.1
 #NVDA_DMP requires diff-match-patch
 fast-diff-match-patch==2.1.0
 
-# typing_extensions are required for specifying default value for `TypeVar`, which is not yet possible with any released version of Python (see PEP 696)
-typing-extensions==4.9.0
+# typing_extensions are required for specifying default value for `TypeVar` prior to Python 3.13 (see PEP 696)
+typing-extensions==4.12.2
 
 # pycaw is a Core Audio Windows Library used for sound split
 pycaw==20240210

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -87,6 +87,7 @@ Add-ons will need to be re-tested and have their manifest updated.
   * Updated Robot Framework to 7.1.1. (#17329, @josephsl)
   * Updated configobj to 5.1.0 commit `8be5462`. (#17328)
   * Updated pre-commit to 4.0.1. (#17260)
+  * Updated typing-extensions to 4.12.2. (#17438, @josephsl)
 * `ui.browseableMessage` may now be called with options to present a button for copying to clipboard, and/or a button for closing the window. (#17018, @XLTechie)
 * Several additions to identify link types (#16994, @LeonarddeR, @nvdaes)
   * A new `utils.urlUtils` module with different functions to determine link types


### PR DESCRIPTION

### Link to issue number:
Closes #17438 

### Summary of the issue:
Updates typing-extensions form 4.9 to 4.12.2.

### Description of user facing changes
None

### Description of development approach
Allows devleopers to use TypeVar more efficiently, along with preparing to migrate to newer Python releases such as 3.13 as the dependency supports it.

### Testing strategy:
Manual: making sure typing defines are working as in previous releases.

### Known issues with pull request:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
