### PR TITLE
Fix NULL pointer access error in SynthDriverAudioStream

### DIFF
--- a/source/synthDrivers/sapi5.py
+++ b/source/synthDrivers/sapi5.py
@@ -4,7 +4,7 @@
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
-from ctypes import POINTER, c_ubyte, c_wchar_p, cast, windll, _Pointer
+from ctypes import POINTER, c_ubyte, c_ulong, c_wchar_p, cast, windll, _Pointer
 from enum import IntEnum
 import locale
 from collections import OrderedDict
@@ -50,8 +50,12 @@ class SpeechVoiceEvents(IntEnum):
 
 if TYPE_CHECKING:
 	LP_c_ubyte = _Pointer[c_ubyte]
+	LP_c_ulong = _Pointer[c_ulong]
+	LP__ULARGE_INTEGER = _Pointer[_ULARGE_INTEGER]
 else:
 	LP_c_ubyte = POINTER(c_ubyte)
+	LP_c_ulong = POINTER(c_ulong)
+	LP__ULARGE_INTEGER = POINTER(_ULARGE_INTEGER)
 
 
 class SynthDriverAudioStream(COMObject):
@@ -68,36 +72,47 @@ class SynthDriverAudioStream(COMObject):
 		self.synthRef = synthRef
 		self._writtenBytes = 0
 
-	def ISequentialStream_RemoteWrite(self, pv: LP_c_ubyte, cb: int) -> int:
+	def ISequentialStream_RemoteWrite(self, this, pv: LP_c_ubyte, cb: int, pcbWritten: LP_c_ulong):
 		"""This is called when SAPI wants to write (output) a wave data chunk.
 		:param pv: A pointer to the first wave data byte.
 		:param cb: The number of bytes to write.
-		:returns: The number of bytes written.
+		:param pcbWritten: A pointer to a variable where the actual number of bytes written will be stored.
+			Can be null.
+		:returns: HRESULT code.
 		"""
 		synth = self.synthRef()
+		if pcbWritten:
+			pcbWritten[0] = 0
 		if synth is None:
 			log.debugWarning("Called Write method on AudioStream while driver is dead")
-			return 0
+			return hresult.E_UNEXPECTED
 		if not synth.isSpeaking:
-			return 0
+			return hresult.E_FAIL
 		synth.player.feed(pv, cb)
+		if pcbWritten:
+			pcbWritten[0] = cb
 		self._writtenBytes += cb
-		return cb
+		return hresult.S_OK
 
-	def IStream_RemoteSeek(self, dlibMove: _LARGE_INTEGER, dwOrigin: int) -> _ULARGE_INTEGER:
+	def IStream_RemoteSeek(
+		self, this, dlibMove: _LARGE_INTEGER, dwOrigin: int, plibNewPosition: LP__ULARGE_INTEGER
+	):
 		"""This is called when SAPI wants to get the current stream position.
 		Seeking to another position is not supported.
 		:param dlibMove: The displacement to be added to the location indicated by the dwOrigin parameter.
 			Only 0 is supported.
 		:param dwOrigin: The origin for the displacement specified in dlibMove.
 			Only 1 (STREAM_SEEK_CUR) is supported.
-		:returns: The current stream position.
+		:param plibNewPosition: A pointer to a ULARGE_INTEGER where the current stream position will be stored.
+			Can be null.
+		:returns: HRESULT code.
 		"""
 		if dwOrigin == 1 and dlibMove.QuadPart == 0:
 			# SAPI is querying the current position.
-			return _ULARGE_INTEGER(self._writtenBytes)
-		# Return E_NOTIMPL without logging an error.
-		raise ReturnHRESULT(hresult.E_NOTIMPL, None)
+			if plibNewPosition:
+				plibNewPosition.QuadPart = self._writtenBytes
+			return hresult.S_OK
+		return hresult.E_NOTIMPL
 
 	def IStream_Commit(self, grfCommitFlags: int):
 		"""This is called when MSSP wants to flush the written data.

--- a/source/synthDrivers/sapi5.py
+++ b/source/synthDrivers/sapi5.py
@@ -11,7 +11,7 @@ from collections import OrderedDict
 from typing import TYPE_CHECKING
 from comInterfaces.SpeechLib import ISpEventSource, ISpNotifySource, ISpNotifySink
 import comtypes.client
-from comtypes import COMError, COMObject, IUnknown, hresult, ReturnHRESULT
+from comtypes import COMError, COMObject, IUnknown, hresult
 import winreg
 import nvwave
 from objidl import _LARGE_INTEGER, _ULARGE_INTEGER, IStream
@@ -95,7 +95,11 @@ class SynthDriverAudioStream(COMObject):
 		return hresult.S_OK
 
 	def IStream_RemoteSeek(
-		self, this, dlibMove: _LARGE_INTEGER, dwOrigin: int, plibNewPosition: LP__ULARGE_INTEGER
+		self,
+		this,
+		dlibMove: _LARGE_INTEGER,
+		dwOrigin: int,
+		plibNewPosition: LP__ULARGE_INTEGER,
 	):
 		"""This is called when SAPI wants to get the current stream position.
 		Seeking to another position is not supported.

--- a/source/synthDrivers/sapi5.py
+++ b/source/synthDrivers/sapi5.py
@@ -72,7 +72,13 @@ class SynthDriverAudioStream(COMObject):
 		self.synthRef = synthRef
 		self._writtenBytes = 0
 
-	def ISequentialStream_RemoteWrite(self, this, pv: LP_c_ubyte, cb: int, pcbWritten: LP_c_ulong):
+	def ISequentialStream_RemoteWrite(
+		self,
+		this: int,
+		pv: LP_c_ubyte,
+		cb: int,
+		pcbWritten: LP_c_ulong,
+	) -> int:
 		"""This is called when SAPI wants to write (output) a wave data chunk.
 		:param pv: A pointer to the first wave data byte.
 		:param cb: The number of bytes to write.
@@ -96,11 +102,11 @@ class SynthDriverAudioStream(COMObject):
 
 	def IStream_RemoteSeek(
 		self,
-		this,
+		this: int,
 		dlibMove: _LARGE_INTEGER,
 		dwOrigin: int,
 		plibNewPosition: LP__ULARGE_INTEGER,
-	):
+	) -> int:
 		"""This is called when SAPI wants to get the current stream position.
 		Seeking to another position is not supported.
 		:param dlibMove: The displacement to be added to the location indicated by the dwOrigin parameter.


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
None

### Summary of the issue:

This is a fix for the NULL pointer access error introduced by #17592 and reported in [this comment](https://github.com/nvaccess/nvda/pull/17592#issuecomment-2581765785).

According to Microsoft's documentation, the `pcbWritten` parameter in `ISequentialStream::Write` and the `plibNewPosition` parameter in `IStream::Seek` can be NULL, in which case the function should ignore the output parameter and succeed.

### Description of user facing changes
None

### Description of development approach

`ISequentialStream_RemoteWrite` and `IStream_RemoteSeek` are changed to use the low level implementation. This makes checking the output parameter easier. Then, check if the output pointer is NULL before assigning the output value.

### Testing strategy:

### Known issues with pull request:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [ ] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [ ] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
