### PR TITLE
Revert audio ducking fixes

### DIFF
--- a/source/audioDucking.py
+++ b/source/audioDucking.py
@@ -111,12 +111,12 @@ def _ensureDucked():
 		_duckingRefCount += 1
 		if _isDebug():
 			log.debug("Increased ref count, _duckingRefCount=%d" % _duckingRefCount)
+		if _audioDuckingMode != AudioDuckingMode.NONE:
+			_setDuckingState(True)
 		if _duckingRefCount == 1 and _audioDuckingMode != AudioDuckingMode.NONE:
 			delta = 0
 		else:
 			delta = time.time() - _lastDuckedTime
-		if _audioDuckingMode != AudioDuckingMode.NONE and (_duckingRefCount == 1 or delta > 1):
-			_setDuckingState(True)
 		return delta, _modeChangeEvent
 
 

--- a/source/audioDucking.py
+++ b/source/audioDucking.py
@@ -111,9 +111,8 @@ def _ensureDucked():
 		_duckingRefCount += 1
 		if _isDebug():
 			log.debug("Increased ref count, _duckingRefCount=%d" % _duckingRefCount)
-		if _audioDuckingMode != AudioDuckingMode.NONE:
-			_setDuckingState(True)
 		if _duckingRefCount == 1 and _audioDuckingMode != AudioDuckingMode.NONE:
+			_setDuckingState(True)
 			delta = 0
 		else:
 			delta = time.time() - _lastDuckedTime

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -132,7 +132,6 @@ In any document, if the cursor is on the last line, it will be moved to the end 
 * The NVDA Highlighter Window icon is no longer fixed in the taskbar after restarting Explorer. (#17696, @hwf1324)
 * Fixed an issue where some SAPI4 voices (e.g. IBM TTS Chinese) cannot be loaded. (#17726, @gexgd0419)
 * In Excel, the element list dialog (`NVDA+f7`) no longer fails to list comment or formulas on some non-English systems. (#11366, @CyrilleB79)
-* NVDA can now restore the audio ducking behavior when speaking a new utterance, when another app such as Magnifier changes the behavior system-wide. (#17747, @gexgd0419)
 * Math equations only represented by an image and alt text with no mathml for rich navigation, are now treated like normal images, rather than math with no content, allowing the user to jump to them with `g` and to be able to arrow through the alt text by character. (#16007)
 
 ### Changes for Developers


### PR DESCRIPTION
### Reverts PR
Reverts #17806, #17770.

### Issues fixed
<!-- Issues that will be closed by reverting, i.e. the issues introduced via the PR getting reverted  -->
Fixes #17798.

### Issues reopened
<!-- Issues that will be re-opened by reverting, i.e. the issues that were fixed via the PR getting reverted  -->
Reopens #17747.

### Reason for revert

The fix introduces lags when audio ducking is enabled.

### Can this PR be reimplemented? If so, what is required for the next attempt

Currrently there's no documented way to check the global audio ducking state in Windows.
