### PR TITLE
Start dev cycle for 2025.2

### DIFF
--- a/source/buildVersion.py
+++ b/source/buildVersion.py
@@ -64,7 +64,7 @@ def formatVersionForGUI(year, major, minor):
 # Version information for NVDA
 name = "NVDA"
 version_year = 2025
-version_major = 1
+version_major = 2
 version_minor = 0
 version_build = 0  # Should not be set manually. Set in 'sconscript' provided by 'appVeyor.yml'
 version = _formatDevVersionString()

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -1,5 +1,21 @@
 # What's New in NVDA
 
+## 2025.2
+
+### Important notes
+
+### New Features
+
+### Changes
+
+### Bug Fixes
+
+### Changes for Developers
+
+Please refer to [the developer guide](https://www.nvaccess.org/files/nvda/documentation/developerGuide.html#API) for information on NVDA's API deprecation and removal process.
+
+#### Deprecations
+
 ## 2025.1
 
 ### Important notes


### PR DESCRIPTION
Start the dev cycle for the 2025.2 release.
This won't be a compatibility breaking release.

Complete:
- [x] New section in the change log.
- [x] Update NVDA version in `master`
- [x] Update [`nvdaAPIVersions.json` to include the next version](https://github.com/nvaccess/addon-datastore-transform)
  - Re-run the last "Transform NVDA addons to views" on [addon-datastore](https://github.com/nvaccess/addon-datastore/actions/workflows/transformDataToViews.yml) to regenerate projections (views) for the add-on datastore API.

On merge:
- [x] [Update auto milestone ID](https://github.com/nvaccess/nvda/settings/variables/actions)