### PR TITLE
Remove winsound.PlaySound from NVDA

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,9 @@ logger-objects = ["logHandler.log"]
 "sconstruct" = ["F821"]
 "*sconscript" = ["F821"]
 
+[tool.ruff.lint.flake8-tidy-imports.banned-api]
+"winsound.PlaySound".msg= "PlaySound uses winmm, which is deprecated in favor of the Windows core audio APIs."
+
 [tool.licensecheck]
 using = "requirements:requirements.txt"
 only_licenses = ["BSD", "MIT", "Python", "LGPLV3+", "Apache"]

--- a/source/NVDAObjects/window/excel.py
+++ b/source/NVDAObjects/window/excel.py
@@ -1804,7 +1804,7 @@ class ExcelCell(ExcelBase):
 			and controlTypes.State.UNLOCKED not in self.states
 			and controlTypes.State.PROTECTED in self.parent.states
 		):
-			winsound.PlaySound("Default", winsound.SND_ALIAS | winsound.SND_NOWAIT | winsound.SND_ASYNC)
+			winsound.MessageBeep()
 			return
 		super(ExcelCell, self).event_typedCharacter(ch)
 

--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -444,7 +444,7 @@ class BrowseModeTreeInterceptor(treeInterceptorHandler.TreeInterceptor):
 		return config.conf["virtualBuffers"]["trapNonCommandGestures"]
 
 	def script_trapNonCommandGesture(self, gesture):
-		winsound.PlaySound("default", 1)
+		winsound.MessageBeep()
 
 	singleLetterNavEnabled = True  #: Whether single letter navigation scripts should be active (true) or if these letters should fall to the application.
 

--- a/source/logHandler.py
+++ b/source/logHandler.py
@@ -393,10 +393,7 @@ class RemoteHandler(logging.Handler):
 class FileHandler(logging.FileHandler):
 	def handle(self, record):
 		if record.levelno >= logging.CRITICAL:
-			try:
-				winsound.PlaySound("SystemHand", winsound.SND_ALIAS | winsound.SND_ASYNC)
-			except:  # noqa: E722
-				pass
+			winsound.MessageBeep(winsound.MB_ICONHAND)
 		elif record.levelno >= logging.ERROR and shouldPlayErrorSound():
 			getOnErrorSoundRequested().notify()
 		return super().handle(record)


### PR DESCRIPTION
### Link to issue number:

None

### Summary of the issue:

NVDA currently uses `winsound.PlaySound` in a few places, which is part of the winmm API.

### Description of user facing changes

None.

### Description of development approach

Replaced these calls with calls to `winsound.MessageBeep`, as they are all calls to play system sounds.

### Testing strategy:

Tested:

* Pressing an unbound key in browse mode
* Logging a message at level critical

I was unable to test typing into a protected cell, as my version of Excel brings up a dialog if you attempt to type into or edit a protected cell.

### Known issues with pull request:

None.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
