### PR TITLE
Added short version for most commonly used command line options

### DIFF
--- a/source/argsParsing.py
+++ b/source/argsParsing.py
@@ -71,14 +71,19 @@ _parser: NoConsoleOptionParser | None = None
 """The arguments parser used by NVDA.
 """
 
+
 def _createNVDAArgParser() -> NoConsoleOptionParser:
-	"""Create a parser to process NVDA option arguments.
-	"""
+	"""Create a parser to process NVDA option arguments."""
 
 	parser = NoConsoleOptionParser(formatter_class=_WideParserHelpFormatter, allow_abbrev=False)
 	quitGroup = parser.add_mutually_exclusive_group()
 	quitGroup.add_argument(
-		"-q", "--quit", action="store_true", dest="quit", default=False, help="Quit already running copy of NVDA"
+		"-q",
+		"--quit",
+		action="store_true",
+		dest="quit",
+		default=False,
+		help="Quit already running copy of NVDA",
 	)
 	parser.add_argument(
 		"-k",
@@ -220,7 +225,11 @@ def _createNVDAArgParser() -> NoConsoleOptionParser:
 		help="The path where a portable copy will be created",
 	)
 	parser.add_argument(
-		"--launcher", action="store_true", dest="launcher", default=False, help="Started from the launcher"
+		"--launcher",
+		action="store_true",
+		dest="launcher",
+		default=False,
+		help="Started from the launcher",
 	)
 	parser.add_argument(
 		"--enable-start-on-logon",
@@ -254,6 +263,7 @@ def _createNVDAArgParser() -> NoConsoleOptionParser:
 		help="Started by Windows Ease of Access",
 	)
 	return parser
+
 
 def getParser() -> NoConsoleOptionParser:
 	global _parser

