### PR TITLE
Improved Input help on message to add a hint for users on how to turn it off

### DIFF
--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -188,7 +188,9 @@ class GlobalCommands(ScriptableObject):
 	def script_toggleInputHelp(self, gesture):
 		inputCore.manager.isInputHelpActive = not inputCore.manager.isInputHelpActive
 		# Translators: This will be presented when the input help is toggled.
-		stateOn = _("input help on. Press {gestureKeys} again to turn it off.").format(gestureKeys=gesture.displayName)
+		stateOn = _("input help on. Press {gestureKeys} again to turn it off.").format(
+			gestureKeys=gesture.displayName
+		)
 		# Translators: This will be presented when the input help is toggled.
 		stateOff = _("input help off")
 		state = stateOn if inputCore.manager.isInputHelpActive else stateOff

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -188,7 +188,7 @@ class GlobalCommands(ScriptableObject):
 	def script_toggleInputHelp(self, gesture):
 		inputCore.manager.isInputHelpActive = not inputCore.manager.isInputHelpActive
 		# Translators: This will be presented when the input help is toggled.
-		stateOn = _("input help on")
+		stateOn = _("input help on. Press {gestureKeys} again to turn it off.").format(gestureKeys=gesture.displayName)
 		# Translators: This will be presented when the input help is toggled.
 		stateOff = _("input help off")
 		state = stateOn if inputCore.manager.isInputHelpActive else stateOff

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -189,7 +189,7 @@ class GlobalCommands(ScriptableObject):
 		inputCore.manager.isInputHelpActive = not inputCore.manager.isInputHelpActive
 		# Translators: This will be presented when the input help is toggled.
 		stateOn = _("input help on. Press {gestureKeys} again to turn it off.").format(
-			gestureKeys=gesture.displayName
+			gestureKeys=gesture.displayName,
 		)
 		# Translators: This will be presented when the input help is toggled.
 		stateOff = _("input help off")


### PR DESCRIPTION
### Link to issue number:
fixes #17446 
### Summary of the issue:
When entering the input help mode users do not have any indication on how it can be turned off again unless they read the user guide or look into the input gestures dialog.
On IOS, voice over for example reports which gesture needs to be done to turn it off after it has been turned on.
### Description of user facing changes
NVDA will report a short indication after input help comand is pressed.

### Description of development approach
Extended the input on message in globalCommands.py

### Testing strategy:
Tested that the message is reported when pressing nvda+1 to turn it on.

### Known issues with pull request:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [ ] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [ ] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [ ] API is compatible with existing add-ons.
- [ ] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
