### PR TITLE
Allow to remove a remaining file created during a failed add-on removal process

### DIFF
--- a/source/addonHandler/__init__.py
+++ b/source/addonHandler/__init__.py
@@ -1,6 +1,6 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2012-2024 Rui Batista, NV Access Limited, Noelia Ruiz Martínez,
-# Joseph Lee, Babbage B.V., Arnold Loubriat, Łukasz Golonka, Leonard de Ruijter, Julien Cochuyt
+# Copyright (C) 2012-2025 Rui Batista, NV Access Limited, Noelia Ruiz Martínez, Joseph Lee, Babbage B.V.,
+# Arnold Loubriat, Łukasz Golonka, Leonard de Ruijter, Julien Cochuyt, Cyrille Bougot
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -262,6 +262,11 @@ def getIncompatibleAddons(
 
 def removeFailedDeletion(path: os.PathLike):
 	shutil.rmtree(path, ignore_errors=True)
+	if os.path.exists(path):
+		try:
+			os.remove(path)
+		except Exception:
+			pass
 	if os.path.exists(path):
 		log.error(f"Failed to delete path {path}, try removing manually")
 


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
If you try to remove an add-on while the folder containing its files is opened in Windows Explorer, the removal fails and at next restart NVDA warns you of it. At subsequents restarts, the following error appears in the log:
```
ERROR - addonHandler.removeFailedDeletion (10:17:51.026) - MainThread (2736):
Failed to delete path C:\Users\Cyrille\AppData\Roaming\nvda\addons\tmptvtvvco8.delete, try removing manually
```

It's because this path was a temp file which could not be `os.replace`'d by the add-on's folder during the removal process since this folder was opened in Windows Explorer. Then at subsequent restarts, NVDA has code to remove such paths, but it only handles the case where this path is a folder, not a file.

### Description of user facing changes

No more error logged forever after a failed add-on deletion attempt. and no need to clean up manually remaining ".delete" files.

### Description of development approach
* In addition to folder case, also handle file case in `removeFailedDeletion`.
* No change log for such a little fix.

### Testing strategy:

Tested install/remove add-ons in the following cases:
* normal case
* add-on's code folder opened in Windows Explorer
* add-on's code file opened in editor

### Known issues with pull request:
None.
### Code Review Checklist:


- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
