### PR TITLE
Download add-ons in the BG for automatic update notifications

### DIFF
--- a/source/addonStore/models/addon.py
+++ b/source/addonStore/models/addon.py
@@ -398,7 +398,7 @@ def _createAddonGUICollection() -> AddonGUICollectionT:
 	Therefore addon IDs should be treated as case insensitive.
 	"""
 	return AddonGUICollectionT(
-		{channel: CaseInsensitiveDict() for channel in Channel if channel != Channel.ALL}
+		{channel: CaseInsensitiveDict() for channel in Channel if channel != Channel.ALL},
 	)
 
 

--- a/source/addonStore/network.py
+++ b/source/addonStore/network.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2022-2024 NV Access Limited
+# Copyright (C) 2022-2025 NV Access Limited
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -246,8 +246,14 @@ class AddonFileDownloader:
 		log.debug(f"starting download: {addonData.addonId}")
 		cacheFilePath = addonData.cachedDownloadPath
 		if os.path.exists(cacheFilePath):
-			log.debug(f"Cache file already exists, deleting {cacheFilePath}")
-			os.remove(cacheFilePath)
+			if self._checkChecksum(cacheFilePath, addonData):
+				return cast(os.PathLike, cacheFilePath)  # The file is already downloaded and valid
+			else:
+				log.debug(
+					f"Cache file {cacheFilePath} already exists and doesn't match checksum. "
+					"Likely a failed download, deleting and re-downloading. ",
+				)
+				os.remove(cacheFilePath)
 
 		inProgressFilePath = addonData.tempDownloadPath
 		with self.DOWNLOAD_LOCK:

--- a/source/gui/addonStoreGui/controls/messageDialogs.py
+++ b/source/gui/addonStoreGui/controls/messageDialogs.py
@@ -606,7 +606,7 @@ class UpdatableAddonsDialog(
 				raise NotImplementedError("Unknown automatic update setting")
 
 		# Download add-ons in the background
-		installCallback = threading.Thread(
+		threading.Thread(
 			name="AutomaticAddonUpdateDownload",
 			target=cls._downloadAddons,
 			args=(listItemVMs, installCallback),

--- a/source/gui/addonStoreGui/viewModels/addonList.py
+++ b/source/gui/addonStoreGui/viewModels/addonList.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2022-2023 NV Access Limited, Cyrille Bougot
+# Copyright (C) 2022-2025 NV Access Limited, Cyrille Bougot
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -13,7 +13,6 @@ from typing import (
 	List,
 	Optional,
 	TYPE_CHECKING,
-	TypeVar,
 )
 
 from requests.structures import CaseInsensitiveDict
@@ -22,6 +21,7 @@ from addonStore.models.addon import (
 	_AddonGUIModel,
 	_AddonStoreModel,
 	_AddonManifestModel,
+	_AddonModelT,
 )
 from addonStore.models.status import (
 	_installedAddonStatuses,
@@ -95,9 +95,6 @@ class AddonListField(_AddonListFieldData, Enum):
 		pgettext("addonStore", "Date"),
 		50,
 	)
-
-
-_AddonModelT = TypeVar("_AddonModelT", bound=_AddonGUIModel)
 
 
 class AddonListItemVM(Generic[_AddonModelT]):

--- a/tests/manual/addonStore.md
+++ b/tests/manual/addonStore.md
@@ -197,7 +197,7 @@ For example: "Clock".
 
 1. Repeatedly [create updatable add-ons](#simulate-creating-an-updatable-add-on).
 1. Start NVDA
-1. Ensure Automatic update notifications are enabled in the Add-on Store panel
+1. Ensure Automatic update notifications is set to "Notify" in the Add-on Store panel
 1. Trigger the update notification manually, or alternatively wait for the notification to occur
     1. From the NVDA Python console, find the scheduled thread
         ```py
@@ -215,7 +215,21 @@ For example: "Clock".
 
 ### Automatic updating
 
-Full automatic updating is not currently supported.
+1. Repeatedly [create updatable add-ons](#simulate-creating-an-updatable-add-on).
+1. Start NVDA
+1. Ensure Automatic update notifications is set to "Update Automatically" in the Add-on Store panel
+1. Trigger the update notification manually, or alternatively wait for the notification to occur
+    1. From the NVDA Python console, find the scheduled thread
+        ```py
+        import schedule
+        schedule.jobs
+        ```
+    1. Replace `i` with the index of the scheduled thread to find the job
+        ```py
+        schedule.jobs[i].run()
+        ```
+1. Wait for NVDA to announce that updates have been completed
+1. Check the Add-on Store to confirm the updated add-ons are pending install.
 
 ## Other add-on actions
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Fixes #17722 
### Summary of the issue:
When using the automatic update notifications, users must wait until downloads complete before exiting the add-on update dialog. 
Instead, downloads can be pre-fetched, and the user can decide to update all add-ons using the pre-downloaded add-ons, or discard updates.

### Description of user facing changes

When using automatic update notifications the new UX is:

1. Job starts, automatic update is set to notify or automatic update
1. Job fetches and downloads updatable add-ons
1. If update notification is set to notify, open the notification dialog
    1. If the user presses update all - the installation is immediately queued and the dialog is closed. Before you had to click close after update all, and retry closing until downloads are complete.
    1. If the user opens the add-on store to decide which add-ons to update, the add-ons are pre-fetched, and the installation should happen faster
    1. If the user presses close, the downloads are cleared on NVDA restart

### Description of development approach

1. Ensure trying to download an add-on which has successfully already been downloaded in the current NVDA session doesn't retry the download. 
1. Improve typing for add-on collections
1. Pre generate list VMs and download add-ons before branching between automatic BG installation and update notifications, so the same downloads and VMs are used for either path

### Testing strategy:
Tested manually using the add-on store test plan.
Added missing test section for automatic updates in the background

### Known issues with pull request:
Similar logic could potentially be applied to the Add-on Store itself as discussed in #17722 

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
