### PR TITLE
Upgrade licensecheck to 2024.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -44,8 +44,8 @@ sphinx_rtd_theme==3.0.1
 ruff==0.7.2
 pre-commit==4.0.1
 
-# Runing automated license checks
-licensecheck==2024.2
+# Running automated license checks
+licensecheck==2024.3
 
 # Requirements for system tests
 robotframework==7.1.1

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -87,6 +87,7 @@ Add-ons will need to be re-tested and have their manifest updated.
   * Updated Robot Framework to 7.1.1. (#17329, @josephsl)
   * Updated configobj to 5.1.0 commit `8be5462`. (#17328)
   * Updated pre-commit to 4.0.1. (#17260)
+  * Updated licensecheck to 2024.3. (#17440, @josephsl)
 * `ui.browseableMessage` may now be called with options to present a button for copying to clipboard, and/or a button for closing the window. (#17018, @XLTechie)
 * Several additions to identify link types (#16994, @LeonarddeR, @nvdaes)
   * A new `utils.urlUtils` module with different functions to determine link types


### PR DESCRIPTION

### Link to issue number:
Closes #17440 

### Summary of the issue:
NVDA is using licensecheck 2024.2.

### Description of user facing changes
None

### Description of development approach
Upgrade licensecheck to 2024.3.

### Testing strategy:
Manual: run licensecheck to make sure output remains the same as in 2024.2.

### Known issues with pull request:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
