### PR TITLE
Only show Remote Access actions when available

### DIFF
--- a/source/_remoteClient/client.py
+++ b/source/_remoteClient/client.py
@@ -123,6 +123,10 @@ class RemoteClient:
 			# Translators: Message shown when attempting to mute the remote computer when no session is connected.
 			ui.delayedMessage(pgettext("remote", "Not connected"))
 			return
+		elif self.leaderTransport is None:
+			# Translators: Presented when attempting to mute or unmute Remote Access when connected as the controlled computer.
+			ui.message(pgettext("remote", "Not the controlling computer"))
+			return
 		self.localMachine.isMuted = not self.localMachine.isMuted
 		self.menu.muteItem.Check(self.localMachine.isMuted)
 		# Translators: Displayed when muting speech and sounds from the remote computer
@@ -176,7 +180,13 @@ class RemoteClient:
 		:note: Requires an active leader transport connection
 		"""
 		if self.leaderTransport is None:
-			log.error("No leader transport to send SAS")
+			log.debugWarning("No leader transport to send SAS")
+			if not self.isConnected():
+				# Translators: Message shown when attempting to send ctrl+alt+del when no session is connected.
+				ui.message(pgettext("remote", "Not connected"))
+			else:
+				# Translators: Presented when attempting to send ctrl+alt+del when connected as the controlled computer.
+				ui.message(pgettext("remote", "Not the controlling computer"))
 			return
 		self.leaderTransport.send(RemoteMessageType.SEND_SAS)
 

--- a/source/_remoteClient/menu.py
+++ b/source/_remoteClient/menu.py
@@ -136,12 +136,12 @@ class RemoteMenu(wx.Menu):
 			self._switchToDisconnectItem()
 		else:
 			self._switchToConnectItem()
-		self.muteItem.Enable(connected)
+		self.muteItem.Enable(connected and mode is ConnectionMode.LEADER)
 		if not connected:
 			self.muteItem.Check(False)
 		self.pushClipboardItem.Enable(connected)
 		self.copyLinkItem.Enable(connected)
-		self.sendCtrlAltDelItem.Enable(connected)
+		self.sendCtrlAltDelItem.Enable(connected and mode is ConnectionMode.LEADER)
 
 	def handleConnecting(self, mode: ConnectionMode) -> None:
 		self._switchToDisconnectItem()

--- a/tests/unit/test_remote/test_remoteClient.py
+++ b/tests/unit/test_remote/test_remoteClient.py
@@ -110,16 +110,17 @@ class TestRemoteClient(unittest.TestCase):
 		# Initially, local machine should not be muted.
 		self.assertFalse(self.client.localMachine.isMuted)
 		# Toggle mute: should mute the local machine.
-		self.client.toggleMute()
-		self.assertTrue(self.client.localMachine.isMuted)
-		self.assertTrue(self.client.menu.muteItem.checked)
-		self.uiDelayedMessage.assert_called_once()
-		# Now toggle again: should unmute.
-		self.uiDelayedMessage.reset_mock()
-		self.client.toggleMute()
-		self.assertFalse(self.client.localMachine.isMuted)
-		self.assertFalse(self.client.menu.muteItem.checked)
-		self.uiDelayedMessage.assert_called_once()
+		with patch.object(self.client, "leaderTransport", FakeTransport):
+			self.client.toggleMute()
+			self.assertTrue(self.client.localMachine.isMuted)
+			self.assertTrue(self.client.menu.muteItem.checked)
+			self.uiDelayedMessage.assert_called_once()
+			# Now toggle again: should unmute.
+			self.uiDelayedMessage.reset_mock()
+			self.client.toggleMute()
+			self.assertFalse(self.client.localMachine.isMuted)
+			self.assertFalse(self.client.menu.muteItem.checked)
+			self.uiDelayedMessage.assert_called_once()
 
 	@patch.object(rcClient.RemoteClient, "isConnected", lambda self: True)
 	def test_toggleMuteAsFollower(self):

--- a/tests/unit/test_remote/test_remoteClient.py
+++ b/tests/unit/test_remote/test_remoteClient.py
@@ -106,7 +106,7 @@ class TestRemoteClient(unittest.TestCase):
 		self.client = None
 
 	@patch.object(rcClient.RemoteClient, "isConnected", lambda self: True)
-	def test_toggleMute(self):
+	def test_toggleMuteAsLeader(self):
 		# Initially, local machine should not be muted.
 		self.assertFalse(self.client.localMachine.isMuted)
 		# Toggle mute: should mute the local machine.
@@ -120,6 +120,16 @@ class TestRemoteClient(unittest.TestCase):
 		self.assertFalse(self.client.localMachine.isMuted)
 		self.assertFalse(self.client.menu.muteItem.checked)
 		self.uiDelayedMessage.assert_called_once()
+
+	@patch.object(rcClient.RemoteClient, "isConnected", lambda self: True)
+	def test_toggleMuteAsFollower(self):
+		# Initially, local machine should not be muted.
+		self.assertFalse(self.client.localMachine.isMuted)
+		with patch.object(self.client, "leaderTransport", None):
+			# Toggle mute: should have no effect
+			self.client.toggleMute()
+			self.assertFalse(self.client.localMachine.isMuted)
+			self.assertFalse(self.client.menu.muteItem.checked)
 
 	def test_pushClipboardNoConnection(self):
 		# Without any transport (neither follower nor leader), pushClipboard should warn.
@@ -161,9 +171,9 @@ class TestRemoteClient(unittest.TestCase):
 	def test_sendSasNoLeaderTransport(self):
 		# Without a leaderTransport, sendSAS should log an error.
 		self.client.leaderTransport = None
-		with patch("_remoteClient.client.log.error") as mockLogError:
+		with patch("_remoteClient.client.log.debugWarning") as mockLogDebugWarning:
 			self.client.sendSAS()
-			mockLogError.assert_called_once_with("No leader transport to send SAS")
+			mockLogDebugWarning.assert_called_once_with("No leader transport to send SAS")
 
 	def test_sendSasWithLeaderTransport(self):
 		# With a fake leaderTransport, sendSAS should forward the SEND_SAS message.

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -3808,7 +3808,7 @@ Once a Remote Access session is active, you can switch between controlling the r
 
 * Press `NVDA+alt+tab` to toggle between controlling and returning to your own computer.
 * Send text from your clipboard to the other computer by opening the NVDA menu, then selecting Tools, then "Remote Access", then "Send clipboard".
-* Mute the remote computer's speech output on your local computer by opening the NVDA menu, then selecting Tools, then "Remote Access", then "Mute remote".
+* If connected as the controlling computer, mute the remote computer's speech output on your local computer by opening the NVDA menu, then selecting Tools, then "Remote Access", then "Mute remote".
 
 ### Remote Access Key Commands Summary {#RemoteAccessGestures}
 


### PR DESCRIPTION
### Link to issue number:

Fixes #18039

### Summary of the issue:

The mute and send SAS items are available in the Remote Access submenu even when connected as a follower.

### Description of user facing changes

These options are only shown when connected as a leader.

### Description of development approach

In `_remoteClient.menu.Menu.handleConnected`, only enable the mute and send SAS menu items if connected and connection mode is leader.
In `_remoteClient.client.RemoteClient`, updated the `toggleMute` and `sendSAS` methods to report failure and return early when not connected as leader.
Updated unit tests to work with the new checks.

### Testing strategy:

Manually tested that the items are unavailable in the given situations.
Unit tests.

### Known issues with pull request:

None.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
