### PR TITLE
Follow-up #17905: Speak typed characters in classic Calculator when echo mode is 'Only in edit controls'.

### DIFF
--- a/source/appModules/calc.py
+++ b/source/appModules/calc.py
@@ -11,6 +11,7 @@ import NVDAObjects.IAccessible
 import speech
 from config.configFlags import TypingEcho
 
+
 class AppModule(appModuleHandler.AppModule):
 	def chooseNVDAObjectOverlayClasses(self, obj, clsList):
 		windowClassName = obj.windowClassName

--- a/source/appModules/calc.py
+++ b/source/appModules/calc.py
@@ -57,16 +57,16 @@ class Display(NVDAObjects.IAccessible.IAccessible):
 			name = _("Display")
 		return name
 
-	def event_typedCharacter(self, ch):
+	def event_typedCharacter(self, ch: str) -> None:
 		originalMode = config.conf["keyboard"]["speakTypedCharacters"]
 		if originalMode == TypingEcho.EDIT_CONTROLS.value:
 			try:
 				config.conf["keyboard"]["speakTypedCharacters"] = TypingEcho.ALWAYS.value
-				super(Display, self).event_typedCharacter(ch)
+				super().event_typedCharacter(ch)
 			finally:
 				config.conf["keyboard"]["speakTypedCharacters"] = originalMode
 		else:
-			super(Display, self).event_typedCharacter(ch)
+			super().event_typedCharacter(ch)
 		if ch in self.calcCommandChars:
 			self._nextNameIsCalculationResult = True
 

--- a/source/appModules/calc.py
+++ b/source/appModules/calc.py
@@ -6,9 +6,10 @@
 """App module for Windows Calculator (desktop version)"""
 
 import appModuleHandler
+import config
 import NVDAObjects.IAccessible
 import speech
-
+from config.configFlags import TypingEcho
 
 class AppModule(appModuleHandler.AppModule):
 	def chooseNVDAObjectOverlayClasses(self, obj, clsList):
@@ -56,7 +57,15 @@ class Display(NVDAObjects.IAccessible.IAccessible):
 		return name
 
 	def event_typedCharacter(self, ch):
-		super(Display, self).event_typedCharacter(ch)
+		originalMode = config.conf["keyboard"]["speakTypedCharacters"]
+		if originalMode == TypingEcho.EDIT_CONTROLS.value:
+			try:
+				config.conf["keyboard"]["speakTypedCharacters"] = TypingEcho.ALWAYS.value
+				super(Display, self).event_typedCharacter(ch)
+			finally:
+				config.conf["keyboard"]["speakTypedCharacters"] = originalMode
+		else:
+			super(Display, self).event_typedCharacter(ch)
 		if ch in self.calcCommandChars:
 			self._nextNameIsCalculationResult = True
 


### PR DESCRIPTION
### Link to issue number:
Addresses #17670 for the classic Windows Calculator. Follow-up to PR #17905.
### Summary of the issue:
Similar to the issue observed in the modern Windows Calculator, the classic Windows Calculator's display area does not consistently trigger character echo when NVDA's "Speak typed characters" setting is configured to 'Only in edit controls'.
### Description of user facing changes
Users will now hear typed characters echoed when typing into the display field of the **classic Windows Calculator**, even when the "Speak typed characters" option is set to 'Only in edit controls'.
### Description of development approach
This change mirrors the approach taken for the modern Calculator in PR #17905.
The `event_typedCharacter` method within the `Display` overlay class (which specifically targets the display controls of the classic Calculator in `calc.py`) is modified. When this event occurs and the original `speakTypedCharacters` mode is `EDIT_CONTROLS`, the mode is temporarily switched to `ALWAYS` before calling the parent class's event handler. The original mode is then restored in a `finally` block.

### Testing strategy:
Manual testing with the classic Windows Calculator (Windows 10 LTSC, calc.exe):
1. Set NVDA's "Speak typed characters" setting (Keyboard Settings) to 'Only in edit controls'.
2. Open the classic Calculator (calc.exe).
3. Type numbers and operators (e.g., `1`, `+`, `2`, `*`, `3`, `=`).
4. Confirm each typed character is spoken.
5. Change the setting to 'Always' and confirm characters are spoken.
6. Change the setting to 'Off' and confirm characters are *not* spoken.

### Known issues with pull request:

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [ ] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [X] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [X] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [X] API is compatible with existing add-ons.
- [ ] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
