### PR TITLE
Improve focus handling in the Remote Access Connection dialog

### DIFF
--- a/source/_remoteClient/dialogs.py
+++ b/source/_remoteClient/dialogs.py
@@ -365,13 +365,17 @@ class DirectConnectDialog(ContextHelpMixin, wx.Dialog):
 		):
 			# Translators: Message displayed when the host or key field is empty and the user tries to connect.
 			message = _("Both host and key must be set.")
-			focusTarget = self._selectedPanel.host
+			focusTarget = (
+				self._selectedPanel.host if not self._selectedPanel.host.Value else self._selectedPanel.key
+			)
 		elif self._selectedPanel is self._serverPanel and (
 			not self._selectedPanel.port.GetValue() or not self._selectedPanel.key.GetValue()
 		):
 			# Translators: Message displayed when the port or key field is empty and the user tries to connect.
 			message = _("Both port and key must be set.")
-			focusTarget = self._selectedPanel.port
+			focusTarget = (
+				self._selectedPanel.port if not self._selectedPanel.port.Value else self._selectedPanel.key
+			)
 		if message is not None:
 			gui.messageBox(
 				message,


### PR DESCRIPTION
### Link to issue number:

Closes #17973

### Summary of the issue:

Focus handling in the "Connect to another computer" dialog is suboptimal.

### Description of user facing changes

* When connecting using a remote relay server, after a key is generated by the server, the key field is automatically focused.
* When connecting using a local relay server, after detecting the external IP, the external IP field is automatically focused.
* When attempting to initiate a connection with a blank host/port and/or key field, the first erroneously empty field is focused after the error dialog is dismissed.

### Description of development approach

#### Focusing key/external IP fields

Since the indeterminate progress dialog is shown asynchronously, we can't know for certain when the connection dialog will be focusable again. This is problematic as we can only (successfully) call `SetFocus` on children of focusable dialogs.
To work around this, bind an event handler to the dialog after successfully generating a key/detecting the external IP that:

* Is triggered by `wx.EVT_ACTIVATE`, so it fires when the dialog is focused (as this only happens when the dialog is focusable).
* Focuses the key or external IP field, as appropriate.
* Unbinds itself, so the event is only called the once.

#### Focusing the first empty control

Add an `if` statement that selects the appropriate control based on which one is empty.

### Testing strategy:

Attempted to perform a variety of legal and illegal operations with the dialog.

### Known issues with pull request:

None.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
