### PR TITLE
Fix disabling Remote Access

### DIFF
--- a/source/remoteClient/menu.py
+++ b/source/remoteClient/menu.py
@@ -83,12 +83,9 @@ class RemoteMenu(wx.Menu):
 		)
 
 	def terminate(self) -> None:
-		self.Remove(self.connectItem.Id)
-		self.connectItem.Destroy()
-		self.connectItem = None
-		self.Remove(self.disconnectItem.Id)
-		self.disconnectItem.Destroy()
-		self.disconnectItem = None
+		self.Remove(self.connectionItem.Id)
+		self.connectionItem.Destroy()
+		self.connectionItem = None
 		self.Remove(self.muteItem.Id)
 		self.muteItem.Destroy()
 		self.muteItem = None


### PR DESCRIPTION
### Link to issue number:

Fixes #17873

### Summary of the issue:

Disabling Remote Access would fail, causing the settings GUI to stop working, and settings to be saved incorrectly.

### Description of user facing changes

Disabling Remote Access now works properly.

### Description of development approach

Fixed the `remoteClient.menu.Menu.terminate` method.
This was still trying to clear `connectItem` and `disconnectItem`, even those were unified into `connectionItem` in #17825.
I thought I had fixed this issue in that PR, but evidently the changes got lost somewhere along the way 😅

### Testing strategy:

1. Enable Remote Access via NVDA's settings. Save.
2. Disable Remote Access via the settings. Save.

### Known issues with pull request:

None.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
