### PR TITLE
Fix braille table loading with debug logging enabled and/or add-ons disabled

### DIFF
--- a/source/brailleTables.py
+++ b/source/brailleTables.py
@@ -855,6 +855,8 @@ def _loadTablesFromManifestSection(source: str, directory: str, tablesDict: dict
 
 
 def initialize():
+	if config.isAppX or globalVars.appArgs.disableAddons:
+		return
 	# The builtin tables were added at import time to the parent map.
 	# Now, add the custom tables to the first map.
 	import addonHandler
@@ -890,7 +892,7 @@ def initialize():
 						return
 					if (res := manifest.validate(Validator(), preserve_errors=True)) is not True:
 						raise ValueError(f"Errors in scratchpad manifest: {flatten_errors(manifest, res)}")
-					log.debug(f"Found {len(tablesDict)} braille table entries in manifest for scratchpad")
+					log.debug(f"Found {len(section)} braille table entries in manifest for scratchpad")
 					_loadTablesFromManifestSection(TableSource.SCRATCHPAD, directory, section)
 			except Exception:
 				log.exception(

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -81,6 +81,7 @@ Specifically, MathML inside of span and other elements that have the attribute `
 In any document, if the cursor is on the last line, it will be moved to the end when using this command.
 (#17251, #17430, @nvdaes)
 * In web browsers, changes to text selection no longer sometimes fail to be reported in editable text controls. (#17501, @jcsteh)
+* Custom braille tables in the developer scratchpad are now properly ignored when running with add-ons disabled. (#17565, @LeonarddeR)
 
 ### Changes for Developers
 


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
When custom braille tables are available in the manifest of the scratchpad and NVDA starts with debug logging enabled, it will raise an unbound local error due to a wrong logging statement. This actually revealed another bug, namely that scratchpad braille tables weren't ignored when addons are disabled.

### Description of user facing changes
No longer an error in this specific case. Furthermore, custom braille tables from the scratchpad wil be disabled when addons are.

### Description of development approach
1. Fixed the debug logging statement
2. in `brailleTables.initialize`, return early when add-ons disabled or when appX.

### Testing strategy:
Tested from source that the error no longer occurs and that scratchpad tables are no longer loaded

### Known issues with pull request:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
