### PR TITLE
Revert "Add-on Store: Download without duplicates to override incompatibilities."

### DIFF
--- a/source/gui/addonStoreGui/viewModels/store.py
+++ b/source/gui/addonStoreGui/viewModels/store.py
@@ -335,8 +335,7 @@ class AddonStoreVM:
 			shouldInstall = True
 			shouldRememberChoice = True
 		if shouldInstall:
-			if listItemVM.model.overrideIncompatibility:
-				listItemVM.model.enableCompatibilityOverride()
+			listItemVM.model.enableCompatibilityOverride()
 			cls.getAddon(listItemVM)
 		return shouldInstall, shouldRememberChoice
 


### PR DESCRIPTION
### Reverts PR
Reverts #17717

### Issues fixed
<!-- Issues that will be closed by reverting, i.e. the issues introduced via the PR getting reverted  -->
Fixes #17746
Fixes #17767

### Issues reopened
<!-- Issues that will be re-opened by reverting, i.e. the issues that were fixed via the PR getting reverted  -->
Reopens #17655

### Reason for revert

Unable to install Add-ons from the Add-on Store that override incompatibilities

### Can this PR be reimplemented? If so, what is required for the next attempt
