### PR TITLE
Minor Remote Server Fixes

### DIFF
--- a/source/remoteClient/server.py
+++ b/source/remoteClient/server.py
@@ -236,7 +236,7 @@ class LocalRelayServer:
 	:ivar password: Channel password for client authentication
 	:ivar clients: Dictionary mapping sockets to Client objects
 	:ivar clientSockets: List of client sockets
-	:ivar PING_TIME: Seconds between ping messages
+	:ivar PING_TIME_SECONDS: Seconds between ping messages
 	"""
 
 	PING_TIME_SECONDS: int = 300
@@ -323,7 +323,7 @@ class LocalRelayServer:
 					self.acceptNewConnection(sock)
 					continue
 				self.clients[sock].handleData()
-			if time.time() - self.lastPingTime >= self.PING_TIME:
+			if time.time() - self.lastPingTime >= self.PING_TIME_SECONDS:
 				for client in self.clients.values():
 					if client.authenticated:
 						client.send(type=RemoteMessageType.PING)

--- a/source/remoteClient/server.py
+++ b/source/remoteClient/server.py
@@ -295,7 +295,7 @@ class LocalRelayServer:
 		sslContext = self.certManager.createSSLContext()
 		serverSocket = sslContext.wrap_socket(serverSocket, server_side=True)
 		serverSocket.bind(bindAddress)
-		serverSocket.listen(backlog=5)  # Set the maximum number of queued connections
+		serverSocket.listen(5)  # Set the maximum number of queued connections
 		return serverSocket
 
 	def run(self) -> None:


### PR DESCRIPTION
### Link to issue number:
Minor fixes to previous PR #17580

### Summary of the issue:
This PR addresses inconsistencies in the `LocalRelayServer` class in the remote client server implementation. There were variable naming discrepancies and an incorrect method parameter format that needed to be fixed.

### Description of user facing changes
No user-facing changes. These are purely internal code consistency fixes.

### Description of development approach
The changes correct three minor issues:
1. Updated a variable reference in documentation from `PING_TIME` to `PING_TIME_SECONDS` to match the actual variable name
2. Fixed the reference to `PING_TIME` in the code to use the correct variable name `PING_TIME_SECONDS`
3. Updated the `listen()` method call to use positional arguments instead of keyword arguments for better backward compatibility

### Testing strategy:
Verified that the remote client server still functions correctly with these changes. The server successfully:
- Establishes connections
- Authenticates clients
- Sends ping messages at the expected intervals
- Actually works

### Known issues with pull request:
None
