### PR TITLE
Remote, log warning instead of error on secure desktop when no IPC file exists

### DIFF
--- a/source/remoteClient/secureDesktop.py
+++ b/source/remoteClient/secureDesktop.py
@@ -127,7 +127,7 @@ class SecureDesktopHandler:
 		"""Set up necessary components when entering secure desktop."""
 		log.debug("Attempting to enter secure desktop")
 		if self.followerSession is None or self.followerSession.transport is None:
-			log.warning("No follower session connected, not entering secure desktop.")
+			log.warning("No follower session connected, not entering secure desktop.", exc_info=True)
 			return
 		if not self.tempPath.exists():
 			log.debug(f"Creating temp directory: {self.tempPath}")
@@ -224,7 +224,7 @@ class SecureDesktopHandler:
 			)
 
 		except Exception:
-			log.exception("Failed to initialize secure desktop connection.")
+			log.warning("Failed to initialize secure desktop connection.")
 			return None
 
 	def _onLeaderDisplayChange(self, **kwargs: Any) -> None:

--- a/source/remoteClient/secureDesktop.py
+++ b/source/remoteClient/secureDesktop.py
@@ -127,7 +127,7 @@ class SecureDesktopHandler:
 		"""Set up necessary components when entering secure desktop."""
 		log.debug("Attempting to enter secure desktop")
 		if self.followerSession is None or self.followerSession.transport is None:
-			log.warning("No follower session connected, not entering secure desktop.", exc_info=True)
+			log.warning("No follower session connected, not entering secure desktop.")
 			return
 		if not self.tempPath.exists():
 			log.debug(f"Creating temp directory: {self.tempPath}")
@@ -224,7 +224,7 @@ class SecureDesktopHandler:
 			)
 
 		except Exception:
-			log.warning("Failed to initialize secure desktop connection.")
+			log.warning("Failed to initialize secure desktop connection.", exc_info=True)
 			return None
 
 	def _onLeaderDisplayChange(self, **kwargs: Any) -> None:


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
When no follower session connected to a system, the system doesn't create an IPC file when opening the secure desktop. As the secure desktop copy of NVDA tries to find the IPC and logs an exception when it can't, this results on an error on the secure desktop.
Now this error is safely ignored when in secure mode, it is still noticeable when setting serviceDebug to 1.

### Description of user facing changes
None

### Description of development approach
Change exception (error) into a warning.

### Testing strategy:
Can't test on secure desktop, but code review should be sufficient here.

### Known issues with pull request:
None known

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
