### PR TITLE
Changed a message in input help mode for speak command keys command

### DIFF
--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -569,7 +569,7 @@ class GlobalCommands(ScriptableObject):
 
 	@script(
 		# Translators: Input help mode message for toggle speak command keys command.
-		description=_("Toggles on and off the speaking of typed keys, that are not specifically characters"),
+		description=_("Toggles on and off the speaking of command keys"),
 		category=SCRCAT_SPEECH,
 		gesture="kb:NVDA+4",
 	)


### PR DESCRIPTION
### Link to issue number:
fixes #17470 
### Summary of the issue:
Small inconsistency between user guide and input help mode

### Description of user facing changes
same message which is spoken when toggling the setting, and can also be found in the user guide.

### Description of development approach
Changed the coresponding message in globalCommands.py

### Testing strategy:
Tested that it fires correctly when input help is on and nvda+4 is pressed.

### Known issues with pull request:
None


### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [ ] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [ ] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [ ] API is compatible with existing add-ons.
- [ ] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
