### PR TITLE
Respect 'Say all on page load' in PowerPoint slide shows

### DIFF
--- a/source/appModules/powerpnt.py
+++ b/source/appModules/powerpnt.py
@@ -15,6 +15,7 @@ import comtypes.client
 import ctypes
 
 import comtypes.client.lazybind
+import config
 import oleacc
 import comHelper
 import ui
@@ -1386,8 +1387,10 @@ class SlideShowTreeInterceptor(DocumentTreeInterceptor):
 	def event_treeInterceptor_gainFocus(self):
 		braille.handler.handleGainFocus(self)
 		self.rootNVDAObject.reportFocus()
+		doSayAll = not self.hadFocusOnce and config.conf["virtualBuffers"]["autoSayAllOnPageLoad"]
 		if not self.hadFocusOnce:
 			self.hadFocusOnce = True
+		if doSayAll:
 			self.reportNewSlide()
 		else:
 			info = self.selection

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -52,9 +52,10 @@ To use this feature, "allow NVDA to control the volume of other applications" mu
 * Math reading has been fixed for some web elements.
 Specifically, MathML inside of span and other elements that have the attribute `role="math"`. (#15058)
 * Native support for the Dot Pad tactile graphics device from Dot Inc as a multiline braille display. (#17007)
-* Improvements when editing in Microsoft PowerPoint:
+* Improvements in Microsoft PowerPoint:
   * Caret reporting no longer breaks when text contains wide characters, such as emoji. (#17006 , @LeonarddeR)
   * Character location reporting is now accurate (e.g. when pressing `NVDA+Delete`. (#9941, @LeonarddeR)
+  * NVDA no longer starts say all when starting a slide show and the browse mode setting "Automatic Say All on page load" is disabled. (#17488, @LeonarddeR)
 * When using the Seika Notetaker, space and space with dots gestures are now displayed correctly in the Input Gestures dialog. (#17047, @school510587)
 * Configuration profiles:
   * Braille is no longer dysfunctional when activating 'say all' with an associated configuration profile. (#17163, @LeonarddeR)


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
When Browse mode setting "say all on page load" is disabled, NVDA yet starts say all in a slide show.

### Description of user facing changes
NVDA no longer automatically starts say all when starting a PowerPoint slide show and "say all on page load" is disabled.

### Description of development approach
Check the config setting.

### Testing strategy:
Tested that NVDA no longer starts say all when the option is disabled.

### Known issues with pull request:
None known

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
