### PR TITLE
Migrate gestures out of script decorator

### DIFF
--- a/source/core.py
+++ b/source/core.py
@@ -390,6 +390,7 @@ def resetConfiguration(factoryDefaults=False):
 	log.debug("Reloading user and locale input gesture maps")
 	inputCore.manager.loadUserGestureMap()
 	inputCore.manager.loadLocaleGestureMap()
+	inputCore.manager.loadDefaultGestureMap()
 	import audioDucking
 
 	if audioDucking.isAudioDuckingSupported():

--- a/source/inputCore.py
+++ b/source/inputCore.py
@@ -500,8 +500,11 @@ class InputManager(baseObject.AutoPropertyObject):
 		#: The gestures mapped by the user.
 		#: @type: L{GlobalGestureMap}
 		self.userGestureMap = GlobalGestureMap()
+		self.defaultGestureMap = GlobalGestureMap()
+		"""English fallback gestures"""
 		self.loadLocaleGestureMap()
 		self.loadUserGestureMap()
+		self.loadDefaultGestureMap()
 		self._lastInputTime = None
 
 	def executeGesture(self, gesture):
@@ -686,6 +689,10 @@ class InputManager(baseObject.AutoPropertyObject):
 		except IOError:
 			log.debugWarning("No user gesture map")
 
+	def loadDefaultGestureMap(self):
+		self.defaultGestureMap.clear()
+		self.defaultGestureMap.load(os.path.join(globalVars.appDir, "locale", "en", "gestures.ini"))
+
 	def loadLocaleGestureMap(self):
 		self.localeGestureMap.clear()
 		lang = languageHandler.getLanguage()
@@ -738,6 +745,7 @@ class _AllGestureMappingsRetriever(object):
 
 		self.addGlobalMap(manager.userGestureMap)
 		self.addGlobalMap(manager.localeGestureMap)
+		self.addGlobalMap(manager.defaultGestureMap)
 		import braille
 
 		gmap = braille.handler.display.gestureMap if braille.handler and braille.handler.display else None

--- a/source/languageHandler.py
+++ b/source/languageHandler.py
@@ -40,6 +40,8 @@ CP_ACP = "0"
 #: or because it is not a legal locale name (e.g. "zzzz").
 LCID_NONE = 0  # 0 used instead of None for backwards compatibility.
 
+
+FALLBACK_LOCALE = "en"
 LANGS_WITHOUT_TRANSLATIONS: FrozenSet[str] = frozenset(("en",))
 
 _language: str | None = None

--- a/source/locale/en/gestures.ini
+++ b/source/locale/en/gestures.ini
@@ -1,3 +1,8 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2025 NV Access Limited
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
+
 [NVDAObjects.behaviors.EnhancedTermTypedCharSupport]
 	flush_queuedChars = "kb:control+c, kb:control+d, kb:control+pause, kb:enter, kb:numpadEnter, kb:tab"
 [NVDAObjects.behaviors.RowWithFakeNavigation]

