### PR TITLE
Add crowdin upload to GH actions

### DIFF
--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -33,7 +33,7 @@ env:
   # feature_buildSymbols: configured
   # feature_uploadSymbolsToMozilla: configured
   # feature_buildAppx: configured
-  # feature_crowdinSync: configured
+  feature_crowdinSync: configured
   # feature_signing: configured
 
 jobs:
@@ -141,6 +141,29 @@ jobs:
         detailed_summary: true
         annotate_only: true
         report_paths: testOutput/unit/unitTests.xml
+
+  crowdinUpload:
+    name: Upload translations to Crowdin
+    runs-on: windows-latest
+    needs: buildNVDA
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/beta' }}
+    steps:
+    - name: Skip if feature disabled
+      if: ${{ !env.feature_crowdinSync }}
+      run: exit 0
+    - name: Checkout cached build
+      uses: actions/cache/restore@v4
+      with:
+        path: ${{ github.workspace }}
+        key: ${{ github.ref }}-${{ github.run_id }}
+        fail-on-cache-miss: true
+    - name: Install the latest version of uv
+      uses: astral-sh/setup-uv@v5
+    - name: Upload translations to Crowdin
+      env:
+        crowdinProjectID: ${{ vars.CROWDIN_PROJECT_ID }}
+        crowdinAuthToken: ${{ secrets.CROWDIN_AUTH_TOKEN }}
+      run: uv run --with requests --directory appveyor crowdinSync.py uploadSourceFile 2 output\nvda.pot 2>&1
 
   createLauncher:
     name: Create launcher
@@ -255,7 +278,7 @@ jobs:
     name: Cleanup cache
     permissions:
       actions: write
-    needs: [checkPot, licenseCheck, unitTests, systemTests]
+    needs: [checkPot, licenseCheck, unitTests, systemTests, crowdinUpload]
     if: ${{ always() && (github.event_name == 'push' || github.event.pull_request.head.repo.owner == github.repository_owner) }}
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Part of https://github.com/nvaccess/nvda/issues/17878

### Summary of the issue:
Crowdin upload is missing from GitHub actions, which needs to be added to have full parity to AppVeyor

### Description of user facing changes

None

### Description of development approach
Copy logic from AppVeyor

### Testing strategy:

Unfortunately we need to test this on production when we merge master to beta

### Known issues with pull request:

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
