### PR TITLE
Support UIA LabeledBy property

### DIFF
--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -6,6 +6,7 @@
 
 """Support for UI Automation (UIA) controls."""
 
+from __future__ import annotations
 import typing
 from typing import (
 	Generator,
@@ -2386,7 +2387,7 @@ class UIA(Window):
 				objList.append(obj)
 		return objList
 
-	def _get_labeledBy(self):
+	def _get_labeledBy(self) -> UIA | None:
 		try:
 			val = self._getUIACacheablePropertyValue(UIAHandler.UIA_LabeledByPropertyId)
 			if not val or val == UIAHandler.handler.reservedNotSupportedValue:

--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -2386,6 +2386,19 @@ class UIA(Window):
 				objList.append(obj)
 		return objList
 
+	def _get_labeledBy(self):
+		try:
+			val = self._getUIACacheablePropertyValue(UIAHandler.UIA_LabeledByPropertyId)
+			if not val or val == UIAHandler.handler.reservedNotSupportedValue:
+				return None
+			element = val.QueryInterface(UIAHandler.IUIAutomationElement).buildUpdatedCache(
+				UIAHandler.handler.baseCacheRequest,
+			)
+			return UIA(UIAElement=element)
+		except COMError:
+			pass
+		return super()._get_labeledBy()
+
 	def event_UIA_controllerFor(self) -> None:
 		return self.event_controllerForChange()
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -70,7 +70,6 @@ Specifically, MathML inside of span and other elements that have the attribute `
 * Opening the NVDA Python Console will no longer fail in case an error occurs while retrieving snapshot variables. (#17391, @CyrilleB79)
 * In Notepad and other UIA documents on Windows 11, if the last line is empty, the `braille next line command` will move the cursor to the last line.
 In any document, if the cursor is on the last line, it will be moved to the end when using this command. (#17251, @nvdaes)
-* In NVDA's Python console, retrieving the "labeledBy" property now works for UIA elements supporting the corresponding LabeledBy UIA property. (#17442, @michaelweghorn)
 
 ### Changes for Developers
 
@@ -100,6 +99,7 @@ Add-ons will need to be re-tested and have their manifest updated.
 * Removed the requirement to indent function parameter lists by two tabs from NVDA's Coding Standards, to be compatible with modern automatic linting. (#17126, @XLTechie)
 * Added the [VS Code workspace configuration for NVDA](https://nvaccess.org/nvaccess/vscode-nvda) as a git submodule. (#17003)
 * In the `brailleTables` module, a `getDefaultTableForCurrentLang` function has been added (#17222, @nvdaes)
+* Retrieving the "labeledBy" property now works for UIA elements supporting the corresponding LabeledBy UIA property. (#17442, @michaelweghorn)
 
 #### API Breaking Changes
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -70,6 +70,7 @@ Specifically, MathML inside of span and other elements that have the attribute `
 * Opening the NVDA Python Console will no longer fail in case an error occurs while retrieving snapshot variables. (#17391, @CyrilleB79)
 * In Notepad and other UIA documents on Windows 11, if the last line is empty, the `braille next line command` will move the cursor to the last line.
 In any document, if the cursor is on the last line, it will be moved to the end when using this command. (#17251, @nvdaes)
+* In NVDA's Python console, retrieving the "labeledBy" property now works for UIA elements supporting the corresponding LabeledBy UIA property. (#17442, @michaelweghorn)
 
 ### Changes for Developers
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -99,7 +99,7 @@ Add-ons will need to be re-tested and have their manifest updated.
 * Removed the requirement to indent function parameter lists by two tabs from NVDA's Coding Standards, to be compatible with modern automatic linting. (#17126, @XLTechie)
 * Added the [VS Code workspace configuration for NVDA](https://nvaccess.org/nvaccess/vscode-nvda) as a git submodule. (#17003)
 * In the `brailleTables` module, a `getDefaultTableForCurrentLang` function has been added (#17222, @nvdaes)
-* Retrieving the "labeledBy" property now works for UIA elements supporting the corresponding LabeledBy UIA property. (#17442, @michaelweghorn)
+* Retrieving the `labeledBy` property now works for UIA elements supporting the corresponding `LabeledBy` UIA property. (#17442, @michaelweghorn)
 
 #### API Breaking Changes
 


### PR DESCRIPTION
 ### Link to issue number:

Fixes #17442

 ### Summary of the issue:

UIA has a `UIA_LabeledByPropertyId` property, see https://learn.microsoft.com/en-us/windows/win32/winauto/uiauto-automation-element-propids :

> Identifies the LabeledBy property, which is an automation element that contains the text label for this element.
> This property can be used to retrieve, for example, the static text label for a combo box.
> Variant type: VT_UNKNOWN
> Default value: NULL

However, that one was so far not taken into account by NVDA's "labeledBy" property for UIA elements.

 ### Description of user facing changes

None, unless they're using the Python console or addons making use of the property.

 ### Description of development approach

Override `NVDAObject._get_labeledBy` in UIA to retrieve and return the UIAElement reported by the `UIA_LabeledByPropertyId` property.

 ### Testing strategy:

1. start NVDA
2. build Qt's qtbase module including an additional change that implements support for `UIA_LabeledByPropertyId` in Qt ( https://codereview.qt-project.org/c/qt/qtbase/+/606710 )
3. run Qt's "calendarwidgets" sample app (`qtbase/examples/widgets/widgets/calendarwidget/calendarwidget.exe`)
4. move focus to the "Locale" combobox
5. open NVDA's Python console (Ctrl+Insert+Z)
6. print the object that the currently focused edit is labelled by and some of its properties:

    >>> focus.labeledBy
    <NVDAObjects.UIA.UIA object at 0x0BE47ED0>
    >>> focus.labeledBy.name
    'Locale'
    >>> focus.labeledBy.role
    <Role.STATICTEXT: 7>

 ### Known issues with pull request:

None

 ### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary