### PR TITLE
Verify screen curtain at runtime

### DIFF
--- a/nvdaHelper/local/nvdaHelperLocal.def
+++ b/nvdaHelper/local/nvdaHelperLocal.def
@@ -87,3 +87,4 @@ EXPORTS
 	wasSilence_init
 	wasSilence_playFor
 	wasSilence_terminate
+	captureScreen

--- a/nvdaHelper/local/nvdaHelperLocal.def
+++ b/nvdaHelper/local/nvdaHelperLocal.def
@@ -87,4 +87,4 @@ EXPORTS
 	wasSilence_init
 	wasSilence_playFor
 	wasSilence_terminate
-	captureScreen
+	isScreenFullyBlack

--- a/nvdaHelper/local/sconscript
+++ b/nvdaHelper/local/sconscript
@@ -108,7 +108,8 @@ localLib = env.SharedLibrary(
 		"rpcrt4",
 		"shlwapi",
 		detoursLib,
-		"Gdi32.lib",
+		"Gdi32",
+		"Gdiplus",
 	],
 )
 

--- a/nvdaHelper/local/sconscript
+++ b/nvdaHelper/local/sconscript
@@ -97,6 +97,7 @@ localLib = env.SharedLibrary(
 		"mixer.cpp",
 		"oleUtils.cpp",
 		"wasapi.cpp",
+		"screenCurtain.cpp",
 	],
 	LIBS=[
 		"advapi32.lib",
@@ -107,6 +108,7 @@ localLib = env.SharedLibrary(
 		"rpcrt4",
 		"shlwapi",
 		detoursLib,
+		"Gdi32.lib",
 	],
 )
 

--- a/nvdaHelper/local/screenCurtain.cpp
+++ b/nvdaHelper/local/screenCurtain.cpp
@@ -1,3 +1,13 @@
+/**
+ * A part of NonVisual Desktop Access (NVDA)
+ * This file is covered by the GNU General Public License.
+ * See the file COPYING for more details.
+ * Copyright (C) 2025 NV Access Limited
+ *
+ * Utilities for Screen Curtain.
+ *
+ * Must be linked with Gdi32.lib and Gdiplus.lib.
+*/
 #define GDIPVER 0x110   // GDIPlus 1.1, required for histograms.
 #include <windows.h>
 #include <common/log.h>
@@ -7,7 +17,6 @@
 
 using namespace Gdiplus;
 using namespace std;
