### PR TITLE
No longer sentence nav in VS Code

### DIFF
--- a/source/NVDAObjects/window/winword.py
+++ b/source/NVDAObjects/window/winword.py
@@ -40,7 +40,7 @@ from controlTypes.formatFields import TextAlign
 import treeInterceptorHandler
 import browseMode
 from . import Window
-from ..behaviors import EditableTextWithoutAutoSelectDetection
+from ..behaviors import EditableTextBase, EditableTextWithoutAutoSelectDetection
 from . import _msOfficeChart
 from ._msOffice import MsoHyperlink
 import locationHelper
@@ -1573,7 +1573,9 @@ class WordDocumentTreeInterceptor(browseMode.BrowseModeDocumentTreeInterceptor):
 	}
 
 
-class WordDocument(Window):
+class WordDocument(Window, EditableTextBase):
+	_supportsSentenceNavigation = True
+
 	def winwordColorToNVDAColor(self, val):
 		if val >= 0:
 			# normal RGB value

--- a/source/NVDAObjects/window/winword.py
+++ b/source/NVDAObjects/window/winword.py
@@ -1,5 +1,6 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2006-2025 NV Access Limited, Manish Agrawal, Derek Riemer, Babbage B.V., Cyrille Bougot
+# Copyright (C) 2006-2025 NV Access Limited, Manish Agrawal, Derek Riemer, Babbage B.V., Cyrille Bougot,
+# Leonard de Ruijter
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 

--- a/source/appModules/code.py
+++ b/source/appModules/code.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2020-2024 NV Access Limited, Leonard de Ruijter, Cary-Rowen
+# Copyright (C) 2020-2025 NV Access Limited, Leonard de Ruijter, Cary-Rowen
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 

--- a/source/appModules/code.py
+++ b/source/appModules/code.py
@@ -7,6 +7,7 @@
 
 import appModuleHandler
 import controlTypes
+from NVDAObjects.behaviors import EditableTextBase
 from NVDAObjects.IAccessible.chromium import Document
 from NVDAObjects import NVDAObject, NVDAObjectTextInfo
 
@@ -26,6 +27,8 @@ class AppModule(appModuleHandler.AppModule):
 			clsList.insert(0, VSCodeDocument)
 
 	def event_NVDAObject_init(self, obj: NVDAObject):
+		if isinstance(obj, EditableTextBase):
+			obj._supportsSentenceNavigation = False
 		# TODO: This is a specific fix for Visual Studio Code.
 		# Once the underlying issue is resolved, this workaround can be removed.
 		# See issue #15159 for more details.

--- a/source/editableText.py
+++ b/source/editableText.py
@@ -245,11 +245,11 @@ class EditableText(TextContainerObject, ScriptableObject):
 			if not caretMoved and self._supportsSentenceNavigation is not False:
 				info.move(textInfos.UNIT_SENTENCE, direction)
 				info.updateCaret()
-			self._caretScriptPostMovedHelper(
-				textInfos.UNIT_SENTENCE if not caretMoved else textInfos.UNIT_LINE,
-				gesture,
-				info,
-			)
+				self._caretScriptPostMovedHelper(
+					textInfos.UNIT_SENTENCE,
+					gesture,
+					info,
+				)
 		except Exception:
 			if self._supportsSentenceNavigation is True:
 				log.exception("Error in _caretMoveBySentenceHelper")

--- a/source/editableText.py
+++ b/source/editableText.py
@@ -245,6 +245,7 @@ class EditableText(TextContainerObject, ScriptableObject):
 		try:
 			info = self.makeTextInfo(textInfos.POSITION_CARET)
 			caretMoved = False
+			newInfo = None
 			if not self._supportsSentenceNavigation:
 				bookmark = info.bookmark
 				gesture.send()
@@ -252,11 +253,13 @@ class EditableText(TextContainerObject, ScriptableObject):
 			if not caretMoved and self._supportsSentenceNavigation is not False:
 				info.move(textInfos.UNIT_SENTENCE, direction)
 				info.updateCaret()
-				self._caretScriptPostMovedHelper(
-					textInfos.UNIT_SENTENCE,
-					gesture,
-					info,
-				)
+			else:
+				info = newInfo
+			self._caretScriptPostMovedHelper(
+				textInfos.UNIT_SENTENCE if not caretMoved else textInfos.UNIT_LINE,
+				gesture,
+				info,
+			)
 		except Exception:
 			if self._supportsSentenceNavigation is True:
 				log.exception("Error in _caretMoveBySentenceHelper")

