### PR TITLE
COM registration fixing tool: don't run when cancelling with alt+f4 on the Intro screen

### DIFF
--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -532,7 +532,7 @@ class MainFrame(wx.Frame):
 			helpId="RunCOMRegistrationFixingTool",
 		)
 		response: int = introDialog.ShowModal()
-		if response == wx.CANCEL:
+		if response != wx.OK:
 			log.debug("Run of COM Registration Fixing Tool canceled before UAC.")
 			return
 		progressDialog = IndeterminateProgressDialog(

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -168,7 +168,7 @@ This option is enabled by default, but may result in increased battery depletion
 * In web browsers, changes to text selection no longer sometimes fail to be reported in editable text controls. (#17501, @jcsteh)
 * When anchor links point to the same object as the virtual caret is placed, NVDA no longer fails to scroll to the link destination. (#17669, @nvdaes)
 * The NVDA Highlighter Window icon is no longer fixed in the taskbar after restarting Explorer. (#17696, @hwf1324)
-* Closing the COM registration fixing tool while on its intro screen with alt+f4 now correctly cancels the tool rather than letting it try to run. (#18090) 
+* Closing the COM registration fixing tool while on its intro screen with alt+f4 now correctly cancels the tool rather than letting it try to run. (#18090)
 
 ### Changes for Developers
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -168,6 +168,7 @@ This option is enabled by default, but may result in increased battery depletion
 * In web browsers, changes to text selection no longer sometimes fail to be reported in editable text controls. (#17501, @jcsteh)
 * When anchor links point to the same object as the virtual caret is placed, NVDA no longer fails to scroll to the link destination. (#17669, @nvdaes)
 * The NVDA Highlighter Window icon is no longer fixed in the taskbar after restarting Explorer. (#17696, @hwf1324)
+* Closing the COM registration fixing tool while on its intro screen with alt+f4 now correctly cancels the tool rather than letting it try to run. (#18090) 
 
 ### Changes for Developers
 


### PR DESCRIPTION
- **COM reg fixing tool: dismissing the intro dialog with anything but pressing continue should disallow the tool to run. Previously although cancel / escape stopped, alt+f4 allowed it to continue. Alt+f4 on ShowModal() returns 0, not wx.OK or wx.Cancel. So therefore check specifically for wx.OK.**
- **Update what's new**

<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Fixes #18090

### Summary of the issue:
When running the COM registration fixing tool (NVDA menu -> tools -> Run COM Registration fixing tool...), it shows an intro screen with Continue and Cancel buttons. Activating Cancel or pressing escape correctly exits the tool without running it, however pressing alt+f4 on this screen incorrectly allows it to try and continue. 
`ShowModal` on this dialog returns the following:
* Activating Continue button: wx.OK
* Activating cancel button: wx.Cancel
* Pressing escape: wx.Cancel
* Pressing alt+f4: 0

### Description of user facing changes
* when pressing alt+f4 on the COM registration fixing tool's intro screen, the tool is correctly cancelled and does not try and run.

### Description of development approach
If the response from the intro dialog's `showModal` call is not wx.OK, then cancel. Otherwise, continue to run the tool. Previously,  it would cancel if the value was wx.Cancel, and run otherwise. In otherwords, anything other than OK will now cause it to cancel.

### Testing strategy:
* [x]  Tested manually in Python console.
* [x] Test COM registration tool with a signed try build.
Steps include:
* launching tool and pressing continue. It should continue.
* Launching tool and pressing cancel. It should cancel.
* Launching tool and pressing escape. It should cancel.
* Launching tool and pressing alt+f4. It should cancel.
 
### Known issues with pull request:
Perhaps _ContinueCancel dialog should return wx.Cancel on alt+f4. Though I am guessing that would involve custom handling of the close event. It is also possible that  making it inherit from the newer `gui.messageDialog.MessageDialog` and doing any necessary refactoring could have different results? However, for now I went with the smallest change.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
