### PR TITLE
Fix disconnecting  Remote as follower when no leader is attached

### DIFF
--- a/source/remoteClient/secureDesktop.py
+++ b/source/remoteClient/secureDesktop.py
@@ -106,10 +106,11 @@ class SecureDesktopHandler:
 			transport = self._followerSession.transport
 			transport.unregisterInbound(RemoteMessageType.SET_BRAILLE_INFO, self._onLeaderDisplayChange)
 		self._followerSession = session
-		session.transport.registerInbound(
-			RemoteMessageType.SET_BRAILLE_INFO,
-			self._onLeaderDisplayChange,
-		)
+		if session is not None:
+			session.transport.registerInbound(
+				RemoteMessageType.SET_BRAILLE_INFO,
+				self._onLeaderDisplayChange,
+			)
 
 	def _onSecureDesktopChange(self, isSecureDesktop: Optional[bool] = None) -> None:
 		"""Internal callback for secure desktop state changes.


### PR DESCRIPTION
### Link to issue number:

Fixes #17822

### Summary of the issue:

An error occurs when disconnecting Remote when in follower mode if no leader is attached.

### Description of user facing changes

No error occurs.

### Description of development approach

The error occurs because, when a follower session disconnects, it makes sure that the secure desktop handler no longer holds a reference to it. The setter for that reference, however, attempts to mutate it. Since we're setting it to `None`, this fails.

Thus, in `secureDesktop.SecureDesktopHandler`'s `followerSession` setter, check that the new `session` is not `None` before accessing its properties.

### Testing strategy:

Created a follower session, then disconnected while no leader was attached.

### Known issues with pull request:

None known

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
