### PR TITLE
Preserve voice parameters when changing between SAPI4/SAPI5 voices with synth settings ring

### DIFF
--- a/source/synthDrivers/sapi5.py
+++ b/source/synthDrivers/sapi5.py
@@ -266,6 +266,7 @@ class SynthDriver(SynthDriver):
 		"""
 		self._pitch = 50
 		self._rate = 50
+		self._volume = 100
 		self.player = None
 		self.isSpeaking = False
 		self._rateBoost = False
@@ -312,7 +313,7 @@ class SynthDriver(SynthDriver):
 		return self._pitch
 
 	def _get_volume(self) -> int:
-		return self.tts.volume
+		return self._volume
 
 	def _get_voice(self):
 		return self.tts.voice.Id
@@ -356,6 +357,7 @@ class SynthDriver(SynthDriver):
 		self._pitch = value
 
 	def _set_volume(self, value):
+		self._volume = value
 		self.tts.Volume = value
 
 	def _initTts(self, voice=None):
@@ -411,6 +413,9 @@ class SynthDriver(SynthDriver):
 			# Voice not found.
 			return
 		self._initTts(voice=voice)
+		# As _initTts resets the voice parameters on the tts object, set them back to current values.
+		self._set_rate(self._rate)
+		self._set_volume(self._volume)
 
 	def _percentToPitch(self, percent):
 		return percent // 2 - 25

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -114,6 +114,7 @@ In any document, if the cursor is on the last line, it will be moved to the end 
 * Fixed an issue where continuous reading (say all) stopped at the end of the first sentence when using some SAPI5 synthesizers. (#16691, @gexgd0419)
 * In Visual Studio Code, NVDA no longer hijacks the `alt+upArrow` and `alt+downArrow` gestures for sentence navigation. (#17082, @LeonarddeR)
 * When anchor links point to the same object as the virtual caret is placed, NVDA no longer fails to scroll to the link destination. (#17669, @nvdaes)
+* Voice parameters, such as rate and volume, will no longer be reset to default when changing between SAPI5 voices with the synth settings ring. (#2320, @gexgd0419)
 
 ### Changes for Developers
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -114,7 +114,7 @@ In any document, if the cursor is on the last line, it will be moved to the end 
 * Fixed an issue where continuous reading (say all) stopped at the end of the first sentence when using some SAPI5 synthesizers. (#16691, @gexgd0419)
 * In Visual Studio Code, NVDA no longer hijacks the `alt+upArrow` and `alt+downArrow` gestures for sentence navigation. (#17082, @LeonarddeR)
 * When anchor links point to the same object as the virtual caret is placed, NVDA no longer fails to scroll to the link destination. (#17669, @nvdaes)
-* Voice parameters, such as rate and volume, will no longer be reset to default when changing between SAPI5 voices with the synth settings ring. (#2320, @gexgd0419)
+* Voice parameters, such as rate and volume, will no longer be reset to default when using the synth settings ring to change between voices in the SAPI5 and SAPI4 synthesizer. (#17693, #2320, @gexgd0419)
 
 ### Changes for Developers
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:

Fixes #17693. Fixes #2320.

### Summary of the issue:

When using the synth settings ring to switch to another SAPI4/SAPI5 voice, its parameters such as rate and volume will be reset to the default value.

This is because the synth driver destroys and re-creates the SAPI object when changing the voice, which resets all its parameters. Then the synth driver selects the correct voice, but other parameters are not preserved.

Changing the voice with the settings dialog works, because the settings dialog reads the property values and assigns them to the slider controls in order to display them, which triggers the event of the slider controls, which assigns the property values just read from the synth back to the synth, which refreshes the property values and therefore "fixes" the problem.

However, when using the synth settings ring, only the voice property is changed. Other properties are not refreshed, which makes the issue appear.

### Description of user facing changes

The SAPI4/SAPI5 synthesizer will be able to preserve the settings when switching between voices.

### Description of development approach

SAPI5:

In `_set_voice`, after using `_initTts` to re-create the SAPI5 object and select the voice, restore the rate and volume parameters to the value stored previously. Pitch does not need to be restored, as it is not a parameter of the SAPI5 object.

SAPI4:

For volume, the percentage is preserved, so that 80% volume is always 80% of the voice's volume range.

For rate and pitch, the difference (delta) between the current value and the default value is preserved. If the rate is set to be 50 WPM faster, when switched to another voice, the rate will also be 50 WPM faster.

### Testing strategy:

Tested manually.

### Known issues with pull request:

None.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [ ] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