-#pragma comment(lib, "Gdiplus.lib")
 
 /**
  * @brief Captures the entire virtual screen and determines if the screen is entirely black.

--- a/nvdaHelper/local/screenCurtain.cpp
+++ b/nvdaHelper/local/screenCurtain.cpp
@@ -185,8 +185,6 @@ bool isScreenFullyBlack() {
 		}
 		LOG_DEBUG(ssHist->str());
 
-
-
 		// If the entire screen is black, then the only colour in the histogram must be (0, 0, 0).
 		// Since the sum of values in each channel must be the number of pixels in the image,
 		// if the screen is entirely black,

--- a/nvdaHelper/local/screenCurtain.cpp
+++ b/nvdaHelper/local/screenCurtain.cpp
@@ -14,6 +14,7 @@
 #include <gdiplus.h>
 #include <memory>
 #include <wil/resource.h>
+#include <string>
 
 using namespace Gdiplus;
 using namespace std;
@@ -177,6 +178,14 @@ bool isScreenFullyBlack() {
 		auto histB = std::make_shared<UINT[]>(histogramSize);
 
 		diScreenshot->GetHistogram(HistogramFormatRGB, histogramSize, histR.get(), histG.get(), histB.get(), NULL);
+		auto ssHist = make_unique<wostringstream>();
+		*ssHist << L"Histogram of virtual screen:";
+		for (UINT i = 0; i < histogramSize; i++) {
+			*ssHist << L" (" << histR[i] << L", " << histG[i] << L", " << histB[i] << L")";
+		}
+		LOG_DEBUG(ssHist->str());
+
+
 
 		// If the entire screen is black, then the only colour in the histogram must be (0, 0, 0).
 		// Since the sum of values in each channel must be the number of pixels in the image,

--- a/nvdaHelper/local/screenCurtain.cpp
+++ b/nvdaHelper/local/screenCurtain.cpp
@@ -3,17 +3,22 @@
 #include <windows.h>
 #include <common/log.h>
 #include <objidl.h>
-// #include<gdiplusheaders.h>
 #include <gdiplus.h>
-// #include <gdiplustypes.h>
-// #include <gdiplus.h>
+#include <memory>
 using namespace Gdiplus;
+using namespace std;
 #pragma comment (lib,"Gdiplus.lib")
 
 bool captureScreen() {
+	// Bitmap *image;
+	// Status s;
+	// UINT histSize;
+	// UINT* histR = new UINT[300];
+	// UINT* histG = new UINT[300];
+	// UINT  *histB = new UINT[300];
 	// A false negative is better than a false positive,
 	// So return false until proven otherwise.
-	bool returnValue = false;
+	bool returnValue = false, success;
 	// The virtual screen is the bounding rectangle of all of the monitors on the system.
 	int screenWidth = GetSystemMetrics(SM_CXVIRTUALSCREEN),
 		screenHeight = GetSystemMetrics(SM_CYVIRTUALSCREEN),
@@ -25,19 +30,55 @@ bool captureScreen() {
 		// Screen coordinates are 16-bit integers,
 		// and since 2^16 * 2^16 = 2^32,
 		// the area of the screen is guaranteed to fit in an int on all supported platforms.
-		screenSize = screenWidth * screenHeight;
-		DWORD screenshotSize;
-	HWND desktopWnd = GetDesktopWindow();
-	HDC desktopDc = GetDC(desktopWnd),
-		captureDc = CreateCompatibleDC(desktopDc);
-	HBITMAP captureBitmap = CreateCompatibleBitmap(desktopDc, screenWidth, screenHeight);
+		screenSize = screenWidth * screenHeight,
+		bytesWritten;
+	DWORD screenshotSize;
+	HWND desktopWnd;
+	HDC desktopDc , captureDc ;
+	HBITMAP captureBitmap;
 	BITMAP screenshot;
+	HGDIOBJ oldObj;
+	BITMAPINFOHEADER bmpInfoHeader;
+	LPVOID buff ;
 
+	LOG_INFO(L"Get desktop window");
+	desktopWnd = GetDesktopWindow();
+	if (desktopWnd == NULL) {
+		LOG_ERROR(L"Failed to get handle for desktop window.");
+		// goto done;
+	}
+
+	LOG_INFO(L"Get desktop device context.");
+	desktopDc = GetDC(desktopWnd);
+	if (desktopDc == NULL) {
+		LOG_ERROR(L"Failed to get device context for desktop.");
+		// goto done;
+	}
+	LOG_INFO(L"Get compatible DC.");
+	captureDc = CreateCompatibleDC(desktopDc);
+	if (captureDc == NULL) {
+		LOG_ERROR("Failed to create compatible device context.");
+		// goto done;
+	}
+
+	LOG_INFO("Getting compatible bitmap.");
+	captureBitmap = CreateCompatibleBitmap(desktopDc, screenWidth, screenHeight);
+	if (captureBitmap == NULL) {
+		LOG_ERROR(L"Failed to create compatible bitmap.");
+		// goto done;
+	}
+
+	LOG_INFO(L"Setting captureDC to paint to captureBitmap.");
 	// Set captureDc to draw to captureBitmap.
-	SelectObject(captureDc, captureBitmap);
+	oldObj = SelectObject(captureDc, captureBitmap);
+	if (oldObj == NULL) {
+		LOG_ERROR("Failed to select capture bitmap into capture device context.");
+		// goto done;
+	}
 
+	LOG_INFO(L"Bit blitting.");
 	// Replace the contents of captureDc with those of desktopDc
-	BitBlt(
+	success = BitBlt(
 		// Destination device context
 		captureDc,
 		// Top left of destination
@@ -52,32 +93,44 @@ bool captureScreen() {
 		// In this case, replace destination with source.
 		SRCCOPY
 	);
+	if (!success) {
+		LOG_ERROR("Failed to bit blit desktop device context to capture device context. Error #" << GetLastError());
+		// goto done;
+	}
 
+	LOG_INFO(L"Getting DDB properties.");
 	// Get properties of captureBitmap
-	GetObject(captureBitmap, sizeof(BITMAP), &screenshot);
-// BITMAPFILEHEADER bmpFileHeader;
-BITMAPINFOHEADER bmpInfoHeader;
-bmpInfoHeader.biSize = sizeof(BITMAPINFOHEADER);
-bmpInfoHeader.biWidth = screenshot.bmWidth;
-bmpInfoHeader.biHeight = screenshot.bmHeight;
-bmpInfoHeader.biPlanes = 1;  // Can only ever be 1
-bmpInfoHeader.biBitCount = 32;  // High byte unused
-bmpInfoHeader.biCompression = BI_RGB;  // Uncompressed
-bmpInfoHeader.biSizeImage = 0;  // Unneeded as uncompressed
-bmpInfoHeader.biXPelsPerMeter = 0;
-bmpInfoHeader.biYPelsPerMeter = 0;
-bmpInfoHeader.biClrUsed = 0;
-bmpInfoHeader.biClrImportant = 0;  // All colours are needed
+	bytesWritten = GetObject(captureBitmap, sizeof(BITMAP), &screenshot);
+	if (bytesWritten == 0) {
+		LOG_ERROR("Failed to get bitmap metadata.");
+		// goto done;
+	}
 
-screenshotSize = ((screenshot.bmWidth * bmpInfoHeader.biBitCount + 31) / 32) * 4 * screenshot.bmHeight;
-// dibSize = screenshotSize + sizeof(BITMAPFILEHEADER) + sizeof(BITMAPINFOHEADER);
-// bmpFileHeader.bfOffBits = (DWORD)sizeof(BITMAPFILEHEADER) + (DWORD)sizeof(BITMAPINFOHEADER);
-// bmpFileHeader.bfSize = dibSize;
-// bmpFileHeader.bfType = 0x4D42;  // BM
+	LOG_INFO(L"Setting DIB props.");
+	bmpInfoHeader.biSize = sizeof(BITMAPINFOHEADER);
+	bmpInfoHeader.biWidth = screenshot.bmWidth;
+	bmpInfoHeader.biHeight = screenshot.bmHeight;
+	bmpInfoHeader.biPlanes = 1;  // Can only ever be 1
+	bmpInfoHeader.biBitCount = 32;  // High byte unused
+	bmpInfoHeader.biCompression = BI_RGB;  // Uncompressed
+	bmpInfoHeader.biSizeImage = 0;  // Unneeded as uncompressed
+	bmpInfoHeader.biXPelsPerMeter = 0;
+	bmpInfoHeader.biYPelsPerMeter = 0;
+	bmpInfoHeader.biClrUsed = 0;
+	bmpInfoHeader.biClrImportant = 0;  // All colours are needed
 
-// Convert the device-dependent bitmap to a device-independent bitmap.
-	LPVOID buff = HeapAlloc(GetProcessHeap(), HEAP_GENERATE_EXCEPTIONS, screenshotSize);
-	GetDIBits(
+	LOG_INFO("Calculating DIB size.");
+	screenshotSize = ((screenshot.bmWidth * bmpInfoHeader.biBitCount + 31) / 32) * 4 * screenshot.bmHeight;
+
+	// Convert the device-dependent bitmap to a device-independent bitmap.
+	LOG_INFO("Allocating size for DIB.");
+	buff = HeapAlloc(GetProcessHeap(), HEAP_GENERATE_EXCEPTIONS, screenshotSize);
+	if (buff == NULL) {
+		LOG_ERROR("Failed to allocate space on heap for device independent bitmap.");
+		// goto done;
+	}
+	LOG_INFO(L"Getting DIB.");
+	bytesWritten = GetDIBits(
 		// Source device context and device-dependent bitmap
 		captureDc, captureBitmap,
 		// Range of scan lines to copy
@@ -87,39 +140,46 @@ screenshotSize = ((screenshot.bmWidth * bmpInfoHeader.biBitCount + 31) / 32) * 4
 		// Format of DIB
 		(BITMAPINFO*)&bmpInfoHeader, DIB_RGB_COLORS
 	);
+	if (bytesWritten == 0 || bytesWritten == ERROR_INVALID_PARAMETER) {
+		LOG_ERROR(L"Failed to convert device dependent bitmap to device independent bitmap. Return " << bytesWritten);
+		// goto done;
+	}
 
-// IStream *stream = SHCreateMemStream(NULL, dibSize);
+	// Create a GDI+ bitmap from the captured virtual screen, and calculate a histogram of colours.
+	LOG_INFO(L"Create GDIPLUS bmp.");
+	Bitmap image((BITMAPINFO*)&bmpInfoHeader, buff);
+	UINT hsize;
+	LOG_INFO("Calculate hist size.");
+	Status s = image.GetHistogramSize(HistogramFormatARGB, &hsize);
 
-// HANDLE hFile = CreateFile(L"screenshot.bmp", GENERIC_WRITE, 0, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
+	LOG_INFO("Allocate size for histogram.");
+	auto histR = std::make_shared<UINT[]>(hsize);
+	auto histG = std::make_shared<UINT[]>(hsize);
+	auto histB = std::make_shared<UINT[]>(hsize);
 
-// WriteFile(hFile, (LPSTR)&bmpFileHeader, sizeof(bmpFileHeader), &bytesWritten, NULL);
-// stream->Write((LPSTR)&bmpFileHeader, sizeof(bmpFileHeader), &bytesWritten);
-// WriteFile(hFile, (LPSTR)&bmpInfoHeader, sizeof(bmpInfoHeader), &bytesWritten, NULL);
-// stream->Write((LPSTR)&bmpInfoHeader, sizeof(bmpInfoHeader), &bytesWritten);
-// WriteFile(hFile, (LPSTR)buff, screenshotSize, &bytesWritten, NULL);
-// stream->Write((LPSTR)buff, screenshotSize, &bytesWritten);
+	LOG_INFO(L"Get histogram.");
+	image.GetHistogram(HistogramFormatRGB, hsize, histR.get(), histG.get(), histB.get(), NULL);
 
-// CloseHandle(hFile);
+	// If the entire screen is black, then the only colour in the histogram must be (0, 0, 0).
+	// Since the sum of values in each channel must be the number of pixels in the image,
+	// if the screen is entirely black,
+	// the 0th entry in each of the channels must be the number of pixels in the image.
+	LOG_INFO("Work out if is black.");
+	returnValue = (histR[0] == screenSize && histG[0] == screenSize && histB[0] == screenSize);
 
-Bitmap image((BITMAPINFO*)&bmpInfoHeader, buff);
-UINT hsize;
-Status s = image.GetHistogramSize(HistogramFormatARGB, &hsize);
-UINT* histR = new UINT[hsize];
-UINT* histG = new UINT[hsize];
-UINT* histB = new UINT[hsize];
-
-image.GetHistogram(HistogramFormatRGB, hsize, histR, histG, histB, NULL);
-// bool isBlack;
-// If the entire screen is black, then the only colour in the histogram must be (0, 0, 0).
-// Since the sum of values in each channel must be the number of pixels in the image,
-// if the screen is entirely black,
-// the 0th entry in each of the channels must be the number of pixels in the image.
-returnValue = (histR[0] == screenSize && histG[0] == screenSize && histB[0] == screenSize);
-
-HeapFree(GetProcessHeap(), NULL, buff);
-ReleaseDC(desktopWnd, desktopDc);
-DeleteDC(captureDc);
-DeleteObject(captureBitmap);
+// done:
+	LOG_INFO("Clean up.");
+	HeapFree(GetProcessHeap(), NULL, buff);
+	if (desktopWnd != NULL) {
+		if (desktopDc != NULL)
+			ReleaseDC(desktopWnd, desktopDc);
+		CloseHandle(desktopWnd);
+	}
+	if (captureDc != NULL) {
+		SelectObject(captureDc, oldObj);
+		DeleteDC(captureDc);
+	}
+	if (captureBitmap != NULL) DeleteObject(captureBitmap);
 	return returnValue;
 }
 

--- a/nvdaHelper/local/screenCurtain.cpp
+++ b/nvdaHelper/local/screenCurtain.cpp
@@ -147,7 +147,8 @@ bool isScreenFullyBlack() {
 
 	try {
 		// Convert the device-dependent bitmap to a device-independent bitmap.
-		auto diScreenshotBits = make_shared<char[]>(diScreenshotSize);
+		// Initialise each byte to 1 as a canary.
+		auto diScreenshotBits = make_shared<char[]>(diScreenshotSize, 1);
 		bytesWritten = GetDIBits(
 			// Source device context and device-dependent bitmap
 			captureDc.get(), captureBitmap.get(),

--- a/nvdaHelper/local/screenCurtain.cpp
+++ b/nvdaHelper/local/screenCurtain.cpp
@@ -139,6 +139,10 @@ bool isScreenFullyBlack() {
 	diScreenshotHeader.biClrImportant = 0; // All colours are needed
 
 	// Calculate the size (in bytes) of the DIB.
+	// Each scan line must be a multiple of 32bits long, including padding if necessary.
+	// So add 31 to push us to that boundary if padding is needed.
+	// If the scan line doesn't need any padding, adding 31 will make no difference,
+	// since (32n + 31) / 32 = n R 31.
 	diScreenshotSize = ((ddScreenshot.bmWidth * diScreenshotHeader.biBitCount + 31) / 32) * 4 * ddScreenshot.bmHeight;
 
 	try {

--- a/nvdaHelper/local/screenCurtain.cpp
+++ b/nvdaHelper/local/screenCurtain.cpp
@@ -1,0 +1,88 @@
+#define GDIPVER 0x110
+#include <shlwapi.h>
+#include <windows.h>
+#include <common/log.h>
+#include <objidl.h>
+// #include<gdiplusheaders.h>
+#include <gdiplus.h>
+// #include <gdiplustypes.h>
+// #include <gdiplus.h>
+using namespace Gdiplus;
+#pragma comment (lib,"Gdiplus.lib")
+
+bool captureScreen()
+{
+	int screenWidth = GetSystemMetrics(SM_CXSCREEN),
+		screenHeight = GetSystemMetrics(SM_CYSCREEN);
+	HWND desktopWnd = GetDesktopWindow();
+	HDC desktopDc = GetDC(desktopWnd),
+		captureDc = CreateCompatibleDC(desktopDc);
+	HBITMAP captureBitmap = CreateCompatibleBitmap(desktopDc, screenWidth, screenHeight);
+	BITMAP screenshot;
+	DWORD screenshotSize=0, bytesWritten=0, dibSize=0;
+	SelectObject(captureDc, captureBitmap);
+	bool isBlack = true;
+
+	BitBlt(captureDc, 0, 0, screenWidth, screenHeight, desktopDc, 0, 0, SRCCOPY);
+
+	GetObject(captureBitmap, sizeof(BITMAP), &screenshot);
+	BITMAPFILEHEADER bmpFileHeader;
+	BITMAPINFOHEADER bmpInfoHeader;
+	bmpInfoHeader.biSize = sizeof(BITMAPINFOHEADER);
+	bmpInfoHeader.biWidth = screenshot.bmWidth;
+	bmpInfoHeader.biHeight = screenshot.bmHeight;
+	bmpInfoHeader.biPlanes = 1;
+	bmpInfoHeader.biBitCount = 32;
+	bmpInfoHeader.biCompression = BI_RGB;
+	bmpInfoHeader.biSizeImage = 0;
+	bmpInfoHeader.biXPelsPerMeter = 0;
+	bmpInfoHeader.biYPelsPerMeter = 0;
+	bmpInfoHeader.biClrUsed = 0;
+	bmpInfoHeader.biClrImportant = 0;
+
+	screenshotSize = ((screenshot.bmWidth * bmpInfoHeader.biBitCount + 31) / 32) * 4 * screenshot.bmHeight;
+	dibSize = screenshotSize + sizeof(BITMAPFILEHEADER) + sizeof(BITMAPINFOHEADER);
+	bmpFileHeader.bfOffBits = (DWORD)sizeof(BITMAPFILEHEADER) + (DWORD)sizeof(BITMAPINFOHEADER);
+	bmpFileHeader.bfSize = dibSize;
+	bmpFileHeader.bfType = 0x4D42;  // BM
+
+	LPVOID buff = HeapAlloc(GetProcessHeap(), HEAP_GENERATE_EXCEPTIONS, screenshotSize);
+
+	GetDIBits(captureDc, captureBitmap, 0, (UINT)screenshot.bmHeight, buff, (BITMAPINFO*)&bmpInfoHeader, DIB_RGB_COLORS);
+
+	IStream *stream = SHCreateMemStream(NULL, dibSize);
+
+	HANDLE hFile = CreateFile(L"screenshot.bmp", GENERIC_WRITE, 0, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
+
+	WriteFile(hFile, (LPSTR)&bmpFileHeader, sizeof(bmpFileHeader), &bytesWritten, NULL);
+	stream->Write((LPSTR)&bmpFileHeader, sizeof(bmpFileHeader), &bytesWritten);
+	WriteFile(hFile, (LPSTR)&bmpInfoHeader, sizeof(bmpInfoHeader), &bytesWritten, NULL);
+	stream->Write((LPSTR)&bmpInfoHeader, sizeof(bmpInfoHeader), &bytesWritten);
+	WriteFile(hFile, (LPSTR)buff, screenshotSize, &bytesWritten, NULL);
+	stream->Write((LPSTR)buff, screenshotSize, &bytesWritten);
+
+	CloseHandle(hFile);
+
+	Bitmap image((BITMAPINFO*)&bmpInfoHeader, buff);
+	UINT hsize;
+	Status s = image.GetHistogramSize(HistogramFormatARGB, &hsize);
+	UINT* ch0 = new UINT[hsize];
+	UINT* ch1 = new UINT[hsize];
+	UINT* ch2 = new UINT[hsize];
+
+	image.GetHistogram(HistogramFormatRGB, hsize, ch0, ch1, ch2, NULL);
+
+// Print the histogram values for the three channels: red, green, blue.
+for(UINT j = 1; j < hsize; ++j)
+{
+// check all channels' values
+}
+
+
+
+	HeapFree(GetProcessHeap(), NULL, buff);
+	ReleaseDC(desktopWnd, desktopDc);
+	DeleteDC(captureDc);
+	DeleteObject(captureBitmap);
+	return isBlack;
+}

--- a/nvdaHelper/local/screenCurtain.cpp
+++ b/nvdaHelper/local/screenCurtain.cpp
@@ -1,12 +1,10 @@
-#define GDIPVER 0x110
-#include <shlwapi.h>
+#define GDIPVER 0x110   // GDIPlus 1.1, required for histograms.
 #include <windows.h>
 #include <common/log.h>
-#include <objidl.h>
 #include <gdiplus.h>
 #include <memory>
-#include <functional>
 #include <wil/resource.h>
+
 using namespace Gdiplus;
 using namespace std;
 #pragma comment(lib, "Gdiplus.lib")
@@ -57,7 +55,7 @@ bool isScreenFullyBlack() {
 	HGDIOBJ oldObj;
 	BITMAPINFOHEADER diScreenshotHeader;
 	bool bStatus ;
-	Gdiplus::Status sStatus;
+	Status sStatus;
 
 	// The desktop window covers the entire virtual screen.
 	desktopWnd = GetDesktopWindow();
@@ -135,7 +133,7 @@ bool isScreenFullyBlack() {
 
 	try {
 		// Convert the device-dependent bitmap to a device-independent bitmap.
-		auto diScreenshotBits = std::make_shared<char[]>(diScreenshotSize);
+		auto diScreenshotBits = make_shared<char[]>(diScreenshotSize);
 		bytesWritten = GetDIBits(
 			// Source device context and device-dependent bitmap
 			captureDc.get(), captureBitmap.get(),
@@ -153,12 +151,12 @@ bool isScreenFullyBlack() {
 		// Create a GDI+ bitmap from the captured virtual screen, and calculate a histogram of colours.
 		auto diScreenshot = make_shared<Bitmap>((BITMAPINFO *)&diScreenshotHeader, diScreenshotBits.get());
 		sStatus = diScreenshot->GetHistogramSize(HistogramFormatARGB, &histogramSize);
-		if (sStatus != Gdiplus::Ok) {
+		if (sStatus != Ok) {
 			LOG_ERROR(L"Failed to calculate histogram size. Error #" << sStatus << L".");
 			return false;
 		}
 		// Allocate size for the histogram.
-		auto histR = std::make_shared<UINT[]>(histogramSize);
+		auto histR = make_shared<UINT[]>(histogramSize);
 		auto histG = std::make_shared<UINT[]>(histogramSize);
 		auto histB = std::make_shared<UINT[]>(histogramSize);
 

--- a/nvdaHelper/local/screenCurtain.cpp
+++ b/nvdaHelper/local/screenCurtain.cpp
@@ -11,7 +11,32 @@ using namespace Gdiplus;
 using namespace std;
 #pragma comment(lib, "Gdiplus.lib")
 
-bool captureScreen() {
+/**
+ * @brief Captures the entire virtual screen and determines if the screen is entirely black.
+ *
+ * This function captures the contents of the virtual screen, which is the bounding rectangle
+ * of all monitors on the system. It creates a device-independent bitmap (DIB) from the captured
+ * screen and calculates a histogram of colors to determine if the screen is entirely black.
+ *
+ * @return true if the screen is entirely black, false otherwise or if an error occurs.
+ *
+ * @details
+ * - The function retrieves the dimensions and origin of the virtual screen using `GetSystemMetrics`.
+ * - It creates a compatible device context and bitmap for capturing the screen.
+ * - The screen contents are copied into the compatible device context using `BitBlt`.
+ * - The captured bitmap is converted into a device-independent bitmap (DIB) using `GetDIBits`.
+ * - A GDI+ bitmap is created from the DIB, and a histogram of colors is calculated.
+ * - The function checks if the histogram indicates that the entire screen is black by verifying
+ *   that the only color present is black (0, 0, 0) and that the count of black pixels matches
+ *   the total screen area.
+ *
+ * @note
+ * - The function uses the GDI+ library for bitmap manipulation and histogram calculation.
+ * - Error handling is implemented to log and handle failures at various stages.
+ * - Per <https://learn.microsoft.com/en-us/windows/win32/gdi/the-virtual-screen>,
+ *   We assume that the screen coordinates and dimensions fit within 16-bit integers.
+ */
+bool isScreenFullyBlack() {
 	// The virtual screen is the bounding rectangle of all of the monitors on the system.
 	int screenWidth = GetSystemMetrics(SM_CXVIRTUALSCREEN),
 		screenHeight = GetSystemMetrics(SM_CYVIRTUALSCREEN),
@@ -152,99 +177,3 @@ bool captureScreen() {
 		return false;
 	}
 }
