### PR TITLE
Fix hosting the remote server locally when acting as follower

### DIFF
--- a/source/remoteClient/session.py
+++ b/source/remoteClient/session.py
@@ -342,7 +342,7 @@ class FollowerSession(RemoteSession):
 	def handleChannelJoined(
 		self,
 		channel: str,
-		clients: list[dict[str, Any]],
+		clients: list[dict[str, Any]] | None = None,
 		origin: int | None = None,
 	) -> None:
 		if clients is None:


### PR DESCRIPTION
### Link to issue number:

None

### Summary of the issue:

1. NVDA menu -> Tools -> Remote -> Connect...
2. Set mode to "Allow this machine to be controlled" and server to "Host locally". Set a key.
3. Connect. Observe that an error is logged and no connection cue is played.

The issue arrises because the `clients` parameter to `FollowerSession.handleChannelJoined` does not have a default, and the in-built relay server sends `None` when no clients are connected.

This is not an issue for `LeaderSession`, as its `handleChannelJoined` already supports `clients=None`.

### Description of user facing changes

No error is logged, and the connection sound is heard.

### Description of development approach

Fixed `remoteClient.session.FollowerSession.handleChannelJoined`:

* The `clients` parameter is now typed as accepting a dict or None, and defaults to `None`.
* The method body already handled `clients` being `None`, so no further changes were necessary.

### Testing strategy:

Started a remote session as follower with a local relay server.

### Known issues with pull request:

None.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
