### PR TITLE
When using Word shortcuts to change view type, report the new view

### DIFF
--- a/source/appModules/winword.py
+++ b/source/appModules/winword.py
@@ -69,6 +69,19 @@ class WinwordWordDocument(WordDocument):
 		except AttributeError:
 			return super()._get_description()
 
+	@script(gestures=["kb:control+alt+o", "kb:control+alt+p"])
+	def script_changeViewType(self, gesture: "inputCore.InputGesture") -> None:
+		if not self.WinwordWindowObject:
+			# We cannot fetch the Word object model, so we therefore cannot report the status change.
+			# The object model may be unavailable because it's within Windows Defender Application Guard.
+			# In this case, just let the gesture through and don't report anything.
+			return gesture.send()
+		val = self._WaitForValueChangeForAction(
+			lambda: gesture.send(),
+			lambda: self.WinwordWindowObject.view.Type,
+		)
+		ui.message(ViewType(val).displayString)
+
 	@script(gesture="kb:control+shift+e")
 	def script_toggleChangeTracking(self, gesture):
 		if not self.WinwordDocumentObject:

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -6,6 +6,8 @@
 
 ### New Features
 
+* In MS Word the new view is now reported when using the shortcuts to switch to page view (`control+alt+p`) or outline view (`control+alt+o`). (#18091, @CyrilleB79)
+
 ### Changes
 
 ### Bug Fixes

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -6,7 +6,7 @@
 
 ### New Features
 
-* In MS Word the new view is now reported when using the shortcuts to switch to page view (`control+alt+p`) or outline view (`control+alt+o`). (#18091, @CyrilleB79)
+* In Microsoft Word, the new view is now reported when using the shortcuts to switch to page view (`control+alt+p`) or outline view (`control+alt+o`). (#18091, @CyrilleB79)
 
 ### Changes
 


### PR DESCRIPTION
### Link to issue number:
None
### Summary of the issue:
Word has shortcuts to change view type (page, outline, etc.)

### Description of user facing changes
When using Word shortcuts to change the view type, the new view type is reported. The following shortcuts are supported:
* `control+alt+p`: page view
* `control+alt+o`: outline view

Words has also a shortcut `control+alt+n` to switch to draft (normal) mode. Since it is overridden by NVDA's launch shortcut, it is not supported in this PR. Changing NVDA's well known default launch shortcut to free Word's native `control+alt+n` is not worth it.

### Description of development approach
Usual pattern for Word toggle scripts using the object model.

### Testing strategy:
Manuel test in Word (2021 LTSC).

### Known issues with pull request:
None
### Code Review Checklist:


- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
