### PR TITLE
Avoid error in PowerPoint slideshows when focus highlighting is on

### DIFF
--- a/source/appModules/powerpnt.py
+++ b/source/appModules/powerpnt.py
@@ -41,7 +41,7 @@ import controlTypes
 from controlTypes import TextPosition
 from logHandler import log
 import scriptHandler
-from locationHelper import RectLTRB
+from locationHelper import RectLTRB, RectLTWH
 from NVDAObjects.window._msOfficeChart import OfficeChart
 from utils.urlUtils import _LinkData
 
@@ -1360,7 +1360,7 @@ class SlideShowTreeInterceptorTextInfo(NVDAObjectTextInfo):
 	def _getStoryText(self):
 		return self.obj.rootNVDAObject.basicText
 
-	def _get_boundingRects(self) -> list[locationHelper.RectLTWH]:
+	def _get_boundingRects(self) -> list[RectLTWH]:
 		if self.obj.rootNVDAObject.hasIrrelevantLocation:
 			raise LookupError("Object is off screen, invisible or has no location")
 		return [self.obj.rootNVDAObject.location]

--- a/source/appModules/powerpnt.py
+++ b/source/appModules/powerpnt.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2012-2024 NV Access Limited, Leonard de Ruijter
+# Copyright (C) 2012-2025 NV Access Limited, Leonard de Ruijter
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -1359,6 +1359,11 @@ class SlideShowTreeInterceptorTextInfo(NVDAObjectTextInfo):
 
 	def _getStoryText(self):
 		return self.obj.rootNVDAObject.basicText
+
+	def _get_boundingRects(self):
+		if self.obj.rootNVDAObject.hasIrrelevantLocation:
+			raise LookupError("Object is off screen, invisible or has no location")
+		return [self.obj.rootNVDAObject.location]
 
 	def _getOffsetsFromNVDAObject(self, obj):
 		if obj == self.obj.rootNVDAObject:

--- a/source/appModules/powerpnt.py
+++ b/source/appModules/powerpnt.py
@@ -1360,7 +1360,7 @@ class SlideShowTreeInterceptorTextInfo(NVDAObjectTextInfo):
 	def _getStoryText(self):
 		return self.obj.rootNVDAObject.basicText
 
-	def _get_boundingRects(self):
+	def _get_boundingRects(self) -> list[locationHelper.RectLTWH]:
 		if self.obj.rootNVDAObject.hasIrrelevantLocation:
 			raise LookupError("Object is off screen, invisible or has no location")
 		return [self.obj.rootNVDAObject.location]


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
NVDA raises the following error when the highlighter is on in a PowerPoint slide show

```log
Error running handler <bound method NVDAHighlighter.handleBrowseModeMove of <visionEnhancementProviders.NVDAHighlighter.NVDAHighlighter object at 0x088D25D0>> for <extensionPoints.Action object at 0x0640C350>
Traceback (most recent call last):
  File "extensionPoints\__init__.pyc", line 56, in notify
  File "extensionPoints\util.pyc", line 216, in callWithSupportedKwargs
  File "visionEnhancementProviders\NVDAHighlighter.pyc", line 497, in handleBrowseModeMove
  File "visionEnhancementProviders\NVDAHighlighter.pyc", line 481, in updateContextRect
  File "vision\util.pyc", line 79, in getContextRect
  File "vision\util.pyc", line 48, in getCaretRect
  File "vision\util.pyc", line 94, in getRectFromTextInfo
  File "baseObject.pyc", line 39, in __get__
  File "NVDAObjects\__init__.pyc", line 72, in _get_boundingRects
AttributeError: 'ReviewableSlideshowTreeInterceptor' object has no attribute 'hasIrrelevantLocation'

```

### Description of user facing changes
No longer an error in the log

### Description of development approach
Added an override of `boundingRects` on `SlideShowTreeInterceptorTextInfo`

### Testing strategy:
Ensured that the error no longer occurs.

### Known issues with pull request:
I didn't add a changelog error as this was only revealed by an error sound, and the release versions of NVDA have their error sound disabled, so this is an invisible bug.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
