### PR TITLE
Word collapse/expand headings: add gestures with numlock on

### DIFF
--- a/source/appModules/winword.py
+++ b/source/appModules/winword.py
@@ -88,7 +88,14 @@ class WinwordWordDocument(WordDocument):
 			ui.message(_("Change tracking off"))
 
 	@script(
-		gestures=["kb:alt+shift+-", "kb:alt+shift+=", "kb:alt+shift+numpadPlus", "kb:alt+shift+numpadMinus"],
+		gestures=[
+			"kb:alt+shift+-",
+			"kb:alt+shift+=",
+			"kb:alt+shift+numpadPlus",
+			"kb:alt+shift+numpadMinus",
+			"kb:numLock+shift+alt+numpadPlus",
+			"kb:numLock+shift+alt+numpadMinus",
+		],
 	)
 	def script_collapseOrExpandHeading(self, gesture: "inputCore.InputGesture") -> None:
 		if not self.WinwordSelectionObject:


### PR DESCRIPTION
### Link to issue number:
Follow-up of #17545

Blocked by #17900

### Summary of the issue:
#17545 has implemented the announcement resulting of the action to collapse or expand headings in Word with `shift+alt+plus/-` when using plus/minus on the main keyboard and on the numpad. Thought, using the numpad plus/minus key on the numpad does not report anything if numlock is enabled.

### Description of user facing changes
`alt+shift+numpadPlus/Minus` will now report headings expanding / collapsing, no matter if numlock is on or off.

### Description of development approach
Added the two gestures with numlock on in the gestures list of the script.

### Testing strategy:

In a branch integrating #17900, tested the script on Word with numlock on and off.

### Known issues with pull request:
None
### Code Review Checklist:


- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
