### PR TITLE
Removed a reference to the launcher audio logo from the quick start guide

### DIFF
--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -133,7 +133,7 @@ The setup file is named "nvda_2022.1.exe" or similar.
 The year and version changes between updates to reflect the current release.
 
 1. Run the downloaded file.
-You may need to wait a few seconds  while a temporary copy of NVDA loads.
+You may need to wait a few seconds while a temporary copy of NVDA loads.
 Once loaded, NVDA will speak throughout the rest of the process.
 1. The NVDA Launcher window appears with the license agreement.
 Press `downArrow` to read the license agreement if desired.

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -133,7 +133,7 @@ The setup file is named "nvda_2022.1.exe" or similar.
 The year and version changes between updates to reflect the current release.
 
 1. Run the downloaded file.
-Music plays while a temporary copy of NVDA loads.
+You may need to wait a few seconds  while a temporary copy of NVDA loads.
 Once loaded, NVDA will speak throughout the rest of the process.
 1. The NVDA Launcher window appears with the license agreement.
 Press `downArrow` to read the license agreement if desired.


### PR DESCRIPTION
### Link to issue number:
None
### Summary of the issue:
In #17507, the audio logo played while the NVDA launcher is loading has been removed. However, the quick start guide still makes a reference to the music playing before a temporary copy of NVDA loads.
### Description of user facing changes
The quick start guide no longer includes misleading information. Instead, it has been replaced with a note that it may take a few seconds for the temporary copy to load.

### Description of development approach
Replaced the information in the user guide.

### Testing strategy:
Check the user guide, ensuring there are no references to the launcher music.
### Known issues with pull request:
None known.
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
