### PR TITLE
Update schedule to 1.2.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ wxPython==4.2.2
 configobj @ git+https://github.com/DiffSK/configobj@8be54629ee7c26acb5c865b74c76284e80f3aa31#egg=configobj
 requests==2.32.0
 url-normalize==1.4.3
-schedule==1.2.1
+schedule==1.2.2
 -c constraints.txt
 
 #NVDA_DMP requires diff-match-patch

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -90,6 +90,7 @@ Add-ons will need to be re-tested and have their manifest updated.
   * Updated pre-commit to 4.0.1. (#17260)
   * Updated typing-extensions to 4.12.2. (#17438, @josephsl)
   * Updated licensecheck to 2024.3. (#17440, @josephsl)
+  * Updated schedule to 1.2.2. (#17455, @josephsl)
 * `ui.browseableMessage` may now be called with options to present a button for copying to clipboard, and/or a button for closing the window. (#17018, @XLTechie)
 * Several additions to identify link types (#16994, @LeonarddeR, @nvdaes)
   * A new `utils.urlUtils` module with different functions to determine link types


### PR DESCRIPTION

### Link to issue number:
Closes #17455 

### Summary of the issue:
NVDA is using schedule 1.2.1.

### Description of user facing changes
None

### Description of development approach
Update schedule to 1.2.2 and perform compilation/testing.

### Testing strategy:
Manual testing (with unit tests): make sure schedule functions are working after upgradin the dependency.

### Known issues with pull request:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
