### PR TITLE
Fix issues with pushing the clipboard

### DIFF
--- a/source/remoteClient/client.py
+++ b/source/remoteClient/client.py
@@ -139,7 +139,7 @@ class RemoteClient:
 			return
 		elif self.connectedClientsCount < 1:
 			# Translators: Reported when performing a Remote Access action, but there are no other computers in the channel.
-			ui.message(pgettext("remote", "No-one else is connected."))
+			ui.message(pgettext("remote", "No one else is connected"))
 			return
 		try:
 			connector.send(RemoteMessageType.SET_CLIPBOARD_TEXT, text=api.getClipData())

--- a/source/remoteClient/client.py
+++ b/source/remoteClient/client.py
@@ -140,8 +140,8 @@ class RemoteClient:
 		try:
 			connector.send(RemoteMessageType.SET_CLIPBOARD_TEXT, text=api.getClipData())
 			cues.clipboardPushed()
-		except TypeError:
-			log.exception("Unable to push clipboard")
+		except (TypeError, OSError):
+			log.debug("Unable to push clipboard", exc_info=True)
 			# Translators: Message shown when clipboard content cannot be sent to the remote computer.
 			ui.message(_("Unable to push clipboard"))
 

--- a/source/remoteClient/client.py
+++ b/source/remoteClient/client.py
@@ -137,6 +137,10 @@ class RemoteClient:
 			# Translators: Message shown when trying to push the clipboard to the remote computer while not connected.
 			ui.message(_("Not connected."))
 			return
+		elif self.connectedClientsCount < 1:
+			# Translators: Reported when performing a Remote Access action, but there are no other computers in the channel.
+			ui.message(pgettext("remote", "No-one else is connected."))
+			return
 		try:
 			connector.send(RemoteMessageType.SET_CLIPBOARD_TEXT, text=api.getClipData())
 			cues.clipboardPushed()
@@ -574,3 +578,17 @@ class RemoteClient:
 		:param script: Script function to unregister
 		"""
 		self.localScripts.discard(script)
+
+	@property
+	def connectedClientsCount(self) -> int:
+		if not self.isConnected():
+			return 0
+		elif self.leaderSession is not None:
+			return len(self.leaderSession.followers)
+		elif self.followerSession is not None:
+			return len(self.followerSession.leaders)
+		log.error(
+			"is connected returned true, but neither leaderSession or followerSession is not None.",
+			stack_info=True,
+		)
+		return 0

--- a/source/remoteClient/client.py
+++ b/source/remoteClient/client.py
@@ -584,9 +584,9 @@ class RemoteClient:
 		if not self.isConnected():
 			return 0
 		elif self.leaderSession is not None:
-			return len(self.leaderSession.followers)
+			return self.leaderSession.connectedClientsCount
 		elif self.followerSession is not None:
-			return len(self.followerSession.leaders)
+			return self.followerSession.connectedClientsCount
 		log.error(
 			"is connected returned true, but neither leaderSession or followerSession is not None.",
 			stack_info=True,

--- a/source/remoteClient/session.py
+++ b/source/remoteClient/session.py
@@ -538,6 +538,8 @@ class LeaderSession(RemoteSession):
 	def handleClientConnected(self, client: dict[str, Any] | None = None):
 		hasFollowers = bool(self.followers)
 		super().handleClientConnected(client)
+		if client["connection_type"] == connectionInfo.ConnectionMode.FOLLOWER.value:
+			self.followers[client["id"]]["active"] = True
 		self.sendBrailleInfo()
 		if not hasFollowers:
 			self.registerCallbacks()
@@ -547,6 +549,8 @@ class LeaderSession(RemoteSession):
 		Also calls parent class disconnection handler.
 		"""
 		super().handleClientDisconnected(client)
+		if client["connection_type"] == connectionInfo.ConnectionMode.FOLLOWER.value:
+			del self.followers[client["id"]]
 		if self.callbacksAdded and not self.followers:
 			self.unregisterCallbacks()
 

--- a/source/remoteClient/session.py
+++ b/source/remoteClient/session.py
@@ -62,6 +62,7 @@ See Also:
 	local_machine.py: NVDA interface
 """
 
+from collections.abc import Collection
 import hashlib
 from collections import defaultdict
 from typing import Any, Final
@@ -112,6 +113,12 @@ class RemoteSession:
 
 	callbacksAdded: bool = False
 	"""Whether callbacks are currently registered"""
+
+	leaders: Collection[str]
+	"""Information about connected leaders."""
+
+	followers: Collection[str]
+	"""Information about connected followers."""
 
 	def __init__(
 		self,
@@ -248,6 +255,18 @@ Please use a different server."""),
 		"""Ensure transport is closed when object is deleted."""
 		self.close()
 
