### PR TITLE
Enable whole-program optimization when compiling eSpeak-NG

### DIFF
--- a/nvdaHelper/espeak/sconscript
+++ b/nvdaHelper/espeak/sconscript
@@ -94,9 +94,6 @@ class espeak_AUDIO_OUTPUT(enum.IntEnum):
 env: SCons.Environment.Environment = thirdPartyEnv.Clone()
 env.Append(
 	CCFLAGS=[
-		# Whole-program optimization causes eSpeak to distort and warble with its Klatt4 voice
-		# Therefore specifically force it off
-		"/GL-",
 		# Ignore all warnings as the code is not ours.
 		"/W0",
 		# Preprocessor definitions. Migrated from 'nvdaHelper/espeak/config.h'


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Closes #17623

### Summary of the issue:

As for now, whole-program optimization for eSpeak-NG is intentionally turned off.

``` python
# Whole-program optimization causes eSpeak to distort and warble with its Klatt4 voice
# Therefore specifically force it off
"/GL-",
```

This was introduced in commit cf0443bf9d54e9861701224d12232e5f999349f6 when MSVC 2012 was used to compile eSpeak.

Enabling whole-program optimization can make the eSpeak DLL more efficient and smaller, from 637 KiB to 624 KiB.

It can also solve the problem of [using a dynamically linked version of Sonic](https://github.com/nvaccess/nvda/pull/17610#issuecomment-2586119532) without `__declspec(dllimport)` in the header, because the optimization will be performed by the linker, if whole-program optimization is enabled.

### Description of user facing changes
None.

### Description of development approach

Enable whole-program optimization by removing the `/GL-` option.
### Testing strategy:

I tried the klatt4 variant, but couldn't notice the difference between enabling and disabling the whole-program optimization. In fact, the waveforms generated are exactly the same.

### Known issues with pull request:
None.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [ ] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