--- a/source/editableText.py
+++ b/source/editableText.py
@@ -9,6 +9,7 @@
 """
 
 import time
+from numbers import Number
 from speech import sayAll
 import api
 import review
@@ -50,7 +51,7 @@ class EditableText(TextContainerObject, ScriptableObject):
 	"""The minimum amount of time that should elapse before checking if the word under the caret has changed"""
 	_useEvents_maxTimeoutSec: float = 0.06
 	"""The maximum amount of time that may elapse before we no longer rely on caret events to detect movement."""
-	_caretMovementTimeoutMultiplier = 1
+	_caretMovementTimeoutMultiplier: Number = 1
 	"""A multiplier to apply to the caret movement timeout to increase or decrease it in a subclass."""
 	_supportsSentenceNavigation: bool | None = None
 	"""Whether the editable text supports sentence navigation.

--- a/source/editableText.py
+++ b/source/editableText.py
@@ -1,7 +1,7 @@
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-# Copyright (C) 2006-2022 NV Access Limited, Davy Kager, Julien Cochuyt, Rob Meredith
+# Copyright (C) 2006-2025 NV Access Limited, Davy Kager, Julien Cochuyt, Rob Meredith, Leonard de Ruijter
 
 """Common support for editable text.
 @note: If you want editable text functionality for an NVDAObject,

--- a/source/editableText.py
+++ b/source/editableText.py
@@ -9,7 +9,7 @@
 """
 
 import time
-from numbers import Number
+from numbers import Real
 from speech import sayAll
 import api
 import review
@@ -37,22 +37,29 @@ class EditableText(TextContainerObject, ScriptableObject):
 		* When the object gains focus, L{initAutoSelectDetection} must be called.
 		* When the object notifies of a possible selection change, L{detectPossibleSelectionChange} must be called.
 		* Optionally, if the object notifies of changes to its content, L{hasContentChangedSinceLastSelection} should be set to C{True}.
-	@ivar hasContentChangedSinceLastSelection: Whether the content has changed since the last selection occurred.
-	@type hasContentChangedSinceLastSelection: bool
 	"""
+
+	hasContentChangedSinceLastSelection: bool
+	"""Whether the content has changed since the last selection occurred."""
 
 	shouldFireCaretMovementFailedEvents: bool = False
 	"""Whether to fire caretMovementFailed events when the caret doesn't move in response to a caret movement key."""
+
 	announceNewLineText: bool = True
 	"""Whether or not to announce text found before the caret on a new line (e.g. auto numbering)"""
+
 	announceEntireNewLine: bool = False
 	"""When announcing new line text: should the entire line be announced, or just text after the caret?"""
+
 	_hasCaretMoved_minWordTimeoutSec: float = 0.03
 	"""The minimum amount of time that should elapse before checking if the word under the caret has changed"""
+
 	_useEvents_maxTimeoutSec: float = 0.06
 	"""The maximum amount of time that may elapse before we no longer rely on caret events to detect movement."""
-	_caretMovementTimeoutMultiplier: Number = 1
+
+	_caretMovementTimeoutMultiplier: Real = 1
 	"""A multiplier to apply to the caret movement timeout to increase or decrease it in a subclass."""
