### PR TITLE
Fix bug in bdDetect device registration affecting Albatross

### DIFF
--- a/source/bdDetect.py
+++ b/source/bdDetect.py
@@ -741,7 +741,9 @@ class DriverRegistrar:
 			)
 		devs = self._getDriverDict()
 		driverUsb = devs[CommunicationType.USB]
-		driverUsb.add(_UsbDeviceRegistryEntry(type, id, useAsFallback, matchFunc))
+		driverUsb.add(
+			_UsbDeviceRegistryEntry(id=id, type=type, useAsFallback=useAsFallback, matchFunc=matchFunc),
+		)
 
 	def addUsbDevices(
 		self,
@@ -774,7 +776,12 @@ class DriverRegistrar:
 			)
 		devs = self._getDriverDict()
 		driverUsb = devs[CommunicationType.USB]
-		driverUsb.update((_UsbDeviceRegistryEntry(id, type, useAsFallback, matchFunc) for id in ids))
+		driverUsb.update(
+			(
+				_UsbDeviceRegistryEntry(id=id, type=type, useAsFallback=useAsFallback, matchFunc=matchFunc)
+				for id in ids
+			)
+		)
 
 	def addBluetoothDevices(self, matchFunc: MatchFuncT):
 		"""Associate Bluetooth HID or COM ports with the driver on this instance.

--- a/source/brailleDisplayDrivers/albatross/driver.py
+++ b/source/brailleDisplayDrivers/albatross/driver.py
@@ -1,7 +1,7 @@
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-# Copyright (C) 2023 NV Access Limited, Burman's Computer and Education Ltd.
+# Copyright (C) 2023-25 NV Access Limited, Burman's Computer and Education Ltd., Leonard de Ruijter
 
 """Main code for Tivomatic Caiku Albatross braille display driver.
 Communication with display is done here. See class L{BrailleDisplayDriver}

--- a/tests/unit/test_bdDetect.py
+++ b/tests/unit/test_bdDetect.py
@@ -45,7 +45,7 @@ class TestDriverRegistration(unittest.TestCase):
 
 		registrar = bdDetect.DriverRegistrar(albatross.BrailleDisplayDriver.name)
 
-		def matchFunc(match):
+		def matchFunc(match: bdDetect.DeviceMatch) -> bool:
 			return match.deviceInfo.get("busReportedDeviceDescription") == albatross.driver.BUS_DEVICE_DESC
 
 		registrar.addUsbDevice(
@@ -66,7 +66,7 @@ class TestDriverRegistration(unittest.TestCase):
 
 		registrar = bdDetect.DriverRegistrar(albatross.BrailleDisplayDriver.name)
 
-		def matchFunc(match):
+		def matchFunc(match: bdDetect.DeviceMatch) -> bool:
 			return match.deviceInfo.get("busReportedDeviceDescription") == albatross.driver.BUS_DEVICE_DESC
 
 		fakeVidAndPid = "VID_0403&PID_6002"
@@ -94,7 +94,7 @@ class TestDriverRegistration(unittest.TestCase):
 
 		registrar = bdDetect.DriverRegistrar(albatross.BrailleDisplayDriver.name)
 
-		def matchFunc(match):
+		def matchFunc(match: bdDetect.DeviceMatch) -> bool:
 			return True
 
 		registrar.addBluetoothDevices(matchFunc)

--- a/tests/unit/test_bdDetect.py
+++ b/tests/unit/test_bdDetect.py
@@ -1,7 +1,7 @@
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-# Copyright (C) 2023 NV Access Limited, Babbage B.V., Leonard de Ruijter
+# Copyright (C) 2023-25 NV Access Limited, Babbage B.V., Leonard de Ruijter
 
 """Unit tests for the bdDetect module."""
 
@@ -31,3 +31,71 @@ class TestBdDetectExtensionPoints(unittest.TestCase):
 				shouldStopEvaluator=lambda detector: detector is None,
 			)
 			self.assertTrue(success)
+
+
+class TestDriverRegistration(unittest.TestCase):
+	"""A test for driver device registration."""
+
+	def tearDown(self):
+		bdDetect._driverDevices.clear()
+
+	def test_addUsbDevice(self):
+		"""Test adding a USB device."""
+		from brailleDisplayDrivers import albatross
+
+		registrar = bdDetect.DriverRegistrar(albatross.BrailleDisplayDriver.name)
+
+		def matchFunc(match):
+			return match.deviceInfo.get("busReportedDeviceDescription") == albatross.driver.BUS_DEVICE_DESC
+
+		registrar.addUsbDevice(
+			bdDetect.ProtocolType.SERIAL,
+			albatross.driver.VID_AND_PID,
+			matchFunc=matchFunc,
+		)
+		expected = bdDetect._UsbDeviceRegistryEntry(
+			albatross.driver.VID_AND_PID,
+			bdDetect.ProtocolType.SERIAL,
+			matchFunc=matchFunc,
+		)
+		self.assertIn(expected, registrar._getDriverDict().get(bdDetect.CommunicationType.USB))
+
+	def test_addUsbDevices(self):
+		"""Test adding multiple USB devices."""
+		from brailleDisplayDrivers import albatross
+
+		registrar = bdDetect.DriverRegistrar(albatross.BrailleDisplayDriver.name)
+
+		def matchFunc(match):
+			return match.deviceInfo.get("busReportedDeviceDescription") == albatross.driver.BUS_DEVICE_DESC
+
+		fakeVidAndPid = "VID_0403&PID_6002"
+		registrar.addUsbDevices(
+			bdDetect.ProtocolType.SERIAL,
+			{albatross.driver.VID_AND_PID, fakeVidAndPid},
+			matchFunc=matchFunc,
+		)
+		expected = bdDetect._UsbDeviceRegistryEntry(
+			albatross.driver.VID_AND_PID,
+			bdDetect.ProtocolType.SERIAL,
+			matchFunc=matchFunc,
+		)
+		self.assertIn(expected, registrar._getDriverDict().get(bdDetect.CommunicationType.USB))
+		expected2 = bdDetect._UsbDeviceRegistryEntry(
+			fakeVidAndPid,
+			bdDetect.ProtocolType.SERIAL,
+			matchFunc=matchFunc,
+		)
+		self.assertIn(expected2, registrar._getDriverDict().get(bdDetect.CommunicationType.USB))
+
+	def test_addBluetoothDevices(self):
+		"""Test adding a fake Bluetooth match func."""
+		from brailleDisplayDrivers import albatross
+
+		registrar = bdDetect.DriverRegistrar(albatross.BrailleDisplayDriver.name)
+
+		def matchFunc(match):
+			return True
+
+		registrar.addBluetoothDevices(matchFunc)
+		self.assertEqual(registrar._getDriverDict().get(bdDetect.CommunicationType.BLUETOOTH), matchFunc)


### PR DESCRIPTION
### Link to issue number:
Fixes https://github.com/nvaccess/nvda/pull/17537#issuecomment-2573760772

### Summary of the issue:
In #17537, I introduced aa new addUsbDevice method on `DriverRegistrar`, but it had parameter ordering wrong.

### Description of user facing changes
Albatross detection should work again.

### Description of development approach
Fixed order. I added a bunch of unit tests to avoid this in the future.

### Testing strategy:
Unit tests.

### Known issues with pull request:
None known

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
