### PR TITLE
Add fully automatic add-on updates

### DIFF
--- a/source/addonHandler/__init__.py
+++ b/source/addonHandler/__init__.py
@@ -1062,7 +1062,7 @@ docFileName = string(default=None)
 
 	def __init__(self, input: IO[bytes], translatedInput: IO[bytes] | None = None):
 		"""Constructs an :class:`AddonManifest` instance from manifest string data
-		
+
 		:param input: data to read the manifest information
 		:param translatedInput: Optional translated manifest input, defaults to ``None``
 		"""

--- a/source/addonHandler/__init__.py
+++ b/source/addonHandler/__init__.py
@@ -1061,9 +1061,10 @@ docFileName = string(default=None)
 	)
 
 	def __init__(self, input: IO[bytes], translatedInput: IO[bytes] | None = None):
-		"""Constructs an L{AddonManifest} instance from manifest string data
-		@param input: data to read the manifest information
-		@param translatedInput: translated manifest input
+		"""Constructs an :class:`AddonManifest` instance from manifest string data
+		
+		:param input: data to read the manifest information
+		:param translatedInput: Optional translated manifest input, defaults to ``None``
 		"""
 		super().__init__(input, configspec=self.configspec, encoding="utf-8", default_encoding="utf-8")
 		self._errors = None

--- a/source/addonHandler/__init__.py
+++ b/source/addonHandler/__init__.py
@@ -20,6 +20,7 @@ from six import string_types
 from typing import (
 	Callable,
 	Dict,
+	IO,
 	Literal,
 	Optional,
 	Set,
@@ -1059,12 +1060,10 @@ docFileName = string(default=None)
 		),
 	)
 
-	def __init__(self, input, translatedInput=None):
+	def __init__(self, input: IO[bytes], translatedInput: IO[bytes] | None = None):
 		"""Constructs an L{AddonManifest} instance from manifest string data
 		@param input: data to read the manifest information
-		@type input: a fie-like object.
 		@param translatedInput: translated manifest input
