### PR TITLE
Improve logging in Remote Access

### DIFF
--- a/source/_remoteClient/configuration.py
+++ b/source/_remoteClient/configuration.py
@@ -34,3 +34,7 @@ def writeConnectionToConfig(connectionInfo: ConnectionInfo):
 	# so will not know that the underlying list has been mutated.
 	# Set the list to itself to force configobj to realise the key is dirty.
 	conf["connections"]["lastConnected"] = lastConnections
+
+
+def _isDebugForRemoteClient() -> bool:
+	return config.conf["debugLog"]["remoteClient"]

--- a/source/_remoteClient/localMachine.py
+++ b/source/_remoteClient/localMachine.py
@@ -19,7 +19,6 @@ muting and uses wxPython's CallAfter for thread synchronization.
 """
 
 import ctypes
-import logging
 import os
 from typing import Any, Dict, List, Optional
 
@@ -34,10 +33,9 @@ from speech.priorities import Spri
 from speech.types import SpeechSequence
 from systemUtils import hasUiAccess
 import ui
+from logHandler import log
 
 from . import cues, input
-
-logger = logging.getLogger("local_machine")
 
 
 def setSpeechCancelledToFalse() -> None:
@@ -258,4 +256,4 @@ class LocalMachine:
 		else:
 			# Translators: Message displayed when a remote computer tries to send ctrl+alt+del but UI Access is disabled.
 			ui.message(_("Unable to trigger Alt Control Delete from remote"))
-			logger.warning("UI Access is disabled on this machine so cannot trigger CTRL+ALT+DEL")
+			log.debug("UI Access is disabled on this machine so cannot trigger CTRL+ALT+DEL")

--- a/source/_remoteClient/serializer.py
+++ b/source/_remoteClient/serializer.py
@@ -23,12 +23,11 @@ Supported Data Types
 import json
 from abc import ABCMeta, abstractmethod
 from enum import Enum
-from logging import getLogger
 from typing import Any, Dict, Optional, Type, TypeVar, Union
 
 import speech.commands
+from logHandler import log
 
-log = getLogger("serializer")
 
 T = TypeVar("T")
 JSONDict = Dict[str, Any]

--- a/source/_remoteClient/transport.py
+++ b/source/_remoteClient/transport.py
@@ -33,7 +33,7 @@ import threading
 import time
 from collections.abc import Callable
 from dataclasses import dataclass
-from logging import getLogger
+from logHandler import log
 from queue import Queue
 from typing import Any, Literal, Optional, Self
 
@@ -44,8 +44,6 @@ from . import configuration
 from .connectionInfo import ConnectionInfo
 from .protocol import PROTOCOL_VERSION, RemoteMessageType, hostPortToAddress
 from .serializer import Serializer
-
-log = getLogger("transport")
 
 
 @dataclass
@@ -514,6 +512,8 @@ class TCPTransport(Transport):
 		:note: Handlers execute asynchronously on wx main thread
 		"""
 		obj = self.serializer.deserialize(line)
+		if configuration._isDebugForRemoteClient():
+			log.debug(f"Received message: {obj!r}")
 		if "type" not in obj:
 			log.warn(f"Received message without type: {obj!r}")
 			return
@@ -538,6 +538,8 @@ class TCPTransport(Transport):
 		"""
 		while True:
 			item = self.queue.get()
+			if configuration._isDebugForRemoteClient():
+				log.debug(f"Sending outbound message: {item!r}")
 			if item is None:
 				return
 			try:
@@ -556,6 +558,8 @@ class TCPTransport(Transport):
 		"""
 		if self.connected:
 			obj = self.serializer.serialize(type=type, **kwargs)
+			if configuration._isDebugForRemoteClient():
+				log.debug(f"Enqueuing outbound message: {obj!r}")
 			self.queue.put(obj)
 		else:
 			log.error(f"Attempted to send message {type} while not connected")

--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -317,6 +317,7 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 	annotations = boolean(default=false)
 	events = boolean(default=false)
 	garbageHandler = boolean(default=false)
+	remoteClient = boolean(default=False)
 
 [uwpOcr]
 	language = string(default="")

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -4072,6 +4072,7 @@ class AdvancedPanelControls(
 			"annotations",
 			"events",
 			"garbageHandler",
+			"remoteClient",
 		]
 		# Translators: This is the label for a list in the
 		#  Advanced settings panel

--- a/tests/unit/test_remote/test_transport.py
+++ b/tests/unit/test_remote/test_transport.py
@@ -37,6 +37,7 @@ from _remoteClient.transport import (
 	Transport,
 	clearQueue,
 )
+import logHandler
 
 
 # ---------------------------------------------------------------------------
@@ -459,18 +460,18 @@ class TestParseErrorHandling(unittest.TestCase):
 		self.transport.inboundHandlers = {}
 
 	def test_parseNoType(self):
-		with self.assertLogs(level="WARN") as cm:
+		with self.assertLogs(logHandler.log, level="WARN") as cm:
 			self.transport.parse(b"invalid message\n")
 			self.assertTrue(any("Received message without type" in log for log in cm.output))
 
 	def test_parseInvalidType(self):
-		with self.assertLogs(level="WARN") as cm:
+		with self.assertLogs(logHandler.log, level="WARN") as cm:
 			message = self.serializer.serialize(type="NONEXISTENT", a=10)
 			self.transport.parse(message)
 			self.assertTrue(any("Received message with invalid type" in log for log in cm.output))
 
 	def test_parseUnhandledType(self):
-		with self.assertLogs(level="WARN") as cm:
+		with self.assertLogs(logHandler.log, level="WARN") as cm:
 			message = self.serializer.serialize(type=RemoteMessageType.GENERATE_KEY, b=10)
 			self.transport.parse(message)
 			self.assertTrue(any("Received message with unhandled type" in log for log in cm.output))


### PR DESCRIPTION
### Link to issue number:

None

### Summary of the issue:

Remote Access's logging strategy is currently suboptimal.

### Description of user facing changes

1. A new debug logging category, `remoteClient`, has been added.
2. When this is enabled, more information is logged by Remote Access.
3. Log messages that were previously not stored are now shown in NVDA's logs.

### Description of development approach

* In the config schema, add a new boolean key, `remoteClient`, to the `debugLogging` category. Add this to the list of log categories in the advanced settings panel. Also add a `_isDebugForRemoteClient` function to `_remoteClient.configuration` which returns the value of this config item.
* In the `TCPTransport` class, if debug logging is enabled for remoteClient, log incoming and outgoing messages to make debugging easier.
* In `_remoteClient.localMachine` and `_remoteClient.serializer`, switch to using `logHandler.log`, rather than a custom logger, so that all logs are collected in the same place.

### Testing strategy:

Unit tests.
Checked that messages were logged when using Remote.

### Known issues with pull request:

More work is still needed on logging throughout the Remote Access code, however I feel this is better handled piecemeal as issues are identified.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
