### PR TITLE
    Fix the link for "Build (for testing PR)" in appVeyor message

### DIFF
--- a/appveyor/scripts/pushPackagingInfo.ps1
+++ b/appveyor/scripts/pushPackagingInfo.ps1
@@ -3,7 +3,7 @@ $ErrorActionPreference = "Stop";
 .\venvUtils\exportPackageList.bat installed_python_packages.txt
 Push-AppveyorArtifact installed_python_packages.txt
 $appVeyorUrl = "https://ci.appveyor.com"
-$exe = Get-ChildItem -Name output\*.exe
+$exe = Get-ChildItem -Name output\nvda_*.exe
 if($?){
 	$exeUrl="$appVeyorUrl/api/buildjobs/$env:APPVEYOR_JOB_ID/artifacts/output/$exe"
 	if ($env:APPVEYOR_PULL_REQUEST_NUMBER -ne $null) {

--- a/tests/unit/test_winVersion.py
+++ b/tests/unit/test_winVersion.py
@@ -24,7 +24,7 @@ class TestWinVersion(unittest.TestCase):
 
 	def test_getWinVerFromNonExistentRelease(self):
 		# Test the fact that there is no Windows 10 2003 (2004 exists, however).
-		with self.assertRaises(AttributeError):
+		with self.assertRaises(IndexError):
 			winVersion.WIN10_2003
 
 	def test_moreRecentWinVer(self):

--- a/tests/unit/test_winVersion.py
+++ b/tests/unit/test_winVersion.py
@@ -24,7 +24,7 @@ class TestWinVersion(unittest.TestCase):
 
 	def test_getWinVerFromNonExistentRelease(self):
 		# Test the fact that there is no Windows 10 2003 (2004 exists, however).
-		with self.assertRaises(IndexError):
+		with self.assertRaises(AttributeError):
 			winVersion.WIN10_2003
 
 	def test_moreRecentWinVer(self):


### PR DESCRIPTION
### Link to issue number:
Probably fix-up of #17214.
Follow-up of #17249.
### Summary of the issue:
When an appVeyor test failure message is issued, the build link in this message is on `l10nUtil.exe` rather than on `nvda_snapshot_xxxx.exe`.
### Description of user facing changes
The NVDA snapshot executable will be again downloadable from appVeyor messages.
### Description of development approach
Refine the filtering to find the snapshot executable on "nvda_*.exe" rather than on "*.exe", as done in the deploy script in #17249 in appVeyor script.

### Testing strategy:
Introduce an error in unit tests to trigger the message and check the result: see https://github.com/nvaccess/nvda/pull/17510#issuecomment-2539057970.

### Known issues with pull request:
None
### Code Review Checklist:


- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
