### PR TITLE
Save previously connected Remote Access servers to disc

### DIFF
--- a/source/_remoteClient/configuration.py
+++ b/source/_remoteClient/configuration.py
@@ -24,7 +24,7 @@ def writeConnectionToConfig(connectionInfo: ConnectionInfo):
 	lastConnections = conf["connections"]["lastConnected"]
 	address = connectionInfo.getAddress()
 	if address in lastConnections:
-		if lastConnections.index(address) == len(lastConnections) - 1:
+		if lastConnections[-1] == address:
 			# This address is already the last connected address, so no action is needed.
 			return
 		# Remove the address from the list, so appending it won't result in a duplicate.

--- a/source/_remoteClient/configuration.py
+++ b/source/_remoteClient/configuration.py
@@ -24,5 +24,13 @@ def writeConnectionToConfig(connectionInfo: ConnectionInfo):
 	lastConnections = conf["connections"]["lastConnected"]
 	address = connectionInfo.getAddress()
 	if address in lastConnections:
-		conf["connections"]["lastConnected"].remove(address)
-	conf["connections"]["lastConnected"].append(address)
+		if lastConnections.index(address) == len(lastConnections) - 1:
+			# This address is already the last connected address, so no action is needed.
+			return
+		# Remove the address from the list, so appending it won't result in a duplicate.
+		lastConnections.remove(address)
+	lastConnections.append(address)
+	# Configobj recognises items as changed based on calls to __setitem__,
+	# so will not know that the underlying list has been mutated.
+	# Set the list to itself to force configobj to realise the key is dirty.
+	conf["connections"]["lastConnected"] = lastConnections


### PR DESCRIPTION
### Link to issue number:

Fixes #18037

### Summary of the issue:

Remote Access's previously connected servers aren't being written to disc when the config is saved.

### Description of user facing changes

Previously connected Remote Access servers are now persisted across NVDA restarts.

### Description of development approach

The issue is because configobj only recognises config items as having changed when `__setitem__` is called. Since lists are mutable, this was not happening.

1. Tidied up the `_remoteClient.configuration.writeConnectionToConfig` function a bit.
2. Don't take any action if the server to persist is already the last server stored in `config.conf["remote"]["connections"]["lastConnected"]`.
3. Set `config.conf["remote"]["connections"]["lastConnected"]` to itself so that configobj recognises that it has changed, and will thuss write it out when saving the config.

### Testing strategy:

Connected to `nvdaremote.com`. Terminated the connection. Opened the connection dialog again, and verified that nvdaremote.com was prefilled in the host field. Restarted NVDA, opened the connection dialog, and verified that nvdaremote.com was still prefilled.

### Known issues with pull request:

None known.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
