### PR TITLE
Fix definition of controlling and controlled computers being swapped

### DIFF
--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -3141,8 +3141,8 @@ This option is only available when [Automatically connect after NVDA starts](#Re
 
 |Option |Behaviour |
 |---|---|
-|Allow this machine to be controlled |Use this computer as the "controlling" computer. This allows you to execute commands on the remote computer. |
-|Control another machine |Use this computer as the "controlled" computer. This allows the operator of the "controlling" computer to use this computer as if they were sitting in front of it. |
+|Allow this computer to be controlled |Use this computer as the "controlled" computer. This allows the operator of the "controlling" computer to use this computer as if they were sitting in front of it. |
+|Control another computer |Use this computer as the "controlling" computer. This allows you to execute commands on the remote computer. |
 
 ##### Server {#RemoteAutoconnectServer}
 


### PR DESCRIPTION
### Link to issue number:

https://groups.io/g/nvda-translations/message/4636?p=,,,20,0,0,0

### Summary of the issue:

In the user guide section for the Remote Access automatic connection mode, the definitions for "Control another computer" and "Allow this computer to be controlled" were swapped.

### Description of user facing changes

1. The definitions have been swapped, so they are now correctly paired.
2. "machine" has been replaced with "computer" per #17943.

### Description of development approach

Modify the table in `user_docs/en/userGuide.md`.

### Testing strategy:

Build user documentation and check generated output.

### Known issues with pull request:

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