-		@type translatedInput: file-like object
 		"""
 		super().__init__(input, configspec=self.configspec, encoding="utf-8", default_encoding="utf-8")
 		self._errors = None

--- a/source/addonStore/dataManager.py
+++ b/source/addonStore/dataManager.py
@@ -37,7 +37,7 @@ from .models.addon import (
 	_createStoreCollectionFromJson,
 )
 from .models.channel import Channel
-from .models.status import AvailableAddonStatus, getStatus, _StatusFilterKey
+from .models.status import AvailableAddonStatus, _canUpdateAddon, getStatus, _StatusFilterKey
 from .network import (
 	_getCurrentApiVersionForURL,
 	_getAddonStoreURL,
@@ -352,13 +352,17 @@ class _DataManager:
 			return None
 		return _createInstalledStoreModelFromData(cacheData)
 
-	def _addonsPendingUpdate(self) -> list["_AddonGUIModel"]:
-		# TODO: Add AvailableAddonStatus.UPDATE_INCOMPATIBLE,
-		# to allow updates that are incompatible with the current NVDA version,
-		# only if a config setting is enabled
+	def _addonsPendingUpdate(
+		self,
+		onDisplayableError: "DisplayableError.OnDisplayableErrorT | None" = None,
+	) -> list["_AddonGUIModel"]:
 		updatableAddonStatuses = {AvailableAddonStatus.UPDATE}
-		addonsPendingUpdate: list["_AddonGUIModel"] = []
-		compatibleAddons = self.getLatestCompatibleAddons()
+		addonsPendingUpdate: dict["str", "_AddonGUIModel"] = {}
+		if config.conf["addonStore"]["allowIncompatibleUpdates"]:
+			updatableAddonStatuses.add(AvailableAddonStatus.UPDATE_INCOMPATIBLE)
+			compatibleAddons = self.getLatestAddons(onDisplayableError)
+		else:
+			compatibleAddons = self.getLatestCompatibleAddons(onDisplayableError)
 		for channel in compatibleAddons:
 			for addon in compatibleAddons[channel].values():
 				if getStatus(addon, _StatusFilterKey.UPDATE) in updatableAddonStatuses:
@@ -374,8 +378,14 @@ class _DataManager:
 						installedChannel,
 					)
 					if addon.channel in availableUpdateChannels:
-						addonsPendingUpdate.append(addon)
-		return addonsPendingUpdate
+						# get latest add-on from channel
+						if addon.name in addonsPendingUpdate:
+							# See if this version is newer than the currently tracked versions
+							if _canUpdateAddon(addon, addonsPendingUpdate[addon.name]):
+								addonsPendingUpdate[addon.name] = addon
+						else:
+							addonsPendingUpdate[addon.name] = addon
+		return list(addonsPendingUpdate.values())
 
 
 class _InstalledAddonsCache(AutoPropertyObject):

--- a/source/addonStore/dataManager.py
+++ b/source/addonStore/dataManager.py
@@ -364,9 +364,10 @@ class _DataManager:
 		else:
 			compatibleAddons = self.getLatestCompatibleAddons(onDisplayableError)
 		for channel in compatibleAddons:
+			# Ensure add-on update channel is within the preferred update channels
 			for addon in compatibleAddons[channel].values():
+				# Ensure add-on is updatable
 				if getStatus(addon, _StatusFilterKey.UPDATE) in updatableAddonStatuses:
-					# Ensure add-on update channel is within the preferred update channels
 					if (installedStoreData := addon._addonHandlerModel._addonStoreData) is not None:
 						installedChannel = installedStoreData.channel
 					else:
@@ -377,8 +378,8 @@ class _DataManager:
 					availableUpdateChannels = selectedUpdateChannel._availableChannelsForAddonWithChannel(
 						installedChannel,
 					)
+					# Ensure add-on channel is valid to update to given update preferences
 					if addon.channel in availableUpdateChannels:
-						# get latest add-on from channel
 						if addon.name in addonsPendingUpdate:
 							# See if this version is newer than the currently tracked versions
 							if _canUpdateAddon(addon, addonsPendingUpdate[addon.name]):

--- a/source/addonStore/models/addon.py
+++ b/source/addonStore/models/addon.py
@@ -222,6 +222,10 @@ class _AddonManifestModel(_AddonGUIModel):
 		return description
 
 	@property
+	def installDate(self) -> datetime:
+		return datetime.fromtimestamp(os.path.getctime(self.installPath))
+
+	@property
 	def author(self) -> str:
 		return self.manifest["author"]
 

--- a/source/config/configFlags.py
+++ b/source/config/configFlags.py
@@ -235,8 +235,7 @@ class ReportCellBorders(DisplayStringIntEnum):
 
 class AddonsAutomaticUpdate(DisplayStringStrEnum):
 	NOTIFY = "notify"
-	# TODO: uncomment when implementing #3208
-	# UPDATE = "update"
+	UPDATE = "update"
 	DISABLED = "disabled"
 
 	@property
@@ -245,7 +244,8 @@ class AddonsAutomaticUpdate(DisplayStringStrEnum):
 			# Translators: This is a label for the automatic update behaviour for add-ons.
 			# It will notify the user when updates are available.
 			self.NOTIFY: _("Notify"),
-			# self.UPDATE: _("Update Automatically"),
+			# Translators: This is a label for the automatic update behaviour for add-ons.
+			self.UPDATE: _("Update Automatically"),
 			# Translators: This is a label for the automatic update behaviour for add-ons.
 			self.DISABLED: _("Disabled"),
 		}

--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -336,7 +336,8 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 	playErrorSound = integer(0, 1, default=0)
 
 [addonStore]
-	automaticUpdates = option("notify", "disabled", default="notify")
+	automaticUpdates = option("notify", "update", "disabled", default="notify")
+	allowIncompatibleUpdates = boolean(default=false)
 	baseServerURL = string(default="")
 	# UpdateChannel values:
 	# same channel (default), any channel, do not update, stable, beta & dev, beta, dev

--- a/source/gui/addonStoreGui/controls/details.py
+++ b/source/gui/addonStoreGui/controls/details.py
@@ -344,6 +344,14 @@ class AddonDetails(
 							details.reviewURL,
 						)
 
+					if isinstance(details, _AddonManifestModel):
+						# Installed add-ons with a manifest only
+						self._appendDetailsLabelValue(
+							# Translators: Label for an extra detail field for the selected add-on. In the add-on store dialog.
+							pgettext("addonStore", "Install date:"),
+							details.installDate.strftime("%x"),
+						)
+
 					if details.publicationDate is not None:
 						self._appendDetailsLabelValue(
 							# Translators: Label for an extra detail field for the selected add-on. In the add-on store dialog.

--- a/source/gui/addonStoreGui/controls/details.py
+++ b/source/gui/addonStoreGui/controls/details.py
@@ -347,7 +347,7 @@ class AddonDetails(
 					if isinstance(details, _AddonManifestModel):
 						# Installed add-ons with a manifest only
 						self._appendDetailsLabelValue(
-							# Translators: Label for an extra detail field for the selected add-on. In the add-on store dialog.
+							# Translators: Label for an extra detail field for the selected add-on in the add-on store dialog.
 							pgettext("addonStore", "Install date:"),
 							details.installDate.strftime("%x"),
 						)

--- a/source/gui/addonStoreGui/controls/messageDialogs.py
+++ b/source/gui/addonStoreGui/controls/messageDialogs.py
@@ -3,6 +3,8 @@
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
+import threading
+from time import sleep
 from typing import (
 	TYPE_CHECKING,
 )
@@ -30,9 +32,10 @@ from gui.guiHelper import (
 	ButtonHelper,
 	SPACE_BETWEEN_VERTICAL_DIALOG_ITEMS,
 )
-from gui.message import DisplayableError, displayDialogAsModal, messageBox
+from gui.message import DisplayableError, displayDialogAsModal, messageBox, _countAsMessageBox
 from logHandler import log
 import NVDAState
+from speech.priorities import SpeechPriority
 import ui
 import windowUtils
 
@@ -366,12 +369,12 @@ class UpdatableAddonsDialog(
 	"""A dialog notifying users that updatable add-ons are available"""
 
 	helpId = "AutomaticAddonUpdates"
+	onDisplayableError = DisplayableError.OnDisplayableErrorT()
 
 	def __init__(self, parent: wx.Window, addonsPendingUpdate: list[_AddonGUIModel]):
 		# Translators: The warning of a dialog
 		super().__init__(parent, title=pgettext("addonStore", "Add-on updates available"))
 		self.addonsPendingUpdate = addonsPendingUpdate
-		self.onDisplayableError = DisplayableError.OnDisplayableErrorT()
 		self._setupUI()
 		self.Raise()
 		self.SetFocus()
@@ -552,6 +555,10 @@ class UpdatableAddonsDialog(
 		self.DestroyLater()
 		self.SetReturnCode(wx.ID_CLOSE)
 
+	@staticmethod
+	def handleDisplayableError(displayableError: DisplayableError):
+		displayableError.displayError(gui.mainFrame)
+
 	@classmethod
 	def _checkForUpdatableAddons(cls):
 		if not NVDAState.shouldWriteToDisk() or (
@@ -560,11 +567,57 @@ class UpdatableAddonsDialog(
 			log.debug("automatic add-on updates are disabled")
 			return
 		log.debug("checking for updatable add-ons")
-		addonsPendingUpdate = addonDataManager._addonsPendingUpdate()
-		if addonsPendingUpdate:
-			log.debug("updatable add-ons found")
 
-			def delayCreateDialog():
-				displayDialogAsModal(cls(gui.mainFrame, addonsPendingUpdate))
+		UpdatableAddonsDialog.onDisplayableError.register(UpdatableAddonsDialog.handleDisplayableError)
+		addonsPendingUpdate = addonDataManager._addonsPendingUpdate(UpdatableAddonsDialog.onDisplayableError)
+		UpdatableAddonsDialog.onDisplayableError.unregister(UpdatableAddonsDialog.handleDisplayableError)
 
-			wx.CallAfter(delayCreateDialog)
+		if not addonsPendingUpdate:
+			log.debug("no updatable add-ons found")
+			return
+
+		log.debug("updatable add-ons found")
+
+		match config.conf["addonStore"]["automaticUpdates"]:
+			case AddonsAutomaticUpdate.NOTIFY:
+
+				def delayCreateDialog():
+					displayDialogAsModal(cls(gui.mainFrame, addonsPendingUpdate))
+
+				wx.CallAfter(delayCreateDialog)
+
+			case AddonsAutomaticUpdate.UPDATE:
+				threading.Thread(
+					name="AutomaticAddonUpdate",
+					target=_updateAddons,
+					args=(addonsPendingUpdate,),
+					daemon=True,
+				).start()
+
+			case _:
+				raise NotImplementedError("Unknown automatic update setting")
+
+
+@_countAsMessageBox()
+def _updateAddons(addonsPendingUpdate: list[_AddonGUIModel]):
+	"""Update the add-ons in the background.
+	Blocks while downloading occurs.
+	This function is treated as message box to prevent NVDA from exiting while the download/install is in progress.
+	"""
+	from ..viewModels.store import AddonStoreVM
+
+	# Translators: Message shown when updating add-ons automatically
+	ui.message(pgettext("addonStore", "Updating add-ons..."), SpeechPriority.NOW)
+	listVMs = {AddonListItemVM(a, status=AvailableAddonStatus.UPDATE) for a in addonsPendingUpdate}
+	AddonStoreVM.getAddons(listVMs)
+
+	while AddonStoreVM._downloader.progress:
+		log.debug("Waiting for add-ons to be downloaded {}".format(AddonStoreVM._downloader.progress))
+		sleep(0.1)
+
+	def mainThreadCallback():
+		# Add-on installations must happen on main thread
+		AddonStoreVM.installPending()
+		promptUserForRestart()
+
+	wx.CallAfter(mainThreadCallback)

--- a/source/gui/addonStoreGui/controls/messageDialogs.py
+++ b/source/gui/addonStoreGui/controls/messageDialogs.py
@@ -8,6 +8,7 @@ from time import sleep
 from typing import (
 	TYPE_CHECKING,
 )
+import winsound
 
 import wx
 
@@ -582,6 +583,7 @@ class UpdatableAddonsDialog(
 			case AddonsAutomaticUpdate.NOTIFY:
 
 				def delayCreateDialog():
+					winsound.MessageBeep(winsound.MB_ICONEXCLAMATION)
 					displayDialogAsModal(cls(gui.mainFrame, addonsPendingUpdate))
 
 				wx.CallAfter(delayCreateDialog)
@@ -606,6 +608,7 @@ def _updateAddons(addonsPendingUpdate: list[_AddonGUIModel]):
 	"""
 	from ..viewModels.store import AddonStoreVM
 
