### PR TITLE
fix typing in baseObject.ScriptableType

### DIFF
--- a/source/baseObject.py
+++ b/source/baseObject.py
@@ -183,7 +183,7 @@ class AutoPropertyObject(garbageHandler.TrackedObject, metaclass=AutoPropertyTyp
 class ScriptableType(AutoPropertyType):
 	"""A metaclass used for collecting and caching gestures on a ScriptableObject"""
 
-	def __new__(cls, name: str, bases: tuple[type, ...], dict: [str, Any], /, **kwargs: Any):
+	def __new__(cls, name: str, bases: tuple[type, ...], dict: dict[str, Any], /, **kwargs: Any):
 		newCls = super().__new__(cls, name, bases, dict, **kwargs)
 		gesturesDictName = "_%s__gestures" % newCls.__name__
 		# #8463: To avoid name mangling conflicts, create a copy of the __gestures dictionary.


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:

Follow-up to 17744

### Summary of the issue:

As pointed out in https://github.com/nvaccess/nvda/pull/17744#discussion_r1988168944, the type hint for the `dict` argument to `baseObject.ScriptableType.__new__` is incorrectly `[str, Any]` since #17744 was merged.

### Description of user facing changes

None.

### Description of development approach

Corrected the type annotation to `dict[str, Any]`.

### Testing strategy:

Automated tests via CI.

### Known issues with pull request:

None.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
