### PR TITLE
Improve the UX of Remote

### DIFF
--- a/source/config/configFlags.py
+++ b/source/config/configFlags.py
@@ -294,3 +294,23 @@ class ParagraphStartMarker(DisplayStringStrEnum):
 			# Ensure this is consistent with other strings with the context "paragraphMarker".
 			self.PILCROW: pgettext("paragraphMarker", "Pilcrow (¶)"),
 		}
+
+
+class RemoteConnectionType(DisplayStringIntEnum):
+	"""Enumeration containing the possible remote connection types (roles for connected clients).
+
+	Use RemoteConnectionType.MEMBER.value to compare with the config;
+	use RemoteConnectionType.MEMBER.displayString in the UI for a translatable description of this member.
+	"""
+
+	FOLLOWER = 0
+	LEADER = 1
+
+	@property
+	def _displayStringLabels(self):
+		return {
+			# Translators: Allow this computer to be controlled by the remote computer.
+			RemoteConnectionType.FOLLOWER: pgettext("Remote", "Allow this machine to be controlled"),
+			# Translators: Allow this computer to control the remote computer.
+			RemoteConnectionType.LEADER: pgettext("remote", "Control another machine"),
+		}


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:

### Summary of the issue:

### Description of user facing changes

### Description of development approach

### Testing strategy:

### Known issues with pull request:

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [ ] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [ ] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [ ] API is compatible with existing add-ons.
- [ ] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