--- a/source/locale/en/gestures.ini
+++ b/source/locale/en/gestures.ini
@@ -1,0 +1,559 @@
+[NVDAObjects.behaviors.EnhancedTermTypedCharSupport]
+	flush_queuedChars = "kb:control+c, kb:control+d, kb:control+pause, kb:enter, kb:numpadEnter, kb:tab"
+[NVDAObjects.behaviors.RowWithFakeNavigation]
+	# Moves the navigator object to the next column
+	moveToNextColumn = kb:control+alt+rightArrow
+	# Moves the navigator object to the previous column
+	moveToPreviousColumn = kb:control+alt+leftArrow
+	# Moves the navigator object and focus to the next row
+	moveToNextRow = kb:control+alt+downArrow
+	# Moves the navigator object and focus to the previous row
+	moveToPreviousRow = kb:control+alt+upArrow
+	# Moves the navigator object to the first column
+	moveToFirstColumn = kb:Control+Alt+Home
+	# Moves the navigator object to the last column
+	moveToLastColumn = kb:Control+Alt+End
+	# Moves the navigator object and focus to the first row
+	moveToFirstRow = kb:Control+Alt+PageUp
+	# Moves the navigator object and focus to the last row
+	moveToLastRow = kb:Control+Alt+PageDown
+[cursorManager.CursorManager]
+	# find the next occurrence of the previously entered text string from the current cursor's position
+	findNext = kb:NVDA+f3
+	# find the previous occurrence of the previously entered text string from the current cursor's position
+	findPrevious = kb:NVDA+shift+f3
+[browseMode.BrowseModeDocumentTreeInterceptor]
+	# Toggles on and off if the screen layout is preserved while rendering the document content
+	toggleScreenLayout = kb:NVDA+v
+	# Toggles native selection mode on and off
+	toggleNativeAppSelectionMode = kb:NVDA+shift+f10
+[globalCommands.GlobalCommands]
+	# Cycles through audio ducking modes which determine when NVDA lowers the volume of other sounds
+	cycleAudioDuckingMode = kb:NVDA+shift+d
+	# Turns input help on or off. When on, any input such as pressing a key on the keyboard will tell you what script is associated with that input, if any.
+	toggleInputHelp = kb:NVDA+1
+	# Toggles sleep mode on and off for the active application.
+	toggleCurrentAppSleepMode = "kb(desktop):NVDA+shift+s, kb(laptop):NVDA+shift+z"
+	# Reports the current line under the application cursor. Pressing this key twice will spell the current line. Pressing three times will spell the line using character descriptions.
+	reportCurrentLine = "kb(desktop):NVDA+upArrow, kb(laptop):NVDA+l"
+	# Clicks the left mouse button once at the current mouse position
+	leftMouseClick = "kb(laptop):NVDA+[, kb:numpadDivide"
+	# Clicks the right mouse button once at the current mouse position
+	rightMouseClick = "kb(laptop):NVDA+], kb:numpadMultiply"
+	# Locks or unlocks the left mouse button
+	toggleLeftMouseButton = "kb(laptop):NVDA+control+[, kb:shift+numpadDivide"
+	# Locks or unlocks the right mouse button
+	toggleRightMouseButton = "kb(laptop):NVDA+control+], kb:shift+numpadMultiply"
+	# Scroll up at the mouse position
+	mouseScrollUp = ""
+	# Scroll down at the mouse position
+	mouseScrollDown = ""
+	# Scroll left at the mouse position
+	mouseScrollLeft = ""
+	# Scroll right at the mouse position
+	mouseScrollRight = ""
+	# Announces the current selection in edit controls and documents. Pressing twice spells this information. Pressing three times spells it using character descriptions. Pressing four times shows it in a browsable message. 
+	reportCurrentSelection = "kb(desktop):NVDA+shift+upArrow, kb(laptop):NVDA+shift+s"
+	# If pressed once, reports the current time. If pressed twice, reports the current date
+	dateTime = kb:NVDA+f12
+	# Set the first value of the current setting in the synth settings ring
+	firstValueSynthRing = ""
+	# Set the last value of the current setting in the synth settings ring
+	lastValueSynthRing = ""
+	# Increases the currently active setting in the synth settings ring
+	increaseSynthSetting = "kb(desktop):NVDA+control+upArrow, kb(laptop):NVDA+shift+control+upArrow"
+	# Increases the currently active setting in the synth settings ring in a larger step
+	increaseLargeSynthSetting = "kb(desktop):NVDA+control+pageUp, kb(laptop):NVDA+shift+control+pageUp"
+	# Decreases the currently active setting in the synth settings ring
+	decreaseSynthSetting = "kb(desktop):NVDA+control+downArrow, kb(laptop):NVDA+control+shift+downArrow"
+	# Decreases the currently active setting in the synth settings ring in a larger step
+	decreaseLargeSynthSetting = "kb(desktop):NVDA+control+pageDown, kb(laptop):NVDA+control+shift+pageDown"
+	# Moves to the next available setting in the synth settings ring
+	nextSynthSetting = "kb(desktop):NVDA+control+rightArrow, kb(laptop):NVDA+shift+control+rightArrow"
+	# Moves to the previous available setting in the synth settings ring
+	previousSynthSetting = "kb(desktop):NVDA+control+leftArrow, kb(laptop):NVDA+shift+control+leftArrow"
+	# Cycles through options for when to speak typed characters.
+	toggleSpeakTypedCharacters = kb:NVDA+2
+	# Cycles through options for when to speak typed words.
+	toggleSpeakTypedWords = kb:NVDA+3
+	# Toggles on and off the speaking of command keys
+	toggleSpeakCommandKeys = kb:NVDA+4
+	# Toggles on and off the reporting of font changes
+	toggleReportFontName = ""
+	# Toggles on and off the reporting of font size changes
+	toggleReportFontSize = ""
+	# Cycles font attribute reporting between speech, braille, speech and braille, and off.
+	toggleReportFontAttributes = ""
+	# Toggles on and off the reporting of superscripts and subscripts
+	toggleReportSuperscriptsAndSubscripts = ""
+	# Toggles on and off the reporting of revisions
+	toggleReportRevisions = ""
+	# Toggles on and off the reporting of emphasis
+	toggleReportEmphasis = ""
+	# Toggles on and off the reporting of highlighted text
+	toggleReportHighlightedText = ""
+	# Toggles on and off the reporting of colors
+	toggleReportColor = ""
+	# Toggles on and off the reporting of text alignment
+	toggleReportAlignment = ""
+	# Toggles on and off the reporting of style changes
+	toggleReportStyle = ""
+	# Toggles on and off the reporting of spelling errors
+	toggleReportSpellingErrors = ""
+	# Toggles on and off the reporting of pages
+	toggleReportPage = ""
+	# Toggles on and off the reporting of line numbers
+	toggleReportLineNumber = ""
+	# Cycles through line indentation settings
+	toggleReportLineIndentation = ""
+	# Toggles on and off the ignoring of blank lines for line indentation reporting
+	toggleignoreBlankLinesForReportLineIndentation = ""
+	# Toggles on and off the reporting of paragraph indentation
+	toggleReportParagraphIndentation = ""
+	# Toggles on and off the reporting of line spacing
+	toggleReportLineSpacing = ""
+	# Toggles on and off the reporting of tables
+	toggleReportTables = ""
+	# Cycle through the possible modes to report table row and column headers
+	toggleReportTableHeaders = ""
+	# Toggles on and off the reporting of table cell coordinates
+	toggleReportTableCellCoords = ""
+	# Cycles through the cell border reporting settings
+	toggleReportCellBorders = ""
+	# Toggles on and off the reporting of links
+	toggleReportLinks = ""
+	# Toggles on and off the reporting of link type
+	toggleReportLinkType = ""
+	# Toggles on and off the reporting of graphics
+	toggleReportGraphics = ""
+	# Toggles on and off the reporting of comments
+	toggleReportComments = ""
+	# Toggles on and off the reporting of lists
+	toggleReportLists = ""
+	# Toggles on and off the reporting of headings
+	toggleReportHeadings = ""
+	# Toggles on and off the reporting of groupings
+	toggleReportGroupings = ""
+	# Toggles on and off the reporting of block quotes
+	toggleReportBlockQuotes = ""
+	# Toggles on and off the reporting of landmarks
+	toggleReportLandmarks = ""
+	# Toggles on and off the reporting of articles
+	toggleReportArticles = ""
+	# Toggles on and off the reporting of frames
+	toggleReportFrames = ""
+	# Toggles on and off reporting if clickable
+	toggleReportClickable = ""
+	# Toggles on and off the reporting of figures and captions
+	toggleReportFigures = ""
+	# Cycles through the possible choices for automatic language switching: off, language only and language and dialect.
+	cycleSpeechAutomaticLanguageSwitching = ""
+	# Cycles through speech symbol levels which determine what symbols are spoken
+	cycleSpeechSymbolLevel = kb:NVDA+p
+	# Toggles on and off delayed descriptions for characters on cursor movement
+	toggleDelayedCharacterDescriptions = ""
+	# Moves the mouse pointer to the current navigator object
+	moveMouseToNavigatorObject = "kb(laptop):NVDA+shift+m, kb:NVDA+numpadDivide"
+	# Sets the navigator object to the current object under the mouse pointer and speaks it
+	moveNavigatorObjectToMouse = "kb(laptop):NVDA+shift+n, kb:NVDA+numpadMultiply"
+	# Switches to the next review mode (e.g. object, document or screen) and positions the review position at the point of the navigator object
+	reviewMode_next = "kb(laptop):NVDA+pageUp, kb:NVDA+numpad7, ts(object):2finger_flickUp"
+	# Switches to the previous review mode (e.g. object, document or screen) and positions the review position at the point of the navigator object
+	reviewMode_previous = "kb(laptop):NVDA+pageDown, kb:NVDA+numpad1, ts(object):2finger_flickDown"
+	# Toggles simple review mode on and off
+	toggleSimpleReviewMode = ""
+	# Reports the current navigator object. Pressing twice spells this information, and pressing three times Copies name and value of this object to the clipboard
+	navigatorObject_current = "kb(laptop):NVDA+shift+o, kb:NVDA+numpad5"
+	# Reports information about the location of the text at the review cursor, or location of the navigator object if there is no text under review cursor.
+	reportReviewCursorLocation = ""
+	# Reports information about the location of the current navigator object.
+	reportCurrentNavigatorObjectLocation = ""
+	# Reports information about the location of the text at the caret, or location of the currently focused object if there is no caret.
+	reportCaretLocation = ""
+	# Reports information about the location of the currently focused object.
+	reportFocusObjectLocation = ""
+	# Reports information about the location of the text or object at the review cursor. Pressing twice may provide further detail.
+	navigatorObject_currentDimensions = "kb(laptop):NVDA+shift+delete, kb:NVDA+shift+numpadDelete"
+	# Reports information about the location of the text or object at the position of system caret. Pressing twice may provide further detail.
+	caretPos_currentDimensions = "kb(laptop):NVDA+delete, kb:NVDA+numpadDelete"
+	# Sets the navigator object to the current focus, and the review cursor to the position of the caret inside it, if possible.
+	navigatorObject_toFocus = "kb(laptop):NVDA+backspace, kb:NVDA+numpadMinus"
+	# Pressed once sets the keyboard focus to the navigator object, pressed twice sets the system caret to the position of the review cursor
+	navigatorObject_moveFocus = "kb(laptop):NVDA+shift+backspace, kb:NVDA+shift+numpadMinus"
+	# Moves the navigator object to the object containing it
+	navigatorObject_parent = "kb(laptop):NVDA+shift+upArrow, kb:NVDA+numpad8, ts(object):flickup"
+	# Moves the navigator object to the next object
+	navigatorObject_next = "kb(laptop):NVDA+shift+rightArrow, kb:NVDA+numpad6, ts(object):2finger_flickright"
+	# Moves the navigator object to the previous object
+	navigatorObject_previous = "kb(laptop):NVDA+shift+leftArrow, kb:NVDA+numpad4, ts(object):2finger_flickleft"
+	# Moves the navigator object to the first object inside it
+	navigatorObject_firstChild = "kb(laptop):NVDA+shift+downArrow, kb:NVDA+numpad2, ts(object):flickdown"
+	# Performs the default action on the current navigator object (example: presses it if it is a button).
+	review_activate = "kb(laptop):NVDA+enter, kb:NVDA+numpadEnter, ts:double_tap"
+	# Moves the review cursor to the top line of the current navigator object and speaks it
+	review_top = "kb(laptop):NVDA+control+home, kb:shift+numpad7"
+	# Moves the review cursor to the previous line of the current navigator object and speaks it
+	review_previousLine = "kb(laptop):NVDA+upArrow, kb:numpad7, ts(text):flickUp"
+	# Reports the line of the current navigator object where the review cursor is situated. If this key is pressed twice, the current line will be spelled. Pressing three times will spell the line using character descriptions.
+	review_currentLine = "kb(laptop):NVDA+shift+., kb:numpad8"
+	# Moves the review cursor to the next line of the current navigator object and speaks it
+	review_nextLine = "kb(laptop):NVDA+downArrow, kb:numpad9, ts(text):flickDown"
+	# Moves the review cursor to the previous page of the current navigator object and speaks it
+	review_previousPage = "kb(laptop):NVDA+shift+pageUp, kb:NVDA+pageUp"
+	# Moves the review cursor to the next page of the current navigator object and speaks it
+	review_nextPage = "kb(laptop):NVDA+shift+pageDown, kb:NVDA+pageDown"
+	# Moves the review cursor to the bottom line of the current navigator object and speaks it
+	review_bottom = "kb(laptop):NVDA+control+end, kb:shift+numpad9"
+	# Moves the review cursor to the previous word of the current navigator object and speaks it
+	review_previousWord = "kb(laptop):NVDA+control+leftArrow, kb:numpad4, ts(text):2finger_flickLeft"
+	# Speaks the word of the current navigator object where the review cursor is situated. Pressing twice spells the word. Pressing three times spells the word using character descriptions
+	review_currentWord = "kb(laptop):NVDA+control+., kb:numpad5, ts(text):hoverUp"
+	# Moves the review cursor to the next word of the current navigator object and speaks it
+	review_nextWord = "kb(laptop):NVDA+control+rightArrow, kb:numpad6, ts(text):2finger_flickRight"
+	# Moves the review cursor to the first character of the line where it is situated in the current navigator object and speaks it
+	review_startOfLine = "kb(laptop):NVDA+home, kb:shift+numpad1"
+	# Moves the review cursor to the previous character of the current navigator object and speaks it
+	review_previousCharacter = "kb(laptop):NVDA+leftArrow, kb:numpad1, ts(text):flickLeft"
+	# Reports the character of the current navigator object where the review cursor is situated. Pressing twice reports a description or example of that character. Pressing three times reports the numeric value of the character in decimal and hexadecimal
+	review_currentCharacter = "kb(laptop):NVDA+., kb:numpad2"
+	# Moves the review cursor to the next character of the current navigator object and speaks it
+	review_nextCharacter = "kb(laptop):NVDA+rightArrow, kb:numpad3, ts(text):flickRight"
+	# Moves the review cursor to the last character of the line where it is situated in the current navigator object and speaks it
+	review_endOfLine = "kb(laptop):NVDA+end, kb:shift+numpad3"
+	# Moves the review cursor to the first character of the selection, and speaks it
+	review_startOfSelection = kb:NVDA+alt+home
+	# Moves the review cursor to the last character of the selection, and speaks it
+	review_endOfSelection = kb:NVDA+alt+end
+	# Reports the symbol where the review cursor is positioned. Pressed twice, shows the symbol and the text used to speak it in browse mode
+	review_currentSymbol = ""
+	# Cycles between speech modes.
+	speechMode = kb:NVDA+s
+	# Moves the focus out of the current embedded object and into the document that contains it
+	moveToParentTreeInterceptor = kb:NVDA+control+space
+	# Toggles between browse mode and focus mode. When in focus mode, keys will pass straight through to the application, allowing you to interact directly with a control. When in browse mode, you can navigate the document with the cursor, quick navigation keys, etc.
+	toggleVirtualBufferPassThrough = kb:NVDA+space
+	# Quits NVDA!
+	quit = kb:NVDA+q
+	# Restarts NVDA!
+	restart = ""
+	# Shows the NVDA menu
+	showGui = "kb:NVDA+n, ts:2finger_double_tap"
+	# Reads from the review cursor up to the end of the current text, moving the review cursor as it goes
+	review_sayAll = "kb(laptop):NVDA+shift+a, kb:numpadPlus, ts(text):3finger_flickDown"
+	# Reads from the system caret up to the end of the text, moving the caret as it goes
+	sayAll = "kb(desktop):NVDA+downArrow, kb(laptop):NVDA+a"
+	# Reports formatting info for the current review cursor position.
+	reportFormattingAtReview = ""
+	# Presents, in browse mode, formatting info for the current review cursor position.
+	showFormattingAtReview = ""
+	# Reports formatting info for the current review cursor position. If pressed twice, presents the information in browse mode
+	reportFormatting = kb:NVDA+shift+f
+	# Reports formatting info for the text under the caret.
+	reportFormattingAtCaret = ""
+	# Presents, in browse mode, formatting info for the text under the caret.
+	showFormattingAtCaret = ""
+	# Reports formatting info for the text under the caret. If pressed twice, presents the information in browse mode
+	reportOrShowFormattingAtCaret = kb:NVDA+f
+	# Report summary of any annotation details at the system caret.
+	reportDetailsSummary = kb:NVDA+d
+	# Reports the object with focus. If pressed twice, spells the information. Pressing three times spells it using character descriptions.
+	reportCurrentFocus = kb:NVDA+tab
+	# Reads the current application status bar.
+	readStatusLine = ""
+	# Spells the current application status bar.
+	spellStatusLine = ""
+	# Copies content of the status bar  of current application to the clipboard.
+	copyStatusLine = ""
+	# Reads the current application status bar and moves navigator object into it.
+	reviewCursorToStatusLine = ""
+	# Reads the current application status bar. If pressed twice, spells the information. If pressed three times, copies the status bar to the clipboard
+	reportStatusLine = "kb(desktop):NVDA+end, kb(laptop):NVDA+shift+end"
+	# Reports the shortcut key of the currently focused object
+	reportFocusObjectAccelerator = "kb(laptop):NVDA+control+shift+., kb:shift+numpad2"
+	# Toggles the reporting of information as the mouse moves
+	toggleMouseTracking = kb:NVDA+m
+	# Toggles how much text will be spoken when the mouse moves
+	toggleMouseTextResolution = ""
+	# Reports the title of the current application or foreground window. If pressed twice, spells the title. If pressed three times, copies the title to the clipboard
+	title = kb:NVDA+t
+	# Reads all controls in the active window
+	speakForeground = kb:NVDA+b
+	test_navigatorDisplayModelText = kb(desktop):NVDA+control+f2
+	# Opens the WX GUI inspection tool. Used to get more information about the state of GUI components.
+	startWxInspectionTool = ""
+	# Logs information about the current navigator object which is useful to developers and activates the log viewer so the information can be examined.
+	navigatorObject_devInfo = kb:NVDA+f1
+	# Mark the current end of the log as the start of the fragment to be copied to clipboard by pressing again.
+	log_markStartThenCopy = kb:NVDA+control+shift+f1
+	# Opens NVDA configuration directory for the current user.
+	openUserConfigurationDirectory = ""
+	# Toggles between beeps, speech, beeps and speech, and off, for reporting progress bar updates
+	toggleProgressBarOutput = kb:NVDA+u
+	# Toggles on and off the reporting of dynamic content changes, such as new text in dos console windows
+	toggleReportDynamicContentChanges = kb:NVDA+5
+	# Toggles on and off the movement of the review cursor due to the caret moving.
+	toggleCaretMovesReviewCursor = kb:NVDA+6
+	# Toggles on and off the movement of the navigator object due to focus changes
+	toggleFocusMovesNavigatorObject = kb:NVDA+7
+	# Reports battery status and time remaining if AC is not plugged in
+	say_battery_status = kb:NVDA+shift+b
+	# The next key that is pressed will not be handled at all by NVDA, it will be passed directly through to Windows.
+	passNextKeyThrough = kb:NVDA+f2
+	# Speaks the filename of the active application along with the name of the currently loaded appModule
+	reportAppModuleInfo = kb:NVDA+control+f1
+	# Shows NVDA's general settings
+	activateGeneralSettingsDialog = kb:NVDA+control+g
+	# Shows the NVDA synthesizer selection dialog
+	activateSynthesizerDialog = kb:NVDA+control+s
+	# Shows NVDA's speech settings
+	activateVoiceDialog = kb:NVDA+control+v
+	# Shows the NVDA braille display selection dialog
+	activateBrailleDisplayDialog = kb:NVDA+control+a
+	# Shows NVDA's braille settings
+	activateBrailleSettingsDialog = ""
+	# Shows NVDA's audio settings
+	activateAudioSettingsDialog = kb:NVDA+control+u
+	# Shows NVDA's keyboard settings
+	activateKeyboardSettingsDialog = kb:NVDA+control+k
+	# Shows NVDA's mouse settings
+	activateMouseSettingsDialog = kb:NVDA+control+m
+	# Shows NVDA's review cursor settings
+	activateReviewCursorDialog = ""
+	# Shows NVDA's input composition settings
+	activateInputCompositionDialog = ""
+	# Shows NVDA's object presentation settings
+	activateObjectPresentationDialog = kb:NVDA+control+o
+	# Shows NVDA's browse mode settings
+	activateBrowseModeDialog = kb:NVDA+control+b
+	# Shows NVDA's document formatting settings
+	activateDocumentFormattingDialog = kb:NVDA+control+d
+	# Shows the NVDA default dictionary dialog
+	activateDefaultDictionaryDialog = ""
+	# Shows the NVDA voice-specific dictionary dialog
+	activateVoiceDictionaryDialog = ""
+	# Shows the NVDA temporary dictionary dialog
+	activateTemporaryDictionaryDialog = ""
+	# Shows the NVDA symbol pronunciation dialog
+	activateSpeechSymbolsDialog = ""
+	# Shows the NVDA input gestures dialog
+	activateInputGesturesDialog = ""
+	# Reports the name of the current NVDA configuration profile
+	reportActiveConfigurationProfile = ""
+	# Saves the current NVDA configuration
+	saveConfiguration = kb:NVDA+control+c
+	# Pressing once reverts the current configuration to the most recently saved state. Pressing three times resets to factory defaults.
+	revertConfiguration = kb:NVDA+control+r
+	# Activates the NVDA Python Console, primarily useful for development
+	activatePythonConsole = kb:NVDA+control+z
+	# Activates the Add-on Store to browse and manage add-on packages for NVDA
+	activateAddonsManager = ""
+	# Toggles the NVDA Speech viewer, a floating window that allows you to view all the text that NVDA is currently speaking
+	toggleSpeechViewer = ""
+	# Toggles the NVDA Braille viewer, a floating window that allows you to view braille output, and the text equivalent for each braille character
+	toggleBrailleViewer = ""
+	# Toggle tethering of braille between the focus and the review position
+	braille_toggleTether = kb:NVDA+control+t
+	# Toggles braille mode
+	toggleBrailleMode = kb:nvda+alt+t
+	# Cycle through the braille move system caret when routing review cursor states
+	braille_cycleReviewRoutingMovesSystemCaret = ""
+	# Toggle the way context information is presented in braille
+	braille_toggleFocusContextPresentation = ""
+	# Toggle the braille cursor on and off
+	braille_toggleShowCursor = ""
+	# Toggles speaking the character under the cursor when routing cursor in text
+	braille_toggleSpeakOnRouting = ""
+	# Toggles on and off speaking when navigating by lines or paragraph with braille
+	toggleSpeakingOnNavigatingByUnit = ""
+	# Cycle through the braille cursor shapes
+	braille_cycleCursorShape = ""
+	# Cycle through the braille show messages modes
+	braille_cycleShowMessages = ""
+	# Cycle through the braille show selection states
+	braille_cycleShowSelection = ""
+	# Cycle through the braille Unicode normalization states
+	braille_cycleUnicodeNormalization = ""
+	# Reports the text on the Windows clipboard. Pressing twice spells this information. Pressing three times spells it using character descriptions.
+	reportClipboardText = kb:NVDA+c
+	# Marks the current position of the review cursor as the start of text to be selected or copied
+	review_markStartForCopy = kb:NVDA+f9
+	# Move the review cursor to the position marked as the start of text to be selected or copied
+	review_moveToStartMarkedForCopy = kb:NVDA+shift+F9
+	# If pressed once, the text from the previously set start marker up to and including the current position of the review cursor is selected. If pressed twice, the text is copied to the clipboard
+	review_copy = kb:NVDA+f10
+	# Scrolls the braille display back
+	braille_scrollBack = ""
+	# Scrolls the braille display forward
+	braille_scrollForward = ""
+	# Routes the cursor to or activates the object under this braille cell
+	braille_routeTo = ""
+	# Reports formatting info for the text under this braille cell
+	braille_reportFormatting = ""
+	# Moves the braille display to the previous line
+	braille_previousLine = ""
+	# Moves the braille display to the next line
+	braille_nextLine = ""
+	# Inputs braille dots via the braille keyboard
+	braille_dots = bk:dots
+	# Moves the braille display to the current focus
+	braille_toFocus = ""
+	# Erases the last entered braille cell or character
+	braille_eraseLastCell = bk:dot7
+	# Translates any braille input and presses the enter key
+	braille_enter = bk:dot8
+	# Translates any braille input
+	braille_translate = bk:dot7+dot8
+	# Virtually toggles the shift key to emulate a keyboard shortcut with braille input
+	braille_toggleShift = ""
+	# Virtually toggles the control key to emulate a keyboard shortcut with braille input
+	braille_toggleControl = ""
+	# Virtually toggles the alt key to emulate a keyboard shortcut with braille input
+	braille_toggleAlt = ""
+	# Virtually toggles the left windows key to emulate a keyboard shortcut with braille input
+	braille_toggleWindows = ""
+	# Virtually toggles the NVDA key to emulate a keyboard shortcut with braille input
+	braille_toggleNVDAKey = ""
+	# Virtually toggles the control and shift keys to emulate a keyboard shortcut with braille input
+	braille_toggleControlShift = ""
+	# Virtually toggles the alt and shift keys to emulate a keyboard shortcut with braille input
+	braille_toggleAltShift = ""
+	# Virtually toggles the left windows and shift keys to emulate a keyboard shortcut with braille input
+	braille_toggleWindowsShift = ""
+	# Virtually toggles the NVDA and shift keys to emulate a keyboard shortcut with braille input
+	braille_toggleNVDAKeyShift = ""
+	# Virtually toggles the control and alt keys to emulate a keyboard shortcut with braille input
+	braille_toggleControlAlt = ""
+	# Virtually toggles the control, alt, and shift keys to emulate a keyboard shortcut with braille input
+	braille_toggleControlAltShift = ""
+	# Reloads app modules and global plugins without restarting NVDA, which can be Useful for developers
+	reloadPlugins = kb:NVDA+control+f3
+	# Report the destination URL of the link at the position of caret or focus. If pressed twice, shows the URL in a window for easier review.
+	reportLinkDestination = kb:NVDA+k
+	# Displays the destination URL of the link at the position of caret or focus in a window, instead of just speaking it. May be preferred by braille users.
+	reportLinkDestinationInWindow = ""
+	# Moves to the next object in a flattened view of the object navigation hierarchy
+	navigatorObject_nextInFlow = "kb(laptop):shift+NVDA+], kb:NVDA+numpad3, ts(object):flickright"
+	# Moves to the previous object in a flattened view of the object navigation hierarchy
+	navigatorObject_previousInFlow = "kb(laptop):shift+NVDA+[, kb:NVDA+numpad9, ts(object):flickleft"
+	# Toggles the support of touch interaction
+	toggleTouchSupport = kb:NVDA+control+alt+t
+	# Cycles between available touch modes
+	touch_changeMode = ts:3finger_tap
+	# Reports the object and content directly under your finger
+	touch_newExplore = "ts:hoverDown, ts:tap"
+	# Reports the new object or content under your finger if different to where your finger was last
+	touch_explore = ts:hover
+	touch_hoverUp = ts:hoverUp
+	# Clicks the right mouse button at the current touch position. This is generally used to activate a context menu.
+	touch_rightClick = ts:tapAndHold
+	# Shows the NVDA Configuration Profiles dialog
+	activateConfigProfilesDialog = kb:NVDA+control+p
+	# Toggles disabling of all configuration profile triggers. Disabling remains in effect until NVDA is restarted
+	toggleConfigProfileTriggers = ""
+	# Begins interaction with math content
+	interactWithMath = kb:NVDA+alt+m
+	# Recognizes the content of the current navigator object with Windows OCR
+	recognizeWithUwpOcr = kb:NVDA+r
+	# Cycles through the available languages for Windows OCR
+	cycleOcrLanguage = ""
+	# Toggles on and off the reporting of CLDR characters, such as emojis
+	toggleReportCLDR = ""
+	# Cycle through the speech Unicode normalization states
+	speech_cycleUnicodeNormalization = ""
+	# Toggles the state of the screen curtain, enable to make the screen black or disable to show the contents of the screen. Pressed once, screen curtain is enabled until you restart NVDA. Pressed twice, screen curtain is enabled until you disable it
+	toggleScreenCurtain = kb:NVDA+control+escape
+	# Cycles through paragraph navigation styles
+	cycleParagraphStyle = ""
+	# Cycles through sound split modes
+	cycleSoundSplit = kb:NVDA+alt+s
+	# Increases the volume of other applications
+	increaseApplicationsVolume = ""
+	# Decreases the volume of other applications
+	decreaseApplicationsVolume = ""
+	# Toggles application volume control on and off
+	toggleApplicationsVolumeAdjuster = ""
+	# Mutes or unmutes other applications
+	toggleApplicationsMute = ""
+[virtualBuffers.VirtualBuffer]
+	# Toggles on and off if the screen layout is preserved while rendering the document content
+	toggleScreenLayout = kb:NVDA+v
+[appModules.nvda.NvdaPythonConsoleUIOutputClear]
+	# Clear the output pane
+	clearOutput = kb:control+l
+[appModules.nvda.NvdaPythonConsoleUIOutputCtrl]
+	# Move to the next result
+	moveToNextResult = kb:alt+downArrow
+	# Move to the previous result
+	moveToPrevResult = kb:alt+upArrow
+	# Select until the end of the current result
+	selectToResultEnd = kb:alt+downArrow+shift
+	# Select until the start of the current result
+	selectToResultStart = kb:alt+shift+upArrow
+[appModules.foobar2000.AppModule]
+	# Reports the remaining time of the currently playing track, if any
+	reportRemainingTime = kb:control+shift+r
+	# Reports the elapsed time of the currently playing track, if any
+	reportElapsedTime = kb:control+shift+e
+	# Reports the length of the currently playing track, if any
+	reportTotalTime = kb:control+shift+t
+[NVDAObjects.window.excel.ExcelBrowseModeTreeInterceptor]
+	moveLeft = kb:leftArrow
+	moveRight = kb:rightArrow
+	moveUp = kb:upArrow
+	moveDown = kb:downArrow
+	startOfColumn = kb:control+upArrow
+	startOfRow = kb:control+leftArrow
+	endOfRow = kb:control+rightArrow
+	endOfColumn = kb:control+downArrow
+[NVDAObjects.window.excel.ExcelWorksheet]
+	changeSelection = "kb:alt+backspace, kb:alt+pageDown, kb:alt+pageUp, kb:alt+shift+pageDown, kb:alt+shift+pageUp, kb:control+a, kb:control+downArrow, kb:control+end, kb:control+home, kb:control+leftArrow, kb:control+pageDown, kb:control+pageUp, kb:control+rightArrow, kb:control+shift+8, kb:control+space, kb:control+upArrow, kb:control+v, kb:control+y, kb:control+z, kb:downArrow, kb:end, kb:enter, kb:home, kb:leftArrow, kb:numpadEnter, kb:pageDown, kb:pageUp, kb:rightArrow, kb:shift+control+downArrow, kb:shift+control+end, kb:shift+control+home, kb:shift+control+leftArrow, kb:shift+control+rightArrow, kb:shift+control+upArrow, kb:shift+downArrow, kb:shift+end, kb:shift+enter, kb:shift+f11, kb:shift+home, kb:shift+leftArrow, kb:shift+numpadEnter, kb:shift+pageDown, kb:shift+pageUp, kb:shift+rightArrow, kb:shift+space, kb:shift+tab, kb:shift+upArrow, kb:tab, kb:upArrow"
+	toggleBold = "kb:control+2, kb:control+b"
+	toggleItalic = "kb:control+3, kb:control+i"
+	toggleUnderline = "kb:control+4, kb:control+u"
+	toggleStrikethrough = kb:control+5
+[NVDAObjects.window.excel.ExcelCell]
+	openDropdown = kb:alt+downArrow
+	# Sets the current cell as start of column header. Pressing once will set this cell as the first column header for any cell lower and to the right of it within this region. Pressing twice will forget the current column header for this cell.
+	setColumnHeader = kb:NVDA+shift+c
+	# Sets the current cell as start of row headers. Pressing once will set this cell as the first row header for any cell lower and to the right of it within this region. Pressing twice will forget the current row header for this cell.
+	setRowHeader = kb:NVDA+shift+r
+	# Reports the note on the current cell. If pressed twice, presents the information in browse mode
+	reportComment = kb:NVDA+alt+c
+	# Opens the note editing dialog
+	editComment = kb:shift+f2
+[NVDAObjects.window.excel.ExcelDropdown]
+	selectionChange = "kb:downArrow, kb:end, kb:home, kb:leftArrow, kb:rightArrow, kb:upArrow"
+	closeDropdown = "kb:enter, kb:escape, kb:space"
+[NVDAObjects.window.excel.ExcelFormControl]
+	doAction = "kb(desktop):numpadEnter, kb:enter, kb:space"
+[NVDAObjects.window.excel.ExcelFormControlListBox]
+	moveUp = kb:upArrow
+	moveDown = kb:downArrow
+[NVDAObjects.window.excel.ExcelFormControlDropDown]
+	moveUp = kb:upArrow
+	moveDown = kb:downArrow
+[NVDAObjects.window.excel.ExcelFormControlScrollBar]
+	moveUpSmall = kb:upArrow
+	moveDownSmall = kb:downArrow
+	moveUpLarge = kb:pageUp
+	moveDownLarge = kb:pageDown
+[NVDAObjects.window._msOfficeChart.OfficeChart]
+	# Toggles between browse mode and focus mode. When in focus mode, keys will pass straight through to the application, allowing you to interact directly with a control. When in browse mode, you can navigate the document with the cursor, quick navigation keys, etc.
+	activatePosition = "kb(desktop):numpadEnter, kb:enter, kb:space"
+[NVDAObjects.window.winword.WordDocument]
+	toggleBold = kb:control+b
+	toggleItalic = "kb:control+i, kb:control+shift+i"
+	toggleUnderline = "kb:control+shift+d, kb:control+shift+u, kb:control+u"
+	toggleCaps = kb:control+shift+k
+	changeCase = kb:shift+f3
+	toggleAlignment = "kb:control+e, kb:control+j, kb:control+l, kb:control+r"
+	changeParagraphLeftIndent = "kb:control+m, kb:control+shift+m, kb:control+shift+t, kb:control+t"
+	toggleSuperscriptSubscript = "kb:control+=, kb:control+shift+="
+	moveParagraphDown = kb:alt+shift+downArrow
+	moveParagraphUp = kb:alt+shift+upArrow
+	increaseDecreaseOutlineLevel = "kb:alt+shift+leftArrow, kb:alt+shift+rightArrow, kb:control+alt+1, kb:control+alt+2, kb:control+alt+3, kb:control+shift+n"
+	increaseDecreaseFontSize = "kb:control+[, kb:control+], kb:control+shift+,, kb:control+shift+."
+	toggleDisplayNonprintingCharacters = kb:control+shift+8
+	tab = "kb:shift+tab, kb:tab"
+	changeLineSpacing = "kb:control+1, kb:control+2, kb:control+5"
+	changeParagraphSpacing = kb:control+0

