### PR TITLE
Fix-up of the toggle apps volume control command

### DIFF
--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -3211,7 +3211,7 @@ class AudioPanel(SettingsPanel):
 		audio.appsVolume._updateAppsVolumeImpl(
 			volume=self.appSoundVolSlider.GetValue() / 100.0,
 			muted=self.muteOtherAppsCheckBox.GetValue(),
-			state=self.appVolAdjusterCombo._getControlCurrentFlag(),
+			state=self.appVolAdjusterCombo._getControlCurrentFlag().calculated(),
 		)
 
 		if audioDucking.isAudioDuckingSupported():


### PR DESCRIPTION
### Link to issue number:
Fixes #17882
### Summary of the issue:
The toggle command for apps volume control does not report its state after having performed the switch.
Also, while fixing this, I have realized that some state comparison were not performed as expected: confusion between volume control state (enabled/disabled) vs config state (enabled/disabled/default)

### Description of user facing changes
The command now works as expected.

### Description of development approach
* Changed variable names and added type hints to distinguish between config state and real apps volume control state
* Calculate the config state when needed

### Testing strategy:
Manual tests:
* Test of other apps volume control features: control disabled/enabled, change apps volume, mute other apps.
* Perform these tests through keyboard shortcut and through Audio settings panel
* Check that #17300 not reintroduced
### Known issues with pull request:
None
### Code Review Checklist:


- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