+	winsound.MessageBeep(winsound.MB_ICONEXCLAMATION)
 	# Translators: Message shown when updating add-ons automatically
 	ui.message(pgettext("addonStore", "Updating add-ons..."), SpeechPriority.NOW)
 	listVMs = {AddonListItemVM(a, status=AvailableAddonStatus.UPDATE) for a in addonsPendingUpdate}

--- a/source/gui/addonStoreGui/viewModels/store.py
+++ b/source/gui/addonStoreGui/viewModels/store.py
@@ -493,11 +493,14 @@ class AddonStoreVM:
 		cls._downloader.download(listItemVM, cls._downloadComplete, cls.onDisplayableError)
 
 	@classmethod
-	def getAddons(cls, listItemVMs: Iterable[AddonListItemVM[_AddonStoreModel]]) -> None:
-		shouldReplace = True
-		shouldInstallIncompatible = True
-		shouldRememberReplaceChoice = False
-		shouldRememberInstallChoice = False
+	def getAddons(
+		cls,
+		listItemVMs: Iterable[AddonListItemVM[_AddonStoreModel]],
+		shouldReplace: bool = True,
+		shouldInstallIncompatible: bool = True,
+		shouldRememberReplaceChoice: bool = False,
+		shouldRememberInstallChoice: bool = False,
+	) -> None:
 		for aVM in listItemVMs:
 			if aVM.canUseInstallAction() or aVM.canUseUpdateAction():
 				cls.getAddon(aVM)

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -3244,9 +3244,7 @@ class AddonStorePanel(SettingsPanel):
 	def makeSettings(self, settingsSizer: wx.BoxSizer) -> None:
 		sHelper = guiHelper.BoxSizerHelper(self, sizer=settingsSizer)
 		# Translators: This is a label for the automatic updates combo box in the Add-on Store Settings dialog.
