### PR TITLE
Fix installing a downloaded update

### DIFF
--- a/source/updateCheck.py
+++ b/source/updateCheck.py
@@ -779,12 +779,12 @@ class UpdateDownloader(garbageHandler.TrackedObject):
 		from addonAPIVersion import getAPIVersionTupleFromString
 
 		self.updateInfo = updateInfo
-		self.urls = updateInfo.launcher_url.split(" ")
+		self.urls = updateInfo.launcherUrl.split(" ")
 		self.version = updateInfo.version
-		self.apiVersion = getAPIVersionTupleFromString(updateInfo.api_version)
-		self.backCompatToAPIVersion = getAPIVersionTupleFromString(updateInfo.api_compat_to)
+		self.apiVersion = getAPIVersionTupleFromString(updateInfo.apiVersion)
+		self.backCompatToAPIVersion = getAPIVersionTupleFromString(updateInfo.apiCompatTo)
 		self.versionTuple = None
-		self.fileHash = updateInfo.launcher_hash
+		self.fileHash = updateInfo.launcherHash
 		self.destPath = _createEmptyTempFileForDeletingFile(prefix="nvda_update_", suffix=".exe")
 
 	def start(self):


### PR DESCRIPTION
### Link to issue number:

Fixes #17811
Follow-up to #17310

### Summary of the issue:

Attempting to install a just-downloaded update fails on latest alphas.

### Description of user facing changes

Update installation should work again

### Description of development approach

Fixed several instances of property access on the `UpdateInfo` object using snake_case instead of camelCase.

### Testing strategy:

Created a portable from source, spoofing the version and update version type:

```ps
./scons source version=2024.1 updateVersionType=stable
```

Ran the following tests:

1. Update and install immediately
   1. Launch the portable
   1. Check for updates, and download the update
   1. When prompted, choose to install the update
   1. Wait for the launcher to run, then cancel by answering No when asked whether to update the portable
1. Update and install later manually
   1. Launch the portable
   1. Check for updates, and download the update
   1. When prompted, choose to postpone the update
   1. Exit NVDA via the exit dialog, and choose to install the pending update
   1. Wait for the launcher to run, then cancel by answering No when asked whether to update the portable
1. Update and install later when prompted
   1. Launch the portable
   1. Check for updates, and download the update
   1. When prompted, choose to postpone the update
   1. Restart the portable
   1. When prompted, choose to install the pending update
   1. Wait for the launcher to run, then cancel by answering No when asked whether to update the portable

### Known issues with pull request:

None.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
