### PR TITLE
Create experts contact list

### DIFF
--- a/projectDocs/community/expertsList.md
+++ b/projectDocs/community/expertsList.md
@@ -20,4 +20,5 @@ For optimal responses, please avoid tagging NV Access employees on unrelated tic
 
 | GitHub | email | topics |
 |---|---|---|
+| @nvdaes | <nrm1977@gmail.com> | Add-on store, braille |
 | | | |

--- a/projectDocs/community/expertsList.md
+++ b/projectDocs/community/expertsList.md
@@ -15,7 +15,6 @@ General enquiries should be directed to <info@nvaccess.org>.
 | @SaschaCowley | <sascha@nvaccess.org> | Issue triage, technical decisions |
 | @michaelDCurran | <mick@nvaccess.org> | Advanced technical consulting |
 | @Qchristensen | <quentin@nvaccess.org> | User documentation, user support |
-| @jcsteh | <jamie@nvaccess.org> | Firefox bugs |
 
 ## Community
 
@@ -24,3 +23,4 @@ General enquiries should be directed to <info@nvaccess.org>.
 | @codeofdusk | <codeofdusk@gmail.com> | Windows Terminal and console, Microsoft UI Automation |
 | @nvdaes | <nrm1977@gmail.com> | Add-on store, braille |
 | @michaelweghorn | <m.weghorn@posteo.de> | LibreOffice |
+| @jcsteh | <jamie@nvaccess.org> | Mozilla Firefox |

--- a/projectDocs/community/expertsList.md
+++ b/projectDocs/community/expertsList.md
@@ -1,0 +1,23 @@
+# Community experts list
+
+This document outlines NV Access employees and community contributors.
+This can be used a reference to contact or tag developers in regards to relevant issues and pull requests.
+
+## NV Access
+
+For optimal responses, please avoid tagging NV Access employees on unrelated tickets.
+
+| GitHub | email | topics |
+|---|---|---|
+| @gerald-hartig | <gerald@nvaccess.org> | Controversial product decisions |
+| @seanbudd | <sean@nvaccess.org> | Issue triage, technical decisions |
+| @SaschaCowley | <sascha@nvaccess.org> | Issue triage, technical decisions |
+| @michaelDCurran | <mick@nvaccess.org> | Advanced technical consulting |
+| @Qchristensen | <quentin@nvaccess.org> | User documentation, user support |
+| @jcsteh | <jamie@nvaccess.org> | Firefox bugs |
+
+## Community
+
+| GitHub | email | topics |
+|---|---|---|
+| | | |

--- a/projectDocs/community/expertsList.md
+++ b/projectDocs/community/expertsList.md
@@ -23,3 +23,4 @@ General enquiries should be directed to <info@nvaccess.org>.
 |---|---|---|
 | @codeofdusk | <codeofdusk@gmail.com> | Windows Terminal and console, Microsoft UI Automation |
 | @nvdaes | <nrm1977@gmail.com> | Add-on store, braille |
+| @michaelweghorn | <m.weghorn@posteo.de> | LibreOffice |

--- a/projectDocs/community/expertsList.md
+++ b/projectDocs/community/expertsList.md
@@ -1,7 +1,7 @@
 # Community experts list
 
 This document outlines NV Access employees and community contributors.
-This can be used a reference to contact or tag developers in regards to relevant issues and pull requests.
+This can be used as a reference for people to contact or tag in regards to relevant issues and pull requests.
 
 ## NV Access
 
@@ -21,4 +21,5 @@ General enquiries should be directed to <info@nvaccess.org>.
 
 | GitHub | email | topics |
 |---|---|---|
+| @codeofdusk | <codeofdusk@gmail.com> | Windows Terminal and console, Microsoft UI Automation |
 | @nvdaes | <nrm1977@gmail.com> | Add-on store, braille |

--- a/projectDocs/community/expertsList.md
+++ b/projectDocs/community/expertsList.md
@@ -22,4 +22,3 @@ General enquiries should be directed to <info@nvaccess.org>.
 | GitHub | email | topics |
 |---|---|---|
 | @nvdaes | <nrm1977@gmail.com> | Add-on store, braille |
