### PR TITLE
Avoid error playing wave file when playing multiple subsequent waves

### DIFF
--- a/source/nvwave.py
+++ b/source/nvwave.py
@@ -122,6 +122,7 @@ def playWaveFile(
 
 	def play():
 		global fileWavePlayer
+		# #17918: Create a function local copy of the player to avoid cases where it becomes None during playback.
 		p = fileWavePlayer
 		try:
 			p.feed(f.readframes(f.getnframes()))

--- a/source/nvwave.py
+++ b/source/nvwave.py
@@ -122,9 +122,10 @@ def playWaveFile(
 
 	def play():
 		global fileWavePlayer
+		p = fileWavePlayer
 		try:
-			fileWavePlayer.feed(f.readframes(f.getnframes()))
-			fileWavePlayer.idle()
+			p.feed(f.readframes(f.getnframes()))
+			p.idle()
 		except Exception:
 			log.exception("Error playing wave file")
 		# #11169: Files might not be played that often. Leaving the device open

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -11,7 +11,7 @@
 ### Bug Fixes
 
 * In WinUI 3 apps including Microsoft Copilot and parts of Windows 11 File Explorer, NVDA will no longer fail to announce controls when using mouse and touch interaction. (#17407, #17771, @josephsl)
-* Fixed some rare cases where playing sounds by NVDA could result in unexpected errors. (#17918, @LeonarddeR)
+* Fixed some rare cases where NVDA playing sounds could result in unexpected errors. (#17918, @LeonarddeR)
 
 ### Changes for Developers
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -11,6 +11,7 @@
 ### Bug Fixes
 
 * In WinUI 3 apps including Microsoft Copilot and parts of Windows 11 File Explorer, NVDA will no longer fail to announce controls when using mouse and touch interaction. (#17407, #17771, @josephsl)
+* Fixed some rare cases where playing sounds by NVDA could result in unexpected errors. (#17918, @LeonarddeR)
 
 ### Changes for Developers
 


### PR DESCRIPTION
### Link to issue number:
NOne

### Summary of the issue:
First of all, I can't reliably reproduce this, but i have seen several cases lately where an exception was raised in playWaveFile, telling me that None object has no attribute feed. It happens to me around twice a day or so.
```
ERROR - nvwave.play (10:43:12.334) - nvwave.playWaveFile(error.wav) (17056):
Error playing wave file
Traceback (most recent call last):
  File "nvwave.pyc", line 127, in play
AttributeError: 'NoneType' object has no attribute 'idle'

```
I think I can somewhat understand the issue. playWaveFile can play asynchronously. It has a local function play that sets the global `fileWavePlayer` to None when done. However when playing several sounds in a row, there can be a case where `fileWavePlayer` is set to None by one playback, then the next player tries to feed or idle to a None player.

### Description of user facing changes
Hopefully, no longer rare errors.

### Description of development approach
In the local function, copy the reference to the player in a local variable p and then use that variable to do feed and idle.

### Testing strategy:
As i have no steps to reproduce, this is hard to test. That said, I think that from a code point of view, this is nevertheless an improvement.

### Known issues with pull request:
None known

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
