### PR TITLE
Fix SAPI4 WASAPI implementation

### DIFF
--- a/source/synthDrivers/sapi4.py
+++ b/source/synthDrivers/sapi4.py
@@ -618,12 +618,9 @@ class SynthDriverAudio(COMObject):
 		elif self._deviceState in (_AudioState.UNCLAIMED, _AudioState.UNCLAIMING):
 			log.debugWarning("Audio data written when device is not claimed")
 			raise ReturnHRESULT(AudioError.NOT_CLAIMED, None)
-		elif self._freeBytes < dwSize:
-			raise ReturnHRESULT(AudioError.NOT_ENOUGH_DATA, None)
 		with self._audioCond:
 			self._audioQueue.append(string_at(pBuffer, dwSize))
 			self._writtenBytes += dwSize
-			self._freeBytes -= dwSize
 			self._audioCond.notify()
 
 	@_logTrace()
@@ -666,7 +663,6 @@ class SynthDriverAudio(COMObject):
 
 	def _onChunkFinished(self, size: int):
 		self._playedBytes += size
-		self._freeBytes += size
 		if self._notifySink:
 			self._queueNotification(self._notifySink.FreeSpace, self._freeBytes, 0)
 

--- a/source/synthDrivers/sapi4.py
+++ b/source/synthDrivers/sapi4.py
@@ -392,6 +392,19 @@ class SynthDriverAudio(COMObject):
 		)
 		self._setLevel(self._level)
 
+	def _calculateInitialFreeSpace(self) -> int:
+		wfx = self._waveFormat
+		size = wfx.nAvgBytesPerSec >> 3
+		if (wfx.nAvgBytesPerSec & 8) != 0:
+			size -= 1
+		size -= size % wfx.nBlockAlign
+		if size == 0:
+			size = wfx.nBlockAlign
+		size *= 16
+		if isDebugForSynthDriver():
+			log.debug(f"SAPI4: Initial buffer space is {size} bytes")
+		return size
+
 	@_logTrace(logAll=True)
 	def IAudio_Flush(self) -> None:
 		"""Clears the object's internal buffer and resets the audio device,
@@ -408,7 +421,7 @@ class SynthDriverAudio(COMObject):
 					self._queueNotification(self._notifySink.BookMark, bookmark.id, 1)
 			self._audioQueue.clear()
 			self._bookmarkQueue.clear()
-			self._freeBytes = self._waveFormat.nAvgBytesPerSec * BUFFER_LENGTH_S
+			self._freeBytes = self._calculateInitialFreeSpace()
 			# As byte positions can only increase,
 			# set _playedBytes to the current _writtenBytes
 			# to make sure that bookmarks that use byte positions still work.
@@ -592,7 +605,7 @@ class SynthDriverAudio(COMObject):
 		self._waveFormat = wfx
 		self._initPlayer()
 		self._deviceState = _AudioState.UNCLAIMED
-		self._freeBytes = wfx.nAvgBytesPerSec * BUFFER_LENGTH_S
+		self._freeBytes = self._calculateInitialFreeSpace()
 		self._audioThread.start()
 
 	@_logTrace(format="{result[0]} bytes free")


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Fixes #17964

### Summary of the issue:

Responsiveness issue when using the SAPI4 version of Infovox desktop standard voices.

Seems that commit c26c1c9 caused the issue.

### Description of user facing changes

The issue mentioned above should be fixed.

### Description of development approach

Removed the 2-second size limit on the buffer. `FreeSpace` still returns a "2 seconds" size, but the size is actually unlimited, and audio data will never be rejected because of insufficient buffer size.

### Testing strategy:

The issue author reported that the issue is fixed.

### Known issues with pull request:

This is not the same behavior as the built-in WinMM implementation, which uses a buffer of a fixed size, and will reject new data when the buffer is full. So it's possible that this behavior doesn't work well with some certain voices.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [ ] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
