### PR TITLE
Update eSpeak to 1.52.0 stable

### DIFF
--- a/include/espeak.md
+++ b/include/espeak.md
@@ -36,10 +36,10 @@ Modifications will need to be made in [`nvdaHelper/espeak/sconscript`](../nvdaHe
 1. Update our record of the version number and build.
    1. Change back to the NVDA repo root
    1. Update the `/DPACKAGE_VERSION` in [`nvdaHelper/espeak/sconscript`](../nvdaHelper/espeak/sconscript)
-      *-* The preprocessor definition is used to supply these definitions instead of [`nvdaHelper/espeak/config.h`](../nvdaHelper/espeak/config.h)
-      *-* [`nvdaHelper/espeak/config.h`](../nvdaHelper/espeak/config.h) must exist (despite being empty) since a "config.h" is included within eSpeak.
-      *-* Compare to eSpeak source config: [`include/espeak/src/windows/config.h`](./espeak/src/windows/config.h).
-      *-* Diff `src/windows/config.h` with the previous commit.
+      * The preprocessor definition is used to supply these definitions instead of [`nvdaHelper/espeak/config.h`](../nvdaHelper/espeak/config.h)
+      * [`nvdaHelper/espeak/config.h`](../nvdaHelper/espeak/config.h) must exist (despite being empty) since a "config.h" is included within eSpeak.
+      * Compare to eSpeak source config: [`include/espeak/src/windows/config.h`](./espeak/src/windows/config.h).
+      * Diff `src/windows/config.h` with the previous commit.
    1. Update NVDA's [dev environment documentation](../projectDocs/dev/createDevEnvironment.md#git-submodules) and [changelog](../user_docs/en/changes.md) with eSpeak version and commit.
    1. Build NVDA: `scons source`
       * Expected warnings from eSpeak compilation:

--- a/nvdaHelper/espeak/sconscript
+++ b/nvdaHelper/espeak/sconscript
@@ -100,7 +100,7 @@ env.Append(
 		# Ignore all warnings as the code is not ours.
 		"/W0",
 		# Preprocessor definitions. Migrated from 'nvdaHelper/espeak/config.h'
-		'/DPACKAGE_VERSION=\\"1.52-dev 961454ff\\"',  # See 'include/espeak/src/windows/config.h'
+		'/DPACKAGE_VERSION=\\"1.52.0\\"',  # See 'include/espeak/src/windows/config.h'
 		"/DHAVE_STDINT_H=1",
 		"/D__WIN32__#1",
 		"/DLIBESPEAK_NG_EXPORT",

--- a/projectDocs/dev/createDevEnvironment.md
+++ b/projectDocs/dev/createDevEnvironment.md
@@ -81,7 +81,7 @@ If you aren't sure, run `git submodule update` after every git pull, merge or ch
 
 #### Run time dependencies
 
-* [eSpeak NG](https://github.com/espeak-ng/espeak-ng), version 1.52-dev commit `961454ffaa894d981526f4d424daef1d3bc4175f`
+* [eSpeak NG](https://github.com/espeak-ng/espeak-ng), version 1.52.0
 * [Sonic](https://github.com/waywardgeek/sonic), commit `8694c596378c24e340c09ff2cd47c065494233f1`
 * [IAccessible2](https://wiki.linuxfoundation.org/accessibility/iaccessible2/start), commit `3d8c7f0b833453f761ded6b12d8be431507bfe0b`
 * [liblouis](http://www.liblouis.io/), version 3.31.0

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -30,7 +30,7 @@ To use this feature, "allow NVDA to control the volume of other applications" mu
 
 ### Changes
 
-* eSpeak NG has been updated to 1.52.0 release. (#17056)
+* eSpeak NG has been updated to 1.52.0. (#17056)
 * The Report link destination, Character formatting information, and Speak selection dialogs, now include "Close" and "Copy" buttons for user convenience. (#17018, @XLTechie)
 * The exit dialog now allows you to restart NVDA with add-ons disabled and debug logging enabled simultaneously. (#11538, @CyrilleB79)
 * Unicode Normalization is now enabled by default for speech output. (#17017, @LeonarddeR).

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -30,6 +30,7 @@ To use this feature, "allow NVDA to control the volume of other applications" mu
 
 ### Changes
 
+* eSpeak NG has been updated to 1.52.0 release. (#17056)
 * The Report link destination, Character formatting information, and Speak selection dialogs, now include "Close" and "Copy" buttons for user convenience. (#17018, @XLTechie)
 * The exit dialog now allows you to restart NVDA with add-ons disabled and debug logging enabled simultaneously. (#11538, @CyrilleB79)
 * Unicode Normalization is now enabled by default for speech output. (#17017, @LeonarddeR).


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Closes #17056

### Summary of the issue:
Janitorial update of eSpeak

### Description of user facing changes
None

### Description of development approach
Followed instructions in `espeak.md`, no changes to eSpeak required.
### Testing strategy:
Ran eSpeak after compiling with 1.52.0 code

### Known issues with pull request:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
