### PR TITLE
Fix SAPI4 failing to load some voices

### DIFF
--- a/source/synthDrivers/sapi4.py
+++ b/source/synthDrivers/sapi4.py
@@ -6,6 +6,7 @@
 
 import locale
 from collections import OrderedDict, deque
+from sys import exc_info
 import winreg
 from comtypes import CoCreateInstance, COMObject, COMError, GUID
 from ctypes import byref, c_ulong, POINTER, c_wchar, create_string_buffer, sizeof, windll
@@ -315,10 +316,9 @@ class SynthDriver(SynthDriver):
 		if self._ttsCentral:
 			try:
 				# Some SAPI4 synthesizers may fail this call.
-				# Ignore, as _ttsCentral will be destroyed afterwards.
 				self._ttsCentral.UnRegister(self._sinkRegKey)
 			except COMError:
-				pass
+				log.debugWarning("Error unregistering ITTSCentral sink", exc_info=True)
 			# Some SAPI4 synthesizers assume that only one instance of ITTSCentral
 			# will be created by the client, and will stop working if more are created.
 			# Here we make sure that the previous _ttsCentral is released

--- a/source/synthDrivers/sapi4.py
+++ b/source/synthDrivers/sapi4.py
@@ -188,6 +188,7 @@ class SynthDriver(SynthDriver):
 		self._rateDelta = 0
 		self._pitchDelta = 0
 		self._volume = 100
+		self._paused = False
 		self.voice = str(self._enginesList[0].gModeID)
 
 	def terminate(self):
@@ -268,6 +269,12 @@ class SynthDriver(SynthDriver):
 			# cancel all pending bookmarks
 			self._bookmarkLists.clear()
 			self._bookmarks = None
+			if self._paused:
+				# Unpause the voice before resetting,
+				# because some voices keep the pausing state
+				# even after resetting.
+				self._ttsCentral.AudioResume()
+				self._paused = False
 			self._ttsCentral.AudioReset()
 		except COMError:
 			log.error("Error cancelling speech", exc_info=True)
@@ -282,6 +289,7 @@ class SynthDriver(SynthDriver):
 				log.debugWarning("Error pausing speech", exc_info=True)
 		else:
 			self._ttsCentral.AudioResume()
+		self._paused = switch
 
 	def removeSetting(self, name):
 		# Putting it here because currently no other synths make use of it. OrderedDict, where you are?

--- a/source/synthDrivers/sapi4.py
+++ b/source/synthDrivers/sapi4.py
@@ -193,6 +193,8 @@ class SynthDriver(SynthDriver):
 
 	def terminate(self):
 		self._bufSink._allowDelete = True
+		self._ttsCentral = None
+		self._ttsAttrs = None
 
 	def speak(self, speechSequence: SpeechSequence):
 		textList = []

--- a/source/synthDrivers/sapi4.py
+++ b/source/synthDrivers/sapi4.py
@@ -6,7 +6,6 @@
 
 import locale
 from collections import OrderedDict, deque
-from sys import exc_info
 import winreg
 from comtypes import CoCreateInstance, COMObject, COMError, GUID
 from ctypes import byref, c_ulong, POINTER, c_wchar, create_string_buffer, sizeof, windll

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -126,6 +126,7 @@ In any document, if the cursor is on the last line, it will be moved to the end 
 * When anchor links point to the same object as the virtual caret is placed, NVDA no longer fails to scroll to the link destination. (#17669, @nvdaes)
 * Voice parameters, such as rate and volume, will no longer be reset to default when using the synth settings ring to change between voices in the SAPI5 and SAPI4 synthesizer. (#17693, #2320, @gexgd0419)
 * The NVDA Highlighter Window icon is no longer fixed in the taskbar after restarting Explorer. (#17696, @hwf1324)
+* Fixed an issue where some SAPI4 voices cannot be loaded and report errors when selected. (#17726, @gexgd0419)
 
 ### Changes for Developers
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -126,7 +126,7 @@ In any document, if the cursor is on the last line, it will be moved to the end 
 * When anchor links point to the same object as the virtual caret is placed, NVDA no longer fails to scroll to the link destination. (#17669, @nvdaes)
 * Voice parameters, such as rate and volume, will no longer be reset to default when using the synth settings ring to change between voices in the SAPI5 and SAPI4 synthesizer. (#17693, #2320, @gexgd0419)
 * The NVDA Highlighter Window icon is no longer fixed in the taskbar after restarting Explorer. (#17696, @hwf1324)
-* Fixed an issue where some SAPI4 voices cannot be loaded and report errors when selected. (#17726, @gexgd0419)
+* Fixed an issue where some SAPI4 voices (e.g. IBM TTS Chinese) cannot be loaded. (#17726, @gexgd0419)
 
 ### Changes for Developers
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
None

### Summary of the issue:

The SAPI4 synth driver fails to load some voices, because the voices do not support certain parameters, or because the voices do not expect the client to create multiple instances of `ITTSCentral` objects (with feature flag `TTSFEATURE_SINGLEINSTANCE`).

The synth driver tries to detect whether a parameter is supported or not when loading the voice. However, `removeSetting` is checking against the `name` attribute of each setting, which should now be called `id`. This can cause errors when loading a voice that does not support all the parameters.

### Description of user facing changes
Some of the SAPI4 voices will no longer fail to load.

### Description of development approach

In `removeSetting`, `if s.name == name` is changed to `if s.id == name`.

Before creating a new `ITTSCentral` object, and when `terminate` is called, set both `_ttsCentral` and `_ttsAttrs` to `None` to release the previous `ITTSCentral` object.

Ignore the exception thrown from `_ttsCentral.UnRegister`. Some voices do not handle this well, and the whole `ITTSCentral` will be released anyway.

Some voices keep the pausing state even after resetting, meaning that they will still pause the audio after `_ttsCentral.AudioReset` and silence the output. A variable `_paused` is used to track the pausing state, and if it's paused, unpause it before resetting.

### Testing strategy:
Manually tested with some voices.

### Known issues with pull request:
None yet

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [ ] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
