### PR TITLE
Added favicon to user_docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ dlldata.c
 *.md.sub
 user_docs/*/*.html
 user_docs/*/*.css
+user_docs/*/*.ico
 extras/controllerClient/x86/nvdaController.h
 extras/controllerClient/x64
 extras/controllerClient/arm64

--- a/sconstruct
+++ b/sconstruct
@@ -332,6 +332,11 @@ for po in env.Glob(sourceDir.path + "/locale/*/lc_messages/*.po"):
 styles = os.path.join(userDocsDir.path, "styles.css")
 numberedHeadingsStyle = os.path.join(userDocsDir.path, "numberedHeadings.css")
 logo = os.path.join(sourceDir.path, "images", "nvda.ico")
+favicon = env.Command(
+	outputDir.File("favicon.ico"),
+	logo,
+	Copy("$TARGET", "$SOURCE"),
+)
 
 # Create Non-english md files in user_docs from localized xliff and English skel files
 for xliffFile in env.Glob(os.path.join(userDocsDir.path, "*", "*.xliff")):
@@ -366,7 +371,7 @@ for mdFile in env.Glob(os.path.join(userDocsDir.path, "*", "*.md")):
 	styleInstallPath = os.path.dirname(mdFile.abspath)
 	installedStyle = env.Install(styleInstallPath, styles)
 	installedHeadingsStyle = env.Install(styleInstallPath, numberedHeadingsStyle)
-	installedLogo = env.Install(styleInstallPath, logo)
+	installedLogo = env.Install(styleInstallPath, favicon)
 	env.Depends(
 		htmlFile,
 		[
@@ -374,6 +379,8 @@ for mdFile in env.Glob(os.path.join(userDocsDir.path, "*", "*.md")):
 			installedStyle,
 			numberedHeadingsStyle,
 			installedHeadingsStyle,
+			favicon,
+			installedLogo
 		],
 	)
 	env.Depends(htmlFile, mdFile)
@@ -590,8 +597,8 @@ outputHeadingStylesFile = env.Command(
 	Copy("$TARGET", "$SOURCE"),
 )
 outputLogoFile = env.Command(
-	outputDir.File("nvda.ico"),
-	sourceDir.File("images/nvda.ico"),
+	outputDir.File("favicon.ico"),
+	logo,
 	Copy("$TARGET", "$SOURCE")
 )
 changesFile = env.Command(

--- a/sconstruct
+++ b/sconstruct
@@ -331,6 +331,7 @@ for po in env.Glob(sourceDir.path + "/locale/*/lc_messages/*.po"):
 
 styles = os.path.join(userDocsDir.path, "styles.css")
 numberedHeadingsStyle = os.path.join(userDocsDir.path, "numberedHeadings.css")
+logo = os.path.join(sourceDir.path, "images", "nvda.ico")
 
 # Create Non-english md files in user_docs from localized xliff and English skel files
 for xliffFile in env.Glob(os.path.join(userDocsDir.path, "*", "*.xliff")):
@@ -365,6 +366,7 @@ for mdFile in env.Glob(os.path.join(userDocsDir.path, "*", "*.md")):
 	styleInstallPath = os.path.dirname(mdFile.abspath)
 	installedStyle = env.Install(styleInstallPath, styles)
 	installedHeadingsStyle = env.Install(styleInstallPath, numberedHeadingsStyle)
+	installedLogo = env.Install(styleInstallPath, logo)
 	env.Depends(
 		htmlFile,
 		[
@@ -586,6 +588,11 @@ outputHeadingStylesFile = env.Command(
 	outputDir.File("numberedHeadings.css"),
 	userDocsDir.File("numberedHeadings.css"),
 	Copy("$TARGET", "$SOURCE"),
+)
+outputLogoFile = env.Command(
+	outputDir.File("nvda.ico"),
+	sourceDir.File("images/nvda.ico"),
+	Copy("$TARGET", "$SOURCE")
 )
 changesFile = env.Command(
 	outputDir.File("%s_changes.html" % outFilePrefix),

--- a/source/md2html.py
+++ b/source/md2html.py
@@ -45,6 +45,7 @@ HTML_HEADERS = """
 <title>{title}</title>
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <link rel="stylesheet" href="styles.css">
+<link rel="shortcut icon" href="nvda.ico">
 {extraStylesheet}
 </head>
 <body>

--- a/source/md2html.py
+++ b/source/md2html.py
@@ -45,7 +45,7 @@ HTML_HEADERS = """
 <title>{title}</title>
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <link rel="stylesheet" href="styles.css">
-<link rel="shortcut icon" href="nvda.ico">
+<link rel="shortcut icon" href="favicon.ico">
 {extraStylesheet}
 </head>
 <body>

--- a/source/setup.py
+++ b/source/setup.py
@@ -311,6 +311,7 @@ freeze(
 				"*.xliff",
 				"*/user_docs/styles.css",
 				"*/user_docs/numberedHeadings.css",
+				"*/source/images/nvda.ico",
 				"*/developerGuide.*",
 			),
 		)

--- a/source/setup.py
+++ b/source/setup.py
@@ -311,7 +311,7 @@ freeze(
 				"*.xliff",
 				"*/user_docs/styles.css",
 				"*/user_docs/numberedHeadings.css",
-				"*/source/images/nvda.ico",
+				"*/user_docs/favicon.ico",
 				"*/developerGuide.*",
 			),
 		)


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:  
Fixes #17971 

### Summary of the issue:  
When loading NVDA HTML documentation in the browser, there's no page icon (favicon.ico).

### Description of user facing changes:  
The NVDA logo is visible when opening any .html file in the user_docs

### Description of development approach:  
I added a simple rel="shortcut icon" similar to nvaccess' [website](https://www.nvaccess.org/) using the NVDA logo  
which I found [here](https://commons.wikimedia.org/wiki/File:Logo_NVDA.jpg).  
I also changed the logic in sconstruct.py to make sure that the favicon is pulled locally in every subfolder and cleaned when running scons -c

### Testing strategy:  
Run .\scons.bat user_docs to generate the .html files and the favicon.ico  
Run .\scons.bat -c user_docs to clear out the generated files

### Known issues with pull request:

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