--- a/source/argsParsing.py
+++ b/source/argsParsing.py
@@ -1,0 +1,262 @@
+# -*- coding: UTF-8 -*-
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2024 NV Access Limited, Cyrille Bougot
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+
+import argparse
+import sys
+import winUser
+
+from typing import IO
+
+
+class _WideParserHelpFormatter(argparse.RawTextHelpFormatter):
+	def __init__(self, prog: str, indent_increment: int = 2, max_help_position: int = 50, width: int = 1000):
+		"""
+		A custom formatter for argparse help messages that uses a wider width.
+		:param prog: The program name.
+		:param indent_increment: The number of spaces to indent for each level of nesting.
+		:param max_help_position: The maximum starting column of the help text.
+		:param width: The width of the help text.
+		"""
+
+		super().__init__(prog, indent_increment, max_help_position, width)
+
+
+class NoConsoleOptionParser(argparse.ArgumentParser):
+	"""
+	A commandline option parser that shows its messages using dialogs,
+	as this pyw file has no dos console window associated with it.
+	"""
+
+	def print_help(self, file: IO[str] | None = None):
+		"""Shows help in a standard Windows message dialog"""
+		winUser.MessageBox(0, self.format_help(), "Help", 0)
+
+	def error(self, message: str):
+		"""Shows an error in a standard Windows message dialog, and then exits NVDA"""
+		out = ""
+		out = self.format_usage()
+		out += f"\nerror: {message}"
+		winUser.MessageBox(0, out, "Command-line Argument Error", winUser.MB_ICONERROR)
+		sys.exit(2)
+
+
+def stringToBool(string):
+	"""Wrapper for configobj.validate.is_boolean to raise the proper exception for wrong values."""
+	from configobj.validate import is_boolean, ValidateError
+
+	try:
+		return is_boolean(string)
+	except ValidateError as e:
+		raise argparse.ArgumentTypeError(e.message)
+
+
+def stringToLang(value: str) -> str:
+	"""Perform basic case normalization for ease of use."""
+	import languageHandler
+
+	if value.casefold() == "Windows".casefold():
+		normalizedLang = "Windows"
+	else:
+		normalizedLang = languageHandler.normalizeLanguage(value)
+	possibleLangNames = languageHandler.listNVDALocales()
+	if normalizedLang is not None and normalizedLang in possibleLangNames:
+		return normalizedLang
+	raise argparse.ArgumentTypeError(f"Language code should be one of:\n{', '.join(possibleLangNames)}.")
+
+
+_parser: NoConsoleOptionParser | None = None
+"""The arguments parser used by NVDA.
+"""
+
+def _createNVDAArgParser() -> NoConsoleOptionParser:
+	"""Create a parser to process NVDA option arguments.
+	"""
+
+	parser = NoConsoleOptionParser(formatter_class=_WideParserHelpFormatter, allow_abbrev=False)
+	quitGroup = parser.add_mutually_exclusive_group()
+	quitGroup.add_argument(
+		"-q", "--quit", action="store_true", dest="quit", default=False, help="Quit already running copy of NVDA"
+	)
+	parser.add_argument(
+		"-k",
+		"--check-running",
+		action="store_true",
+		dest="check_running",
+		default=False,
+		help="Report whether NVDA is running via the exit code; 0 if running, 1 if not running",
+	)
+	parser.add_argument(
+		"-f",
+		"--log-file",
+		dest="logFileName",
+		type=str,
+		help="The file to which log messages should be written.\n"
+		'Default destination is "%%TEMP%%\\nvda.log".\n'
+		"Logging is always disabled if secure mode is enabled.\n",
+	)
+	parser.add_argument(
+		"-l",
+		"--log-level",
+		dest="logLevel",
+		type=int,
+		default=0,  # 0 means unspecified in command line.
+		choices=[10, 12, 15, 20, 100],
+		help="The lowest level of message logged (debug 10, input/output 12, debugwarning 15, info 20, off 100).\n"
+		"Default value is 20 (info) or the user configured setting.\n"
+		"Logging is always disabled if secure mode is enabled.\n",
+	)
+	parser.add_argument(
+		"-c",
+		"--config-path",
+		dest="configPath",
+		default=None,
+		type=str,
+		help="The path where all settings for NVDA are stored.\n"
+		"The default value is forced if secure mode is enabled.\n",
+	)
+	parser.add_argument(
+		"-n",
+		"--lang",
+		dest="language",
+		default=None,
+		type=stringToLang,
+		help=(
+			"Override the configured NVDA language.\n"
+			'Set to "Windows" for current user default, "en" for English, etc.'
+		),
+	)
+	parser.add_argument(
+		"-m",
+		"--minimal",
+		action="store_true",
+		dest="minimal",
+		default=False,
+		help="No sounds, no interface, no start message etc",
+	)
+	# --secure is used to force secure mode.
+	# Documented in the userGuide in #SecureMode.
+	parser.add_argument(
+		"-s",
+		"--secure",
+		action="store_true",
+		dest="secure",
+		default=False,
+		help="Starts NVDA in secure mode",
+	)
+	parser.add_argument(
+		"-d",
+		"--disable-addons",
+		action="store_true",
+		dest="disableAddons",
+		default=False,
+		help="Disable all add-ons",
+	)
+	parser.add_argument(
+		"--debug-logging",
+		action="store_true",
+		dest="debugLogging",
+		default=False,
+		help="Enable debug level logging just for this run.\n"
+		"This setting will override any other log level (--loglevel, -l) argument given, "
+		"as well as no logging option.",
+	)
+	parser.add_argument(
+		"--no-logging",
+		action="store_true",
+		dest="noLogging",
+		default=False,
+		help="Disable logging completely for this run.\n"
+		"This setting can be overwritten with other log level (--loglevel, -l) "
+		"switch or if debug logging is specified.",
+	)
+	parser.add_argument(
+		"--no-sr-flag",
+		action="store_false",
+		dest="changeScreenReaderFlag",
+		default=True,
+		help="Don't change the global system screen reader flag",
+	)
+	installGroup = parser.add_mutually_exclusive_group()
+	installGroup.add_argument(
+		"--install",
+		action="store_true",
+		dest="install",
+		default=False,
+		help="Installs NVDA (starting the new copy after installation)",
+	)
+	installGroup.add_argument(
+		"--install-silent",
+		action="store_true",
+		dest="installSilent",
+		default=False,
+		help="Installs NVDA silently (does not start the new copy after installation).",
+	)
+	installGroup.add_argument(
+		"--create-portable",
+		action="store_true",
+		dest="createPortable",
+		default=False,
+		help="Creates a portable copy of NVDA (and starts the new copy).\n"
+		"Requires `--portable-path` to be specified.\n",
+	)
+	installGroup.add_argument(
+		"--create-portable-silent",
+		action="store_true",
+		dest="createPortableSilent",
+		default=False,
+		help="Creates a portable copy of NVDA (without starting the new copy).\n"
+		"This option suppresses warnings when writing to non-empty directories "
+		"and may overwrite files without warning.\n"
+		"Requires --portable-path to be specified.\n",
+	)
+	parser.add_argument(
+		"--portable-path",
+		dest="portablePath",
+		default=None,
+		type=str,
+		help="The path where a portable copy will be created",
+	)
+	parser.add_argument(
+		"--launcher", action="store_true", dest="launcher", default=False, help="Started from the launcher"
+	)
+	parser.add_argument(
+		"--enable-start-on-logon",
+		metavar="True|False",
+		type=stringToBool,
+		dest="enableStartOnLogon",
+		default=None,
+		help="When installing, enable NVDA's start on the logon screen",
+	)
+	parser.add_argument(
+		"--copy-portable-config",
+		action="store_true",
+		dest="copyPortableConfig",
+		default=False,
+		help=(
+			"When installing, copy the portable configuration "
+			"from the provided path (--config-path, -c) to the current user account"
+		),
+	)
+	# This option is passed by Ease of Access so that if someone downgrades without uninstalling
+	# (despite our discouragement), the downgraded copy won't be started in non-secure mode on secure desktops.
+	# (Older versions always required the --secure option to start in secure mode.)
+	# If this occurs, the user will see an obscure error,
+	# but that's far better than a major security hazzard.
+	# If this option is provided, NVDA will not replace an already running instance (#10179)
+	parser.add_argument(
+		"--ease-of-access",
+		action="store_true",
+		dest="easeOfAccess",
+		default=False,
+		help="Started by Windows Ease of Access",
+	)
+	return parser
+
+def getParser() -> NoConsoleOptionParser:
+	global _parser
+	if not _parser:
+		_parser = _createNVDAArgParser()
+	return _parser

