### PR TITLE
Fix up user-facing Remote Access terminology

### DIFF
--- a/source/_remoteClient/client.py
+++ b/source/_remoteClient/client.py
@@ -227,7 +227,7 @@ class RemoteClient:
 				parent=gui.mainFrame,
 				# Translators: Title of the connection error dialog.
 				caption=_("Error Connecting"),
-				# Translators: Message shown when cannot connect to the remote computer.
+				# Translators: Message shown when unable to connect to the remote computer.
 				message=_("Unable to connect to the remote computer"),
 				style=wx.OK | wx.ICON_WARNING,
 			)

--- a/source/_remoteClient/client.py
+++ b/source/_remoteClient/client.py
@@ -147,7 +147,7 @@ class RemoteClient:
 		except (TypeError, OSError):
 			log.debug("Unable to push clipboard", exc_info=True)
 			# Translators: Message shown when clipboard content cannot be sent to the remote computer.
-			ui.message(_("Unable to send clipboard"))
+			ui.message(pgettext("remote", "Unable to send clipboard"))
 
 	def copyLink(self):
 		"""Copy connection URL to clipboard.

--- a/source/_remoteClient/client.py
+++ b/source/_remoteClient/client.py
@@ -134,7 +134,7 @@ class RemoteClient:
 		"""
 		connector = self.followerTransport or self.leaderTransport
 		if not getattr(connector, "connected", False):
-			# Translators: Message shown when trying to push the clipboard to the remote computer while not connected.
+			# Translators: Message shown when trying to send the clipboard to the remote computer while not connected.
 			ui.message(pgettext("remote", "Not connected"))
 			return
 		elif self.connectedClientsCount < 1:
@@ -147,7 +147,7 @@ class RemoteClient:
 		except (TypeError, OSError):
 			log.debug("Unable to push clipboard", exc_info=True)
 			# Translators: Message shown when clipboard content cannot be sent to the remote computer.
-			ui.message(_("Unable to push clipboard"))
+			ui.message(_("Unable to send clipboard"))
 
 	def copyLink(self):
 		"""Copy connection URL to clipboard.

--- a/source/_remoteClient/client.py
+++ b/source/_remoteClient/client.py
@@ -525,7 +525,7 @@ class RemoteClient:
 				pgettext(
 					"remote",
 					# Translators: Message shown when trying to connect while already connected.
-					"Remote Access is already connected. Disconnect before starting a new connection.",
+					"A Remote Access session is already in progress. Disconnect before starting a new session.",
 				),
 				# Translators: Title of the connection error dialog.
 				pgettext("remote", "Already Connected"),

--- a/source/_remoteClient/client.py
+++ b/source/_remoteClient/client.py
@@ -135,7 +135,7 @@ class RemoteClient:
 		connector = self.followerTransport or self.leaderTransport
 		if not getattr(connector, "connected", False):
 			# Translators: Message shown when trying to push the clipboard to the remote computer while not connected.
-			ui.message(_("Not connected."))
+			ui.message(_("Not connected"))
 			return
 		elif self.connectedClientsCount < 1:
 			# Translators: Reported when performing a Remote Access action, but there are no other computers in the channel.
@@ -157,7 +157,7 @@ class RemoteClient:
 		session = self.leaderSession or self.followerSession
 		if session is None:
 			# Translators: Message shown when trying to copy the link to connect to the remote computer while not connected.
-			ui.message(_("Not connected."))
+			ui.message(_("Not connected"))
 			return
 		url = session.getConnectionInfo().getURLToConnect()
 		api.copyToClip(str(url))

--- a/source/_remoteClient/client.py
+++ b/source/_remoteClient/client.py
@@ -541,11 +541,11 @@ class RemoteClient:
 			# Prepare connection request message based on mode
 			if conInfo.mode == ConnectionMode.LEADER:
 				# Translators: Ask the user if they want to control the remote computer.
-				question = _("Do you wish to control the machine on server {server} with key {key}?")
+				question = _("Do you wish to control the computer on server {server} with key {key}?")
 			else:
 				question = _(
 					# Translators: Ask the user if they want to allow the remote computer to control this computer.
-					"Do you wish to allow this machine to be controlled on server {server} with key {key}?",
+					"Do you wish to allow this computer to be controlled on server {server} with key {key}?",
 				)
 
 			question = question.format(server=serverAddr, key=key)

--- a/source/_remoteClient/client.py
+++ b/source/_remoteClient/client.py
@@ -135,7 +135,7 @@ class RemoteClient:
 		connector = self.followerTransport or self.leaderTransport
 		if not getattr(connector, "connected", False):
 			# Translators: Message shown when trying to push the clipboard to the remote computer while not connected.
-			ui.message(_("Not connected"))
+			ui.message(pgettext("remote", "Not connected"))
 			return
 		elif self.connectedClientsCount < 1:
 			# Translators: Reported when performing a Remote Access action, but there are no other computers in the channel.
@@ -157,7 +157,7 @@ class RemoteClient:
 		session = self.leaderSession or self.followerSession
 		if session is None:
 			# Translators: Message shown when trying to copy the link to connect to the remote computer while not connected.
-			ui.message(_("Not connected"))
+			ui.message(pgettext("remote", "Not connected"))
 			return
 		url = session.getConnectionInfo().getURLToConnect()
 		api.copyToClip(str(url))
@@ -528,7 +528,7 @@ class RemoteClient:
 					"Remote Access is already connected. Disconnect before starting a new connection.",
 				),
 				# Translators: Title of the connection error dialog.
-				_("Already Connected"),
+				pgettext("remote", "Already Connected"),
 				wx.OK | wx.ICON_WARNING,
 			)
 			return
@@ -540,10 +540,14 @@ class RemoteClient:
 
 			# Prepare connection request message based on mode
 			if conInfo.mode == ConnectionMode.LEADER:
-				# Translators: Ask the user if they want to control the remote computer.
-				question = _("Do you wish to control the computer on server {server} with key {key}?")
+				question = pgettext(
+					"remote",
+					# Translators: Ask the user if they want to control the remote computer.
+					"Do you wish to control the computer on server {server} with key {key}?",
+				)
 			else:
-				question = _(
+				question = pgettext(
+					"remote",
 					# Translators: Ask the user if they want to allow the remote computer to control this computer.
 					"Do you wish to allow this computer to be controlled on server {server} with key {key}?",
 				)
@@ -551,7 +555,7 @@ class RemoteClient:
 			question = question.format(server=serverAddr, key=key)
 
 			# Translators: Title of the connection request dialog.
-			dialogTitle = _("Remote Access Connection Request")
+			dialogTitle = pgettext("remote", "Remote Access Connection Request")
 
 			# Show confirmation dialog
 			if (

--- a/source/_remoteClient/client.py
+++ b/source/_remoteClient/client.py
@@ -522,10 +522,13 @@ class RemoteClient:
 		"""
 		if self.isConnected() or self.connecting:
 			gui.messageBox(
-				# Translators: Message shown when trying to connect while already connected.
-				_("NVDA Remote is already connected. Disconnect before opening a new connection."),
+				pgettext(
+					"remote",
+					# Translators: Message shown when trying to connect while already connected.
+					"Remote Access is already connected. Disconnect before starting a new connection.",
+				),
 				# Translators: Title of the connection error dialog.
-				_("NVDA Remote Already Connected"),
+				_("Already Connected"),
 				wx.OK | wx.ICON_WARNING,
 			)
 			return
@@ -548,7 +551,7 @@ class RemoteClient:
 			question = question.format(server=serverAddr, key=key)
 
 			# Translators: Title of the connection request dialog.
