### PR TITLE
Fix only show add-on incompatibility warning to only show when updating to an incompatible API

### DIFF
--- a/source/updateCheck.py
+++ b/source/updateCheck.py
@@ -450,7 +450,7 @@ class UpdateResultDialog(
 				# applied.
 				"Update to NVDA version {version} has been downloaded and is ready to be applied.",
 			).format(**updateInfo)
-			log.info(pendingUpdateDetails)
+
 			self.apiVersion = pendingUpdateDetails[2]
 			self.backCompatTo = pendingUpdateDetails[3]
 			showAddonCompat = (self.backCompatTo[0] > addonAPIVersion.BACK_COMPAT_TO[0]) and any(

--- a/source/updateCheck.py
+++ b/source/updateCheck.py
@@ -450,7 +450,7 @@ class UpdateResultDialog(
 				# applied.
 				"Update to NVDA version {version} has been downloaded and is ready to be applied.",
 			).format(**updateInfo)
-
+			log.info(pendingUpdateDetails)
 			self.apiVersion = pendingUpdateDetails[2]
 			self.backCompatTo = pendingUpdateDetails[3]
 			showAddonCompat = (self.backCompatTo[0] > addonAPIVersion.BACK_COMPAT_TO[0]) and any(
@@ -571,7 +571,7 @@ class UpdateAskInstallDialog(
 		# Translators: A message indicating that an update to NVDA is ready to be applied.
 		message = _("Update to NVDA version {version} is ready to be applied.\n").format(version=version)
 
-		showAddonCompat = any(
+		showAddonCompat = (self.backCompatTo[0] > addonAPIVersion.BACK_COMPAT_TO[0]) and any(
 			getIncompatibleAddons(
 				currentAPIVersion=self.apiVersion,
 				backCompatToAPIVersion=self.backCompatTo,

--- a/source/versionInfo.py
+++ b/source/versionInfo.py
@@ -32,5 +32,3 @@ It can also be viewed online at: https://www.gnu.org/licenses/old-licenses/gpl-2
 {name} is developed by NV Access, a non-profit organisation committed to helping and promoting free and open source solutions for blind and vision impaired people.
 If you find NVDA useful and want it to continue to improve, please consider donating to NV Access. You can do this by selecting Donate from the NVDA menu.""",  # noqa: E501 line too long
 ).format(**globals())
-
-updateVersionType = "snapshot:alpha"

--- a/source/versionInfo.py
+++ b/source/versionInfo.py
@@ -32,3 +32,5 @@ It can also be viewed online at: https://www.gnu.org/licenses/old-licenses/gpl-2
 {name} is developed by NV Access, a non-profit organisation committed to helping and promoting free and open source solutions for blind and vision impaired people.
 If you find NVDA useful and want it to continue to improve, please consider donating to NV Access. You can do this by selecting Donate from the NVDA menu.""",  # noqa: E501 line too long
 ).format(**globals())
+
+updateVersionType = "snapshot:alpha"

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -41,7 +41,7 @@ To use this feature, "allow NVDA to control the volume of other applications" mu
 * In Word and Outlook the result of more font formatting shortcuts is now reported. (#10271, @CyrilleB79)
 * Default input and output braille tables can now be determined based on the NVDA language. (#17306, #16390, #290, @nvdaes)
 * In Microsoft Word, when using the "report focus" command, the document layout will be announced if this information is available and reporting object descriptions is enabled. (#15088, @nvdaes)
-* NVDA will now only warn about add-on incompatibility when updating to a version which has an incompatible add-on API to the currently installed copy. (#17071)
+* NVDA will now only warn about add-on incompatibility when updating to a version which has an incompatible add-on API to the currently installed copy. (#17071, #17506)
 * Added commands to move the review cursor to the first and last character of the selected text, assigned to `NVDA+alt+home` and `NVDA+alt+end`, respectively. (#17299, @nvdaes)
 * Component updates:
   * Updated LibLouis Braille translator to [3.32.0](https://github.com/liblouis/liblouis/releases/tag/v3.32.0). (#17469, @LeonarddeR)


### PR DESCRIPTION
### Link to issue number:

Closes #17490
Fix up of #17370 

### Summary of the issue:

NVDA still presents the add-on incompatibility message in some situations when updating to a backwards-compatible add-on API with incompatible add-ons installed.

### Description of user facing changes

The add-on incompatibility message should no-longer be presented when updating to a backwards-compatible add-on API.

### Description of development approach

Updated the logic in `UpdateAskInstallDialog` to match the new logic in `UpdateResultDialog`, so they both only present the warning when updating to a backwards-incompatible API and incompatible add-ons are installed.

### Testing strategy:

Tested from source while spoofing to allow update checks, with version (and addon backcompat) set to 2025.1 and 2024.1 (to simulate both situations).

### Known issues with pull request:

None.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
