### PR TITLE
Fix typos related to MessageDialog API

### DIFF
--- a/projectDocs/dev/developerGuide/developerGuide.md
+++ b/projectDocs/dev/developerGuide/developerGuide.md
@@ -1673,5 +1673,5 @@ The following convenience class methods are provided (keyword arguments for over
 | Method | Buttons | Return values |
 |---|---|---|
 | `alert` | OK (`okLabel`) | `None` |
-| `confirm` | OK (`okLabel`) and Cancel (`cancelLabel`) | `ReturnCode.OK` or `ReturnCode.Cancel` |
+| `confirm` | OK (`okLabel`) and Cancel (`cancelLabel`) | `ReturnCode.OK` or `ReturnCode.CANCEL` |
 | `ask` | Yes (`yesLabel`), No (`noLabel`) and Cancel (`cancelLabel`) | `ReturnCode.YES`, `ReturnCode.NO` or `ReturnCode.CANCEL` |

--- a/source/gui/blockAction.py
+++ b/source/gui/blockAction.py
@@ -35,7 +35,7 @@ def _modalDialogOpenCallback():
 	from gui.message import MessageDialog
 
 	if MessageDialog.blockingInstancesExist():
-		MessageDialog.FocusBlockingInstances()
+		MessageDialog.focusBlockingInstances()
 
 
 @dataclass


### PR DESCRIPTION
- **Fix typo in _modalDialogOpenCallback method**
- **Developer guide: fix capitalization for ReturnCode in confirm meth of MessageDialog documentation**

<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
None
### Summary of the issue:
When a modal message dialog is open and we tried to use blocked actions like opening the NVDA's menu or the exit dialog, an error is raised
### Description of user facing changes

### Description of development approach
- Fixed tipo in `_modalDialogOpenCallback` method of `source/gui/blockAction.py`.
- Additionally, fixed capitalization of the `confirm` method in the developer guide.
### Testing strategy:
Tested locally with clipContentsDesigner add-on, version 45.0.1 (dev channel), and opening message dialogs in the Python console, trying to activate the NVDA's menu or the exit dialog.
### Known issues with pull request:
None
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
