### PR TITLE
Add leading silence detection and removal logic

### DIFF
--- a/nvdaHelper/local/nvdaHelperLocal.def
+++ b/nvdaHelper/local/nvdaHelperLocal.def
@@ -82,6 +82,7 @@ EXPORTS
 	wasPlay_pause
 	wasPlay_resume
 	wasPlay_setChannelVolume
+	wasPlay_startTrimmingLeadingSilence
 	wasPlay_startup
 	wasSilence_init
 	wasSilence_playFor

--- a/nvdaHelper/local/silenceDetect.h
+++ b/nvdaHelper/local/silenceDetect.h
@@ -163,10 +163,10 @@ size_t getLeadingSilenceSizeMono(
 	SampleType smp = SampleType();
 	const unsigned char* p = waveData;
 	const unsigned char* pEnd = waveData + (size - (size % bytesPerSample));
-	for (; p != pEnd; p += bytesPerSample) {
+	for (; p < pEnd; p += bytesPerSample) {
 		memcpy(&smp, p, bytesPerSample);
 		smp = Fmt::signExtend(smp);
-		// this sample is out of range, so the leading silence starts at the previous sample
+		// this sample is out of range, so the previous sample is the final sample of leading silence.
 		if (smp < minValue || smp > maxValue)
 			return p - waveData;
 	}
@@ -205,7 +205,7 @@ size_t getTrailingSilenceSizeMono(
 		// this sample is out of range, so the trailing silence starts at the next sample
 		if (smp < minValue || smp > maxValue)
 			return size - (p - waveData) - bytesPerSample;
-	} while (p != waveData);
+	} while (p > waveData);
 
 	// The whole data block is silence
 	return size;

--- a/nvdaHelper/local/silenceDetect.h
+++ b/nvdaHelper/local/silenceDetect.h
@@ -1,0 +1,295 @@
+#ifndef SILENCEDETECT_H
+#define SILENCEDETECT_H
+
+#include <windows.h>
+#include <mmreg.h>
+#include <stdint.h>
+#include <type_traits>
+#include <limits>
+
+namespace SilenceDetect {
+
+/**
+ * Compile-time wave format tag.
+ * Supports integer and floating-point formats.
+ * `SampleType` should be the smallest numeric type that can hold a sample, for example, 32-bit int for 24-bit format.
+ * Signedness of `SampleType` matters. For unsigned types, the zero point is at middle, e.g. 128 for 8-bit unsigned.
+ * `bytesPerSample` should be <= `sizeof(SampleType)` for integer formats,
+ * and == `sizeof(SampleType)` for floating-point formats.
+ * Assumes C++20 standard.
+ */
+template <typename SampleType, size_t bytesPerSample = sizeof(SampleType)>
+struct WaveFormat {
+	static_assert(std::is_arithmetic_v<SampleType>, "SampleType should be an integer or floating-point type");
+	static_assert(!(std::is_floating_point_v<SampleType> && bytesPerSample != sizeof(SampleType)),
+		"When SampleType is a floating-point type, bytesPerSample should be equal to sizeof(SampleType)");
+	static_assert(!(std::is_integral_v<SampleType> && !(bytesPerSample <= sizeof(SampleType) && bytesPerSample > 0)),
+		"When SampleType is an integer type, bytesPerSample should be less than or equal to sizeof(SampleType) and greater than 0");
+
+	typedef SampleType SampleType;
+	static constexpr size_t bytesPerSample = bytesPerSample;
+
+	static constexpr SampleType zeroPoint() {
+		// for unsigned types, zero point is at middle
+		// for signed types, zero is zero
+		if constexpr (std::is_unsigned_v<SampleType>)
+			return SampleType(1) << (bytesPerSample * 8 - 1);
+		else
+			return SampleType();
+	}
+
+	static constexpr SampleType (max)() {
+		if constexpr (std::is_floating_point_v<SampleType>)
+			return SampleType(1);
+		else
+			return (std::numeric_limits<SampleType>::max)() >> ((sizeof(SampleType) - bytesPerSample) * 8);
+	}
+
+	static constexpr SampleType (min)() {
+		if constexpr (std::is_floating_point_v<SampleType>)
+			return SampleType(-1);
+		else
+			return (std::numeric_limits<SampleType>::min)() >> ((sizeof(SampleType) - bytesPerSample) * 8);
+	}
+
+	static constexpr SampleType defaultThreshold() {
+		// Default threshold: 1 / 2^10 or 0.0009765625
+		if constexpr (std::is_floating_point_v<SampleType>)
+			return SampleType(1) / (1 << 10);
+		else if constexpr (bytesPerSample * 8 > 10)
+			return SampleType(1) << (bytesPerSample * 8 - 10);
+		else
+			return SampleType();
+	}
+
+	static constexpr auto toSigned(SampleType smp) {
+		if constexpr (std::is_integral_v<SampleType>) {
+			// In C++20, signed integer types must use two's complement,
+			// so the following conversion is well-defined.
+			using SignedType = std::make_signed_t<SampleType>;
+			return SignedType(smp - zeroPoint());
+		} else {
+			return smp;
+		}
+	}
+
+	static constexpr SampleType fromSigned(SampleType smp) {
+		if constexpr (std::is_integral_v<SampleType>) {
+			// Signed overflow is undefined behavior,
+			// so convert to unsigned first.
+			using UnsignedType = std::make_unsigned_t<SampleType>;
+			return SampleType(UnsignedType(smp) + zeroPoint());
+		} else {
+			return smp;
+		}
+	}
+
+	static constexpr SampleType signExtend(SampleType smp) {
+		if constexpr (std::is_unsigned_v<SampleType> || bytesPerSample == sizeof(SampleType)) {
+			return smp;
+		} else {
+			constexpr auto shift = (sizeof(SampleType) - bytesPerSample) * 8;
+			// Convert to unsigned first to prevent left-shifting negative numbers
+			using UnsignedType = std::make_unsigned_t<SampleType>;
+			return SampleType(UnsignedType(smp) << shift) >> shift;
+		}
+	}
+
+	template <class SrcFmt>
+	static constexpr SampleType convertFrom(SrcFmt::SampleType smp) {
+		using SrcType = SrcFmt::SampleType;
+		if constexpr (std::is_floating_point_v<SrcType> && std::is_floating_point_v<SampleType>) {
+			// both floating points, convert directly
+			return SampleType(smp);
+		} else if constexpr (std::is_integral_v<SrcType> && std::is_integral_v<SampleType>) {
+			// both integers, do bit shifting
+			const auto dstsmp = SrcFmt::toSigned(smp);
+			if constexpr (bytesPerSample >= SrcFmt::bytesPerSample) {
+				constexpr auto shift = (bytesPerSample - SrcFmt::bytesPerSample) * 8;
+				// Convert to unsigned target type first to prevent overflows and left-shifting negative numbers
+				using UnsignedType = std::make_unsigned_t<SampleType>;
+				return fromSigned(UnsignedType(dstsmp) << shift);
+			} else {
+				constexpr auto shift = (SrcFmt::bytesPerSample - bytesPerSample) * 8;
+				return fromSigned(dstsmp >> shift);
+			}
+		} else if constexpr (std::is_floating_point_v<SrcType> && std::is_integral_v<SampleType>) {
+			// floating point to integer, e.g. [-1.0f, 1.0f] -> [-32767, 32767]
+			return fromSigned(smp * ((max)() - zeroPoint()));
+		} else {
+			// integer to floating point, e.g. [-32768, 32767] -> [-1.0f, 1.0f)
+			return SampleType(SrcFmt::toSigned(smp) / (SrcFmt::zeroPoint() - (SrcFmt::min)()));
+		}
+	}
+};
+
+inline WORD getFormatTag(const WAVEFORMATEX* wfx) {
+	if (wfx->wFormatTag == WAVE_FORMAT_EXTENSIBLE) {
+		auto wfext = reinterpret_cast<const WAVEFORMATEXTENSIBLE*>(wfx);
+		if (IS_VALID_WAVEFORMATEX_GUID(&wfext->SubFormat))
+			return EXTRACT_WAVEFORMATEX_ID(&wfext->SubFormat);
+	}
+	return wfx->wFormatTag;
+}
+
+/**
+ * Return the leading silence wave data length, in bytes.
+ * Assumes the wave data to be of one channel (mono).
+ * Uses a `WaveFormat` type (`Fmt`) to determine the wave format.
+ */
+template <class Fmt>
+size_t getLeadingSilenceSizeMono(
+	const unsigned char* waveData,
+	size_t size,
+	typename Fmt::SampleType threshold
+) {
+	using SampleType = Fmt::SampleType;
+	constexpr size_t bytesPerSample = Fmt::bytesPerSample;
+
+	if (size < bytesPerSample)
+		return 0;
+
+	constexpr SampleType zeroPoint = Fmt::zeroPoint();
+	const SampleType minValue = zeroPoint - threshold, maxValue = zeroPoint + threshold;
+
+	// Check each sample
+	const unsigned char* p = waveData;
+	const unsigned char* pEnd = waveData + (size - (size % bytesPerSample));
+	for (; p != pEnd; p += bytesPerSample) {
+		SampleType smp;
+		memcpy(&smp, p, bytesPerSample);
+		smp = Fmt::signExtend(smp);
+		// this sample is out of range, so the leading silence starts at the previous sample
+		if (smp < minValue || smp > maxValue)
+			return p - waveData;
+	}
+
+	// The whole data block is silence
+	return size;
+}
+
+/**
+ * Return the trailing silence wave data length, in bytes.
+ * Assumes the wave data to be of one channel (mono).
+ * Uses a `WaveFormat` type (`Fmt`) to determine the wave format.
+ */
+template <class Fmt>
+size_t getTrailingSilenceSizeMono(
+	const unsigned char* waveData,
+	size_t size,
+	typename Fmt::SampleType threshold
+) {
+	using SampleType = Fmt::SampleType;
+	constexpr size_t bytesPerSample = Fmt::bytesPerSample;
+
+	if (size < bytesPerSample)
+		return 0;
+
+	constexpr SampleType zeroPoint = Fmt::zeroPoint();
+	const SampleType minValue = zeroPoint - threshold, maxValue = zeroPoint + threshold;
+
+	// Check each sample in reverse order
+	const unsigned char* p = waveData + (size - (size % bytesPerSample));
+	do {
+		p -= bytesPerSample;
+		SampleType smp;
+		memcpy(&smp, p, bytesPerSample);
+		smp = Fmt::signExtend(smp);
+		// this sample is out of range, so the trailing silence starts at the next sample
+		if (smp < minValue || smp > maxValue)
+			return size - (p - waveData) - bytesPerSample;
+	} while (p != waveData);
+
+	// The whole data block is silence
+	return size;
+}
+
+/**
+ * Invoke a functor with an argument of a WaveFormat type that corresponds to the specified WAVEFORMATEX.
+ * Return false if the WAVEFORMATEX is unknown.
+ */
+template <class Func>
+bool callByWaveFormat(const WAVEFORMATEX* wfx, Func&& func) {
+	switch (getFormatTag(wfx)) {
+	case WAVE_FORMAT_PCM:
+		switch (wfx->wBitsPerSample) {
+		case 8:  // 8-bits are unsigned, others are signed
+			func(WaveFormat<uint8_t>());
+			break;
+		case 16:
+			func(WaveFormat<int16_t>());
+			break;
+		case 24:
+			func(WaveFormat<int32_t, 3>());
+			break;
+		case 32:
+			func(WaveFormat<int32_t>());
+			break;
+		default:
+			return false;
+		}
+		break;
+	case WAVE_FORMAT_IEEE_FLOAT:
+		switch (wfx->wBitsPerSample) {
+		case 32:
+			func(WaveFormat<float>());
+			break;
+		case 64:
+			func(WaveFormat<double>());
+			break;
+		default:
+			return false;
+		}
+		break;
+	default:
+		return false;
+	}
+	return true;
+}
+
+/**
+ * Return the leading silence wave data length, in bytes.
+ * Uses a `WAVEFORMATEX` to determine the wave format.
+ */
+inline size_t getLeadingSilenceSize(
+	const WAVEFORMATEX* wfx,
+	const unsigned char* waveData,
+	size_t size
+) {
+	size_t len;
+	if (!callByWaveFormat(wfx, [=, &len](auto fmtTag) {
+			using Fmt = decltype(fmtTag);
+			len = getLeadingSilenceSizeMono<Fmt>(
+				waveData, size, Fmt::defaultThreshold());
+		}))
+		return 0;
+
+	return len - len % wfx->nBlockAlign;  // round down to block (channel) boundaries
+}
+
+/**
+ * Return the trailing silence wave data length, in bytes.
+ * Uses a `WAVEFORMATEX` to determine the wave format.
+ */
+inline size_t getTrailingSilenceSize(
+	const WAVEFORMATEX* wfx,
+	const unsigned char* waveData,
+	size_t size
+) {
+	size_t len;
+	if (!callByWaveFormat(wfx, [=, &len](auto fmtTag) {
+			using Fmt = decltype(fmtTag);
+			len = getTrailingSilenceSizeMono<Fmt>(
+				waveData, size, Fmt::defaultThreshold());
+		}))
+		return 0;
+
+	size_t align = wfx->nBlockAlign;
+	len += align - 1;
+	len -= len % align;  // round up to block (channel) boundaries
+	return len;
+}
+
+}  // namespace SilenceDetect
+
+#endif  // SILENCEDETECT_H

--- a/nvdaHelper/local/silenceDetect.h
+++ b/nvdaHelper/local/silenceDetect.h
@@ -161,9 +161,8 @@ size_t getLeadingSilenceSizeMono(
 
 	// Check each sample
 	SampleType smp = SampleType();
-	const unsigned char* p = waveData;
-	const unsigned char* pEnd = waveData + (size - (size % bytesPerSample));
-	for (; p < pEnd; p += bytesPerSample) {
+	const unsigned char* const pEnd = waveData + (size - (size % bytesPerSample));
+	for (const unsigned char* p = waveData; p < pEnd; p += bytesPerSample) {
 		memcpy(&smp, p, bytesPerSample);
 		smp = Fmt::signExtend(smp);
 		// this sample is out of range, so the previous sample is the final sample of leading silence.

--- a/nvdaHelper/local/silenceDetect.h
+++ b/nvdaHelper/local/silenceDetect.h
@@ -6,7 +6,6 @@
 #include <stdint.h>
 #include <type_traits>
 #include <limits>
-#include <vector>
 
 namespace SilenceDetect {
 
@@ -294,33 +293,6 @@ inline size_t getTrailingSilenceSize(
 	len += align - 1;
 	len -= len % align;  // round up to block (channel) boundaries
 	return len;
-}
-
-inline std::vector<unsigned char> generateSilenceBytes(const WAVEFORMATEX* wfx, size_t size) {
-	std::vector<unsigned char> wave;
-	size -= size % wfx->nBlockAlign;
-	callByWaveFormat(wfx, [=, &wave](auto fmtTag) {
-		using Fmt = decltype(fmtTag);
-		constexpr auto bytesPerSample = Fmt::bytesPerSample;
-		constexpr auto zeroPoint = Fmt::zeroPoint();
-		if constexpr (zeroPoint == 0) {
-			wave.assign(size, 0);
-		} else if constexpr (bytesPerSample == 1) {
-			wave.assign(size, zeroPoint);
-		} else {
-			wave.assign(size, 0);
-			unsigned char *p = wave.data();
-			unsigned char *pEnd = p + size;
-			for (; p != pEnd; p += bytesPerSample) {
-				memcpy(p, &zeroPoint, bytesPerSample);
-			}
-		}
-	});
-	return wave;
-}
-
-inline std::vector<unsigned char> generateSilenceMs(const WAVEFORMATEX* wfx, unsigned int milliseconds) {
-	return generateSilenceBytes(wfx, (size_t)wfx->nAvgBytesPerSec * milliseconds / 1000);
 }
 
 }  // namespace SilenceDetect

--- a/nvdaHelper/local/silenceDetect.h
+++ b/nvdaHelper/local/silenceDetect.h
@@ -154,10 +154,10 @@ size_t getLeadingSilenceSizeMono(
 	const SampleType minValue = zeroPoint - threshold, maxValue = zeroPoint + threshold;
 
 	// Check each sample
+	SampleType smp = SampleType();
 	const unsigned char* p = waveData;
 	const unsigned char* pEnd = waveData + (size - (size % bytesPerSample));
 	for (; p != pEnd; p += bytesPerSample) {
-		SampleType smp;
 		memcpy(&smp, p, bytesPerSample);
 		smp = Fmt::signExtend(smp);
 		// this sample is out of range, so the leading silence starts at the previous sample
@@ -191,9 +191,9 @@ size_t getTrailingSilenceSizeMono(
 
 	// Check each sample in reverse order
 	const unsigned char* p = waveData + (size - (size % bytesPerSample));
+	SampleType smp = SampleType();
 	do {
 		p -= bytesPerSample;
-		SampleType smp;
 		memcpy(&smp, p, bytesPerSample);
 		smp = Fmt::signExtend(smp);
 		// this sample is out of range, so the trailing silence starts at the next sample

--- a/nvdaHelper/local/silenceDetect.h
+++ b/nvdaHelper/local/silenceDetect.h
@@ -40,17 +40,23 @@ struct WaveFormat {
 	}
 
 	static constexpr SampleType (max)() {
-		if constexpr (std::is_floating_point_v<SampleType>)
+		if constexpr (std::is_floating_point_v<SampleType>) {
+			// For floating-point samples, maximum value is 1.0
 			return SampleType(1);
-		else
+		} else {
+			// Trim the maximum value to `bytesPerSample` bytes
 			return (std::numeric_limits<SampleType>::max)() >> ((sizeof(SampleType) - bytesPerSample) * 8);
+		}
 	}
 
 	static constexpr SampleType (min)() {
-		if constexpr (std::is_floating_point_v<SampleType>)
+		if constexpr (std::is_floating_point_v<SampleType>) {
+			// For floating-point samples, minimum value is -1.0
 			return SampleType(-1);
-		else
+		} else {
+			// Trim the minimum value to `bytesPerSample` bytes
 			return (std::numeric_limits<SampleType>::min)() >> ((sizeof(SampleType) - bytesPerSample) * 8);
+		}
 	}
 
 	static constexpr SampleType defaultThreshold() {

--- a/nvdaHelper/local/silenceDetect.h
+++ b/nvdaHelper/local/silenceDetect.h
@@ -1,3 +1,8 @@
+// A part of NonVisual Desktop Access (NVDA)
+// This file is covered by the GNU General Public License.
+// See the file COPYING for more details.
+// Copyright (C) 2025 NV Access Limited, gexgd0419
+
 #ifndef SILENCEDETECT_H
 #define SILENCEDETECT_H
 

--- a/projectDocs/dev/developerGuide/developerGuide.md
+++ b/projectDocs/dev/developerGuide/developerGuide.md
@@ -1393,6 +1393,7 @@ For examples of how to define and use new extension points, please see the code 
 |`Action` |`synthIndexReached` |Notifies when a synthesizer reaches an index during speech.|
 |`Action` |`synthDoneSpeaking` |Notifies when a synthesizer finishes speaking.|
 |`Action` |`synthChanged` |Notifies of synthesizer changes.|
+|`Action` |`pre_synthSpeak` |Notifies when the current synthesizer is about to speak something.|
 
 ### tones {#tonesExtPts}
 

--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -45,6 +45,7 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 	autoDialectSwitching = boolean(default=false)
 	delayedCharacterDescriptions = boolean(default=false)
 	excludedSpeechModes = int_list(default=list())
+	trimLeadingSilence = boolean(default=true)
 
 	[[__many__]]
 		capPitchChange = integer(default=30,min=-100,max=100)

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -3985,6 +3985,14 @@ class AdvancedPanelControls(
 
 	def onSave(self):
 		log.debug("Saving advanced config")
+
+		if config.conf["speech"]["trimLeadingSilence"] != self.trimLeadingSilenceCheckBox.IsChecked():
+			# Reload the synthesizer if "trimLeadingSilence" changes
+			config.conf["speech"]["trimLeadingSilence"] = self.trimLeadingSilenceCheckBox.IsChecked()
+			currentSynth = getSynth()
+			if not setSynth(currentSynth.name):
+				_synthWarningDialog(currentSynth.name)
+
 		config.conf["development"]["enableScratchpadDir"] = self.scratchpadCheckBox.IsChecked()
 		selectiveUIAEventRegistrationChoice = self.selectiveUIAEventRegistrationCombo.GetSelection()
 		config.conf["UIA"]["eventRegistration"] = self.selectiveUIAEventRegistrationVals[
@@ -3997,7 +4005,6 @@ class AdvancedPanelControls(
 		config.conf["featureFlag"]["cancelExpiredFocusSpeech"] = (
 			self.cancelExpiredFocusSpeechCombo.GetSelection()
 		)
-		config.conf["speech"]["trimLeadingSilence"] = self.trimLeadingSilenceCheckBox.IsChecked()
 		config.conf["UIA"]["allowInChromium"] = self.UIAInChromiumCombo.GetSelection()
 		self.enhancedEventProcessingComboBox.saveCurrentValueToConf()
 		config.conf["terminals"]["speakPasswords"] = self.winConsoleSpeakPasswordsCheckBox.IsChecked()

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -3755,7 +3755,7 @@ class AdvancedPanelControls(
 		#  Advanced settings panel.
 		label = _("Trim leading silence in speech audio")
 		self.trimLeadingSilenceCheckBox = speechGroup.addItem(wx.CheckBox(speechBox, label=label))
-		self.bindHelpEvent("AdvancedSettingsTrimLeadingSilence", self.trimLeadingSilenceCheckBox)
+		self.bindHelpEvent("TrimLeadingSilence", self.trimLeadingSilenceCheckBox)
 		self.trimLeadingSilenceCheckBox.SetValue(config.conf["speech"]["trimLeadingSilence"])
 		self.trimLeadingSilenceCheckBox.defaultValue = self._getDefaultValue(["speech", "trimLeadingSilence"])
 

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -3720,6 +3720,7 @@ class AdvancedPanelControls(
 		#  Advanced settings panel
 		label = _("Speech")
 		speechSizer = wx.StaticBoxSizer(wx.VERTICAL, self, label=label)
+		speechBox = speechSizer.GetStaticBox()
 		speechGroup = guiHelper.BoxSizerHelper(speechSizer, sizer=speechSizer)
 		sHelper.addItem(speechGroup)
 
@@ -3749,6 +3750,14 @@ class AdvancedPanelControls(
 		self.cancelExpiredFocusSpeechCombo.defaultValue = self._getDefaultValue(
 			["featureFlag", "cancelExpiredFocusSpeech"],
 		)
+
+		# Translators: This is the label for a checkbox control in the
+		#  Advanced settings panel.
+		label = _("Trim leading silence in speech audio")
+		self.trimLeadingSilenceCheckBox = speechGroup.addItem(wx.CheckBox(speechBox, label=label))
+		self.bindHelpEvent("AdvancedSettingsTrimLeadingSilence", self.trimLeadingSilenceCheckBox)
+		self.trimLeadingSilenceCheckBox.SetValue(config.conf["speech"]["trimLeadingSilence"])
+		self.trimLeadingSilenceCheckBox.defaultValue = self._getDefaultValue(["speech", "trimLeadingSilence"])
 
 		# Translators: This is the label for a group of advanced options in the
 		#  Advanced settings panel
@@ -3934,6 +3943,7 @@ class AdvancedPanelControls(
 			and self.wtStrategyCombo.isValueConfigSpecDefault()
 			and self.cancelExpiredFocusSpeechCombo.GetSelection()
 			== self.cancelExpiredFocusSpeechCombo.defaultValue
+			and self.trimLeadingSilenceCheckBox.IsChecked() == self.trimLeadingSilenceCheckBox.defaultValue
 			and self.loadChromeVBufWhenBusyCombo.isValueConfigSpecDefault()
 			and self.caretMoveTimeoutSpinControl.GetValue() == self.caretMoveTimeoutSpinControl.defaultValue
 			and self.reportTransparentColorCheckBox.GetValue()
@@ -3963,6 +3973,7 @@ class AdvancedPanelControls(
 		self.diffAlgoCombo.SetSelection(self.diffAlgoCombo.defaultValue)
 		self.wtStrategyCombo.resetToConfigSpecDefault()
 		self.cancelExpiredFocusSpeechCombo.SetSelection(self.cancelExpiredFocusSpeechCombo.defaultValue)
+		self.trimLeadingSilenceCheckBox.SetValue(self.trimLeadingSilenceCheckBox.defaultValue)
 		self.loadChromeVBufWhenBusyCombo.resetToConfigSpecDefault()
 		self.caretMoveTimeoutSpinControl.SetValue(self.caretMoveTimeoutSpinControl.defaultValue)
 		self.reportTransparentColorCheckBox.SetValue(self.reportTransparentColorCheckBox.defaultValue)
@@ -3986,6 +3997,7 @@ class AdvancedPanelControls(
 		config.conf["featureFlag"]["cancelExpiredFocusSpeech"] = (
 			self.cancelExpiredFocusSpeechCombo.GetSelection()
 		)
+		config.conf["speech"]["trimLeadingSilence"] = self.trimLeadingSilenceCheckBox.IsChecked()
 		config.conf["UIA"]["allowInChromium"] = self.UIAInChromiumCombo.GetSelection()
 		self.enhancedEventProcessingComboBox.saveCurrentValueToConf()
 		config.conf["terminals"]["speakPasswords"] = self.winConsoleSpeakPasswordsCheckBox.IsChecked()

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -3755,7 +3755,7 @@ class AdvancedPanelControls(
 		#  Advanced settings panel.
 		label = _("Trim leading silence in speech audio")
 		self.trimLeadingSilenceCheckBox = speechGroup.addItem(wx.CheckBox(speechBox, label=label))
-		self.bindHelpEvent("TrimLeadingSilence", self.trimLeadingSilenceCheckBox)
+		self.bindHelpEvent("TrimLeadingSilenceSpeech", self.trimLeadingSilenceCheckBox)
 		self.trimLeadingSilenceCheckBox.SetValue(config.conf["speech"]["trimLeadingSilence"])
 		self.trimLeadingSilenceCheckBox.defaultValue = self._getDefaultValue(["speech", "trimLeadingSilence"])
 

--- a/source/nvwave.py
+++ b/source/nvwave.py
@@ -481,6 +481,8 @@ class WasapiWavePlayer(garbageHandler.TrackedObject):
 
 	def startTrimmingLeadingSilence(self, start: bool = True) -> None:
 		"""Start or stop trimming the leading silence from the next audio chunk."""
+		if not config.conf["speech"]["trimLeadingSilence"]:
+			return  ## disabled by user
 		NVDAHelper.localLib.wasPlay_startTrimmingLeadingSilence(self._player, start)
 
 	def _setVolumeFromConfig(self):

--- a/source/nvwave.py
+++ b/source/nvwave.py
@@ -289,6 +289,7 @@ class WasapiWavePlayer(garbageHandler.TrackedObject):
 			if config.conf["audio"]["audioAwakeTime"] > 0:
 				NVDAHelper.localLib.wasSilence_init(outputDevice)
 				WasapiWavePlayer._silenceDevice = outputDevice
+		NVDAHelper.localLib.wasPlay_startTrimmingLeadingSilence(self._player, True)
 
 	@wasPlay_callback
 	def _callback(cppPlayer, feedId):
@@ -393,6 +394,7 @@ class WasapiWavePlayer(garbageHandler.TrackedObject):
 	def idle(self):
 		"""Indicate that this player is now idle; i.e. the current continuous segment  of audio is complete."""
 		self.sync()
+		NVDAHelper.localLib.wasPlay_startTrimmingLeadingSilence(self._player, True)
 		if self._audioDucker:
 			self._audioDucker.disable()
 

--- a/source/nvwave.py
+++ b/source/nvwave.py
@@ -403,6 +403,7 @@ class WasapiWavePlayer(garbageHandler.TrackedObject):
 		if self._audioDucker:
 			self._audioDucker.disable()
 		NVDAHelper.localLib.wasPlay_stop(self._player)
+		NVDAHelper.localLib.wasPlay_startTrimmingLeadingSilence(self._player, True)
 		self._lastActiveTime = None
 		self._isPaused = False
 		self._doneCallbacks = {}
@@ -510,6 +511,7 @@ class WasapiWavePlayer(garbageHandler.TrackedObject):
 			if player._lastActiveTime <= threshold:
 				try:
 					NVDAHelper.localLib.wasPlay_idle(player._player)
+					NVDAHelper.localLib.wasPlay_startTrimmingLeadingSilence(player._player, True)
 				except OSError:
 					# #16125: IAudioClock::GetPosition sometimes fails with an access
 					# violation on a device which has been invalidated. This shouldn't happen

--- a/source/nvwave.py
+++ b/source/nvwave.py
@@ -294,7 +294,9 @@ class WasapiWavePlayer(garbageHandler.TrackedObject):
 				NVDAHelper.localLib.wasSilence_init(outputDevice)
 				WasapiWavePlayer._silenceDevice = outputDevice
 		# Enable trimming by default for speech only
-		self.enableTrimmingLeadingSilence(purpose is AudioPurpose.SPEECH)
+		self.enableTrimmingLeadingSilence(
+			purpose is AudioPurpose.SPEECH and config.conf["speech"]["trimLeadingSilence"]
+		)
 		if self._enableTrimmingLeadingSilence:
 			self.startTrimmingLeadingSilence()
 
@@ -481,8 +483,6 @@ class WasapiWavePlayer(garbageHandler.TrackedObject):
 
 	def startTrimmingLeadingSilence(self, start: bool = True) -> None:
 		"""Start or stop trimming the leading silence from the next audio chunk."""
-		if not config.conf["speech"]["trimLeadingSilence"]:
-			return  ## disabled by user
 		NVDAHelper.localLib.wasPlay_startTrimmingLeadingSilence(self._player, start)
 
 	def _setVolumeFromConfig(self):

--- a/source/nvwave.py
+++ b/source/nvwave.py
@@ -295,7 +295,7 @@ class WasapiWavePlayer(garbageHandler.TrackedObject):
 				WasapiWavePlayer._silenceDevice = outputDevice
 		# Enable trimming by default for speech only
 		self.enableTrimmingLeadingSilence(
-			purpose is AudioPurpose.SPEECH and config.conf["speech"]["trimLeadingSilence"]
+			purpose is AudioPurpose.SPEECH and config.conf["speech"]["trimLeadingSilence"],
 		)
 		if self._enableTrimmingLeadingSilence:
 			self.startTrimmingLeadingSilence()

--- a/source/nvwave.py
+++ b/source/nvwave.py
@@ -567,7 +567,6 @@ class WasapiWavePlayer(garbageHandler.TrackedObject):
 				break
 
 
-
 WavePlayer = WasapiWavePlayer
 fileWavePlayer: Optional[WavePlayer] = None
 fileWavePlayerThread: threading.Thread | None = None

--- a/source/nvwave.py
+++ b/source/nvwave.py
@@ -274,8 +274,6 @@ class WasapiWavePlayer(garbageHandler.TrackedObject):
 			if audioDucking.isAudioDuckingSupported():
 				self._audioDucker = audioDucking.AudioDucker()
 		self._purpose = purpose
-		# Enable trimming by default for speech only
-		self.enableTrimmingLeadingSilence(purpose is AudioPurpose.SPEECH)
 		if outputDevice == self.DEFAULT_DEVICE_KEY:
 			outputDevice = ""
 		self._player = NVDAHelper.localLib.wasPlay_create(
@@ -295,6 +293,8 @@ class WasapiWavePlayer(garbageHandler.TrackedObject):
 			if config.conf["audio"]["audioAwakeTime"] > 0:
 				NVDAHelper.localLib.wasSilence_init(outputDevice)
 				WasapiWavePlayer._silenceDevice = outputDevice
+		# Enable trimming by default for speech only
+		self.enableTrimmingLeadingSilence(purpose is AudioPurpose.SPEECH)
 		if self._enableTrimmingLeadingSilence:
 			self.startTrimmingLeadingSilence()
 

--- a/source/speech/manager.py
+++ b/source/speech/manager.py
@@ -22,7 +22,7 @@ from .commands import (
 
 from .priorities import Spri, SPEECH_PRIORITIES
 from logHandler import log
-from synthDriverHandler import getSynth
+from synthDriverHandler import getSynth, pre_synthSpeak
 from typing import (
 	Dict,
 	Any,
@@ -431,6 +431,7 @@ class SpeechManager(object):
 					self._indexesSpeaking.append(item.index)
 			self._cancelledLastSpeechWithSynth = False
 			log._speechManagerUnitTest(f"Synth Gets: {seq}")
+			pre_synthSpeak.notify(speechSequence=seq)
 			getSynth().speak(seq)
 
 	def _getNextPriority(self):

--- a/source/synthDriverHandler.py
+++ b/source/synthDriverHandler.py
@@ -567,3 +567,11 @@ The local system should be notified about synth parameters at the remote system.
 @param isFallback: Whether the synth is set as fallback synth due to another synth's failure
 @type isFallback: bool
 """
+
+pre_synthSpeak = extensionPoints.Action()
+"""
+Notifies when speak() of the current synthesizer is about to be called.
+
+:param speechSequence: the speech sequence to pass to speak()
+:type speechSequence: speech.SpeechSequence
+"""

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -148,6 +148,7 @@ Add-ons will need to be re-tested and have their manifest updated.
   * Added the `matchFunc` parameter to `addUsbDevices` which is also available on `addUsbDevice`.
     * This way device detection can be constrained further in cases where a VID/PID-combination is shared by multiple devices across multiple drivers, or when a HID device offers multiple endpoints, for example.
     * See the method documentation as well as examples in the albatross and brailliantB drivers for more information.
+* Added a new extension point `pre_synthSpeak` in `synthDriverHandler`, which will be called before the speech manager calls `speak` of the current synthesizer.
 
 #### API Breaking Changes
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -59,7 +59,7 @@ Prefix matching on command line flags, e.g. using `--di` for `--disable-addons` 
 * Microsoft Speech API version 5 and Microsoft Speech Platform voices now use WASAPI for audio output, which may improve the responsiveness of those voices. (#13284, @gexgd0419)
 * The keyboard settings for "Speak typed characters" and "Speak typed words" now have three options: Off, Only in edit controls, and Always. (#17505, @Cary-rowen)
   * By default, "Speak typed characters" is now set to "Only in edit controls".
-* The silence at the beginning of speech will now be trimmed when using OneCore voices, SAPI5 voices, and some of the third-party voice add-ons to improve their responsiveness. (#17614, @gexgd0419)
+* The silence at the beginning of speech will now be trimmed when using OneCore voices, SAPI5 voices, and some third-party voice add-ons to improve their responsiveness. (#17614, @gexgd0419)
 
 ### Bug Fixes
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -59,6 +59,7 @@ Prefix matching on command line flags, e.g. using `--di` for `--disable-addons` 
 * Microsoft Speech API version 5 and Microsoft Speech Platform voices now use WASAPI for audio output, which may improve the responsiveness of those voices. (#13284, @gexgd0419)
 * The keyboard settings for "Speak typed characters" and "Speak typed words" now have three options: Off, Only in edit controls, and Always. (#17505, @Cary-rowen)
   * By default, "Speak typed characters" is now set to "Only in edit controls".
+* The silence at the beginning of speech will now be trimmed when using OneCore voices, SAPI5 voices, and some of the third-party voice add-ons to improve their responsiveness. (#17614, @gexgd0419)
 
 ### Bug Fixes
 

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -3321,6 +3321,11 @@ This option enables behaviour which attempts to cancel speech for expired focus 
 In particular moving quickly through messages in Gmail with Chrome can cause NVDA to speak outdated information.
 This functionality is enabled by default as of NVDA 2021.1.
 
+##### Trim leading silence in speech audio {#AdvancedSettingsTrimLeadingSilence}
+
+This option enables NVDA to trim the silence at the beginning of the speech audio, making the voices respond faster.
+This option is enabled by default, and should only affect the silence at the beginning. But if you find that some necessary silence periods are also missing (e.g. pause between two sentences) when using a speech synthesizer add-on, you may try turning off this feature.
+
 ##### Caret move timeout (in MS) {#AdvancedSettingsCaretMoveTimeout}
 
 This option allows you to configure the number of milliseconds NVDA will wait for the caret (insertion point) to move in editable text controls.

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -3323,8 +3323,9 @@ This functionality is enabled by default as of NVDA 2021.1.
 
 ##### Trim leading silence in speech audio {#TrimLeadingSilence}
 
-This option enables NVDA to trim the silence at the beginning of the speech audio, making the voices respond faster.
-This option is enabled by default, and should only affect the silence at the beginning. But if you find that some necessary silence periods are also missing (e.g. pause between two sentences) when using a speech synthesizer add-on, you may try turning off this feature.
+When enabled, NVDA will remove silence from the start of speech audio, which may improve the responsiveness of some speech synthesizers.
+This option is enabled by default, and should only affect the silence at the beginning of speech.
+If you find that some necessary silence periods are also missing (e.g. pause between two sentences) when using a speech synthesizer add-on, you may turn this feature off entirely to resolve the issue.
 
 ##### Caret move timeout (in MS) {#AdvancedSettingsCaretMoveTimeout}
 

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -3321,7 +3321,7 @@ This option enables behaviour which attempts to cancel speech for expired focus 
 In particular moving quickly through messages in Gmail with Chrome can cause NVDA to speak outdated information.
 This functionality is enabled by default as of NVDA 2021.1.
 
-##### Trim leading silence in speech audio {#TrimLeadingSilence}
+##### Trim leading silence in speech audio {#TrimLeadingSilenceSpeech}
 
 When enabled, NVDA will remove silence from the start of speech audio, which may improve the responsiveness of some speech synthesizers.
 This option is enabled by default, and should only affect the silence at the beginning of speech.

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -3321,7 +3321,7 @@ This option enables behaviour which attempts to cancel speech for expired focus 
 In particular moving quickly through messages in Gmail with Chrome can cause NVDA to speak outdated information.
 This functionality is enabled by default as of NVDA 2021.1.
 
-##### Trim leading silence in speech audio {#AdvancedSettingsTrimLeadingSilence}
+##### Trim leading silence in speech audio {#TrimLeadingSilence}
 
 This option enables NVDA to trim the silence at the beginning of the speech audio, making the voices respond faster.
 This option is enabled by default, and should only affect the silence at the beginning. But if you find that some necessary silence periods are also missing (e.g. pause between two sentences) when using a speech synthesizer add-on, you may try turning off this feature.


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Closes #17614

### Summary of the issue:
Some voices output a leading silence part before the actual speech voice. By removing the silence part, the delay between keypress and user hearing the audio will be shorter, therefore make the voices more responsive.

### Description of user facing changes

Users may find the voices more responsive. All voices using NVDA's `WavePlayer` will be affected, including eSpeak-NG, OneCore, SAPI5, and some third-party voice add-ons.

This should only affect the leading silence parts. Silence between sentences or at punctuation marks are not changed, but this may depend on how the voice uses `WavePlayer`.

### Description of development approach

I wrote a header-only library `silenceDetect.h` in `nvdaHelper/local`. It supports most wave formats (8/16/24/32-bit integer and 32/64-bit float wave), and uses a simple algorithm: check each sample to see if it's outside threshold range (currently hard-coded to +/- 1/2^10 or 0.0009765625). It uses template-related code and requires C++ 20 standard.

The `WasapiPlayer` in `wasapi.cpp` is updated to handle silence. A new member function, `startTrimmingLeadingSilence`, and the exported version `wasPlay_startTrimmingLeadingSilence`, is added, to set or clear the `isTrimmingLeadingSilence` flag. If `isTrimmingLeadingSilence` is true, the next chunk fed in will have its leading silence removed. When non-silence is detected, `isTrimmingLeadingSilence` will be reset to false. So every time a new utterance is about to be spoken, `startTrimmingLeadingSilence` should be called.

In `nvwave.py`, `startTrimmingLeadingSilence()` will be called when:
- the player is initialized;
- the player is stopped;
- `idle` is called;
- `_idleCheck` determines that the player is idle.

Usually voices will call `idle` when an utterance is completed, so that audio ducking can work correctly, so here `idle` is used to mark the starting point of the next utterance. If a voice doesn't use `idle` this way, then this logic might be messed up.

As long as the synthesizer uses `idle` as intended, the synthesizer's code doesn't need to be modified to benefit from this feature.

As leading silence can also be introduced by a `BreakCommand` at the beginning of the speech sequence, `WavePlayer` will check the speech sequence first; if there's a `BreakCommand` at the beginning, the leading silence will not be trimmed for the current utterance. To check the exact speech sequence that is about to be spoken, a new extension point, `pre_synthSpeak`, is added in `synthDriverHandler`, which will be invoked just before `SpeechManager` calls `getSynth().speak()`. The existing `pre_speech` is called before `SpeechManager` processes and queues the speech sequence, so `pre_synthSpeak` is needed to provide a more accurate sequence.

When the purpose of a `WavePlayer` is not `SPEECH`, it does not trim the leading silence by default, because of the way `playWaveFile` works (it calls `idle` after every chunk). Users of `WavePlayer` will still be able to enable/disable automatic trimming by calling `enableTrimmingLeadingSilence`, or to initiate trimming manually for the next audio section by calling `startTrimmingLeadingSilence`.

Other possible ways/things that may worth considering (but hasn't been implemented):
- Put silence detection/removal logic in a separate module instead of in `WavePlayer`. The drawback is that every voice synthesizer module needs to be modified to utilize a separate module.
- Use another audio library, such as [PyDub](https://github.com/jiaaro/pydub), to detect/remove silence.
- Add a setting item to turn this feature on or off. (Update: this has been added in advanced settings)
- Add a public API function to allow a synthesizer to opt out of this feature.

### Testing strategy:

These are the delay results I got using 1X speed. "Improved delay" means the delay after applying this PR.

| Voice          | Original Delay | Improved Delay |
| -------------- | -------------- | -------------- |
| eSpeak NG      |      89ms      |      69ms      |
| Huihui OneCore |     192ms      |      74ms      |
| Huihui SAPI5   |     166ms      |      57ms      |

If the speech rate is higher than 1X, the original delay may be shorter, because the leading silence is also shortened during the speed-up process. When there's no leading silence, changing the rate does not affect the delay much.

Considering the margin of error, we can say that the delay of eSpeak NG, OneCore and SAPI5 voices are now at the same level.

### Known issues with pull request:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [ ] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
