### PR TITLE
Improve translation documentation for Crowdin

### DIFF
--- a/projectDocs/translating/crowdin.md
+++ b/projectDocs/translating/crowdin.md
@@ -54,9 +54,6 @@ PoEdit's homepage is: <http://www.poedit.net/>
 1. Download the latest Windows PoEdit version at <https://poedit.net/download>
 1. Install it by following the on-screen instructions, the default options should be sufficient.
 
-As PoEdit only supports viewing approved strings, large translator teams need to co-ordinate submitting unapproved strings to prevent conflicts.
-Using Crowdin's interface avoids this problem.
-
 #### Locating the NVDA l10n utility
 
 The NVDA l10n utility is required for safely and efficiently downloading and uploading translation files from / to Crowdin when translating with Poedit.

--- a/projectDocs/translating/crowdin.md
+++ b/projectDocs/translating/crowdin.md
@@ -1,45 +1,83 @@
-# Translating using Crowdin
+# Translating With Crowdin
 
-Crowdin is used to translate the main NVDA interface and user documentation.
+Crowdin is used to manage the translations of the main NVDA interface and user documentation.
 NVDA's Crowdin project: <https://crowdin.com/project/nvda>.
 
-This document covers setting up a Crowdin account, connecting it with PoEdit, and translating the main interface and user documentation using Crowdin and PoEdit.
+This document covers setting up a Crowdin account, and translating the main interface and user documentation using either the Crowdin web interface or Poedit / nvdaL10nUtil. 
 
