### PR TITLE
Don't toggle mute when not connected

### DIFF
--- a/source/_remoteClient/client.py
+++ b/source/_remoteClient/client.py
@@ -118,6 +118,10 @@ class RemoteClient:
 
 		:note: Updates menu item state and announces new mute status
 		"""
+		if not self.isConnected():
+			# Translators: Message shown when attempting to mute the remote computer when no session is connected.
+			ui.message(pgettext("remote", "Not connected"))
+			return
 		self.localMachine.isMuted = not self.localMachine.isMuted
 		self.menu.muteItem.Check(self.localMachine.isMuted)
 		# Translators: Displayed when muting speech and sounds from the remote computer

--- a/tests/unit/test_remote/test_remoteClient.py
+++ b/tests/unit/test_remote/test_remoteClient.py
@@ -101,6 +101,7 @@ class TestRemoteClient(unittest.TestCase):
 	def tearDown(self):
 		self.client = None
 
+	@patch.object(rcClient.RemoteClient, "isConnected", lambda self: True)
 	def test_toggleMute(self):
 		# Initially, local machine should not be muted.
 		self.assertFalse(self.client.localMachine.isMuted)


### PR DESCRIPTION
### Link to issue number:

Fixes #17985

### Summary of the issue:

Muting remote via an input gesture works even if no remote access session is in progress.

### Description of user facing changes

Using an input gesture to mute Remote Access is now disallowed when not connected.

### Description of development approach

Check whether connected in `_remoteClient.client.RemoteClient.toggleMute`.

### Testing strategy:

Tested muting and unmuting when connected and not connected.

### Known issues with pull request:

Muting is still allowed when connected as follower, which doesn't seem to make sense.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
