### PR TITLE
Add a payload argument to message dialog callbacks

### DIFF
--- a/projectDocs/dev/developerGuide/developerGuide.md
+++ b/projectDocs/dev/developerGuide/developerGuide.md
@@ -1670,7 +1670,7 @@ A convenient way of responding to button presses, especially for non-modal messa
 This is achieved by passing a `callback` function to `addButton`, `addButtons`, or any of the add button helpers.
 
 A callback should be a function which accepts exactly one positional argument.
-When called, a `Payload` datastructure will be passed in.
+When called, a `Payload` data structure will be passed in.
 This data structure currently contains no information, though in future it may be augmented to contain information about the dialog's state and the context from which the callback was called.
 
 #### Convenience methods

--- a/projectDocs/dev/developerGuide/developerGuide.md
+++ b/projectDocs/dev/developerGuide/developerGuide.md
@@ -1504,13 +1504,15 @@ match saveDialog.ShowModal():
 For non-modal dialogs, the easiest way to respond to the user pressing a button is via callback methods.
 
 ```py
-def readChangelog():
+from gui.message import Payload
+
+def readChangelog(payload: Payload):
 	...  # Do something
 
-def downloadUpdate():
+def downloadUpdate(payload: Payload):
 	...  # Do something
 
-def remindLater():
+def remindLater(payload: Payload):
 	...  # Do something
 
 updateDialog = MessageDialog(
@@ -1661,6 +1663,15 @@ The following default button sets are available:
 | `SAVE_NO_CANCEL` | `DefaultButton.SAVE`, `DefaultButton.NO`, `DefaultButton.CANCEL` | `addSaveNoCancelButtons` | The label of the no button is overridden to be "Do&n't save". |
 
 If none of the standard `ReturnCode` values are suitable for your button, you may also use `ReturnCode.CUSTOM_1` through `ReturnCode.CUSTOM_5`, which will not conflict with any built-in identifiers.
+
+#### Callbacks
+
+A convenient way of responding to button presses, especially for non-modal message dialogs, is to attach callbacks to the buttons.
+This is achieved by passing a `callback` function to `addButton`, `addButtons`, or any of the add button helpers.
+
+A callback should be a function which accepts exactly one positional argument.
+When called, a `Payload` datastructure will be passed in.
+This data structure currently contains no information, though in future it may be augmented to contain information about the dialog's state and the context from which the callback was called.
 
 #### Convenience methods
 

--- a/source/gui/message.py
+++ b/source/gui/message.py
@@ -5,6 +5,7 @@
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
+from dataclasses import dataclass
 import threading
 import time
 import warnings
@@ -154,8 +155,13 @@ class DisplayableError(Exception):
 		)
 
 
+@dataclass(frozen=True)
+class Payload:
+	"""Payload of information to pass to message dialog callbacks."""
+
+
 # TODO: Change to type statement when Python 3.12 or later is in use.
-_Callback_T: TypeAlias = Callable[[], Any]
+_Callback_T: TypeAlias = Callable[[Payload], Any]
 
 
 class _Missing_Type:
@@ -1139,7 +1145,8 @@ class MessageDialog(DpiScalingHelperMixinWithoutInit, ContextHelpMixin, wx.Dialo
 		if callback is not None:
 			if close:
 				self.Hide()
-			callback()
+			payload = Payload()
+			callback(payload)
 		if close:
 			self.SetReturnCode(returnCode)
 			self.Close()

--- a/source/synthDrivers/sapi4.py
+++ b/source/synthDrivers/sapi4.py
@@ -486,7 +486,7 @@ def _mmDeviceEndpointIdToWaveOutId(targetEndpointId: str) -> int:
 def _sapi4DeprecationWarning(synth: SynthDriver, audioOutputDevice: str, isFallback: bool):
 	"""A synthChanged event handler to alert the user about the deprecation of SAPI4."""
 
-	def setShown():
+	def setShown(payload: gui.message.Payload):
 		synth._hasWarningBeenShown = True
 		synth.saveSettings()
 
@@ -509,7 +509,7 @@ def _sapi4DeprecationWarning(synth: SynthDriver, audioOutputDevice: str, isFallb
 		).addHelpButton(
 			# Translators: A button in a dialog.
 			label=_("Open user guide"),
-			callback=lambda: gui.contextHelp.showHelp("SupportedSpeechSynths"),
+			callback=lambda payload: gui.contextHelp.showHelp("SupportedSpeechSynths"),
 		).Show()
 
 	if (not isFallback) and (synth.name == "sapi4") and (not getattr(synth, "_hasWarningBeenShown", False)):


### PR DESCRIPTION
### Link to issue number:

Fixes #17658 

### Summary of the issue:

There is currently no way to pass information between message dialogs and their callbacks. This reduces the functionality available to callbacks in future.

### Description of user facing changes

None.

### Description of development approach

Add a `Payload` dataclass to `gui.message`. It currently has no fields, though these can be added without breaking the API in future, for example to implement #17646 .
In `MessageDialog._executeCommand`, if a command has a callback, instantiate a `Payload` and pass it to the callback when calling it.
Update the few uses of the message dialog API in NVDA which use callbacks:

* `synthDrivers.sapi4._sapi4DeprecationWarning`

Updated the developer guide to note the new requirements for callback functions.

### Testing strategy:

Ran NVDA from source, and triggered the affected dialogs. Ensured they worked as expected.

Ran from source, with `versionInfo.updateVersionType` set to `"snapshot:alpha`, and checked that updating worked.

Built and installed this branch, then ran the CRFT, cancelling and continuing, and ensured that no issues occured.

### Known issues with pull request:

None known.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
