### PR TITLE
Fix a couple of accidentally f-less f-strings in MessageDialog

### DIFF
--- a/source/gui/message.py
+++ b/source/gui/message.py
@@ -1029,7 +1029,7 @@ class MessageDialog(DpiScalingHelperMixinWithoutInit, ContextHelpMixin, wx.Dialo
 		buttons: list[wx.Button] = []
 		for id in ids:
 			if id not in self._commands:
-				raise KeyError("No button with {id=} registered.")
+				raise KeyError(f"No button with {id=} registered.")
 			elif isinstance((button := self.FindWindow(id)), wx.Button):
 				buttons.append(button)
 			else:
@@ -1099,7 +1099,7 @@ class MessageDialog(DpiScalingHelperMixinWithoutInit, ContextHelpMixin, wx.Dialo
 		self.Hide()
 		if self.IsModal():
 			self.EndModal(self.GetReturnCode())
-		log.debug("Queueing {self!r} for destruction")
+		log.debug(f"Queueing {self!r} for destruction")
 		self.DestroyLater()
 		log.debug(f"Removing {self!r} from instances.")
 		self._instances.remove(self)


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:

None

### Summary of the issue:

A couple of strings introduced in the message dialog API work were supposed to be f-strings, but the `f` prefix was missed, making them string literals.

### Description of user facing changes

### Description of development approach

Changed the erroneous strings to f-strings.

### Testing strategy:

Created a `MessageDialog` in the python console and ensured the debug and exception messages were output correctly.

### Known issues with pull request:

None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
