### PR TITLE
Manually refresh the recognized content with `NVDA+f5` in a recognition result

### DIFF
--- a/source/contentRecog/recogUi.py
+++ b/source/contentRecog/recogUi.py
@@ -169,7 +169,7 @@ class RefreshableRecogResultNVDAObject(RecogResultNVDAObject, LiveText):
 	@script(
 		# Translators: Describes a command.
 		description=_("Refresh the recognition result"),
-		# gesture="kb:NVDA+f5",
+		gesture="kb:NVDA+f5",
 	)
 	def script_refreshBuffer(self, gesture: "inputCore.InputGesture") -> None:
 		if self.recognizer.allowAutoRefresh:

--- a/source/contentRecog/recogUi.py
+++ b/source/contentRecog/recogUi.py
@@ -169,9 +169,9 @@ class RefreshableRecogResultNVDAObject(RecogResultNVDAObject, LiveText):
 	@script(
 		# Translators: Describes a command.
 		description=_("Refresh the recognition result"),
-		gesture="kb:f5",
+		# gesture="kb:NVDA+f5",
 	)
-	def script_refreshRecogContent(self, gesture: "inputCore.InputGesture") -> None:
+	def script_refreshBuffer(self, gesture: "inputCore.InputGesture") -> None:
 		if self.recognizer.allowAutoRefresh:
 			# Translators: Reported when a manual update of a content recognition result (e.g. OCR result) is
 			# requested, but the content is already updated automatically.

--- a/source/contentRecog/recogUi.py
+++ b/source/contentRecog/recogUi.py
@@ -30,6 +30,7 @@ from . import RecogImageInfo, ContentRecognizer, RecognitionResult, onRecognizeR
 if TYPE_CHECKING:
 	import inputCore
 
+
 class RecogResultNVDAObject(cursorManager.CursorManager, NVDAObjects.window.Window):
 	"""Fake NVDAObject used to present a recognition result in a cursor manager.
 	This allows the user to read the result with cursor keys, etc.

--- a/source/contentRecog/recogUi.py
+++ b/source/contentRecog/recogUi.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2017-2023 NV Access Limited, James Teh, Leonard de RUijter
+# Copyright (C) 2017-2025 NV Access Limited, James Teh, Leonard de Ruijter, Cyrille Bougot
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -10,7 +10,7 @@ and present the result to the user so they can read it with cursor keys, etc.
 NVDA scripts or GUI call the L{recognizeNavigatorObject} function with the recognizer they wish to use.
 """
 
-from typing import Optional, Union
+from typing import Optional, Union, TYPE_CHECKING
 import api
 import ui
 import screenBitmap
@@ -24,8 +24,11 @@ import textInfos
 from logHandler import log
 import queueHandler
 import core
+from scriptHandler import script
 from . import RecogImageInfo, ContentRecognizer, RecognitionResult, onRecognizeResultCallbackT
 
+if TYPE_CHECKING:
+	import inputCore
 
 class RecogResultNVDAObject(cursorManager.CursorManager, NVDAObjects.window.Window):
 	"""Fake NVDAObject used to present a recognition result in a cursor manager.
@@ -109,7 +112,7 @@ class RecogResultNVDAObject(cursorManager.CursorManager, NVDAObjects.window.Wind
 
 class RefreshableRecogResultNVDAObject(RecogResultNVDAObject, LiveText):
 	"""NVDA Object that itself is responsible for fetching the recognizition result.
