### PR TITLE
Only play sounds or beeps for Remote cues

### DIFF
--- a/source/remoteClient/cues.py
+++ b/source/remoteClient/cues.py
@@ -54,15 +54,15 @@ CUES: Dict[str, Cue] = {
 
 def _playCue(cueName: str) -> None:
 	"""Helper function to play a cue by name"""
-	if not shouldPlaySounds():
+	if shouldPlaySounds():
+		# Play wave file
+		if wave := CUES[cueName].get("wave"):
+			nvwave.playWaveFile(os.path.join(globalVars.appDir, "waves", wave + ".wav"))
+	else:
 		# Play beep sequence
 		if beeps := CUES[cueName].get("beeps"):
 			filteredBeeps = [(freq, dur) for freq, dur in beeps if freq is not None]
 			beepSequenceAsync(*filteredBeeps)
-
-	# Play wave file
-	if wave := CUES[cueName].get("wave"):
-		nvwave.playWaveFile(os.path.join(globalVars.appDir, "waves", wave + ".wav"))
 
 	# Show message if specified
 	if message := CUES[cueName].get("message"):

--- a/source/remoteClient/cues.py
+++ b/source/remoteClient/cues.py
@@ -58,11 +58,10 @@ def _playCue(cueName: str) -> None:
 		# Play wave file
 		if wave := CUES[cueName].get("wave"):
 			nvwave.playWaveFile(os.path.join(globalVars.appDir, "waves", wave + ".wav"))
-	else:
+	elif beeps := CUES[cueName].get("beeps"):
 		# Play beep sequence
-		if beeps := CUES[cueName].get("beeps"):
-			filteredBeeps = [(freq, dur) for freq, dur in beeps if freq is not None]
-			beepSequenceAsync(*filteredBeeps)
+		filteredBeeps = [(freq, dur) for freq, dur in beeps if freq is not None]
+		beepSequenceAsync(*filteredBeeps)
 
 	# Show message if specified
 	if message := CUES[cueName].get("message"):


### PR DESCRIPTION
### Link to issue number:

Fixes #17849

### Summary of the issue:

If set to play beeps instead of sounds, Remote still plays the sound, as well as the beep, when outputting cues.

### Description of user facing changes

Only beeps or sounds are played, as appropriate.

### Description of development approach

Fixed the logic in `remoteClient.cues._playCue`  to have the sound and beep playing code on separate branches.

Previously, if playing sounds was selected, the sound was played and the function returned before the beep code was reached. However, this also stopped text cues from being output.
When the premature return was removed, the logic was not updated, resulting in both a beep and sound being heard when beep output was selected.

### Testing strategy:

Connected and disconnected Remote with "Play sounds instead of beeps" enabled and disabled in Remote settings.

### Known issues with pull request:

None.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
