### PR TITLE
Initialize auto select detection when focus returns to an editable text control from outside a browse mode document.

### DIFF
--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -1999,6 +1999,12 @@ class BrowseModeDocumentTreeInterceptor(
 			# and this was the last non-root node with focus, so ignore this focus event.
 			# Otherwise, if the user switches away and back to this document, the cursor will jump to this node.
 			# This is not ideal if the user was positioned over a node which cannot receive focus.
+			# #17501: Even though we're ignoring this event, we still need to call
+			# _postGainFocus. This does things such as initialize auto select detection
+			# for editable text controls. Without this, the focus object might not
+			# behave correctly (e.g. text selection changes might not be reported) if the
+			# user switches to focus mode with this object still focused.
+			self._postGainFocus(obj)
 			return
 		if obj == self.rootNVDAObject:
 			if self.passThrough:

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -76,6 +76,7 @@ Specifically, MathML inside of span and other elements that have the attribute `
 * In Notepad and other UIA documents, and Notepad++ documents on Windows 11, if the last line is empty, the "braille next line command" will move the cursor to the last line.
 In any document, if the cursor is on the last line, it will be moved to the end when using this command.
 (#17251, #17430, @nvdaes)
+* In web browsers, changes to text selection no longer sometimes fail to be reported in editable text controls. (#17501, @jcsteh)
 
 ### Changes for Developers
 


### PR DESCRIPTION
### Link to issue number:
Fixes #17501.

### Summary of the issue:
In web browsers, if you focus an editable text control, switch to browse mode, move focus out of the document (e.g. by switching applications) and then switch back to focus mode, changes to the text selection (e.g. shift+arrows) stop being reported.

### Description of user facing changes
In web browsers, changes to text selection no longer sometimes fail to be reported in editable text controls.

### Description of development approach
EditableTextWithAutoSelectDetection objects initialize auto select detection in event_gainFocus. However, when in browse mode, we deliberately ignore focus events when focus returns from outside the document. This means that event_gainFocus is never called and thus auto select detection is never initialized. The result is that when the user returns to focus mode with an editable text control focused, auto text selection isn't initialized and thus doesn't work at all.

We already handle this initialization in BrowseModeDocumentTreeInterceptor._postGainFocus for some cases. However, we previously weren't calling this when focus returned from outside the document. With this change, we do.

Note that initAutoSelectDetection is the only thing currently performed by `_postGainFocus`, via the override in the Gecko_ia2 vbuf.

### Testing strategy:
Tested the steps to reproduce in #17501. Verified that the expected result occurs.

### Known issues with pull request:
None.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
