### PR TITLE
Add ability to disable Remote

### DIFF
--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -347,6 +347,7 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 
 # Remote Settings
 [remote]
+	enabled = boolean(default=False)
 	[[connections]]
 		last_connected = list(default=list())
 	[[controlserver]]

--- a/source/core.py
+++ b/source/core.py
@@ -900,9 +900,8 @@ def main():
 
 	import remoteClient
 
-	if config.conf["remote"]["enabled"]:
-		log.debug("Initializing remote client")
-		remoteClient.initialize()
+	# if config.conf["remote"]["enabled"]:
+	remoteClient.initialize()
 
 	if globalVars.appArgs.install or globalVars.appArgs.installSilent:
 		import gui.installerGui
@@ -1056,8 +1055,8 @@ def main():
 			" This likely indicates NVDA is exiting due to WM_QUIT.",
 		)
 		queueHandler.pumpAll()
-	if remoteClient.remoteRunning():
-		_terminate(remoteClient)
+	# if remoteClient.remoteRunning():
+	_terminate(remoteClient)
 	_terminate(gui)
 	config.saveOnExit()
 

--- a/source/core.py
+++ b/source/core.py
@@ -548,6 +548,7 @@ def _handleNVDAModuleCleanupBeforeGUIExit():
 	import brailleViewer
 	import globalPluginHandler
 	import watchdog
+	import remoteClient
 
 	try:
 		import updateCheck
@@ -563,6 +564,8 @@ def _handleNVDAModuleCleanupBeforeGUIExit():
 	_terminate(globalPluginHandler)
 	# the brailleViewer should be destroyed safely before closing the window
 	brailleViewer.destroyBrailleViewer()
+	# Terminating remote causes it to clean up its menus, so do it here while they still exist
+	_terminate(remoteClient)
 
 
 def _initializeObjectCaches():
@@ -900,7 +903,6 @@ def main():
 
 	import remoteClient
 
-	# if config.conf["remote"]["enabled"]:
 	remoteClient.initialize()
 
 	if globalVars.appArgs.install or globalVars.appArgs.installSilent:
@@ -1055,8 +1057,6 @@ def main():
 			" This likely indicates NVDA is exiting due to WM_QUIT.",
 		)
 		queueHandler.pumpAll()
-	# if remoteClient.remoteRunning():
-	_terminate(remoteClient)
 	_terminate(gui)
 	config.saveOnExit()
 

--- a/source/core.py
+++ b/source/core.py
@@ -898,10 +898,11 @@ def main():
 	log.debug("Initializing global plugin handler")
 	globalPluginHandler.initialize()
 
-	log.debug("Initializing remote client")
 	import remoteClient
 
-	remoteClient.initialize()
+	if config.conf["remote"]["enabled"]:
+		log.debug("Initializing remote client")
+		remoteClient.initialize()
 
 	if globalVars.appArgs.install or globalVars.appArgs.installSilent:
 		import gui.installerGui
@@ -1055,7 +1056,8 @@ def main():
 			" This likely indicates NVDA is exiting due to WM_QUIT.",
 		)
 		queueHandler.pumpAll()
-	_terminate(remoteClient)
+	if remoteClient.remoteRunning():
+		_terminate(remoteClient)
 	_terminate(gui)
 	config.saveOnExit()
 

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -4982,7 +4982,7 @@ class GlobalCommands(ScriptableObject):
 
 	@script(
 		# Translators: Describes the command that creates a remote session, or disconnects it if one already exists.
-		description=pgettext("Remote Access", "Toggle Remote connection"),
+		description=pgettext("remote", "Toggle Remote connection"),
 		category=SCRCAT_REMOTE,
 		gesture="kb:NVDA+alt+r",
 	)

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -4982,10 +4982,11 @@ class GlobalCommands(ScriptableObject):
 
 	@script(
 		# Translators: Describes the command that creates a remote session, or disconnects it if one already exists.
-		"Toggle Remote connection",
+		description=pgettext("Remote Access", "Toggle Remote connection"),
 		category=SCRCAT_REMOTE,
 		gesture="kb:NVDA+alt+r",
 	)
