### PR TITLE
Update docs links to new server infrastructure endpoints

### DIFF
--- a/extras/controllerClient/readme.md
+++ b/extras/controllerClient/readme.md
@@ -16,14 +16,14 @@ These functions are supported in NVDA 2024.1 and newer. On older versions, they 
 
 ## Security practices
 
-Developers should be aware that NVDA runs on the lock screen and [secure screens](https://www.nvaccess.org/files/nvda/documentation/userGuide.html#SecureScreens).
+Developers should be aware that NVDA runs on the lock screen and [secure screens](https://download.nvaccess.org/documentation/userGuide.html#SecureScreens).
 Before providing information to the end user (e.g. via `nvdaController_speakText`), developers should check if Windows is locked or running on a secure screen to prevent secure data being leaked.
 
 ## How to get it?
 
 You can build locally or download pre-built, details:
 - **Built with the release:**
-  - Download the `*controllerClient.zip` from the releases folder: EG [Latest stable](https://www.nvaccess.org/files/nvda/releases/stable/)
+  - Download the `*controllerClient.zip` from the releases folder: e.g. [Latest stable](https://download.nvaccess.org/releases/stable/)
 - **Latest, in development version:**
   - The libraries are built by Appveyor (our CI).
   - Downloads are available from the artifacts tab.

--- a/projectDocs/community/readme.md
+++ b/projectDocs/community/readme.md
@@ -11,20 +11,20 @@ Here is an overview of the most important support sources.
 * [Contributing to NVDA](../../.github/CONTRIBUTING.md).
 This includes information on reporting issues, triaging issues, testing, translating, contributing code/documentation and creating add-ons.
 * The NVDA repository [Wiki](https://github.com/nvaccess/nvda/wiki) contains more guides and documentation.
-* [NVDA development snapshots](https://www.nvaccess.org/files/nvda/snapshots/): Automatically generated builds of the project in its current state of development
+* [NVDA development snapshots](https://download.nvaccess.org/snapshots/alpha/): Automatically generated builds of the project in its current state of development
 * [Translating NVDA](../translating/readme.md): Information about how to translate NVDA into another language
 
 ### Documentation
 
-* [NVDA User Guide](https://www.nvaccess.org/files/nvda/documentation/userGuide.html)
-* [NVDA Developer Guide](https://www.nvaccess.org/files/nvda/documentation/developerGuide.html)
-* [Key Commands](https://www.nvaccess.org/files/nvda/documentation/keyCommands.html)
-* [Changes in the latest release](https://www.nvaccess.org/files/nvda/documentation/changes.html)
+* [NVDA User Guide](https://download.nvaccess.org/documentation/userGuide.html)
+* [NVDA Developer Guide](https://download.nvaccess.org/documentation/developerGuide.html)
+* [Key Commands](https://download.nvaccess.org/documentation/keyCommands.html)
+* [Changes in the latest release](https://download.nvaccess.org/documentation/changes.html)
 * [Release process](./releaseProcess.md)
 
 ### Add-ons
 
-* [The NVDA Add-on store](https://www.nvaccess.org/files/nvda/documentation/userGuide.html#AddonsManager)
+* [The NVDA Add-on store](https://download.nvaccess.org/documentation/userGuide.html#AddonsManager)
 * [Community add-ons website](https://addons.nvda-project.org/).
 This website is considered legacy software, using the NVDA Add-on Store instead is encouraged.
 

--- a/projectDocs/design/technicalDesignOverview.md
+++ b/projectDocs/design/technicalDesignOverview.md
@@ -47,7 +47,7 @@ See also:
 
 #### Tools for investigating Accessibility APIs
 
-- Using [NVDA Object Navigation](https://www.nvaccess.org/files/nvda/documentation/userGuide.html#ObjectNavigation) and [logging developer information](https://www.nvaccess.org/files/nvda/documentation/userGuide.html#LogViewer).
+- Using [NVDA Object Navigation](https://download.nvaccess.org/documentation/userGuide.html#ObjectNavigation) and [logging developer information](https://download.nvaccess.org/documentation/userGuide.html#LogViewer).
 - [Accessibility Viewer (aViewer)](https://github.com/ThePacielloGroup/aviewer/)
 	- handles MSAA, IA2, UIA but can be a bit buggy
 	- tends to provide user friendly display strings that make it harder to map back to raw values
@@ -70,9 +70,9 @@ Tasks that can be performed include moving/clicking the mouse and sending key pr
 ### Logging
 
 #### Logging in secure mode
-`logHandler.initialize` prevents logging in [secure mode](https://www.nvaccess.org/files/nvda/documentation/userGuide.html#SecureMode).
-This is because it is a security concern to log during secure mode (e.g. passwords are logged on [secure screens](https://www.nvaccess.org/files/nvda/documentation/userGuide.html#SecureScreens).
-To change this for testing, use the [serviceDebug](https://www.nvaccess.org/files/nvda/documentation/userGuide.html#SystemWideParameters) system wide parameter to prevent secure mode on secure screens.
+`logHandler.initialize` prevents logging in [secure mode](https://download.nvaccess.org/documentation/userGuide.html#SecureMode).
+This is because it is a security concern to log during secure mode (e.g. passwords are logged on [secure screens](https://download.nvaccess.org/documentation/userGuide.html#SecureScreens).
+To change this for testing, use the [serviceDebug](https://download.nvaccess.org/documentation/userGuide.html#SystemWideParameters) system wide parameter to prevent secure mode on secure screens.
 When logging from a secure screen, `nvda.log` files are generated in the System profile's `%TEMP%` directory.
 
 ## NVDA Components

--- a/projectDocs/dev/addons.md
+++ b/projectDocs/dev/addons.md
@@ -1,7 +1,8 @@
 ### Important links
-* [Changes in the latest release](https://www.nvaccess.org/files/nvda/documentation/changes.html)
+
+* [Changes in the latest release](https://download.nvaccess.org/documentation/changes.html)
 * [NVDA Add-on API Mailing List](https://groups.google.com/a/nvaccess.org/g/nvda-api)
-* [The NVDA Add-on Store](https://www.nvaccess.org/files/nvda/documentation/userGuide.html#AddonsManager)
+* [The NVDA Add-on Store](https://download.nvaccess.org/documentation/userGuide.html#AddonsManager)
 * [Submitting to the NVDA Add-on Store](https://github.com/nvaccess/addon-datastore/blob/master/docs/submitters/submissionGuide.md)
 * [Community add-ons website](https://addons.nvda-project.org/).
 This website is considered legacy software, using the NVDA Add-on Store instead is encouraged.
@@ -10,24 +11,28 @@ This website is considered legacy software, using the NVDA Add-on Store instead 
 * The NVDA repository [Wiki](https://github.com/nvaccess/nvda/wiki) contains more guides and documentation.
 
 ### Documentation
+
 * [NVDA release process](../community/releaseProcess.md)
-* [NVDA Developer Guide](https://www.nvaccess.org/files/nvda/documentation/developerGuide.html)
+* [NVDA Developer Guide](https://download.nvaccess.org/documentation/developerGuide.html)
 * [Technical design overview](../design/technicalDesignOverview.md)
 * [NVDA Add-on Development Community Guide](https://github.com/nvdaaddons/DevGuide/wiki/NVDA-Add-on-Development-Guide)
 * [NVDA ControllerClient manual (NVDA API for external applications to directly speak or braille messages, etc.)](../../extras/controllerClient)
 
 ### Communication channels
+
 #### NV Access
 * [GitHub discussions](https://github.com/nvaccess/nvda/discussions)
 * [NVDA Add-on API Mailing List](https://groups.google.com/a/nvaccess.org/g/nvda-api)
 
 #### NVDA Community
+
 * [NVDA Developers Mailing List](https://groups.io/g/nvda-devel)
 * [NVDA Add-ons Mailing List](https://groups.io/g/nvda-addons)
 * [NVDA Community Gitter channel](https://gitter.im/nvaccess/NVDA) (Instant Messaging)
 * [Other sources including groups and profiles on social media channels, language-specific websites and mailing lists etc.](https://github.com/nvaccess/nvda/wiki/Connect)
 
 ## NVDA project links
+
 * [NVDA on GitHub](https://github.com/nvaccess/nvda)
 * [Reporting issues on GitHub](../issues/readme.md)
-* [NVDA development snapshots](https://www.nvaccess.org/files/nvda/snapshots/): Automatically generated builds of the project in its current state of development
+* [NVDA development snapshots](https://download.nvaccess.org/snapshots/alpha/): Automatically generated builds of the project in its current state of development

--- a/projectDocs/dev/addons.md
+++ b/projectDocs/dev/addons.md
@@ -21,6 +21,7 @@ This website is considered legacy software, using the NVDA Add-on Store instead 
 ### Communication channels
 
 #### NV Access
+
 * [GitHub discussions](https://github.com/nvaccess/nvda/discussions)
 * [NVDA Add-on API Mailing List](https://groups.google.com/a/nvaccess.org/g/nvda-api)
 

--- a/projectDocs/dev/buildingNVDA.md
+++ b/projectDocs/dev/buildingNVDA.md
@@ -41,7 +41,7 @@ It is possible to run NVDA directly from source without having to build the full
 To launch NVDA from source, using `cmd.exe`, execute `runnvda.bat` in the root of the repository.
 
 To view help on the arguments that NVDA will accept, use the `-h` or `--help` option.
-These arguments are also documented in the [user guide](https://www.nvaccess.org/files/nvda/documentation/userGuide.html#CommandLineOptions).
+These arguments are also documented in the [user guide](https://download.nvaccess.org/documentation/userGuide.html#CommandLineOptions).
 
 ## Making Binary Builds
 

--- a/projectDocs/dev/developerGuide/developerGuide.md
+++ b/projectDocs/dev/developerGuide/developerGuide.md
@@ -14,7 +14,7 @@ The NVDA Add-on API includes all NVDA internals, except symbols that are prefixe
 
 The NVDA Add-on API changes over time, for example because of the addition of new features, removal or replacement of outdated libraries, deprecation of unused or replaced code and methodologies, and changes to Python.
 Important changes to the API are announced on the [NVDA API mailing list](https://groups.google.com/a/nvaccess.org/g/nvda-api/about).
-Changes relevant to developers are also announced via the [NVDA changes file](https://www.nvaccess.org/files/nvda/documentation/changes.html).
+Changes relevant to developers are also announced via the [NVDA changes file](https://download.nvaccess.org/documentation/changes.html).
 Any changes to the API policy outlined in this section will be conveyed via these two channels.
 
 API breaking releases happen at most once per year, these are `.1` releases, e.g. `2022.1`.

--- a/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
+++ b/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
@@ -147,12 +147,13 @@ Discuss under "testing strategy" heading:
   highlight it under the "Known issues" heading
 
 ### Security precautions taken
+
 Windows allows NVDA to access secure information from a user's desktop while the lock screen is activated.
 When handling NVDAObjects, code should check if an object should be available while the lock screen is activated.
 This can be done checking `utils.security._isSecureObjectWhileLockScreenActivated`.
 If this function returns `True`, code should not process the NVDAObject any further, and return gracefully.
 It is important that information from the object does not reach the user.
 
-Any code which should not performed on [secure screens](https://www.nvaccess.org/files/nvda/documentation/userGuide.html#SecureScreens), should check `globalVars.appArgs.secure` and return gracefully.
+Any code which should not performed on [secure screens](https://download.nvaccess.org/documentation/userGuide.html#SecureScreens), should check `globalVars.appArgs.secure` and return gracefully.
 If this is a user initiated action `gui.blockAction` should be used to notify the user that the action cannot be performed.
 This can be done by decorating the function with `@blockAction.when(blockAction.Context.SECURE_MODE)`.

--- a/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
+++ b/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
@@ -154,6 +154,6 @@ This can be done checking `utils.security._isSecureObjectWhileLockScreenActivate
 If this function returns `True`, code should not process the NVDAObject any further, and return gracefully.
 It is important that information from the object does not reach the user.
 
-Any code which should not performed on [secure screens](https://download.nvaccess.org/documentation/userGuide.html#SecureScreens), should check `globalVars.appArgs.secure` and return gracefully.
+Any code which should not be performed on [secure screens](https://download.nvaccess.org/documentation/userGuide.html#SecureScreens) should check `globalVars.appArgs.secure` and return gracefully.
 If this is a user initiated action `gui.blockAction` should be used to notify the user that the action cannot be performed.
 This can be done by decorating the function with `@blockAction.when(blockAction.Context.SECURE_MODE)`.

--- a/projectDocs/dev/readme.md
+++ b/projectDocs/dev/readme.md
@@ -1,14 +1,16 @@
 ### Important links
+
 * [Refer to contributing.md](./contributing.md) for contributing code/documentation to NVDA.
 * [Refer to addons.md](./addons.md) for key links for add-on development.
 * [Reporting issues on GitHub](../issues/readme.md)
 * [Contributing to NVDA](../../.github/CONTRIBUTING.md).
 This includes information on reporting issues, triaging issues, testing, translating, contributing code/documentation and creating add-ons.
 * The NVDA repository [Wiki](https://github.com/nvaccess/nvda/wiki) contains more guides and documentation.
-* [NVDA development snapshots](https://www.nvaccess.org/files/nvda/snapshots/): Automatically generated builds of the project in its current state of development
+* [NVDA development snapshots](https://download.nvaccess.org/snapshots/alpha/): Automatically generated builds of the project in its current state of development
 
 ### Documentation
-* [NVDA Developer Guide](https://www.nvaccess.org/files/nvda/documentation/developerGuide.html)
+
+* [NVDA Developer Guide](https://download.nvaccess.org/documentation/developerGuide.html)
 * [Technical design overview](../design/technicalDesignOverview.md)
 * [Configuring AppVeyor to build forks of NVDA (making a local build environment unnecessary)](./buildingNVDAOnAppVeyor.md)
 * [Remote debugging NVDA (for when you need to step through NVDA's code as it runs)](./remoteDebugging.md)
@@ -16,12 +18,15 @@ This includes information on reporting issues, triaging issues, testing, transla
 * [Release process](../community/releaseProcess.md)
 
 ### Communication channels
+
 #### NV Access
+
 * [NVDA on GitHub](https://github.com/nvaccess/nvda)
 	* Report [NVDA issues and feature requests on GitHub](https://github.com/nvaccess/nvda/issues).
 	* Start a [GitHub discussion with the development community](https://github.com/nvaccess/nvda/discussions).
 * [NVDA Developers Mailing List](https://groups.io/g/nvda-devel)
 
 #### NVDA Community
+
 * [NVDA Community Gitter channel](https://gitter.im/nvaccess/NVDA) (Instant Messaging)
 * [Other sources including groups and profiles on social media channels, language-specific websites and mailing lists etc.](https://github.com/nvaccess/nvda/wiki/Connect)

--- a/projectDocs/issues/triage.md
+++ b/projectDocs/issues/triage.md
@@ -201,11 +201,8 @@ Summarising this information and opening a new issue filling out the issue templ
 
 NV Access migrated tickets from our old issue tracker (Trac) into Github issues. These issues can be identified by having an author of `nvaccessauto`.
 
-### Missing attachments
 Some of the migrated issues have comments that indicate an attachment should be available, but it is not.
-All of these Trac attachments are accessible on the [NV Access website](https://www.nvaccess.org/files/nvdaTracAttachments/), you can search for issue numbers in the folder, or append the GitHub issue number to the URL.
-As an example, for issue [#2396](https://github.com/nvaccess/nvda/issues/2396), get the attachments from <https://www.nvaccess.org/files/nvdaTracAttachments/2396>.
-If you come across one of these missing attachments, please upload if you think they're relevant to GitHub. Note you'll need to pay attention to GitHub's attachment naming restrictions, if it fails try zipping it.
+These attachments have been lost.
 
 ## NV Access staff-created tickets
 

--- a/projectDocs/testing/contributing.md
+++ b/projectDocs/testing/contributing.md
@@ -3,7 +3,7 @@
 ## Builds
 
 Testing alpha / beta / and release candidates (RC) help to ensure the quality of the NVDA project.
-You can find the latest builds [here](https://www.nvaccess.org/files/nvda/snapshots/).
+Download the [latest alpha builds](https://download.nvaccess.org/snapshots/alpha) or [beta/RC builds](https://download.nvaccess.org/snapshots/beta/).
 
 * The alpha builds are bleeding edge.
 It includes code that is being tested for possible inclusion in upcoming releases, but it may not yet be tested much (if at all) and there may be major bugs.

--- a/projectDocs/testing/readme.md
+++ b/projectDocs/testing/readme.md
@@ -1,18 +1,21 @@
 ### Important links
+
 * [How to contribute to NVDA by testing](./contributing.md)
 * [Reporting issues on GitHub](../issues/readme.md)
 * [Triaging issues on GitHub](../issues/triage.md)
 * The NVDA repository [Wiki](https://github.com/nvaccess/nvda/wiki) contains more guides and documentation.
-* [NVDA development snapshots](https://www.nvaccess.org/files/nvda/snapshots/): Automatically generated builds of the project in its current state of development
+* [NVDA development snapshots](https://download.nvaccess.org/snapshots/alpha/): Automatically generated builds of the project in its current state of development
 
 ### Documentation
-* [NVDA User Guide](https://www.nvaccess.org/files/nvda/documentation/userGuide.html)
-* [Changes in the latest release](https://www.nvaccess.org/files/nvda/documentation/changes.html)
+
+* [NVDA User Guide](https://download.nvaccess.org/documentation/userGuide.html)
+* [Changes in the latest release](https://download.nvaccess.org/documentation/changes.html)
 * [Manual test plans](../../tests/manual/README.md)
 * [Automated tests for developers](./automated.md)
 * [Release process](../community/releaseProcess.md)
 
 ### Community communication channels
+
 * [NVDA Users Mailing List](https://nvda.groups.io/g/nvda)
 * [NVDA Developers Mailing List](https://groups.io/g/nvda-devel)
 * [Other sources including groups and profiles on social media channels, language-specific websites and mailing lists etc.](https://github.com/nvaccess/nvda/wiki/Connect)

--- a/projectDocs/translating/crowdin.md
+++ b/projectDocs/translating/crowdin.md
@@ -57,7 +57,7 @@ You may then replace it with your translation as normal.
 Press `control+s` at any moment to save your work.
 Each time you press this key, PoEdit saves the po file, and if you check compile mo file checkbox in preferences, the .mo file will be re-generated.
 
-NVDA provides additional shortcuts for PoEdit which are described in [the User Guide](https://www.nvaccess.org/files/nvda/documentation/userGuide.html#Poedit).
+NVDA provides additional shortcuts for PoEdit which are described in [the User Guide](https://download.nvaccess.org/documentation/userGuide.html#Poedit).
 
 If you are unsure of the meaning of the original interface message, consult automatic comments (also called translator comments), by pressing `control+shift+a`.
 Some comments provide an example output message to help you understand what NVDA will say when speaking or brailling such messages.
@@ -136,7 +136,7 @@ Example:
 In the [Crowdin web interface](https://support.crowdin.com/online-editor/), these can be set for each language using the "Form" section which replaces the standard translation edit box.
 
 In PoEdit, the standard translation edit box has tabs for each plural form.
-[Object navigation](https://www.nvaccess.org/files/nvda/documentation/userGuide.html#ObjectNavigation) is required to move focus to each tab button for the plural form.
+[Object navigation](https://download.nvaccess.org/documentation/userGuide.html#ObjectNavigation) is required to move focus to each tab button for the plural form.
 You can do this by:
 
 - By moving to the previous focus object from the edit box, you can cycle through each plural form tab button by continuing to more backward.

--- a/projectDocs/translating/github.md
+++ b/projectDocs/translating/github.md
@@ -6,9 +6,9 @@ This guide provides technical steps on how to translate symbols and character de
 
 For detailed information on the format of these files, please refer to the following sections in the developer guide:
 
-- `characterDescriptions.dic`: [Translating Character Descriptions](https://www.nvaccess.org/files/nvda/documentation/developerGuide.html#characterDescriptions)
-- `symbols.dic`: [Translating Symbols](https://www.nvaccess.org/files/nvda/documentation/developerGuide.html#symbolPronunciation)
-- `gestures.ini`: [Translating Gestures](https://www.nvaccess.org/files/nvda/documentation/developerGuide.html#TranslatingGestures)
+- `characterDescriptions.dic`: [Translating Character Descriptions](https://download.nvaccess.org/documentation/developerGuide.html#characterDescriptions)
+- `symbols.dic`: [Translating Symbols](https://download.nvaccess.org/documentation/developerGuide.html#symbolPronunciation)
+- `gestures.ini`: [Translating Gestures](https://download.nvaccess.org/documentation/developerGuide.html#TranslatingGestures)
 
 To keep these files up to date, translators must be concious of changes in NVDA.
 For changes to `symbols.dic` and `characterDescriptions.dic`, please subscribe to the read-only [NVDA localisation mailing list](https://groups.google.com/a/nvaccess.org/g/nvda-l10n).
@@ -86,5 +86,5 @@ New gestures will be announced there, and localisations can be added to `gesture
 1. Await feedback from NV Access
     - NV Access will provide feedback if any further work is required.
     - You will receive a notification when your proposal is accepted - the request will be merged and closed.
-    - After merging, the changes will become available in [alpha builds](https://www.nvaccess.org/files/nvda/snapshots/) for testing.
-    The changes will also be made available in the next beta release.
+    - After merging, the changes will become available in [beta builds](https://download.nvaccess.org/snapshots/beta/) for testing.
+    The changes will also be made available in the next [beta release](https://download.nvaccess.org/releases/beta/).

--- a/projectDocs/translating/github.md
+++ b/projectDocs/translating/github.md
@@ -86,5 +86,5 @@ New gestures will be announced there, and localisations can be added to `gesture
 1. Await feedback from NV Access
     - NV Access will provide feedback if any further work is required.
     - You will receive a notification when your proposal is accepted - the request will be merged and closed.
-    - After merging, the changes will become available in [alpha builds](https://download.nvaccess.org/snapshots/alpha/) for testing.
+    - After merging, the changes will become available in [beta builds](https://download.nvaccess.org/snapshots/beta/) for testing.
     The changes will also be made available in the next [beta release](https://download.nvaccess.org/releases/beta/).

--- a/projectDocs/translating/github.md
+++ b/projectDocs/translating/github.md
@@ -86,5 +86,5 @@ New gestures will be announced there, and localisations can be added to `gesture
 1. Await feedback from NV Access
     - NV Access will provide feedback if any further work is required.
     - You will receive a notification when your proposal is accepted - the request will be merged and closed.
-    - After merging, the changes will become available in [beta builds](https://download.nvaccess.org/snapshots/beta/) for testing.
+    - After merging, the changes will become available in [alpha builds](https://download.nvaccess.org/snapshots/alpha/) for testing.
     The changes will also be made available in the next [beta release](https://download.nvaccess.org/releases/beta/).

--- a/projectDocs/translating/readme.md
+++ b/projectDocs/translating/readme.md
@@ -47,9 +47,9 @@ If your language is no longer maintained, you can request to be the new maintain
 ## Files to be Localized
 
 - nvda.po: NVDA's interface messages, see [Translating using Crowdin](./crowdin.md) for more information.
-- characterDescriptions.dic: names of characters in your language, see [Translating Character Descriptions](https://www.nvaccess.org/files/nvda/documentation/developerGuide.html#characterDescriptions) for more info.
-- symbols.dic: names of symbols and punctuation in your language, see [Translating Symbols](https://www.nvaccess.org/files/nvda/documentation/developerGuide.html#symbolPronunciation) for more information.
-- gestures.ini: remapping of gestures for your language, see [Translating Gestures](https://www.nvaccess.org/files/nvda/documentation/developerGuide.html#TranslatingGestures) for more information.
+- characterDescriptions.dic: names of characters in your language, see [Translating Character Descriptions](https://download.nvaccess.org/documentation/developerGuide.html#characterDescriptions) for more info.
+- symbols.dic: names of symbols and punctuation in your language, see [Translating Symbols](https://download.nvaccess.org/documentation/developerGuide.html#symbolPronunciation) for more information.
+- gestures.ini: remapping of gestures for your language, see [Translating Gestures](https://download.nvaccess.org/documentation/developerGuide.html#TranslatingGestures) for more information.
 - userGuide.md: the User Guide, see [Translating using Crowdin](./crowdin.md) for more information.
 - changes.md (optional): a list of changes between releases, see [Translating using Crowdin](./crowdin.md) for more information.
 - Add-ons (optional, out of date): a set of optional features that users can install, see [Translating Addons](https://github.com/nvaccess/nvda/wiki/TranslatingAddons) for more information.

--- a/readme.md
+++ b/readme.md
@@ -22,7 +22,7 @@ Their contribution helps us maintain the security and integrity of our releases.
 
 * [Support and information for NVDA users](https://www.nvaccess.org/get-help/)
 * [Report an issue or feature request](./projectDocs/issues/readme.md)
-* [Getting add-ons](https://www.nvaccess.org/files/nvda/documentation/userGuide.html#AddonsManager)
+* [Getting add-ons](https://download.nvaccess.org/documentation/userGuide.html#AddonsManager)
 * [Contact list](./projectDocs/community/expertsList.md) for NV Access and community experts.
 * [More important links and community information](./projectDocs/community/readme.md)
 

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -4053,7 +4053,7 @@ To toggle the braille viewer from anywhere, please assign a custom gesture using
 ### Python Console {#PythonConsole}
 
 The NVDA Python console, found under Tools in the NVDA menu, is a development tool which is useful for debugging, general inspection of NVDA internals or inspection of the accessibility hierarchy of an application.
-For more information, please see the [NVDA Developer Guide](https://www.nvaccess.org/files/nvda/documentation/developerGuide.html).
+For more information, please see the [NVDA Developer Guide](https://download.nvaccess.org/documentation/developerGuide.html).
 
 ### Add-on Store {#AddonStoreMenuItem}
 


### PR DESCRIPTION
NV Access recently changed the endpoint URLs for various aspects of nvaccess.org.
While redirects exist for now, we should move links over.