### PR TITLE
Always re-enable audio ducking when starting a new utterance

### DIFF
--- a/source/audioDucking.py
+++ b/source/audioDucking.py
@@ -111,7 +111,8 @@ def _ensureDucked():
 		_duckingRefCount += 1
 		if _isDebug():
 			log.debug("Increased ref count, _duckingRefCount=%d" % _duckingRefCount)
-		_setDuckingState(True)
+		if _audioDuckingMode != AudioDuckingMode.NONE:
+			_setDuckingState(True)
 		if _duckingRefCount == 1 and _audioDuckingMode != AudioDuckingMode.NONE:
 			delta = 0
 		else:

--- a/source/audioDucking.py
+++ b/source/audioDucking.py
@@ -111,8 +111,8 @@ def _ensureDucked():
 		_duckingRefCount += 1
 		if _isDebug():
 			log.debug("Increased ref count, _duckingRefCount=%d" % _duckingRefCount)
+		_setDuckingState(True)
 		if _duckingRefCount == 1 and _audioDuckingMode != AudioDuckingMode.NONE:
-			_setDuckingState(True)
 			delta = 0
 		else:
 			delta = time.time() - _lastDuckedTime

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -128,6 +128,7 @@ In any document, if the cursor is on the last line, it will be moved to the end 
 * The NVDA Highlighter Window icon is no longer fixed in the taskbar after restarting Explorer. (#17696, @hwf1324)
 * Fixed an issue where some SAPI4 voices (e.g. IBM TTS Chinese) cannot be loaded. (#17726, @gexgd0419)
 * In Excel, the element list dialog (`NVDA+f7`) no longer fails to list comment or formulas on some non-English systems. (#11366, @CyrilleB79)
+* NVDA can now restore the audio ducking behavior when speaking a new utterance, when another app such as Magnifier changes the behavior system-wide. (#17747, @gexgd0419)
 
 ### Changes for Developers
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:

#17747. Does not fix it completely, but makes it better.

### Summary of the issue:

When audio ducking is set to always duck, starting Magnifier overrides the audio ducking behavior, until the user changes the NVDA setting again.

### Description of user facing changes

NVDA will now change the audio ducking behavior back to "always duck" each time a new utterance is started.

Although Magnifier can still cancel audio ducking when it's started, NVDA will fix this next time it starts an utterance.

### Description of development approach

Made `_setDuckingState(True)` always executed regardless of the current ref count.

### Testing strategy:
Tested manually.

### Known issues with pull request:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [ ] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
