### PR TITLE
Do not interrupt Remote Access status messages when executing from the NVDA Menu

### DIFF
--- a/source/_remoteClient/client.py
+++ b/source/_remoteClient/client.py
@@ -140,11 +140,11 @@ class RemoteClient:
 		connector = self.followerTransport or self.leaderTransport
 		if not getattr(connector, "connected", False):
 			# Translators: Message shown when trying to send the clipboard to the remote computer while not connected.
-			ui.message(pgettext("remote", "Not connected"))
+			ui.delayedMessage(pgettext("remote", "Not connected"))
 			return
 		elif self.connectedClientsCount < 1:
 			# Translators: Reported when performing a Remote Access action, but there are no other computers in the channel.
-			ui.message(pgettext("remote", "No one else is connected"))
+			ui.delayedMessage(pgettext("remote", "No one else is connected"))
 			return
 		try:
 			connector.send(RemoteMessageType.SET_CLIPBOARD_TEXT, text=api.getClipData())
@@ -152,7 +152,7 @@ class RemoteClient:
 		except (TypeError, OSError):
 			log.debug("Unable to push clipboard", exc_info=True)
 			# Translators: Message shown when clipboard content cannot be sent to the remote computer.
-			ui.message(pgettext("remote", "Unable to send clipboard"))
+			ui.delayedMessage(pgettext("remote", "Unable to send clipboard"))
 
 	def copyLink(self):
 		"""Copy connection URL to clipboard.

--- a/source/_remoteClient/client.py
+++ b/source/_remoteClient/client.py
@@ -162,10 +162,12 @@ class RemoteClient:
 		session = self.leaderSession or self.followerSession
 		if session is None:
 			# Translators: Message shown when trying to copy the link to connect to the remote computer while not connected.
-			ui.message(pgettext("remote", "Not connected"))
+			ui.delayedMessage(pgettext("remote", "Not connected"))
 			return
 		url = session.getConnectionInfo().getURLToConnect()
 		api.copyToClip(str(url))
+		# Translators: A message indicating that a link has been copied to the clipboard.
+		ui.delayedMessage(_("Copied link"))
 
 	def sendSAS(self):
 		"""Send Secure Attention Sequence to remote computer.

--- a/source/_remoteClient/client.py
+++ b/source/_remoteClient/client.py
@@ -120,7 +120,7 @@ class RemoteClient:
 		"""
 		if not self.isConnected():
 			# Translators: Message shown when attempting to mute the remote computer when no session is connected.
-			ui.message(pgettext("remote", "Not connected"))
+			ui.delayedMessage(pgettext("remote", "Not connected"))
 			return
 		self.localMachine.isMuted = not self.localMachine.isMuted
 		self.menu.muteItem.Check(self.localMachine.isMuted)
@@ -129,7 +129,7 @@ class RemoteClient:
 		# Translators: Displayed when unmuting speech and sounds from the remote computer
 		UNMUTE_MESSAGE = _("Unmuted remote")
 		status = MUTE_MESSAGE if self.localMachine.isMuted else UNMUTE_MESSAGE
-		ui.message(status)
+		ui.delayedMessage(status)
 
 	def pushClipboard(self):
 		"""Send local clipboard content to the remote computer.

--- a/source/_remoteClient/cues.py
+++ b/source/_remoteClient/cues.py
@@ -65,7 +65,7 @@ def _playCue(cueName: str) -> None:
 
 	# Show message if specified
 	if message := CUES[cueName].get("message"):
-		ui.message(message)
+		ui.delayedMessage(message)
 
 
 def connected():

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -4911,8 +4911,6 @@ class GlobalCommands(ScriptableObject):
 	@gui.blockAction.when(gui.blockAction.Context.REMOTE_ACCESS_DISABLED)
 	def script_copyRemoteLink(self, gesture: "inputCore.InputGesture"):
 		_remoteClient._remoteClient.copyLink()
