### PR TITLE
Excel: fix comments/formulas listing (`NVDA+f7`) on some non-English systems

### DIFF
--- a/source/NVDAObjects/window/excel.py
+++ b/source/NVDAObjects/window/excel.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2006-2023 NV Access Limited, Dinesh Kaushal, Siddhartha Gupta, Accessolutions, Julien Cochuyt,
+# Copyright (C) 2006-2025 NV Access Limited, Dinesh Kaushal, Siddhartha Gupta, Accessolutions, Julien Cochuyt,
 # Cyrille Bougot, Leonard de Ruijter
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
@@ -148,6 +148,15 @@ xlToRight = -4161
 xlUp = -4162
 xlCellWidthUnitToPixels = 7.5919335705812574139976275207592
 xlSheetVisible = -1
+
+class XlApplicationInternational(enum.IntEnum):
+	"""Specifies country/region and international settings.
+
+	.. seealso:: ```XlApplicationInternational`` enumeration (Excel) <https://learn.microsoft.com/en-us/office/vba/api/excel.xlapplicationinternational>`_
+	"""
+
+	LIST_SEPARATOR = 5
+
 
 xlA1 = 1
 xlRC = 2
@@ -1517,10 +1526,12 @@ class ExcelCellInfoQuicknavIterator(object, metaclass=abc.ABCMeta):
 		cellInfos = (ExcelCellInfo * count)()
 		numCellsFetched = ctypes.c_long()
 		address = collectionObject.address(True, True, xlA1, True)
+		sep = worksheet.Application.International(XlApplicationInternational.LIST_SEPARATOR)
+		localeAwareAddress = address.replace(',', sep)
 		NVDAHelper.localLib.nvdaInProcUtils_excel_getCellInfos(
 			self.document.appModule.helperLocalBindingHandle,
 			self.document.windowHandle,
-			BSTR(address),
+			BSTR(localeAwareAddress),
 			self.cellInfoFlags,
 			count,
 			cellInfos,
@@ -1560,10 +1571,12 @@ class ExcelCell(ExcelBase):
 		ci = ExcelCellInfo()
 		numCellsFetched = ctypes.c_long()
 		address = self.excelCellObject.address(True, True, xlA1, True)
+		sep = self.excelCellObject.Application.International(XlApplicationInternational.LIST_SEPARATOR)
+		localeAwareAddress = address.replace(',', sep)
 		res = NVDAHelper.localLib.nvdaInProcUtils_excel_getCellInfos(
 			self.appModule.helperLocalBindingHandle,
 			self.windowHandle,
-			BSTR(address),
+			BSTR(localeAwareAddress),
 			NVCELLINFOFLAG_ALL,
 			1,
 			ctypes.byref(ci),

--- a/source/NVDAObjects/window/excel.py
+++ b/source/NVDAObjects/window/excel.py
@@ -149,6 +149,7 @@ xlUp = -4162
 xlCellWidthUnitToPixels = 7.5919335705812574139976275207592
 xlSheetVisible = -1
 
+
 class XlApplicationInternational(enum.IntEnum):
 	"""Specifies country/region and international settings.
 
@@ -1527,7 +1528,7 @@ class ExcelCellInfoQuicknavIterator(object, metaclass=abc.ABCMeta):
 		numCellsFetched = ctypes.c_long()
 		address = collectionObject.address(True, True, xlA1, True)
 		sep = worksheet.Application.International(XlApplicationInternational.LIST_SEPARATOR)
-		localeAwareAddress = address.replace(',', sep)
+		localeAwareAddress = address.replace(",", sep)
 		NVDAHelper.localLib.nvdaInProcUtils_excel_getCellInfos(
 			self.document.appModule.helperLocalBindingHandle,
 			self.document.windowHandle,
@@ -1572,7 +1573,7 @@ class ExcelCell(ExcelBase):
 		numCellsFetched = ctypes.c_long()
 		address = self.excelCellObject.address(True, True, xlA1, True)
 		sep = self.excelCellObject.Application.International(XlApplicationInternational.LIST_SEPARATOR)
-		localeAwareAddress = address.replace(',', sep)
+		localeAwareAddress = address.replace(",", sep)
 		res = NVDAHelper.localLib.nvdaInProcUtils_excel_getCellInfos(
 			self.appModule.helperLocalBindingHandle,
 			self.windowHandle,

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -127,6 +127,7 @@ In any document, if the cursor is on the last line, it will be moved to the end 
 * Voice parameters, such as rate and volume, will no longer be reset to default when using the synth settings ring to change between voices in the SAPI5 and SAPI4 synthesizer. (#17693, #2320, @gexgd0419)
 * The NVDA Highlighter Window icon is no longer fixed in the taskbar after restarting Explorer. (#17696, @hwf1324)
 * Fixed an issue where some SAPI4 voices (e.g. IBM TTS Chinese) cannot be loaded. (#17726, @gexgd0419)
+* In Excel, the element list dialog (`NVDA+f7`) no longer fails to list comment or formulas on some non-English systems. (#11366, @CyrilleB79)
 
 ### Changes for Developers
 


### PR DESCRIPTION
### Link to issue number:

Fixes #11366
### Summary of the issue:
In an Excel sheet, when comments or formulas are located in non-contiguous cells (i.e. most of the time), listing them in the elements dialog (`NVDA+f7`) fails on some non-English systems.
It's because the range containing the addresses of the cells of interest are retrieved in native (English) format whereas the call to `application.range` in cpp code expects a locale aware version of the range's address to retrieve the cells content. The two formats differ one from another because they do not use the same list separator: "," in English / ";" in some other languages such as French (where "," is already the decimal separator).

### Description of user facing changes
Excel will no longer fail to list formulas/comments in its elements dialog on some non-English systems for non-contiguous cells.

### Description of development approach
In a first attempt, I added one extra loop to retrieve the content for each area separately; however, calling NVDA helper many times may lead to numerous cross-process calls causing delays.

Finally, (thanks to @michaelDCurran), I have converted the native (English) address range before passing it to NVDA helper which calls `application.range()`.

### Testing strategy:
Manual test for comments, formulas in non-contiguous cells.
Tested on French system with:
* Excel 2021 LTSC (Microsoft® Excel® LTSC MSO (16.0.14332.20824) 64 bits)
* Excel 2016 (Microsoft® Excel® 2016 MSO (Version 2501 Build 16.0.18429.20132) 32 bits)

If someone  wants to test on other office versions (e.g. 365, or older ones) feel free to provide feedback. Thanks.

### Known issues with pull request:
None

### Code Review Checklist:


- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
