### PR TITLE
Don't send send keys gesture if not connected

### DIFF
--- a/source/remoteClient/client.py
+++ b/source/remoteClient/client.py
@@ -476,13 +476,13 @@ class RemoteClient:
 		if self.sendingKeys:
 			self.hostPendingModifiers = gesture.modifiers
 			# Translators: Presented when sending keyboard keys from the controlling computer to the controlled computer.
-			ui.message(_("Controlling remote machine."))
+			ui.message(pgettext("remote", "Controlling remote computer"))
 			if self.localMachine.isMuted:
 				self.toggleMute()
 		else:
 			self.releaseKeys()
 			# Translators: Presented when keyboard control is back to the controlling computer.
-			ui.message(_("Controlling local machine."))
+			ui.message(pgettext("remote", "Controlling local computer"))
 
 	def releaseKeys(self):
 		"""Release all pressed keys on the remote machine.

--- a/source/remoteClient/client.py
+++ b/source/remoteClient/client.py
@@ -458,8 +458,17 @@ class RemoteClient:
 		:param gesture: The keyboard gesture that triggered this
 		:note: Also toggles braille input and mute state
 		"""
-		if not self.leaderTransport:
-			gesture.send()
+		if not self.isConnected():
+			# Translators: A message indicating that the remote client is not connected.
+			ui.message(_("Not connected"))
+			return
+		elif not self.leaderTransport:
+			# Translators: Presented when attempting to switch to controling a remote computer when connected as the controlled computer.
+			ui.message(pgettext("remote", "Not the controlling computer"))
+			return
+		elif self.leaderSession.connectedFollowersCount < 1:
+			# Translators: Presented when attempting to switch to controling a remote computer when there are no controllable computers in the channel.
+			ui.message(pgettext("remote", "No controlled computers are connected"))
 			return
 		self.sendingKeys = not self.sendingKeys
 		log.info(f"Remote key control {'enabled' if self.sendingKeys else 'disabled'}")

--- a/source/remoteClient/client.py
+++ b/source/remoteClient/client.py
@@ -460,7 +460,7 @@ class RemoteClient:
 		"""
 		if not self.isConnected():
 			# Translators: A message indicating that the remote client is not connected.
-			ui.message(_("Not connected"))
+			ui.message(pgettext("remote", "Not connected"))
 			return
 		elif not self.leaderTransport:
 			# Translators: Presented when attempting to switch to controling a remote computer when connected as the controlled computer.


### PR DESCRIPTION
### Link to issue number:

Fixes #17874

### Summary of the issue:

Performing the "Toggle Control" gesture (`NVDA+alt+tab`) when no Remote Access session is in progress results in the gesture being sent to the operating system.

### Description of user facing changes

The gesture is always trapped by NVDA.

### Description of development approach

In `remoteClient.client.RemoteClient.toggleRemoteKeyControl`, no longer call `gesture.send` if there is no leader session. Also inform the user if not connected, if not connected as leader, or if there are no followers connected.

### Testing strategy:

Performed the gesture:

* When not connected
* When connected as follower with no one else in the channel
* When connected as follower with a remote leader in the channel
* When connected as follower with a remote follower in the channel
* When connected as leader with no one else in the channel
* When connected as leader with a remote leader in the channel
* When connected as leader with a remote follower in the channel

### Known issues with pull request:

None

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
