### PR TITLE
Fix SAPI4 WASAPI implementation

### DIFF
--- a/source/synthDrivers/sapi4.py
+++ b/source/synthDrivers/sapi4.py
@@ -358,7 +358,7 @@ class SynthDriverAudio(COMObject):
 	def _getFreeSpace(self) -> int:
 		if not self._waveFormat:
 			raise ReturnHRESULT(AudioError.NEED_WAVE_FORMAT, None)
-		return self._waveFormat.nAvgBytesPerSec // 5  # always 200ms
+		return self._waveFormat.nAvgBytesPerSec * 2  # always 2 seconds
 
 	def IAudioDest_FreeSpace(self) -> tuple[DWORD, BOOL]:
 		"""Returns the number of bytes that are free in the object's internal buffer.

--- a/source/synthDrivers/sapi4.py
+++ b/source/synthDrivers/sapi4.py
@@ -214,10 +214,11 @@ class SynthDriverAudio(COMObject):
 		"""Sets the volume level, ranging from 0x0000 to 0xFFFF.
 		Low word is for the left (or mono) channel, and high word is for the right channel."""
 		self._level = dwLevel
-		if dwLevel & 0xFFFF0000:
-			self._player.setVolume(left=float(dwLevel & 0xFFFF) / 0xFFFF, right=float(dwLevel >> 16) / 0xFFFF)
-		else:
-			self._player.setVolume(all=float(dwLevel) / 0xFFFF)
+		if self._player:
+			if dwLevel & 0xFFFF0000:
+				self._player.setVolume(left=float(dwLevel & 0xFFFF) / 0xFFFF, right=float(dwLevel >> 16) / 0xFFFF)
+			else:
+				self._player.setVolume(all=float(dwLevel) / 0xFFFF)
 
 	def IAudio_PassNotify(self, pNotifyInterface: c_void_p, IIDNotifyInterface: GUID) -> None:
 		"""Passes in an implementation of IAudioDestNotifySink to receive notifications.

--- a/source/synthDrivers/sapi4.py
+++ b/source/synthDrivers/sapi4.py
@@ -202,7 +202,10 @@ class SynthDriverAudio(COMObject):
 					if isinstance(item, BookmarkT):
 						# Flush all untriggered bookmarks.
 						# 1 (TRUE) means that the bookmark is sent because of flushing.
-						self._notifySink.BookMark(item, 1)
+						try:
+							self._notifySink.BookMark(item, 1)
+						except COMError:
+							pass
 			self._audioQueue.clear()
 
 	def IAudio_LevelGet(self) -> int:
@@ -257,7 +260,10 @@ class SynthDriverAudio(COMObject):
 		self._maybeInitPlayer()
 		self._deviceClaimed = True
 		if self._notifySink:
-			self._notifySink.AudioStart()
+			try:
+				self._notifySink.AudioStart()
+			except COMError:
+				pass
 
 	def IAudio_UnClaim(self) -> None:
 		"""Releases the multimedia device asynchronously.
@@ -279,7 +285,10 @@ class SynthDriverAudio(COMObject):
 				self._player.stop()
 			self._deviceClaimed = False
 			if self._notifySink:
-				self._notifySink.AudioStop(0)  # IANSRSN_NODATA
+				try:
+					self._notifySink.AudioStop(0)  # IANSRSN_NODATA
+				except COMError:
+					pass
 
 	def IAudio_Start(self) -> None:
 		"""Starts (or resumes) playing the audio in the buffer."""
@@ -429,11 +438,17 @@ class SynthDriverAudio(COMObject):
 	def _onChunkFinished(self, chunk: AudioT):
 		self._playedBytes += len(chunk)
 		if self._notifySink:
-			self._notifySink.FreeSpace(self._getFreeSpace(), 0)
+			try:
+				self._notifySink.FreeSpace(self._getFreeSpace(), 0)
+			except COMError:
+				pass
 
 	def _onBookmark(self, dwMarkID: BookmarkT):
 		if self._notifySink:
-			self._notifySink.BookMark(dwMarkID, 0)
+			try:
+				self._notifySink.BookMark(dwMarkID, 0)
+			except COMError:
+				pass
 
 	def _finishUnClaim(self, bytePos: int):
 		"""Finishes the asynchronous UnClaim call.
@@ -448,7 +463,10 @@ class SynthDriverAudio(COMObject):
 		self._deviceClaimed = False
 		if self._notifySink:
 			# Notify when the device is finally closed
-			self._notifySink.AudioStop(0)  # IANSRSN_NODATA
+			try:
+				self._notifySink.AudioStop(0)  # IANSRSN_NODATA
+			except COMError:
+				pass
 
 
 class SynthDriverSink(COMObject):

--- a/source/synthDrivers/sapi4.py
+++ b/source/synthDrivers/sapi4.py
@@ -219,7 +219,9 @@ class SynthDriverAudio(COMObject):
 		self._level = dwLevel
 		if self._player:
 			if dwLevel & 0xFFFF0000:
-				self._player.setVolume(left=float(dwLevel & 0xFFFF) / 0xFFFF, right=float(dwLevel >> 16) / 0xFFFF)
+				self._player.setVolume(
+					left=float(dwLevel & 0xFFFF) / 0xFFFF, right=float(dwLevel >> 16) / 0xFFFF
+				)
 			else:
 				self._player.setVolume(all=float(dwLevel) / 0xFFFF)
 

--- a/source/synthDrivers/sapi4.py
+++ b/source/synthDrivers/sapi4.py
@@ -220,7 +220,8 @@ class SynthDriverAudio(COMObject):
 		if self._player:
 			if dwLevel & 0xFFFF0000:
 				self._player.setVolume(
-					left=float(dwLevel & 0xFFFF) / 0xFFFF, right=float(dwLevel >> 16) / 0xFFFF
+					left=float(dwLevel & 0xFFFF) / 0xFFFF,
+					right=float(dwLevel >> 16) / 0xFFFF,
 				)
 			else:
 				self._player.setVolume(all=float(dwLevel) / 0xFFFF)


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:

Fixes #17755. Fixes #17756.

### Summary of the issue:

Some SAPI4 voices fail to load with `'NoneType' object has no attribute 'setVolume'`.

Some SAPI4 voices such as TruVoice stopped producing sound, with no error sound or log generated.

Some SAPI4 voices work, but cause errors to be logged continuously.

### Description of user facing changes
The issues mentioned above should be fixed.

### Description of development approach

Check if `self._player` is `None` before setting the volume level in `IAudio_LevelSet`, as some voices call `LevelSet` before calling `Claim` to initialize the audio device.

Made `IAudioDest_FreeSpace` return a bigger buffer free space. Although the "free space" is actually unlimited and a fixed size of 200ms was used, 200ms is too small for some voices to send the first audio chunk, and therefore the voice will wait indefinitely for the free space to grow, which never happens. So the free space is now changed to be 2 seconds long, the minimum requirement in SAPI4 documentation.

Failure HRESULT codes returned from `_self.notifySink` should be ignored, according to the SAPI4 documentation. Those are now ignored so that no errors will be logged.

### Testing strategy:
Tested manually with TruVoice.

### Known issues with pull request:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [ ] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [ ] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
