### PR TITLE
Remove deprecated config options

### DIFF
--- a/source/config/__init__.py
+++ b/source/config/__init__.py
@@ -48,7 +48,6 @@ from typing import (
 	Set,
 	Tuple,
 )
-from addonAPIVersion import BACK_COMPAT_TO
 import NVDAState
 from NVDAState import WritePaths
 
@@ -1305,45 +1304,37 @@ class AggregatedSection:
 		self.manager._markWriteProfileDirty()
 		self._cache[key] = val
 
-		# Alias ["documentFormatting"]["reportFontAttributes"] and ["speech"]["includeCLDR"]
-		# for backwards compatibility.
-		# TODO: Comment out in 2025.1.
-		if BACK_COMPAT_TO < (2025, 1, 0) and NVDAState._allowDeprecatedAPI():
-			self._linkDeprecatedValues(key, val)
+		# Alias old config items to their new counterparts for backwards compatibility.
+		# Uncomment when there are new links that need to be made.
+		# if BACK_COMPAT_TO < (2026, 1, 0) and NVDAState._allowDeprecatedAPI():
+		# self._linkDeprecatedValues(key, val)
 
 	def _linkDeprecatedValues(self, key: aggregatedSection._cacheKeyT, val: aggregatedSection._cacheValueT):
 		"""Link deprecated config keys and values to their replacements.
 
 		:arg key: The configuration key to link to its new or old counterpart.
 		:arg val: The value associated with the configuration key.
+
+		Example of how to link values:
+
+		>>> match self.path:
+		>>> 	...
+		>>> 	case ("path", "segments"):
+		>>> 		...
+		>>> 		match key:
+		>>> 			case "newKey":
+		>>> 				# Do something to alias the new path/key to the old path/key for backwards compatibility.
+		>>> 			case "oldKey":
+		>>> 				# Do something to alias the old path/key to the new path/key for forwards compatibility.
+		>>> 			case _:
+		>>> 				# We don't care about other keys in this section.
+		>>> 				return
+		>>> 	case _:
+		>>> 		# We don't care about other sections.
+		>>> 		return
+		>>> ...
 		"""
 		match self.path:
-			case ("speech",):
-				match key:
-					case "symbolDictionaries":
-						# Alias speech.symbolDictionaries to speech.includeCLDR for backwards compatibility.
-						key = "includeCLDR"
-						val = "cldr" in val
-
-					case "includeCLDR":
-						# Alias speech.includeCLDR to speech.symbolDictionaries for forwards compatibility.
-						log.warning(
-							"speech.includeCLDR is deprecated. Use speech.symbolDictionaries instead.",
-							# Include stack info so testers can report warning to add-on author.
-							stack_info=True,
-						)
-						key = "symbolDictionaries"
-						curVal = self.get(key, []).copy()
-						if val and "cldr" not in curVal:
-							curVal.append("cldr")
-						elif not val and "cldr" in curVal:
-							curVal.remove("cldr")
-						val = curVal
-
-					case _:
-						# We don't care about other keys in this section.
-						return
-
 			case _:
 				# We don't care about other sections.
 				return

--- a/source/config/__init__.py
+++ b/source/config/__init__.py
@@ -36,7 +36,6 @@ import extensionPoints
 from . import profileUpgrader
 from . import aggregatedSection
 from .configSpec import confspec
-from .configFlags import OutputMode
 from .featureFlag import (
 	_transformSpec_AddFeatureFlagDefault,
 	_validateConfig_featureFlag,
@@ -1315,39 +1314,10 @@ class AggregatedSection:
 	def _linkDeprecatedValues(self, key: aggregatedSection._cacheKeyT, val: aggregatedSection._cacheValueT):
 		"""Link deprecated config keys and values to their replacements.
 
-		Args:
-			key: The configuration key to link to its new or old counterpart.
-			val: The value associated with the configuration key.
-
-		postconditions:
-			- If self.path is "documentFormatting":
-				- If key is "reportFontAttributes":
-					- If val is True, "documentFormatting.fontAttributeReporting" is set to OutputMode.SPEECH_AND_BRAILLE, otherwise, it is set to OutputMode.OFF.
-				- If key is "fontAttributeReporting":
-					- if val is OutputMode.OFF, "documentFormatting.reportFontAttributes" is set to False, otherwise, it is set to True.
+		:arg key: The configuration key to link to its new or old counterpart.
+		:arg val: The value associated with the configuration key.
 		"""
 		match self.path:
-			case ("documentFormatting",):
-				match key:
-					case "fontAttributeReporting":
-						# Alias documentFormatting.fontAttributeReporting to documentFormatting.reportFontAttributes for backwards compatibility.
-						key = "reportFontAttributes"
-						val = bool(val)
-
-					case "reportFontAttributes":
-						# Alias documentFormatting.reportFontAttributes to documentFormatting.fontAttributeReporting for forwards compatibility.
-						log.warning(
-							"documentFormatting.reportFontAttributes is deprecated. Use documentFormatting.fontAttributeReporting instead.",
-							# Include stack info so testers can report warning to add-on author.
-							stack_info=True,
-						)
-						key = "fontAttributeReporting"
-						val = OutputMode.SPEECH_AND_BRAILLE if val else OutputMode.OFF
-
-					case _:
-						# We don't care about other keys in this section.
-						return
-
 			case ("speech",):
 				match key:
 					case "symbolDictionaries":

--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -38,8 +38,6 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 	trustVoiceLanguage = boolean(default=true)
 	unicodeNormalization = featureFlag(optionsEnum="BoolFlag", behaviorOfDefault="enabled")
 	reportNormalizedForCharacterNavigation = boolean(default=true)
-	# Deprecated in 2025.1
-	includeCLDR = boolean(default=True)
 	symbolDictionaries = string_list(default=list("cldr"))
 	beepSpeechModePitch = integer(default=10000,min=50,max=11025)
 	autoLanguageSwitching = boolean(default=true)

--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -215,8 +215,6 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 	detectFormatAfterCursor = boolean(default=false)
 	reportFontName = boolean(default=false)
 	reportFontSize = boolean(default=false)
-	# Deprecated in 2025.1
-	reportFontAttributes = boolean(default=false)
 	# 0: Off, 1: Speech, 2: Braille, 3: Speech and Braille
 	fontAttributeReporting = integer(0, 3, default=0)
 	reportRevisions = boolean(default=true)

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -4671,14 +4671,15 @@ class GlobalCommands(ScriptableObject):
 		category=SCRCAT_SPEECH,
 	)
 	def script_toggleReportCLDR(self, gesture):
