### PR TITLE
Error message for users when pushClipboard remote tool used with no connection

### DIFF
--- a/source/_remoteClient/client.py
+++ b/source/_remoteClient/client.py
@@ -135,19 +135,17 @@ class RemoteClient:
 		connector = self.followerTransport or self.leaderTransport
 		if not getattr(connector, "connected", False):
 			# Translators: Message shown when trying to push the clipboard to the remote computer while not connected.
-			ui.message(_("Not connected."))
-			return
+			raise RuntimeError(_("Not connected."))
 		elif self.connectedClientsCount < 1:
 			# Translators: Reported when performing a Remote Access action, but there are no other computers in the channel.
-			ui.message(pgettext("remote", "No one else is connected"))
-			return
+			raise RuntimeError(_("No one else is connected"))
 		try:
 			connector.send(RemoteMessageType.SET_CLIPBOARD_TEXT, text=api.getClipData())
 			cues.clipboardPushed()
 		except (TypeError, OSError):
 			log.debug("Unable to push clipboard", exc_info=True)
 			# Translators: Message shown when clipboard content cannot be sent to the remote computer.
-			ui.message(_("Unable to push clipboard"))
+			raise RuntimeError(_("Unable to push clipboard"))
 
 	def copyLink(self):
 		"""Copy connection URL to clipboard.

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -4892,7 +4892,11 @@ class GlobalCommands(ScriptableObject):
 	)
 	@gui.blockAction.when(gui.blockAction.Context.REMOTE_ACCESS_DISABLED)
 	def script_pushClipboard(self, gesture: "inputCore.InputGesture"):
-		_remoteClient._remoteClient.pushClipboard()
+		try:
+			_remoteClient._remoteClient.pushClipboard()
+		except RuntimeError as e:
+			log.error("Error pushing clipboard to remote machine", exc_info=True)
+			ui.message(str(e))
 
 	@script(
 		# Translators: Documentation string for the script that copies a link to the remote session to the clipboard.

--- a/tests/unit/test_remote/test_remoteClient.py
+++ b/tests/unit/test_remote/test_remoteClient.py
@@ -120,8 +120,9 @@ class TestRemoteClient(unittest.TestCase):
 		# Without any transport (neither follower nor leader), pushClipboard should warn.
 		self.client.followerTransport = None
 		self.client.leaderTransport = None
-		self.client.pushClipboard()
-		self.uiMessage.assert_called_with("Not connected.")
+		with self.assertRaises(RuntimeError) as cm:
+			self.client.pushClipboard()
+		self.assertEqual(str(cm.exception), "Not connected.")
 
 	def test_pushClipboardWithTransport(self):
 		# With a fake transport, pushClipboard should send the clipboard text.


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
https://github.com/nvaccess/nvda/issues/17947

### Summary of the issue:
Previously, when attempting to push clipboard content to a remote machine without a connection, NVDA would silently fail or show a message via ui.message(). This behavior wasn't accessible for non-visual users in all contexts and was inconsistent with other parts of NVDA that use structured exception handling.

### Description of user facing changes
Users now receive a spoken error message when pushing clipboard content fails due to no connection

### Description of development approach
- Updated pushClipboard() to raise RuntimeError instead of silently failing or calling ui.message(). This allows higher-level functions to handle the error and present it in a consistent, user-facing way.

- Updated script_pushClipboard() to catch RuntimeError and call ui.message() after logging the traceback. This pattern is consistent with how other NVDA script actions handle errors.

- Updated unit test test_pushClipboardNoConnection() to expect RuntimeError rather than assert ui.message() calls.

### Testing strategy:
- Ran unit tests, including updated test_pushClipboardNoConnection, to confirm exceptions are raised and contain the correct error message.

- Manually tested clipboard pushing with and without a connection using the remote add-on.

### Known issues with pull request:
- Does not address sending Ctrl+Alt+Delete or system-reserved commands. These still fail silently or require a different mechanism.
- This solution is a minimal improvement

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [ ] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
