### PR TITLE
Disallow initiating a new Remote Access session when in Secure Mode

### DIFF
--- a/source/_remoteClient/client.py
+++ b/source/_remoteClient/client.py
@@ -233,7 +233,7 @@ class RemoteClient:
 				style=wx.OK | wx.ICON_WARNING,
 			)
 
-	def doConnect(self, evt=None):
+	def doConnect(self, evt: inputCore.InputGesture = None):
 		"""Show connection dialog and handle connection initiation.
 
 		:param evt: Optional wx event object

--- a/source/_remoteClient/client.py
+++ b/source/_remoteClient/client.py
@@ -10,6 +10,7 @@ import api
 import braille
 from config.configFlags import RemoteConnectionMode
 import core
+import globalVars
 import gui
 import inputCore
 import ui
@@ -240,6 +241,12 @@ class RemoteClient:
 		"""
 		if evt is not None:
 			evt.Skip()
+		if globalVars.appArgs.secure:
+			log.error(
+				"Creating new Remote Access connections is not allowed in Secure Mode.",
+				stack_info=True,
+			)
+			return
 		previousConnections = configuration.getRemoteConfig()["connections"]["lastConnected"]
 		hostnames = list(reversed(previousConnections))
 		dlg = dialogs.DirectConnectDialog(

--- a/source/_remoteClient/menu.py
+++ b/source/_remoteClient/menu.py
@@ -10,6 +10,7 @@ import wx
 if TYPE_CHECKING:
 	from .client import RemoteClient
 
+import globalVars
 import gui
 
 from .connectionInfo import ConnectionMode
@@ -158,6 +159,9 @@ class RemoteMenu(wx.Menu):
 			self.client.doConnect,
 			self.connectionItem,
 		)