--- a/source/scriptHandler.py
+++ b/source/scriptHandler.py
@@ -412,10 +412,8 @@ def _registerEnglishGesture(script: types.FunctionType, gestures: list[str], des
 	if gestures:
 		scriptLogName = f"{scriptLocation}.{script.__name__}"
 		logMsg = f"{scriptLogName}: Setting gesture for via @script is now deprecated. Add the gesture to /en/gestures.ini instead."
-		# Note this appears to not log correctly
-		# import warnings
-		# warnings.warn(logMsg, DeprecationWarning)
-		log.warning(logMsg)
+		import warnings
+		warnings.warn(logMsg, DeprecationWarning)
 	if scriptLocation not in _gestureConfig:
 		_gestureConfig[scriptLocation] = {}
 	gestureStr = ", ".join(sorted(gestures))

--- a/source/scriptHandler.py
+++ b/source/scriptHandler.py
@@ -408,7 +408,7 @@ def _registerEnglishGesture(script: types.FunctionType, gestures: list[str], des
 		# In future, check for conflicts when registering an add-on gesture.
 		return
 	scriptLocation = f"{script.__module__}.{className}"
-	scriptName = script.__name__.replace("script_", "")
+	scriptName = script.__name__.removeprefix("script_")
 	if gestures:
 		scriptLogName = f"{scriptLocation}.{script.__name__}"
 		logMsg = f"{scriptLogName}: Setting gesture for via @script is now deprecated. Add the gesture to /en/gestures.ini instead."

--- a/source/scriptHandler.py
+++ b/source/scriptHandler.py
@@ -363,6 +363,7 @@ def _findScriptInGlobalMap(gesture: str) -> _FindScriptResultsT:
 	"""Find global scripts for a gesture"""
 	from inputCore import manager, normalizeGestureIdentifier
 
+	assert manager
 	normalizedGesture = normalizeGestureIdentifier(gesture)
 	globalScripts = [manager.userGestureMap, manager.localeGestureMap, manager.defaultGestureMap]
 	conflicts: _FindScriptResultsT = []
@@ -393,7 +394,7 @@ def _checkForConflicts(script: types.FunctionType, gestures: list[str]):
 			)
 
 
-def _registerGesture(script: types.FunctionType, gestures: list[str], description: str):
+def _registerEnglishGesture(script: types.FunctionType, gestures: list[str], description: str):
 	"""
 	Register a gesture for a script registered with the @script decorator.
 	Creates an entry in the English gestures.ini file.
@@ -487,7 +488,7 @@ def script(
 			gestures.append(gesture)
 		if gestures:
 			decoratedScript.gestures = gestures
-		_registerGesture(decoratedScript, gestures, description)
+		_registerEnglishGesture(decoratedScript, gestures, description)
 		_checkForConflicts(decoratedScript, gestures)
 		decoratedScript.canPropagate = canPropagate
 		decoratedScript.bypassInputHelp = bypassInputHelp

--- a/source/scriptHandler.py
+++ b/source/scriptHandler.py
@@ -413,6 +413,7 @@ def _registerEnglishGesture(script: types.FunctionType, gestures: list[str], des
 		scriptLogName = f"{scriptLocation}.{script.__name__}"
 		logMsg = f"{scriptLogName}: Setting gesture for via @script is now deprecated. Add the gesture to /en/gestures.ini instead."
 		import warnings
+
 		warnings.warn(logMsg, DeprecationWarning)
 	if scriptLocation not in _gestureConfig:
 		_gestureConfig[scriptLocation] = {}


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Related to #15242
Blocked by #17590

### Summary of the issue:
NVDA's gestures are mapped at run time, whenever relevant code is loaded.
In #15242 it's noted that gesture conflicts from add-ons can occur with NVDA's default gestures, a locale's gestures or a users custom gestures.
In order to detect default gesture conflicts, default gestures must be loaded before add-ons are loaded.
Custom gestures and locale gestures are already stored statically in `gestures.ini` files.


### Description of user facing changes
None - in future it may make it easier to detect gesture conflicts.

### Description of development approach

- An english `gestures.ini` file has been created to serve as the place to store default gestures statically
- Setting gestures via `@script` decorators from source is now discouraged/deprecated. Add-ons should continue to use this decorator. in future we may need to create a new interface for add-ons to register gestures and detect conflicts
- A script was created to add gestures to `gestures.ini` whenever code with a `@script` decorator is loaded when running NVDA from source. This makes it easy for devs to migrate gestures. This also warns at runtime when a gesture is added via `@script` to core.
- Basic functionality for checking conflicts is added. If an add-on has a conflict with a known script, an error is logged.
- NVDA was run from source, and run from unit tests, to generate a base `gestures.ini` file.
These gestures need to be removed manually from the relevant `@script` decorators.

### Testing strategy:

- Tested generating a `gestures.ini` file from running from source

### Known issues with pull request:

We may want to stop empty gestures from being generated, however it is useful to document these gestures.

- [ ] After #17590 is merged, this PR should be updated to add notifications for gestures and instruct translators to use the English file as a base

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [ ] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [ ] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [ ] API is compatible with existing add-ons.
- [ ] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