-			dialogTitle = _("NVDA Remote Connection Request")
+			dialogTitle = _("Remote Access Connection Request")
 
 			# Show confirmation dialog
 			if (

--- a/source/_remoteClient/cues.py
+++ b/source/_remoteClient/cues.py
@@ -33,7 +33,7 @@ CUES: Dict[str, Cue] = {
 		"wave": "controlled",
 		"beeps": [(720, 100), (None, 50), (720, 100), (None, 50), (720, 100)],
 		# Translators: Presented in direct (client to server) remote connection when the controlled computer is ready.
-		"message": _("Connected to control server"),
+		"message": _("Connected as controlled computer"),
 	},
 	"clientConnected": {"wave": "controlling", "beeps": [(1000, 300)]},
 	"clientDisconnected": {"wave": "disconnected", "beeps": [(108, 300)]},

--- a/source/_remoteClient/cues.py
+++ b/source/_remoteClient/cues.py
@@ -40,8 +40,8 @@ CUES: Dict[str, Cue] = {
 	"clipboardPushed": {
 		"wave": "clipboardPush",
 		"beeps": [(500, 100), (600, 100)],
-		# Translators: Message shown when the clipboard is successfully pushed to the remote computer.
-		"message": _("Clipboard pushed"),
+		# Translators: Message shown when the clipboard is successfully sent to the remote computer.
+		"message": _("Clipboard sent"),
 	},
 	"clipboardReceived": {
 		"wave": "clipboardReceive",

--- a/source/_remoteClient/cues.py
+++ b/source/_remoteClient/cues.py
@@ -33,7 +33,7 @@ CUES: Dict[str, Cue] = {
 		"wave": "controlled",
 		"beeps": [(720, 100), (None, 50), (720, 100), (None, 50), (720, 100)],
 		# Translators: Presented in direct (client to server) remote connection when the controlled computer is ready.
-		"message": _("Connected as controlled computer"),
+		"message": pgettext("remote", "Connected as controlled computer"),
 	},
 	"clientConnected": {"wave": "controlling", "beeps": [(1000, 300)]},
 	"clientDisconnected": {"wave": "disconnected", "beeps": [(108, 300)]},

--- a/source/_remoteClient/cues.py
+++ b/source/_remoteClient/cues.py
@@ -32,7 +32,7 @@ CUES: Dict[str, Cue] = {
 	"controlServerConnected": {
 		"wave": "controlled",
 		"beeps": [(720, 100), (None, 50), (720, 100), (None, 50), (720, 100)],
-		# Translators: Presented in direct (client to server) remote connection when the controlled computer is ready.
+		# Translators: Presented in direct (client to server) remote Access connection when the controlled computer is ready.
 		"message": pgettext("remote", "Connected as controlled computer"),
 	},
 	"clientConnected": {"wave": "controlling", "beeps": [(1000, 300)]},

--- a/source/_remoteClient/cues.py
+++ b/source/_remoteClient/cues.py
@@ -32,7 +32,7 @@ CUES: Dict[str, Cue] = {
 	"controlServerConnected": {
 		"wave": "controlled",
 		"beeps": [(720, 100), (None, 50), (720, 100), (None, 50), (720, 100)],
-		# Translators: Presented in direct (client to server) remote Access connection when the controlled computer is ready.
+		# Translators: Presented in direct (client to server) Remote Access connection when the controlled computer is ready.
 		"message": pgettext("remote", "Connected as controlled computer"),
 	},
 	"clientConnected": {"wave": "controlling", "beeps": [(1000, 300)]},
@@ -41,7 +41,7 @@ CUES: Dict[str, Cue] = {
 		"wave": "clipboardPush",
 		"beeps": [(500, 100), (600, 100)],
 		# Translators: Message shown when the clipboard is successfully sent to the remote computer.
-		"message": _("Clipboard sent"),
+		"message": pgettext("remote", "Clipboard sent"),
 	},
 	"clipboardReceived": {
 		"wave": "clipboardReceive",

--- a/source/_remoteClient/dialogs.py
+++ b/source/_remoteClient/dialogs.py
@@ -42,7 +42,7 @@ class ClientPanel(ContextHelpMixin, wx.Panel):
 			wx.ComboBox,
 		)
 		self.key = sizerHelper.addLabeledControl(
-			# Translators: Label of the edit field to enter key (password) to secure the remote connection.
+			# Translators: Label of the edit field to enter key (password) to secure the remote Access connection.
 			_("&Key:"),
 			wx.TextCtrl,
 		)
@@ -70,9 +70,9 @@ class ClientPanel(ContextHelpMixin, wx.Panel):
 	def _generateKeyCommand(self, insecure: bool = False) -> None:
 		self._keyGenerationProgressDialog = gui.IndeterminateProgressDialog(
 			self,
-			# Translators: Title of a dialog shown to users when asking a Remote control server to generate a key
+			# Translators: Title of a dialog shown to users when asking a Remote Access server to generate a key
 			pgettext("remote", "Generating key"),
-			# Translators: Message on a dialog shown to users when asking a Remote control server to generate a key
+			# Translators: Message on a dialog shown to users when asking a Remote Access server to generate a key
 			pgettext("remote", "Generating key..."),
 		)
 		address = protocol.addressToHostPort(self.host.GetValue())
@@ -103,8 +103,8 @@ class ClientPanel(ContextHelpMixin, wx.Panel):
 		gui.messageBox(
 			pgettext(
 				"remote",
-				# Translators: Message shown to users when requesting that a Remote control server generate a key fails.
-				# {host} will be replaced with the address of the Remote control server.
+				# Translators: Message shown to users when requesting that a Remote Access server generate a key fails.
+				# {host} will be replaced with the address of the Remote Access server.
 				"Unable to connect to {host}. Check that you have internet access, and that there are no mistakes in the host field.",
 			).format(host=self.host.GetValue()),
 			# Translators: Title of a dialog.
@@ -193,7 +193,7 @@ class ServerPanel(ContextHelpMixin, wx.Panel):
 			max=65535,
 			initial=SERVER_PORT,
 		)
-		# Translators: Label of the edit field to enter key (password) to secure the remote connection.
+		# Translators: Label of the edit field to enter key (password) to secure the remote Access connection.
 		self.key = sizerHelper.addLabeledControl(pgettext("remote", "&Key"), wx.TextCtrl)
 		# Translators: The button used to generate a random key/password.
 		self._generateKeyButton = wx.Button(parent=self, label=_("&Generate Key"))

--- a/source/_remoteClient/dialogs.py
+++ b/source/_remoteClient/dialogs.py
@@ -338,13 +338,13 @@ class DirectConnectDialog(ContextHelpMixin, wx.Dialog):
 		if self._selectedPanel is self._clientPanel and (
 			not self._selectedPanel.host.GetValue() or not self._selectedPanel.key.GetValue()
 		):
-			# Translators: A message box displayed when the host or key field is empty and the user tries to connect.
+			# Translators: Message displayed when the host or key field is empty and the user tries to connect.
 			message = _("Both host and key must be set.")
 			focusTarget = self._selectedPanel.host
 		elif self._selectedPanel is self._serverPanel and (
 			not self._selectedPanel.port.GetValue() or not self._selectedPanel.key.GetValue()
 		):
-			# Translators: A message box displayed when the port or key field is empty and the user tries to connect.
+			# Translators: Message displayed when the port or key field is empty and the user tries to connect.
 			message = _("Both port and key must be set.")
 			focusTarget = self._selectedPanel.port
 		if message is not None:
@@ -389,11 +389,12 @@ class DirectConnectDialog(ContextHelpMixin, wx.Dialog):
 
 class CertificateUnauthorizedDialog(wx.MessageDialog):
 	def __init__(self, parent: wx.Window | None, fingerprint: str | None = None):
-		# Translators: A title bar of a window presented when an attempt has been made to connect with a server with unauthorized certificate.
+		# Translators: Title of the dialog presented when attempting to connect to a server with an untrusted certificate.
 		title = pgettext("remote", "Security Warning")
 		message = pgettext(
 			"remote",
-			# Translators: {fingerprint} is a SHA256 fingerprint of the server certificate.
+			# Translators: Message presented when attempting to connect to a server with an untrusted certificate.
+			# {fingerprint} will be replaced with the SHA256 fingerprint of the server certificate.
 			"The certificate of this server could not be verified. Using the wrong fingerprint may allow a third party to access the Remote Access session.\n"
 			"\n"
 			"Before continuing, please make sure that the following server certificate fingerprint is correct.\n"

--- a/source/_remoteClient/dialogs.py
+++ b/source/_remoteClient/dialogs.py
@@ -194,7 +194,7 @@ class ServerPanel(ContextHelpMixin, wx.Panel):
 			initial=SERVER_PORT,
 		)
 		# Translators: Label of the edit field to enter key (password) to secure the remote connection.
-		self.key = sizerHelper.addLabeledControl(_("&Key"), wx.TextCtrl)
+		self.key = sizerHelper.addLabeledControl(pgettext("remote", "&Key"), wx.TextCtrl)
 		# Translators: The button used to generate a random key/password.
 		self._generateKeyButton = wx.Button(parent=self, label=_("&Generate Key"))
 		self._generateKeyButton.Bind(wx.EVT_BUTTON, self.onGenerateKey)
@@ -390,10 +390,11 @@ class DirectConnectDialog(ContextHelpMixin, wx.Dialog):
 class CertificateUnauthorizedDialog(wx.MessageDialog):
 	def __init__(self, parent: wx.Window | None, fingerprint: str | None = None):
 		# Translators: A title bar of a window presented when an attempt has been made to connect with a server with unauthorized certificate.
-		title = _("NVDA Remote Connection Security Warning")
-		message = _(
+		title = pgettext("remote", "Security Warning")
+		message = pgettext(
+			"remote",
 			# Translators: {fingerprint} is a SHA256 fingerprint of the server certificate.
-			"The certificate of this server could not be verified. Using the wrong fingerprint may allow a third party to access the remote session..\n"
+			"The certificate of this server could not be verified. Using the wrong fingerprint may allow a third party to access the Remote Access session.\n"
 			"\n"
 			"Before continuing, please make sure that the following server certificate fingerprint is correct.\n"
 			"Server SHA256 fingerprint: {fingerprint}\n"

--- a/source/_remoteClient/dialogs.py
+++ b/source/_remoteClient/dialogs.py
@@ -42,7 +42,7 @@ class ClientPanel(ContextHelpMixin, wx.Panel):
 			wx.ComboBox,
 		)
 		self.key = sizerHelper.addLabeledControl(
-			# Translators: Label of the edit field to enter key (password) to secure the remote Access connection.
+			# Translators: Label of the edit field to enter key (password) to secure the Remote Access connection.
 			_("&Key:"),
 			wx.TextCtrl,
 		)
@@ -193,7 +193,7 @@ class ServerPanel(ContextHelpMixin, wx.Panel):
 			max=65535,
 			initial=SERVER_PORT,
 		)
-		# Translators: Label of the edit field to enter key (password) to secure the remote Access connection.
+		# Translators: Label of the edit field to enter key (password) to secure the Remote Access connection.
 		self.key = sizerHelper.addLabeledControl(pgettext("remote", "&Key"), wx.TextCtrl)
 		# Translators: The button used to generate a random key/password.
 		self._generateKeyButton = wx.Button(parent=self, label=_("&Generate Key"))

--- a/source/_remoteClient/localMachine.py
+++ b/source/_remoteClient/localMachine.py
@@ -256,6 +256,6 @@ class LocalMachine:
 		if hasUiAccess():
 			ctypes.windll.sas.SendSAS(0)
 		else:
-			# Translators: Message displayed when a remote machine tries to send a SAS but UI Access is disabled.
+			# Translators: Message displayed when a remote computer tries to send alt+ctrl+del but UI Access is disabled.
 			ui.message(_("Unable to trigger Alt Control Delete from remote"))
 			logger.warning("UI Access is disabled on this machine so cannot trigger CTRL+ALT+DEL")

--- a/source/_remoteClient/localMachine.py
+++ b/source/_remoteClient/localMachine.py
@@ -256,6 +256,6 @@ class LocalMachine:
 		if hasUiAccess():
 			ctypes.windll.sas.SendSAS(0)
 		else:
-			# Translators: Message displayed when a remote computer tries to send alt+ctrl+del but UI Access is disabled.
+			# Translators: Message displayed when a remote computer tries to send ctrl+alt+del but UI Access is disabled.
 			ui.message(_("Unable to trigger Alt Control Delete from remote"))
 			logger.warning("UI Access is disabled on this machine so cannot trigger CTRL+ALT+DEL")

--- a/source/_remoteClient/menu.py
+++ b/source/_remoteClient/menu.py
@@ -37,10 +37,10 @@ class RemoteMenu(wx.Menu):
 		sysTrayIcon.Bind(wx.EVT_MENU, self.onMuteItem, self.muteItem)
 		self.pushClipboardItem: wx.MenuItem = self.Append(
 			wx.ID_ANY,
-			# Translators: Menu item in NVDA Remote submenu to push clipboard content to the remote computer.
-			_("&Push clipboard"),
-			# Translators: Tooltip for the Push Clipboard menu item in the NVDA Remote submenu.
-			pgettext("remote", "Push the clipboard to the remote computer."),
+			# Translators: Menu item in NVDA Remote submenu to send clipboard content to the remote computer.
+			_("&Send clipboard"),
+			# Translators: Tooltip for the Send clipboard menu item in the NVDA Remote submenu.
+			pgettext("remote", "Send the text on the clipboard to the remote computer."),
 		)
 		self.pushClipboardItem.Enable(False)
 		sysTrayIcon.Bind(

--- a/source/_remoteClient/menu.py
+++ b/source/_remoteClient/menu.py
@@ -27,9 +27,9 @@ class RemoteMenu(wx.Menu):
 		self._switchToConnectItem()
 		self.muteItem: wx.MenuItem = self.Append(
 			wx.ID_ANY,
-			# Translators: Menu item in NvDA Remote submenu to mute speech and sounds from the remote computer.
+			# Translators: Menu item in Remote Access submenu to mute speech and sounds from the remote computer.
 			_("Mute remote"),
-			# Translators: Tooltip for the Mute Remote menu item in the NVDA Remote submenu.
+			# Translators: Tooltip for the Mute Remote menu item in the Remote Access submenu.
 			pgettext("remote", "Mute speech and sounds from the remote computer."),
 			kind=wx.ITEM_CHECK,
 		)
@@ -37,9 +37,9 @@ class RemoteMenu(wx.Menu):
 		sysTrayIcon.Bind(wx.EVT_MENU, self.onMuteItem, self.muteItem)
 		self.pushClipboardItem: wx.MenuItem = self.Append(
 			wx.ID_ANY,
-			# Translators: Menu item in NVDA Remote submenu to send clipboard content to the remote computer.
+			# Translators: Menu item in the Remote Access submenu to send the contents of the clipboard to the remote computer.
 			_("&Send clipboard"),
-			# Translators: Tooltip for the Send clipboard menu item in the NVDA Remote submenu.
+			# Translators: Tooltip for the Send clipboard menu item in the Remote Access submenu.
 			pgettext("remote", "Send the text on the clipboard to the remote computer."),
 		)
 		self.pushClipboardItem.Enable(False)
@@ -50,9 +50,9 @@ class RemoteMenu(wx.Menu):
 		)
 		self.copyLinkItem: wx.MenuItem = self.Append(
 			wx.ID_ANY,
-			# Translators: Menu item in NVDA Remote submenu to copy a link to the current session.
+			# Translators: Menu item in the Remote Access submenu to copy a link to the current session.
 			_("Copy &link"),
-			# Translators: Tooltip for the Copy Link menu item in the NVDA Remote submenu.
+			# Translators: Tooltip for the Copy Link menu item in the Remote Access submenu.
 			pgettext("remote", "Copy a link to the current Remote Access session to the clipboard."),
 		)
 		self.copyLinkItem.Enable(False)
@@ -63,9 +63,9 @@ class RemoteMenu(wx.Menu):
 		)
 		self.sendCtrlAltDelItem: wx.MenuItem = self.Append(
 			wx.ID_ANY,
-			# Translators: Menu item in NVDA Remote submenu to send Control+Alt+Delete to the remote computer.
+			# Translators: Menu item in the Remote Access submenu to send Control+Alt+Delete to the remote computer.
 			pgettext("remote", "Send ctrl+alt+del"),
-			# Translators: Tooltip for the Send Ctrl+Alt+Del menu item in the NVDA Remote submenu.
+			# Translators: Tooltip for the Send Ctrl+Alt+Del menu item in the Remote Access submenu.
 			pgettext("remote", "Send control+alt+delete to the controlled computer."),
 		)
 		sysTrayIcon.Bind(
@@ -151,9 +151,9 @@ class RemoteMenu(wx.Menu):
 		Sets the label, help text and event bindings of the connection item
 		to those appropriate for creating a new Remote session.
 		"""
-		# Translators: Item in the Remote Access submenu to connect to a remote computer.
+		# Translators: Item in the Remote Access submenu to connect to another computer.
 		self.connectionItem.SetItemLabel(_("Connect..."))
-		# Translators: Tooltip for the Connect menu item in the NVDA Remote Access submenu.
+		# Translators: Tooltip for the Connect menu item in the Remote Access submenu.
 		self.connectionItem.SetHelp(pgettext("remote", "Remotely connect to another computer running NVDA."))
 		gui.mainFrame.sysTrayIcon.Unbind(wx.EVT_MENU, self.connectionItem)
 		gui.mainFrame.sysTrayIcon.Bind(
@@ -168,7 +168,7 @@ class RemoteMenu(wx.Menu):
 		Sets the label, help text and event bindings of the connection item
 		to those appropriate for disconnecting an existing Remote session.
 		"""
-		# Translators: Menu item in the Remote Access submenu to disconnect from another computer running NVDA Remote Access.
+		# Translators: Menu item in the Remote Access submenu to disconnect from another computer running NVDA.
 		self.connectionItem.SetItemLabel(_("Disconnect"))
 		# Translators: Tooltip for the Disconnect menu item in the Remote Access submenu.
 		self.connectionItem.SetHelp(pgettext("remote", "Disconnect from the current Remote Access session."))

--- a/source/_remoteClient/menu.py
+++ b/source/_remoteClient/menu.py
@@ -77,7 +77,7 @@ class RemoteMenu(wx.Menu):
 		self.remoteItem = toolsMenu.AppendSubMenu(
 			self,
 			# Translators: Label of the Remote Access submenu in the NVDA tools menu.
-			_("R&emote Access"),
+			pgettext("remote", "R&emote Access"),
 			pgettext(
 				"remote",
 				# Translators: Tooltip for the Remote Access submenu in the NVDA Tools menu.
@@ -154,7 +154,7 @@ class RemoteMenu(wx.Menu):
 		# Translators: Item in the Remote Access submenu to connect to a remote computer.
 		self.connectionItem.SetItemLabel(_("Connect..."))
 		# Translators: Tooltip for the Connect menu item in the NVDA Remote Access submenu.
-		self.connectionItem.SetHelp(_("Remotely connect to another computer running NVDA."))
+		self.connectionItem.SetHelp(pgettext("remote", "Remotely connect to another computer running NVDA."))
 		gui.mainFrame.sysTrayIcon.Unbind(wx.EVT_MENU, self.connectionItem)
 		gui.mainFrame.sysTrayIcon.Bind(
 			wx.EVT_MENU,
@@ -171,7 +171,7 @@ class RemoteMenu(wx.Menu):
 		# Translators: Menu item in the Remote Access submenu to disconnect from another computer running NVDA Remote Access.
 		self.connectionItem.SetItemLabel(_("Disconnect"))
 		# Translators: Tooltip for the Disconnect menu item in the Remote Access submenu.
-		self.connectionItem.SetHelp(_("Disconnect from the current Remote Access session."))
+		self.connectionItem.SetHelp(pgettext("remote", "Disconnect from the current Remote Access session."))
 		gui.mainFrame.sysTrayIcon.Unbind(wx.EVT_MENU, self.connectionItem)
 		gui.mainFrame.sysTrayIcon.Bind(
 			wx.EVT_MENU,

--- a/source/_remoteClient/menu.py
+++ b/source/_remoteClient/menu.py
@@ -40,7 +40,7 @@ class RemoteMenu(wx.Menu):
 			# Translators: Menu item in NVDA Remote submenu to push clipboard content to the remote computer.
 			_("&Push clipboard"),
 			# Translators: Tooltip for the Push Clipboard menu item in the NVDA Remote submenu.
-			_("Push the clipboard to the other machine"),
+			_("Push the clipboard to the remote computer"),
 		)
 		self.pushClipboardItem.Enable(False)
 		sysTrayIcon.Bind(

--- a/source/_remoteClient/menu.py
+++ b/source/_remoteClient/menu.py
@@ -30,7 +30,7 @@ class RemoteMenu(wx.Menu):
 			# Translators: Menu item in NvDA Remote submenu to mute speech and sounds from the remote computer.
 			_("Mute remote"),
 			# Translators: Tooltip for the Mute Remote menu item in the NVDA Remote submenu.
-			_("Mute speech and sounds from the remote computer"),
+			pgettext("remote", "Mute speech and sounds from the remote computer."),
 			kind=wx.ITEM_CHECK,
 		)
 		self.muteItem.Enable(False)
@@ -40,7 +40,7 @@ class RemoteMenu(wx.Menu):
 			# Translators: Menu item in NVDA Remote submenu to push clipboard content to the remote computer.
 			_("&Push clipboard"),
 			# Translators: Tooltip for the Push Clipboard menu item in the NVDA Remote submenu.
-			_("Push the clipboard to the remote computer"),
+			pgettext("remote", "Push the clipboard to the remote computer."),
 		)
 		self.pushClipboardItem.Enable(False)
 		sysTrayIcon.Bind(
@@ -53,7 +53,7 @@ class RemoteMenu(wx.Menu):
 			# Translators: Menu item in NVDA Remote submenu to copy a link to the current session.
 			_("Copy &link"),
 			# Translators: Tooltip for the Copy Link menu item in the NVDA Remote submenu.
-			_("Copy a link to the remote session"),
+			pgettext("remote", "Copy a link to the current Remote Access session to the clipboard."),
 		)
 		self.copyLinkItem.Enable(False)
 		sysTrayIcon.Bind(
@@ -64,9 +64,9 @@ class RemoteMenu(wx.Menu):
 		self.sendCtrlAltDelItem: wx.MenuItem = self.Append(
 			wx.ID_ANY,
 			# Translators: Menu item in NVDA Remote submenu to send Control+Alt+Delete to the remote computer.
-			_("Send Ctrl+Alt+Del"),
+			pgettext("remote", "Send ctrl+alt+del"),
 			# Translators: Tooltip for the Send Ctrl+Alt+Del menu item in the NVDA Remote submenu.
-			_("Send Ctrl+Alt+Del"),
+			pgettext("remote", "Send control+alt+delete to the controlled computer."),
 		)
 		sysTrayIcon.Bind(
 			wx.EVT_MENU,

--- a/source/_remoteClient/menu.py
+++ b/source/_remoteClient/menu.py
@@ -77,9 +77,12 @@ class RemoteMenu(wx.Menu):
 		self.remoteItem = toolsMenu.AppendSubMenu(
 			self,
 			# Translators: Label of menu in NVDA tools menu.
-			_("R&emote"),
-			# Translators: Tooltip for the Remote menu in the NVDA Tools menu.
-			_("NVDA Remote Access"),
+			_("R&emote Access"),
+			pgettext(
+				"remote",
+				# Translators: Tooltip for the Remote menu in the NVDA Tools menu.
+				"Allow someone to control this computer from elsewhere, or control another computer running NVDA with this one.",
+			),
 		)
 
 	def terminate(self) -> None:
@@ -151,7 +154,7 @@ class RemoteMenu(wx.Menu):
 		# Translators: Item in NVDA Remote submenu to connect to a remote computer.
 		self.connectionItem.SetItemLabel(_("Connect..."))
 		# Translators: Tooltip for the Connect menu item in the NVDA Remote submenu.
-		self.connectionItem.SetHelp(_("Remotely connect to another computer running NVDA Remote Access"))
+		self.connectionItem.SetHelp(_("Remotely connect to another computer running NVDA."))
 		gui.mainFrame.sysTrayIcon.Unbind(wx.EVT_MENU, self.connectionItem)
 		gui.mainFrame.sysTrayIcon.Bind(
 			wx.EVT_MENU,
@@ -168,7 +171,7 @@ class RemoteMenu(wx.Menu):
 		# Translators: Menu item in NVDA Remote submenu to disconnect from another computer running NVDA Remote Access.
 		self.connectionItem.SetItemLabel(_("Disconnect"))
 		# Translators: Tooltip for the Disconnect menu item in the NVDA Remote submenu.
-		self.connectionItem.SetHelp(_("Disconnect from another computer running NVDA Remote Access"))
+		self.connectionItem.SetHelp(_("Disconnect from the current Remote Access session."))
 		gui.mainFrame.sysTrayIcon.Unbind(wx.EVT_MENU, self.connectionItem)
 		gui.mainFrame.sysTrayIcon.Bind(
 			wx.EVT_MENU,

--- a/source/_remoteClient/menu.py
+++ b/source/_remoteClient/menu.py
@@ -38,9 +38,9 @@ class RemoteMenu(wx.Menu):
 		self.pushClipboardItem: wx.MenuItem = self.Append(
 			wx.ID_ANY,
 			# Translators: Menu item in the Remote Access submenu to send the contents of the clipboard to the remote computer.
-			_("&Send clipboard"),
+			pgettext("remote", "&Send clipboard"),
 			# Translators: Tooltip for the Send clipboard menu item in the Remote Access submenu.
-			pgettext("remote", "Send the text on the clipboard to the remote computer."),
+			pgettext("remote", "Send the clipboard text to the remote computer."),
 		)
 		self.pushClipboardItem.Enable(False)
 		sysTrayIcon.Bind(

--- a/source/_remoteClient/menu.py
+++ b/source/_remoteClient/menu.py
@@ -76,11 +76,11 @@ class RemoteMenu(wx.Menu):
 		self.sendCtrlAltDelItem.Enable(False)
 		self.remoteItem = toolsMenu.AppendSubMenu(
 			self,
-			# Translators: Label of menu in NVDA tools menu.
+			# Translators: Label of the Remote Access submenu in the NVDA tools menu.
 			_("R&emote Access"),
 			pgettext(
 				"remote",
-				# Translators: Tooltip for the Remote menu in the NVDA Tools menu.
+				# Translators: Tooltip for the Remote Access submenu in the NVDA Tools menu.
 				"Allow someone to control this computer from elsewhere, or control another computer running NVDA with this one.",
 			),
 		)
@@ -151,9 +151,9 @@ class RemoteMenu(wx.Menu):
 		Sets the label, help text and event bindings of the connection item
 		to those appropriate for creating a new Remote session.
 		"""
-		# Translators: Item in NVDA Remote submenu to connect to a remote computer.
+		# Translators: Item in the Remote Access submenu to connect to a remote computer.
 		self.connectionItem.SetItemLabel(_("Connect..."))
-		# Translators: Tooltip for the Connect menu item in the NVDA Remote submenu.
+		# Translators: Tooltip for the Connect menu item in the NVDA Remote Access submenu.
 		self.connectionItem.SetHelp(_("Remotely connect to another computer running NVDA."))
 		gui.mainFrame.sysTrayIcon.Unbind(wx.EVT_MENU, self.connectionItem)
 		gui.mainFrame.sysTrayIcon.Bind(
@@ -168,9 +168,9 @@ class RemoteMenu(wx.Menu):
 		Sets the label, help text and event bindings of the connection item
 		to those appropriate for disconnecting an existing Remote session.
 		"""
-		# Translators: Menu item in NVDA Remote submenu to disconnect from another computer running NVDA Remote Access.
+		# Translators: Menu item in the Remote Access submenu to disconnect from another computer running NVDA Remote Access.
 		self.connectionItem.SetItemLabel(_("Disconnect"))
-		# Translators: Tooltip for the Disconnect menu item in the NVDA Remote submenu.
+		# Translators: Tooltip for the Disconnect menu item in the Remote Access submenu.
 		self.connectionItem.SetHelp(_("Disconnect from the current Remote Access session."))
 		gui.mainFrame.sysTrayIcon.Unbind(wx.EVT_MENU, self.connectionItem)
 		gui.mainFrame.sysTrayIcon.Bind(

--- a/source/_remoteClient/session.py
+++ b/source/_remoteClient/session.py
@@ -550,7 +550,7 @@ class LeaderSession(RemoteSession):
 		speech.cancelSpeech()
 		ui.message(
 			# Translators: Message for when the remote NVDA is not connected
-			_("Remote NVDA not connected"),
+			pgettext("remote", "Remote NVDA not connected"),
 		)
 
 	def handleChannelJoined(

--- a/source/_remoteClient/session.py
+++ b/source/_remoteClient/session.py
@@ -550,7 +550,7 @@ class LeaderSession(RemoteSession):
 		speech.cancelSpeech()
 		ui.message(
 			# Translators: Message for when the remote NVDA is not connected
-			_("Remote NVDA not connected."),
+			_("Remote NVDA not connected"),
 		)
 
 	def handleChannelJoined(

--- a/source/_remoteClient/session.py
+++ b/source/_remoteClient/session.py
@@ -162,9 +162,11 @@ class RemoteSession:
 		"""
 		log.error("Protocol version mismatch detected with relay server")
 		ui.message(
-			# Translators: Message for version mismatch
-			_("""The version of the relay server which you have connected to is not compatible with this version of the Remote Client.
-Please use a different server."""),
+			pgettext(
+				"remote",
+				# Translators: Message for version mismatch
+				"The Remote Access server you have connected to is not compatible with this version of NVDA. Please use a different server.",
+			),
 		)
 		self.transport.close()
 

--- a/source/_remoteClient/session.py
+++ b/source/_remoteClient/session.py
@@ -164,7 +164,7 @@ class RemoteSession:
 		ui.message(
 			pgettext(
 				"remote",
-				# Translators: Message for version mismatch
+				# Translators: Message presented when attempting to connect to an incompatible Remote Access server.
 				"The Remote Access server you have connected to is not compatible with this version of NVDA. Please use a different server.",
 			),
 		)

--- a/source/_remoteClient/session.py
+++ b/source/_remoteClient/session.py
@@ -184,8 +184,8 @@ class RemoteSession:
 		if force_display or self.shouldDisplayMotd(motd):
 			gui.messageBox(
 				parent=gui.mainFrame,
-				# Translators: Caption for message of the day dialog
-				caption=_("Message of the Day"),
+				# Translators: Title of a dialog showing a message sent by a Remote Access server.
+				caption=pgettext("remote", "Message from Remote Access Server"),
 				message=motd,
 			)
 

--- a/source/config/configFlags.py
+++ b/source/config/configFlags.py
@@ -318,9 +318,9 @@ class RemoteConnectionMode(DisplayStringIntEnum):
 	@property
 	def _displayStringLabels(self):
 		return {
-			# Translators: Allow this computer to be controlled by the remote computer.
+			# Translators: Option that allows this computer to be controlled by the remote computer.
 			RemoteConnectionMode.FOLLOWER: pgettext("remote", "Allow this computer to be controlled"),
-			# Translators: Allow this computer to control the remote computer.
+			# Translators: Option that allows this computer to control the remote computer.
 			RemoteConnectionMode.LEADER: pgettext("remote", "Control another computer"),
 		}
 

--- a/source/config/configFlags.py
+++ b/source/config/configFlags.py
@@ -319,9 +319,9 @@ class RemoteConnectionMode(DisplayStringIntEnum):
 	def _displayStringLabels(self):
 		return {
 			# Translators: Allow this computer to be controlled by the remote computer.
-			RemoteConnectionMode.FOLLOWER: pgettext("remote", "Allow this machine to be controlled"),
+			RemoteConnectionMode.FOLLOWER: pgettext("remote", "Allow this computer to be controlled"),
 			# Translators: Allow this computer to control the remote computer.
-			RemoteConnectionMode.LEADER: pgettext("remote", "Control another machine"),
+			RemoteConnectionMode.LEADER: pgettext("remote", "Control another computer"),
 		}
 
 	def toConnectionMode(self) -> "_remoteClient.connectionInfo.ConnectionMode":

--- a/source/core.py
+++ b/source/core.py
@@ -564,7 +564,7 @@ def _handleNVDAModuleCleanupBeforeGUIExit():
 	_terminate(globalPluginHandler)
 	# the brailleViewer should be destroyed safely before closing the window
 	brailleViewer.destroyBrailleViewer()
-	# Terminating remote causes it to clean up its menus, so do it here while they still exist
+	# Terminating remoteClient causes it to clean up its menus, so do it here while they still exist
 	_terminate(_remoteClient)
 
 

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -4887,8 +4887,8 @@ class GlobalCommands(ScriptableObject):
 
 	@script(
 		category=SCRCAT_REMOTE,
-		# Translators: Documentation string for the script that sends the contents of the clipboard to the remote machine.
-		description=_("Sends the contents of the clipboard to the remote machine"),
+		# Translators: Documentation string for the script that sends the contents of the clipboard to the remote computer.
+		description=_("Sends the contents of the clipboard to the remote computer"),
 	)
 	@gui.blockAction.when(gui.blockAction.Context.REMOTE_ACCESS_DISABLED)
 	def script_pushClipboard(self, gesture: "inputCore.InputGesture"):
@@ -4952,8 +4952,11 @@ class GlobalCommands(ScriptableObject):
 			self.script_connectToRemote(gesture)
 
 	@script(
-		# Translators: Documentation string for the script that toggles the control between guest and host machine.
-		description=_("Toggles the control between guest and host machine"),
+		description=pgettext(
+			"remote",
+			# Translators: Documentation string for the script that toggles the control between guest and host computers.
+			"Switches whether the keyboard controls the local or remote computer",
+		),
 		category=SCRCAT_REMOTE,
 		gesture="kb:NVDA+alt+tab",
 	)

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -4878,7 +4878,7 @@ class GlobalCommands(ScriptableObject):
 
 	@script(
 		# Translators: Describes a command.
-		description=_("Mute or unmute the speech coming from the remote computer"),
+		description=_("Mutes or unmutes the speech coming from the remote computer"),
 		category=SCRCAT_REMOTE,
 	)
 	@gui.blockAction.when(gui.blockAction.Context.REMOTE_ACCESS_DISABLED)
@@ -4923,7 +4923,7 @@ class GlobalCommands(ScriptableObject):
 
 	@script(
 		# Translators: Documentation string for the script that invokes the remote session.
-		description=_("Connect to a remote computer"),
+		description=_("Connects to a remote computer"),
 		category=SCRCAT_REMOTE,
 	)
 	@gui.blockAction.when(
@@ -4940,7 +4940,7 @@ class GlobalCommands(ScriptableObject):
 
 	@script(
 		# Translators: Describes the command that creates a remote session, or disconnects it if one already exists.
-		description=pgettext("remote", "Toggle Remote Access connection"),
+		description=pgettext("remote", "Toggles Remote Access connection"),
 		category=SCRCAT_REMOTE,
 		gesture="kb:NVDA+alt+r",
 	)

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -120,7 +120,7 @@ SCRCAT_DOCUMENTFORMATTING = _("Document formatting")
 #: Script category for audio streaming commands.
 # Translators: The name of a category of NVDA commands.
 SCRCAT_AUDIO = _("Audio")
-#: Script category for Remote commands.
+#: Script category for Remote Access commands.
 # Translators: The name of a category of NVDA commands.
 SCRCAT_REMOTE = pgettext("remote", "Remote Access")
 
@@ -4895,7 +4895,7 @@ class GlobalCommands(ScriptableObject):
 		_remoteClient._remoteClient.pushClipboard()
 
 	@script(
-		# Translators: Documentation string for the script that copies a link to the remote session to the clipboard.
+		# Translators: Documentation string for the script that copies a link to the remote Access session to the clipboard.
 		description=pgettext("remote", "Copies a link to the current Remote Access session to the clipboard"),
 		category=SCRCAT_REMOTE,
 	)
@@ -4907,7 +4907,7 @@ class GlobalCommands(ScriptableObject):
 
 	@script(
 		category=SCRCAT_REMOTE,
-		# Translators: Documentation string for the script that disconnects a remote session.
+		# Translators: Documentation string for the script that disconnects a remote Access session.
 		description=pgettext("remote", "Disconnects from the current Remote Access session"),
 	)
 	@gui.blockAction.when(
@@ -4922,7 +4922,7 @@ class GlobalCommands(ScriptableObject):
 		_remoteClient._remoteClient.disconnect()
 
 	@script(
-		# Translators: Documentation string for the script that starts a new remote session.
+		# Translators: Documentation string for the script that starts a new remote Access session.
 		description=pgettext("remote", "Connects to a remote computer"),
 		category=SCRCAT_REMOTE,
 	)
@@ -4939,7 +4939,7 @@ class GlobalCommands(ScriptableObject):
 		_remoteClient._remoteClient.doConnect()
 
 	@script(
-		# Translators: Describes the script that creates a new remote session, or disconnects it if one already exists.
+		# Translators: Describes the script that creates a new remote Access session, or disconnects it if one already exists.
 		description=pgettext("remote", "Toggles whether Remote Access is connected"),
 		category=SCRCAT_REMOTE,
 		gesture="kb:NVDA+alt+r",

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -4895,7 +4895,7 @@ class GlobalCommands(ScriptableObject):
 		_remoteClient._remoteClient.pushClipboard()
 
 	@script(
-		# Translators: Documentation string for the script that copies a link to the remote Access session to the clipboard.
+		# Translators: Documentation string for the script that copies a link to the Remote Access session to the clipboard.
 		description=pgettext("remote", "Copies a link to the current Remote Access session to the clipboard"),
 		category=SCRCAT_REMOTE,
 	)
@@ -4907,7 +4907,7 @@ class GlobalCommands(ScriptableObject):
 
 	@script(
 		category=SCRCAT_REMOTE,
-		# Translators: Documentation string for the script that disconnects a remote Access session.
+		# Translators: Documentation string for the script that disconnects a Remote Access session.
 		description=pgettext("remote", "Disconnects from the current Remote Access session"),
 	)
 	@gui.blockAction.when(
@@ -4922,7 +4922,7 @@ class GlobalCommands(ScriptableObject):
 		_remoteClient._remoteClient.disconnect()
 
 	@script(
-		# Translators: Documentation string for the script that starts a new remote Access session.
+		# Translators: Documentation string for the script that starts a new Remote Access session.
 		description=pgettext("remote", "Connects to a remote computer"),
 		category=SCRCAT_REMOTE,
 	)
@@ -4939,7 +4939,7 @@ class GlobalCommands(ScriptableObject):
 		_remoteClient._remoteClient.doConnect()
 
 	@script(
-		# Translators: Describes the script that creates a new remote Access session, or disconnects it if one already exists.
+		# Translators: Describes the script that creates a new Remote Access session, or disconnects it if one already exists.
 		description=pgettext("remote", "Toggles whether Remote Access is connected"),
 		category=SCRCAT_REMOTE,
 		gesture="kb:NVDA+alt+r",

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -4877,7 +4877,7 @@ class GlobalCommands(ScriptableObject):
 		audio._toggleSoundSplitState()
 
 	@script(
-		# Translators: Describes a command.
+		# Translators: Documentation string for the script that toggles whether the output from the remote computer is muted.
 		description=_("Mutes or unmutes the speech coming from the remote computer"),
 		category=SCRCAT_REMOTE,
 	)
@@ -4922,7 +4922,7 @@ class GlobalCommands(ScriptableObject):
 		_remoteClient._remoteClient.disconnect()
 
 	@script(
-		# Translators: Documentation string for the script that invokes the remote session.
+		# Translators: Documentation string for the script that starts a new remote session.
 		description=_("Connects to a remote computer"),
 		category=SCRCAT_REMOTE,
 	)
@@ -4939,7 +4939,7 @@ class GlobalCommands(ScriptableObject):
 		_remoteClient._remoteClient.doConnect()
 
 	@script(
-		# Translators: Describes the command that creates a remote session, or disconnects it if one already exists.
+		# Translators: Describes the script that creates a new remote session, or disconnects it if one already exists.
 		description=pgettext("remote", "Toggles Remote Access connection"),
 		category=SCRCAT_REMOTE,
 		gesture="kb:NVDA+alt+r",

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -122,7 +122,7 @@ SCRCAT_DOCUMENTFORMATTING = _("Document formatting")
 SCRCAT_AUDIO = _("Audio")
 #: Script category for Remote commands.
 # Translators: The name of a category of NVDA commands.
-SCRCAT_REMOTE = _("Remote")
+SCRCAT_REMOTE = _("Remote Access")
 
 # Translators: Reported when there are no settings to configure in synth settings ring
 # (example: when there is no setting for language).
@@ -4896,7 +4896,7 @@ class GlobalCommands(ScriptableObject):
 
 	@script(
 		# Translators: Documentation string for the script that copies a link to the remote session to the clipboard.
-		description=_("Copies a link to the remote session to the clipboard"),
+		description=pgettext("remote", "Copies a link to the current Remote Access session to the clipboard"),
 		category=SCRCAT_REMOTE,
 	)
 	@gui.blockAction.when(gui.blockAction.Context.REMOTE_ACCESS_DISABLED)
@@ -4908,7 +4908,7 @@ class GlobalCommands(ScriptableObject):
 	@script(
 		category=SCRCAT_REMOTE,
 		# Translators: Documentation string for the script that disconnects a remote session.
-		description=_("Disconnect a remote session"),
+		description=pgettext("remote", "Disconnects from the current Remote Access session"),
 	)
 	@gui.blockAction.when(
 		gui.blockAction.Context.REMOTE_ACCESS_DISABLED,
@@ -4940,7 +4940,7 @@ class GlobalCommands(ScriptableObject):
 
 	@script(
 		# Translators: Describes the command that creates a remote session, or disconnects it if one already exists.
-		description=pgettext("remote", "Toggle Remote connection"),
+		description=pgettext("remote", "Toggle Remote Access connection"),
 		category=SCRCAT_REMOTE,
 		gesture="kb:NVDA+alt+r",
 	)

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -122,7 +122,7 @@ SCRCAT_DOCUMENTFORMATTING = _("Document formatting")
 SCRCAT_AUDIO = _("Audio")
 #: Script category for Remote commands.
 # Translators: The name of a category of NVDA commands.
-SCRCAT_REMOTE = _("Remote Access")
+SCRCAT_REMOTE = pgettext("remote", "Remote Access")
 
 # Translators: Reported when there are no settings to configure in synth settings ring
 # (example: when there is no setting for language).
@@ -4878,7 +4878,7 @@ class GlobalCommands(ScriptableObject):
 
 	@script(
 		# Translators: Documentation string for the script that toggles whether the output from the remote computer is muted.
-		description=_("Mutes or unmutes the speech coming from the remote computer"),
+		description=pgettext("remote", "Mutes or unmutes the speech coming from the remote computer"),
 		category=SCRCAT_REMOTE,
 	)
 	@gui.blockAction.when(gui.blockAction.Context.REMOTE_ACCESS_DISABLED)
@@ -4888,7 +4888,7 @@ class GlobalCommands(ScriptableObject):
 	@script(
 		category=SCRCAT_REMOTE,
 		# Translators: Documentation string for the script that sends the contents of the clipboard to the remote computer.
-		description=_("Sends the contents of the clipboard to the remote computer"),
+		description=pgettext("remote", "Sends the contents of the clipboard to the remote computer"),
 	)
 	@gui.blockAction.when(gui.blockAction.Context.REMOTE_ACCESS_DISABLED)
 	def script_pushClipboard(self, gesture: "inputCore.InputGesture"):
@@ -4917,13 +4917,13 @@ class GlobalCommands(ScriptableObject):
 	def script_disconnectFromRemote(self, gesture: "inputCore.InputGesture"):
 		if not _remoteClient._remoteClient.isConnected:
 			# Translators: A message indicating that the remote client is not connected.
-			ui.message(_("Not connected"))
+			ui.message(pgettext("remote", "Not connected"))
 			return
 		_remoteClient._remoteClient.disconnect()
 
 	@script(
 		# Translators: Documentation string for the script that starts a new remote session.
-		description=_("Connects to a remote computer"),
+		description=pgettext("remote", "Connects to a remote computer"),
 		category=SCRCAT_REMOTE,
 	)
 	@gui.blockAction.when(
@@ -4940,7 +4940,7 @@ class GlobalCommands(ScriptableObject):
 
 	@script(
 		# Translators: Describes the script that creates a new remote session, or disconnects it if one already exists.
-		description=pgettext("remote", "Toggles Remote Access connection"),
+		description=pgettext("remote", "Toggles whether Remote Access is connected"),
 		category=SCRCAT_REMOTE,
 		gesture="kb:NVDA+alt+r",
 	)

--- a/source/gui/blockAction.py
+++ b/source/gui/blockAction.py
@@ -91,7 +91,7 @@ class Context(_Context, Enum):
 	REMOTE_ACCESS_DISABLED = (
 		_isRemoteAccessDisabled,
 		# Translators: Reported when an action cannot be performed because Remote Access functionality is disabled.
-		_("Action unavailable when Remote Access is disabled"),
+		pgettext("remote", "Action unavailable when Remote Access is disabled"),
 	)
 
 

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -3379,7 +3379,7 @@ class RemoteSettingsPanel(SettingsPanel):
 
 		self.clientOrServer = autoConnectionGroupHelper.addLabeledControl(
 			# Translators: Label for a control in Remote Access settings,
-			# allowing users to choose whether they want to use an existing Remote relay server, or host their own.
+			# allowing users to choose whether they want to use an existing server, or host their own.
 			pgettext("remote", "&Server:"),
 			wx.Choice,
 			choices=tuple(serverType.displayString for serverType in RemoteServerType.__members__.values()),
@@ -3389,7 +3389,7 @@ class RemoteSettingsPanel(SettingsPanel):
 
 		self.host = autoConnectionGroupHelper.addLabeledControl(
 			# Translators: Label for the host field in Remote Access settings.
-			# This is where users should enter the URL of the Remote server they want to use if they are not hosting their own.
+			# This is where users should enter the URL of the Remote Access server they want to use if they are not hosting their own.
 			_("&Host:"),
 			wx.TextCtrl,
 		)
@@ -3419,7 +3419,7 @@ class RemoteSettingsPanel(SettingsPanel):
 
 		self.key = autoConnectionGroupHelper.addLabeledControl(
 			# Translators: Label for a control in Remote Access settings,
-			# Where users set the key for their Remote connection.
+			# Where users set the key for their connection.
 			_("&Key:"),
 			wx.TextCtrl,
 		)

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -3385,7 +3385,7 @@ class RemoteSettingsPanel(SettingsPanel):
 			choices=tuple(serverType.displayString for serverType in RemoteServerType.__members__.values()),
 		)
 		self.clientOrServer.Bind(wx.EVT_CHOICE, self._onClientOrServer)
-		self.bindHelpEvent("RemoteAutoerver", self.clientOrServer)
+		self.bindHelpEvent("RemoteAutoconnectServer", self.clientOrServer)
 
 		self.host = autoConnectionGroupHelper.addLabeledControl(
 			# Translators: Label for the host field in Remote Access settings.
@@ -3489,7 +3489,7 @@ class RemoteSettingsPanel(SettingsPanel):
 				"remote",
 				# Translators: This message is presented when the user tries to delete all stored trusted fingerprints.
 				"This will cause NVDA to forget all previously trusted Remote Access servers. "
-				"When connecting to a previously trusted unrecognised Remote Access server, you will again be asked whether to trust its certificate.\n\n"
+				"When connecting to a previously trusted unrecognised server, you will again be asked whether to trust its certificate.\n\n"
 				"Are you sure you want to continue? This action cannot be undone.",
 			),
 			# Translators: This is the title of the dialog presented when the user tries to delete all stored trusted fingerprints.
@@ -3516,7 +3516,7 @@ class RemoteSettingsPanel(SettingsPanel):
 				message = pgettext(
 					"remote",
 					# Translators: This message is presented when the user tries to save the settings with the port or key field empty.
-					"Both port and key must be set in the Remote Access section in order to automatically connect using a locally hosted Remote Access server after NVDA starts.",
+					"Both port and key must be set in the Remote Access category in order to automatically connect using a locally hosted server after NVDA starts.",
 				)
 			if message is not None:
 				gui.messageBox(

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -3317,7 +3317,7 @@ class AddonStorePanel(SettingsPanel):
 
 class RemoteSettingsPanel(SettingsPanel):
 	# Translators: This is the label for the Remote Access settings category in NVDA's Settings screen.
-	title = _("Remote Access")
+	title = pgettext("remote", "Remote Access")
 	helpId = "RemoteSettings"
 
 	def makeSettings(self, sizer: wx.BoxSizer):
@@ -3385,7 +3385,7 @@ class RemoteSettingsPanel(SettingsPanel):
 			choices=tuple(serverType.displayString for serverType in RemoteServerType.__members__.values()),
 		)
 		self.clientOrServer.Bind(wx.EVT_CHOICE, self._onClientOrServer)
-		self.bindHelpEvent("RemoteAutoconnectServer", self.clientOrServer)
+		self.bindHelpEvent("RemoteAutoerver", self.clientOrServer)
 
 		self.host = autoConnectionGroupHelper.addLabeledControl(
 			# Translators: Label for the host field in Remote Access settings.

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -3316,7 +3316,7 @@ class AddonStorePanel(SettingsPanel):
 
 
 class RemoteSettingsPanel(SettingsPanel):
-	# Translators: This is the label for the remote settings category in NVDA Settings screen.
+	# Translators: This is the label for the Remote Access settings category in NVDA's Settings screen.
 	title = _("Remote Access")
 	helpId = "RemoteSettings"
 
@@ -3325,7 +3325,7 @@ class RemoteSettingsPanel(SettingsPanel):
 		sHelper = guiHelper.BoxSizerHelper(self, sizer=sizer)
 
 		self.enableRemote = sHelper.addItem(
-			# Translators: Label of a checkbox in Remote's settings
+			# Translators: Label of a checkbox in Remote Access settings
 			wx.CheckBox(self, label=pgettext("remote", "Enable Remote Access")),
 		)
 		self.enableRemote.Bind(wx.EVT_CHECKBOX, self._onEnableRemote)
@@ -3342,7 +3342,7 @@ class RemoteSettingsPanel(SettingsPanel):
 		self.playSounds = remoteSettingsGroupHelper.addItem(
 			wx.CheckBox(
 				self.remoteSettingsGroupBox,
-				# Translators: A checkbox in Remote settings to set whether sounds play instead of beeps.
+				# Translators: A checkbox in Remote Access settings to set whether sounds play instead of beeps.
 				label=pgettext("remote", "&Play sounds instead of beeps"),
 			),
 		)
@@ -3351,7 +3351,7 @@ class RemoteSettingsPanel(SettingsPanel):
 		self.autoconnect = remoteSettingsGroupHelper.addItem(
 			wx.CheckBox(
 				self.remoteSettingsGroupBox,
-				# Translators: A checkbox in Remote settings to set whether NVDA should automatically connect to a control server on startup.
+				# Translators: A checkbox in Remote Access settings to set whether NVDA should automatically connect to a control server on startup.
 				label=pgettext("remote", "Automatically &connect after NVDA starts"),
 			),
 		)
@@ -3361,7 +3361,7 @@ class RemoteSettingsPanel(SettingsPanel):
 		self.autoConnectGroupSizer = wx.StaticBoxSizer(
 			wx.VERTICAL,
 			self.remoteSettingsGroupBox,
-			# Translators: A group of settings configuring how to connect if NVDA is set to automatically establish a Remote connection at startup.
+			# Translators: A group of settings configuring how to connect if NVDA is set to automatically establish a Remote Access connection at startup.
 			label=pgettext("remote", "Automatic connection"),
 		)
 		self.autoConnectionGroupBox: wx.StaticBox = self.autoConnectGroupSizer.GetStaticBox()
@@ -3369,7 +3369,7 @@ class RemoteSettingsPanel(SettingsPanel):
 		remoteSettingsGroupHelper.addItem(autoConnectionGroupHelper)
 
 		self.connectionMode = autoConnectionGroupHelper.addLabeledControl(
-			# Translators: Label for a control in NVDA's Remote settings,
+			# Translators: Label for a control in Remote Access settings,
 			# allowing the user to select whether their computer is controlling or controlled.
 			pgettext("remote", "&Mode:"),
 			wx.Choice,
@@ -3378,7 +3378,7 @@ class RemoteSettingsPanel(SettingsPanel):
 		self.bindHelpEvent("RemoteAutoconnectMode", self.connectionMode)
 
 		self.clientOrServer = autoConnectionGroupHelper.addLabeledControl(
-			# Translators: Label for a control in NVDA's Remote settings,
+			# Translators: Label for a control in Remote Access settings,
 			# allowing users to choose whether they want to use an existing Remote relay server, or host their own.
 			pgettext("remote", "&Server:"),
 			wx.Choice,
@@ -3388,7 +3388,7 @@ class RemoteSettingsPanel(SettingsPanel):
 		self.bindHelpEvent("RemoteAutoconnectServer", self.clientOrServer)
 
 		self.host = autoConnectionGroupHelper.addLabeledControl(
-			# Translators: Label for the host field in NVDA's Remote settings.
+			# Translators: Label for the host field in Remote Access settings.
 			# This is where users should enter the URL of the Remote server they want to use if they are not hosting their own.
 			_("&Host:"),
 			wx.TextCtrl,
@@ -3396,7 +3396,7 @@ class RemoteSettingsPanel(SettingsPanel):
 		self.bindHelpEvent("RemoteAutoconnectHost", self.host)
 
 		self.port = autoConnectionGroupHelper.addLabeledControl(
-			# Translators: Label for the port field in NVDA's Remote settings.
+			# Translators: Label for the port field in Remote Access settings.
 			# This is the port on which the local control server will be accessible,
 			# if the user has chosen to host their own.
 			_("&Port:"),
@@ -3418,7 +3418,7 @@ class RemoteSettingsPanel(SettingsPanel):
 			item.AssignSpacer(0, 0)
 
 		self.key = autoConnectionGroupHelper.addLabeledControl(
-			# Translators: Label for a control in NVDA's Remote settings,
+			# Translators: Label for a control in Remote Access settings,
 			# Where users set the key for their Remote connection.
 			_("&Key:"),
 			wx.TextCtrl,
@@ -3426,7 +3426,7 @@ class RemoteSettingsPanel(SettingsPanel):
 		self.bindHelpEvent("RemoteAutoconnectKey", self.key)
 
 		self.deleteFingerprints = sHelper.addItem(
-			# Translators: A button in NVDA's Remote settings to delete all fingerprints of unauthorized certificates.
+			# Translators: A button in Remote Access settings to delete all fingerprints of unauthorized certificates.
 			wx.Button(self, label=_("Delete all trusted fingerprints")),
 		)
 		self.deleteFingerprints.Bind(wx.EVT_BUTTON, self.onDeleteFingerprints)

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -3317,7 +3317,7 @@ class AddonStorePanel(SettingsPanel):
 
 class RemoteSettingsPanel(SettingsPanel):
 	# Translators: This is the label for the remote settings category in NVDA Settings screen.
-	title = _("Remote")
+	title = _("Remote Access")
 	helpId = "RemoteSettings"
 
 	def makeSettings(self, sizer: wx.BoxSizer):
@@ -3488,12 +3488,12 @@ class RemoteSettingsPanel(SettingsPanel):
 			pgettext(
 				"remote",
 				# Translators: This message is presented when the user tries to delete all stored trusted fingerprints.
-				"This will cause NVDA to forget all previously trusted Remote servers. "
-				"When connecting to a previously trusted unauthorized Remote server, you will again be asked whether to trust its certificate.\n\n"
+				"This will cause NVDA to forget all previously trusted Remote Access servers. "
+				"When connecting to a previously trusted unrecognised Remote Access server, you will again be asked whether to trust its certificate.\n\n"
 				"Are you sure you want to continue? This action cannot be undone.",
 			),
 			# Translators: This is the title of the dialog presented when the user tries to delete all stored trusted fingerprints.
-			pgettext("remote", "Delete all trusted fingerprints"),
+			pgettext("remote", "Delete All Trusted Fingerprints"),
 			wx.YES | wx.NO | wx.NO_DEFAULT | wx.ICON_WARNING,
 		)
 		if deleteFingerprints == wx.YES:
@@ -3510,13 +3510,13 @@ class RemoteSettingsPanel(SettingsPanel):
 				message = pgettext(
 					"remote",
 					# Translators: This message is presented when the user tries to save the settings with the host or key field empty.
-					"Both host and key must be set in the Remote section in order to automatically connect using an existing Remote Access server after NVDA starts.",
+					"Both host and key must be set in the Remote Access section in order to automatically connect using an existing Remote Access server after NVDA starts.",
 				)
 			elif self.clientOrServer.GetSelection() and not self.port.GetValue() or not self.key.GetValue():
 				message = pgettext(
 					"remote",
 					# Translators: This message is presented when the user tries to save the settings with the port or key field empty.
-					"Both port and key must be set in the Remote section in order to automatically connect using a locally hosted Remote Access server after NVDA starts.",
+					"Both port and key must be set in the Remote Access section in order to automatically connect using a locally hosted Remote Access server after NVDA starts.",
 				)
 			if message is not None:
 				gui.messageBox(

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -3510,7 +3510,7 @@ class RemoteSettingsPanel(SettingsPanel):
 				message = pgettext(
 					"remote",
 					# Translators: This message is presented when the user tries to save the settings with the host or key field empty.
-					"Both host and key must be set in the Remote Access section in order to automatically connect using an existing Remote Access server after NVDA starts.",
+					"Both host and key must be set in the Remote Access section in order to automatically connect using an existing server after NVDA starts.",
 				)
 			elif self.clientOrServer.GetSelection() and not self.port.GetValue() or not self.key.GetValue():
 				message = pgettext(

--- a/tests/unit/test_remote/test_remoteClient.py
+++ b/tests/unit/test_remote/test_remoteClient.py
@@ -121,7 +121,7 @@ class TestRemoteClient(unittest.TestCase):
 		self.client.followerTransport = None
 		self.client.leaderTransport = None
 		self.client.pushClipboard()
-		self.uiMessage.assert_called_with("Not connected.")
+		self.uiMessage.assert_called_with("Not connected")
 
 	def test_pushClipboardWithTransport(self):
 		# With a fake transport, pushClipboard should send the clipboard text.
@@ -143,7 +143,7 @@ class TestRemoteClient(unittest.TestCase):
 		self.client.followerSession = None
 		self.uiMessage.reset_mock()
 		self.client.copyLink()
-		self.uiMessage.assert_called_with("Not connected.")
+		self.uiMessage.assert_called_with("Not connected")
 
 	def test_copyLinkWithSession(self):
 		# With a fake session, copyLink should call api.copyToClip with the proper URL.

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -3697,7 +3697,7 @@ With NVDA's built-in remote access feature, you can control another computer run
 This makes it easy to provide or receive assistance, collaborate, or access your own computer remotely.
 
 Remote access is disabled by default for your security.
-You can enable Remote Access [in Remote settings](#RemoteSettings).
+You can enable Remote Access [in Remote Access settings](#RemoteSettings).
 
 ### Getting Started {#RemoteAccessGettingStarted}
 
@@ -3710,26 +3710,27 @@ You’ll need to decide which computer will be controlled (the controlled comput
 
 #### Steps for the Controlled Computer {#RemoteAccessSetupControlled}
 
-1. Open the NVDA menu and select Tools, then Remote Access, then Connect....
+1. Open the NVDA menu and select Tools, then "Remote Access", then "Connect...".
 1. For Mode, choose "Allow this computer to be controlled".
 1. Enter the connection details provided by the person controlling your computer:
    * Existing Remote Access server: If using a server, enter the hostname (e.g., `nvdaremote.com`).
    * Direct Connection: If connecting directly, share your external IP address and port (default: 6837). Ensure your network is set up for direct connections.
-1. Press OK. Share the connection key with the other person.
+1. Press OK.
+Share the connection key with the other person.
 
 #### Steps for the Controlling Computer {#RemoteAccessSetupControlling}
 
-1. Open the NVDA menu and select Tools, then Remote Access, then Connect....
+1. Open the NVDA menu and select Tools, then "Remote Access", then "Connect...".
 1. For Mode, choose "Control another computer".
 1. Enter the connection details and key provided by the controlled computer.
 1. Press OK to connect.
 
 Once connected, you can control the other computer, including typing and navigating applications, just as if you were sitting in front of it.
 
-### The Remote Connection Dialog {#RemoteAccessConnect}
+### The Remote Access Connection Dialog {#RemoteAccessConnect}
 
-The Remote connection dialog allows you to set up a Remote Access session.
-To get to the Remote Connection dialog, open the NVDA menu, and navigate to Tools, then Remote Access, then Connect....
+The Remote Access connection dialog allows you to connect to a new or existing session.
+To open the dialog, open the NVDA menu, and navigate to Tools, then "Remote Access", then "Connect...".
 
 The first control in this dialog is the Mode control.
 This allows you to select whether your computer will be controlled remotely, or be remotely controlling another.
@@ -3793,8 +3794,8 @@ Alternatively, press "Generate key" to have NVDA generate a key for you.
 Once a Remote Access session is active, you can switch between controlling the remote computer and your own, share your clipboard, and mute the remote session:
 
 * Press `NVDA+alt+tab` to toggle between controlling and returning to your own computer.
-* Push text from your clipboard to the other computer by opening the NVDA menu, then selecting Tools, then Remote, then Push Clipboard.
-* Mute the remote computer's speech output on your local computer by opening the NVDA menu, then selecting Tools, then Remote, then Mute Remote.
+* Push text from your clipboard to the other computer by opening the NVDA menu, then selecting Tools, then "Remote Access", then "Push Clipboard".
+* Mute the remote computer's speech output on your local computer by opening the NVDA menu, then selecting Tools, then "Remote Access", then "Mute Remote".
 
 ### Remote Access Key Commands Summary {#RemoteAccessGestures}
 

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -3794,8 +3794,8 @@ Alternatively, press "Generate key" to have NVDA generate a key for you.
 Once a Remote Access session is active, you can switch between controlling the remote computer and your own, share your clipboard, and mute the remote session:
 
 * Press `NVDA+alt+tab` to toggle between controlling and returning to your own computer.
-* Push text from your clipboard to the other computer by opening the NVDA menu, then selecting Tools, then "Remote Access", then "Push Clipboard".
-* Mute the remote computer's speech output on your local computer by opening the NVDA menu, then selecting Tools, then "Remote Access", then "Mute Remote".
+* Send text from your clipboard to the other computer by opening the NVDA menu, then selecting Tools, then "Remote Access", then "Send clipboard".
+* Mute the remote computer's speech output on your local computer by opening the NVDA menu, then selecting Tools, then "Remote Access", then "Mute remote".
 
 ### Remote Access Key Commands Summary {#RemoteAccessGestures}
 
@@ -3808,7 +3808,7 @@ Once a Remote Access session is active, you can switch between controlling the r
 | Copy link | None | Copies a link to the remote session to the clipboard. |
 | Disconnect | None | Ends an existing Remote Access session. |
 | Mute remote | None | Mutes or unmutes the speech coming from the remote computer. |
-| Push clipboard | None | Sends the contents of the clipboard to the remote computer. |
+| Send clipboard | None | Sends the contents of the clipboard to the remote computer. |
 <!-- KC:endInclude -->
 
 ## Add-ons and the Add-on Store {#AddonsManager}

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -27,12 +27,12 @@ Major highlights include:
 * Reporting of textual formatting where available such as font name and size, style and spelling errors
 * Automatic announcement of text under the mouse and optional audible indication of the mouse position
 * Support for many refreshable braille displays, including the ability to detect many of them automatically as well as braille input on braille displays with a braille keyboard
-* Remote Access: Connect to and control another computer running NVDA for remote assistance or collaboration.
+* Ability to [connect to and control another computer running NVDA](#RemoteAccess) for remote assistance or collaboration
 * Ability to run entirely from a USB flash drive or other portable media without the need for installation
 * Easy to use talking installer
 * Translated into 54 languages
 * Support for modern Windows Operating Systems including both 32 and 64 bit variants
-* Ability to run during Windows sign-in and [other secure screens](#SecureScreens).
+* Ability to run during Windows sign-in and [other secure screens](#SecureScreens)
 * Announcing controls and text while using touch gestures
 * Support for common accessibility interfaces such as Microsoft Active Accessibility, Java Access Bridge, IAccessible2 and UI Automation
 * Support for Windows Command Prompt and console applications
@@ -3103,7 +3103,7 @@ If no mirror is in use (i.e. the NV Access Add-on Store server is being used), "
 
 If you wish to change the Add-on Store mirror, press the "Change..." button to open the [Set Add-on Store Mirror dialog](#SetURLDialog).
 
-#### Remote Settings {#RemoteSettings}
+#### Remote Access Settings {#RemoteSettings}
 
 This category allows you to configure the behaviour of [Remote Access](#RemoteAccess).
 
@@ -3119,9 +3119,9 @@ The following options are only available if Remote Access is enabled.
 
 ##### Play sounds instead of beeps {#RemoteSoundsOrBeeps}
 
-Use this option to select the type of audio cues played by Remote.
+Use this option to select the type of audio cues played by Remote Access.
 
-When checked, NVDA will produce natural-sounding audio cues for Remote events.
+When checked, NVDA will produce natural-sounding audio cues for Remote Access events.
 When unchecked, NVDA will beep for Remote events.
 
 ##### Automatically connect after NVDA starts {#RemoteAutoconnect}
@@ -3175,7 +3175,7 @@ This option is only available when [Automatically connect after NVDA starts](#Re
 ##### Delete all trusted fingerprints {#RemoteDeleteFingerprints}
 
 This button allows you to forget the fingerprints of all previously trusted Remote Access servers.
-This means that you will again be asked whether to connect to all unauthorized Remote Access servers, even ones that you have previously connected to.
+This means that you will again be asked whether to connect to all unrecognised Remote Access servers, even ones that you have previously connected to.
 You will be asked to confirm before all trusted fingerprints are deleted.
 This action cannot be undone.
 
@@ -3704,23 +3704,23 @@ You can enable Remote Access [in Remote settings](#RemoteSettings).
 Before you begin, ensure NVDA is installed and running on both computers.
 The remote access feature is available from the Tools menu in NVDA—there’s no need for additional downloads or installations.
 
-### Setting Up a Remote Session {#RemoteAccessSetup}
+### Setting Up a Remote Access Session {#RemoteAccessSetup}
 
 You’ll need to decide which computer will be controlled (the controlled computer) and which will be controlling (the controlling computer).
 
 #### Steps for the Controlled Computer {#RemoteAccessSetupControlled}
 
-1. Open the NVDA menu and select Tools, then Remote, then Connect.
-1. Choose Allow this computer to be controlled.
+1. Open the NVDA menu and select Tools, then Remote Access, then Connect....
+1. For Mode, choose "Allow this computer to be controlled".
 1. Enter the connection details provided by the person controlling your computer:
-   * Relay Server: If using a server, enter the hostname (e.g., `nvdaremote.com`).
+   * Existing Remote Access server: If using a server, enter the hostname (e.g., `nvdaremote.com`).
    * Direct Connection: If connecting directly, share your external IP address and port (default: 6837). Ensure your network is set up for direct connections.
 1. Press OK. Share the connection key with the other person.
 
 #### Steps for the Controlling Computer {#RemoteAccessSetupControlling}
 
-1. Open the NVDA menu and select Tools, then Remote, then Connect.
-1. Choose Control another computer.
+1. Open the NVDA menu and select Tools, then Remote Access, then Connect....
+1. For Mode, choose "Control another computer".
 1. Enter the connection details and key provided by the controlled computer.
 1. Press OK to connect.
 
@@ -3729,14 +3729,14 @@ Once connected, you can control the other computer, including typing and navigat
 ### The Remote Connection Dialog {#RemoteAccessConnect}
 
 The Remote connection dialog allows you to set up a Remote Access session.
-To get to the Remote Connection dialog, open the NVDA menu, and navigate to Tools, then Remote, then Connect....
+To get to the Remote Connection dialog, open the NVDA menu, and navigate to Tools, then Remote Access, then Connect....
 
 The first control in this dialog is the Mode control.
 This allows you to select whether your computer will be controlled remotely, or be remotely controlling another.
 You cannot change the connection mode once a connection is established.
 Choose "Allow this computer to be controlled" if you are going to be getting technical assistance.
 
-Next is the Server control, which lets you choose the type of control server you would like to use.
+Next is the Server control, which lets you choose the type of Remote Access connection you would like to use.
 Most users should select to use an existing Relay server.
 
 You can choose between two connection types depending on your setup:
@@ -3790,7 +3790,7 @@ Alternatively, press "Generate key" to have NVDA generate a key for you.
 
 ### Using Remote Access {#RemoteAccessUsage}
 
-Once the session is active, you can switch between controlling the remote computer and your own, share your clipboard, and mute the remote session:
+Once a Remote Access session is active, you can switch between controlling the remote computer and your own, share your clipboard, and mute the remote session:
 
 * Press `NVDA+alt+tab` to toggle between controlling and returning to your own computer.
 * Push text from your clipboard to the other computer by opening the NVDA menu, then selecting Tools, then Remote, then Push Clipboard.
@@ -3809,8 +3809,6 @@ Once the session is active, you can switch between controlling the remote comput
 | Mute remote | None | Mutes or unmutes the speech coming from the remote computer. |
 | Push clipboard | None | Sends the contents of the clipboard to the remote computer. |
 <!-- KC:endInclude -->
-
-You can assign further commands in the Remote section of the [Input Gestures dialog](#InputGestures).
 
 ## Add-ons and the Add-on Store {#AddonsManager}
 


### PR DESCRIPTION
### Link to issue number:

Fixes #17815

### Summary of the issue:

NVDA's new Remote Access feature currently uses inconsistent terminology.

### Description of user facing changes

Remote Access:

* Is consistently referred to as "Remote Access".
* Uses the term "computer" to refer to clients.
  * Previously both "computer" and "machine" were used. I also considered "device", as this seems to be the preferred terminology in Windows.
* Uses the word "send" instead of "push" for sending the clipboard to connected clients.
* Has descriptive help items for its menu items, all of which are complete sentences.
* Uses sentence fragments for UI messages where appropriate

### Description of development approach

Generated a pot file, and searched for the word "remote" therein. If it was referring to Remote Access, and some other name was used, replaced it with Remote Access.

Searched for the word "remote" in the user guide and edited as appropriate. Also did a full readthrough of the remote section.

Reviewed the strings in the settings dialog, menu, and cues explicitly and edited as appropriate.

Calculated the diff `1b4a28d4d...9833d7812`. Searched in it for newly introduced translator comments, and edited them if related to Remote Access and I thought they were unclear.

Calculated the diff `9833d7812...42aaea791`. Reviewed it for any changed strings that used gettext (`_(...)`), and changed to use pgettext (`pgettext("remote", ...)`).

### Testing strategy:

pre-commit.
Unit tests.
Checking the generated pot file.

### Known issues with pull request:

The remote section of the user guide still needs some TLC, however I believe this is best worked through in a separate PR with input from @qchristenson.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
