### PR TITLE
Remove unnecessary reference to Python test module

### DIFF
--- a/tests/unit/test_remote/test_transport.py
+++ b/tests/unit/test_remote/test_transport.py
@@ -301,20 +301,16 @@ class TestTCPTransportCreateOutboundSocket(unittest.TestCase):
 		self.host = "localhost"
 		self.port = 8090
 
-	@mock.patch("test.mock_socket.socket", autospec=True)
-	def test_createOutboundSocketOnion(self, mockSocket):
+	def test_createOutboundSocketOnion(self):
 		t = TCPTransport(self.serializer, (self.host + ".onion", self.port))
 		fakeSocket = DummyTCPSocket()
-		mockSocket.return_value = fakeSocket
 		sock = t.createOutboundSocket(self.host + ".onion", self.port, insecure=False)
 		self.assertFalse(fakeSocket.connected)
 		self.assertTrue(isinstance(sock, ssl.SSLSocket))
 
-	@mock.patch("test.mock_socket.socket", autospec=True)
-	def test_createOutboundSocketRegularInsecure(self, mockSocket):
+	def test_createOutboundSocketRegularInsecure(self):
 		t = TCPTransport(self.serializer, (self.host, self.port))
 		fakeSocket = DummyTCPSocket()
-		mockSocket.return_value = fakeSocket
 		sock = t.createOutboundSocket(self.host, self.port, insecure=True)
 		self.assertFalse(fakeSocket.connected)
 		self.assertTrue(isinstance(sock, ssl.SSLSocket))


### PR DESCRIPTION
### Link to issue number:
Fixes #18005 

### Summary of the issue:
Remote client has an unnecessary reference to the Python test module. This module is meant as a module internal to Python testing. The reference is unnecessary because the mocket socket is never used within the test.

### Description of user facing changes
None

### Description of development approach
Just removed the patch call

### Testing strategy:
Unit tests

### Known issues with pull request:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
