### PR TITLE
Remove the option for Remote Access to play beeps

### DIFF
--- a/source/_remoteClient/cues.py
+++ b/source/_remoteClient/cues.py
@@ -9,43 +9,41 @@ from typing import Dict, Optional, TypedDict
 import globalVars
 import nvwave
 import ui
-from tones import BeepSequence, beepSequenceAsync
-
-from . import configuration
 
 
 class Cue(TypedDict, total=False):
 	wave: Optional[str]
-	beeps: Optional[BeepSequence]
 	message: Optional[str]
 
 
 # Declarative dictionary of all possible cues
 CUES: Dict[str, Cue] = {
-	"connected": {"wave": "connected", "beeps": [(440, 60), (660, 60)]},
+	"connected": {
+		"wave": "connected",
+	},
 	"disconnected": {
 		"wave": "disconnected",
-		"beeps": [(660, 60), (440, 60)],
 		# Translators: Message shown when the connection to the remote computer is lost.
 		"message": _("Disconnected"),
 	},
 	"controlServerConnected": {
 		"wave": "controlled",
-		"beeps": [(720, 100), (None, 50), (720, 100), (None, 50), (720, 100)],
 		# Translators: Presented in direct (client to server) Remote Access connection when the controlled computer is ready.
 		"message": pgettext("remote", "Connected as controlled computer"),
 	},
-	"clientConnected": {"wave": "controlling", "beeps": [(1000, 300)]},
-	"clientDisconnected": {"wave": "disconnected", "beeps": [(108, 300)]},
+	"clientConnected": {
+		"wave": "controlling",
+	},
+	"clientDisconnected": {
+		"wave": "disconnected",
+	},
 	"clipboardPushed": {
 		"wave": "clipboardPush",
-		"beeps": [(500, 100), (600, 100)],
 		# Translators: Message shown when the clipboard is successfully sent to the remote computer.
 		"message": pgettext("remote", "Clipboard sent"),
 	},
 	"clipboardReceived": {
 		"wave": "clipboardReceive",
-		"beeps": [(600, 100), (500, 100)],
 		# Translators: Message shown when the clipboard is successfully received from the remote computer.
 		"message": _("Clipboard received"),
 	},
@@ -54,14 +52,9 @@ CUES: Dict[str, Cue] = {
 
 def _playCue(cueName: str) -> None:
 	"""Helper function to play a cue by name"""
-	if shouldPlaySounds():
-		# Play wave file
-		if wave := CUES[cueName].get("wave"):
-			nvwave.playWaveFile(os.path.join(globalVars.appDir, "waves", wave + ".wav"))
-	elif beeps := CUES[cueName].get("beeps"):
-		# Play beep sequence
-		filteredBeeps = [(freq, dur) for freq, dur in beeps if freq is not None]
-		beepSequenceAsync(*filteredBeeps)
+	# Play wave file
+	if wave := CUES[cueName].get("wave"):
+		nvwave.playWaveFile(os.path.join(globalVars.appDir, "waves", wave + ".wav"))
 
 	# Show message if specified
 	if message := CUES[cueName].get("message"):
@@ -94,7 +87,3 @@ def clipboardPushed():
 
 def clipboardReceived():
 	_playCue("clipboardReceived")
-
-
-def shouldPlaySounds() -> bool:
-	return configuration.getRemoteConfig()["ui"]["playSounds"]

--- a/source/_remoteClient/cues.py
+++ b/source/_remoteClient/cues.py
@@ -12,12 +12,12 @@ import ui
 
 
 class Cue(TypedDict, total=False):
-	wave: Optional[str]
-	message: Optional[str]
+	wave: str | None
+	message: str | None
 
 
 # Declarative dictionary of all possible cues
-CUES: Dict[str, Cue] = {
+CUES: dict[str, Cue] = {
 	"connected": {
 		"wave": "connected",
 	},

--- a/source/_remoteClient/cues.py
+++ b/source/_remoteClient/cues.py
@@ -4,7 +4,7 @@
 # See the file COPYING for more details.
 
 import os
-from typing import Dict, Optional, TypedDict
+from typing import TypedDict
 
 import globalVars
 import nvwave

--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -362,7 +362,6 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 	[[trustedCertificates]]
 		__many__ = string(default="")
 	[[ui]]
-		playSounds = boolean(default=True)
 		confirmDisconnectAsFollower = boolean(default=True)
 """
 

--- a/source/config/profileUpgradeSteps.py
+++ b/source/config/profileUpgradeSteps.py
@@ -553,7 +553,6 @@ def upgradeConfigFrom_16_to_17(profile: ConfigObj) -> None:
 	RENAMED_ITEMS: dict[str, dict[str, str]] = {
 		"connections": {"last_connected": "lastConnected"},
 		"controlServer": {"connection_type": "connectionMode", "self_hosted": "selfHosted"},
-		"ui": {"play_sounds": "playSounds"},
 	}
 	if "remote" not in profile:
 		log.debug("No remote section in config, no action taken.")

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -3349,15 +3349,6 @@ class RemoteSettingsPanel(SettingsPanel):
 		remoteSettingsGroupHelper = guiHelper.BoxSizerHelper(self, sizer=remoteSettingsGroupSizer)
 		remoteControlsGroupHelper.addItem(remoteSettingsGroupHelper)
 
-		self.playSounds = remoteSettingsGroupHelper.addItem(
-			wx.CheckBox(
-				self.remoteSettingsGroupBox,
-				# Translators: A checkbox in Remote Access settings to set whether sounds play instead of beeps.
-				label=pgettext("remote", "&Play sounds instead of beeps"),
-			),
-		)
-		self.bindHelpEvent("RemoteSoundsOrBeeps", self.playSounds)
-
 		self.confirmDisconnectAsFollower = remoteSettingsGroupHelper.addItem(
 			wx.CheckBox(
 				self.remoteSettingsGroupBox,
@@ -3499,7 +3490,6 @@ class RemoteSettingsPanel(SettingsPanel):
 		self.host.SetValue(controlServer["host"])
 		self.port.SetValue(str(controlServer["port"]))
 		self.key.SetValue(controlServer["key"])
-		self.playSounds.SetValue(self.config["ui"]["playSounds"])
 		self.confirmDisconnectAsFollower.SetValue(self.config["ui"]["confirmDisconnectAsFollower"])
 		self._setControls()
 
@@ -3564,7 +3554,6 @@ class RemoteSettingsPanel(SettingsPanel):
 		enabled = self.enableRemote.GetValue()
 		oldEnabled = self.config["enabled"]
 		self.config["enabled"] = enabled
-		self.config["ui"]["playSounds"] = self.playSounds.GetValue()
 		self.config["ui"]["confirmDisconnectAsFollower"] = self.confirmDisconnectAsFollower.GetValue()
 		controlServer = self.config["controlServer"]
 		selfHosted = self.clientOrServer.GetSelection()

--- a/source/tones.py
+++ b/source/tones.py
@@ -6,12 +6,7 @@
 """Utilities to generate and play tones"""
 
 import atexit
-import collections
-import threading
-import time
 from ctypes import create_string_buffer
-from typing import TypeAlias
-import collections.abc
 
 import config
 import extensionPoints
@@ -93,31 +88,3 @@ def beep(
 	generateBeep(buf, hz, length, left, right)
 	player.stop()
 	player.feed(buf.raw)
-
-
-BeepSequenceElement: TypeAlias = int | tuple[int, int]  # Either delay_ms or (frequency_hz, duration_ms)
-BeepSequence: TypeAlias = collections.abc.Iterable[BeepSequenceElement]
-
-
-def beepSequence(*sequence: BeepSequenceElement) -> None:
-	"""Play a simple synchronous monophonic beep sequence
-	A beep sequence is an iterable containing one of two kinds of elements.
-	An element consisting of a tuple of two items is interpreted as a frequency and duration. Note, this function plays beeps synchronously, unlike tones.beep
-	A single integer is assumed to be a delay in ms.
-	"""
-	for element in sequence:
-		if not isinstance(element, collections.abc.Sequence):
-			time.sleep(float(element) / 1000)
-		else:
-			freq, duration = element
-			time.sleep(float(duration) / 1000)
-			beep(freq, duration)
-
-
-def beepSequenceAsync(*sequence: BeepSequenceElement) -> threading.Thread:
-	"""Play an asynchronous beep sequence.
-	This is the same as `beepSequence`, except it runs in a thread."""
-	thread = threading.Thread(target=beepSequence, args=sequence)
-	thread.daemon = True
-	thread.start()
-	return thread

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1063,8 +1063,6 @@ class Config_upgradeProfileSteps_upgradeProfileFrom_16_to_17(unittest.TestCase):
 		nvdaremote.com:6837=7B502C3A1F48C8609AE212CDFB639DEE39673F5E
 	[[trusted_certs]]
 		sketchyServer.example.com:6837 = 64EC88CA00B268E5BA1A35678A1B5316D212F4F366B2477232534A8AECA37F3C
-	[[ui]]
-		play_sounds = False
 """
 		expectedV16Config = {
 			"remote": {
@@ -1084,9 +1082,6 @@ class Config_upgradeProfileSteps_upgradeProfileFrom_16_to_17(unittest.TestCase):
 				},
 				"trustedCertificates": {
 					"sketchyServer.example.com:6837": "64EC88CA00B268E5BA1A35678A1B5316D212F4F366B2477232534A8AECA37F3C",
-				},
-				"ui": {
-					"playSounds": "False",
 				},
 			},
 		}

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -3119,13 +3119,6 @@ This means that you cannot, for instance, start a Remote Access session with a p
 
 The following options are only available if Remote Access is enabled.
 
-##### Play sounds instead of beeps {#RemoteSoundsOrBeeps}
-
-Use this option to select the type of audio cues played by Remote Access.
-
-When checked, NVDA will produce natural-sounding audio cues for Remote Access events.
-When unchecked, NVDA will beep for Remote events.
-
 ##### Confirm before disconnecting when controlled {#RemoteConfirmDisconnect}
 
 This option controls whether confirmation is required before disconnecting from a Remote Access session when connected as the controlled computer.


### PR DESCRIPTION
### Link to issue number:

Closes #18087 

### Summary of the issue:

Remote Access currently has the option to choose between sounds and beeps for audio cues. This is extra code that we have to maintain, and is not an option that is present elsewhere in NVDA.

### Description of user facing changes

The option has been removed. Remote Access will only play audio cues.

### Description of development approach

1. In `gui.settingsDialogs.RemoteSettingsPanel`, removed the checkbox and references thereto that controlled this setting.
2. In `_remoteClient.cues`, removed the code that playes beep sequences from `_playCue`, including `shouldPlaySounds`, as this is now always `True`. Removed each `beeps` field from the various cues, and edited the type definition of `Cue` to no longer include this field.
3. In `tones`, removed `beepSequence`, `beepSequenceAsync`, and associated datatypes and imports.
4. Remove the `playSounds` option from the config spec, and the rename from the `upgradeConfigFrom_16_to_17` function.
5. Edit the user guide to no longer refer to the "Play sounds instead of beeps" option.

### Testing strategy:

1. Tested opening, closing, and saving the Remote Access settings to ensure that they still work as expected.
2. Started a Remote Access session, and sent the clipboard to make sure various cues still work as expected.
3. Unit tests.

### Known issues with pull request:
None known

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
