### PR TITLE
Fix SAPI 5 initialisation

### DIFF
--- a/source/synthDrivers/sapi5.py
+++ b/source/synthDrivers/sapi5.py
@@ -14,7 +14,6 @@ import winreg
 import audioDucking
 from synthDriverHandler import SynthDriver, VoiceInfo, synthIndexReached, synthDoneSpeaking
 import config
-import nvwave
 from logHandler import log
 import weakref
 import languageHandler
@@ -205,9 +204,10 @@ class SynthDriver(SynthDriver):
 			# Therefore, set the voice before setting the audio output.
 			# Otherwise, we will get poor speech quality in some cases.
 			self.tts.voice = voice
-		outputDeviceID = nvwave.outputDeviceNameToID(config.conf["speech"]["outputDevice"], True)
-		if outputDeviceID >= 0:
-			self.tts.audioOutput = self.tts.getAudioOutputs()[outputDeviceID]
+		for audioOutput in self.tts.GetAudioOutputs():
+			if audioOutput.GetDescription() == config.conf["speech"]["outputDevice"]:
+				self.tts.audioOutput = audioOutput
+				break
 		self._eventsConnection = comtypes.client.GetEvents(self.tts, SapiSink(weakref.ref(self)))
 		self.tts.EventInterests = (
 			SpeechVoiceEvents.StartInputStream | SpeechVoiceEvents.Bookmark | SpeechVoiceEvents.EndInputStream


### PR DESCRIPTION
### Link to issue number:

Closes #17512
Fix-up of #17496

### Summary of the issue:

After the removal of winmm support, SAPI5 synthesisers failed to initialise.
This is because we switched from integer-based IDs as used by winmm, to ID strings as used by Windows Core Audio.

### Description of user facing changes

SAPI5 synthesisers now initialise correctly.

### Description of development approach

Rather than calling `outputDeviceNameToID` to index into the audio outputs returned by SAPI, iterate over them and look for one whose `Description` matches the friendly name of the output device to use as stored in the user's config.

### Testing strategy:

Tested loading SAPI5 with a number of output devices selected, and changing output devices with SAPI5 loaded.

### Known issues with pull request:

None.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
