### PR TITLE
Images with role=math but no actual mathml should be treated as normal images

### DIFF
--- a/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.cpp
+++ b/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.cpp
@@ -609,6 +609,19 @@ VBufStorage_fieldNode_t* GeckoVBufBackend_t::fillVBuf(
 		}
 	}
 
+	// Force equation role back to graphic role if the underlying tag is img.
+	// #16007: Many publishers were setting role=math on images with alt text.
+	// We want to just treat these as normal images.
+	// We do this very early in the rendering so that all our graphic rules apply.
+	if(role == ROLE_SYSTEM_EQUATION) {
+		if(auto it = IA2AttribsMap.find(L"tag");
+			it != IA2AttribsMap.end()
+			&&it->second==L"img"
+		) {
+			role = ROLE_SYSTEM_GRAPHIC;
+		}
+	}
+
 	if (roleString) {
 		roleAttr = roleString;
 	} else {

--- a/source/NVDAObjects/IAccessible/ia2Web.py
+++ b/source/NVDAObjects/IAccessible/ia2Web.py
@@ -373,6 +373,18 @@ class Math(Ia2Web):
 			)
 			raise LookupError
 
+	def _get_role(self):
+		if self.IA2Attributes.get('tag') == 'img':
+			try:
+				mathMl = self.mathMl
+			except LookupError:
+				mathMl = None
+			if mathMl is None:
+				# #16007: Many publishers were setting role=math on plain images with alt text.
+				# We want to just treat these as normal images.
+				return controlTypes.Role.GRAPHIC
+		return super().role
+
 
 class Switch(Ia2Web):
 	# role="switch" gets mapped to IA2_ROLE_TOGGLE_BUTTON, but it uses the

--- a/source/NVDAObjects/IAccessible/ia2Web.py
+++ b/source/NVDAObjects/IAccessible/ia2Web.py
@@ -374,7 +374,7 @@ class Math(Ia2Web):
 			raise LookupError
 
 	def _get_role(self):
-		if self.IA2Attributes.get('tag') == 'img':
+		if self.IA2Attributes.get("tag") == "img":
 			try:
 				mathMl = self.mathMl
 			except LookupError:

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -134,6 +134,7 @@ In any document, if the cursor is on the last line, it will be moved to the end 
 * Fixed an issue where some SAPI4 voices (e.g. IBM TTS Chinese) cannot be loaded. (#17726, @gexgd0419)
 * In Excel, the element list dialog (`NVDA+f7`) no longer fails to list comment or formulas on some non-English systems. (#11366, @CyrilleB79)
 * NVDA can now restore the audio ducking behavior when speaking a new utterance, when another app such as Magnifier changes the behavior system-wide. (#17747, @gexgd0419)
+* Math equations only represented by an image and alt text with no mathml for rich navigation, are now treated like normal images, rather than math with no content, allowing the user to jump to them with `g` and to be able to arrow through the alt text by character. (#16007)
 
 ### Changes for Developers
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Fixes #16007

### Summary of the issue:
In the past, many content publishers have been representing math equations is an image along with alt text containing some kind of plain-text math representation, rather than using actual mathml. However, they have also been placing role=math on these images, which confuses NVDA. The image then no longer is treated in browse mode like an image (it does not report graphic, you can't jump to it with g, nor can you arrow through the alt text character by character). And since there is no mathml for rich navigation, the equation cannot be navigated through at all.
 
### Description of user facing changes
* Math equations represented by an image and alt text with no mathml for rich navigation, are now treated like normal images, rather than math with no content, allowing the user to jump to them with `g` and to be able to arrow through the alt text by character. (#16007)

### Description of development approach
* gecko_ia2 c++ virtualBuffer: change the accRole from equation to graphic, if the `tag` IAccessible2 object attribute is `img`, as this Accessible represents an image, whose role has been inappropriately overridden to equation by an ARIA role of `math`. This then allows all standard logic for images to apply in Browse Moe for this node.
 * in the math NVDAObject: change the role to graphic, if the accRole is equation and there is no mathml for this node. This correct reporting wih object navigation.
 

### Testing strategy:
* Tested with provided testcase on #16007
* Tested with standard mathml tests from NV Access

### Known issues with pull request:
None known.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
