### PR TITLE
Fix nvwave.outputDeviceIDToName

### DIFF
--- a/source/nvwave.py
+++ b/source/nvwave.py
@@ -102,7 +102,7 @@ def outputDeviceIDToName(ID: str) -> str:
 	:param ID: The device ID.
 	:return: The device name.
 	"""
-	device = AudioUtilities.GetDeviceEnumerator().GetDevice(id)
+	device = AudioUtilities.GetDeviceEnumerator().GetDevice(ID)
 	return AudioUtilities.CreateDevice(device).FriendlyName
 
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
None

### Summary of the issue:

Fix the following exception in `nvwave.outputDeviceIDToName`:

```
Traceback (most recent call last):
  File "<console>", line 1, in <module>
  File "nvwave.pyc", line 105, in outputDeviceIDToName
ctypes.ArgumentError: argument 1: TypeError: wrong type
```

### Description of user facing changes
None

### Description of development approach

The variable was incorrect, so I fixed it to an uppercase `ID`.

### Testing strategy:
I ran the test manually.

### Known issues with pull request:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
