### PR TITLE
Add more notes on triage

### DIFF
--- a/projectDocs/issues/triage.md
+++ b/projectDocs/issues/triage.md
@@ -154,6 +154,7 @@ Community members should apply the `triaged` label where an issue is a well form
 * Can clearly be reproduced
 * Can clearly be prioritised
 * Doesn't require a controversial solution
+* They have not submitted the issue themselves
 
 If an issue has been checked by NV Access, and needs further triage, the `needs-triage` label will be applied.
 Please notify NV Access when you believe the issue is ready for the `triaged` label.
@@ -211,7 +212,7 @@ If you come across one of these missing attachments, please upload if you think 
 The NVDA project greatly appreciates the involvement and contributions of its vibrant community, and we strongly encourage community members to actively engage with the project's issues and pull requests.
 
 However, it's important to maintain a clear distinction between community contributions and the internal workflow of NV Access staff.
-To that end, we kindly request that community members refrain from closing or consolidating tickets (issues, pull requests, etc.) that are created by NV Access staff.
+To that end, we kindly request that community members refrain from closing or consolidating tickets (issues, pull requests, etc.) that are created by NV Access staff, or are pending response from NV Access.
 
 Community members are welcome and encouraged to interact with staff tickets in the following ways:
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Summary of the issue:
To improve objectivity in the triage process, community members are discouraged from self-triaging their own issues. As employees, we generally do not triage our own issues either.

To prevent interfering in NV Access's workflow, clarifications around closing tickets need to be improved.
Tickets which are pending a response from NV Access should not be closed, to help ensure a response is given.
