### PR TITLE
Fixed the disconnect confirmation box blocking the main thread

### DIFF
--- a/source/_remoteClient/client.py
+++ b/source/_remoteClient/client.py
@@ -18,7 +18,7 @@ import wx
 from config import isInstalledCopy
 from keyboardHandler import KeyboardInputGesture
 from logHandler import log
-from gui.guiHelper import alwaysCallAfter, wxCallOnMain
+from gui.guiHelper import alwaysCallAfter
 from utils.security import isRunningOnSecureDesktop
 from gui.message import MessageDialog, DefaultButton, ReturnCode, DialogType
 import scriptHandler
@@ -192,6 +192,7 @@ class RemoteClient:
 		elif connectionInfo.mode == ConnectionMode.FOLLOWER:
 			self.connectAsFollower(connectionInfo)
 
+	@alwaysCallAfter
 	def disconnect(self):
 		"""Close all active connections and clean up resources.
 
@@ -226,7 +227,7 @@ class RemoteClient:
 					buttons=confirmation_buttons,
 				)
 
-				if wxCallOnMain(dialog.ShowModal) != ReturnCode.YES:
+				if dialog.ShowModal() != ReturnCode.YES:
 					log.info("Remote disconnection cancelled by user.")
 					return
 

--- a/tests/unit/test_remote/test_remoteClient.py
+++ b/tests/unit/test_remote/test_remoteClient.py
@@ -202,7 +202,9 @@ class TestRemoteClient(unittest.TestCase):
 		self.client.leaderSession = None
 		self.client.followerSession = None
 		with patch("_remoteClient.client.log.debug") as mockLogDebug:
-			self.client.disconnect()
+			# `disconnect` is decorated with `alwaysCallAfter`, which causes it to be executed on the GUI thread.
+			# Unwrap it since we want it to run on this thread.
+			rcClient.RemoteClient.disconnect.__wrapped__(self.client)
 			mockLogDebug.assert_called()
 		# Test disconnect with an active localControlServer.
 		fakeControl = MagicMock()
@@ -210,7 +212,9 @@ class TestRemoteClient(unittest.TestCase):
 		self.client.leaderSession = MagicMock()
 		self.client.followerSession = MagicMock()
 		with patch.object(rcClient.MessageDialog, "ShowModal", lambda *a, **k: ReturnCode.YES):
-			self.client.disconnect()
+			# `disconnect` is decorated with `alwaysCallAfter`, which causes it to be executed on the GUI thread.
+			# Unwrap it since we want it to run on this thread.
+			rcClient.RemoteClient.disconnect.__wrapped__(self.client)
 		fakeControl.close.assert_called_once()
 
 


### PR DESCRIPTION
### Link to issue number:

Follow-up to #18044

### Summary of the issue:

The Remote Access disconnect confirmation dialog blocks the main thread.

### Description of user facing changes

Dialog doesn't block the main thread.

### Description of development approach

Undid my change that only called the dialog on the GUI thread, and instead called the whole disconnect function on the GUI thread (as @@cary-rowen did). Waiting for the response from the GUI thread still blocked the main thread, causing NVDA to lock up.
Modified the unit tests to unwrap `RemoteClient.disconnect` before calling it, so that it runs on the same thread as the unit tests. Failure to do so causes the tests to fail as the two threads aren't synchronised. This is why I initially changed this function, but evidently I wasn't thinking or testing properly.

### Testing strategy:

Ran from source, connected as follower, tried to disconnect, ensured I could still use NVDA and that the process worked as expected.

### Known issues with pull request:
None

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
