### PR TITLE
Disable GH Actions releases

### DIFF
--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -7,8 +7,10 @@ on:
     - beta
     - rc
     - 'try-**'
-    tags:
-    - 'release-**'
+    # Currently disabled while the 2025.1 release is in progress.
+    # Blocked by #17878
+    # tags:
+    # - 'release-**'
 
   pull_request:
     branches:


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Fixup to #17728 
Due to #17878 

### Summary of the issue:
GitHub actions is now building NVDA, however we are not ready to release and deploy a signed copy of NVDA yet (see #17878).
As such, we shouldn't build tagged releases with GitHub actions

### Description of user facing changes
None
### Description of development approach
Disable tagged releases from GitHub actions until #17878 is closed
