### PR TITLE
Fix NVDA not reading the ribbon in Geekbench 6.4

### DIFF
--- a/source/UIAHandler/__init__.py
+++ b/source/UIAHandler/__init__.py
@@ -1172,7 +1172,7 @@ class UIAHandler(COMObject):
 			# Testing shows that these controls emits proper events but they are ignored by NVDA.
 			try:
 				isOfficeApp = appModule.productName.startswith(("Microsoft Office", "Microsoft Outlook"))
-				isOffice2013OrOlder = int(appModule.productVersion.split(".")[0]) < 16
+				isOffice2013OrOlder = isOfficeApp and int(appModule.productVersion.split(".")[0]) < 16
 			except RuntimeError:
 				# this is not necessarily an office app, or an app with version information, for example geekbench 6.
 				log.debugWarning(

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -12,8 +12,7 @@
 
 * In WinUI 3 apps including Microsoft Copilot and parts of Windows 11 File Explorer, NVDA will no longer fail to announce controls when using mouse and touch interaction. (#17407, #17771, @josephsl)
 * Fixed some rare cases where NVDA playing sounds could result in unexpected errors. (#17918, @LeonarddeR)
-
-* In Geekbench 6.4, NVDA can again  read the ribbon and options within. (#17892, @mzanm)
+* In Geekbench 6.4, NVDA can again read the ribbon and options within. (#17892, @mzanm)
 
 ### Changes for Developers
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -12,6 +12,8 @@
 
 * In WinUI 3 apps including Microsoft Copilot and parts of Windows 11 File Explorer, NVDA will no longer fail to announce controls when using mouse and touch interaction. (#17407, #17771, @josephsl)
 
+* In Geekbench 6.4, NVDA can again  read the ribbon and options within. (#17892, @mzanm)
+
 ### Changes for Developers
 
 Please refer to [the developer guide](https://www.nvaccess.org/files/nvda/documentation/developerGuide.html#API) for information on NVDA's API deprecation and removal process.


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Fixes #17892 

### Summary of the issue:
NVDA Does not read the controls in the Geekbench 6.4 ribbon when navigating and errors in the log.

### Description of user facing changes
The menu can be navigated and interacted with normally.

### Description of development approach
Geekbench uses something similar to the Microsoft Office ribbon. The code to check for older Office versions expected a normal productVersion for Office apps, however, Geekbench's productVersion is "6,4,0,0". This is the cause of the ValueError. I've fixed this by only checking the version if isOfficeApp is True first.

### Testing strategy:
- Tested that the Geekbench ribbon can be navigated and interacted with.
- Tested the Microsoft Office ribbon just in case.

### Known issues with pull request:
None.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