+	@gui.blockAction.when(gui.blockAction.Context.REMOTE_ACCESS_DISABLED)
 	def script_toggleRemoteConnection(self, gesture: "inputCore.InputGesture") -> None:
 		if remoteClient._remoteClient.isConnected():
 			self.script_disconnectFromRemote(gesture)

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -130,6 +130,8 @@ SCRCAT_REMOTE = _("Remote")
 NO_SETTINGS_MSG = _("No settings")
 # Translators: Reported when there is no selection
 NO_SELECTION_MESSAGE = _("No selection")
+# Translators: Reported when attempting to execute a Remote Access gesture when Remote Access is disabled.
+REMOTE_DISABLED_MESSAGE: str = _("Action unavailable while Remote Access is disabled.")
 
 
 def toggleBooleanValue(
@@ -4923,7 +4925,10 @@ class GlobalCommands(ScriptableObject):
 		category=SCRCAT_REMOTE,
 	)
 	def script_toggleRemoteMute(self, gesture: "inputCore.InputGesture"):
-		remoteClient._remoteClient.toggleMute()
+		if remoteClient.remoteRunning():
+			remoteClient._remoteClient.toggleMute()
+		else:
+			ui.message(REMOTE_DISABLED_MESSAGE)
 
 	@script(
 		gesture="kb:control+shift+NVDA+c",
@@ -4932,7 +4937,10 @@ class GlobalCommands(ScriptableObject):
 		description=_("Sends the contents of the clipboard to the remote machine"),
 	)
 	def script_pushClipboard(self, gesture: "inputCore.InputGesture"):
-		remoteClient._remoteClient.pushClipboard()
+		if remoteClient.remoteRunning():
+			remoteClient._remoteClient.pushClipboard()
+		else:
+			ui.message(REMOTE_DISABLED_MESSAGE)
 
 	@script(
 		# Translators: Documentation string for the script that copies a link to the remote session to the clipboard.
@@ -4940,9 +4948,12 @@ class GlobalCommands(ScriptableObject):
 		category=SCRCAT_REMOTE,
 	)
 	def script_copyRemoteLink(self, gesture: "inputCore.InputGesture"):
-		remoteClient._remoteClient.copyLink()
-		# Translators: A message indicating that a link has been copied to the clipboard.
-		ui.message(_("Copied link"))
+		if remoteClient.remoteRunning():
+			remoteClient._remoteClient.copyLink()
+			# Translators: A message indicating that a link has been copied to the clipboard.
+			ui.message(_("Copied link"))
+		else:
+			ui.message(REMOTE_DISABLED_MESSAGE)
 
 	@script(
 		gesture="kb:alt+NVDA+pageDown",
@@ -4952,11 +4963,14 @@ class GlobalCommands(ScriptableObject):
 	)
 	@gui.blockAction.when(gui.blockAction.Context.SECURE_MODE)
 	def script_disconnectFromRemote(self, gesture: "inputCore.InputGesture"):
