### PR TITLE
Add unassigned command to show Remote Access settings

### DIFF
--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -3428,7 +3428,7 @@ class GlobalCommands(ScriptableObject):
 
 	@script(
 		# Translators: Input help mode message for go to Remote Access settings command.
-		description=_("Shows the Remote Access settings"),
+		description=pgettext("remote", "Shows the Remote Access settings"),
 		category=SCRCAT_CONFIG,
 	)
 	@gui.blockAction.when(gui.blockAction.Context.MODAL_DIALOG_OPEN)

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -3427,6 +3427,15 @@ class GlobalCommands(ScriptableObject):
 		wx.CallAfter(gui.mainFrame.onDocumentFormattingCommand, None)
 
 	@script(
+		# Translators: Input help mode message for go to Remote Access settings command.
+		description=_("Shows the Remote Access settings"),
+		category=SCRCAT_CONFIG,
+	)
+	@gui.blockAction.when(gui.blockAction.Context.MODAL_DIALOG_OPEN)
+	def script_activateRemoteAccessSettings(self, gesture: "inputCore.InputGesture"):
+		wx.CallAfter(gui.mainFrame.onRemoteAccessSettingsCommand, None)
+
+	@script(
 		# Translators: Input help mode message for opening default dictionary dialog.
 		description=_("Shows the NVDA default dictionary dialog"),
 		category=SCRCAT_CONFIG,

--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -370,6 +370,7 @@ class MainFrame(wx.Frame):
 	def onUwpOcrCommand(self, evt):
 		self.popupSettingsDialog(NVDASettingsDialog, UwpOcrPanel)
 
+	@blockAction.when(blockAction.Context.SECURE_MODE)
 	def onRemoteAccessSettingsCommand(self, evt):
 		self.popupSettingsDialog(NVDASettingsDialog, RemoteSettingsPanel)
 

--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -59,6 +59,7 @@ from .settingsDialogs import (
 	MultiCategorySettingsDialog,
 	NVDASettingsDialog,
 	ObjectPresentationPanel,
+	RemoteSettingsPanel,
 	SettingsDialog,
 	SpeechSettingsPanel,
 	SpeechSymbolsDialog,
@@ -368,6 +369,9 @@ class MainFrame(wx.Frame):
 
 	def onUwpOcrCommand(self, evt):
 		self.popupSettingsDialog(NVDASettingsDialog, UwpOcrPanel)
+
+	def onRemoteAccessSettingsCommand(self, evt):
+		self.popupSettingsDialog(NVDASettingsDialog, RemoteSettingsPanel)
 
 	@blockAction.when(blockAction.Context.SECURE_MODE)
 	def onSpeechSymbolsCommand(self, evt):


### PR DESCRIPTION
### Link to issue number:

Closes #17962 

### Summary of the issue:

There is no way to open Remote Access' settings directly.

### Description of user facing changes

There is now an unassigned command to open Remote Access's settings.

### Description of development approach

Added a function to open Remote Access's settings to `gui.MainFrame`, and added an unbound script that calls that function in `globalCommands.GlobalCommands`. Modelled off other "Shows NVDA's <category> settings" scripts.

### Testing strategy:

Bound the command to a gesture and executed.

### Known issues with pull request:
After #17946 is closed, the block on the gesture in secure mode will have to be removed.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