+	@property
+	def connectedLeadersCount(self) -> int:
+		return len(self.leaders)
+
+	@property
+	def connectedFollowersCount(self) -> int:
+		return len(self.followers)
+
+	@property
+	def connectedClientsCount(self) -> int:
+		return self.connectedLeadersCount + self.connectedFollowersCount
+
 
 class FollowerSession(RemoteSession):
 	"""Session that runs on the controlled (follower) NVDA instance.
@@ -266,6 +285,7 @@ class FollowerSession(RemoteSession):
 	# Information about connected leader clients
 	leaders: dict[int, dict[str, Any]]
 	leaderDisplaySizes: list[int]  # Braille display sizes of connected leaders
+	followers: set[str]
 
 	def __init__(
 		self,
@@ -279,6 +299,7 @@ class FollowerSession(RemoteSession):
 		)
 		self.leaders = defaultdict(dict)
 		self.leaderDisplaySizes = []
+		self.followers = set()
 		self.transport.transportClosing.register(self.handleTransportClosing)
 		self.transport.registerInbound(
 			RemoteMessageType.CHANNEL_JOINED,
@@ -336,6 +357,8 @@ class FollowerSession(RemoteSession):
 		super().handleClientConnected(client)
 		if client["connection_type"] == connectionInfo.ConnectionMode.LEADER.value:
 			self.leaders[client["id"]]["active"] = True
+		elif client["connection_type"] == connectionInfo.ConnectionMode.FOLLOWER.value:
+			self.followers.add(client["id"])
 		if self.leaders:
 			self.registerCallbacks()
 
@@ -373,6 +396,8 @@ class FollowerSession(RemoteSession):
 		if client["connection_type"] == connectionInfo.ConnectionMode.LEADER.value:
 			log.info("Leader client disconnected: %r", client)
 			del self.leaders[client["id"]]
+		elif client["connection_type"] == connectionInfo.ConnectionMode.FOLLOWER.value:
+			self.followers.discard(client["id"])
 		if not self.leaders:
 			self.unregisterCallbacks()
 
@@ -457,6 +482,7 @@ class LeaderSession(RemoteSession):
 
 	mode: Final[connectionInfo.ConnectionMode] = connectionInfo.ConnectionMode.LEADER
 	followers: dict[int, dict[str, Any]]  # Information about connected follower
+	leaders: set[str]
 
 	def __init__(
 		self,
@@ -465,6 +491,7 @@ class LeaderSession(RemoteSession):
 	) -> None:
 		super().__init__(localMachine, transport)
 		self.followers = defaultdict(dict)
+		self.leaders = set()
 		self.transport.registerInbound(
 			RemoteMessageType.SPEAK,
 			self.localMachine.speak,
@@ -540,6 +567,8 @@ class LeaderSession(RemoteSession):
 		super().handleClientConnected(client)
 		if client["connection_type"] == connectionInfo.ConnectionMode.FOLLOWER.value:
 			self.followers[client["id"]]["active"] = True
+		elif client["connection_type"] == connectionInfo.ConnectionMode.LEADER.value:
+			self.leaders.add(client["id"])
 		self.sendBrailleInfo()
 		if not hasFollowers:
 			self.registerCallbacks()
@@ -551,6 +580,8 @@ class LeaderSession(RemoteSession):
 		super().handleClientDisconnected(client)
 		if client["connection_type"] == connectionInfo.ConnectionMode.FOLLOWER.value:
 			del self.followers[client["id"]]
+		elif client["connection_type"] == connectionInfo.ConnectionMode.LEADER.value:
+			self.leaders.discard(client["id"])
 		if self.callbacksAdded and not self.followers:
 			self.unregisterCallbacks()
 

--- a/tests/unit/test_remote/test_remote_client.py
+++ b/tests/unit/test_remote/test_remote_client.py
@@ -127,7 +127,7 @@ class TestRemoteClient(unittest.TestCase):
 		# With a fake transport, pushClipboard should send the clipboard text.
 		fakeTransport = FakeTransport()
 		fakeSession = FakeSession("")
-		fakeSession.followers = {1: "a", 2: "b"}
+		fakeSession.connectedClientsCount = 1
 		self.client.leaderTransport = fakeTransport
 		self.client.leaderSession = fakeSession
 		FakeAPI.clipData = "TestClipboard"

--- a/tests/unit/test_remote/test_remote_client.py
+++ b/tests/unit/test_remote/test_remote_client.py
@@ -126,7 +126,10 @@ class TestRemoteClient(unittest.TestCase):
 	def test_pushClipboardWithTransport(self):
 		# With a fake transport, pushClipboard should send the clipboard text.
 		fakeTransport = FakeTransport()
+		fakeSession = FakeSession("")
+		fakeSession.followers = {1: "a", 2: "b"}
 		self.client.leaderTransport = fakeTransport
+		self.client.leaderSession = fakeSession
 		FakeAPI.clipData = "TestClipboard"
 		self.client.pushClipboard()
 		self.assertTrue(len(fakeTransport.sent) > 0)


### PR DESCRIPTION
### Link to issue number:

Fixes #17881
Fixes #17875

### Summary of the issue:

Currently, the push clipboard command:
1. Fails with a logged error but no useful output when attempting to push a non-text clipboard
2. Reports success when there is no-one else connected.

### Description of user facing changes

1. An error message is reported when attempting to push non-text clipboard
2. An error message is reported when pushing the clipboard to an empty channel

### Description of development approach

1. Catch `OSError` when attempting to push clipboard, as this is raised when there is no text content on the clipboard.
2. Record connected leaders and followers on both leader and follower sessions. Add read-only properties, `connectedLeadersCount`, `connectedFollowersCount`, and `connectedClientsCount` (sum of leaders and followers counts) to `RemoteSession`.
3. Add a read only property, `connectedClientsCount` to `RemoteClient`, which grabs the `connectedClientsCount` from the appropriate `session`, or returns `0` if there is no session in progress.
4. Check that the remote client's count of connected clients is greater than 0 before pushing the clipboard.

### Testing strategy:

Attempt pushing the clipboard:
* In a new channel where the local machine is the only connected machine
* In a channel where there is a remote that connected after the local machine, and after the remote machine has disconnected
* In a channel where there is another client that joined before the local machine, and after the remote machine has disconnected

### Known issues with pull request:

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