-		if not remoteClient._remoteClient.isConnected:
-			# Translators: A message indicating that the remote client is not connected.
-			ui.message(_("Not connected"))
-			return
-		remoteClient._remoteClient.disconnect()
+		if remoteClient.remoteRunning():
+			if not remoteClient._remoteClient.isConnected:
+				# Translators: A message indicating that the remote client is not connected.
+				ui.message(_("Not connected"))
+				return
+			remoteClient._remoteClient.disconnect()
+		else:
+			ui.message(REMOTE_DISABLED_MESSAGE)
 
 	@script(
 		gesture="kb:alt+NVDA+pageUp",
@@ -4967,11 +4981,14 @@ class GlobalCommands(ScriptableObject):
 	@gui.blockAction.when(gui.blockAction.Context.MODAL_DIALOG_OPEN)
 	@gui.blockAction.when(gui.blockAction.Context.SECURE_MODE)
 	def script_connectToRemote(self, gesture: "inputCore.InputGesture"):
-		if remoteClient._remoteClient.isConnected() or remoteClient._remoteClient.connecting:
-			# Translators: A message indicating that the remote client is already connected.
-			ui.message(_("Already connected"))
-			return
-		remoteClient._remoteClient.doConnect()
+		if remoteClient.remoteRunning():
+			if remoteClient._remoteClient.isConnected() or remoteClient._remoteClient.connecting:
+				# Translators: A message indicating that the remote client is already connected.
+				ui.message(_("Already connected"))
+				return
+			remoteClient._remoteClient.doConnect()
+		else:
+			ui.message(REMOTE_DISABLED_MESSAGE)
 
 	@script(
 		# Translators: Documentation string for the script that toggles the control between guest and host machine.
@@ -4980,7 +4997,10 @@ class GlobalCommands(ScriptableObject):
 		gesture="kb:NVDA+f11",
 	)
 	def script_sendKeys(self, gesture: "inputCore.InputGesture"):
-		remoteClient._remoteClient.toggleRemoteKeyControl(gesture)
+		if remoteClient.remoteRunning():
+			remoteClient._remoteClient.toggleRemoteKeyControl(gesture)
+		else:
+			ui.message(REMOTE_DISABLED_MESSAGE)
 
 
 #: The single global commands instance.

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -130,8 +130,6 @@ SCRCAT_REMOTE = _("Remote")
 NO_SETTINGS_MSG = _("No settings")
 # Translators: Reported when there is no selection
 NO_SELECTION_MESSAGE = _("No selection")
-# Translators: Reported when attempting to execute a Remote Access gesture when Remote Access is disabled.
-REMOTE_DISABLED_MESSAGE: str = _("Action unavailable while Remote Access is disabled.")
 
 
 def toggleBooleanValue(
@@ -4921,14 +4919,12 @@ class GlobalCommands(ScriptableObject):
 
 	@script(
 		# Translators: Describes a command.
-		description=_("""Mute or unmute the speech coming from the remote computer"""),
+		description=_("Mute or unmute the speech coming from the remote computer"),
 		category=SCRCAT_REMOTE,
 	)
+	@gui.blockAction.when(gui.blockAction.Context.REMOTE_ACCESS_DISABLED)
 	def script_toggleRemoteMute(self, gesture: "inputCore.InputGesture"):
-		if remoteClient.remoteRunning():
-			remoteClient._remoteClient.toggleMute()
-		else:
-			ui.message(REMOTE_DISABLED_MESSAGE)
+		remoteClient._remoteClient.toggleMute()
 
 	@script(
 		gesture="kb:control+shift+NVDA+c",
@@ -4936,24 +4932,20 @@ class GlobalCommands(ScriptableObject):
 		# Translators: Documentation string for the script that sends the contents of the clipboard to the remote machine.
 		description=_("Sends the contents of the clipboard to the remote machine"),
 	)
+	@gui.blockAction.when(gui.blockAction.Context.REMOTE_ACCESS_DISABLED)
 	def script_pushClipboard(self, gesture: "inputCore.InputGesture"):
-		if remoteClient.remoteRunning():
-			remoteClient._remoteClient.pushClipboard()
-		else:
-			ui.message(REMOTE_DISABLED_MESSAGE)
+		remoteClient._remoteClient.pushClipboard()
 
 	@script(
 		# Translators: Documentation string for the script that copies a link to the remote session to the clipboard.
-		description=_("""Copies a link to the remote session to the clipboard"""),
+		description=_("Copies a link to the remote session to the clipboard"),
 		category=SCRCAT_REMOTE,
 	)
+	@gui.blockAction.when(gui.blockAction.Context.REMOTE_ACCESS_DISABLED)
 	def script_copyRemoteLink(self, gesture: "inputCore.InputGesture"):
-		if remoteClient.remoteRunning():
-			remoteClient._remoteClient.copyLink()
-			# Translators: A message indicating that a link has been copied to the clipboard.
-			ui.message(_("Copied link"))
-		else:
-			ui.message(REMOTE_DISABLED_MESSAGE)
+		remoteClient._remoteClient.copyLink()
+		# Translators: A message indicating that a link has been copied to the clipboard.
+		ui.message(_("Copied link"))
 
 	@script(
 		gesture="kb:alt+NVDA+pageDown",
@@ -4961,34 +4953,34 @@ class GlobalCommands(ScriptableObject):
 		# Translators: Documentation string for the script that disconnects a remote session.
 		description=_("Disconnect a remote session"),
 	)
-	@gui.blockAction.when(gui.blockAction.Context.SECURE_MODE)
+	@gui.blockAction.when(
+		gui.blockAction.Context.REMOTE_ACCESS_DISABLED,
+		gui.blockAction.Context.SECURE_MODE,
+	)
 	def script_disconnectFromRemote(self, gesture: "inputCore.InputGesture"):
-		if remoteClient.remoteRunning():
-			if not remoteClient._remoteClient.isConnected:
-				# Translators: A message indicating that the remote client is not connected.
-				ui.message(_("Not connected"))
-				return
-			remoteClient._remoteClient.disconnect()
-		else:
-			ui.message(REMOTE_DISABLED_MESSAGE)
+		if not remoteClient._remoteClient.isConnected:
+			# Translators: A message indicating that the remote client is not connected.
+			ui.message(_("Not connected"))
+			return
+		remoteClient._remoteClient.disconnect()
 
 	@script(
 		gesture="kb:alt+NVDA+pageUp",
 		# Translators: Documentation string for the script that invokes the remote session.
-		description=_("""Connect to a remote computer"""),
+		description=_("Connect to a remote computer"),
 		category=SCRCAT_REMOTE,
 	)
-	@gui.blockAction.when(gui.blockAction.Context.MODAL_DIALOG_OPEN)
-	@gui.blockAction.when(gui.blockAction.Context.SECURE_MODE)
+	@gui.blockAction.when(
+		gui.blockAction.Context.REMOTE_ACCESS_DISABLED,
+		gui.blockAction.Context.MODAL_DIALOG_OPEN,
+		gui.blockAction.Context.SECURE_MODE,
+	)
 	def script_connectToRemote(self, gesture: "inputCore.InputGesture"):
-		if remoteClient.remoteRunning():
-			if remoteClient._remoteClient.isConnected() or remoteClient._remoteClient.connecting:
-				# Translators: A message indicating that the remote client is already connected.
-				ui.message(_("Already connected"))
-				return
-			remoteClient._remoteClient.doConnect()
-		else:
-			ui.message(REMOTE_DISABLED_MESSAGE)
+		if remoteClient._remoteClient.isConnected() or remoteClient._remoteClient.connecting:
+			# Translators: A message indicating that the remote client is already connected.
+			ui.message(_("Already connected"))
+			return
+		remoteClient._remoteClient.doConnect()
 
 	@script(
 		# Translators: Documentation string for the script that toggles the control between guest and host machine.
@@ -4996,11 +4988,9 @@ class GlobalCommands(ScriptableObject):
 		category=SCRCAT_REMOTE,
 		gesture="kb:NVDA+f11",
 	)
+	@gui.blockAction.when(gui.blockAction.Context.REMOTE_ACCESS_DISABLED)
 	def script_sendKeys(self, gesture: "inputCore.InputGesture"):
-		if remoteClient.remoteRunning():
-			remoteClient._remoteClient.toggleRemoteKeyControl(gesture)
-		else:
-			ui.message(REMOTE_DISABLED_MESSAGE)
+		remoteClient._remoteClient.toggleRemoteKeyControl(gesture)
 
 
 #: The single global commands instance.

--- a/source/gui/blockAction.py
+++ b/source/gui/blockAction.py
@@ -38,6 +38,14 @@ def _modalDialogOpenCallback():
 		MessageDialog.focusBlockingInstances()
 
 
+def _isRemoteAccessDisabled() -> bool:
+	"""Whether Remote Access functionality is **disabled**."""
+	# Import late to avoid circular import
+	from remoteClient import remoteRunning
+
+	return not remoteRunning()
+
+
 @dataclass
 class _Context:
 	blockActionIf: Callable[[], bool]
@@ -79,6 +87,11 @@ class Context(_Context, Enum):
 		lambda: config.conf["braille"]["mode"] == BrailleMode.SPEECH_OUTPUT.value,
 		# Translators: Reported when trying to toggle an unsupported setting in speech output mode.
 		_("Action unavailable while the braille mode is set to speech output"),
+	)
+	REMOTE_ACCESS_DISABLED = (
+		_isRemoteAccessDisabled,
+		# Translators: Reported when an action cannot be performed because Remote Access functionality is disabled.
+		_("Action unavailable when Remote Access is disabled"),
 	)
 
 

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -3381,10 +3381,10 @@ class RemoteSettingsPanel(SettingsPanel):
 
 	def makeSettings(self, sizer):
 		self.config = configuration.getRemoteConfig()
-		import gui.guiHelper
 
 		sHelper = gui.guiHelper.BoxSizerHelper(self, sizer=sizer)
-		self.enableRemote = sHelper.addItem(wx.CheckBox(self, label="Enable Remote Access"))
+		# Translators: Label of a checkbox in Remote's settings
+		self.enableRemote = sHelper.addItem(wx.CheckBox(self, label=_("Enable Remote Access")))
 		self.enableRemote.SetValue(self.config["enabled"])
 		self.autoconnect = wx.CheckBox(
 			parent=self,
@@ -3528,10 +3528,8 @@ class RemoteSettingsPanel(SettingsPanel):
 			import remoteClient
 
 			if enabled and not remoteClient.remoteRunning():
-				log.debug("Initializing Remote")
 				remoteClient.initialize()
 			elif not enabled and remoteClient.remoteRunning():
-				log.debug("Terminating remote")
 				remoteClient.terminate()
 
 

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -3381,7 +3381,11 @@ class RemoteSettingsPanel(SettingsPanel):
 
 	def makeSettings(self, sizer):
 		self.config = configuration.getRemoteConfig()
+		import gui.guiHelper
+
 		sHelper = gui.guiHelper.BoxSizerHelper(self, sizer=sizer)
+		self.enableRemote = sHelper.addItem(wx.CheckBox(self, label="Enable Remote Access"))
+		self.enableRemote.SetValue(self.config["enabled"])
 		self.autoconnect = wx.CheckBox(
 			parent=self,
 			id=wx.ID_ANY,
@@ -3517,6 +3521,18 @@ class RemoteSettingsPanel(SettingsPanel):
 			cs["port"] = int(self.port.GetValue())
 		cs["key"] = self.key.GetValue()
 		self.config["ui"]["play_sounds"] = self.playSounds.GetValue()
+		enabled = self.enableRemote.GetValue()
+		oldEnabled = self.config["enabled"]
+		self.config["enabled"] = enabled
+		if enabled != oldEnabled:
+			import remoteClient
+
+			if enabled and not remoteClient.remoteRunning():
+				log.debug("Initializing Remote")
+				remoteClient.initialize()
+			elif not enabled and remoteClient.remoteRunning():
+				log.debug("Terminating remote")
+				remoteClient.terminate()
 
 
 class TouchInteractionPanel(SettingsPanel):

--- a/source/remoteClient/__init__.py
+++ b/source/remoteClient/__init__.py
@@ -20,5 +20,10 @@ def initialize():
 def terminate():
 	"""Terminate the remote client."""
 	global _remoteClient
-	_remoteClient.terminate()
-	_remoteClient = None
+	if _remoteClient is not None:
+		_remoteClient.terminate()
+		_remoteClient = None
+
+
+def remoteRunning() -> bool:
+	return _remoteClient is not None

--- a/source/remoteClient/__init__.py
+++ b/source/remoteClient/__init__.py
@@ -2,8 +2,10 @@
 # Copyright (C) 2015-2025 NV Access Limited, Christopher Toth, Tyler Spivey, Babbage B.V., David Sexton and others.
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
+from logHandler import log
 
 from .client import RemoteClient
+from .configuration import getRemoteConfig
 
 _remoteClient: RemoteClient = None
 
@@ -11,8 +13,12 @@ _remoteClient: RemoteClient = None
 def initialize():
 	"""Initialise the remote client."""
 	global _remoteClient
+	if not getRemoteConfig()["enabled"]:
+		log.debug("Remote Access disabled. Not initializing.")
+		return
 	import globalCommands
 
+	log.debug("Initializing Remote Access")
 	_remoteClient = RemoteClient()
 	_remoteClient.registerLocalScript(globalCommands.commands.script_sendKeys)
 
@@ -20,9 +26,12 @@ def initialize():
 def terminate():
 	"""Terminate the remote client."""
 	global _remoteClient
-	if _remoteClient is not None:
-		_remoteClient.terminate()
-		_remoteClient = None
+	if _remoteClient is None:
+		log.debug("Remote Access not running.")
+		return
+	log.debug("Terminating Remote Access")
+	_remoteClient.terminate()
+	_remoteClient = None
 
 
 def remoteRunning() -> bool:

--- a/source/remoteClient/client.py
+++ b/source/remoteClient/client.py
@@ -103,7 +103,9 @@ class RemoteClient:
 		self.disconnect()
 		self.localMachine.terminate()
 		self.localMachine = None
-		self.menu = None
+		if self.menu is not None:
+			self.menu.terminate()
+			self.menu = None
 		self.localScripts.clear()
 		core.postNvdaStartup.unregister(self.performAutoconnect)
 		inputCore.decide_handleRawKey.unregister(self.processKeyInput)

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -3692,11 +3692,11 @@ Once the session is active, you can switch between controlling the remote comput
 ### Remote Access Key Commands Summary {#RemoteAccessGestures}
 
 <!-- KC:beginInclude -->
-| Action                   | Key Command          | Description                               |
-|--------------------------|----------------------|-------------------------------------------|
-| Toggle Control           | `NVDA+f11`               | Switch between controlling and local.     |
-| Push Clipboard           | `NVDA+ctrl+shift+c`        | Send clipboard text to the other machine. |
-| Connect or disconnect | `NVDA+alt+r`| If a remote session is in progress, disconnect from it. Otherwise, start a new Remote session. |
+| Action | Key Command | Description |
+|---|---|---|
+| Toggle control | `NVDA+f11` | Switch between controlling the local and remote computer. |
+| Push clipboard | `NVDA+ctrl+shift+c` | Send clipboard text to the other computer. |
+| Connect or disconnect | `NVDA+alt+r` | If a remote session is in progress, disconnect from it. Otherwise, start a new Remote session. |
 <!-- KC:endInclude -->
 
 You can assign further commands in the Remote section of the [Input Gestures dialog](#InputGestures).

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -3696,7 +3696,7 @@ Once the session is active, you can switch between controlling the remote comput
 |---|---|---|
 | Toggle control | `NVDA+f11` | Switch between controlling the local and remote computer. |
 | Push clipboard | `NVDA+ctrl+shift+c` | Send clipboard text to the other computer. |
-| Connect or disconnect | `NVDA+alt+r` | If a remote session is in progress, disconnect from it. Otherwise, start a new Remote session. |
+| Connect or disconnect | `NVDA+alt+r` | If a remote session is in progress, disconnect from it. Otherwise, start a new remote session. |
 <!-- KC:endInclude -->
 
 You can assign further commands in the Remote section of the [Input Gestures dialog](#InputGestures).


### PR DESCRIPTION
### Link to issue number:

Closes #17791

### Summary of the issue:

In some cases, it may be desireable to disable NVDA's Remote Access functionality entirely. Before this PR, this was not possible.

### Description of user facing changes

A checkbox has been added in Remote settings to enable/disable Remote. When remote is disabled, the entire feature is unavailable.
As users cannot access the Remote settings panel in secure mode, sysadmins can prevent users from using this feature in secure environments by ensuring the feature is disabled, and forcing secure mode.
Remote is disabled by default.

### Description of development approach

Added a boolean config item, `config.conf["remote"]["enabled"]`, which sets whether or not Remote is enabled. When initialising NVDA, check this item is `True` before calling `remoteClient.initialize`.

Added a new function, `remoteRunning`, to `remoteClient`. When terminating NVDA, if `remoteClient.remoteRunning` returns `True`, call `remoteClient.terminate()`.

Added a checkbox to `RemoteSettingsPanel` to enable/disable remote. When saving settings, if the value of `config.conf["remote"]["enabled"] has changed, initialize or terminate Remote, as appropriate.

Updated `remoteClient.client.RemoteClient.terminate` to `terminate` its `menu`, if it has one.

Added a `gui.blockAction.Context` member, `REMOTE_ACCESS_DISABLED`, to block performing gestures when Remote is disabled. Decorated Remote's gestures with this block action.

### Remaining questions:

1. Secure desktops
   - We want remote to be disabled by default
   - We want remote to work on secure desktops, if the user has reached the secure desktop while a remote session was active
   - If we disable remote by default, that means it will be disabled on secure desktops, so this won't work
   - Even in organisations where they want Remote to be available, or don't force secure mode, users probably can't save their config to secure desktops
   - You cannot initiate a Remote connection on secure screens, only continue an already running one, so an option could be to default to enabling Remote on secure screens
   - If that is the case, how do we force it to disabled on secure screens?

### Testing strategy:

Started and quit NVDA with Remote enabled and disabled.

Started NVDA with Remote enabled, disabled it through settings, and attempted to use Remote.

Started NVDA with Remote disabled, enabled Remote, and established a connection.

### Known issues with pull request:

None known.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
