### PR TITLE
Word UIA: Support native table extended navigation commands

### DIFF
--- a/source/NVDAObjects/IAccessible/winword.py
+++ b/source/NVDAObjects/IAccessible/winword.py
@@ -442,7 +442,7 @@ class WordDocument(IAccessible, EditableTextWithoutAutoSelectDetection, winWordW
 		newInfo.updateCaret()
 		return True
 
-	def _inTable(self, info):
+	def _inTable(self, info: textInfos.TextInfo):
 		return info._rangeObj.tables.count > 0
 
 	@script(

--- a/source/NVDAObjects/IAccessible/winword.py
+++ b/source/NVDAObjects/IAccessible/winword.py
@@ -7,11 +7,9 @@ from comtypes import COMError
 import ctypes
 import operator
 import uuid
-import time
 from logHandler import log
 import winUser
 import speech
-import braille
 import controlTypes
 import config
 import tableUtils

--- a/source/NVDAObjects/IAccessible/winword.py
+++ b/source/NVDAObjects/IAccessible/winword.py
@@ -442,7 +442,7 @@ class WordDocument(IAccessible, EditableTextWithoutAutoSelectDetection, winWordW
 		newInfo.updateCaret()
 		return True
 
-	def _inTable(self, info: textInfos.TextInfo):
+	def _inTable(self, info: textInfos.TextInfo) -> bool:
 		return info._rangeObj.tables.count > 0
 
 	@script(

--- a/source/NVDAObjects/IAccessible/winword.py
+++ b/source/NVDAObjects/IAccessible/winword.py
@@ -343,45 +343,6 @@ class WordDocument(IAccessible, EditableTextWithoutAutoSelectDetection, winWordW
 				)
 
 	@script(
-		gestures=(
-			"kb:alt+home",
-			"kb:alt+end",
-			"kb:alt+pageUp",
-			"kb:alt+pageDown",
-		),
-	)
-	def script_caret_moveByCell(self, gesture: inputCore.InputGesture) -> None:
-		info = self.makeTextInfo(textInfos.POSITION_SELECTION)
-		inTable = info._rangeObj.tables.count > 0
-		if not inTable:
-			gesture.send()
-			return
-		oldSelection = info.start, info.end
-		gesture.send()
-		start = time.time()
-		retryInterval = 0.01
-		maxTimeout = 0.15
-		elapsed = 0
-		while True:
-			if scriptHandler.isScriptWaiting():
-				# Prevent lag if keys are pressed rapidly
-				return
-			info = self.makeTextInfo(textInfos.POSITION_SELECTION)
-			newSelection = info.start, info.end
-			if newSelection != oldSelection:
-				elapsed = time.time() - start
-				log.debug(f"Detected new selection after {elapsed} sec")
-				break
-			elapsed = time.time() - start
-			if elapsed >= maxTimeout:
-				log.debug(f"Canceled detecting new selection after {elapsed} sec")
-				break
-			time.sleep(retryInterval)
-		info.expand(textInfos.UNIT_CELL)
-		speech.speakTextInfo(info, reason=controlTypes.OutputReason.FOCUS)
-		braille.handler.handleCaretMove(self)
-
-	@script(
 		description=_(
 			# Translators: a description for a script
 			"Reports the text of the comment where the system caret is located."
@@ -482,6 +443,9 @@ class WordDocument(IAccessible, EditableTextWithoutAutoSelectDetection, winWordW
 		newInfo.collapse()
 		newInfo.updateCaret()
 		return True
+
+	def _inTable(self, info):
+		return info._rangeObj.tables.count > 0
 
 	@script(
 		gesture="kb:control+alt+downArrow",

--- a/source/NVDAObjects/UIA/wordDocument.py
+++ b/source/NVDAObjects/UIA/wordDocument.py
@@ -308,6 +308,12 @@ class WordDocumentTextInfo(UIATextInfo):
 		return super(WordDocumentTextInfo, self).move(unit, direction, endPoint)
 
 	def expand(self, unit):
+		if unit == textInfos.UNIT_CELL:
+			cell = self.obj._getTableCellCoordsCached(self, axis=None)
+			info = self.obj._getTableCellAt(cell.tableID, self, cell.row, cell.col)
+			self.start = info.start
+			self.end = info.end
+			return
 		super(WordDocumentTextInfo, self).expand(unit)
 		# #7970: MS Word refuses to expand to line when on the final line and it is blank.
 		# This among other things causes a newly inserted bullet not to be spoken or brailled.

--- a/source/documentBase.py
+++ b/source/documentBase.py
@@ -190,7 +190,7 @@ class DocumentWithTableNavigation(TextContainerObject, ScriptableObject):
 				)
 		return cell
 
-	def _inTable(self, info: textInfos.TextInfo):
+	def _inTable(self, info: textInfos.TextInfo) -> bool:
 		try:
 			self._getTableCellCoords(info)
 			return True

--- a/source/documentBase.py
+++ b/source/documentBase.py
@@ -190,7 +190,7 @@ class DocumentWithTableNavigation(TextContainerObject, ScriptableObject):
 				)
 		return cell
 
-	def _inTable(self, info):
+	def _inTable(self, info: textInfos.TextInfo):
 		try:
 			self._getTableCellCoords(info)
 			return True

--- a/source/documentBase.py
+++ b/source/documentBase.py
@@ -190,6 +190,13 @@ class DocumentWithTableNavigation(TextContainerObject, ScriptableObject):
 				)
 		return cell
 
+	def _inTable(self, info):
+		try:
+			self._getTableCellCoords(info)
+			return True
+		except LookupError:
+			return False
+
 	def _getTableDimensions(self, info: textInfos.TextInfo) -> Tuple[int, int]:
 		"""
 		Fetches information about the deepest table dimension.

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -46,7 +46,7 @@ If you suspect this option is negatively impacting your battery life, you're adv
 * In a recognition result, `NVDA+f5` manually refreshes the recognized content. (#17715, @CyrilleB79)
 * Added an unassigned gesture to toggle periodical refresh of the Windows OCR result.
 * NVDA browse mode's native selection mode (`NVDA+shift+f10`) is now supported in Google Chrome and other applications based on Chromium 134 or newer. (#17838)
-* In Word with UIA, when using the native extended table navigation commands alt+home, alt+end, alt+pageUp and alt+pageDown, the landing cell will now be reported. (#17867, @CyrilleB79)
+* In Word with UIA, when using the native extended table navigation commands (`alt+home`, `alt+end`, `alt+pageUp`, and `alt+pageDown`), the caret  movement will now be reported. (#17867, @CyrilleB79)
 
 ### Changes
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -46,6 +46,7 @@ If you suspect this option is negatively impacting your battery life, you're adv
 * In a recognition result, `NVDA+f5` manually refreshes the recognized content. (#17715, @CyrilleB79)
 * Added an unassigned gesture to toggle periodical refresh of the Windows OCR result.
 * NVDA browse mode's native selection mode (`NVDA+shift+f10`) is now supported in Google Chrome and other applications based on Chromium 134 or newer. (#17838)
+* In Word with UIA, when using the native extended table navigation commands alt+home, alt+end, alt+pageUp and alt+pageDown, the landing cell will now be reported. (#17867, @CyrilleB79)
 
 ### Changes
 


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
In word, native extended table navigation commands `alt+home`, `alt+end`, `alt+pageUp` and `alt+pageDown` are report their result (i.e. the content of the landing cell) when using legacy document access, but not when using UIA.

### Description of user facing changes
In Word with UIA, when using the native extended table navigation commands `alt+home`, `alt+end`, `alt+pageUp` and `alt+pageDown`, the landing cell will now be reported.

### Description of development approach
* Factorize the script for this commands to use it for legacy as well as for UIA.
* Create separate `_inTable` methods for UIA and for legacy.
* For UIA text info's `expand` method, implement the support for cell unit.

### Testing strategy:
Manual testing for both UIA and legacy.
### Known issues with pull request:
None
### Code Review Checklist:


- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
