### PR TITLE
Filter for the correct usage page in the Brailliant driver

### DIFF
--- a/source/brailleDisplayDrivers/brailliantB.py
+++ b/source/brailleDisplayDrivers/brailliantB.py
@@ -35,6 +35,7 @@ HR_CAPS = b"\x01"
 HR_KEYS = b"\x04"
 HR_BRAILLE = b"\x05"
 HR_POWEROFF = b"\x07"
+HID_USAGE_PAGE = 0x93
 
 KEY_NAMES = {
 	1: "power",  # Brailliant BI 32, 40 and 80.
@@ -147,6 +148,9 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 			# Try talking to the display.
 			try:
 				if self.isHid:
+					if (usasePage := portInfo.get("HIDUsagePage")) != HID_USAGE_PAGE:
+						log.debugWarning(f"Ignoring device {port!r} with usage page {usasePage!r}")
+						continue
 					self._dev = hwIo.Hid(port, onReceive=self._hidOnReceive)
 				else:
 					self._dev = hwIo.Serial(

--- a/source/hwPortUtils.py
+++ b/source/hwPortUtils.py
@@ -500,7 +500,7 @@ class HIDD_ATTRIBUTES(ctypes.Structure):
 _getHidInfoCache: dict[str, dict] = {}
 
 
-def _getHidInfo(hwId: str, path: str) -> dict[str, str | None]:
+def _getHidInfo(hwId: str, path: str) -> dict[str, typing.Any]:
 	info = {
 		"hardwareID": hwId,
 		"devicePath": path,

--- a/source/hwPortUtils.py
+++ b/source/hwPortUtils.py
@@ -538,9 +538,9 @@ def _getHidInfo(hwId: str, path: str) -> dict[str, typing.Any]:
 					f"Opening device {path} to get additional info failed because the device is being used. "
 					"Falling back to cache for device info",
 				)
-				if cachedInfo := _getHidInfoCache.get(path):
-					cachedInfo.update(info)
-					return cachedInfo
+			if cachedInfo := _getHidInfoCache.get(path):
+				cachedInfo.update(info)
+				return cachedInfo
 		elif _isDebug():
 			log.debugWarning(f"Opening device {path} to get additional info failed: {ctypes.WinError(err)}")
 		return info

--- a/source/hwPortUtils.py
+++ b/source/hwPortUtils.py
@@ -16,6 +16,7 @@ import config
 import hidpi
 import winKernel
 from logHandler import log
+from winAPI.constants import SystemErrorCodes
 from winKernel import SYSTEMTIME
 
 
@@ -496,7 +497,10 @@ class HIDD_ATTRIBUTES(ctypes.Structure):
 		super().__init__(Size=ctypes.sizeof(HIDD_ATTRIBUTES), **kwargs)
 
 
-def _getHidInfo(hwId, path):
+_getHidInfoCache: dict[str, dict] = {}
+
+
+def _getHidInfo(hwId: str, path: str) -> dict[str, str | None]:
 	info = {
 		"hardwareID": hwId,
 		"devicePath": path,
@@ -517,18 +521,28 @@ def _getHidInfo(hwId, path):
 	# Fetch additional info about the HID device.
 	from serial.win32 import FILE_FLAG_OVERLAPPED, INVALID_HANDLE_VALUE, CreateFile
 
-	handle = CreateFile(
-		path,
-		0,
-		winKernel.FILE_SHARE_READ | winKernel.FILE_SHARE_WRITE,
-		None,
-		winKernel.OPEN_EXISTING,
-		FILE_FLAG_OVERLAPPED,
-		None,
-	)
-	if handle == INVALID_HANDLE_VALUE:
-		if _isDebug():
-			log.debugWarning(f"Opening device {path} to get additional info failed: {ctypes.WinError()}")
+	if (
+		handle := CreateFile(
+			path,
+			0,
+			winKernel.FILE_SHARE_READ | winKernel.FILE_SHARE_WRITE,
+			None,
+			winKernel.OPEN_EXISTING,
+			FILE_FLAG_OVERLAPPED,
+			None,
+		)
+	) == INVALID_HANDLE_VALUE:
+		if (err := ctypes.GetLastError()) == SystemErrorCodes.SHARING_VIOLATION:
+			if _isDebug():
+				log.debugWarning(
+					f"Opening device {path} to get additional info failed because the device is being used. "
+					"Falling back to cache for device info",
+				)
+				if cachedInfo := _getHidInfoCache.get(path):
+					cachedInfo.update(info)
+					return cachedInfo
+		elif _isDebug():
+			log.debugWarning(f"Opening device {path} to get additional info failed: {ctypes.WinError(err)}")
 		return info
 	try:
 		attribs = HIDD_ATTRIBUTES()
@@ -555,6 +569,7 @@ def _getHidInfo(hwId, path):
 				ctypes.windll.hid.HidD_FreePreparsedData(pd)
 	finally:
 		winKernel.closeHandle(handle)
+	_getHidInfoCache[path] = info
 	return info
 
 

--- a/source/winAPI/constants.py
+++ b/source/winAPI/constants.py
@@ -28,6 +28,8 @@ class SystemErrorCodes(enum.IntEnum):
 	ACCESS_DENIED = 0x5
 	INVALID_DATA = 0xD
 	NOT_READY = 0x15
+	SHARING_VIOLATION = 0x20
+	"""The process cannot access the file because it is being used by another process."""
 	INVALID_PARAMETER = 0x57
 	MOD_NOT_FOUND = 0x7E
 	CANCELLED = 0x4C7

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
-* When the Standard HID Braille Display driver is explicitly set as braille display driver and the braille display list is fetched again, NVDA reports the HID driver as the selected driver rather than no driver at all. (#17522, @LeonarddeR)
+* When the Standard HID Braille Display driver is explicitly selected as the braille display driver, and the braille display list is opened, NVDA correctly identifies the HID driver as the selected driver instead of showing no driver selected. (#17522, @LeonarddeR)
 * The Humanware Brailliant driver is now more reliable in selecting the right connection endpoint, resulting in better connection stability and less errors.  (#17522, @LeonarddeR)
 
 ## 2024.4.1

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -4,6 +4,9 @@
 
 ### Bug Fixes
 
+* When the Standard HID Braille Display driver is explicitly set as braille display driver and the braille display list is fetched again, NVDA reports the HID driver as the selected driver rather than no driver at all. (#17522, @LeonarddeR)
+* The Humanware Brailliant driver is now more reliable in selecting the right connection endpoint, resulting in better connection stability and less errors.  (#17522, @LeonarddeR)
+
 ## 2024.4.1
 
 This is a patch release to fix a bug when saving speech symbol dictionaries.


### PR DESCRIPTION
### Link to issue number:
Related to #17518 

### Summary of the issue:
The Brailliant driver doesn't filter for HID usage page properly, meaning that attempts are made to connect to device entries with other usage pages, such as HID braille and keyboard.
Also, when explicitly selecting the HID driver and then opening the display list again results in no display driver being selected at all and the HID driver being unavailable to select again.

### Description of user facing changes
Quicker USB and Bluetooth connection.

### Description of development approach
1. Hardcoded a usage page of 0x93 and ignore all other usage pages in the Brailliant driver.
2. Added a small caching mechanism to `hwPortUtils` that caches device info like usage page, manufacturer, vendor, etc. This is necessary because when the display is connected, NVDA is unable to open a second handle to the device to get this information. This means that for example, when a HID braille driver device is connected, NVDA is unable to detect the same HID device again because it can't fetch the usage page.

### Testing strategy:
- [x] Tested USB and Bluetooth with a Brailliant BI20 on Firmware 2.0
- [x] Tested USB and Bluetooth with a APH Mantis Q40 on Firmware 2.0

### Known issues with pull request:
- As @bramd reported in #17518, Bluetooth is currently broken with the Brailliant on Firwmare 2.4. This patch does not fix this issue, but this is fixed by #17526 instead.
- I opened #17521, since I believe this kind of patches should apply to the bdDetect level, i.e. I don't want the driver to ignore devices that are inappropriate, but bdDetect shouldn't offer inappropriate device matches to the driver wherever possible

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes for NVDA 2024.4.2

- **New Features**
	- Improved identification of the Standard HID Braille Display driver.
	- Enhanced reliability for the Humanware Brailliant driver, leading to better connection stability.

- **Bug Fixes**
	- Resolved issues with driver selection and connection errors for Braille displays.

- **Documentation**
	- Updated user documentation to reflect the latest changes and features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

