### PR TITLE
Revert "Fix SAPI4 WASAPI implementation (#17999)"

### DIFF
--- a/source/synthDrivers/sapi4.py
+++ b/source/synthDrivers/sapi4.py
@@ -618,9 +618,12 @@ class SynthDriverAudio(COMObject):
 		elif self._deviceState in (_AudioState.UNCLAIMED, _AudioState.UNCLAIMING):
 			log.debugWarning("Audio data written when device is not claimed")
 			raise ReturnHRESULT(AudioError.NOT_CLAIMED, None)
+		elif self._freeBytes < dwSize:
+			raise ReturnHRESULT(AudioError.NOT_ENOUGH_DATA, None)
 		with self._audioCond:
 			self._audioQueue.append(string_at(pBuffer, dwSize))
 			self._writtenBytes += dwSize
+			self._freeBytes -= dwSize
 			self._audioCond.notify()
 
 	@_logTrace()
@@ -663,6 +666,7 @@ class SynthDriverAudio(COMObject):
 
 	def _onChunkFinished(self, size: int):
 		self._playedBytes += size
+		self._freeBytes += size
 		if self._notifySink:
 			self._queueNotification(self._notifySink.FreeSpace, self._freeBytes, 0)
 


### PR DESCRIPTION
### Reverts PR
Reverts #17999

### Issues fixed
<!-- Issues that will be closed by reverting, i.e. the issues introduced via the PR getting reverted  -->
No GitHub issue yet

### Issues reopened
<!-- Issues that will be re-opened by reverting, i.e. the issues that were fixed via the PR getting reverted  -->
Reopens #17964

### Reason for revert

In the "Known issues with pull request" section of #17999:

> This is not the same behavior as the built-in WinMM implementation, which uses a buffer of a fixed size, and will reject new data when the buffer is full. So it's possible that this behavior doesn't work well with some certain voices.

As a user reported, this makes certain SAPI4 voices respond slower when the text to be spoken is longer.

Those SAPI4 voices won't start playing the audio until the audio buffer is full or the whole utterance has been synthesized. As #17999 made the buffer size "infinite", the audio buffer will never be full, so the longer the text, the longer it takes to synthesize the utterance, and user have to wait for the entire utterance to be synthesized.

The built-in implementation uses a buffer of a fixed size, so the buffer will be filled up quickly, and the audio will start playing while the rest of the utterance is being synthesized.

### Can this PR be reimplemented? If so, what is required for the next attempt

We should look for another way to fix the problem, and make the WASAPI implementation as similar to the original implementation as we can.

Unfortunately I haven't been able to reproduce #17964 yet. So I want to revert #17999 first to prevent breaking more voices.