### PR TITLE
Add an unassigned command to toggle periodical refresh of the Windows  OCR result

### DIFF
--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -4649,10 +4649,11 @@ class GlobalCommands(ScriptableObject):
 			disabledMsg=_("Automatic refresh disabled"),
 		)
 		from contentRecog.recogUi import RecogResultNVDAObject
+
 		focus = api.getFocusObject()
 		if isinstance(focus, RecogResultNVDAObject):
 			focus._scheduleRecognize()
-	
+
 	@script(
 		# Translators: Input help mode message for toggle report CLDR command.
 		description=_("Toggles on and off the reporting of CLDR characters, such as emojis"),

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -4632,6 +4632,28 @@ class GlobalCommands(ScriptableObject):
 		ui.message(languageHandler.getLanguageDescription(languageHandler.normalizeLanguage(lang)))
 
 	@script(
+		# Translators: Describes a command.
+		description=_("Toggle periodical refresh of a Windows OCR result"),
+	)
+	def script_toggleAutomaticRefreshOfRecogResult(self, gesture: inputCore.InputGesture) -> None:
+		if not winVersion.isUwpOcrAvailable():
+			# Translators: Reported when Windows OCR is not available.
+			ui.message(_("Windows OCR not available"))
+			return
+		toggleBooleanValue(
+			configSection="uwpOcr",
+			configKey="autoRefresh",
+			# Translators: The message announced when toggling automatic refresh of recognized content
+			enabledMsg=_("Automatic refresh enabled"),
+			# Translators: The message announced when toggling automatic refresh of recognized content
+			disabledMsg=_("Automatic refresh disabled"),
+		)
+		from contentRecog.recogUi import RecogResultNVDAObject
+		focus = api.getFocusObject()
+		if isinstance(focus, RecogResultNVDAObject):
+			focus._scheduleRecognize()
+	
+	@script(
 		# Translators: Input help mode message for toggle report CLDR command.
 		description=_("Toggles on and off the reporting of CLDR characters, such as emojis"),
 		category=SCRCAT_SPEECH,

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -43,6 +43,7 @@ This option is enabled by default, but can possibly result in shorter battery li
 If you suspect this option is negatively impacting your battery life, you're advised to disable it. (#17649, @LeonarddeR)
 * Rate boost is now supported when using Microsoft Speech API version 5 (SAPI5) and Microsoft Speech Platform voices, which supports up to 6X speed. (#17606, @gexgd0419)
 * In a recognition result, `NVDA+f5` manually refreshes the recognized content. (#17715, @CyrilleB79)
+* Added an unassigned gesture to toggle periodical refresh of the Windows OCR result.
 
 ### Changes
 


### PR DESCRIPTION
### Link to issue number:
Discussed in https://github.com/nvaccess/nvda/pull/15331#pullrequestreview-1599792792 and following
### Summary of the issue:
Most options in the UI have an associated toggle script (assigned or unassigned). In Windows OCR settings, "Periodically refresh recognized content" has no such toggle script.

### Description of user facing changes
An unassigned command has been added to toggle the value of "Periodically refresh recognized content". In an OCR result, using this script takes immediately effect.

### Description of development approach
* Use the toggle helper fonction defined for global commands.
* If the final state is enabled, schedule a new recognition
* If the final state is disabled, nothing more needs to be done, the next recognition will not schedule subsequent ones.

### Testing strategy:
Manual testing in the OCR result and out of it.
### Known issues with pull request:
None.
### Code Review Checklist:


- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