+
 	_supportsSentenceNavigation: bool | None = None
 	"""Whether the editable text supports sentence navigation.
 	When `None` (default), the state is undetermined, e.g. sentence navigation will be attempted, when it fails, the gesture will be send to the OS.

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -31,6 +31,7 @@ As a consequence, announcement of first line indent is now supported for LibreOf
 * NVDA can now be configured to speak the current line or paragraph when navigating with braille navigation keys. (#17053, @nvdaes)
 * In Word, the selection update is now reported when using Word commands to extend or reduce the selection (`f8` or `shift+f8`). (#3293, @CyrilleB79)
 * In Microsoft Word 16.0.18226 and higher or when using Word object model, NVDA will now report if a heading is collapsed in both speech and braille. (#17499)
+* NVDA is now able to report caret changes when pressing `alt+upArrow` or `alt+downArrow` gestures, for example in Visual Studio. (#17082, @LeonarddeR)
 
 ### Changes
 
@@ -96,7 +97,7 @@ In any document, if the cursor is on the last line, it will be moved to the end 
 * Custom braille tables in the developer scratchpad are now properly ignored when running with add-ons disabled. (#17565, @LeonarddeR)
 * Fix issue with certain section elements not being recognized as editable controls in Visual Studio Code. (#17573, @Cary-rowen)
 * Fixed an issue where continuous reading (say all) stopped at the end of the first sentence when using some SAPI5 synthesizers. (#16691, @gexgd0419)
-* In Visual Studio Code, NVDA no longer hijacks the `alt+up` and `alt+down` gestures for sentence navigation. (#17082, @LeonarddeR)
+* In Visual Studio Code, NVDA no longer hijacks the `alt+upArrow` and `alt+downArrow` gestures for sentence navigation. (#17082, @LeonarddeR)
 
 ### Changes for Developers
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -31,7 +31,7 @@ As a consequence, announcement of first line indent is now supported for LibreOf
 * NVDA can now be configured to speak the current line or paragraph when navigating with braille navigation keys. (#17053, @nvdaes)
 * In Word, the selection update is now reported when using Word commands to extend or reduce the selection (`f8` or `shift+f8`). (#3293, @CyrilleB79)
 * In Microsoft Word 16.0.18226 and higher or when using Word object model, NVDA will now report if a heading is collapsed in both speech and braille. (#17499)
-* NVDA is now able to report caret changes when pressing `alt+upArrow` or `alt+downArrow` gestures, for example in Visual Studio. (#17082, @LeonarddeR)
+* NVDA is now able to report caret changes when pressing `alt+upArrow` or `alt+downArrow` gestures, for example in Visual Studio. (#17652, @LeonarddeR)
 
 ### Changes
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -31,7 +31,6 @@ As a consequence, announcement of first line indent is now supported for LibreOf
 * NVDA can now be configured to speak the current line or paragraph when navigating with braille navigation keys. (#17053, @nvdaes)
 * In Word, the selection update is now reported when using Word commands to extend or reduce the selection (`f8` or `shift+f8`). (#3293, @CyrilleB79)
 * In Microsoft Word 16.0.18226 and higher or when using Word object model, NVDA will now report if a heading is collapsed in both speech and braille. (#17499)
-* NVDA is now able to report caret changes when pressing `alt+upArrow` or `alt+downArrow` gestures, for example in Visual Studio. (#17652, @LeonarddeR)
 
 ### Changes
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -31,6 +31,7 @@ As a consequence, announcement of first line indent is now supported for LibreOf
 * NVDA can now be configured to speak the current line or paragraph when navigating with braille navigation keys. (#17053, @nvdaes)
 * In Word, the selection update is now reported when using Word commands to extend or reduce the selection (`f8` or `shift+f8`). (#3293, @CyrilleB79)
 * In Microsoft Word 16.0.18226 and higher or when using Word object model, NVDA will now report if a heading is collapsed in both speech and braille. (#17499)
+* NVDA is now able to report caret changes when pressing `alt+upArrow` or `alt+downArrow` gestures, for example in Visual Studio. (#17652, @LeonarddeR)
 
 ### Changes
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -96,6 +96,7 @@ In any document, if the cursor is on the last line, it will be moved to the end 
 * Custom braille tables in the developer scratchpad are now properly ignored when running with add-ons disabled. (#17565, @LeonarddeR)
 * Fix issue with certain section elements not being recognized as editable controls in Visual Studio Code. (#17573, @Cary-rowen)
 * Fixed an issue where continuous reading (say all) stopped at the end of the first sentence when using some SAPI5 synthesizers. (#16691, @gexgd0419)
+* In Visual Studio Code, NVDA no longer hijacks the `alt+up` and `alt+down` gestures for sentence navigation. (#17082, @LeonarddeR)
 
 ### Changes for Developers
 


### PR DESCRIPTION
### Link to issue number:
Fixes #17082

### Summary of the issue:
Since we support sentence navigation in IA2 controls, alt+upArrow and alt+downArrow no longer work in Visual Studio Code as NVDA performs sentence navigation.

### Description of user facing changes
1. No longer sentence navigation with alt+up and alt+down in VS Code
2. Reporting of caret changes for alt+up and alt+down in software such as Visual Studio Code

### Description of development approach
1. Added `_supportsSentenceNavigation` on `EditableText`:
    - When `None` (default), the state is undetermined. The gesture will be send to the OS. When this doesn't result in caret movement, sentence navigation will be tried.to the OS.
    - When `True`, sentence navigation is explicitly supported and will be performed. When it fails, the gesture is discarded. It will never reach the OS.
    - When `False`, sentence navigation is explicitly not supported and the gesture is sent to the OS.

2. Since we're checking caret movement after executing the gesture when sentence nav is False or undetermined, we can report caret changes appropriately. We assume a unit of line in that case.

### Testing strategy:
Tested:

- [x] Sentence navigation works appropriately in Word
- [x] When pressing alt+up / alt+down arrow in Visual Studio Code or Enterprise, NVDA will report the caret position. Basically, this means that the line that was moved will be repeated.

### Known issues with pull request:
None known

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