-/*
-bool oldCaptureScreen()
-{
-	// The virtual screen is the bounding rectangle of all of the monitors on the system.
-	int screenWidth = GetSystemMetrics(SM_CXVIRTUALSCREEN),
-		screenHeight = GetSystemMetrics(SM_CYVIRTUALSCREEN),
-		// While the primary monitor'sStatus top left corner is at the origin,
-		// it is not necessarily at the top left of the virtual screen.
-		// Thus, the top left of the virtual screen may be negative.
-		screenOriginX = GetSystemMetrics(SM_XVIRTUALSCREEN),
-		screenOriginY = GetSystemMetrics(SM_YVIRTUALSCREEN),
-		// Screen coordinates are 16-bit integers,
-		// and since 2^16 * 2^16 = 2^32,
-		// the area of the screen is guaranteed to fit in an int on all supported platforms.
-		screenArea = screenWidth * screenHeight;
-	LOG_INFO(L"Screen is " << screenWidth << L"x" << screenHeight << " = " << screenArea << "\n");
-	HWND desktopWnd = GetDesktopWindow();
-	HDC desktopDc = GetDC(desktopWnd),
-		captureDc = CreateCompatibleDC(desktopDc);
-	HBITMAP captureBitmap = CreateCompatibleBitmap(desktopDc, screenWidth, screenHeight);
-	BITMAP ddScreenshot;
-	DWORD screenshotSize = 0, bytesWritten = 0, dibSize = 0;
-	SelectObject(captureDc, captureBitmap);
-
-	// Replace the contents of captureDc with those of desktopDc
-	BitBlt(
-		// Destination device context
-		captureDc,
-		// Top left of destination
-		0, 0,
-		// Size of source and destination
-		screenWidth, screenHeight,
-		// Source device context
-		desktopDc,
-		// Top left of source
-		screenOriginX, screenOriginY,
-		// Raster operation to perform.
-		// In this case, replace destination with source.
-		SRCCOPY);
-
-	GetObject(captureBitmap, sizeof(BITMAP), &ddScreenshot);
-	BITMAPFILEHEADER bmpFileHeader;
-	BITMAPINFOHEADER bmpInfoHeader;
-	bmpInfoHeader.biSize = sizeof(BITMAPINFOHEADER);
-	bmpInfoHeader.biWidth = ddScreenshot.bmWidth;
-	bmpInfoHeader.biHeight = ddScreenshot.bmHeight;
-	bmpInfoHeader.biPlanes = 1;
-	bmpInfoHeader.biBitCount = 32;
-	bmpInfoHeader.biCompression = BI_RGB;
-	bmpInfoHeader.biSizeImage = 0;
-	bmpInfoHeader.biXPelsPerMeter = 0;
-	bmpInfoHeader.biYPelsPerMeter = 0;
-	bmpInfoHeader.biClrUsed = 0;
-	bmpInfoHeader.biClrImportant = 0;
-
-	screenshotSize = ((ddScreenshot.bmWidth * bmpInfoHeader.biBitCount + 31) / 32) * 4 * ddScreenshot.bmHeight;
-	dibSize = screenshotSize + sizeof(BITMAPFILEHEADER) + sizeof(BITMAPINFOHEADER);
-	bmpFileHeader.bfOffBits = (DWORD)sizeof(BITMAPFILEHEADER) + (DWORD)sizeof(BITMAPINFOHEADER);
-	bmpFileHeader.bfSize = dibSize;
-	bmpFileHeader.bfType = 0x4D42; // BM
-
-	LPVOID buff = HeapAlloc(GetProcessHeap(), HEAP_GENERATE_EXCEPTIONS, screenshotSize);
-
-	GetDIBits(captureDc, captureBitmap, 0, (UINT)ddScreenshot.bmHeight, buff, (BITMAPINFO *)&bmpInfoHeader, DIB_RGB_COLORS);
-
-	IStream *stream = SHCreateMemStream(NULL, dibSize);
-
-	HANDLE hFile = CreateFile(L"ddScreenshot.bmp", GENERIC_WRITE, 0, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
-
-	WriteFile(hFile, (LPSTR)&bmpFileHeader, sizeof(bmpFileHeader), &bytesWritten, NULL);
-	stream->Write((LPSTR)&bmpFileHeader, sizeof(bmpFileHeader), &bytesWritten);
-	WriteFile(hFile, (LPSTR)&bmpInfoHeader, sizeof(bmpInfoHeader), &bytesWritten, NULL);
-	stream->Write((LPSTR)&bmpInfoHeader, sizeof(bmpInfoHeader), &bytesWritten);
-	WriteFile(hFile, (LPSTR)buff, screenshotSize, &bytesWritten, NULL);
-	stream->Write((LPSTR)buff, screenshotSize, &bytesWritten);
-
-	CloseHandle(hFile);
-
-	Bitmap image((BITMAPINFO *)&bmpInfoHeader, buff);
-	UINT histogramSize;
-	Status sStatus = image.GetHistogramSize(HistogramFormatARGB, &histogramSize);
-	UINT *histR = new UINT[histogramSize];
-	UINT *histG = new UINT[histogramSize];
-	UINT *histB = new UINT[histogramSize];
-
-	image.GetHistogram(HistogramFormatRGB, histogramSize, histR, histG, histB, NULL);
-	bool isBlack;
-	isBlack = (histR[0] == screenArea || histG[0] == screenArea || histB[0] == screenArea);
-
-	HeapFree(GetProcessHeap(), NULL, buff);
-	ReleaseDC(desktopWnd, desktopDc);
-	DeleteDC(captureDc);
-	DeleteObject(captureBitmap);
-	return isBlack;
-}
-*/

