### PR TITLE
Allow Remote Access leaders to regain control after the last follower has disconnected

### DIFF
--- a/source/_remoteClient/client.py
+++ b/source/_remoteClient/client.py
@@ -470,19 +470,30 @@ class RemoteClient:
 			# Translators: Presented when attempting to switch to controling a remote computer when there are no controllable computers in the channel.
 			ui.message(pgettext("remote", "No controlled computers are connected"))
 			return
-		self.sendingKeys = not self.sendingKeys
-		log.info(f"Remote key control {'enabled' if self.sendingKeys else 'disabled'}")
-		self.setReceivingBraille(self.sendingKeys)
 		if self.sendingKeys:
-			self.hostPendingModifiers = gesture.modifiers
-			# Translators: Presented when sending keyboard keys from the controlling computer to the controlled computer.
-			ui.message(pgettext("remote", "Controlling remote computer"))
-			if self.localMachine.isMuted:
-				self.toggleMute()
+			self._switchToLocalControl()
 		else:
-			self.releaseKeys()
-			# Translators: Presented when keyboard control is back to the controlling computer.
-			ui.message(pgettext("remote", "Controlling local computer"))
+			self._switchToRemoteControl(gesture)
+
+	def _switchToLocalControl(self) -> None:
+		"""Switch to controlling the local computer."""
+		self.sendingKeys = False
+		log.info("Remote key control disabled")
+		self.setReceivingBraille(False)
+		self.releaseKeys()
+		# Translators: Presented when keyboard control is back to the controlling computer.
+		ui.message(pgettext("remote", "Controlling local computer"))
+
+	def _switchToRemoteControl(self, gesture: KeyboardInputGesture) -> None:
+		"""Switch to controlling the remote computer."""
+		self.sendingKeys = True
+		log.info("Remote key control enabled")
+		self.setReceivingBraille(self.sendingKeys)
+		self.hostPendingModifiers = gesture.modifiers
+		# Translators: Presented when sending keyboard keys from the controlling computer to the controlled computer.
+		ui.message(pgettext("remote", "Controlling remote computer"))
+		if self.localMachine.isMuted:
+			self.toggleMute()
 
 	def releaseKeys(self):
 		"""Release all pressed keys on the remote machine.

--- a/source/_remoteClient/client.py
+++ b/source/_remoteClient/client.py
@@ -12,8 +12,6 @@ from config.configFlags import RemoteConnectionMode
 import core
 import gui
 import inputCore
-import queueHandler
-import speech
 import ui
 import wx
 from config import isInstalledCopy
@@ -445,21 +443,6 @@ class RemoteClient:
 			if script in self.localScripts:
 				wx.CallAfter(script, gesture)
 				return False
-		if self.connectedFollowersCount < 1:
-			if pressed:
-				queueHandler.queueFunction(
-					queueHandler.eventQueue,
-					speech.cancelSpeech,
-					_immediate=True,
-				)
-				# Translators: Presented when sending keys to a remote computer when there are no controllable computers in the channel.
-				queueHandler.queueFunction(
-					queueHandler.eventQueue,
-					ui.message,
-					pgettext("remote", "No controlled computers are connected"),
-					_immediate=True,
-				)
-			return False
 		self.leaderTransport.send(
 			RemoteMessageType.KEY,
 			vk_code=vkCode,

--- a/source/_remoteClient/client.py
+++ b/source/_remoteClient/client.py
@@ -611,17 +611,3 @@ class RemoteClient:
 			stack_info=True,
 		)
 		return 0
-
-	@property
-	def connectedFollowersCount(self) -> int:
-		if not self.isConnected():
-			return 0
-		elif self.leaderSession is not None:
-			return self.leaderSession.connectedFollowersCount
-		elif self.followerSession is not None:
-			return self.followerSession.connectedFollowersCount
-		log.error(
-			"is connected returned true, but neither leaderSession or followerSession is not None.",
-			stack_info=True,
-		)
-		return 0

--- a/source/_remoteClient/client.py
+++ b/source/_remoteClient/client.py
@@ -466,7 +466,7 @@ class RemoteClient:
 			# Translators: Presented when attempting to switch to controling a remote computer when connected as the controlled computer.
 			ui.message(pgettext("remote", "Not the controlling computer"))
 			return
-		elif self.leaderSession.connectedFollowersCount < 1:
+		elif self.leaderSession.connectedFollowersCount < 1 and not self.sendingKeys:
 			# Translators: Presented when attempting to switch to controling a remote computer when there are no controllable computers in the channel.
 			ui.message(pgettext("remote", "No controlled computers are connected"))
 			return

--- a/source/_remoteClient/session.py
+++ b/source/_remoteClient/session.py
@@ -580,13 +580,6 @@ class LeaderSession(RemoteSession):
 		super().handleClientDisconnected(client)
 		if client["connection_type"] == connectionInfo.ConnectionMode.FOLLOWER.value:
 			del self.followers[client["id"]]
-			# If the last follower has disconnected, switch back to controlling the local computer.
-			# if not self.followers:
-			# import late to avoid circular import
-			# from . import _remoteClient
-
-			# if _remoteClient.sendingKeys:
-			# _remoteClient._switchToLocalControl
 		elif client["connection_type"] == connectionInfo.ConnectionMode.LEADER.value:
 			self.leaders.discard(client["id"])
 		if self.callbacksAdded and not self.followers:

--- a/source/_remoteClient/session.py
+++ b/source/_remoteClient/session.py
@@ -581,12 +581,12 @@ class LeaderSession(RemoteSession):
 		if client["connection_type"] == connectionInfo.ConnectionMode.FOLLOWER.value:
 			del self.followers[client["id"]]
 			# If the last follower has disconnected, switch back to controlling the local computer.
-			if not self.followers:
-				# import late to avoid circular import
-				from . import _remoteClient
+			# if not self.followers:
+			# import late to avoid circular import
+			# from . import _remoteClient
 
-				if _remoteClient.sendingKeys:
-					_remoteClient._switchToLocalControl
+			# if _remoteClient.sendingKeys:
+			# _remoteClient._switchToLocalControl
 		elif client["connection_type"] == connectionInfo.ConnectionMode.LEADER.value:
 			self.leaders.discard(client["id"])
 		if self.callbacksAdded and not self.followers:

--- a/source/_remoteClient/session.py
+++ b/source/_remoteClient/session.py
@@ -580,6 +580,13 @@ class LeaderSession(RemoteSession):
 		super().handleClientDisconnected(client)
 		if client["connection_type"] == connectionInfo.ConnectionMode.FOLLOWER.value:
 			del self.followers[client["id"]]
+			# If the last follower has disconnected, switch back to controlling the local computer.
+			if not self.followers:
+				# import late to avoid circular import
+				from . import _remoteClient
+
+				if _remoteClient.sendingKeys:
+					_remoteClient._switchToLocalControl
 		elif client["connection_type"] == connectionInfo.ConnectionMode.LEADER.value:
 			self.leaders.discard(client["id"])
 		if self.callbacksAdded and not self.followers:


### PR DESCRIPTION
### Link to issue number:

Fixes #17965

### Summary of the issue:

If the controlling computer is sending keyboard input to the controlled computer when the controlled computer disconnects from the session, the controlling computer is unable to regain control of the local session.

### Description of user facing changes

* The `NVDA+Alt+Tab` gesture now allows control to return to the local computer even if no followers are connected.

### Description of development approach

* In the `toggleRemoteKeyControl` method of `RemoteClient`, adjust the threshhold for refusing to toggle sending keys from simply having connected followers, to currently controlling the local computer and having connected followers.
  * This means that the check does not apply when sending keys, meaning control can be returned to the local computer regardless of the number of connected followers.
* Add new `_switchToRemoteControl` and `_switchToRemoteControl` methods to `RemoteClient`, and refactor `toggleRemoteKeyControl` to use these new methods. The logic in these methods is almost identical to that in the original `toggleRemoteKeyControl` method.

### Testing strategy:

In a Remote Access channel with a leader and a follower:

* Switch the leader to controlling the follower. Perform some actions on the leader to ensure it is working as expected. Return the leader to controlling the current computer.
* Switch the leader to controlling the follower. Disconnect the follower from the session. Switch the leader back to local control.
* Attempt to switch the leader to controlling the follower. Observe that it fails.

### Known issues with pull request:

If the user is controlling a remote computer when that computer disconnects, no indication is given that subsequent keyboard input is (essentially) a no-op. In attempting to add such an indication, I discovered #18004.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
