### PR TITLE
Handle BrailliantB devices that do not report their number of cells

### DIFF
--- a/source/brailleDisplayDrivers/brailliantB.py
+++ b/source/brailleDisplayDrivers/brailliantB.py
@@ -206,6 +206,8 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 				if reportedNumCells > 0:
 					# Update numCells based on reported cell count from the device
 					numCells = reportedNumCells
+				else:
+					log.debugWarning("Could not get number of cells from HID device using HR_CAPS")
 			except WindowsError:
 				return  # Fail!
 			self.numCells = numCells

--- a/source/brailleDisplayDrivers/brailliantB.py
+++ b/source/brailleDisplayDrivers/brailliantB.py
@@ -190,11 +190,25 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 
 	def _initAttempt(self):
 		if self.isHid:
+			# Ensure to set self.numCells only at the end of this method to prevent display writes before the capabilities/numCells request
+			numCells = 0
+			# First try to get cell count from _writeSize
+			try:
+				# _writeSize includes 4 bytes of overhead, so subtract 4
+				numCells = self._dev._writeSize - 4
+			except AttributeError:
+				log.debugWarning("Could not get _writeSize from HID device")
+
+			# Adjust numCells based on reported number of cells
 			try:
 				data: bytes = self._dev.getFeature(HR_CAPS)
+				reportedNumCells = data[24]
+				if reportedNumCells > 0:
+					# Update numCells based on reported cell count from the device
+					numCells = reportedNumCells
 			except WindowsError:
 				return  # Fail!
-			self.numCells = data[24]
+			self.numCells = numCells
 		else:
 			# This will cause the display to return the number of cells.
 			# The _serOnReceive callback will see this and set self.numCells.

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
-* Brailliant BI 40X and similar devices now work as epected with the latest firmware (version 2.4) (#17518, @bramd)
+* Humanware Brailliant BI 40X devices running firmware version 2.4 now work as expected. (#17518, @bramd)
 
 ## 2024.4.1
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -4,6 +4,8 @@
 
 ### Bug Fixes
 
+* Brailliant BI 40X and similar devices now work as epected with the latest firmware (version 2.4) (#17518, @bramd)
+
 ## 2024.4.1
 
 This is a patch release to fix a bug when saving speech symbol dictionaries.


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Partially fixes #17518
### Summary of the issue:
Some HumanWare devices do not report the number of cells in their HID capabilities report. This is the case for Brailliant BI 40X since firmware 2.4.
### Description of user facing changes
The Brailliant BI 40X and similar display with firmware version 2.4 is working correctly again.

### Description of development approach
This PR fixes the issue by using the HID output report size to calculate the number of cells. If the device reports a cell count, this is still being used.

### Testing strategy:
Tested with a Brailliant BI 40X over Bluetooth.

### Known issues with pull request:
Since firmware 2.4 this device is recognized by the Standard HID driver over Bluetooth. However, the keys do not work using that driver. This PR does not fix the Standard HID driver.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added support for Windows 10 features, including the Emoji panel and dictation.
	- Enhanced braille display functionality with automatic detection and braille input support.
	- Introduced new commands for improved navigation and interaction with content.
	- Enhanced performance in Microsoft Office and web browsers, along with better support for mathematical content.

- **Bug Fixes**
	- Various bug fixes across multiple applications and scenarios.

- **Version Update**
	- Minor version updated from 1 to 2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
