### PR TITLE
Add acceleration key to remote menu

### DIFF
--- a/source/remoteClient/menu.py
+++ b/source/remoteClient/menu.py
@@ -28,7 +28,7 @@ class RemoteMenu(wx.Menu):
 		self.muteItem: wx.MenuItem = self.Append(
 			wx.ID_ANY,
 			# Translators: Menu item in NvDA Remote submenu to mute speech and sounds from the remote computer.
-			_("Mute remote"),
+			_("&Mute remote"),
 			# Translators: Tooltip for the Mute Remote menu item in the NVDA Remote submenu.
 			_("Mute speech and sounds from the remote computer"),
 			kind=wx.ITEM_CHECK,
@@ -64,7 +64,7 @@ class RemoteMenu(wx.Menu):
 		self.sendCtrlAltDelItem: wx.MenuItem = self.Append(
 			wx.ID_ANY,
 			# Translators: Menu item in NVDA Remote submenu to send Control+Alt+Delete to the remote computer.
-			_("Send Ctrl+Alt+Del"),
+			_("&Send Ctrl+Alt+Del"),
 			# Translators: Tooltip for the Send Ctrl+Alt+Del menu item in the NVDA Remote submenu.
 			_("Send Ctrl+Alt+Del"),
 		)
@@ -152,7 +152,7 @@ class RemoteMenu(wx.Menu):
 		to those appropriate for creating a new Remote session.
 		"""
 		# Translators: Item in NVDA Remote submenu to connect to a remote computer.
-		self.connectionItem.SetItemLabel(_("Connect..."))
+		self.connectionItem.SetItemLabel(_("&Connect..."))
 		# Translators: Tooltip for the Connect menu item in the NVDA Remote submenu.
 		self.connectionItem.SetHelp(_("Remotely connect to another computer running NVDA Remote Access"))
 		gui.mainFrame.sysTrayIcon.Unbind(wx.EVT_MENU, self.connectionItem)
@@ -169,7 +169,7 @@ class RemoteMenu(wx.Menu):
 		to those appropriate for disconnecting an existing Remote session.
 		"""
 		# Translators: Menu item in NVDA Remote submenu to disconnect from another computer running NVDA Remote Access.
-		self.connectionItem.SetItemLabel(_("Disconnect"))
+		self.connectionItem.SetItemLabel(_("&Disconnect"))
 		# Translators: Tooltip for the Disconnect menu item in the NVDA Remote submenu.
 		self.connectionItem.SetHelp(_("Disconnect from another computer running NVDA Remote Access"))
 		gui.mainFrame.sysTrayIcon.Unbind(wx.EVT_MENU, self.connectionItem)


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Partially completed #17869 

### Summary of the issue:
Most menu items in NVDA already have acceleration keys, but some menus still do not specify acceleration keys. For English environments, this can be quickly redirected by pressing the initial letter of the menu item, but for other locales (such as Chinese), you need to append (&letter) after translation to assign acceleration keys.

### Description of user facing changes
Add acceleration keys to some menu items in the remote menu

### Description of development approach
Add acceleration keys to some menu items in the remote menu

### Testing strategy:
Manual test after build

### Known issues with pull request:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
