### PR TITLE
Small fixes to SAPI5

### DIFF
--- a/source/synthDrivers/sapi5.py
+++ b/source/synthDrivers/sapi5.py
@@ -120,7 +120,7 @@ class SynthDriverAudioStream(COMObject):
 		if dwOrigin == 1 and dlibMove.QuadPart == 0:
 			# SAPI is querying the current position.
 			if plibNewPosition:
-				plibNewPosition.QuadPart = self._writtenBytes
+				plibNewPosition[0].QuadPart = self._writtenBytes
 			return hresult.S_OK
 		return hresult.E_NOTIMPL
 
@@ -194,13 +194,13 @@ class SapiSink(COMObject):
 
 	def EndStream(self, streamNum: int, pos: int):
 		synth = self.synthRef()
+		synth.player.idle()
 		# trigger all untriggered bookmarks
 		if streamNum in synth._streamBookmarks:
 			for bookmark in synth._streamBookmarks[streamNum]:
 				synthIndexReached.notify(synth=synth, index=bookmark)
 			del synth._streamBookmarks[streamNum]
 		synth.isSpeaking = False
-		synth.player.idle()
 		synthDoneSpeaking.notify(synth=synth)
 
 	def onIndexReached(self, streamNum: int, index: int):


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
None

### Summary of the issue:
Some small fixes to the SAPI5 code part that I wrote. Those things didn't cause crashes or obvious errors, so they slipped by.

### Description of user facing changes
None

### Description of development approach

`plibNewPosition` is a pointer, so writing to `plibNewPosition->QuadPart` should be `plibNewPosition[0].QuadPart` in Python. This is now corrected.

`synth.player.idle()` is moved to before the "trigger all untriggered bookmarks" part, to let the audio and the contained bookmarks finish first.

### Testing strategy:

### Known issues with pull request:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