-| | | |

--- a/projectDocs/community/expertsList.md
+++ b/projectDocs/community/expertsList.md
@@ -1,7 +1,7 @@
 # Community experts list
 
 This document outlines NV Access employees and community contributors.
-This can be used as a reference for people to contact or tag in regards to relevant issues and pull requests.
+This can be used as a reference for people to contact or tag in regard to relevant issues and pull requests.
 
 ## NV Access
 

--- a/projectDocs/community/expertsList.md
+++ b/projectDocs/community/expertsList.md
@@ -6,6 +6,7 @@ This can be used a reference to contact or tag developers in regards to relevant
 ## NV Access
 
 For optimal responses, please avoid tagging NV Access employees on unrelated tickets.
+General enquiries should be directed to <info@nvaccess.org>.
 
 | GitHub | email | topics |
 |---|---|---|

--- a/projectDocs/community/readme.md
+++ b/projectDocs/community/readme.md
@@ -1,7 +1,9 @@
 ## Get support
+
 Whether you are a beginner, an advanced user, a new or a long time developer; or if you represent an organization wishing to know more or to contribute to NVDA: you can get support through the included documentation as well as several communication channels dedicated to the NVDA screen reader. Here is an overview of the most important support sources.
 
 ### Important links
+
 * You can find information on user support on the [NV Access website](https://www.nvaccess.org/get-help/).
 * [Reporting issues on GitHub](../issues/readme.md)
 * [NVDA on GitHub](https://github.com/nvaccess/nvda)
@@ -12,6 +14,7 @@ This includes information on reporting issues, triaging issues, testing, transla
 * [Translating NVDA](../translating/readme.md): Information about how to translate NVDA into another language
 
 ### Documentation
+
 * [NVDA User Guide](https://www.nvaccess.org/files/nvda/documentation/userGuide.html)
 * [NVDA Developer Guide](https://www.nvaccess.org/files/nvda/documentation/developerGuide.html)
 * [Key Commands](https://www.nvaccess.org/files/nvda/documentation/keyCommands.html)
@@ -19,16 +22,22 @@ This includes information on reporting issues, triaging issues, testing, transla
 * [Release process](./releaseProcess.md)
 
 ### Add-ons
+
 * [The NVDA Add-on store](https://www.nvaccess.org/files/nvda/documentation/userGuide.html#AddonsManager)
 * [Community add-ons website](https://addons.nvda-project.org/).
 This website is considered legacy software, using the NVDA Add-on Store instead is encouraged.
 
 ### Communication channels
+
+* [Experts list](./expertsList.md) for finding experts in the NVDA community
+
 #### NV Access
+
 * See the [NV Access](https://www.nvaccess.org/contact-us/) website for our social media accounts and other contact information.
 * [NVDA Add-on API Mailing List](https://groups.google.com/a/nvaccess.org/g/nvda-api)
 
 #### NVDA Community
+
 * [NVDA Users Mailing List](https://nvda.groups.io/g/nvda)
 * [NVDA Developers Mailing List](https://groups.io/g/nvda-devel)
 * [NVDA Translators list](https://groups.io/g/nvda-translations)

--- a/projectDocs/community/readme.md
+++ b/projectDocs/community/readme.md
@@ -1,6 +1,7 @@
 ## Get support
 
-Whether you are a beginner, an advanced user, a new or a long time developer; or if you represent an organization wishing to know more or to contribute to NVDA: you can get support through the included documentation as well as several communication channels dedicated to the NVDA screen reader. Here is an overview of the most important support sources.
+Whether you are a beginner, an advanced user, a new or a long time developer; or if you represent an organization wishing to know more or to contribute to NVDA: you can get support through the included documentation as well as several communication channels dedicated to the NVDA screen reader.
+Here is an overview of the most important support sources.
 
 ### Important links
 

--- a/projectDocs/issues/triage.md
+++ b/projectDocs/issues/triage.md
@@ -157,7 +157,7 @@ Community members should apply the `triaged` label where an issue is a well form
 
 If an issue has been checked by NV Access, and needs further triage, the `needs-triage` label will be applied.
 Please notify NV Access when you believe the issue is ready for the `triaged` label.
-You can do this by tagging `@nvaccess/developers` or emailing <info@nvaccess.org>.
+You can do this by tagging [relevant NV Access employees](../community/expertsList.md#nv-access) or emailing <info@nvaccess.org>.
 
 A `triaged` issue that requires a complex fix may require advice from NV Access, such as a project plan, before implementation is started.
 

--- a/readme.md
+++ b/readme.md
@@ -14,23 +14,27 @@ NVDA is available under a modified GNU General Public License version 2.
 Please refer to [our license](./copying.txt) for more information.
 
 ## Acknowledgements
+
 We would like to extend our sincere gratitude to [SignPath](https://www.signpath.io/) for their generous support in providing code signing services to many open source projects, including NVDA.
 Their contribution helps us maintain the security and integrity of our releases.
 
 ## NVDA Community
+
 * [Support and information for NVDA users](https://www.nvaccess.org/get-help/)
 * [Report an issue or feature request](./projectDocs/issues/readme.md)
 * [Getting add-ons](https://www.nvaccess.org/files/nvda/documentation/userGuide.html#AddonsManager)
+* [Contact list](./projectDocs/community/expertsList.md) for NV Access and community experts.
 * [More important links and community information](./projectDocs/community/readme.md)
 
 ## Contributing to NVDA
+
 If you would like to contribute to NVDA, you can read more information in our [contributing guide](./.github/CONTRIBUTING.md).
 This includes information on reporting issues, triaging issues, testing, translating, contributing code/documentation and creating add-ons.
 
 ## Status checks
 
 * AppVeyor
-   * Alpha build status: [![view latest alpha builds](https://ci.appveyor.com/api/projects/status/sqeer6p8lc80lvqe/branch/master?svg=true)](https://ci.appveyor.com/project/NVAccess/nvda/branch/master)
-   * Beta build status: [![view latest beta builds](https://ci.appveyor.com/api/projects/status/sqeer6p8lc80lvqe/branch/beta?svg=true)](https://ci.appveyor.com/project/NVAccess/nvda/branch/beta)
+  * Alpha build status: [![view latest alpha builds](https://ci.appveyor.com/api/projects/status/sqeer6p8lc80lvqe/branch/master?svg=true)](https://ci.appveyor.com/project/NVAccess/nvda/branch/master)
+  * Beta build status: [![view latest beta builds](https://ci.appveyor.com/api/projects/status/sqeer6p8lc80lvqe/branch/beta?svg=true)](https://ci.appveyor.com/project/NVAccess/nvda/branch/beta)
 * Pre-commit status (master): [![view pre-commit checks on master](https://results.pre-commit.ci/badge/github/nvaccess/nvda/master.svg)](https://results.pre-commit.ci/latest/github/nvaccess/nvda/master)
 * CodeQL security analysis status (master): [![view CodeQL security analysis checks on master](https://github.com/nvaccess/nvda/actions/workflows/github-code-scanning/codeql/badge.svg?branch=master)](https://github.com/nvaccess/nvda/actions/workflows/github-code-scanning/codeql?query=branch%3Amaster)


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
None

### Summary of the issue:
It is unclear who to tag on issues and pull requests.
Contributors require insider knowledge on who should be tagged on relevant issues/PRs.
Other projects such as [Python](https://devguide.python.org/core-developers/experts/index.html) and [wxWidgets](https://www.wxwidgets.org/about/team/) maintain experts lists to make communicating with the community easier.

### Description of user facing changes
Add an experts list for community contact

### Suggested topics

CI/CD, Scons / build, C++, wx / GUI, Add-on Store, i18n infra, Braille, Audio, Mouse, Speech, Web browsers, MS Office, Windows interface, Java apps, Virtual buffers, LibreOffice, Docs, Testing / QA, Dependency maintenance


### Known issues

It would be ideal to use [GitHub teams](https://docs.github.com/en/organizations/organizing-members-into-teams/about-teams) however these cannot be made publicly visible.
See discussion https://github.com/orgs/community/discussions/146973