### PR TITLE
Avoid unintended consequences when switching control back to the local computer

### DIFF
--- a/source/_remoteClient/client.py
+++ b/source/_remoteClient/client.py
@@ -564,7 +564,6 @@ class RemoteClient:
 			)
 		# release all pressed keys in the guest.
 		for k in self.keyModifiers:
-			log.info(k)
 			self.leaderTransport.send(
 				RemoteMessageType.KEY,
 				vk_code=k[0],

--- a/source/_remoteClient/client.py
+++ b/source/_remoteClient/client.py
@@ -16,12 +16,13 @@ import inputCore
 import ui
 import wx
 from config import isInstalledCopy
-from keyboardHandler import KeyboardInputGesture
+from keyboardHandler import KeyboardInputGesture, canModifiersPerformAction
 from logHandler import log
 from gui.guiHelper import alwaysCallAfter, wxCallOnMain
 from utils.security import isRunningOnSecureDesktop
 from gui.message import MessageDialog, DefaultButton, ReturnCode, DialogType
 import scriptHandler
+import winUser
 
 from . import configuration, cues, dialogs, serializer, server, urlHandler
 from .connectionInfo import ConnectionInfo, ConnectionMode
@@ -542,8 +543,28 @@ class RemoteClient:
 
 		:note: Sends key-up events for all held modifiers
 		"""
+		# Before releasing the keys, check if doing so will cause unintended consequences
+		if canModifiersPerformAction(KeyboardInputGesture._generalizeModifiers(self.keyModifiers)):
+			# Releasing these keys alone could cause an action, which is most likely not what the user wants.
+			# Send special reserved vkcode VK_NONE (0xff)
+			# to notify the remote computer's key state that something happened.
+			# This allows gestures which would cause an action if `NVDA` and the non-modifier key were removed
+			# to be used to toggle between controling the local and remote computers.
+			self.leaderTransport.send(
+				RemoteMessageType.KEY,
+				vk_code=winUser.VK_NONE,
+				extended=False,
+				pressed=True,
+			)
+			self.leaderTransport.send(
+				RemoteMessageType.KEY,
+				vk_code=winUser.VK_NONE,
+				extended=False,
+				pressed=False,
+			)
 		# release all pressed keys in the guest.
 		for k in self.keyModifiers:
+			log.info(k)
 			self.leaderTransport.send(
 				RemoteMessageType.KEY,
 				vk_code=k[0],

--- a/source/keyboardHandler.py
+++ b/source/keyboardHandler.py
@@ -496,6 +496,13 @@ class KeyboardInputGesture(inputCore.InputGesture):
 
 	@classmethod
 	def _generalizeModifiers(cls, modifiers: _ModifierT) -> _ModifierT:
+		"""Return the input set, with specific modifiers replaced with their general equivalents.
+
+		Replaces keys like leftAlt or rightCtrl with their generic alternatives (i.e. alt or ctrl).
+
+		:param modifiers: Set of (vkCode, extended) tuples.
+		:return: A copy of the input set with the specific modifiers replaced with their general equivalents.
+		"""
 		return set((cls.NORMAL_MODIFIER_KEYS.get(mod) or mod, extended) for mod, extended in modifiers)
 
 	def _get_bypassInputHelp(self):


### PR DESCRIPTION
### Link to issue number:

Closes #17969

### Summary of the issue:

The default gesture to toggle control between guest and host (`NVDA+alt+tab`) results in unintended consequences on the remote computer.

### Description of user facing changes

These consequences should be avoided.

### Description of development approach

- Refactored `keyboardHandler.KeyboardInputGesture.__init__` to make the logic for generalising modifier keys its own method.
- In `_remoteClient.client.RemoteClient.releaseKeys`, send a keydown and keyup for `VK_NONE` before releasing all modifiers, if not doing so could cause side effects.
  - Based on the logic in `keyboardHandler.KeyboardInputGesture.executeGesture`.

### Testing strategy:

Tested disconnecting with Firefox opened, and ensured that the menubar did not receive focus.

### Known issues with pull request:

If the user somehow enabled input help on the local computer while controling the remote computer and toggled input back to the local computer via the keyboard, the `VK_NONE`s will not be sent. I don't see how this would ever (reasonably) happen, so I consider it a non-issue.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
