### PR TITLE
appveyor.yml: don't limit deploy with rules. Syntax was wrong and it is not needed.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -110,16 +110,6 @@ deploy:
     url: https://api.nvaccess.org/appveyor/hook
     authorization: Bearer %APPVEYOR_WEBHOOK_TOKEN%
     request_timeout: 5  # minutes
-    on:
-      # Only deploy specific branches
-      branch: 
-        - master
-        - beta
-        - rc
-        - /try-.*/
-        - /release-.*/
-      # Exclude PR builds
-      APPVEYOR_PULL_REQUEST_NUMBER: false
 
 on_failure:
  - ps: appveyor\scripts\uploadArtifacts.ps1


### PR DESCRIPTION
Fix up of #17668.