### PR TITLE
[BUGFIX] Use the correct combinations for Eurobraille braille displays

### DIFF
--- a/source/brailleDisplayDrivers/eurobraille/gestures.py
+++ b/source/brailleDisplayDrivers/eurobraille/gestures.py
@@ -102,7 +102,10 @@ GestureMapEntries = {
 		"kb:shift+tab": ("br(eurobraille):dot2+dot3+dot5+space",),
 		"kb:printScreen": ("br(eurobraille):dot1+dot3+dot4+dot6+space",),
 		"kb:pause": ("br(eurobraille):dot1+dot4+space",),
-		"kb:applications": ("br(eurobraille):dot5+dot6+backspace",),
+		"kb:applications": (
+			"br(eurobraille):dot5+dot6+backspace",
+			"br(eurobraille):l2+l4",
+		),
 		"kb:f1": ("br(eurobraille):dot1+backspace",),
 		"kb:f2": ("br(eurobraille):dot1+dot2+backspace",),
 		"kb:f3": ("br(eurobraille):dot1+dot4+backspace",),
@@ -119,23 +122,29 @@ GestureMapEntries = {
 		"kb:capsLock": ("br(eurobraille):dot7+backspace", "br(eurobraille):dot8+backspace"),
 		"kb:numLock": ("br(eurobraille):dot3+backspace", "br(eurobraille):dot6+backspace"),
 		"braille_toggleShift": (
-			"br(eurobraille):dot1+dot7+space",
-			"br(eurobraille):dot4+dot7+space",
+			#"br(eurobraille):dot1+dot7+space",
+			#"br(eurobraille):dot4+dot7+space",
 			"br(eurobraille):l4",
+			"br(eurobraille):dot7+space"
 		),
-		"kb:shift": ("br(eurobraille):dot7+space",),
+		#"kb:shift": ("br(eurobraille):dot7+space",),
 		"braille_toggleControl": (
-			"br(eurobraille):dot1+dot7+dot8+space",
-			"br(eurobraille):dot4+dot7+dot8+space",
+			#"br(eurobraille):dot1+dot7+dot8+space",
+			#"br(eurobraille):dot4+dot7+dot8+space",
 			"br(eurobraille):l5",
+			"br(eurobraille):dot7+dot8+space",
 		),
-		"kb:control": ("br(eurobraille):dot7+dot8+space",),
+		#"kb:control": ("br(eurobraille):dot7+dot8+space",),
 		"braille_toggleAlt": (
-			"br(eurobraille):dot1+dot8+space",
-			"br(eurobraille):dot4+dot8+space",
+			#"br(eurobraille):dot1+dot8+space",
+			#"br(eurobraille):dot4+dot8+space",
 			"br(eurobraille):l6",
+			"br(eurobraille):dot8+space",
 		),
-		"kb:alt": ("br(eurobraille):dot8+space"),
+		"kb:alt": (
+			#"br(eurobraille):dot8+space",
+			"br(eurobraille):joystick1Down"
+		),
 		"braille_toggleNVDAKey": ("br(eurobraille):l7", "br(eurobraille):dot3+dot5+space"),
 		"kb:control+home": (
 			"br(eurobraille):joystick2left+joystick2up",
@@ -150,6 +159,7 @@ GestureMapEntries = {
 		"braille_toggleWindows": (
 			"br(eurobraille):backspace+dot1+dot2+dot3+dot4",
 			"br(eurobraille):dot2+dot4+dot5+dot6+space",
+			"br(eurobraille):l2+l3"
 		),
 		"kb:control+shift+e": ("br(eurobraille):dot1+dot5+space",),
 	},

--- a/source/brailleDisplayDrivers/eurobraille/gestures.py
+++ b/source/brailleDisplayDrivers/eurobraille/gestures.py
@@ -122,27 +122,27 @@ GestureMapEntries = {
 		"kb:capsLock": ("br(eurobraille):dot7+backspace", "br(eurobraille):dot8+backspace"),
 		"kb:numLock": ("br(eurobraille):dot3+backspace", "br(eurobraille):dot6+backspace"),
 		"braille_toggleShift": (
-			#"br(eurobraille):dot1+dot7+space",
-			#"br(eurobraille):dot4+dot7+space",
+			# "br(eurobraille):dot1+dot7+space",
+			# "br(eurobraille):dot4+dot7+space",
 			"br(eurobraille):l4",
-			"br(eurobraille):dot7+space"
+			"br(eurobraille):dot7+space",
 		),
-		#"kb:shift": ("br(eurobraille):dot7+space",),
+		# "kb:shift": ("br(eurobraille):dot7+space",),
 		"braille_toggleControl": (
-			#"br(eurobraille):dot1+dot7+dot8+space",
-			#"br(eurobraille):dot4+dot7+dot8+space",
+			# "br(eurobraille):dot1+dot7+dot8+space",
+			# "br(eurobraille):dot4+dot7+dot8+space",
 			"br(eurobraille):l5",
 			"br(eurobraille):dot7+dot8+space",
 		),
-		#"kb:control": ("br(eurobraille):dot7+dot8+space",),
+		# "kb:control": ("br(eurobraille):dot7+dot8+space",),
 		"braille_toggleAlt": (
-			#"br(eurobraille):dot1+dot8+space",
-			#"br(eurobraille):dot4+dot8+space",
+			# "br(eurobraille):dot1+dot8+space",
+			# "br(eurobraille):dot4+dot8+space",
 			"br(eurobraille):l6",
 			"br(eurobraille):dot8+space",
 		),
 		"kb:alt": (
-			#"br(eurobraille):dot8+space",
+			# "br(eurobraille):dot8+space",
 			"br(eurobraille):joystick1Down"
 		),
 		"braille_toggleNVDAKey": ("br(eurobraille):l7", "br(eurobraille):dot3+dot5+space"),
@@ -159,7 +159,7 @@ GestureMapEntries = {
 		"braille_toggleWindows": (
 			"br(eurobraille):backspace+dot1+dot2+dot3+dot4",
 			"br(eurobraille):dot2+dot4+dot5+dot6+space",
-			"br(eurobraille):l2+l3"
+			"br(eurobraille):l2+l3",
 		),
 		"kb:control+shift+e": ("br(eurobraille):dot1+dot5+space",),
 	},


### PR DESCRIPTION
### Link to issue number:
There is no issue associated with this pull request
### Summary of the issue:
The purpose of this pull request is to use the official controls of the Eurobraille braille displays. They can be found in the official documentation [here](https://www.eurobraille.com/supports-and-downloads/braille-products/).
### Description of user facing changes
Users will now be able to use the classic controls of the Eurobraille displays that are indicated in the user manuals and given by the hardware suppliers. This will make it clearer and have less confusion between the controls chosen by Eurobraille and the one chosen by the screen reader.
### Description of development approach
Edit the file containing the orders associated with the Eurobraille displays.
### Testing strategy:
- Start NVDA,
- Connect NVDA to a braille display mades by Eurobraille.
- Check that the press control key is now with b78 and space key,
- Check that the press alt key is now with b8 and space key,
- Check that the press shift key is now with b7 and space key.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [ ] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [ ] API is compatible with existing add-ons.
- [ ] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
