### PR TITLE
Add a developer task issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,7 +1,0 @@
-You have arrived at the blank issue template from submitting issues.
-It is preferable to [choose a type of issue](https://github.com/nvaccess/nvda/issues/new/choose) to submit.
-Your issue may be closed if you do not follow one of the following issue templates.
-Hint: Swap to the preview tab to be able to click the links.
-Direct links to the templates:
-- [Bug report](https://github.com/nvaccess/nvda/issues/new?template=bug_report.md)
-- [Feature request](https://github.com/nvaccess/nvda/issues/new?template=feature_request.md)

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,7 @@
 ---
 name: Bug report
 about: Create a report to help us improve
+type: Bug
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/developer_facing_changes.md
+++ b/.github/ISSUE_TEMPLATE/developer_facing_changes.md
@@ -11,7 +11,7 @@ Please read the text in this edit field before filling it in.
 This template is intended for developers to document improvements or maintenance to NVDA's code base that do not have user facing changes.
 This may include API changes, technical debt removal, refactoring and maintenance tasks.
 
-If this involves a user facing change e.g. a feature or bug, please user other templates.
+If this involves a user facing change e.g. a feature or bug, please use one of our other templates.
 -->
 
 ### Related issues, PRs or discussions

--- a/.github/ISSUE_TEMPLATE/developer_facing_changes.md
+++ b/.github/ISSUE_TEMPLATE/developer_facing_changes.md
@@ -21,3 +21,7 @@ If this involves a user facing change e.g. a feature or bug, please user other t
 ### Why are changes required?
 
 ### What technical changes are required?
+
+### Are the proposed technical changes API breaking?
+
+### Are there potential risks or issues with the proposed implementation?

--- a/.github/ISSUE_TEMPLATE/developer_facing_changes.md
+++ b/.github/ISSUE_TEMPLATE/developer_facing_changes.md
@@ -1,0 +1,23 @@
+---
+name: Developer facing changes
+about: Maintenance tasks, API changes, and code changes which are not user facing changes
+type: Task
+
+---
+
+<!--
+Please read the text in this edit field before filling it in.
+
+This template is intended for developers to document improvements or maintenance to NVDA's code base that do not have user facing changes.
+This may include API changes, technical debt removal, refactoring and maintenance tasks.
+
+If this involves a user facing change e.g. a feature or bug, please user other templates.
+-->
+
+### Related issues, PRs or discussions
+
+### What is the current state of the codebase?
+
+### Why are changes required?
+
+### What technical changes are required?

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,7 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
+type: Feature
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/special_case_issue.md
+++ b/.github/ISSUE_TEMPLATE/special_case_issue.md
@@ -1,6 +1,7 @@
 ---
 name: Special Case Issue
 about: A complex or exceptional issue that doesn't fit into the usual templates
+type: Task
 
 ---
 

--- a/projectDocs/issues/githubIssueTemplateExplanationAndExamples.md
+++ b/projectDocs/issues/githubIssueTemplateExplanationAndExamples.md
@@ -10,13 +10,16 @@ If you are not familiar, please take some time to learn about
 **Warning**: In all but exceptional circumstances we require one of these templates to be completed.
 Your issue will likely be closed if a template has not been followed.
 
-We currently have four templates:
+We currently have the following templates:
 
 - For [feature requests](#feature-request-template)
 - For [bug reports](#bug-report-template)
 - For [special case issues](#special-case-issue-template) that cannot easily be categorised as either a bug report or a feature request
 - For security vulnerabilities (please note that these are reported differently, for more information see https://github.com/nvaccess/nvda/blob/master/security.md)
-
+- For developer facing changes:
+  - This template is intended for developers to document improvements or maintenance to NVDA's code base that do not have user facing changes.
+  - This may include API changes, technical debt removal, refactoring and maintenance tasks.
+  - Note there is no further guide for this - it is expected that developers can use the template appropriately.
 
 ## General information
 The following information applies to all issues and pull requests.


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
None

### Summary of the issue:

- We regularly need to create issues to track developer facing changes, but we do not have a good issue tempalte for that.
- <https://github.com/nvaccess/nvda/issues/new/> [no longer uses](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser) `.github\ISSUE_TEMPLATE.md` when we disable blank issues. So we should remove it.
- The new issue experience allows types of issues (e.g. bug, feature, task), we should use them for our issue templates

### Description of user facing changes
None

### Description of development approach
- Add an issue template for dev changes
- Remove redundant blank issue template
- add issue types to templates

