### PR TITLE
Update markdown to 3.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,7 @@ mdx_truly_sane_lists==1.3
 markdown-link-attr-modifier==0.2.1
 mdx-gh-links==0.4
 # Sanitize HTML documentation output to prevent XSS from translators
-nh3==0.2.18
+nh3==0.2.19
 
 # For building developer documentation
 sphinx==8.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ nuitka==2.4.8
 unittest-xml-reporting==3.2.0
 
 # Building user documentation
-Markdown==3.6.0
+Markdown==3.7
 mdx_truly_sane_lists==1.3
 markdown-link-attr-modifier==0.2.1
 mdx-gh-links==0.4

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -90,6 +90,7 @@ Add-ons will need to be re-tested and have their manifest updated.
   * Updated pre-commit to 4.0.1. (#17260)
   * Updated typing-extensions to 4.12.2. (#17438, @josephsl)
   * Updated licensecheck to 2024.3. (#17440, @josephsl)
+  * Updated markdown to 3.7. (#17459, @josephsl)
 * `ui.browseableMessage` may now be called with options to present a button for copying to clipboard, and/or a button for closing the window. (#17018, @XLTechie)
 * Several additions to identify link types (#16994, @LeonarddeR, @nvdaes)
   * A new `utils.urlUtils` module with different functions to determine link types

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -91,6 +91,7 @@ Add-ons will need to be re-tested and have their manifest updated.
   * Updated typing-extensions to 4.12.2. (#17438, @josephsl)
   * Updated licensecheck to 2024.3. (#17440, @josephsl)
   * Updated markdown to 3.7. (#17459, @josephsl)
+  * Updated nh3 0.2.19. (#17465, @josephsl)
 * `ui.browseableMessage` may now be called with options to present a button for copying to clipboard, and/or a button for closing the window. (#17018, @XLTechie)
 * Several additions to identify link types (#16994, @LeonarddeR, @nvdaes)
   * A new `utils.urlUtils` module with different functions to determine link types


### PR DESCRIPTION

### Link to issue number:
Closes #17459 

### Summary of the issue:
NVDA is using markdown 3.6 for documentation generation.

### Description of user facing changes
None

### Description of development approach
Update markdown to 3.7.

### Testing strategy:
Manual and documentation generation: make sure documentation remains the same after markdown upgrade.

### Known issues with pull request:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