+		# The option to start a new Remote Access session should be unavailable in secure mode.
+		if globalVars.appArgs.secure:
+			self.connectionItem.Enable(False)
 
 	def _switchToDisconnectItem(self):
 		"""Switch to showing the "Disconnect" item in the menu.
@@ -175,3 +179,5 @@ class RemoteMenu(wx.Menu):
 			self.doDisconnect,
 			self.connectionItem,
 		)
+		# The option to disconnect from a RemoteAccess session should always be available.
+		self.connectionItem.Enable()

--- a/source/_remoteClient/menu.py
+++ b/source/_remoteClient/menu.py
@@ -179,5 +179,5 @@ class RemoteMenu(wx.Menu):
 			self.doDisconnect,
 			self.connectionItem,
 		)
-		# The option to disconnect from a RemoteAccess session should always be available.
+		# The option to disconnect from a Remote Access session should always be available.
 		self.connectionItem.Enable()

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -4910,10 +4910,7 @@ class GlobalCommands(ScriptableObject):
 		# Translators: Documentation string for the script that disconnects a remote session.
 		description=_("Disconnect a remote session"),
 	)
-	@gui.blockAction.when(
-		gui.blockAction.Context.REMOTE_ACCESS_DISABLED,
-		gui.blockAction.Context.SECURE_MODE,
-	)
+	@gui.blockAction.when(gui.blockAction.Context.REMOTE_ACCESS_DISABLED)
 	def script_disconnectFromRemote(self, gesture: "inputCore.InputGesture"):
 		if not _remoteClient._remoteClient.isConnected:
 			# Translators: A message indicating that the remote client is not connected.

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -4928,8 +4928,8 @@ class GlobalCommands(ScriptableObject):
 	)
 	@gui.blockAction.when(
 		gui.blockAction.Context.REMOTE_ACCESS_DISABLED,
-		gui.blockAction.Context.MODAL_DIALOG_OPEN,
 		gui.blockAction.Context.SECURE_MODE,
+		gui.blockAction.Context.MODAL_DIALOG_OPEN,
 	)
 	def script_connectToRemote(self, gesture: "inputCore.InputGesture"):
 		if _remoteClient._remoteClient.isConnected() or _remoteClient._remoteClient.connecting:

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -3711,6 +3711,7 @@ You’ll need to decide which computer will be controlled (the controlled comput
 If NVDA is running in [secure mode](#SecureMode), you cannot manually initiate a new Remote Access session.
 However, NVDA will still automatically start a new Remote Access session if configured to do so with the [Automatically connect after NVDA starts](#RemoteAutoconnect) setting.
 You can still manually disconnect in secure mode.
+
 #### Steps for the Controlled Computer {#RemoteAccessSetupControlled}
 
 1. Open the NVDA menu and select Tools, then Remote, then Connect.

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -3708,6 +3708,9 @@ The remote access feature is available from the Tools menu in NVDA—there’s n
 
 You’ll need to decide which computer will be controlled (the controlled computer) and which will be controlling (the controlling computer).
 
+You cannot initiate a new Remote Access session if NVDA is running in [secure mode](#SecureMode).
+However, NVDA will still respect the [Automatically connect after NVDA starts](RemoteAutoconnect) setting in secure mode.
+
 #### Steps for the Controlled Computer {#RemoteAccessSetupControlled}
 
 1. Open the NVDA menu and select Tools, then Remote, then Connect.
@@ -3801,9 +3804,9 @@ Once the session is active, you can switch between controlling the remote comput
 <!-- KC:beginInclude -->
 | Name |Key |Description|
 |---|---|---|
-| Connect or disconnect | `NVDA+alt+r` | If a remote session is in progress, disconnects from it. Otherwise, starts a new Remote session. |
+| Connect or disconnect | `NVDA+alt+r` | If a remote session is in progress, disconnects from it. Otherwise, starts a new Remote session. Only works if currently connected in [secure mode](#SecureMode). |
 | Toggle Control | `NVDA+alt+tab` | Switches between controlling the remote and local computer. |
-| Connect | None | Starts a new Remote Access session. |
+| Connect | None | Starts a new Remote Access session. Unavailable in [secure mode](#SecureMode). |
 | Copy link | None | Copies a link to the remote session to the clipboard. |
 | Disconnect | None | Ends an existing Remote Access session. |
 | Mute remote | None | Mutes or unmutes the speech coming from the remote computer. |

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -3708,9 +3708,9 @@ The remote access feature is available from the Tools menu in NVDA—there’s n
 
 You’ll need to decide which computer will be controlled (the controlled computer) and which will be controlling (the controlling computer).
 
-You cannot initiate a new Remote Access session if NVDA is running in [secure mode](#SecureMode).
-However, NVDA will still respect the [Automatically connect after NVDA starts](RemoteAutoconnect) setting in secure mode.
-
+If NVDA is running in [secure mode](#SecureMode), you cannot manually initiate a new Remote Access session.
+However, NVDA will still automatically start a new Remote Access session if configured to do so with the [Automatically connect after NVDA starts](#RemoteAutoconnect) setting.
+You can still manually disconnect in secure mode.
 #### Steps for the Controlled Computer {#RemoteAccessSetupControlled}
 
 1. Open the NVDA menu and select Tools, then Remote, then Connect.
@@ -3804,7 +3804,7 @@ Once the session is active, you can switch between controlling the remote comput
 <!-- KC:beginInclude -->
 | Name |Key |Description|
 |---|---|---|
-| Connect or disconnect | `NVDA+alt+r` | If a remote session is in progress, disconnects from it. Otherwise, starts a new Remote session. Only works if currently connected in [secure mode](#SecureMode). |
+| Toggle Remote connection | `NVDA+alt+r` | Starts a new Remote Access session or, if a session is already in progress, disconnects from it. |
 | Toggle Control | `NVDA+alt+tab` | Switches between controlling the remote and local computer. |
 | Connect | None | Starts a new Remote Access session. Unavailable in [secure mode](#SecureMode). |
 | Copy link | None | Copies a link to the remote session to the clipboard. |


### PR DESCRIPTION
### Link to issue number:

Fixes #17945

### Summary of the issue:

Initiating a new Remote Access session in secure mode is disallowed by the gesture, but still doable via the Remote Access menu.
The user guide now mentions that initiating new Remote Access connections is disallowed in secure mode.

### Description of user facing changes

The "Connect..." item in the Remote Access menu is now disabled in Secure Mode.

### Description of development approach

In the `_switchToConnectItem` method of Remote's `Menu` class, disable the connect/disconnect menuitem if we're running in secure mode. In the `_switchToDisconnectItem` method, always enable the connect/disconnect item, as we always want the user to be able to disconnect from a session, and enabling an already enabled menuitem is a no-op.

In `RemoteClient.doConnect`, check for secure mode, and, if enabled, log an error and return before allowing the user to initiate a new connection. As this method simply creates and shows the connection GUI, this blocks the user from creating a new connection, but doesn't affect the underlying machinery, which is needed to support continuing Remote Access sessions on secure screens.

Remove the secure mode check from the disconnect script, as disconnecting in secure mode is a useful escape mechanism in case of a compromised connection.

### Testing strategy:

Ran NVDA from source in secure mode (`-s` command line flag), and checked that the "Connect..." item was not available in secure mode, before or after a connection, but that the "Disconnect" item was available when an RA session was in progress.

### Known issues with pull request:

None known

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