-		automaticUpdatesLabelText = _("&Update notifications:")
-		# TODO: change label to the following when the feature is implemented
-		# automaticUpdatesLabelText = _("Automatic &updates:")
+		automaticUpdatesLabelText = _("Automatic &updates:")
 		self.automaticUpdatesComboBox = sHelper.addLabeledControl(
 			automaticUpdatesLabelText,
 			wx.Choice,
@@ -3269,6 +3267,13 @@ class AddonStorePanel(SettingsPanel):
 		self.bindHelpEvent("DefaultAddonUpdateChannel", self.defaultUpdateChannelComboBox)
 		index = config.conf["addonStore"]["defaultUpdateChannel"]
 		self.defaultUpdateChannelComboBox.SetSelection(index)
+
+		self.allowIncompatibleUpdates = sHelper.addItem(
+			# Translators: Mute other apps checkbox in settings
+			wx.CheckBox(self, label=_("Allow automatic updates to install incompatible add-ons")),
+		)
+		self.bindHelpEvent("AllowIncompatibleAddonUpdates", self.allowIncompatibleUpdates)
+		self.allowIncompatibleUpdates.SetValue(config.conf["addonStore"]["allowIncompatibleUpdates"])
 
 		# Translators: The label for the mirror server on the Add-on Store Settings panel.
 		mirrorBoxSizer = wx.StaticBoxSizer(wx.HORIZONTAL, self, label=_("Mirror server"))
@@ -3346,6 +3351,7 @@ class AddonStorePanel(SettingsPanel):
 	def onSave(self):
 		index = self.automaticUpdatesComboBox.GetSelection()
 		config.conf["addonStore"]["automaticUpdates"] = [x.value for x in AddonsAutomaticUpdate][index]
+		config.conf["addonStore"]["allowIncompatibleUpdates"] = self.allowIncompatibleUpdates.IsChecked()
 		config.conf["addonStore"]["defaultUpdateChannel"] = self.defaultUpdateChannelComboBox.GetSelection()
 
 

--- a/source/utils/schedule.py
+++ b/source/utils/schedule.py
@@ -73,6 +73,12 @@ class ScheduleThread(threading.Thread):
 	Daily scheduled jobs occur offset by X minutes to avoid overlapping jobs.
 	"""
 
+	START_MINUTE_OFFSET = 1
+	"""
+	Offset in minutes to start scheduling daily jobs.
+	The first scheduled job occurs X minutes after NVDA starts.
+	"""
+
 	def __init__(self, *args, **kwargs) -> None:
 		super().__init__(*args, **kwargs)
 		self.scheduledDailyJobCount = 0
@@ -88,7 +94,9 @@ class ScheduleThread(threading.Thread):
 		# Schedule jobs so that they occur offset by a regular period to avoid overlapping jobs.
 		# Start with a delay to give time for NVDA to start up.
 		startTimeMinuteOffset = (
-			startTime.minute + (self.scheduledDailyJobCount + 1) * self.DAILY_JOB_MINUTE_OFFSET
+			startTime.minute
+			+ self.START_MINUTE_OFFSET
+			+ self.scheduledDailyJobCount * self.DAILY_JOB_MINUTE_OFFSET
 		)
 		# Handle the case where the minute offset is greater than 60.
 		startTimeHourOffset = startTime.hour + (startTimeMinuteOffset // 60)

--- a/tests/unit/test_util/test_schedule.py
+++ b/tests/unit/test_util/test_schedule.py
@@ -145,7 +145,7 @@ class ScheduleThreadTests(unittest.TestCase):
 		expectedMinOffset = (ScheduleThread.START_MINUTE_OFFSET + 59) % 60
 		self.assertEqual(offset, f"12:{expectedMinOffset:02d}")
 
-	def test_calculateDailyTimeOffset_dayOverflow(self):
+	def test_calculateDailyTimeOffset_hourOverflow(self):
 		"""Test the case where the start time is 23:59 to ensure the day and hour offset is calculated correctly"""
 		NVDAState.getStartTime = MagicMock(
 			return_value=ScheduleThreadTests.TODAY_AT_MIDNIGHT.replace(hour=23, minute=59).timestamp(),

--- a/tests/unit/test_util/test_schedule.py
+++ b/tests/unit/test_util/test_schedule.py
@@ -24,6 +24,8 @@ from utils.schedule import (
 
 
 class ScheduleThreadTests(unittest.TestCase):
+	TODAY_AT_MIDNIGHT = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
+
 	def setUp(self):
 		self.oldNVDAStateGetStartTime = NVDAState.getStartTime
 		NVDAState.getStartTime = MagicMock(return_value=datetime.now().timestamp())
@@ -116,31 +118,39 @@ class ScheduleThreadTests(unittest.TestCase):
 			# Call the scheduleJob method with the same cron time
 			_sch.scheduleThread.scheduleJob(jobFunc, jobSchedule, ThreadTarget.GUI)
 
-	def test_calculateDailyTimeOffset(self):
-		todayAtMidnight = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
-		NVDAState.getStartTime = MagicMock(return_value=todayAtMidnight.timestamp())
+	def test_calculateDailyTimeOffset_firstJob(self):
+		"""Test the case where the first job time is calculated correctly"""
+		NVDAState.getStartTime = MagicMock(return_value=ScheduleThreadTests.TODAY_AT_MIDNIGHT.timestamp())
 		offset = _sch.scheduleThread._calculateDailyTimeOffset()
 		# Assert that the offset is calculated correctly
-		self.assertEqual(offset, f"00:{ScheduleThread.DAILY_JOB_MINUTE_OFFSET:02d}")
+		self.assertEqual(offset, f"00:{ScheduleThread.START_MINUTE_OFFSET:02d}")
 
+	def test_calculateDailyTimeOffset_secondJob(self):
+		"""Test the case where the second job time is calculated correctly"""
+		NVDAState.getStartTime = MagicMock(return_value=ScheduleThreadTests.TODAY_AT_MIDNIGHT.timestamp())
 		_sch.scheduleThread.scheduledDailyJobCount = 1
 		offset = _sch.scheduleThread._calculateDailyTimeOffset()
-		self.assertEqual(offset, f"00:{ScheduleThread.DAILY_JOB_MINUTE_OFFSET * 2:02d}")
+		self.assertEqual(
+			offset,
+			f"00:{ScheduleThread.START_MINUTE_OFFSET + ScheduleThread.DAILY_JOB_MINUTE_OFFSET * 1:02d}",
+		)
 
-		# Test the case where the start time is 11:59 to ensure the hour offset is calculated correctly
+	def test_calculateDailyTimeOffset_minuteOverflow(self):
+		"""Test the case where the start time is 11:59 to ensure the hour offset is calculated correctly"""
 		NVDAState.getStartTime = MagicMock(
-			return_value=todayAtMidnight.replace(hour=11, minute=59).timestamp(),
+			return_value=ScheduleThreadTests.TODAY_AT_MIDNIGHT.replace(hour=11, minute=59).timestamp(),
 		)
 		_sch.scheduleThread.scheduledDailyJobCount = 0
 		offset = _sch.scheduleThread._calculateDailyTimeOffset()
-		expectedMinOffset = (ScheduleThread.DAILY_JOB_MINUTE_OFFSET + 59) % 60
+		expectedMinOffset = (ScheduleThread.START_MINUTE_OFFSET + 59) % 60
 		self.assertEqual(offset, f"12:{expectedMinOffset:02d}")
 
-		# Test the case where the start time is 23:59 to ensure the day and hour offset is calculated correctly
+	def test_calculateDailyTimeOffset_dayOverflow(self):
+		"""Test the case where the start time is 23:59 to ensure the day and hour offset is calculated correctly"""
 		NVDAState.getStartTime = MagicMock(
-			return_value=todayAtMidnight.replace(hour=23, minute=59).timestamp(),
+			return_value=ScheduleThreadTests.TODAY_AT_MIDNIGHT.replace(hour=23, minute=59).timestamp(),
 		)
 		_sch.scheduleThread.scheduledDailyJobCount = 0
 		offset = _sch.scheduleThread._calculateDailyTimeOffset()
-		expectedMinOffset = (ScheduleThread.DAILY_JOB_MINUTE_OFFSET + 59) % 60
+		expectedMinOffset = (ScheduleThread.START_MINUTE_OFFSET + 59) % 60
 		self.assertEqual(offset, f"00:{expectedMinOffset:02d}")

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -10,9 +10,14 @@ Any remaining users of SAPI4 speech synthesizers are encouraged to choose a more
 ### New Features
 
 * Add-on Store:
-  * Automatic update channels for add-ons can now be modified. (#3208)
-    * Automatic update channels can be selected for installed add-ons via an "Update channel" submenu.
-    * The default automatic update channel can be set from the Add-on Store panel in NVDA's settings.
+  * Automatic updates:
+    * Automatic update channels for add-ons can now be modified. (#3208)
+      * Automatic update channels can be selected for installed add-ons via an "Update channel" submenu.
+      * The default automatic update channel can be set from the Add-on Store panel in NVDA's settings.
+    * Automatic updates can now happen in the background.
+      * This can be enabled in the Add-on Store panel in NVDA's settings by changing "Automatic updates" to "Update Automatically". (#3208)
+    * Automatic updates can now update incompatible add-ons to another, newer, incompatible version.
+      * This can be enabled in the Add-on Store panel in NVDA's settings. (#3208)
   * Added an action to cancel the install of add-ons. (#15578, @hwf1324)
   * Added an action to retry the installation if the download/installation of an add-on fails. (#17090, @hwf1324)
   * The add-ons lists can be sorted by columns, including publication date, in ascending and descending order. (#15277, #16681, @nvdaes)

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -3071,14 +3071,18 @@ This check is performed every 24 hours.
 By default, notifications will only occur for add-ons with updates available within the same [channel](#AddonStoreFilterChannel) (e.g. stable, beta or dev).
 You can configure add-on update channels [individually for each add-on](#AddonStoreUpdateChannel) or for [all add-ons](#DefaultAddonUpdateChannel).
 
+When set to "Update Automatically", add-ons will automatically update in the background.
+You will be prompted to restart NVDA when the updates are finished.
+
 | . {.hideHeaderRow} |.|
 |---|---|
-|Options |Notify (Default), Disabled |
+|Options |Notify (Default), Update Automatically, Disabled |
 |Default |Notify |
 
 |Option |Behaviour |
 |---|---|
-|Notify |Notify when updates are available to add-ons within the same channel |
+|Notify |Notify when updates are available to add-ons |
+|Update Automatically |Automatically update add-ons |
 |Disabled |Do not automatically check for updates to add-ons |
 
 ##### Default Update Channel {#DefaultAddonUpdateChannel}
@@ -3102,6 +3106,14 @@ You can also change the update channel for a [specific add-on individually from 
 | Beta or dev | Add-ons will automatically update to beta or dev versions |
 | Beta | Add-ons will automatically update to beta versions |
 | Dev | Add-ons will automatically update to dev versions |
+
+##### Allow automatic updates to install incompatible add-ons {#AllowIncompatibleAddonUpdates}
+
+This setting enables automatic updates to add-ons that may not be fully compatible with the current version of NVDA.
+By default, this is disabled, meaning automatic updates will only upgrade to add-on versions marked as compatible with the current version of NVDA.
+Automatic updates will still update an incompatible add-on version to a compatible version when it is released.
+Enabling this may be useful for switching over to using add-on breaking releases (the first release of the year).
+This is particularly useful for alpha and beta testers, who are testing compatibility of add-ons during the early stages of an add-on breaking release.
 
 ##### Mirror server {#AddonStoreMetadataMirror}
 

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -3094,7 +3094,7 @@ You will be prompted to restart NVDA when the updates are finished.
 |Option |Behaviour |
 |---|---|
 |Notify |Notify when updates are available to add-ons |
-|Update Automatically |Automatically update add-ons |
+|Update Automatically |Automatically update add-ons in the background |
 |Disabled |Do not automatically check for updates to add-ons |
 
 ##### Default Update Channel {#DefaultAddonUpdateChannel}


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Closes #3208 
Closes #17162

### Summary of the issue:

To update add-ons automatically, users must click-through a dialog to confirm they wish to update all add-ons.
Instead, this can be done in the background, and the user just needs to confirm whether to restart NVDA once add-on updates are complete.


Additionally:
- Users couldn't automatically update to incompatible add-ons. this is useful for alpha/beta testers testing add-on compatibility in breaking releases
- The update notification was annoying - it queued too late and users should get a ding when it appeared.
- If the add-on store server failed, users didn't receive displayable error messages when using automatic update notification
- Since #17597, the update notification panel will list all available updates for all channels. The update all button would update the add-on for each channel. Instead only the latest add-on version for any channel should be used/listed.
 
### Description of user facing changes

- Added the ability to automatically update add-ons in the background.
This can be changed in the "automatic updates" section.
- Added the ability to update to incompatible add-ons. users can enable this via a new setting in the add-on store panel.
- The update notification is now queued sooner (1 minute not 3 minutes) and provides a ding before focusing the panel
- the update notification panel now only lists the most recent version of an add-on, rather than showing all add-ons that are newer across channels
- Server errors now log an error message if the update notification fails to fetch data

### Description of development approach

- Refactored update status tracking so devs can compare add-ons to see which is newer more easily
- Re-designed message box tracking to make it work for pseudo-modals, e.g. the background update process
- use a shorter starting offset for daily scheduled jobs

### Testing strategy:

- Installed an old add-on
- Tested automatic update notifications
- Tested background automatic updates
- Tested both of these without a server connection

### Known issues with pull request:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
	- Introduced an "Update Automatically" option for managing add-on updates in the background.
	- Added a setting to enable automatic updates for add-ons marked as incompatible.
	- Improved error handling and feedback during the update process.
- Documentation
	- Updated the User Guide to detail the new update options and behaviors. 
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
