### PR TITLE
Fix up config upgrade steps from schema version 14 to 15

### DIFF
--- a/source/config/profileUpgradeSteps.py
+++ b/source/config/profileUpgradeSteps.py
@@ -493,9 +493,10 @@ def _convertTypingEcho(profile: ConfigObj, key: str) -> None:
 		log.debug(f"'{key}' not present in config, no action taken.")
 		return
 	except ValueError:
-		log.error(f"'{key}' is not a boolean, no action taken.")
+		log.error(f"'{key}' is not a boolean, deleting.")
+		del profile["keyboard"][key]
 		return
 	else:
-		newValue = TypingEcho.EDIT_CONTROLS.value if oldValue else TypingEcho.OFF.value
+		newValue = TypingEcho.ALWAYS.value if oldValue else TypingEcho.OFF.value
 		profile["keyboard"][key] = newValue
 		log.debug(f"Converted '{key}' from {oldValue!r} to {newValue} ({TypingEcho(newValue).name}).")

--- a/source/config/profileUpgradeSteps.py
+++ b/source/config/profileUpgradeSteps.py
@@ -497,6 +497,6 @@ def _convertTypingEcho(profile: ConfigObj, key: str) -> None:
 		del profile["keyboard"][key]
 		return
 	else:
-		newValue = TypingEcho.ALWAYS.value if oldValue else TypingEcho.OFF.value
+		newValue = TypingEcho.EDIT_CONTROLS.value if oldValue else TypingEcho.OFF.value
 		profile["keyboard"][key] = newValue
 		log.debug(f"Converted '{key}' from {oldValue!r} to {newValue} ({TypingEcho(newValue).name}).")

--- a/source/config/profileUpgradeSteps.py
+++ b/source/config/profileUpgradeSteps.py
@@ -493,7 +493,7 @@ def _convertTypingEcho(profile: ConfigObj, key: str) -> None:
 		log.debug(f"'{key}' not present in config, no action taken.")
 		return
 	except ValueError:
-		log.error(f"'{key}' is not a boolean, deleting.")
+		log.error(f"'{key}' is not a boolean, got {profile['keyboard'][key]!r}. Deleting.")
 		del profile["keyboard"][key]
 		return
 	else:


### PR DESCRIPTION
### Link to issue number:

Fixes #17637(?)
Follow-up to #17505

### Summary of the issue:

The config upgrade steps for moving from version 14 to 15 of the config schema may leave the user's config in an invalid state if either of `["keyboard"]["speakTypedCharacters"]` or `["keyboard"]["speakTypedWords"]` is not a boolean.
This is because the upgrade steps, as implemented, take no action if those values are not bools.
For most upgrade steps, this approach is perfectly valid.
However, version 15 of the schema expects these values to be integers, so validation of the upgraded config will fail.

These config upgrade steps also upgrade a value of `True` to a value of `TypingEcho.EDIT_CONTROLS`, even though the behaviour of `True` is the same as that of `TypingEcho.ALWAYS`.

### Description of user facing changes

The configuration upgrade should not corrupt the user's config.

If the user has changed the behaviour of either of these options, the behaviour will not change for them.

### Description of development approach

Instead of just `return`ing when we get a `ValueError` in `upgradeConfigFrom_14_to_15`, delete the offending config entry.

Change the mapping for `True` to `TypingEcho.ALWAYS` when converting from an existing boolean to a new integer.

### Testing strategy:

Tested by creating valid and invalid config strings, instantiating `ConfigObj`s with them, and feeding those to `upgradeConfigFrom_14_to_15`.

### Known issues with pull request:

A user may lose their setting for "Speak typed characters" or "Speak typed words", if configobj doesn't recognise it as a boolean.
Theoretically this shouldn't be possible, as the config wouldn't have validated under any of the prior schema versions.
Nevertheless this seems to have happened, and it is better to lose (at most) 2 settings than all settings.

### Code Review Checklist:

- [ ] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [ ] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
