### PR TITLE
Allow browse mode's native selection mode in Chromium-based browsers that can support it.

### DIFF
--- a/source/NVDAObjects/IAccessible/chromium.py
+++ b/source/NVDAObjects/IAccessible/chromium.py
@@ -80,11 +80,6 @@ class ChromeVBufTextInfo(GeckoVBufTextInfo):
 class ChromeVBuf(GeckoVBuf):
 	TextInfo = ChromeVBufTextInfo
 
-	# selecting with IAccessibleTextSelectionContainer is currently broken in Chromium.
-	# Please refer to comments on Chromium issue where this was implemented:
-	# https://bugs.chromium.org/p/chromium/issues/detail?id=1298144
-	_nativeAppSelectionModeSupported = False
-
 	def __contains__(self, obj):
 		if obj.windowHandle != self.rootNVDAObject.windowHandle:
 			return False

--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -18,6 +18,7 @@ import winsound
 import time
 import weakref
 import re
+from comtypes import COMError
 
 import wx
 import core
@@ -2684,8 +2685,11 @@ class BrowseModeDocumentTreeInterceptor(
 		nativeAppSelectionModeOn = not self._nativeAppSelectionMode
 		if nativeAppSelectionModeOn:
 			try:
+				# We need to clear the app selection before updating it when turning it on,
+				# as the app must be able to support clearing / setting empty selections.
+				self.clearAppSelection()
 				self.updateAppSelection()
-			except NotImplementedError:
+			except (NotImplementedError, COMError):
 				log.debugWarning("updateAppSelection failed", exc_info=True)
 				# Translators: the message when native selection mode is not available in this browse mode document.
 				ui.message(_("Native selection mode unsupported in this document"))

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -46,7 +46,7 @@ If you suspect this option is negatively impacting your battery life, you're adv
 * In a recognition result, `NVDA+f5` manually refreshes the recognized content. (#17715, @CyrilleB79)
 * Added an unassigned gesture to toggle periodical refresh of the Windows OCR result.
 * NVDA browse mode's native selection mode (`NVDA+shift+f10`) is now supported in Google Chrome and other applications based on Chromium 134 or newer. (#17838)
- 
+
 ### Changes
 
 * Component updates:

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -45,7 +45,8 @@ If you suspect this option is negatively impacting your battery life, you're adv
 * Rate boost is now supported when using Microsoft Speech API version 5 (SAPI5) and Microsoft Speech Platform voices, which supports up to 6X speed. (#17606, @gexgd0419)
 * In a recognition result, `NVDA+f5` manually refreshes the recognized content. (#17715, @CyrilleB79)
 * Added an unassigned gesture to toggle periodical refresh of the Windows OCR result.
-
+* NVDA browse mode's native selection mode (`NVDA+shift+f10`) is now supported in Google Chrome and other applications based on Chromium 134 or newer. (#17838)
+ 
 ### Changes
 
 * Component updates:

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -1131,7 +1131,7 @@ A key command is provided to return to the original page containing the embedded
 
 By default when selecting text with the `shift+arrow` keys in Browse Mode, a selection is only made within NVDA's Browse Mode representation of the document, and not within the application itself.
 This means that the selection is not visible on screen, and copying text with `control+c` will only copy NVDA's plain text representation of the content. i.e. formatting of tables, or whether something is a link will not be copied.
-However, NVDA has a Native Selection Mode which can be turned on in particular Browse Mode documents (so far only Mozilla Firefox) which causes the document's native selection to follow NVDA's Browse Mode selection.
+However, NVDA has a Native Selection Mode which can be turned on in particular Browse Mode documents which can support it (Mozilla Firefox, and any browser based on Chromium 134 or newer) which causes the document's native selection to follow NVDA's Browse Mode selection.
 
 <!-- KC:beginInclude -->
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Fixes #17591

### Summary of the issue:
In #15830, NVDA browse mode gained a new native Selection Mode (toggled on with `NVDA+shift+f10`) which caused the browser's underlying native selection (DOM selection) to mirror the browse mode virtual selection. Although this worked well in Firefox, it had to be forcefully disabled for Chromium-based browsers as there were major bugs in Chromiums implementation of IAccessibleTextSelectionContainer.
 As of Chromium 134 stable, all known bugs have been addressed, thus NVDA should allow native selection mode in Chromium-based browsers where possible.

### Description of user facing changes
NVDA browse mode's native selection mode (`NVDA+shift+f10`) can now be enabled in any browser based on Chromium 134 or newer.

### Description of development approach
* The Chromium virtualBuffer is no longer marked as not supporting native app selection mode.
* toggling native selection mode on now firstly tries to clear the native selection before updating it, and also catches more errors, ensuring that native selection mode is truly supported when enabling.

### Testing strategy:
* In Firefox, visited nvaccess.org, enabled native selection mode, selected the navbar, copied to clipboard, and pasted to an editor to verify all expected content was there.
* In Chrome134, visited nvaccess.org, enabled native selection mode, selected the navbar, copied to clipboard, and pasted to an editor to verify all expected content was there.
* In MS Edge 135, visited nvaccess.org, enabled native selection mode, selected the navbar, copied to clipboard, and pasted to an editor to verify all expected content was there.
* In VS Code February update (Chromium 132), in browse mode tried to enable native selection mode, which reported as not supported as expected.

### Known issues with pull request:
None known.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
