### PR TITLE
IAccessible2: Evaluate "text-indent" attr for first line indent

### DIFF
--- a/source/NVDAObjects/IAccessible/__init__.py
+++ b/source/NVDAObjects/IAccessible/__init__.py
@@ -100,7 +100,7 @@ def getNVDAObjectFromPoint(x, y):
 FORMAT_OBJECT_ATTRIBS = frozenset({"text-align", "text-indent"})
 
 
-def convertCssLengthToText(cssLength: str) -> str:
+def _convertCssLengthToText(cssLength: str) -> str:
 	"""Returns a text representation of the distance described by the given CSS length
 	string (see https://www.w3.org/TR/CSS2/syndata.html#value-def-length), converted to
 	the local measurement unit.
@@ -153,7 +153,7 @@ def normalizeIA2TextFormatField(formatField):
 	try:
 		val = formatField.pop("text-indent")
 		if val:
-			formatField["first-line-indent"] = convertCssLengthToText(val)
+			formatField["first-line-indent"] = _convertCssLengthToText(val)
 	except KeyError:
 		pass
 

--- a/source/NVDAObjects/IAccessible/__init__.py
+++ b/source/NVDAObjects/IAccessible/__init__.py
@@ -97,7 +97,37 @@ def getNVDAObjectFromPoint(x, y):
 	return obj
 
 
-FORMAT_OBJECT_ATTRIBS = frozenset({"text-align"})
+FORMAT_OBJECT_ATTRIBS = frozenset({"text-align", "text-indent"})
+
+
+def convertCssLengthToText(cssLength: str) -> str:
+	"""Returns a text representation of the distance described by the given CSS length
+	string (see https://www.w3.org/TR/CSS2/syndata.html#value-def-length), converted to
+	the local measurement unit.
+	Currently, only conversion from mm (e.g. "4mm") is supported, but this
+	could be further extended as needed."""
+	match = re.search(r"([0-9]+(\.[0-9]*)?)mm", cssLength)
+	if not match:
+		# return unmodified string if length is not given in mm
+		return cssLength
+	lengthMm = float(match.group(1))
+	if languageHandler.useImperialMeasurements():
+		val = lengthMm / 25.4
+		valText = ngettext(
+			# Translators: a measurement in inches
+			"{val:.2f} inch",
+			"{val:.2f} inches",
+			val,
+		).format(val=val)
+	else:
+		val = lengthMm / 10.0
+		valText = ngettext(
+			# Translators: a measurement in centimetres
+			"{val:.2f} centimetre",
+			"{val:.2f} centimetres",
+			val,
+		).format(val=val)
+	return valText
 
 
 def normalizeIA2TextFormatField(formatField):
@@ -119,6 +149,14 @@ def normalizeIA2TextFormatField(formatField):
 			textAlign = None
 	if textAlign:
 		formatField["text-align"] = textAlign
+
+	try:
+		val = formatField.pop("text-indent")
+		if val:
+			formatField["first-line-indent"] = convertCssLengthToText(val)
+	except KeyError:
+		pass
+
 	try:
 		fontWeight = formatField.pop("font-weight")
 	except KeyError:

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -22,6 +22,7 @@ To use this feature, "allow NVDA to control the volume of other applications" mu
 * When decreasing or increasing the font size in LibreOffice Writer using the corresponding keyboard shortcuts, NVDA announces the new font size. (#6915, @michaelweghorn)
 * When applying the "Body Text" or a heading paragraph style using the corresponding keyboard shortcut in LibreOffice Writer 25.2 or newer, NVDA announces the new paragraph style. (#6915, @michaelweghorn)
 * When toggling double underline in LibreOffice Writer using the corresponding keyboard shortcut, NVDA announces the new state ("double underline on"/"double underline off"). (#6915, @michaelweghorn)
+* NVDA supports the "text-indent" IAccessible2 object attribute. As a consequence, announcement of first line indent is now supported for LibreOffice 25.8 and later. (#13052, @michaelweghorn)
 * Automatic language switching is now supported when using Microsoft Speech API version 5 (SAPI5) and Microsoft Speech Platform voices. (#17146, @gexgd0419)
 * NVDA can now be configured to speak the current line or paragraph when navigating with braille navigation keys. (#17053, @nvdaes)
 * In Word, the selection update is now reported when using Word commands to extend or reduce the selection (`f8` or `shift+f8`). (#3293, @CyrilleB79)

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -22,7 +22,8 @@ To use this feature, "allow NVDA to control the volume of other applications" mu
 * When decreasing or increasing the font size in LibreOffice Writer using the corresponding keyboard shortcuts, NVDA announces the new font size. (#6915, @michaelweghorn)
 * When applying the "Body Text" or a heading paragraph style using the corresponding keyboard shortcut in LibreOffice Writer 25.2 or newer, NVDA announces the new paragraph style. (#6915, @michaelweghorn)
 * When toggling double underline in LibreOffice Writer using the corresponding keyboard shortcut, NVDA announces the new state ("double underline on"/"double underline off"). (#6915, @michaelweghorn)
-* NVDA supports the "text-indent" IAccessible2 object attribute. As a consequence, announcement of first line indent is now supported for LibreOffice 25.8 and later. (#13052, @michaelweghorn)
+* NVDA supports the "text-indent" IAccessible2 object attribute.
+As a consequence, announcement of first line indent is now supported for LibreOffice 25.8 and later. (#13052, @michaelweghorn)
 * Automatic language switching is now supported when using Microsoft Speech API version 5 (SAPI5) and Microsoft Speech Platform voices. (#17146, @gexgd0419)
 * NVDA can now be configured to speak the current line or paragraph when navigating with braille navigation keys. (#17053, @nvdaes)
 * In Word, the selection update is now reported when using Word commands to extend or reduce the selection (`f8` or `shift+f8`). (#3293, @CyrilleB79)


### PR DESCRIPTION
 ### Link to issue number:

Fixes #13052

 ### Summary of the issue:

NVDA did not announce the first line indent for paragraphs in LibreOffice Writer.

 ### Description of user facing changes

NVDA supports the "text-indent" IAccessible2 object attribute. As a consequence, announcement of first line indent is now supported for LibreOffice 25.8 and later.

 ### Description of development approach

Implement support for the "text-indent" object attribute as specified in the
[IAccessible2 object attribute specification](https://github.com/LinuxA11y/IAccessible2/blob/master/spec/objectattributes.md), which references the [CSS spec](https://www.w3.org/TR/CSS2/text.html#propdef-text-indent) that explains:

> This property specifies the indentation of the first line
> of text in a block container.

https://gerrit.libreoffice.org/c/core/+/180574 implements support in LibreOffice, i.e. reporting of that attribute by LibreOffice.

This commit implements evaluation of that IAccessible2 object attribute by NVDA.

As recommended in the IAccessible2 object attribute spec, LibreOffice reports the indentation in mm. Add a helper method that converts that to either cm or inches, depending on whether use of imperial measurements is enabled.

 ### Testing strategy:

1. start NVDA
2. open sample document https://bugs.documentfoundation.org/attachment.cgi?id=198672 in LibreOffice Writer (current development version also including above-mentioned LibreOffice change)
3. move focus to the second paragraph that has a first line indentation of 1 cm set
4. request announcement of text formatting by pressing NVDA+F
5. Make sure that what NVDA says includes the first line indent ("first line indent 1.00 centimetre")

 ### Known issues with pull request:

None

 ### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