--- a/source/core.py
+++ b/source/core.py
@@ -216,7 +216,7 @@ class NewNVDAInstance:
 
 def computeRestartCLIArgs(removeArgsList: list[str] | None = None) -> list[str]:
 	"""Generate an equivalent list of CLI arguments from the values in globalVars.appArgs.
-	:param removeArgsList: A list of value to ignore when looking in globalVars.appArgs.
+	:param removeArgsList: A list of values to ignore when looking in globalVars.appArgs.
 	"""
 	from __main__ import parser  # import from nda.pyw
 

--- a/source/core.py
+++ b/source/core.py
@@ -24,6 +24,7 @@ from enum import Enum
 import logHandler
 import languageHandler
 import globalVars
+import argsParsing
 from logHandler import log
 import addonHandler
 import extensionPoints
@@ -218,8 +219,8 @@ def computeRestartCLIArgs(removeArgsList: list[str] | None = None) -> list[str]:
 	"""Generate an equivalent list of CLI arguments from the values in globalVars.appArgs.
 	:param removeArgsList: A list of values to ignore when looking in globalVars.appArgs.
 	"""
-	from __main__ import parser  # import from nda.pyw
 
+	parser = argsParsing.getParser()
 	if not removeArgsList:
 		removeArgsList = []
 	args = []

--- a/source/globalVars.py
+++ b/source/globalVars.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2006-2022 NV Access Limited, Łukasz Golonka, Leonard de Ruijter, Babbage B.V.,
+# Copyright (C) 2006-2024 NV Access Limited, Łukasz Golonka, Leonard de Ruijter, Babbage B.V.,
 # Aleksey Sadovoy, Peter Vágner
 # This file may be used under the terms of the GNU General Public License, version 2 or later.
 # For more details see: https://www.gnu.org/licenses/gpl-2.0.html
@@ -41,7 +41,7 @@ class DefaultAppArgs(argparse.Namespace):
 	logFileName: Optional[os.PathLike] = ""
 	logLevel: int = 0
 	configPath: Optional[os.PathLike] = None
