### PR TITLE
Fix speech delay caused by audio ducking

### DIFF
--- a/source/audioDucking.py
+++ b/source/audioDucking.py
@@ -111,12 +111,12 @@ def _ensureDucked():
 		_duckingRefCount += 1
 		if _isDebug():
 			log.debug("Increased ref count, _duckingRefCount=%d" % _duckingRefCount)
-		if _audioDuckingMode != AudioDuckingMode.NONE:
-			_setDuckingState(True)
 		if _duckingRefCount == 1 and _audioDuckingMode != AudioDuckingMode.NONE:
 			delta = 0
 		else:
 			delta = time.time() - _lastDuckedTime
+		if _audioDuckingMode != AudioDuckingMode.NONE and (_duckingRefCount == 1 or delta > 1):
+			_setDuckingState(True)
 		return delta, _modeChangeEvent
 
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Fixes #17798, introduced by #17770.

### Summary of the issue:

When audio ducking is enabled, the delay before each utterance increases significantly.

### Description of user facing changes

The delay should return to a normal level compared to unaffected alpha versions.

### Description of development approach

Instead of calling `_setDuckingState` to notify the system each time `_ensureDucked` is called, check the time passed since the last ducking to limit "redundant" calls to `_setDuckingState` to at most once per second. This prevents the delay caused by calling `_setDuckingState` too many times, but still allow audio ducking state to be reset when the next utterance starts more than one second later.

### Testing strategy:
Tested manually.

### Known issues with pull request:
None.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [ ] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [ ] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
