### PR TITLE
Add externalPythonDependencies logging category

### DIFF
--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -318,6 +318,7 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 	events = boolean(default=false)
 	garbageHandler = boolean(default=false)
 	remoteClient = boolean(default=False)
+	externalPythonDependencies = boolean(default=False)
 
 [uwpOcr]
 	language = string(default="")

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -4073,6 +4073,7 @@ class AdvancedPanelControls(
 			"events",
 			"garbageHandler",
 			"remoteClient",
+			"externalPythonDependencies",
 		]
 		# Translators: This is the label for a list in the
 		#  Advanced settings panel

--- a/source/logHandler.py
+++ b/source/logHandler.py
@@ -549,8 +549,10 @@ def _shouldDisableLogging() -> bool:
 def filterExternalDependencyLogging(record: logging.LogRecord) -> bool:
 	import config
 
-	return record.name == NVDA_LOGGER_NAME or (
-		record.levelno >= Logger.WARNING or config.conf["debugLog"]["externalPythonDependencies"]
+	return (
+		record.name == NVDA_LOGGER_NAME
+		or record.levelno >= Logger.WARNING
+		or config.conf["debugLog"]["externalPythonDependencies"]
 	)
 
 

--- a/source/logHandler.py
+++ b/source/logHandler.py
@@ -465,10 +465,11 @@ def redirectStdout(logger):
 	sys.stderr = StreamRedirector("stderr", logger, logging.ERROR)
 
 
+NVDA_LOGGER_NAME = "nvda"
 # Register our logging class as the class for all loggers.
 logging.setLoggerClass(Logger)
 #: The singleton logger instance.
-log: Logger = logging.getLogger("nvda")
+log: Logger = logging.getLogger(NVDA_LOGGER_NAME)
 #: The singleton log handler instance.
 logHandler: Optional[logging.Handler] = None
 
@@ -545,6 +546,14 @@ def _shouldDisableLogging() -> bool:
 	return globalVars.appArgs.secure or noLoggingRequested
 
 
+def filterExternalDependencyLogging(record: logging.LogRecord) -> bool:
+	import config
+
+	return record.name == NVDA_LOGGER_NAME or (
+		record.levelno >= Logger.WARNING or config.conf["debugLog"]["externalPythonDependencies"]
+	)
+
+
 def initialize(shouldDoRemoteLogging=False):
 	"""Initialize logging.
 	This must be called before any logging can occur.
@@ -593,8 +602,7 @@ def initialize(shouldDoRemoteLogging=False):
 				logLevel = Logger.DEBUG
 			elif logLevel <= 0:
 				logLevel = Logger.INFO
-			log.setLevel(logLevel)
-			log.root.setLevel(max(logLevel, logging.WARN))
+			log.root.setLevel(logLevel)
 	else:
 		logHandler = RemoteHandler()
 		logFormatter = Formatter(
@@ -602,6 +610,7 @@ def initialize(shouldDoRemoteLogging=False):
 			style="{",
 		)
 	logHandler.setFormatter(logFormatter)
+	logHandler.addFilter(filterExternalDependencyLogging)
 	log.root.addHandler(logHandler)
 	redirectStdout(log)
 	sys.excepthook = _excepthook
@@ -636,5 +645,4 @@ def setLogLevelFromConfig():
 		log.warning("invalid setting for logging level: %s" % levelName)
 		level = log.INFO
 		config.conf["general"]["loggingLevel"] = logging.getLevelName(log.INFO)
-	log.setLevel(level)
-	log.root.setLevel(max(level, logging.WARN))
+	log.root.setLevel(level)

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -21,6 +21,7 @@ Please refer to [the developer guide](https://www.nvaccess.org/files/nvda/docume
 
 * NVDA now uses [uv](https://docs.astral.sh/uv/) as Python package/project manager. (#17935, #17978, @LeonarddeR)
   * Running `scons` from the source repository will automatically suggest a strategy to install uv when it is not yet available.
+* Added the "externalPythonDependencies" category as an extra debug logging category. When enabled, log messages from external dependencies (such as comtypes) will be delivered to NVDA's log. (@LeonarddeR)
 
 #### Deprecations
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -21,7 +21,7 @@ Please refer to [the developer guide](https://www.nvaccess.org/files/nvda/docume
 
 * NVDA now uses [uv](https://docs.astral.sh/uv/) as Python package/project manager. (#17935, #17978, @LeonarddeR)
   * Running `scons` from the source repository will automatically suggest a strategy to install uv when it is not yet available.
-* Added the "externalPythonDependencies" category as an extra debug logging category. When enabled, log messages from external dependencies (such as comtypes) will be delivered to NVDA's log. (#18067, @LeonarddeR)
+* Added the "externalPythonDependencies" category as an extra debug logging category. When enabled, debug logging messages from external dependencies (such as comtypes) will be delivered to NVDA's log. (#18067, @LeonarddeR)
 
 #### Deprecations
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -21,7 +21,7 @@ Please refer to [the developer guide](https://www.nvaccess.org/files/nvda/docume
 
 * NVDA now uses [uv](https://docs.astral.sh/uv/) as Python package/project manager. (#17935, #17978, @LeonarddeR)
   * Running `scons` from the source repository will automatically suggest a strategy to install uv when it is not yet available.
-* Added the "externalPythonDependencies" category as an extra debug logging category. When enabled, log messages from external dependencies (such as comtypes) will be delivered to NVDA's log. (@LeonarddeR)
+* Added the "externalPythonDependencies" category as an extra debug logging category. When enabled, log messages from external dependencies (such as comtypes) will be delivered to NVDA's log. (#18067, @LeonarddeR)
 
 #### Deprecations
 


### PR DESCRIPTION
### Link to issue number:
Follow up for #10393

### Summary of the issue:
Since #10393, we log at level warning or higher for external Python dependencies. There is no way to enable logging at lower levels, such as debug. This can however be pretty helpful for external dependencies like comtypes to see what's going on under the hood.

### Description of user facing changes
Have extra logging when a new debugging category, `externalPythonDependencies`, is enabled.

### Description of development approach
The overall logging level is now determined from the level of the root logger, which is no longer limited to a minimum of WARNING. Instead, a filter is implemented on the handler that filters appropriately. Note that initially, it made sense to add this filter to the root logger, but filters don't propagate from the root logger to all loggers below.

### Testing strategy:
Calling `comtypes.CoInitialize` with and without the new category enabled, logging at level debug. Ensured that behavior was as expected (i.e. comtypes logged when the category was enabled)

### Known issues with pull request:
In #10393, I mentioned issues with re-entrancy when comtypes logs at level debug. I have not yet reproduced this. That said, the logging categories are documented in such a way that they should only be enabled on request. I don't think this needs extra documentation.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
