### PR TITLE
Make Remote Access settings visible but read only in secure mode

### DIFF
--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -19,6 +19,7 @@ import re
 import typing
 import requests
 import wx
+import wx.adv
 from NVDAState import WritePaths
 
 from utils import mmdevice
@@ -3330,6 +3331,7 @@ class RemoteSettingsPanel(SettingsPanel):
 		sHelper.addItem(remoteControlsGroupHelper)
 
 		if globalVars.appArgs.secure:
+			self._insertReadOnlyNotice(sHelper)
 			remoteControlsGroupBox.Disable()
 
 		self.enableRemote = remoteControlsGroupHelper.addItem(
@@ -3441,6 +3443,18 @@ class RemoteSettingsPanel(SettingsPanel):
 		self.bindHelpEvent("RemoteDeleteFingerprints", self.deleteFingerprints)
 
 		self._setFromConfig()
+
+	def _insertReadOnlyNotice(self, sHelper):
+		banner = wx.adv.BannerWindow(self, dir=wx.TOP)
+		banner.SetText(
+			# Translators: Title of a message presented to users when viewing Remote Access settings in secure mode.
+			pgettext("remote", "Read only"),
+			# Translators: Message presented to users when viewing Remote Access settings in secure mode.
+			pgettext("remote", "Remote Access settings are read only as NVDA is running in secure mode."),
+		)
+		normalBgColour = self.GetBackgroundColour()
+		banner.SetGradient(normalBgColour, normalBgColour)
+		sHelper.sizer.Insert(0, banner)
 
 	def _setControls(self) -> None:
 		"""Ensure the state of the GUI is internally consistent, as well as consistent with the state of the config.
@@ -5463,8 +5477,6 @@ class NVDASettingsDialog(MultiCategorySettingsDialog):
 		AddonStorePanel,
 		RemoteSettingsPanel,
 	]
-	# if not globalVars.appArgs.secure:
-	# categoryClasses.append(RemoteSettingsPanel)
 	if touchHandler.touchSupported():
 		categoryClasses.append(TouchInteractionPanel)
 	if winVersion.isUwpOcrAvailable():

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -3324,20 +3324,25 @@ class RemoteSettingsPanel(SettingsPanel):
 		self.config = config.conf["remote"]
 		sHelper = guiHelper.BoxSizerHelper(self, sizer=sizer)
 
-		self.enableRemote = sHelper.addItem(
+		remoteControlsGroupSizer = wx.StaticBoxSizer(wx.VERTICAL, self)
+		remoteControlsGroupBox = remoteControlsGroupSizer.GetStaticBox()
+		remoteControlsGroupHelper = guiHelper.BoxSizerHelper(self, sizer=remoteControlsGroupSizer)
+		sHelper.addItem(remoteControlsGroupHelper)
+
+		self.enableRemote = remoteControlsGroupHelper.addItem(
 			# Translators: Label of a checkbox in Remote Access settings
-			wx.CheckBox(self, label=pgettext("remote", "Enable Remote Access")),
+			wx.CheckBox(remoteControlsGroupBox, label=pgettext("remote", "Enable Remote Access")),
 		)
 		self.enableRemote.Bind(wx.EVT_CHECKBOX, self._onEnableRemote)
 		self.bindHelpEvent("RemoteEnable", self.enableRemote)
 
 		remoteSettingsGroupSizer = wx.StaticBoxSizer(
 			wx.VERTICAL,
-			self,
+			remoteControlsGroupBox,
 		)
 		self.remoteSettingsGroupBox = remoteSettingsGroupSizer.GetStaticBox()
 		remoteSettingsGroupHelper = guiHelper.BoxSizerHelper(self, sizer=remoteSettingsGroupSizer)
-		sHelper.addItem(remoteSettingsGroupHelper)
+		remoteControlsGroupHelper.addItem(remoteSettingsGroupHelper)
 
 		self.playSounds = remoteSettingsGroupHelper.addItem(
 			wx.CheckBox(
@@ -3425,9 +3430,9 @@ class RemoteSettingsPanel(SettingsPanel):
 		)
 		self.bindHelpEvent("RemoteAutoconnectKey", self.key)
 
-		self.deleteFingerprints = sHelper.addItem(
+		self.deleteFingerprints = remoteControlsGroupHelper.addItem(
 			# Translators: A button in Remote Access settings to delete all fingerprints of unauthorized certificates.
-			wx.Button(self, label=_("Delete all trusted fingerprints")),
+			wx.Button(remoteControlsGroupBox, label=_("Delete all trusted fingerprints")),
 		)
 		self.deleteFingerprints.Bind(wx.EVT_BUTTON, self.onDeleteFingerprints)
 		self.bindHelpEvent("RemoteDeleteFingerprints", self.deleteFingerprints)

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -3325,9 +3325,12 @@ class RemoteSettingsPanel(SettingsPanel):
 		sHelper = guiHelper.BoxSizerHelper(self, sizer=sizer)
 
 		remoteControlsGroupSizer = wx.StaticBoxSizer(wx.VERTICAL, self)
-		remoteControlsGroupBox = remoteControlsGroupSizer.GetStaticBox()
+		remoteControlsGroupBox: wx.StaticBox = remoteControlsGroupSizer.GetStaticBox()
 		remoteControlsGroupHelper = guiHelper.BoxSizerHelper(self, sizer=remoteControlsGroupSizer)
 		sHelper.addItem(remoteControlsGroupHelper)
+
+		if globalVars.appArgs.secure:
+			remoteControlsGroupBox.Disable()
 
 		self.enableRemote = remoteControlsGroupHelper.addItem(
 			# Translators: Label of a checkbox in Remote Access settings
@@ -5458,9 +5461,10 @@ class NVDASettingsDialog(MultiCategorySettingsDialog):
 		DocumentFormattingPanel,
 		DocumentNavigationPanel,
 		AddonStorePanel,
+		RemoteSettingsPanel,
 	]
-	if not globalVars.appArgs.secure:
-		categoryClasses.append(RemoteSettingsPanel)
+	# if not globalVars.appArgs.secure:
+	# categoryClasses.append(RemoteSettingsPanel)
 	if touchHandler.touchSupported():
 		categoryClasses.append(TouchInteractionPanel)
 	if winVersion.isUwpOcrAvailable():

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -3331,7 +3331,7 @@ class RemoteSettingsPanel(SettingsPanel):
 		sHelper.addItem(remoteControlsGroupHelper)
 
 		if globalVars.appArgs.secure:
-			self._insertReadOnlyNotice(sHelper)
+			self._insertReadOnlyNotice(sizer)
 			remoteControlsGroupBox.Disable()
 
 		self.enableRemote = remoteControlsGroupHelper.addItem(
@@ -3444,7 +3444,7 @@ class RemoteSettingsPanel(SettingsPanel):
 
 		self._setFromConfig()
 
-	def _insertReadOnlyNotice(self, sHelper):
+	def _insertReadOnlyNotice(self, sizer: wx.BoxSizer):
 		banner = wx.adv.BannerWindow(self, dir=wx.TOP)
 		banner.SetText(
 			# Translators: Title of a message presented to users when viewing Remote Access settings in secure mode.
@@ -3454,7 +3454,7 @@ class RemoteSettingsPanel(SettingsPanel):
 		)
 		normalBgColour = self.GetBackgroundColour()
 		banner.SetGradient(normalBgColour, normalBgColour)
-		sHelper.sizer.Insert(0, banner)
+		sizer.Insert(0, banner)
 
 	def _setControls(self) -> None:
 		"""Ensure the state of the GUI is internally consistent, as well as consistent with the state of the config.


### PR DESCRIPTION
- **Add all remote controls to a static box sizer**
- **Show Remote Access settings in secure mode disabled**
- **Show a banner window explaining why all options are disabled**
### Link to issue number:

Closes #17946
Supersedes #17987

### Summary of the issue:

Remote Access's settings are entirely absent from the settings dialog in secure mode.

### Description of user facing changes

Remote Access's settings are now present, but disabled, in the settings dialog in secure mode.

### Description of development approach

Add all controls in the Remote Access settings panel to a static box sizer so that they can be disabled en masse. If running in secure mode, disable this static box. Also add a `wx.adv.BannerWindow` explaining why the controls are read-only, similar to the Add-on Store dialog. Move `RemoteSettingsPanel` to always be present in the settings categories.

### Testing strategy:

Started NVDA normally and in secure mode (with `--secure`) and opened Remote Access's settings.

### Known issues with pull request:

The checkboxes are not visually dimmed, though they are inoperable.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
