### PR TITLE
Simplify getDocFilePath function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,8 @@ dlldata.c
 *.md.sub
 user_docs/*/*.html
 user_docs/*/*.css
+user_docs/*/*.md
+!user_docs/en/*.md
 extras/controllerClient/x86/nvdaController.h
 extras/controllerClient/x64
 extras/controllerClient/arm64

--- a/.gitignore
+++ b/.gitignore
@@ -27,8 +27,6 @@ dlldata.c
 *.md.sub
 user_docs/*/*.html
 user_docs/*/*.css
-user_docs/*/*.md
-!user_docs/en/*.md
 extras/controllerClient/x86/nvdaController.h
 extras/controllerClient/x64
 extras/controllerClient/arm64

--- a/source/documentationUtils.py
+++ b/source/documentationUtils.py
@@ -1,6 +1,6 @@
 # -*- coding: UTF-8 -*-
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2006-2025 NV Access Limited, Łukasz Golonka
+# Copyright (C) 2006-2025 NV Access Limited, Łukasz Golonka, Cyrille Bougot
 # This file may be used under the terms of the GNU General Public License, version 2 or later.
 # For more details see: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -42,12 +42,9 @@ def getDocFilePath(fileName: str, localized: bool = True) -> str | None:
 			if not os.path.isdir(tryDir):
 				continue
 
-			# Some out of date translations might include .txt files which are now .html files in newer translations.
-			# Therefore, ignore the extension and try both .html and .txt.
-			for tryExt in ("html", "txt"):
-				tryPath = os.path.join(tryDir, f"{fileName}.{tryExt}")
-				if os.path.isfile(tryPath):
-					return tryPath
+			tryPath = os.path.join(tryDir, f"{fileName}.html")
+			if os.path.isfile(tryPath):
+				return tryPath
 		return None
 	else:
 		# Not localized.

--- a/source/installer.py
+++ b/source/installer.py
@@ -2,7 +2,7 @@
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-# Copyright (C) 2011-2024 NV Access Limited, Joseph Lee, Babbage B.V., Łukasz Golonka
+# Copyright (C) 2011-2025 NV Access Limited, Joseph Lee, Babbage B.V., Łukasz Golonka, Cyrille Bougot
 
 import ctypes
 import pathlib
@@ -140,7 +140,7 @@ def getDocFilePath(fileName, installDir):
 		tryDir = os.path.join(rootPath, tryLang)
 		if not os.path.isdir(tryDir):
 			continue
-		tryPath = os.path.join(tryDir, f"{fileName}.html"
+		tryPath = os.path.join(tryDir, f"{fileName}.html")
 		if os.path.isfile(tryPath):
 			return tryPath
 

--- a/source/installer.py
+++ b/source/installer.py
@@ -140,12 +140,9 @@ def getDocFilePath(fileName, installDir):
 		tryDir = os.path.join(rootPath, tryLang)
 		if not os.path.isdir(tryDir):
 			continue
-		# Some out of date translations might include .txt files which are now .html files in newer translations.
-		# Therefore, ignore the extension and try both .html and .txt.
-		for tryExt in ("html", "txt"):
-			tryPath = os.path.join(tryDir, "%s.%s" % (fileName, tryExt))
-			if os.path.isfile(tryPath):
-				return tryPath
+		tryPath = os.path.join(tryDir, f"{fileName}.html"
+		if os.path.isfile(tryPath):
+			return tryPath
 
 
 def copyProgramFiles(destPath):

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -279,6 +279,7 @@ Instead, a `callback` property has been added, which returns a function that per
   * Added `TypingEcho` enum in `config.configFlags` to represent these modes, 0=Off, 1=Only in edit controls, 2=Always.
   * `gui.settingsDialogs.KeyboardSettingsPanel.wordsCheckBox` and `gui.settingsDialogs.KeyboardSettingsPanel.charsCheckBox` has been removed.
 * The `winUser.paint` has been renamed from `painStruct` to `paintStruct`, fixing a bug where passing in a `PAINTSTRUCT` would raise an exception. (#17744)
+* `documentationUtils.getDocFilePath` and `installer.getDocFilePath` no longer look for `.txt` files in locale documentation folders. (#17911, @CyrilleB79)
 
 #### Deprecations
 


### PR DESCRIPTION
### Link to issue number:
None; related to #13333.
### Summary of the issue:
The file `th\key commands.txt` was an old outdated that was removed during the migration to Crowdin. Now the local documentations do not contain any old txt file, but `getDocFilePath` had still some unused code to handle these files.

### Description of user facing changes
None.

### Description of development approach
Remove dead code in both `getDocFilePath` functions.

While at it, updated `.git-ignore` to also ignore all the `.md` files that are generated when building the documentation (`scons user_docs`), since the source strings are now in .xliff files.

### Testing strategy:
* Test opening the documentation (user guide, key commands and change log) from NVDA menu
* From Python console, test `installer.getDocFilePath` with the same files.
* Test English, de and de_CH, trying to manually remove some documentation to simulate fallback or using other languages where documentation is missing (e.g. "am", "nb_NO")
* Try to open licence file from installer (`runnvda --launcher`) and from NVDA menu

### Known issues with pull request:
None
### Code Review Checklist:


- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