-## Setup
-
-### Create Crowdin account
+## Creating a Crowdin account
 
 1. Create a [Crowdin account](https://accounts.crowdin.com/register?continue=%2Fproject%2Fnvda).
 1. Message the [translators mailing list](https://groups.io/g/nvda-translations) or <info@nvaccess.org> to request being added as a translator.
 Please include your Crowdin username and the languages you wish to translate.
 
-### Setup PoEdit
+## Translation workflows
+
+There are 2 common workflows for translating with Crowdin:
+
+1. Translating strings directly via Crowdin's web interface. Or
+1. Downloading a translation file from Crowdin, translating with Poedit, and uploading the file back to Crowdin.
+
+### Translating via Crowdin's web interface
+For instructions on how to translate strings using Crowdin's web interface, please read [Crowdin's documentation for translators](https://support.crowdin.com/for-translators/).
+
+Note: If you are a screen reader user, you may find Crowdin's web interface inefficient or impossible to use. Therefore you may choose to use the Poedit workflow instead. 
+
+#### Translation Reviews / Approvals
+Due to accessibility issues and to be able to support the alternative workflow using Poedit, the translation approvals feature has been disabled in the NVDA project on Crowdin.
+This means that all new strings are essentially auto approved.
+ However, to maintain quality control, only translators specifically added to the project can add or change strings.
+ 
+### Translating with Poedit
+Poedit is a desktop application which is commonly used to translate files. 
+It is fairly accessible and is used by many blind and vision impaired translators. 
+
+The workflow for translating with Poedit involves:
+1. Downloading the translation file using NVDA's l10n utility
+1. Opening the translation file in Poedit, translating one or more strings, and saving the file.
+1. Uploading the translation file back to Crowdin.
+
+Warning: Do not download / upload translation files via Crowdin's web interface, nor use Poedit's Crowdin cloud translation feature, as these methods have been found to corrupt xliff files.
+Please instead use NvDA's l10n utility for download and upload.
+NVDA's l10n utility will automatically use the appropriate Crowdin settings when downloading and uploading, and will detect and correct corruptions in xliff files. 
+
+#### Setting up PoEdit
 
 It is recommended that you use the latest version of PoEdit and NVDA for translating.
-Alternatively, you can use the [Crowdin web interface](https://support.crowdin.com/online-editor/) directly.
-As PoEdit only supports viewing approved strings, large translator teams need to co-ordinate submitting unapproved strings to prevent conflicts.
-Using Crowdin's interface avoids this problem.
 
 PoEdit's homepage is: <http://www.poedit.net/>
 
 1. Download the latest Windows PoEdit version at <https://poedit.net/download>
 1. Install it by following the on-screen instructions, the default options should be sufficient.
 
-### Translation reviews
-Due to accessibility issues, for now translation approvals have been disabled on Crowdin.
-Any translation uploaded to Crowdin is automatically available in the project.
-However, joining the project as a translator is by invitation only.
+As PoEdit only supports viewing approved strings, large translator teams need to co-ordinate submitting unapproved strings to prevent conflicts.
+Using Crowdin's interface avoids this problem.
 
-## Translation workflows
+#### Locating the NVDA l10n Utility
+The NVDA l10n utility is required for safely and efficiently downloading and uploading translation files from / to Crowdin when translating with Poedit.
+ 
+ This utility is included with all versions of NVDA from 2025.1beta1 onwards.
 
-There are 2 common workflows for translating with Crowdin:
+* For installed copies of NVDA, its path is: `c:\Program Files (x86)\nvda\l10nUtil.exe`
+* For portable copies, it can be found as `l10nUtil.exe` in the root directory of the portable copy.
+ 
+#### Downloading with NVDA's l10n Utility
+```
+l10nUtil.exe downloadTranslationFile <language> <crowdinFilePath> [<localFilePath>]
+```
+E.g.
+```
+l10nUtil.exe downloadTranslationFile fr nvda.po
+```
+The first time you will be asked for an authorization token.
+Please visit [your Crowdin settings API page](https://crowdin.com/settings#api-key) and create a Personal Access Token.
+Ensure that it has at least the translations scope.
+Then paste this into the user prompt.
+This will be saved in ~/.nvda_crowdin for future use. 
 
-1. Translating strings directly via Crowdin's interface. Or
-1. Downloading from Crowdin, translating with Poedit and uploading again.
+#### Translating using PoEdit
 
-## Translating using PoEdit
-
-After opening a .po or .xliff file you will be placed on a list with all of the strings to translate.
+After opening a .po or .xliff file you have previously downloaded with NVDA's l10n utility, you will be placed on a list with all of the strings to translate.
 
 You can read the status bar to see how many strings have already been translated, the number of untranslated messages, and how many are fuzzy.
 A fuzzy string is a message which has been automatically translated, thus it may be wrong.
@@ -62,23 +100,8 @@ NVDA provides additional shortcuts for PoEdit which are described in [the User G
 If you are unsure of the meaning of the original interface message, consult automatic comments (also called translator comments), by pressing `control+shift+a`.
 Some comments provide an example output message to help you understand what NVDA will say when speaking or brailling such messages.
 
-## Translating NVDA's interface
-
-* Download the po file for your language from  Crowdin using NVA's l10nUtil.exe:
-```
-l10nUtil.exe downloadTranslationFile <language> <crowdinFilePath> [<localFilePath>]
-```
-E.g.
-```
-l10nUtil.exe downloadTranslationFile fr nvda.po
-```
-The first time you will be asked for an authorization token.
-Please visit [your Crowdin settings API page](https://crowdin.com/settings#api-key) and create a Personal Access Token.
-Ensure that it has at least the translations scope.
-Then paste this into the user prompt.
-This will be saved in ~/.nvda_crowdin for future use.
-* Open the xliff file in Poedit, translate, and save the file.
-* Upload the translated file using l10nUtil
+#### Uploading with NvDA's l10n Utility
+After translating the file with Poedit, upload the file back to Crowdin.
 ```
 l10nUtil.exe uploadTranslationFile <language> <crowdinFilePath> [<localFilePath>]
 ```
@@ -87,7 +110,12 @@ E.g.
 l10nUtil.exe uploadTranslationFile fr nvda.po
 ```
 
-Alternatively, you can use the [Crowdin interface directly](https://support.crowdin.com/online-editor/).
+## Translating NVDA's interface
+* If translating via the Crowdin web interface, you can find these strings  in the `NVDA interface messages` file.
+* If translating via Poedit, you can download  it as `nvda.po` using NVDA's l10n utility E.g.
+```
+l10nUtil.exe downloadTranslationFile fr nvda.po
+```
 
 ### Messages with formatting strings
 
@@ -180,35 +208,10 @@ Documentation available for translation includes:
 * The NVDA user guide (userGuide.xliff)
 * The NVDA What's New document (changes.xliff)
 
-To translate any of these files:
-
-* Download the xliff file for your language from  Crowdin using NVA's l10nUtil.exe:
-```
-l10nUtil.exe downloadTranslationFile <language> <crowdinFilePath> [<localFilePath>]
-```
-E.g.
-```
-l10nUtil.exe downloadTranslationFile fr userGuide.xliff
-```
-The first time you will be asked for an authorization token.
-Please visit [your Crowdin settings API page](https://crowdin.com/settings#api-key) and create a Personal Access Token.
-Ensure that it has at least the translations scope.
-Then paste this into the user prompt.
-This will be saved in ~/.nvda_crowdin for future use.
-* Make a copy of the downloaded file.
-* Open the xliff file in Poedit, translate, and save the file.
-* Upload the translated file using l10nUtil
-```
-l10nUtil.exe uploadTranslationFile <language> <crowdinFilePath> [<localFilePath>] [--old <oldLocalFilepath>]
-```
-E.g.
-```
-l10nUtil.exe uploadTranslationFile fr userGuide.xliff --old userGuide_backup.xliff
-```
-This will only upload added / changed translations since you downloaded the file.
-
-Alternatively, you can use the [Crowdin interface directly](https://support.crowdin.com/online-editor/).
-
+To translate any of these files either:
+* locate the file in the Crowdin web interface and translate directly, or
+* Download the file using NVDA's l10n utility, open the file in Poedit, translate and save, then upload the file with NVDA's l10n utility.
+ 
 ### Translating markdown
 
 The English NVDA user documentation is written in markdown syntax.

--- a/projectDocs/translating/crowdin.md
+++ b/projectDocs/translating/crowdin.md
@@ -61,7 +61,7 @@ The NVDA l10n utility is required for safely and efficiently downloading and upl
 * For installed copies of NVDA, its path is: `c:\Program Files (x86)\nvda\l10nUtil.exe`
 * For portable copies, it can be found as `l10nUtil.exe` in the root directory of the portable copy.
 
-#### Downloading with NVDA's l10n Utility
+#### Downloading po / xliff files with NVDA's l10n Utility
 ```
 l10nUtil.exe downloadTranslationFile <language> <crowdinFilePath> [<localFilePath>]
 ```
@@ -75,7 +75,7 @@ Ensure that it has at least the translations scope.
 Then paste this into the user prompt.
 This will be saved in ~/.nvda_crowdin for future use.
 
-#### Translating using PoEdit
+#### Translating po / xliff files using PoEdit
 
 After opening a .po or .xliff file you have previously downloaded with NVDA's l10n utility, you will be placed on a list with all of the strings to translate.
 
@@ -100,7 +100,7 @@ NVDA provides additional shortcuts for PoEdit which are described in [the User G
 If you are unsure of the meaning of the original interface message, consult automatic comments (also called translator comments), by pressing `control+shift+a`.
 Some comments provide an example output message to help you understand what NVDA will say when speaking or brailling such messages.
 
-#### Uploading with NvDA's l10n Utility
+#### Uploading po / xliff files with NvDA's l10n Utility
 After translating the file with Poedit, upload the file back to Crowdin.
 ```
 l10nUtil.exe uploadTranslationFile <language> <crowdinFilePath> [<localFilePath>]

--- a/projectDocs/translating/crowdin.md
+++ b/projectDocs/translating/crowdin.md
@@ -61,7 +61,7 @@ Using Crowdin's interface avoids this problem.
 
 The NVDA l10n utility is required for safely and efficiently downloading and uploading translation files from / to Crowdin when translating with Poedit.
 
- This utility is included with all versions of NVDA from 2025.1beta1 onwards.
+This utility is included with all versions of NVDA from 2025.1beta1 onwards.
 
 * For installed copies of NVDA, its path is: `c:\Program Files (x86)\nvda\l10nUtil.exe`
 * For portable copies, it can be found as `l10nUtil.exe` in the root directory of the portable copy.

--- a/projectDocs/translating/crowdin.md
+++ b/projectDocs/translating/crowdin.md
@@ -80,6 +80,9 @@ Ensure that it has at least the translations scope.
 Then paste this into the user prompt.
 This will be saved in ~/.nvda_crowdin for future use.
 
+If your language team has more than one translator who may be downloading, translating and uploading at the same time, it is important that once you have downloaded the file, that you save a copy before you start translating with Poedit.
+ This then allows you to provide l10nUtil with this original file when uploading, so that it can just upload only what has changed, which will avoid accidentally overriding another translator's work.
+ 
 #### Translating po / xliff files using Poedit
 
 After opening a .po or .xliff file you have previously downloaded with NVDA's l10n utility, you will be placed on a list with all of the strings to translate.
@@ -116,6 +119,13 @@ E.g.
 ```
 l10nUtil.exe uploadTranslationFile fr nvda.po
 ```
+
+If you had previously saved a copy of the downloaded file before translation, then you will also want to include this in the command, so that l10nUtil only uploads the strings you have actually changed:
+E.g.
+```
+l10nUtil.exe uploadTranslationFile fr nvda.po --old nvda_old.po
+```
+Where nvda_old.po was the saved copy.
 
 ## Translating NVDA's interface
 

--- a/projectDocs/translating/crowdin.md
+++ b/projectDocs/translating/crowdin.md
@@ -82,7 +82,7 @@ This will be saved in ~/.nvda_crowdin for future use.
 
 If your language team has more than one translator who may be downloading, translating and uploading at the same time, it is important that once you have downloaded the file, that you save a copy before you start translating with Poedit.
  This then allows you to provide l10nUtil with this original file when uploading, so that it can just upload only what has changed, which will avoid accidentally overriding another translator's work.
- 
+
 #### Translating po / xliff files using Poedit
 
 After opening a .po or .xliff file you have previously downloaded with NVDA's l10n utility, you will be placed on a list with all of the strings to translate.

--- a/projectDocs/translating/crowdin.md
+++ b/projectDocs/translating/crowdin.md
@@ -97,7 +97,7 @@ NVDA will beep if you are on an untranslated or fuzzy message.
 If you are using a braille display you'll see a star sign in-front of the messages you have to translate.
 
 You may want to spell the original string to be aware of any punctuation mark, capital letters, etc.
-PoEdit has a keystroke you may press while on an original string, `alt+c`, that copies the original string to the edit field when pressed.
+To copy the original string into the Translated text control ready for further translation, you can press `control+b`. 
 You may then replace it with your translation as normal.
 
 Press `control+s` at any moment to save your work.

--- a/projectDocs/translating/crowdin.md
+++ b/projectDocs/translating/crowdin.md
@@ -81,7 +81,7 @@ Then paste this into the user prompt.
 This will be saved in ~/.nvda_crowdin for future use.
 
 If your language team has more than one translator who may be downloading, translating and uploading at the same time, it is important that once you have downloaded the file, that you save a copy before you start translating with Poedit.
- This then allows you to provide l10nUtil with this original file when uploading, so that it can just upload only what has changed, which will avoid accidentally overriding another translator's work.
+This then allows you to provide l10nUtil with this original file when uploading, so that it can just upload only what has changed, which will avoid accidentally overriding another translator's work.
 
 #### Translating po / xliff files using Poedit
 
@@ -97,7 +97,7 @@ NVDA will beep if you are on an untranslated or fuzzy message.
 If you are using a braille display you'll see a star sign in-front of the messages you have to translate.
 
 You may want to spell the original string to be aware of any punctuation mark, capital letters, etc.
-To copy the original string into the Translated text control ready for further translation, you can press `control+b`.
+To copy the original string into the "Translated text" control ready for further translation, you can press `control+b`.
 You may then replace it with your translation as normal.
 
 Press `control+s` at any moment to save your work.
@@ -125,7 +125,7 @@ E.g.
 ```
 l10nUtil.exe uploadTranslationFile fr nvda.po --old nvda_old.po
 ```
-Where nvda_old.po was the saved copy.
+Where `nvda_old.po` was the saved copy.
 
 ## Translating NVDA's interface
 

--- a/projectDocs/translating/crowdin.md
+++ b/projectDocs/translating/crowdin.md
@@ -1,4 +1,4 @@
-# Translating With Crowdin
+# Translating with Crowdin
 
 Crowdin is used to manage the translations of the main NVDA interface and user documentation.
 NVDA's Crowdin project: <https://crowdin.com/project/nvda>.
@@ -19,16 +19,20 @@ There are 2 common workflows for translating with Crowdin:
 1. Downloading a translation file from Crowdin, translating with Poedit, and uploading the file back to Crowdin.
 
 ### Translating via Crowdin's web interface
+
 For instructions on how to translate strings using Crowdin's web interface, please read [Crowdin's documentation for translators](https://support.crowdin.com/for-translators/).
 
-Note: If you are a screen reader user, you may find Crowdin's web interface inefficient or impossible to use. Therefore you may choose to use the Poedit workflow instead.
+Note: If you are a screen reader user, you may find Crowdin's web interface inefficient or impossible to use.
+Therefore you may choose to use the Poedit workflow instead.
 
 #### Translation Reviews / Approvals
+
 Due to accessibility issues and to be able to support the alternative workflow using Poedit, the translation approvals feature has been disabled in the NVDA project on Crowdin.
 This means that all new strings are essentially auto approved.
- However, to maintain quality control, only translators specifically added to the project can add or change strings.
+However, to maintain quality control, only translators specifically added to the project can add or change strings.
 
 ### Translating with Poedit
+
 Poedit is a desktop application which is commonly used to translate files.
 It is fairly accessible and is used by many blind and vision impaired translators.
 
@@ -53,7 +57,8 @@ PoEdit's homepage is: <http://www.poedit.net/>
 As PoEdit only supports viewing approved strings, large translator teams need to co-ordinate submitting unapproved strings to prevent conflicts.
 Using Crowdin's interface avoids this problem.
 
-#### Locating the NVDA l10n Utility
+#### Locating the NVDA l10n utility
+
 The NVDA l10n utility is required for safely and efficiently downloading and uploading translation files from / to Crowdin when translating with Poedit.
 
  This utility is included with all versions of NVDA from 2025.1beta1 onwards.
@@ -61,12 +66,15 @@ The NVDA l10n utility is required for safely and efficiently downloading and upl
 * For installed copies of NVDA, its path is: `c:\Program Files (x86)\nvda\l10nUtil.exe`
 * For portable copies, it can be found as `l10nUtil.exe` in the root directory of the portable copy.
 
-#### Downloading po / xliff files with NVDA's l10n Utility
-```
+#### Downloading po / xliff files with NVDA's l10n utility
+
+```sh
 l10nUtil.exe downloadTranslationFile <language> <crowdinFilePath> [<localFilePath>]
 ```
+
 E.g.
-```
+
+```sh
 l10nUtil.exe downloadTranslationFile fr nvda.po
 ```
 The first time you will be asked for an authorization token.
@@ -75,7 +83,7 @@ Ensure that it has at least the translations scope.
 Then paste this into the user prompt.
 This will be saved in ~/.nvda_crowdin for future use.
 
-#### Translating po / xliff files using PoEdit
+#### Translating po / xliff files using Poedit
 
 After opening a .po or .xliff file you have previously downloaded with NVDA's l10n utility, you will be placed on a list with all of the strings to translate.
 
@@ -100,8 +108,10 @@ NVDA provides additional shortcuts for PoEdit which are described in [the User G
 If you are unsure of the meaning of the original interface message, consult automatic comments (also called translator comments), by pressing `control+shift+a`.
 Some comments provide an example output message to help you understand what NVDA will say when speaking or brailling such messages.
 
-#### Uploading po / xliff files with NvDA's l10n Utility
+#### Uploading po / xliff files with NvDA's l10n utility
+
 After translating the file with Poedit, upload the file back to Crowdin.
+
 ```
 l10nUtil.exe uploadTranslationFile <language> <crowdinFilePath> [<localFilePath>]
 ```
@@ -111,11 +121,13 @@ l10nUtil.exe uploadTranslationFile fr nvda.po
 ```
 
 ## Translating NVDA's interface
-* If translating via the Crowdin web interface, you can find these strings  in the `NVDA interface messages` file.
-* If translating via Poedit, you can download  it as `nvda.po` using NVDA's l10n utility E.g.
-```
-l10nUtil.exe downloadTranslationFile fr nvda.po
-```
+
+* If translating via the Crowdin web interface, you can find these strings in the `NVDA interface messages` file.
+* If translating via Poedit, you can download it as `nvda.po` using NVDA's l10n utility, e.g.
+
+  ```sh
+  l10nUtil.exe downloadTranslationFile fr nvda.po
+  ```
 
 ### Messages with formatting strings
 
@@ -209,6 +221,7 @@ Documentation available for translation includes:
 * The NVDA What's New document (changes.xliff)
 
 To translate any of these files either:
+
 * locate the file in the Crowdin web interface and translate directly, or
 * Download the file using NVDA's l10n utility, open the file in Poedit, translate and save, then upload the file with NVDA's l10n utility.
 

--- a/projectDocs/translating/crowdin.md
+++ b/projectDocs/translating/crowdin.md
@@ -94,7 +94,7 @@ NVDA will beep if you are on an untranslated or fuzzy message.
 If you are using a braille display you'll see a star sign in-front of the messages you have to translate.
 
 You may want to spell the original string to be aware of any punctuation mark, capital letters, etc.
-To copy the original string into the Translated text control ready for further translation, you can press `control+b`. 
+To copy the original string into the Translated text control ready for further translation, you can press `control+b`.
 You may then replace it with your translation as normal.
 
 Press `control+s` at any moment to save your work.

--- a/projectDocs/translating/crowdin.md
+++ b/projectDocs/translating/crowdin.md
@@ -3,7 +3,7 @@
 Crowdin is used to manage the translations of the main NVDA interface and user documentation.
 NVDA's Crowdin project: <https://crowdin.com/project/nvda>.
 
-This document covers setting up a Crowdin account, and translating the main interface and user documentation using either the Crowdin web interface or Poedit / nvdaL10nUtil. 
+This document covers setting up a Crowdin account, and translating the main interface and user documentation using either the Crowdin web interface or Poedit / nvdaL10nUtil.
 
 ## Creating a Crowdin account
 
@@ -21,16 +21,16 @@ There are 2 common workflows for translating with Crowdin:
 ### Translating via Crowdin's web interface
 For instructions on how to translate strings using Crowdin's web interface, please read [Crowdin's documentation for translators](https://support.crowdin.com/for-translators/).
 
-Note: If you are a screen reader user, you may find Crowdin's web interface inefficient or impossible to use. Therefore you may choose to use the Poedit workflow instead. 
+Note: If you are a screen reader user, you may find Crowdin's web interface inefficient or impossible to use. Therefore you may choose to use the Poedit workflow instead.
 
 #### Translation Reviews / Approvals
 Due to accessibility issues and to be able to support the alternative workflow using Poedit, the translation approvals feature has been disabled in the NVDA project on Crowdin.
 This means that all new strings are essentially auto approved.
  However, to maintain quality control, only translators specifically added to the project can add or change strings.
- 
+
 ### Translating with Poedit
-Poedit is a desktop application which is commonly used to translate files. 
-It is fairly accessible and is used by many blind and vision impaired translators. 
+Poedit is a desktop application which is commonly used to translate files.
+It is fairly accessible and is used by many blind and vision impaired translators.
 
 The workflow for translating with Poedit involves:
 1. Downloading the translation file using NVDA's l10n utility
@@ -39,7 +39,7 @@ The workflow for translating with Poedit involves:
 
 Warning: Do not download / upload translation files via Crowdin's web interface, nor use Poedit's Crowdin cloud translation feature, as these methods have been found to corrupt xliff files.
 Please instead use NvDA's l10n utility for download and upload.
-NVDA's l10n utility will automatically use the appropriate Crowdin settings when downloading and uploading, and will detect and correct corruptions in xliff files. 
+NVDA's l10n utility will automatically use the appropriate Crowdin settings when downloading and uploading, and will detect and correct corruptions in xliff files.
 
 #### Setting up PoEdit
 
@@ -55,12 +55,12 @@ Using Crowdin's interface avoids this problem.
 
 #### Locating the NVDA l10n Utility
 The NVDA l10n utility is required for safely and efficiently downloading and uploading translation files from / to Crowdin when translating with Poedit.
- 
+
  This utility is included with all versions of NVDA from 2025.1beta1 onwards.
 
 * For installed copies of NVDA, its path is: `c:\Program Files (x86)\nvda\l10nUtil.exe`
 * For portable copies, it can be found as `l10nUtil.exe` in the root directory of the portable copy.
- 
+
 #### Downloading with NVDA's l10n Utility
 ```
 l10nUtil.exe downloadTranslationFile <language> <crowdinFilePath> [<localFilePath>]
@@ -73,7 +73,7 @@ The first time you will be asked for an authorization token.
 Please visit [your Crowdin settings API page](https://crowdin.com/settings#api-key) and create a Personal Access Token.
 Ensure that it has at least the translations scope.
 Then paste this into the user prompt.
-This will be saved in ~/.nvda_crowdin for future use. 
+This will be saved in ~/.nvda_crowdin for future use.
 
 #### Translating using PoEdit
 
@@ -211,7 +211,7 @@ Documentation available for translation includes:
 To translate any of these files either:
 * locate the file in the Crowdin web interface and translate directly, or
 * Download the file using NVDA's l10n utility, open the file in Poedit, translate and save, then upload the file with NVDA's l10n utility.
- 
+
 ### Translating markdown
 
 The English NVDA user documentation is written in markdown syntax.


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Fixes #17934

### Summary of the issue:
NVDA's translation documentation for Crowdin is hard to follow and is missing some key information and warnings, such as:
* Where NVDA's l10n utility is located
* Not to download / upload translation files directly with Crowdin or use Poedit's Crowdin cloud translation feature
* The fact that translation approvals are disabled on the project, meaning strings are essentially auto approved.

### Description of user facing changes
Improve Translation documentation for Crowdin.
Specifically:
* Sections are now ordered in a (hopefully) more logical way:
	* Creating a Crowdin account
	* Translation workflows
		* Translating via Crowdin's web interface
			* Translation Reviews / Approvals
		* Translating with Poedit
			* Setting up PoEdit
			* Locating the NVDA l10n Utility
			* Downloading po / xliff files with NVDA's l10n Utility
			* Translating po / xliff files using PoEdit
			* Uploading po / xliff files with NVDA's l10n Utility
	* Translating NVDA's interface
	* Translating NVDA's user documentation
* Provided info on where to find NvDA's l10n utility.
* Clarified that translation approvals are disabled.
* Added a clear warning not to download / upload  translation files directly via Crowdin, nor use Poedit's Crowdin cloud translation feature, as these can corrupt xliff files.

### Description of development approach
n/a

### Testing strategy:
* proof reading by one or more translators would be appreciated.

### Known issues with pull request:
None known.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
