### PR TITLE
Toggle Remote Access, rather than connecting or disconnecting explicitly

### DIFF
--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -4945,7 +4945,6 @@ class GlobalCommands(ScriptableObject):
 		ui.message(_("Copied link"))
 
 	@script(
-		gesture="kb:alt+NVDA+pageDown",
 		category=SCRCAT_REMOTE,
 		# Translators: Documentation string for the script that disconnects a remote session.
 		description=_("Disconnect a remote session"),
@@ -4959,7 +4958,6 @@ class GlobalCommands(ScriptableObject):
 		remoteClient._remoteClient.disconnect()
 
 	@script(
-		gesture="kb:alt+NVDA+pageUp",
 		# Translators: Documentation string for the script that invokes the remote session.
 		description=_("""Connect to a remote computer"""),
 		category=SCRCAT_REMOTE,
@@ -4977,7 +4975,7 @@ class GlobalCommands(ScriptableObject):
 		# Translators: Describes the command that creates a remote session, or disconnects it if one already exists.
 		"Toggle Remote connection",
 		category=SCRCAT_REMOTE,
-		gesture="kb:NVDA+alt+t",
+		gesture="kb:NVDA+alt+r",
 	)
 	def script_toggleRemoteConnection(self, gesture: "inputCore.InputGesture") -> None:
 		if remoteClient._remoteClient.isConnected():

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -4974,6 +4974,18 @@ class GlobalCommands(ScriptableObject):
 		remoteClient._remoteClient.doConnect()
 
 	@script(
+		# Translators: Describes the command that creates a remote session, or disconnects it if one already exists.
+		"Toggle Remote connection",
+		category=SCRCAT_REMOTE,
+		gesture="kb:NVDA+alt+t",
+	)
+	def script_toggleRemoteConnection(self, gesture: "inputCore.InputGesture") -> None:
+		if remoteClient._remoteClient.isConnected():
+			self.script_disconnectFromRemote(gesture)
+		else:
+			self.script_connectToRemote(gesture)
+
+	@script(
 		# Translators: Documentation string for the script that toggles the control between guest and host machine.
 		description=_("Toggles the control between guest and host machine"),
 		category=SCRCAT_REMOTE,

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -3696,7 +3696,7 @@ Once the session is active, you can switch between controlling the remote comput
 |--------------------------|----------------------|-------------------------------------------|
 | Toggle Control           | `NVDA+f11`               | Switch between controlling and local.     |
 | Push Clipboard           | `NVDA+ctrl+shift+c`        | Send clipboard text to the other machine. |
-| Disconnect               | `NVDA+alt+pageDown`| End the remote session.                   |
+| Connect or disconnect               | `NVDA+alt+r`| If a remote session is in progress, disconnect from it. Otherwise, start a new Remote session. |
 <!-- KC:endInclude -->
 
 You can assign further commands in the Remote section of the [Input Gestures dialog](#InputGestures).

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -3696,7 +3696,7 @@ Once the session is active, you can switch between controlling the remote comput
 |--------------------------|----------------------|-------------------------------------------|
 | Toggle Control           | `NVDA+f11`               | Switch between controlling and local.     |
 | Push Clipboard           | `NVDA+ctrl+shift+c`        | Send clipboard text to the other machine. |
-| Connect or disconnect               | `NVDA+alt+r`| If a remote session is in progress, disconnect from it. Otherwise, start a new Remote session. |
+| Connect or disconnect | `NVDA+alt+r`| If a remote session is in progress, disconnect from it. Otherwise, start a new Remote session. |
 <!-- KC:endInclude -->
 
 You can assign further commands in the Remote section of the [Input Gestures dialog](#InputGestures).


### PR DESCRIPTION
### Link to issue number:

Closes #17789
Closes #17790

### Summary of the issue:

Currently, Remote Access uses separate gestures for connecting and disconnecting. However, these actions are mutually exclusive, so only one gesture is strictly necessary.
Likewise, connect and disconnect are both always shown in the Remote menu, though one is always disabled.

### Description of user facing changes

A new gesture has been added, which creates a new, or disconnects from the existing, Remote connection. This gesture has been bound to `NVDA+alt+r` in all layouts.

The `NVDA+alt+pageUp` and `NVDA+alt+pageDown` gesture bindings for connecting and disconnecting remote, respectively, have been removed, though the underlying gestures remain.

The Remote menu (NVDA menu -> Tools -> Remote) now only ever shows the "Conect..." or "Disconnect" items at any given time.

### Description of development approach

Created a new gesture, `globalCommands.GlobalCommands.script_toggleRemoteConnection`, which queries whether remote is connected. If it is, this calls `script_disconnectFromRemote`, otherwise it calls `script_connectToRemote`.

Instead of enabling/disabling `remoteClient._client.menu.connectItem` and `disconnectItem`, remove them where we were disabling them, and insert them where we were enabling them. To help with this, added helper methods, `remoteClient.menu.Menu._hideItem` and `_showItem`, which ensure that when removing the item it is in the menu, and when inserting it it is not.

### Testing strategy:

Tested the existing and new gestures in a range of situations to ensure that the behaviour of the toggle was the same as that of the expected single-purpose command.

Tested connecting and disconnecting from remote using nvdaremote.com and a local relay server, as both leader and follower, checking the menu at each stage to ensure the correct items were present.

### Known issues with pull request:

While this approach means that connecting and disconnecting via the toggle or the single-use commands have the same restrictions, it does mean the messages may be misleading: the message will always be "Action unavailable while X", but the precise action performed, and the restrictions, vary:

* Disconnecting is disallowed when in secure mode.
* Connecting is disallowed when in secure mode, or when a modal dialog is open.

This inconsistency may confuse users. Perhaps a clearer way of communicating the block would be "connecting unavailable when X" or "disconnecting unavailable when X", but this is not currently possible.

Of course, it is always possible to implement functions to consistently handle all of this, but I'm not sure if the slight increase in clarity is worth the effort.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
