### PR TITLE
Libre Office: Fix German heading formatting commands

### DIFF
--- a/source/appModules/soffice.py
+++ b/source/appModules/soffice.py
@@ -1,7 +1,7 @@
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-# Copyright (C) 2006-2022 NV Access Limited, Bill Dengler, Leonard de Ruijter
+# Copyright (C) 2006-2025 NV Access Limited, Bill Dengler, Leonard de Ruijter, Cyrille Bougot
 
 from typing import (
 	Optional,
@@ -572,14 +572,11 @@ class SymphonyDocument(CompoundDocument):
 
 		# changing paragraph style can imply more related formatting changes (e.g. font size, bold,...);
 		# restrict announcement to the paragraph style combobox via its ID
-		if isinstance(gesture, keyboardHandler.KeyboardInputGesture) and gesture.displayName in [
-			"ctrl+0",
-			"ctrl+1",
-			"ctrl+2",
-			"ctrl+3",
-			"ctrl+4",
-			"ctrl+5",
-		]:
+		if (
+			isinstance(gesture, keyboardHandler.KeyboardInputGesture)
+			and gesture.modifierNames == ['control']
+			and gesture.mainKeyName in ['1', '2', '3', '4', '5', '0']
+		):
 			SymphonyDocument.formattingGestureObjectIds = ["applystyle"]
 		else:
 			SymphonyDocument.formattingGestureObjectIds = []

--- a/source/appModules/soffice.py
+++ b/source/appModules/soffice.py
@@ -574,8 +574,8 @@ class SymphonyDocument(CompoundDocument):
 		# restrict announcement to the paragraph style combobox via its ID
 		if (
 			isinstance(gesture, keyboardHandler.KeyboardInputGesture)
-			and gesture.modifierNames == ['control']
-			and gesture.mainKeyName in ['1', '2', '3', '4', '5', '0']
+			and gesture.modifierNames == ["control"]
+			and gesture.mainKeyName in ["1", "2", "3", "4", "5", "0"]
 		):
 			SymphonyDocument.formattingGestureObjectIds = ["applystyle"]
 		else:


### PR DESCRIPTION
### Link to issue number:
Fix-up of #17153.

### Summary of the issue:
When modifying heading style with ctrl+1/2/3/4/5 or turning back to body text with ctrl+0, other formatting changes might be reported in languages where "ctrl" is translated differently, e.g. "Strg" in German.

### Description of user facing changes
Only style and no other associated formatting changes should be reported when modifying heading styles with ctrl+1/2/3/4/5 or turning back to body text with ctrl+0.

### Description of development approach
Do not use the `displayName` property to define which type of gesture we are dealing with, Use `modifierNames` and `mainKeyName` properties instead since they are not translated.

### Testing strategy:
Manual tests done by @michaelweghorn (see https://github.com/nvaccess/nvda/pull/17836#issuecomment-2742013056).

### Known issues with pull request:
If in any language other gestures than ctrl+1/2/3/4/5/0 are used, this code is not be valid. In this case, a specific script should be made for heading/body text formatting.

For now I think that it's not the case (confirmed by @michaelweghorn in https://github.com/nvaccess/nvda/pull/17836#issuecomment-2742013056), so there is no point in developing specific code for a theoretical situation.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
