### PR TITLE
Allow switch from remote to local computer when disconnected.

### DIFF
--- a/source/_remoteClient/client.py
+++ b/source/_remoteClient/client.py
@@ -503,7 +503,7 @@ class RemoteClient:
 		:param gesture: The keyboard gesture that triggered this
 		:note: Also toggles braille input and mute state
 		"""
-		if not self.isConnected():
+		if not self.isConnected() and not self.sendingKeys:
 			# Translators: A message indicating that the remote client is not connected.
 			ui.message(pgettext("remote", "Not connected"))
 			return

--- a/source/_remoteClient/transport.py
+++ b/source/_remoteClient/transport.py
@@ -562,7 +562,7 @@ class TCPTransport(Transport):
 				log.debug(f"Enqueuing outbound message: {obj!r}")
 			self.queue.put(obj)
 		else:
-			log.error(f"Attempted to send message {type} while not connected")
+			log.debugWarning(f"Attempted to send message {type} while not connected")
 
 	def _disconnect(self) -> None:
 		"""Internal method to disconnect the transport.

--- a/tests/unit/test_remote/test_transport.py
+++ b/tests/unit/test_remote/test_transport.py
@@ -151,11 +151,11 @@ class TestTransportSendAndQueue(unittest.TestCase):
 		self.assertEqual(result["type"], "TEST_TYPE")
 		self.assertEqual(result["key"], 123)
 
-	def test_sendWhenNotConnectedLogsError(self):
+	def test_sendWhenNotConnectedLogsWarning(self):
 		self.transport.connected = False
-		with mock.patch("_remoteClient.transport.log.error") as mockError:
+		with mock.patch("_remoteClient.transport.log.debugWarning") as mockWarning:
 			self.transport.send("TEST", a=1)
-		mockError.assert_called_once()
+		mockWarning.assert_called_once()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### Link to issue number:
Fixes #18081.

### Summary of the issue:
When using NVDA Remote Access, if you are disconnected from the remote server while controlling the remote computer, it is impossible to switch back to the local computer.

### Description of user facing changes
It is now possible to switch back to the local computer in this situation.

### Description of development approach
1. In `RemoteClient.toggleRemoteKeyControl`, only check if we're disconnected when switching to the remote computer. If we're switching to the local computer, allow the switch regardless of the connection status.
2. In `TCPTransport.send`, log the disconnected error as a debugWarning instead of an error to prevent spurious error sounds in this case, since it is an expected, albeit less common, scenario.

I considered returning control to the local computer immediately when the server disconnects. However, there are two problems with this that made me decide against it:

1. It is risky because the user might press keys thinking they are going to the remote computer, when they're actually going to the local computer. Switching should always be an explicit user action.
2. The disconnection might be temporary and the user shouldn't have to switch again in that case.

### Testing strategy:
Followed the steps to reproduce from #18081. Verified the expected result.

### Known issues with pull request:
None.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry (did not include because this is a new feature in this release)
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
