### PR TITLE
Remove audio logo from NVDA launcher

### DIFF
--- a/launcher/nvdaLauncher.nsi
+++ b/launcher/nvdaLauncher.nsi
@@ -11,7 +11,6 @@ CRCCheck on
 
 ReserveFile "${NSISDIR}\Plugins\x86-unicode\system.dll"
 ReserveFile "${NSISDIR}\Plugins\x86-unicode\banner.dll"
-ReserveFile "..\miscDeps\launcher\nvda_logo.wav"
 
 Name "NVDA"
 VIProductVersion "${VERSION_YEAR}.${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_BUILD}" ;Needs to be here so other version info shows up
@@ -85,9 +84,6 @@ ${GetParameters} $0
 ; Sets the error flag if the option is missing.
 ; Reference: https://nsis.sourceforge.io/Docs/AppendixE.html#getoptions
 ${GetOptions} $0 "--minimal" $1
-${If} ${Errors}
-	Call PlayLogoSound
-${EndIf}
 CreateDirectory "$PLUGINSDIR\app"
 setOutPath "$PLUGINSDIR\app"
 file /R "${NVDADistDir}\"
@@ -98,17 +94,3 @@ execWait "$PLUGINSDIR\app\nvda_noUIAccess.exe $0 --launcher" $1
 ;If exit code is 3 then execute again (restart)
 intcmp $1 3 exec +1
 SectionEnd
-
-Function PlayLogoSound
-File "..\miscDeps\launcher\nvda_logo.wav"
-Push "$PLUGINSDIR\nvda_logo.wav"
-Call PlaySound	
-FunctionEnd
-
-Function PlaySound
-; Retrieve the file to play
-pop $9
-; The code below is derived from the code example at http://nsis.sourceforge.io/WinAPI:winmm:PlaySound
-IntOp $0 "SND_ASYNC" || 1
-System::Call 'winmm::PlaySound(t r9, i 0, i r0) b'
-FunctionEnd

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -43,6 +43,7 @@ To use this feature, "allow NVDA to control the volume of other applications" mu
 * In Microsoft Word, when using the "report focus" command, the document layout will be announced if this information is available and reporting object descriptions is enabled. (#15088, @nvdaes)
 * NVDA will now only warn about add-on incompatibility when updating to a version which has an incompatible add-on API to the currently installed copy. (#17071)
 * Added commands to move the review cursor to the first and last character of the selected text, assigned to `NVDA+alt+home` and `NVDA+alt+end`, respectively. (#17299, @nvdaes)
+* The NVDA installer no longer plays a sound when launched. (#14068)
 * Component updates:
   * Updated LibLouis Braille translator to [3.32.0](https://github.com/liblouis/liblouis/releases/tag/v3.32.0). (#17469, @LeonarddeR)
   * Updated CLDR to version 46.0. (#17484, @OzancanKaratas)


### PR DESCRIPTION
### Link to issue number:

Closes #14068
Closes #15110

### Summary of the issue:

The NVDA launcher currently plays an audio logo when launched.
This creates a number of problems:

* Playback of this file uses winmm, which is a deprecated API.
* Playback of this file may delay execution of the launcher, if it takes longer than unpacking the launcher does. (#14068)
  * The NVDA audio logo is 10 seconds long, whereas it typically takes around 6 seconds for the launcher to start the temporary NVDA on my machine.
* Some users may want to silence playback of this sound altogether, which is currently not possible. (#15110)

### Description of user facing changes

The NVDA launcher is now silent until the temporary copy of NVDA it includes is started.

### Description of development approach

Removed all code related to playing the audio logo from `launcher/launcher.nsis`.

### Testing strategy:

Built the launcher and ran it from explorer.
Also ran NVDA from source patched to check for updates, and swapped the downloaded launcher for the one without the sound logo.

### Known issues with pull request:

There is now an appreciable period of silence between NVDA quitting to perform an update, and the temporary NVDA speaking to read out the update progress.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