-		if config.conf["speech"]["includeCLDR"]:
+		dictionaries: list[str] = config.conf["speech"]["symbolDictionaries"]
+		if "cldr" in dictionaries:
 			# Translators: presented when the report CLDR is toggled.
 			state = _("report CLDR characters off")
-			config.conf["speech"]["includeCLDR"] = False
+			dictionaries.remove("cldr")
 		else:
 			# Translators: presented when the report CLDR is toggled.
 			state = _("report CLDR characters on")
-			config.conf["speech"]["includeCLDR"] = True
+			dictionaries.append("cldr")
 		characterProcessing.clearSpeechSymbols()
 		ui.message(state)
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -283,7 +283,8 @@ Instead, a `callback` property has been added, which returns a function that per
   * `gui.settingsDialogs.KeyboardSettingsPanel.wordsCheckBox` and `gui.settingsDialogs.KeyboardSettingsPanel.charsCheckBox` has been removed.
 * The `winUser.paint` has been renamed from `painStruct` to `paintStruct`, fixing a bug where passing in a `PAINTSTRUCT` would raise an exception. (#17744)
 * `documentationUtils.getDocFilePath` and `installer.getDocFilePath` no longer look for `.txt` files in locale documentation folders. (#17911, @CyrilleB79)
-* `config.conf["documentFormatting"]["reportFontAttributes"]` has been removed, use`config.conf["documentFormatting"]["fontAttributeReporting"]` instead.
+* `config.conf["documentFormatting"]["reportFontAttributes"]` has been removed, use`config.conf["documentFormatting"]["fontAttributeReporting"]` instead. (#18066)
+* `config.conf["speech"]["includeCLDR"]` has been removed, check/modify whether `config.conf["speech"]["symbolDictionaries"]` contains `"cldr"` instead. (#18066)
 
 #### Deprecations
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -283,6 +283,7 @@ Instead, a `callback` property has been added, which returns a function that per
   * `gui.settingsDialogs.KeyboardSettingsPanel.wordsCheckBox` and `gui.settingsDialogs.KeyboardSettingsPanel.charsCheckBox` has been removed.
 * The `winUser.paint` has been renamed from `painStruct` to `paintStruct`, fixing a bug where passing in a `PAINTSTRUCT` would raise an exception. (#17744)
 * `documentationUtils.getDocFilePath` and `installer.getDocFilePath` no longer look for `.txt` files in locale documentation folders. (#17911, @CyrilleB79)
+* `config.conf["documentFormatting"]["reportFontAttributes"]` has been removed, use`config.conf["documentFormatting"]["fontAttributeReporting"]` instead.
 
 #### Deprecations
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -283,7 +283,7 @@ Instead, a `callback` property has been added, which returns a function that per
   * `gui.settingsDialogs.KeyboardSettingsPanel.wordsCheckBox` and `gui.settingsDialogs.KeyboardSettingsPanel.charsCheckBox` has been removed.
 * The `winUser.paint` has been renamed from `painStruct` to `paintStruct`, fixing a bug where passing in a `PAINTSTRUCT` would raise an exception. (#17744)
 * `documentationUtils.getDocFilePath` and `installer.getDocFilePath` no longer look for `.txt` files in locale documentation folders. (#17911, @CyrilleB79)
-* `config.conf["documentFormatting"]["reportFontAttributes"]` has been removed, use`config.conf["documentFormatting"]["fontAttributeReporting"]` instead. (#18066)
+* `config.conf["documentFormatting"]["reportFontAttributes"]` has been removed, use `config.conf["documentFormatting"]["fontAttributeReporting"]` instead. (#18066)
 * `config.conf["speech"]["includeCLDR"]` has been removed, check/modify whether `config.conf["speech"]["symbolDictionaries"]` contains `"cldr"` instead. (#18066)
 
 #### Deprecations


### PR DESCRIPTION
### Link to issue number:

Closes #18066

### Summary of the issue:

Some deprecated config keys are still included in the config spec.

### Description of user facing changes

None.

### Description of developer facing changes

The `config.conf["documentFormatting"]["reportFontAttributes"]` definition has been removed from the config spec, and the code linking it and `["fontAttributeReporting"]` has been removed.

### Description of development approach

Removed the linking code and the line in the config spec.

### Testing strategy:

Unit tests.

### Known issues with pull request:

`config.conf["speech"]["includeCLDR"] would ideally also be removed, however the deprecation of this key was not documented, so I am unsure whether to remove it.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
