### PR TITLE
GUI message when the configuration cannot be saved

### DIFF
--- a/source/config/__init__.py
+++ b/source/config/__init__.py
@@ -751,6 +751,9 @@ class ConfigManager(object):
 		except PermissionError as e:
 			log.warning("Error saving configuration; probably read only file system", exc_info=True)
 			raise e
+		except Exception as e:
+			log.warning("Error saving configuration", exc_info=True)
+			raise e
 		post_configSave.notify()
 
 	def reset(self, factoryDefaults=False):

--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -234,6 +234,14 @@ class MainFrame(wx.Frame):
 				_("Error"),
 				wx.OK | wx.ICON_ERROR,
 			)
+		except Exception:
+			messageBox(
+				# Translators: Message shown when current configuration cannot be saved, for an unknown reason.
+				_("Could not save configuration; see the log for more details."),
+				# Translators: the title of an error message dialog
+				_("Error"),
+				wx.OK | wx.ICON_ERROR,
+			)
 
 	@blockAction.when(blockAction.Context.MODAL_DIALOG_OPEN)
 	def popupSettingsDialog(self, dialog: Type[SettingsDialog], *args, **kwargs):


### PR DESCRIPTION
### Link to issue number:
None
### Summary of the issue:
When trying to save a string containing both `"""` and `'''`, it fails due to configobj not supporting this. But the user is not warned, only a warning and an error are logged.

Example:
* Open advanced settings
* In Regular expression for text paragraph navigation, add `'''"""` at the end of the regexp.
* Press OK
* Press NVDA+control+C to save the config.

### Description of user facing changes
When the user manually saves the config (`NVDA+control+C` or NVDA menu -> Save configuration), an error message error is displayed in case saving the config fails.

### Description of development approach
* In addition to `PermissionError` which correspond to a specific use case, catch any `Exception` for other unexpected use case and display the appropriate message. For now, the root issue does not need to be fixed since it does not correspond to a real use case, i.e. using `"""` and `'''` in the paragraph nav regexp is not expected in real life.
* No change log for this fix which does not apply to a real-life use case from what I know.

### Testing strategy:
Manual test of the example described in the "Summary of the issue" of this PR's description.
### Known issues with pull request:
None
### Code Review Checklist:


- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
