### PR TITLE
Update to liblouis 3.32

### DIFF
--- a/nvdaHelper/liblouis/strings.h
+++ b/nvdaHelper/liblouis/strings.h
@@ -1,0 +1,7 @@
+/*
+ * liblouis/liblouis#1685: liblouis started using strncasecmp, which is not available on Windows.
+ * Neither can Gnulib be used with NVDA's buildssystem.
+ * Therefore, use _strnicmp as a drop-in replacement.
+*/
+
+#define strncasecmp _strnicmp

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -43,6 +43,8 @@ To use this feature, "allow NVDA to control the volume of other applications" mu
 * In Microsoft Word, when using the "report focus" command, the document layout will be announced if this information is available and reporting object descriptions is enabled. (#15088, @nvdaes)
 * NVDA will now only warn about add-on incompatibility when updating to a version which has an incompatible add-on API to the currently installed copy. (#17071)
 * Added commands to move the review cursor to the first and last character of the selected text, assigned to `NVDA+alt+home` and `NVDA+alt+end`, respectively. (#17299, @nvdaes)
+* Component updates:
+  * Updated LibLouis Braille translator to [3.32.0](https://github.com/liblouis/liblouis/releases/tag/v3.32.0). (#17469, @LeonarddeR)
 
 ### Bug Fixes
 


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
Update to liblouis 3.32

### Description of user facing changes
None

### Description of development approach
1. Update submodule
2. In this version, a dependency on Gnulib was introduced that doesn't build on Windows. See https://github.com/liblouis/liblouis/issues/1689 . I fixed this using the approach from https://github.com/liblouis/liblouis/issues/1686. In short, rather than posix `strncasecmp`, we use `_strnicmp `.

### Testing strategy:
Unit tests, running from source

### Known issues with pull request:
Based on the second point as noted below development approach, an alternative could be just removing the metadata part from our liblouis build, which can be used by simply commenting out 'metadata.c' from sconscript.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
