### PR TITLE
Allow update all add-ons button to be pressed only once

### DIFF
--- a/source/gui/addonStoreGui/controls/messageDialogs.py
+++ b/source/gui/addonStoreGui/controls/messageDialogs.py
@@ -473,6 +473,9 @@ class UpdatableAddonsDialog(
 	def onUpdateAllButton(self, evt: wx.CommandEvent):
 		from gui.addonStoreGui.viewModels.store import AddonStoreVM
 
+		self.updateAllButton.Disable()
+		self.openStoreButton.Disable()
+
 		self.listItemVMs: list[AddonListItemVM] = []
 		for addon in self.addonsPendingUpdate:
 			listItemVM = AddonListItemVM(addon, status=AvailableAddonStatus.UPDATE)
@@ -482,8 +485,6 @@ class UpdatableAddonsDialog(
 		self.addonsList.Refresh()
 		# Translators: Message shown when updating add-ons in the updatable add-ons dialog
 		ui.message(pgettext("addonStore", "Updating add-ons..."))
-		self.updateAllButton.Disable()
-		self.openStoreButton.Disable()
 		self.addonsList.SetFocus()
 		self.addonsList.Focus(0)
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Fixes #17110

### Summary of the issue:
Ever since #16636, users have been able to press the "update all" button to execute downloading and installing all the add-ons multiple times.
This is because the update all button is disabled **_after_** the add-ons have finished downloading, not immediately after it is clicked, preventing subsequent activations.

### Description of user facing changes
Users are unable to press update all button multiple times until add-ons finish downloading.

### Description of development approach
Disable update all button immediately after first activation.

### Testing strategy:
Manual testing by simulating slow internet updating multiple add-ons

### Known issues with pull request:

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