--- a/nvdaHelper/local/screenCurtain.cpp
+++ b/nvdaHelper/local/screenCurtain.cpp
@@ -10,12 +10,132 @@
 using namespace Gdiplus;
 #pragma comment (lib,"Gdiplus.lib")
 
-bool captureScreen()
-{
+bool captureScreen() {
+	// A false negative is better than a false positive,
+	// So return false until proven otherwise.
+	bool returnValue = false;
+	// The virtual screen is the bounding rectangle of all of the monitors on the system.
 	int screenWidth = GetSystemMetrics(SM_CXVIRTUALSCREEN),
 		screenHeight = GetSystemMetrics(SM_CYVIRTUALSCREEN),
+		// While the primary monitor's top left corner is at the origin,
+		// it is not necessarily at the top left of the virtual screen.
+		// Thus, the top left of the virtual screen may be negative.
 		screenOriginX = GetSystemMetrics(SM_XVIRTUALSCREEN),
 		screenOriginY = GetSystemMetrics(SM_YVIRTUALSCREEN),
+		// Screen coordinates are 16-bit integers,
+		// and since 2^16 * 2^16 = 2^32,
+		// the area of the screen is guaranteed to fit in an int on all supported platforms.
+		screenSize = screenWidth * screenHeight;
+		DWORD screenshotSize;
+	HWND desktopWnd = GetDesktopWindow();
+	HDC desktopDc = GetDC(desktopWnd),
+		captureDc = CreateCompatibleDC(desktopDc);
+	HBITMAP captureBitmap = CreateCompatibleBitmap(desktopDc, screenWidth, screenHeight);
+	BITMAP screenshot;
+
+	// Set captureDc to draw to captureBitmap.
+	SelectObject(captureDc, captureBitmap);
+
+	// Replace the contents of captureDc with those of desktopDc
+	BitBlt(
+		// Destination device context
+		captureDc,
+		// Top left of destination
+		0, 0,
+		// Size of source and destination
+		screenWidth, screenHeight,
+		// Source device context
+		desktopDc,
+		// Top left of source
+		screenOriginX, screenOriginY,
+		// Raster operation to perform.
+		// In this case, replace destination with source.
+		SRCCOPY
+	);
+
+	// Get properties of captureBitmap
+	GetObject(captureBitmap, sizeof(BITMAP), &screenshot);
+// BITMAPFILEHEADER bmpFileHeader;
+BITMAPINFOHEADER bmpInfoHeader;
+bmpInfoHeader.biSize = sizeof(BITMAPINFOHEADER);
+bmpInfoHeader.biWidth = screenshot.bmWidth;
+bmpInfoHeader.biHeight = screenshot.bmHeight;
+bmpInfoHeader.biPlanes = 1;  // Can only ever be 1
+bmpInfoHeader.biBitCount = 32;  // High byte unused
+bmpInfoHeader.biCompression = BI_RGB;  // Uncompressed
+bmpInfoHeader.biSizeImage = 0;  // Unneeded as uncompressed
+bmpInfoHeader.biXPelsPerMeter = 0;
+bmpInfoHeader.biYPelsPerMeter = 0;
+bmpInfoHeader.biClrUsed = 0;
+bmpInfoHeader.biClrImportant = 0;  // All colours are needed
+
+screenshotSize = ((screenshot.bmWidth * bmpInfoHeader.biBitCount + 31) / 32) * 4 * screenshot.bmHeight;
+// dibSize = screenshotSize + sizeof(BITMAPFILEHEADER) + sizeof(BITMAPINFOHEADER);
+// bmpFileHeader.bfOffBits = (DWORD)sizeof(BITMAPFILEHEADER) + (DWORD)sizeof(BITMAPINFOHEADER);
+// bmpFileHeader.bfSize = dibSize;
+// bmpFileHeader.bfType = 0x4D42;  // BM
+
+// Convert the device-dependent bitmap to a device-independent bitmap.
+	LPVOID buff = HeapAlloc(GetProcessHeap(), HEAP_GENERATE_EXCEPTIONS, screenshotSize);
+	GetDIBits(
+		// Source device context and device-dependent bitmap
+		captureDc, captureBitmap,
+		// Range of scan lines to copy
+		0, (UINT)screenshot.bmHeight,
+		// Destination buffer
+		buff,
+		// Format of DIB
+		(BITMAPINFO*)&bmpInfoHeader, DIB_RGB_COLORS
+	);
+
+// IStream *stream = SHCreateMemStream(NULL, dibSize);
+
+// HANDLE hFile = CreateFile(L"screenshot.bmp", GENERIC_WRITE, 0, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
+
+// WriteFile(hFile, (LPSTR)&bmpFileHeader, sizeof(bmpFileHeader), &bytesWritten, NULL);
+// stream->Write((LPSTR)&bmpFileHeader, sizeof(bmpFileHeader), &bytesWritten);
+// WriteFile(hFile, (LPSTR)&bmpInfoHeader, sizeof(bmpInfoHeader), &bytesWritten, NULL);
+// stream->Write((LPSTR)&bmpInfoHeader, sizeof(bmpInfoHeader), &bytesWritten);
+// WriteFile(hFile, (LPSTR)buff, screenshotSize, &bytesWritten, NULL);
+// stream->Write((LPSTR)buff, screenshotSize, &bytesWritten);
+
+// CloseHandle(hFile);
+
+Bitmap image((BITMAPINFO*)&bmpInfoHeader, buff);
+UINT hsize;
+Status s = image.GetHistogramSize(HistogramFormatARGB, &hsize);
+UINT* histR = new UINT[hsize];
+UINT* histG = new UINT[hsize];
+UINT* histB = new UINT[hsize];
+
+image.GetHistogram(HistogramFormatRGB, hsize, histR, histG, histB, NULL);
+// bool isBlack;
+// If the entire screen is black, then the only colour in the histogram must be (0, 0, 0).
+// Since the sum of values in each channel must be the number of pixels in the image,
+// if the screen is entirely black,
+// the 0th entry in each of the channels must be the number of pixels in the image.
+returnValue = (histR[0] == screenSize && histG[0] == screenSize && histB[0] == screenSize);
+
+HeapFree(GetProcessHeap(), NULL, buff);
+ReleaseDC(desktopWnd, desktopDc);
+DeleteDC(captureDc);
+DeleteObject(captureBitmap);
+	return returnValue;
+}
+
+bool oldCaptureScreen()
+{
+	// The virtual screen is the bounding rectangle of all of the monitors on the system.
+	int screenWidth = GetSystemMetrics(SM_CXVIRTUALSCREEN),
+		screenHeight = GetSystemMetrics(SM_CYVIRTUALSCREEN),
+		// While the primary monitor's top left corner is at the origin,
+		// it is not necessarily at the top left of the virtual screen.
+		// Thus, the top left of the virtual screen may be negative.
+		screenOriginX = GetSystemMetrics(SM_XVIRTUALSCREEN),
+		screenOriginY = GetSystemMetrics(SM_YVIRTUALSCREEN),
+		// Screen coordinates are 16-bit integers,
+		// and since 2^16 * 2^16 = 2^32,
+		// the area of the screen is guaranteed to fit in an int on all supported platforms.
 		screenSize = screenWidth * screenHeight;
 	LOG_INFO(L"Screen is " << screenWidth << L"x" << screenHeight << " = " << screenSize << "\n");
 	HWND desktopWnd = GetDesktopWindow();
@@ -26,7 +146,22 @@ bool captureScreen()
 	DWORD screenshotSize=0, bytesWritten=0, dibSize=0;
 	SelectObject(captureDc, captureBitmap);
 
-	BitBlt(captureDc, 0, 0, screenWidth, screenHeight, desktopDc, screenOriginX, screenOriginY, SRCCOPY);
+	// Replace the contents of captureDc with those of desktopDc
+	BitBlt(
+		// Destination device context
+		captureDc,
+		// Top left of destination
+		0, 0,
+		// Size of source and destination
+		screenWidth, screenHeight,
+		// Source device context
+		desktopDc,
+		// Top left of source
+		screenOriginX, screenOriginY,
+		// Raster operation to perform.
+		// In this case, replace destination with source.
+		SRCCOPY
+	);
 
 	GetObject(captureBitmap, sizeof(BITMAP), &screenshot);
 	BITMAPFILEHEADER bmpFileHeader;

--- a/nvdaHelper/local/screenCurtain.cpp
+++ b/nvdaHelper/local/screenCurtain.cpp
@@ -63,7 +63,7 @@ bool isScreenFullyBlack() {
 	BITMAP ddScreenshot;
 	HGDIOBJ oldObj;
 	BITMAPINFOHEADER diScreenshotHeader;
-	bool bStatus ;
+	bool bStatus;
 	Status sStatus;
 
 	// The desktop window covers the entire virtual screen.
@@ -109,7 +109,8 @@ bool isScreenFullyBlack() {
 		screenOriginX, screenOriginY,
 		// Raster operation to perform.
 		// In this case, replace destination with source.
-		SRCCOPY);
+		SRCCOPY
+	);
 	// Restore captureDC for safety.
 	SelectObject(captureDc.get(), oldObj);
 	if (!bStatus) {
@@ -128,10 +129,10 @@ bool isScreenFullyBlack() {
 	diScreenshotHeader.biSize = sizeof(BITMAPINFOHEADER);
 	diScreenshotHeader.biWidth = ddScreenshot.bmWidth;
 	diScreenshotHeader.biHeight = ddScreenshot.bmHeight;
-	diScreenshotHeader.biPlanes = 1;			  // Can only ever be 1
-	diScreenshotHeader.biBitCount = 32;		  // High byte unused
-	diScreenshotHeader.biCompression = BI_RGB; // Uncompressed
-	diScreenshotHeader.biSizeImage = 0;		  // Unneeded as uncompressed
+	diScreenshotHeader.biPlanes = 1;  // Can only ever be 1
+	diScreenshotHeader.biBitCount = 32;  // High byte unused
+	diScreenshotHeader.biCompression = BI_RGB;  // Uncompressed
+	diScreenshotHeader.biSizeImage = 0;  // Unneeded as uncompressed
 	diScreenshotHeader.biXPelsPerMeter = 0;
 	diScreenshotHeader.biYPelsPerMeter = 0;
 	diScreenshotHeader.biClrUsed = 0;
@@ -151,14 +152,15 @@ bool isScreenFullyBlack() {
 			// Destination buffer
 			diScreenshotBits.get(),
 			// Format of DIB
-			(BITMAPINFO *)&diScreenshotHeader, DIB_RGB_COLORS);
+			(BITMAPINFO*)&diScreenshotHeader, DIB_RGB_COLORS
+		);
 		if (bytesWritten == 0 || bytesWritten == ERROR_INVALID_PARAMETER) {
 			LOG_ERROR(L"Failed to convert device dependent bitmap to device independent bitmap. Got " << bytesWritten << L".");
 			return false;
 		}
 
 		// Create a GDI+ bitmap from the captured virtual screen, and calculate a histogram of colours.
-		auto diScreenshot = make_shared<Bitmap>((BITMAPINFO *)&diScreenshotHeader, diScreenshotBits.get());
+		auto diScreenshot = make_shared<Bitmap>((BITMAPINFO*)&diScreenshotHeader, diScreenshotBits.get());
 		sStatus = diScreenshot->GetHistogramSize(HistogramFormatARGB, &histogramSize);
 		if (sStatus != Ok) {
 			LOG_ERROR(L"Failed to calculate histogram size. Error #" << sStatus << L".");
@@ -175,7 +177,6 @@ bool isScreenFullyBlack() {
 		// Since the sum of values in each channel must be the number of pixels in the image,
 		// if the screen is entirely black,
 		// the 0th entry in each of the channels must be the number of pixels in the image.
-		LOG_INFO("Work out if is black.");
 		return histR[0] == screenArea && histG[0] == screenArea && histB[0] == screenArea;
 	}
 	catch (bad_alloc)

--- a/nvdaHelper/local/screenCurtain.cpp
+++ b/nvdaHelper/local/screenCurtain.cpp
@@ -9,19 +9,9 @@
 #include <wil/resource.h>
 using namespace Gdiplus;
 using namespace std;
-#pragma comment (lib,"Gdiplus.lib")
-
+#pragma comment(lib, "Gdiplus.lib")
 
 bool captureScreen() {
-	// Bitmap *image;
-	// Status s;
-	// UINT histSize;
-	// UINT* histR = new UINT[300];
-	// UINT* histG = new UINT[300];
-	// UINT  *histB = new UINT[300];
-	// A false negative is better than a false positive,
-	// So return false until proven otherwise.
-	bool returnValue = false, success;
 	// The virtual screen is the bounding rectangle of all of the monitors on the system.
 	int screenWidth = GetSystemMetrics(SM_CXVIRTUALSCREEN),
 		screenHeight = GetSystemMetrics(SM_CYVIRTUALSCREEN),
@@ -35,13 +25,14 @@ bool captureScreen() {
 		// the area of the screen is guaranteed to fit in an int on all supported platforms.
 		screenSize = screenWidth * screenHeight,
 		bytesWritten;
+	UINT hsize;
 	DWORD screenshotSize;
 	HWND desktopWnd;
-	// HBITMAP captureBitmap;
 	BITMAP screenshot;
 	HGDIOBJ oldObj;
 	BITMAPINFOHEADER bmpInfoHeader;
-	// LPVOID buff ;
+	bool success ;
+	Gdiplus::Status s;
 
 	LOG_INFO(L"Get desktop window");
 	desktopWnd = GetDesktopWindow();
@@ -57,7 +48,7 @@ bool captureScreen() {
 	}
 	LOG_INFO(L"Get compatible DC.");
 	wil::unique_hdc captureDc(CreateCompatibleDC(desktopDc.get()));
-	if (!captureDc .is_valid()) {
+	if (!captureDc.is_valid()) {
 		LOG_ERROR("Failed to create compatible device context.");
 		return false;
 	}
@@ -92,8 +83,7 @@ bool captureScreen() {
 		screenOriginX, screenOriginY,
 		// Raster operation to perform.
 		// In this case, replace destination with source.
-		SRCCOPY
-	);
+		SRCCOPY);
 	// Restore captureDC for safety.
 	SelectObject(captureDc.get(), oldObj);
 	if (!success) {
@@ -106,86 +96,76 @@ bool captureScreen() {
 	bytesWritten = GetObject(captureBitmap.get(), sizeof(BITMAP), &screenshot);
 	if (bytesWritten == 0) {
 		LOG_ERROR("Failed to get bitmap metadata.");
-		// goto done;
+		return false;
 	}
 
 	LOG_INFO(L"Setting DIB props.");
 	bmpInfoHeader.biSize = sizeof(BITMAPINFOHEADER);
 	bmpInfoHeader.biWidth = screenshot.bmWidth;
 	bmpInfoHeader.biHeight = screenshot.bmHeight;
-	bmpInfoHeader.biPlanes = 1;  // Can only ever be 1
-	bmpInfoHeader.biBitCount = 32;  // High byte unused
-	bmpInfoHeader.biCompression = BI_RGB;  // Uncompressed
-	bmpInfoHeader.biSizeImage = 0;  // Unneeded as uncompressed
+	bmpInfoHeader.biPlanes = 1;			  // Can only ever be 1
+	bmpInfoHeader.biBitCount = 32;		  // High byte unused
+	bmpInfoHeader.biCompression = BI_RGB; // Uncompressed
+	bmpInfoHeader.biSizeImage = 0;		  // Unneeded as uncompressed
 	bmpInfoHeader.biXPelsPerMeter = 0;
 	bmpInfoHeader.biYPelsPerMeter = 0;
 	bmpInfoHeader.biClrUsed = 0;
-	bmpInfoHeader.biClrImportant = 0;  // All colours are needed
+	bmpInfoHeader.biClrImportant = 0; // All colours are needed
 
 	LOG_INFO("Calculating DIB size.");
 	screenshotSize = ((screenshot.bmWidth * bmpInfoHeader.biBitCount + 31) / 32) * 4 * screenshot.bmHeight;
 
-	// Convert the device-dependent bitmap to a device-independent bitmap.
-	// try {
+	try {
+		// Convert the device-dependent bitmap to a device-independent bitmap.
 		LOG_INFO("Allocating size for DIB.");
 		auto buff = std::make_shared<char[]>(screenshotSize);
-	// } catch (bad_alloc) {
-		// LOG_ERROR("Failed to allocate space on heap for device independent bitmap.");
-		// return false;
-	// }
-	LOG_INFO(L"Getting DIB.");
-	bytesWritten = GetDIBits(
-		// Source device context and device-dependent bitmap
-		captureDc.get(), captureBitmap.get(),
-		// Range of scan lines to copy
-		0, (UINT)screenshot.bmHeight,
-		// Destination buffer
-		buff.get(),
-		// Format of DIB
-		(BITMAPINFO*)&bmpInfoHeader, DIB_RGB_COLORS
-	);
-	if (bytesWritten == 0 || bytesWritten == ERROR_INVALID_PARAMETER) {
-		LOG_ERROR(L"Failed to convert device dependent bitmap to device independent bitmap. Return " << bytesWritten);
+
+		LOG_INFO(L"Getting DIB.");
+		bytesWritten = GetDIBits(
+			// Source device context and device-dependent bitmap
+			captureDc.get(), captureBitmap.get(),
+			// Range of scan lines to copy
+			0, (UINT)screenshot.bmHeight,
+			// Destination buffer
+			buff.get(),
+			// Format of DIB
+			(BITMAPINFO *)&bmpInfoHeader, DIB_RGB_COLORS);
+		if (bytesWritten == 0 || bytesWritten == ERROR_INVALID_PARAMETER) {
+			LOG_ERROR(L"Failed to convert device dependent bitmap to device independent bitmap. Return " << bytesWritten);
+			return false;
+		}
+
+		// Create a GDI+ bitmap from the captured virtual screen, and calculate a histogram of colours.
+		LOG_INFO(L"Create GDIPLUS bmp.");
+		auto image = make_shared<Bitmap>((BITMAPINFO *)&bmpInfoHeader, buff.get());
+
+		LOG_INFO("Calculate hist size.");
+		s = image->GetHistogramSize(HistogramFormatARGB, &hsize);
+		if (s != Gdiplus::Ok) {
+			LOG_ERROR(L"Failed to calculate histogram size. Error #" << s << L".");
+			return false;
+		}
+
+		LOG_INFO("Allocate size for histogram.");
+		auto histR = std::make_shared<UINT[]>(hsize);
+		auto histG = std::make_shared<UINT[]>(hsize);
+		auto histB = std::make_shared<UINT[]>(hsize);
+
+		LOG_INFO(L"Get histogram.");
+		image->GetHistogram(HistogramFormatRGB, hsize, histR.get(), histG.get(), histB.get(), NULL);
+
+		// If the entire screen is black, then the only colour in the histogram must be (0, 0, 0).
+		// Since the sum of values in each channel must be the number of pixels in the image,
+		// if the screen is entirely black,
+		// the 0th entry in each of the channels must be the number of pixels in the image.
+		LOG_INFO("Work out if is black.");
+		return histR[0] == screenSize && histG[0] == screenSize && histB[0] == screenSize;
+	}
+	catch (bad_alloc)
+	{
+		LOG_ERROR("Failed to allocate space on heap for requisite buffers.");
 		return false;
 	}
-
-	// Create a GDI+ bitmap from the captured virtual screen, and calculate a histogram of colours.
-	LOG_INFO(L"Create GDIPLUS bmp.");
-	// Bitmap image((BITMAPINFO*)&bmpInfoHeader, buff.get());
-	auto image = make_shared<Bitmap>((BITMAPINFO*)&bmpInfoHeader, buff.get());
-	UINT hsize;
-	LOG_INFO("Calculate hist size.");
-	Status s = image->GetHistogramSize(HistogramFormatARGB, &hsize);
-
-	LOG_INFO("Allocate size for histogram.");
-	auto histR = std::make_shared<UINT[]>(hsize);
-	auto histG = std::make_shared<UINT[]>(hsize);
-	auto histB = std::make_shared<UINT[]>(hsize);
-
-	LOG_INFO(L"Get histogram.");
-	image->GetHistogram(HistogramFormatRGB, hsize, histR.get(), histG.get(), histB.get(), NULL);
-
-	// If the entire screen is black, then the only colour in the histogram must be (0, 0, 0).
-	// Since the sum of values in each channel must be the number of pixels in the image,
-	// if the screen is entirely black,
-	// the 0th entry in each of the channels must be the number of pixels in the image.
-	LOG_INFO("Work out if is black.");
-	returnValue = (histR[0] == screenSize && histG[0] == screenSize && histB[0] == screenSize);
-
-// done:
-	LOG_INFO("Clean up.");
-	// HeapFree(GetProcessHeap(), NULL, buff);
-	// if (desktopWnd != NULL) {
-		// if (desktopDc != NULL)
-			// ReleaseDC(desktopWnd, desktopDc);
-		// CloseHandle(desktopWnd);
-	// }
-	// if (captureDc != NULL) {
-
-	// }
-	// if (captureBitmap != NULL) DeleteObject(captureBitmap.get());
-
-	return returnValue;
 }
 
 bool oldCaptureScreen()
@@ -208,7 +188,7 @@ bool oldCaptureScreen()
 		captureDc = CreateCompatibleDC(desktopDc);
 	HBITMAP captureBitmap = CreateCompatibleBitmap(desktopDc, screenWidth, screenHeight);
 	BITMAP screenshot;
-	DWORD screenshotSize=0, bytesWritten=0, dibSize=0;
+	DWORD screenshotSize = 0, bytesWritten = 0, dibSize = 0;
 	SelectObject(captureDc, captureBitmap);
 
 	// Replace the contents of captureDc with those of desktopDc
@@ -225,8 +205,7 @@ bool oldCaptureScreen()
 		screenOriginX, screenOriginY,
 		// Raster operation to perform.
 		// In this case, replace destination with source.
-		SRCCOPY
-	);
+		SRCCOPY);
 
 	GetObject(captureBitmap, sizeof(BITMAP), &screenshot);
 	BITMAPFILEHEADER bmpFileHeader;
@@ -247,11 +226,11 @@ bool oldCaptureScreen()
 	dibSize = screenshotSize + sizeof(BITMAPFILEHEADER) + sizeof(BITMAPINFOHEADER);
 	bmpFileHeader.bfOffBits = (DWORD)sizeof(BITMAPFILEHEADER) + (DWORD)sizeof(BITMAPINFOHEADER);
 	bmpFileHeader.bfSize = dibSize;
-	bmpFileHeader.bfType = 0x4D42;  // BM
+	bmpFileHeader.bfType = 0x4D42; // BM
 
 	LPVOID buff = HeapAlloc(GetProcessHeap(), HEAP_GENERATE_EXCEPTIONS, screenshotSize);
 
-	GetDIBits(captureDc, captureBitmap, 0, (UINT)screenshot.bmHeight, buff, (BITMAPINFO*)&bmpInfoHeader, DIB_RGB_COLORS);
+	GetDIBits(captureDc, captureBitmap, 0, (UINT)screenshot.bmHeight, buff, (BITMAPINFO *)&bmpInfoHeader, DIB_RGB_COLORS);
 
 	IStream *stream = SHCreateMemStream(NULL, dibSize);
 
@@ -266,12 +245,12 @@ bool oldCaptureScreen()
 
 	CloseHandle(hFile);
 
-	Bitmap image((BITMAPINFO*)&bmpInfoHeader, buff);
+	Bitmap image((BITMAPINFO *)&bmpInfoHeader, buff);
 	UINT hsize;
 	Status s = image.GetHistogramSize(HistogramFormatARGB, &hsize);
-	UINT* histR = new UINT[hsize];
-	UINT* histG = new UINT[hsize];
-	UINT* histB = new UINT[hsize];
+	UINT *histR = new UINT[hsize];
+	UINT *histG = new UINT[hsize];
+	UINT *histB = new UINT[hsize];
 
 	image.GetHistogram(HistogramFormatRGB, hsize, histR, histG, histB, NULL);
 	bool isBlack;

--- a/source/visionEnhancementProviders/screenCurtain.py
+++ b/source/visionEnhancementProviders/screenCurtain.py
@@ -1,7 +1,7 @@
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-# Copyright (C) 2018-2023 NV Access Limited, Babbage B.V., Leonard de Ruijter
+# Copyright (C) 2018-2025 NV Access Limited, Babbage B.V., Leonard de Ruijter
 
 """Screen curtain implementation based on the windows magnification API.
 The Magnification API has been marked by MS as unsupported for WOW64 applications such as NVDA. (#12491)
@@ -24,6 +24,12 @@ from logHandler import log
 from typing import Optional, Type
 import nvwave
 import globalVars
+import NVDAHelper
+
+
+isScreenFullyBlack = NVDAHelper.localLib.isScreenFullyBlack
+isScreenFullyBlack.argtypes = ()
+isScreenFullyBlack.restype = BOOL
 
 
 class MAGCOLOREFFECT(Structure):
@@ -339,6 +345,8 @@ class ScreenCurtainProvider(providerBase.VisionEnhancementProvider):
 		try:
 			Magnification.MagSetFullscreenColorEffect(TRANSFORM_BLACK)
 			Magnification.MagShowSystemCursor(False)
+			if not isScreenFullyBlack():
+				raise RuntimeError("Screen is not black.")
 		except Exception as e:
 			Magnification.MagUninitialize()
 			raise e


### PR DESCRIPTION
### Link to issue number:

Fixes #12708
Supercedes  #12701

### Summary of the issue:

There is a security risk if the screen curtain fails silently. The Magnification API used by Screen Curtain does not officially support WOW64 applications like NVDA. As this is a risk with untested Windows versions, an external check would be helpful to minimise silent failures of the screen curtain.

Notwithstanding this, as this is a security feature, it is better to check that it is working as expected, and inform the user if it is not.

### Description of user facing changes

None.

### Description of development approach

Implemented a new function , `isScreenFullyBlack`, in `NVDAHelper/local/screenCurtain.cpp`. This method:

1. Obtains a reference to the desktop window, which covers the entire virtual screen, and thus all monitors connected to the computer.
2. USES GDI to capture the screen.
3. USES GDIPlus to calculate a histogram of this screen capture.
   * While this seems like overkill, it performs significantly better on my machine than individually checking that each pixel is black, likely due to optimisations and hardware accelleration in GDIPlus.
4. Checks that, for each channel of the histogram, the value at 0 is the area of the screen.

Call this function after applying the fullscreen colour effect and hiding the cursor in `visionEnhancementProviders.screenCurtain.ScreenCurtainProvider.__init__`. If the return is `False`, raise `RuntimeError`, which disables the screen curtain and informs the user that screen curtain failed to activate.

### Testing strategy:

Perform each of the following tests, with:
* A single monitor connected (in my case, my laptop's display)
* Multiple monitors of the same resolution connected (in my case, an external HDMI monitor connected, and projection mode set to duplicate)
* Multiple monitors with different resolutions connected (in my case, my laptop's display (1920 × 1200) and an HDMI monitor (1920 × 1080) and projection mode set to extend)
* Multiple monitors connected, but only one enabled (in my case, my laptop's display and an HDMI monitor, with projection modes "PC screen only" and "Second screen only" tested).

1. Test the screen curtain activates properly.
2. In the NVDA python console, change the black transformation matrix so it will fail to initialise the screen curtain properly.

   1. ```py
      from visionEnhancementProviders import screenCurtain
      screenCurtain.TRANSFORM_BLACK.transform[1][1] = 1  # retain the green channel
      ```

   2. ```py
      from visionEnhancementProviders import screenCurtain
      screenCurtain.TRANSFORM_BLACK.transform[3][3] = 0  # change the opacity to 0
      ```

3. After each of the above, test that the screen curtain doesn't start and a warning is provided to the user.

### Known issues with pull request:

None.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
