### PR TITLE
Fix syntax for clickable URL of GPL v2 license

### DIFF
--- a/copying.txt
+++ b/copying.txt
@@ -8,7 +8,7 @@ All applicable licenses are included below.
 
 ## GNU GENERAL PUBLIC LICENSE
 
-<https://www.gnu.org/licenses/old-licenses/gpl-2.0.html/>
+<https://www.gnu.org/licenses/old-licenses/gpl-2.0.html>
 
 Version 2, June 1991
 


### PR DESCRIPTION
### Link to issue number:
None
### Summary of the issue:
During 2025.1 dev cycle, the licence has become an HTML document, converted from markdown, and URL are clickable. In markdown `<` and `>` (angle brackets) make an URL clickable.
Though, the URL of GPL v2 is between `<` and `/>`, as if it was an HTML tag; this leads to an extra slash in the URL when the license is displayed, causing an Error 404 when clicked.

### Description of user facing changes
When clicked in the license, the GPL v2 page now correctly opens in the browser.

### Description of development approach
Remove extra slash.

### Testing strategy:
From source, launch:
runnvda.bat --launcher

Click the "View license" button and click the link in the license.

Also tested through NVDA menus with same result.

### Known issues with pull request:
None
### Code Review Checklist:


- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
