### PR TITLE
Always focus remote connection dialog

### DIFF
--- a/source/_remoteClient/dialogs.py
+++ b/source/_remoteClient/dialogs.py
@@ -346,6 +346,7 @@ class DirectConnectDialog(ContextHelpMixin, wx.Dialog):
 		self.Fit()
 		self.CenterOnScreen()
 		self._connectionModeControl.SetFocus()
+		self.Bind(wx.EVT_SHOW, self._onShow)
 
 	def _onClientOrServer(self, evt: wx.CommandEvent) -> None:
 		"""Respond to changing between using a control server or hosting it locally"""
@@ -414,6 +415,12 @@ class DirectConnectDialog(ContextHelpMixin, wx.Dialog):
 			port=port,
 			insecure=insecure,
 		)
+
+	def _onShow(self, evt: wx.ShowEvent):
+		"""Make sure this dialog is focused when opened."""
+		self.Raise()
+		self.SetFocus()
+		evt.Skip()
 
 
 class CertificateUnauthorizedDialog(wx.MessageDialog):


### PR DESCRIPTION
### Link to issue number:

Fixes #18047

### Summary of the issue:

If the Remote Access connection dialog is the first NVDA GUI to be shown, it is not automatically focused.

### Description of user facing changes

The Remote Access connection dialog is automatically focused when opened, even if it is the first NVDA GUI to be shown.

### Description of development approach

Add a `wx.EVT_SHOW` handler that manually brings the dialog to the foreground and focuses it.

### Testing strategy:

Ran from source with the welcome dialog disabled, and pressed `NVDA+alt+r` to bring up the dialog.

### Known issues with pull request:

None.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