-	language: str = "en"
+	language: str | None = None
 	minimal: bool = False
 	secure: bool = False
 	"""

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -800,16 +800,9 @@ class GeneralSettingsPanel(SettingsPanel):
 		self.languageNames = languageHandler.getAvailableLanguages(presentational=True)
 		languageChoices = [x[1] for x in self.languageNames]
 		if languageHandler.isLanguageForced():
-			try:
-				cmdLangDescription = next(
-					ld for code, ld in self.languageNames if code == globalVars.appArgs.language
-				)
-			except StopIteration:
-				# In case --lang=Windows is passed to the command line, globalVars.appArgs.language is the current
-				# Windows language,, which may not be in the list of NVDA supported languages, e.g. Windows language may
-				# be 'fr_FR' but NVDA only supports 'fr'.
-				# In this situation, only use language code as a description.
-				cmdLangDescription = globalVars.appArgs.language
+			cmdLangDescription = next(
+				ld for code, ld in self.languageNames if code == globalVars.appArgs.language
+			)
 			languageChoices.append(
 				# Translators: Shown for a language which has been provided from the command line
 				# 'langDesc' would be replaced with description of the given locale.

--- a/source/nvda.pyw
+++ b/source/nvda.pyw
@@ -326,8 +326,6 @@ parser.add_argument(
 	help="Started by Windows Ease of Access",
 )
 (globalVars.appArgs, globalVars.unknownAppArgs) = parser.parse_known_args()
-# Copy original app args
-globalVars.originalAppArgs = argparse.Namespace(**{k: v for (k, v) in globalVars.appArgs._get_kwargs()})
 # Make any app args path values absolute
 # So as to not be affected by the current directory changing during process lifetime.
 pathAppArgs = [

--- a/source/nvda.pyw
+++ b/source/nvda.pyw
@@ -14,9 +14,10 @@ import logging
 import sys
 import os
 
-from typing import IO
+from typing import Any
 
 import globalVars
+from argsParsing import getParser
 import ctypes
 from ctypes import wintypes
 import monkeyPatches
@@ -59,7 +60,6 @@ globalVars.appDir = appDir
 globalVars.appPid = os.getpid()
 
 
-import argparse  # noqa: E402
 import config  # noqa: E402
 import logHandler  # noqa: E402
 from logHandler import log  # noqa: E402
@@ -79,38 +79,6 @@ else:
 	config.isAppX = GetCurrentPackageFullName(ctypes.byref(bufLen), None) != 15700
 
 
-class _WideParserHelpFormatter(argparse.RawTextHelpFormatter):
-	def __init__(self, prog: str, indent_increment: int = 2, max_help_position: int = 50, width: int = 1000):
-		"""
-		A custom formatter for argparse help messages that uses a wider width.
-		:param prog: The program name.
-		:param indent_increment: The number of spaces to indent for each level of nesting.
-		:param max_help_position: The maximum starting column of the help text.
-		:param width: The width of the help text.
-		"""
-
-		super().__init__(prog, indent_increment, max_help_position, width)
-
-
-class NoConsoleOptionParser(argparse.ArgumentParser):
-	"""
-	A commandline option parser that shows its messages using dialogs,
-	as this pyw file has no dos console window associated with it.
-	"""
-
-	def print_help(self, file: IO[str] | None = None):
-		"""Shows help in a standard Windows message dialog"""
-		winUser.MessageBox(0, self.format_help(), "Help", 0)
-
-	def error(self, message: str):
-		"""Shows an error in a standard Windows message dialog, and then exits NVDA"""
-		out = ""
-		out = self.format_usage()
-		out += f"\nerror: {message}"
-		winUser.MessageBox(0, out, "Command-line Argument Error", winUser.MB_ICONERROR)
-		sys.exit(2)
-
-
 NVDAState._initializeStartTime()
 
 
@@ -122,210 +90,23 @@ if not winVersion.isSupportedOS():
 	sys.exit(1)
 
 
-def stringToBool(string):
-	"""Wrapper for configobj.validate.is_boolean to raise the proper exception for wrong values."""
-	from configobj.validate import is_boolean, ValidateError
-
-	try:
-		return is_boolean(string)
-	except ValidateError as e:
-		raise argparse.ArgumentTypeError(e.message)
-
-
-def stringToLang(value: str) -> str:
-	"""Perform basic case normalization for ease of use."""
-	import languageHandler
-
-	if value.casefold() == "Windows".casefold():
-		normalizedLang = "Windows"
-	else:
-		normalizedLang = languageHandler.normalizeLanguage(value)
-	possibleLangNames = languageHandler.listNVDALocales()
-	if normalizedLang is not None and normalizedLang in possibleLangNames:
-		return normalizedLang
-	raise argparse.ArgumentTypeError(f"Language code should be one of:\n{', '.join(possibleLangNames)}.")
+def __getattr__(attrName: str) -> Any:
+	"""Module level `__getattr__` used to preserve backward compatibility.
+	"""
+	if NVDAState._allowDeprecatedAPI():
+		if attrName in ("NoConsoleOptionParser", "stringToBool", "stringToLang"):
+			import argsParsing
+			log.warning(f"__main__.{attrName} is deprecated, use argsParsing.{attrName} instead.")
+			return getattr(argsParsing, attrName)
+		if attrName == "parser":
+			import argsParsing
+			log.warning(f"__main__.{attrName} is deprecated, use argsParsing.getParser() instead.")
+			return argsParsing.getParser()
+	raise AttributeError(f"module {repr(__name__)} has no attribute {repr(attrName)}")
 
 
-# Process option arguments
-parser = NoConsoleOptionParser(formatter_class=_WideParserHelpFormatter, allow_abbrev=False)
-quitGroup = parser.add_mutually_exclusive_group()
-quitGroup.add_argument(
-	"-q", "--quit", action="store_true", dest="quit", default=False, help="Quit already running copy of NVDA"
-)
-parser.add_argument(
-	"-k",
-	"--check-running",
-	action="store_true",
-	dest="check_running",
-	default=False,
-	help="Report whether NVDA is running via the exit code; 0 if running, 1 if not running",
-)
-parser.add_argument(
-	"-f",
-	"--log-file",
-	dest="logFileName",
-	type=str,
-	help="The file to which log messages should be written.\n"
-	'Default destination is "%%TEMP%%\\nvda.log".\n'
-	"Logging is always disabled if secure mode is enabled.\n",
-)
-parser.add_argument(
-	"-l",
-	"--log-level",
-	dest="logLevel",
-	type=int,
-	default=0,  # 0 means unspecified in command line.
-	choices=[10, 12, 15, 20, 100],
-	help="The lowest level of message logged (debug 10, input/output 12, debugwarning 15, info 20, off 100).\n"
-	"Default value is 20 (info) or the user configured setting.\n"
-	"Logging is always disabled if secure mode is enabled.\n",
-)
-parser.add_argument(
-	"-c",
-	"--config-path",
-	dest="configPath",
-	default=None,
-	type=str,
-	help="The path where all settings for NVDA are stored.\n"
-	"The default value is forced if secure mode is enabled.\n",
-)
-parser.add_argument(
-	"-n",
-	"--lang",
-	dest="language",
-	default=None,
-	type=stringToLang,
-	help=(
-		"Override the configured NVDA language.\n"
-		'Set to "Windows" for current user default, "en" for English, etc.'
-	),
-)
-parser.add_argument(
-	"-m",
-	"--minimal",
-	action="store_true",
-	dest="minimal",
-	default=False,
-	help="No sounds, no interface, no start message etc",
-)
-# --secure is used to force secure mode.
-# Documented in the userGuide in #SecureMode.
-parser.add_argument(
-	"-s",
-	"--secure",
-	action="store_true",
-	dest="secure",
-	default=False,
-	help="Starts NVDA in secure mode",
-)
-parser.add_argument(
-	"-d",
-	"--disable-addons",
-	action="store_true",
-	dest="disableAddons",
-	default=False,
-	help="Disable all add-ons",
-)
-parser.add_argument(
-	"--debug-logging",
-	action="store_true",
-	dest="debugLogging",
-	default=False,
-	help="Enable debug level logging just for this run.\n"
-	"This setting will override any other log level (--loglevel, -l) argument given, "
-	"as well as no logging option.",
-)
-parser.add_argument(
-	"--no-logging",
-	action="store_true",
-	dest="noLogging",
-	default=False,
-	help="Disable logging completely for this run.\n"
-	"This setting can be overwritten with other log level (--loglevel, -l) "
-	"switch or if debug logging is specified.",
-)
-parser.add_argument(
-	"--no-sr-flag",
-	action="store_false",
-	dest="changeScreenReaderFlag",
-	default=True,
-	help="Don't change the global system screen reader flag",
-)
-installGroup = parser.add_mutually_exclusive_group()
-installGroup.add_argument(
-	"--install",
-	action="store_true",
-	dest="install",
-	default=False,
-	help="Installs NVDA (starting the new copy after installation)",
-)
-installGroup.add_argument(
-	"--install-silent",
-	action="store_true",
-	dest="installSilent",
-	default=False,
-	help="Installs NVDA silently (does not start the new copy after installation).",
-)
-installGroup.add_argument(
-	"--create-portable",
-	action="store_true",
-	dest="createPortable",
-	default=False,
-	help="Creates a portable copy of NVDA (and starts the new copy).\n"
-	"Requires `--portable-path` to be specified.\n",
-)
-installGroup.add_argument(
-	"--create-portable-silent",
-	action="store_true",
-	dest="createPortableSilent",
-	default=False,
-	help="Creates a portable copy of NVDA (without starting the new copy).\n"
-	"This option suppresses warnings when writing to non-empty directories "
-	"and may overwrite files without warning.\n"
-	"Requires --portable-path to be specified.\n",
-)
-parser.add_argument(
-	"--portable-path",
-	dest="portablePath",
-	default=None,
-	type=str,
-	help="The path where a portable copy will be created",
-)
-parser.add_argument(
-	"--launcher", action="store_true", dest="launcher", default=False, help="Started from the launcher"
-)
-parser.add_argument(
-	"--enable-start-on-logon",
-	metavar="True|False",
-	type=stringToBool,
-	dest="enableStartOnLogon",
-	default=None,
-	help="When installing, enable NVDA's start on the logon screen",
-)
-parser.add_argument(
-	"--copy-portable-config",
-	action="store_true",
-	dest="copyPortableConfig",
-	default=False,
-	help=(
-		"When installing, copy the portable configuration "
-		"from the provided path (--config-path, -c) to the current user account"
-	),
-)
-# This option is passed by Ease of Access so that if someone downgrades without uninstalling
-# (despite our discouragement), the downgraded copy won't be started in non-secure mode on secure desktops.
-# (Older versions always required the --secure option to start in secure mode.)
-# If this occurs, the user will see an obscure error,
-# but that's far better than a major security hazzard.
-# If this option is provided, NVDA will not replace an already running instance (#10179)
-parser.add_argument(
-	"--ease-of-access",
-	action="store_true",
-	dest="easeOfAccess",
-	default=False,
-	help="Started by Windows Ease of Access",
-)
-(globalVars.appArgs, globalVars.unknownAppArgs) = parser.parse_known_args()
+_parser = getParser()
+(globalVars.appArgs, globalVars.unknownAppArgs) = _parser.parse_known_args()
 # Make any app args path values absolute
 # So as to not be affected by the current directory changing during process lifetime.
 pathAppArgs = [

--- a/source/nvda.pyw
+++ b/source/nvda.pyw
@@ -91,11 +91,11 @@ if not winVersion.isSupportedOS():
 
 
 def __getattr__(attrName: str) -> Any:
-	"""Module level `__getattr__` used to preserve backward compatibility.
-	"""
+	"""Module level `__getattr__` used to preserve backward compatibility."""
 	if NVDAState._allowDeprecatedAPI():
 		if attrName in ("NoConsoleOptionParser", "stringToBool", "stringToLang"):
 			import argsParsing
+
 			log.warning(f"__main__.{attrName} is deprecated, use argsParsing.{attrName} instead.")
 			return getattr(argsParsing, attrName)
 		if attrName == "parser":

--- a/source/nvda.pyw
+++ b/source/nvda.pyw
@@ -100,6 +100,7 @@ def __getattr__(attrName: str) -> Any:
 			return getattr(argsParsing, attrName)
 		if attrName == "parser":
 			import argsParsing
+
 			log.warning(f"__main__.{attrName} is deprecated, use argsParsing.getParser() instead.")
 			return argsParsing.getParser()
 	raise AttributeError(f"module {repr(__name__)} has no attribute {repr(attrName)}")

--- a/source/nvda.pyw
+++ b/source/nvda.pyw
@@ -147,7 +147,7 @@ def stringToLang(value: str) -> str:
 
 
 # Process option arguments
-parser = NoConsoleOptionParser(formatter_class=_WideParserHelpFormatter)
+parser = NoConsoleOptionParser(formatter_class=_WideParserHelpFormatter, allow_abbrev=False)
 quitGroup = parser.add_mutually_exclusive_group()
 quitGroup.add_argument(
 	"-q", "--quit", action="store_true", dest="quit", default=False, help="Quit already running copy of NVDA"

--- a/source/nvda.pyw
+++ b/source/nvda.pyw
@@ -190,9 +190,10 @@ parser.add_argument(
 	"The default value is forced if secure mode is enabled.\n",
 )
 parser.add_argument(
+	"-n",
 	"--lang",
 	dest="language",
-	default="en",
+	default=None,
 	type=stringToLang,
 	help=(
 		"Override the configured NVDA language.\n"
@@ -218,7 +219,12 @@ parser.add_argument(
 	help="Starts NVDA in secure mode",
 )
 parser.add_argument(
-	"--disable-addons", action="store_true", dest="disableAddons", default=False, help="Disable all add-ons"
+	"-d",
+	"--disable-addons",
+	action="store_true",
+	dest="disableAddons",
+	default=False,
+	help="Disable all add-ons",
 )
 parser.add_argument(
 	"--debug-logging",
@@ -320,6 +326,8 @@ parser.add_argument(
 	help="Started by Windows Ease of Access",
 )
 (globalVars.appArgs, globalVars.unknownAppArgs) = parser.parse_known_args()
+# Copy original app args
+globalVars.originalAppArgs = argparse.Namespace(**{k: v for (k, v) in globalVars.appArgs._get_kwargs()})
 # Make any app args path values absolute
 # So as to not be affected by the current directory changing during process lifetime.
 pathAppArgs = [

--- a/tests/unit/test_synthDriverHandler.py
+++ b/tests/unit/test_synthDriverHandler.py
@@ -1,12 +1,11 @@
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-# Copyright (C) 2021-2023 NV Access Limited, Leonard de RUijter
+# Copyright (C) 2021-2024 NV Access Limited, Leonard de Ruijter, Cyrille Bougot
 
 """Unit tests for the synthDriverHandler"""
 
 import config
-import globalVars
 import languageHandler
 import synthDriverHandler
 from synthDrivers.oneCore import SynthDriver as OneCoreSynthDriver
@@ -48,7 +47,7 @@ class test_synthDriverHandler(unittest.TestCase):
 		config.conf["speech"]["synth"] = FAKE_DEFAULT_LANG
 		synthDriverHandler._curSynth = MockSynth(FAKE_DEFAULT_SYNTH_NAME)
 		synthDriverHandler._getSynthDriver = self._mock_getSynthDriver
-		globalVars.appArgs.language = FAKE_DEFAULT_LANG
+		languageHandler._language = FAKE_DEFAULT_LANG
 
 	@staticmethod
 	def _mock_getSynthDriver(synthName: str) -> Callable[[], MockSynth]:
@@ -58,7 +57,7 @@ class test_synthDriverHandler(unittest.TestCase):
 		config.conf["speech"]["synth"] = self._oldSynthConfig
 		synthDriverHandler._curSynth = self._originalSynth
 		synthDriverHandler._getSynthDriver = self._originalGetSynthDriver
-		globalVars.appArgs.language = self._oldLang
+		languageHandler._language = self._oldLang
 
 	def test_setSynth_auto(self):
 		"""
