### PR TITLE
Fix math not being read in Chromium-based browsers (#17421)

### DIFF
--- a/source/NVDAObjects/IAccessible/ia2Web.py
+++ b/source/NVDAObjects/IAccessible/ia2Web.py
@@ -12,6 +12,7 @@ from typing import (
 )
 from ctypes import c_short
 from comtypes import COMError, BSTR
+from comtypes.hresult import E_NOTIMPL
 
 import oleacc
 from annotation import (
@@ -334,7 +335,13 @@ class Math(Ia2Web):
 			# Try the data-mathml attribute.
 			attrNames = (BSTR * 1)("data-mathml")
 			namespaceIds = (c_short * 1)(0)
-			attr = node.attributesForNames(1, attrNames, namespaceIds)
+			try:
+				attr = node.attributesForNames(1, attrNames, namespaceIds)
+			except COMError as e:
+				if e.hresult != E_NOTIMPL:
+					log.debugWarning(f"MathML getting attr error: {e}")
+					raise
+				attr = None
 			if attr:
 				import mathPres
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -1,5 +1,13 @@
 # What's New in NVDA
 
+## 2024.4.2
+
+This is a patch release to fix a bug with reading math in Chromium Browsers (Chrome, Edge).
+
+### Bug fixes
+
+* Fixed bug with with reading math in Chromium Browsers (Chrome, Edge). (#17421, @NSoiffer)
+
 ## 2024.4.1
 
 This is a patch release to fix a bug when saving speech symbol dictionaries.

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -2,7 +2,7 @@
 
 ## 2024.4.2
 
-This is a patch release to release bugs with reading math in Chromium, and braille devices.
+This is a patch release to fix bugs with braille devices and reading math in Chromium.
 
 ### Bug fixes
 


### PR DESCRIPTION
__Note:__: this is the same as #17528 but done on a non-master branch in my fork. According to @seanbudd, permissions to push in the fork don't work properly when coming from master, so here's a second attempt in case it makes life easier.

Fix math not being read in Chromium-based browsers. Chromium made a change that causes a call to (correctly) return E_NOTIMPL.

This simple fix catches the exception and moves on. The NVDA behavior should be the same as before the Chromium change. Only E_NOTIMPL is caught, other COMErrors are re-raised.

Fixes #17421.

_This fixes a very serious user-issue. I recommend that a 2024.4.2 build happen with this fix if possible._

<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Fixes #17421

### Summary of the issue:
Chromium-browsers were changed to return E_NOTIMPL and broke speech and braille of _all_ math equations (i.e., no speech or braille for math) in those browsers because NVDA passes along a 'not implemented' COM exception.

### Description of user facing changes
This restores the behavior of NVDA (i.e., math reads) as before the change.

### Description of development approach
A try/except block is added around the call. If the error is E_NOTIMPL, the code moves on as before. Otherwise, the error is re-raised as before.

### Testing strategy:
Make sure that some math addon is present. I tested with MathCAT, but any math addon will do. Go to any page with math (e.g., https://en.wikipedia.org/wiki/Quadratic_equation). Navigate to a math expression. Without the change, you will not hear any math. With the change, you will hear the math expression being read.

### Known issues with pull request:
None.

### Code Review Checklist:

I did _not_ make a change log entry because I don't know what version this change will go into.  I think a simple entry like
> Restore reading of math in Chromium-based browsers (Chrome/Edge/...) by handling a change they made.

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Support for new braille displays and input methods, including contracted braille input.
	- Automatic language switching for documents with language information.
	- Enhanced support for Microsoft Office applications, including formatting and math content reporting.
	- Improved web browsing support with faster content rendering and ARIA landmark support.
	- Introduction of a new Add-on Manager for managing NVDA add-ons.
	- Experimental support for touch screen interactions.
  
- **Bug Fixes**
	- Various bug fixes and stability improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
