### PR TITLE
Fix leading silence removal feature

### DIFF
--- a/nvdaHelper/local/wasapi.cpp
+++ b/nvdaHelper/local/wasapi.cpp
@@ -354,7 +354,8 @@ HRESULT WasapiPlayer::feed(unsigned char* data, unsigned int size,
 		} else {
 			// Silence ends in this chunk. Skip the silence and continue.
 			data += silenceSize;
-			remainingFrames = (size - silenceSize) / format.nBlockAlign;
+			size -= silenceSize;
+			remainingFrames = size / format.nBlockAlign;
 			isTrimmingLeadingSilence = false;  // Stop checking for silence
 		}
 	}

--- a/nvdaHelper/local/wasapi.cpp
+++ b/nvdaHelper/local/wasapi.cpp
@@ -347,7 +347,8 @@ HRESULT WasapiPlayer::feed(unsigned char* data, unsigned int size,
 	};
 
 	if (isTrimmingLeadingSilence) {
-		size_t silenceSize = SilenceDetect::getLeadingSilenceSize(&format, data, size);
+		// If data is null, treat the whole chunk as silence.
+		size_t silenceSize = data ? SilenceDetect::getLeadingSilenceSize(&format, data, size) : size;
 		if (silenceSize >= size) {
 			// The whole chunk is silence. Continue checking for silence in the next chunk.
 			remainingFrames = 0;

--- a/nvdaHelper/local/wasapi.cpp
+++ b/nvdaHelper/local/wasapi.cpp
@@ -431,7 +431,11 @@ HRESULT WasapiPlayer::feed(unsigned char* data, unsigned int size,
 		}
 		if (shouldInsertSilentFrame) {
 			// If needed, insert one frame of silence at the beginning
-			memset(buffer, 0, format.nBlockAlign);
+			if (format.wFormatTag == WAVE_FORMAT_PCM && format.wBitsPerSample == 8) {
+				memset(buffer, 0x80, format.nBlockAlign);
+			} else {
+				memset(buffer, 0, format.nBlockAlign);
+			}
 			buffer += format.nBlockAlign;
 			shouldInsertSilentFrame = false;
 		}

--- a/source/nvwave.py
+++ b/source/nvwave.py
@@ -539,7 +539,8 @@ class WasapiWavePlayer(garbageHandler.TrackedObject):
 			if player._lastActiveTime <= threshold:
 				try:
 					NVDAHelper.localLib.wasPlay_idle(player._player)
-					player.startTrimmingLeadingSilence()
+					if player._enableTrimmingLeadingSilence:
+						player.startTrimmingLeadingSilence()
 				except OSError:
 					# #16125: IAudioClock::GetPosition sometimes fails with an access
 					# violation on a device which has been invalidated. This shouldn't happen


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
None. Fixes problems introduced by PR #17648.

### Summary of the issue:

The leading silence trimming feature should only trim the silence part of the audio. However, a longer part of the speech audio ended up being chopped off, which makes distinguishing the consonants at the beginning more difficult.

In addition, trimming is incorrectly applied to non-speech audio, and applied even when the feature is turned off in Settings.

### Description of user facing changes
The problem mentioned above should be fixed.

### Description of development approach

Added missing check for `_enableTrimmingLeadingSilence` in `_idleCheck`.

Before sending the trimmed audio to the device, one silent sample will be inserted at the beginning. For some reason, if the first sample is not zero, the audio may be chopped off at the beginning. Although the exact cause is still unknown, prepending one silent sample seems to fix this issue. See [this discussion](https://github.com/nvaccess/nvda/discussions/17697).

### Testing strategy:

Tested manually on my system. Now the output waveform seems normal.

### Known issues with pull request:
None.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [ ] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [ ] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
