### PR TITLE
Skip Screen Curtain unit test if active

### DIFF
--- a/tests/unit/test_visionEnhancementProviders/test_magnificationAPI.py
+++ b/tests/unit/test_visionEnhancementProviders/test_magnificationAPI.py
@@ -7,7 +7,7 @@
 
 import unittest
 
-from visionEnhancementProviders.screenCurtain import Magnification, TRANSFORM_BLACK
+from visionEnhancementProviders.screenCurtain import Magnification, TRANSFORM_BLACK, MAGCOLOREFFECT
 
 
 class _Test_MagnificationAPI(unittest.TestCase):
@@ -19,6 +19,29 @@ class _Test_MagnificationAPI(unittest.TestCase):
 
 
 class Test_ScreenCurtain(_Test_MagnificationAPI):
+	def _isIdentityMatrix(self, magTransformMatrix: MAGCOLOREFFECT) -> bool:
+		for i in range(5):
+			for j in range(5):
+				if i == j:
+					if magTransformMatrix.transform[i][j] != 1:
+						return False
+				else:
+					if magTransformMatrix.transform[i][j] != 0:
+						return False
+		return True
+
+	def setUp(self):
+		super().setUp()
+		resultEffect = Magnification.MagGetFullscreenColorEffect()
+		if not self._isIdentityMatrix(resultEffect):
+			# If the resultEffect is not the identity matrix, skip the test.
+			# This is because a full screen colour effect is already set external to testing.
+			self.skipTest(
+				f"resultEffect={resultEffect}, should be identity matrix. "
+				"Full screen colour effect set external to tests. "
+			)
+		return
+
 	def test_setAndConfirmBlackFullscreenColorEffect(self):
 		result = Magnification.MagSetFullscreenColorEffect(TRANSFORM_BLACK)
 		self.assertTrue(result)
@@ -28,18 +51,6 @@ class Test_ScreenCurtain(_Test_MagnificationAPI):
 				with self.subTest(i=i, j=j):
 					self.assertEqual(
 						TRANSFORM_BLACK.transform[i][j],
-						resultEffect.transform[i][j],
-						msg=f"i={i}, j={j}, resultEffect={resultEffect}",
-					)
-
-	def test_getDefaultIdentityFullscreenColorEffect(self):
-		resultEffect = Magnification.MagGetFullscreenColorEffect()
-		for i in range(5):
-			for j in range(5):
-				with self.subTest(i=i, j=j):
-					# The transform matrix should be the identity matrix
-					self.assertEqual(
-						int(i == j),
 						resultEffect.transform[i][j],
 						msg=f"i={i}, j={j}, resultEffect={resultEffect}",
 					)

--- a/tests/unit/test_visionEnhancementProviders/test_magnificationAPI.py
+++ b/tests/unit/test_visionEnhancementProviders/test_magnificationAPI.py
@@ -37,7 +37,7 @@ class Test_ScreenCurtain(_Test_MagnificationAPI):
 			# If the resultEffect is not the identity matrix, skip the test.
 			# This is because a full screen colour effect is already set external to testing.
 			self.skipTest(
-				f"resultEffect={resultEffect}, should be identity matrix. "
+				f"{resultEffect=}, should be identity matrix. "
 				"Full screen colour effect set external to tests. ",
 			)
 		return

--- a/tests/unit/test_visionEnhancementProviders/test_magnificationAPI.py
+++ b/tests/unit/test_visionEnhancementProviders/test_magnificationAPI.py
@@ -38,7 +38,7 @@ class Test_ScreenCurtain(_Test_MagnificationAPI):
 			# This is because a full screen colour effect is already set external to testing.
 			self.skipTest(
 				f"resultEffect={resultEffect}, should be identity matrix. "
-				"Full screen colour effect set external to tests. "
+				"Full screen colour effect set external to tests. ",
 			)
 		return
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Follow up to https://github.com/nvaccess/nvda/pull/17413#issuecomment-2506816322

### Summary of the issue:
The screen curtain unit tests fail if the screen curtain (or another colour transform e.g. contrast mode) is active.
Instead these test should be skipped.
Alternatively, they could be run in [debug](https://docs.python.org/3/library/unittest.html#unittest.TestCase.debug) mode to do the test without collecting the failure
