### PR TITLE
Check before saving Add-on Store settings

### DIFF
--- a/source/addonStore/dataManager.py
+++ b/source/addonStore/dataManager.py
@@ -113,7 +113,8 @@ class _DataManager:
 		self._initialiseAvailableAddonsThread.start()
 
 	def terminate(self):
-		self.storeSettings.save()
+		if NVDAState.shouldWriteToDisk():
+			self.storeSettings.save()
 		if self._initialiseAvailableAddonsThread.is_alive():
 			self._initialiseAvailableAddonsThread.join(timeout=1)
 		if self._initialiseAvailableAddonsThread.is_alive():


### PR DESCRIPTION
### Link to issue number:

Fixes #17805
Follow-up to #17597

### Summary of the issue:

An error is logged when exiting from the launcher, as `addonStore.storeSettings._AddonStoreSettings.save` is called regardless of the return value of `NVDAState.shouldWriteToDisk`.

### Description of user facing changes

An error tone is no longer heard after running the launcher.

### Description of development approach

Only attempt to save Add-on Store settings if `NVDAState.shouldWriteToDisk` returns `True`.

While the error was harmless, it was worrying some users.

### Testing strategy:

Created a portable copy with the launcher for NVDA alpha 35962,a503ae32 to ensure the issue was present.

Created a launcher (`scons launcher`), and used it to create a portable copy. Verified that the issue no-longer occurs.

### Known issues with pull request:

None.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