-	It is also able to refresh the result at intervals whenthe recognizer supports it.
+	It is also able to refresh the result at intervals or on demand when the recognizer supports it.
 	"""
 
 	def __init__(
@@ -162,17 +165,30 @@ class RefreshableRecogResultNVDAObject(RecogResultNVDAObject, LiveText):
 	def _scheduleRecognize(self):
 		core.callLater(self.recognizer.autoRefreshInterval, self._recognize, self._onResult)
 
+	@script(
+		# Translators: Describes a command.
+		description=_("Refresh the recognition result"),
+		gesture="kb:f5",
+	)
+	def script_refreshRecogContent(self, gesture: "inputCore.InputGesture") -> None:
+		if self.recognizer.allowAutoRefresh:
+			# Translators: Reported when a manual update of a content recognition result (e.g. OCR result) is
+			# requested, but the content is already updated automatically.
+			ui.message(_("The result of content recognition is already automatically updated"))
+			return
+		core.callLater(0, self._recognize, self._onResult)
+
 	def _onResult(self, result: Union[RecognitionResult, Exception]):
 		if not self.hasFocus:
 			# The user has dismissed the recognition result.
 			return
 		if isinstance(result, Exception):
-			log.error(f"Subsequent recognition failed: {result}")
+			log.error(f"Refresh recognition failed: {result}")
 			queueHandler.queueFunction(
 				queueHandler.eventQueue,
 				ui.message,
 				# Translators: Reported when recognition (e.g. OCR) fails during automatic refresh.
-				_("Automatic refresh of recognition result failed"),
+				_("Refresh of recognition result failed"),
 			)
 			self.stopMonitoring()
 			return
@@ -182,7 +198,8 @@ class RefreshableRecogResultNVDAObject(RecogResultNVDAObject, LiveText):
 		self.selection = self.makeTextInfo(self._selection.bookmark)
 		# Tell LiveText that our text has changed.
 		self.event_textChange()
-		self._scheduleRecognize()
+		if self.recognizer.allowAutoRefresh:
+			self._scheduleRecognize()
 
 	def event_gainFocus(self):
 		super().event_gainFocus()

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -40,6 +40,7 @@ As a consequence, announcement of first line indent is now supported for LibreOf
 This option is enabled by default, but can possibly result in shorter battery life.
 If you suspect this option is negatively impacting your battery life, you're advised to disable it. (#17649, @LeonarddeR)
 * Rate boost is now supported when using Microsoft Speech API version 5 (SAPI5) and Microsoft Speech Platform voices, which supports up to 6X speed. (#17606, @gexgd0419)
+* In a recognition result, `f5` allows to manually refresh the recognized content.
 
 ### Changes
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -40,7 +40,7 @@ As a consequence, announcement of first line indent is now supported for LibreOf
 This option is enabled by default, but can possibly result in shorter battery life.
 If you suspect this option is negatively impacting your battery life, you're advised to disable it. (#17649, @LeonarddeR)
 * Rate boost is now supported when using Microsoft Speech API version 5 (SAPI5) and Microsoft Speech Platform voices, which supports up to 6X speed. (#17606, @gexgd0419)
-* In a recognition result, `f5` allows to manually refresh the recognized content.
+* In a recognition result, `f5` allows to manually refresh the recognized content. (#17715, @CyrilleB79)
 
 ### Changes
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -40,7 +40,7 @@ As a consequence, announcement of first line indent is now supported for LibreOf
 This option is enabled by default, but can possibly result in shorter battery life.
 If you suspect this option is negatively impacting your battery life, you're advised to disable it. (#17649, @LeonarddeR)
 * Rate boost is now supported when using Microsoft Speech API version 5 (SAPI5) and Microsoft Speech Platform voices, which supports up to 6X speed. (#17606, @gexgd0419)
-* In a recognition result, `NVDA+f5` allows to manually refresh the recognized content. (#17715, @CyrilleB79)
+* In a recognition result, `NVDA+f5` manually refreshes the recognized content. (#17715, @CyrilleB79)
 
 ### Changes
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -40,7 +40,7 @@ As a consequence, announcement of first line indent is now supported for LibreOf
 This option is enabled by default, but can possibly result in shorter battery life.
 If you suspect this option is negatively impacting your battery life, you're advised to disable it. (#17649, @LeonarddeR)
 * Rate boost is now supported when using Microsoft Speech API version 5 (SAPI5) and Microsoft Speech Platform voices, which supports up to 6X speed. (#17606, @gexgd0419)
-* In a recognition result, `f5` allows to manually refresh the recognized content. (#17715, @CyrilleB79)
+* In a recognition result, `NVDA+f5` allows to manually refresh the recognized content. (#17715, @CyrilleB79)
 
 ### Changes
 

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -1430,6 +1430,7 @@ However, you may wish to use object navigation directly to, for example, recogni
 Once recognition is complete, the result will be presented in a document similar to browse mode, allowing you to read the information with cursor keys, etc.
 Pressing enter or space will activate (normally click) the text at the cursor if possible.
 Pressing escape dismisses the recognition result.
+Pressing `f5` refreshes the recognition result.
 
 ### Windows OCR {#Win10Ocr}
 

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -1430,7 +1430,7 @@ However, you may wish to use object navigation directly to, for example, recogni
 Once recognition is complete, the result will be presented in a document similar to browse mode, allowing you to read the information with cursor keys, etc.
 Pressing enter or space will activate (normally click) the text at the cursor if possible.
 Pressing escape dismisses the recognition result.
-Pressing `f5` refreshes the recognition result.
+Pressing `NVDA+f5` refreshes the recognition result.
 
 ### Windows OCR {#Win10Ocr}
 


### PR DESCRIPTION
### Link to issue number:
None
### Summary of the issue:
Even if not using the automatic refresh of the content recognition, the user may want to update the recognized content once manually. Today, they needs to close the recog result and perform a recognition again.
### Description of user facing changes
In a result of content recognition, the user can now press `NVDA+f5` to refresh the result of recognized content. This refresh gesture is the same as the one to refresh the content of virtual buffers.
### Description of development approach
In `RefreshableRecogResultNVDAObject`, added a script to refresh the recognition result. If automatic recognition is enabled, the script reports an error message.

### Testing strategy:
Manual test of the script with and without auto-refresh enabled.

### Known issues with pull request:
None

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