-		# Translators: A message indicating that a link has been copied to the clipboard.
-		ui.message(_("Copied link"))
 
 	@script(
 		category=SCRCAT_REMOTE,

--- a/source/gui/blockAction.py
+++ b/source/gui/blockAction.py
@@ -11,15 +11,8 @@ from enum import Enum
 from functools import wraps
 import globalVars
 from typing import Any
-from speech.priorities import SpeechPriority
 import ui
 from utils.security import isLockScreenModeActive, isRunningOnSecureDesktop
-import core
-
-_DELAY_BEFORE_MESSAGE_MS = 1
-"""Duration in milliseconds for which to delay announcing that an action has been blocked, so that any UI changes don't interrupt it.
-1ms is a magic number. It can be increased if it is found to be too short, but it should be kept to a minimum.
-"""
 
 
 def _isModalMessageBoxActive() -> bool:
@@ -114,12 +107,7 @@ def when(*contexts: Context):
 					if context.callback is not None:
 						context.callback()
 					# We need to delay this message so that, if a UI change is triggered by the callback, the UI change doesn't interrupt it.
-					core.callLater(
-						_DELAY_BEFORE_MESSAGE_MS,
-						ui.message,
-						context.translatedMessage,
-						SpeechPriority.NOW,
-					)
+					ui.delayedMessage(context.translatedMessage)
 					return
 			return func(*args, **kwargs)
 

--- a/tests/unit/test_remote/test_remoteClient.py
+++ b/tests/unit/test_remote/test_remoteClient.py
@@ -125,7 +125,7 @@ class TestRemoteClient(unittest.TestCase):
 		self.client.followerTransport = None
 		self.client.leaderTransport = None
 		self.client.pushClipboard()
-		self.uiMessage.assert_called_with("Not connected")
+		self.uiDelayedMessage.assert_called_with("Not connected")
 
 	def test_pushClipboardWithTransport(self):
 		# With a fake transport, pushClipboard should send the clipboard text.

--- a/tests/unit/test_remote/test_remoteClient.py
+++ b/tests/unit/test_remote/test_remoteClient.py
@@ -147,7 +147,7 @@ class TestRemoteClient(unittest.TestCase):
 		self.client.followerSession = None
 		self.uiMessage.reset_mock()
 		self.client.copyLink()
-		self.uiMessage.assert_called_with("Not connected")
+		self.uiDelayedMessage.assert_called_with("Not connected")
 
 	def test_copyLinkWithSession(self):
 		# With a fake session, copyLink should call api.copyToClip with the proper URL.

--- a/tests/unit/test_remote/test_remoteClient.py
+++ b/tests/unit/test_remote/test_remoteClient.py
@@ -88,6 +88,9 @@ class TestRemoteClient(unittest.TestCase):
 		patcher = patch("_remoteClient.client.ui.message")
 		self.addCleanup(patcher.stop)
 		self.uiMessage = patcher.start()
+		delayedMessagePatcher = patch("_remoteClient.client.ui.delayedMessage")
+		self.addCleanup(delayedMessagePatcher.stop)
+		self.uiDelayedMessage = delayedMessagePatcher.start()
 		# Patch the API module to use our fake API.
 		patcherAPI = patch("_remoteClient.client.api", new=FakeAPI)
 		self.addCleanup(patcherAPI.stop)
@@ -109,13 +112,13 @@ class TestRemoteClient(unittest.TestCase):
 		self.client.toggleMute()
 		self.assertTrue(self.client.localMachine.isMuted)
 		self.assertTrue(self.client.menu.muteItem.checked)
-		self.uiMessage.assert_called_once()
+		self.uiDelayedMessage.assert_called_once()
 		# Now toggle again: should unmute.
-		self.uiMessage.reset_mock()
+		self.uiDelayedMessage.reset_mock()
 		self.client.toggleMute()
 		self.assertFalse(self.client.localMachine.isMuted)
 		self.assertFalse(self.client.menu.muteItem.checked)
-		self.uiMessage.assert_called_once()
+		self.uiDelayedMessage.assert_called_once()
 
 	def test_pushClipboardNoConnection(self):
 		# Without any transport (neither follower nor leader), pushClipboard should warn.


### PR DESCRIPTION
### Link to issue number:

Closes #17947
Supersedes #17991 

### Summary of the issue:

When executing some Remote Access actions via the Remote Access submenu in the NVDA menu, the status is interrupted by the focus changing, making the messages useless.

### Description of user facing changes

Remote Access actions performed via the NVDA menu should now correctly report their status.

### Description of development approach

- Add a `delayedMessage` function to `ui`, based on the approach taken for focusing open blocking modals in #17582.
  - Remove the now duplicated code, and replace it with a call to `ui.delayedMessage`.
- In `_remoteClient.client.RemoteClient`, updated `copyLink`, `pushClipboard`, and `toggleMute`, to use `ui.delayedMessage` instead of `ui.message`, as these methods can be envoked directly from the menu.
  - Also moved the success message out of `globalCommands.GlobalCommands.script_copyRemoteLink` into `_remoteClient.client.RemoteClient.copyLink`.
- Updated `_remoteClient.cues._playCue` to use `ui.delayedMessage` instead of `ui.message`, as the "Disconnect" menu item causes a cue to be issued. This means that cues should work even if issued at the same time as a UI change, and should have very little performance impact.

### Testing strategy:

- Performed the above listed commands with and without a Remote Access session in progress.

### Known issues with pull request:

None

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