@@ -113,7 +112,7 @@ class test_synthDriverHandler(unittest.TestCase):
 		Ensures that if oneCore doesn't support the current language, setSynth("auto") falls back to the
 		current synth, or espeak if there is no current synth.
 		"""
-		globalVars.appArgs.language = "bar"  # set the lang so it is not supported
+		languageHandler._language = "bar"  # set the lang so it is not supported
 		synthDriverHandler.setSynth("auto")
 		self.assertEqual(synthDriverHandler.getSynth().name, FAKE_DEFAULT_SYNTH_NAME)
 		synthDriverHandler.setSynth(None)  # reset the synth so there is no fallback

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -138,6 +138,7 @@ As the NVDA update check URL is now configurable directly within NVDA, no replac
 * The `[upgrade]` configuration section including `[upgrade][newLaptopKeyboardLayout]` has been removed. (#17191)
 * In `NVDAObjects.window.scintilla.ScintillaTextInfo`, if no text is selected, the `collapse` method is overriden to expand to line if the `end` parameter is set to `True` (#17431, @nvdaes)
 * `languageHandler.getLanguageCliArgs` has been removed with no replacement. (#17486, @CyrilleB79)
+* Prefix matching on command line flags, e.g. using `--di` for `--disable-addons` is no longer supported. (#11644, @CyrilleB79)
 
 #### Deprecations
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -46,6 +46,7 @@ To use this feature, "allow NVDA to control the volume of other applications" mu
 * Component updates:
   * Updated LibLouis Braille translator to [3.32.0](https://github.com/liblouis/liblouis/releases/tag/v3.32.0). (#17469, @LeonarddeR)
   * Updated CLDR to version 46.0. (#17484, @OzancanKaratas)
+* Short versions of the most commonly used command line Options have been added: `-d` for `--disable-addons` and `-n` for `--lang`. (#11644, @CyrilleB79)
 
 ### Bug Fixes
 
@@ -135,6 +136,7 @@ As the NVDA update check URL is now configurable directly within NVDA, no replac
 * The `space` keyword argument for `brailleDisplayDrivers.seikantk.InputGesture` now expects an `int` rather than a `bool`. (#17047, @school510587)
 * The `[upgrade]` configuration section including `[upgrade][newLaptopKeyboardLayout]` has been removed. (#17191)
 * In `NVDAObjects.window.scintilla.ScintillaTextInfo`, if no text is selected, the `collapse` method is overriden to expand to line if the `end` parameter is set to `True` (#17431, @nvdaes)
+* `languageHandler.getLanguageCliArgs` has been removed with no replacement. (#17486, @CyrilleB79)
 
 #### Deprecations
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -46,7 +46,7 @@ To use this feature, "allow NVDA to control the volume of other applications" mu
 * Component updates:
   * Updated LibLouis Braille translator to [3.32.0](https://github.com/liblouis/liblouis/releases/tag/v3.32.0). (#17469, @LeonarddeR)
   * Updated CLDR to version 46.0. (#17484, @OzancanKaratas)
-* Short versions of the most commonly used command line Options have been added: `-d` for `--disable-addons` and `-n` for `--lang`.
+* Short versions of the most commonly used command line options have been added: `-d` for `--disable-addons` and `-n` for `--lang`.
 Prefix matching on command line flags, e.g. using `--di` for `--disable-addons` is no longer supported. (#11644, @CyrilleB79)
 
 ### Bug Fixes

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -137,13 +137,16 @@ As the NVDA update check URL is now configurable directly within NVDA, no replac
 * The `space` keyword argument for `brailleDisplayDrivers.seikantk.InputGesture` now expects an `int` rather than a `bool`. (#17047, @school510587)
 * The `[upgrade]` configuration section including `[upgrade][newLaptopKeyboardLayout]` has been removed. (#17191)
 * In `NVDAObjects.window.scintilla.ScintillaTextInfo`, if no text is selected, the `collapse` method is overriden to expand to line if the `end` parameter is set to `True` (#17431, @nvdaes)
-* `languageHandler.getLanguageCliArgs` has been removed with no replacement. (#17486, @CyrilleB79)
+* The following symbols have been removed with no replacement: `languageHandler.getLanguageCliArgs`, `__main__.quitGroup` and `__main__.installGroup` . (#17486, @CyrilleB79)
 * Prefix matching on command line flags, e.g. using `--di` for `--disable-addons` is no longer supported. (#11644, @CyrilleB79)
 
 #### Deprecations
 
 * The `braille.filter_displaySize` extension point is deprecated.
 Please use `braille.filter_displayDimensions` instead. (#17011)
+* The following symbols are deprecated (#17486, @CyrilleB79):
+  * `NoConsoleOptionParser`, `stringToBool`, `stringToLang` in `__main__`; use the same symbols in `argsParsing` instead.
+  * `__main__.parser`; use `argsParsing.getParser()` instead.
 
 ## 2024.4.1
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -46,7 +46,8 @@ To use this feature, "allow NVDA to control the volume of other applications" mu
 * Component updates:
   * Updated LibLouis Braille translator to [3.32.0](https://github.com/liblouis/liblouis/releases/tag/v3.32.0). (#17469, @LeonarddeR)
   * Updated CLDR to version 46.0. (#17484, @OzancanKaratas)
-* Short versions of the most commonly used command line Options have been added: `-d` for `--disable-addons` and `-n` for `--lang`. (#11644, @CyrilleB79)
+* Short versions of the most commonly used command line Options have been added: `-d` for `--disable-addons` and `-n` for `--lang`.
+Prefix matching on command line flags, e.g. using `--di` for `--disable-addons` is no longer supported. (#11644, @CyrilleB79)
 
 ### Bug Fixes
 


### PR DESCRIPTION
### Link to issue number:
Fixes #11644
Fixes #17485
### Summary of the issue:
* Most common command line options need a short version.
* Command line options is not robust, leading to undesirable effects when restarting NVDA
### Description of user facing changes
* Short versions of two command line flags have been added: `-d` for `--disable-addons` and `-n` for `--lang`
* Using incomplete command line flags or duplicated command line options should not produce unexpected effects when restarting NVDA.

### Description of development approach
* Added new flags
* Check parsed app args rather than raw `sys.argv` to know the options that NVDA has actually taken into account.
* Removed `languageHandler.getLanguageCliArgs` since we do not use this function anymore and it was not correctly working as expected for some corner case (duplicated flag, incomplete flag)

### Testing strategy:
Manual tests from source:
* Start NVDA with `--lang`, `-n`, `--disable-addons`, `-d`.
* When language is forced from command line, check the language combo-box in general settings
* STR1, STR2 and STR3 from #17485
* Various other options to launch NVDA and then restarting it.

Also tested from launcher with options.

### Known issues with pull request:
None
### Code Review Checklist:


- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
