### PR TITLE
Do not mention automatic update when only dealing with update check

### DIFF
--- a/source/config/configFlags.py
+++ b/source/config/configFlags.py
@@ -238,7 +238,7 @@ class ReportCellBorders(DisplayStringIntEnum):
 		}
 
 
-class AddonsUpdateMode(DisplayStringStrEnum):
+class AddonUpdateCheck(DisplayStringStrEnum):
 	NOTIFY = "notify"
 	UPDATE = "update"
 	DISABLED = "disabled"
@@ -246,12 +246,12 @@ class AddonsUpdateMode(DisplayStringStrEnum):
 	@property
 	def _displayStringLabels(self):
 		return {
-			# Translators: This is a label for the add-on update behaviour for add-ons.
+			# Translators: This is a label for the add-on update check behaviour.
 			# It will notify the user when updates are available.
 			self.NOTIFY: _("Notify"),
-			# Translators: This is a label for the add-on update behaviour for add-ons.
+			# Translators: This is a label for the add-on update check behaviour.
 			self.UPDATE: _("Update Automatically"),
-			# Translators: This is a label for the add-on update behaviour for add-ons.
+			# Translators: This is a label for the add-on update check behaviour.
 			self.DISABLED: _("Disabled"),
 		}
 

--- a/source/config/configFlags.py
+++ b/source/config/configFlags.py
@@ -238,7 +238,7 @@ class ReportCellBorders(DisplayStringIntEnum):
 		}
 
 
-class AddonsAutomaticUpdate(DisplayStringStrEnum):
+class AddonsUpdateMode(DisplayStringStrEnum):
 	NOTIFY = "notify"
 	UPDATE = "update"
 	DISABLED = "disabled"
@@ -246,12 +246,12 @@ class AddonsAutomaticUpdate(DisplayStringStrEnum):
 	@property
 	def _displayStringLabels(self):
 		return {
-			# Translators: This is a label for the automatic update behaviour for add-ons.
+			# Translators: This is a label for the add-on update behaviour for add-ons.
 			# It will notify the user when updates are available.
 			self.NOTIFY: _("Notify"),
-			# Translators: This is a label for the automatic update behaviour for add-ons.
+			# Translators: This is a label for the add-on update behaviour for add-ons.
 			self.UPDATE: _("Update Automatically"),
-			# Translators: This is a label for the automatic update behaviour for add-ons.
+			# Translators: This is a label for the add-on update behaviour for add-ons.
 			self.DISABLED: _("Disabled"),
 		}
 

--- a/source/gui/addonStoreGui/controls/actions.py
+++ b/source/gui/addonStoreGui/controls/actions.py
@@ -123,7 +123,7 @@ class _UpdateChannelSubMenu(_ActionsContextMenuP[AddonUpdateChannelActionVM]):
 		selectedAddon = actionVM.actionTarget
 		actionVM.actionHandler(selectedAddon)
 		log.debug(
-			f"update check channel changed for selectedAddon: {selectedAddon} changed to {actionVM.channel}"
+			f"update check channel changed for selectedAddon: {selectedAddon} changed to {actionVM.channel}",
 		)
 
 	def _insertToContextMenu(self, action: AddonUpdateChannelActionVM, prevActionIndex: int):

--- a/source/gui/addonStoreGui/controls/actions.py
+++ b/source/gui/addonStoreGui/controls/actions.py
@@ -122,7 +122,9 @@ class _UpdateChannelSubMenu(_ActionsContextMenuP[AddonUpdateChannelActionVM]):
 	def _menuItemClicked(self, evt: wx.ContextMenuEvent, actionVM: AddonUpdateChannelActionVM):
 		selectedAddon = actionVM.actionTarget
 		actionVM.actionHandler(selectedAddon)
-		log.debug(f"update channel changed for selectedAddon: {selectedAddon} changed to {actionVM.channel}")
+		log.debug(
+			f"update check channel changed for selectedAddon: {selectedAddon} changed to {actionVM.channel}"
+		)
 
 	def _insertToContextMenu(self, action: AddonUpdateChannelActionVM, prevActionIndex: int):
 		self._actionMenuItemMap[action] = self._contextMenu.InsertRadioItem(
@@ -166,9 +168,9 @@ class _MonoActionsContextMenu(_ActionsContextMenuP[AddonActionVM]):
 			_updateChannelSubMenu = _UpdateChannelSubMenu(self._storeVM)
 			self._contextMenu.AppendSubMenu(
 				_updateChannelSubMenu._contextMenu,
-				# Translators: Label for a submenu that allows the user to change the default update
+				# Translators: Label for a submenu that allows the user to change the default update check
 				# channel of the selected add-on
-				_("Upd&ate channel"),
+				_("Upd&ate check channel"),
 			)
 
 

--- a/source/gui/addonStoreGui/controls/messageDialogs.py
+++ b/source/gui/addonStoreGui/controls/messageDialogs.py
@@ -21,7 +21,7 @@ from addonStore.models.addon import (
 from addonStore.dataManager import addonDataManager
 from addonStore.models.status import _StatusFilterKey, AvailableAddonStatus, getStatus
 import config
-from config.configFlags import AddonsAutomaticUpdate
+from config.configFlags import AddonsUpdateMode
 import gui
 from gui import nvdaControls
 from gui.addonGui import ConfirmAddonInstallDialog, ErrorAddonInstallDialog, promptUserForRestart
@@ -578,9 +578,9 @@ class UpdatableAddonsDialog(
 	@classmethod
 	def _checkForUpdatableAddons(cls):
 		if not NVDAState.shouldWriteToDisk() or (
-			AddonsAutomaticUpdate.DISABLED == config.conf["addonStore"]["automaticUpdates"]
+			AddonsUpdateMode.DISABLED == config.conf["addonStore"]["automaticUpdates"]
 		):
-			log.debug("automatic add-on updates are disabled")
+			log.debug("add-on updates are disabled")
 			return
 		log.debug("checking for updatable add-ons")
 
@@ -595,7 +595,7 @@ class UpdatableAddonsDialog(
 		log.debug("updatable add-ons found")
 
 		match config.conf["addonStore"]["automaticUpdates"]:
-			case AddonsAutomaticUpdate.NOTIFY:
+			case AddonsUpdateMode.NOTIFY:
 
 				def delayCreateDialog():
 					winsound.MessageBeep(winsound.MB_ICONEXCLAMATION)
@@ -603,7 +603,7 @@ class UpdatableAddonsDialog(
 
 				wx.CallAfter(delayCreateDialog)
 
-			case AddonsAutomaticUpdate.UPDATE:
+			case AddonsUpdateMode.UPDATE:
 				threading.Thread(
 					name="AutomaticAddonUpdate",
 					target=_updateAddons,
@@ -612,7 +612,7 @@ class UpdatableAddonsDialog(
 				).start()
 
 			case _:
-				raise NotImplementedError("Unknown automatic update setting")
+				raise NotImplementedError("Unknown add-ons update setting")
 
 
 @_countAsMessageBox()

--- a/source/gui/addonStoreGui/controls/messageDialogs.py
+++ b/source/gui/addonStoreGui/controls/messageDialogs.py
@@ -21,7 +21,7 @@ from addonStore.models.addon import (
 from addonStore.dataManager import addonDataManager
 from addonStore.models.status import _StatusFilterKey, AvailableAddonStatus, getStatus
 import config
-from config.configFlags import AddonsUpdateMode
+from config.configFlags import AddonUpdateCheck
 import gui
 from gui import nvdaControls
 from gui.addonGui import ConfirmAddonInstallDialog, ErrorAddonInstallDialog, promptUserForRestart
@@ -578,9 +578,9 @@ class UpdatableAddonsDialog(
 	@classmethod
 	def _checkForUpdatableAddons(cls):
 		if not NVDAState.shouldWriteToDisk() or (
-			AddonsUpdateMode.DISABLED == config.conf["addonStore"]["automaticUpdates"]
+			AddonUpdateCheck.DISABLED == config.conf["addonStore"]["automaticUpdates"]
 		):
-			log.debug("add-on updates are disabled")
+			log.debug("add-on updates check is disabled")
 			return
 		log.debug("checking for updatable add-ons")
 
@@ -595,7 +595,7 @@ class UpdatableAddonsDialog(
 		log.debug("updatable add-ons found")
 
 		match config.conf["addonStore"]["automaticUpdates"]:
-			case AddonsUpdateMode.NOTIFY:
+			case AddonUpdateCheck.NOTIFY:
 
 				def delayCreateDialog():
 					winsound.MessageBeep(winsound.MB_ICONEXCLAMATION)
@@ -603,7 +603,7 @@ class UpdatableAddonsDialog(
 
 				wx.CallAfter(delayCreateDialog)
 
-			case AddonsUpdateMode.UPDATE:
+			case AddonUpdateCheck.UPDATE:
 				threading.Thread(
 					name="AutomaticAddonUpdate",
 					target=_updateAddons,
@@ -612,7 +612,7 @@ class UpdatableAddonsDialog(
 				).start()
 
 			case _:
-				raise NotImplementedError("Unknown add-ons update setting")
+				raise NotImplementedError("Unknown add-on update check setting")
 
 
 @_countAsMessageBox()

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -3205,7 +3205,7 @@ class AddonStorePanel(SettingsPanel):
 	def makeSettings(self, settingsSizer: wx.BoxSizer) -> None:
 		sHelper = guiHelper.BoxSizerHelper(self, sizer=settingsSizer)
 		# Translators: This is a label for the add-ons update combo box in the Add-on Store Settings dialog.
-		addonsUpdateLabelText = _("Add-ons &update:")
+		addonsUpdateLabelText = _("Add-on &update check:")
 		self.addonsUpdateComboBox = sHelper.addLabeledControl(
 			addonsUpdateLabelText,
 			wx.Choice,

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -32,7 +32,7 @@ import installer
 from synthDriverHandler import changeVoice, getSynth, getSynthList, setSynth, SynthDriver
 import config
 from config.configFlags import (
-	AddonsUpdateMode,
+	AddonUpdateCheck,
 	NVDAKey,
 	RemoteConnectionMode,
 	RemoteServerType,
@@ -3204,16 +3204,16 @@ class AddonStorePanel(SettingsPanel):
 
 	def makeSettings(self, settingsSizer: wx.BoxSizer) -> None:
 		sHelper = guiHelper.BoxSizerHelper(self, sizer=settingsSizer)
-		# Translators: This is a label for the add-ons update combo box in the Add-on Store Settings dialog.
-		addonsUpdateLabelText = _("Add-on &update check:")
-		self.addonsUpdateComboBox = sHelper.addLabeledControl(
-			addonsUpdateLabelText,
+		# Translators: This is a label for the add-on update check combo box in the Add-on Store Settings dialog.
+		addonUpdateCheckLabelText = _("Add-on &update check:")
+		self.addonUpdateCheckComboBox = sHelper.addLabeledControl(
+			addonUpdateCheckLabelText,
 			wx.Choice,
-			choices=[mode.displayString for mode in AddonsUpdateMode],
+			choices=[mode.displayString for mode in AddonUpdateCheck],
 		)
-		self.bindHelpEvent("AddonsUpdateMode", self.addonsUpdateComboBox)
-		index = [x.value for x in AddonsUpdateMode].index(config.conf["addonStore"]["automaticUpdates"])
-		self.addonsUpdateComboBox.SetSelection(index)
+		self.bindHelpEvent("AddonUpdateCheck", self.addonUpdateCheckComboBox)
+		index = [x.value for x in AddonUpdateCheck].index(config.conf["addonStore"]["automaticUpdates"])
+		self.addonUpdateCheckComboBox.SetSelection(index)
 
 		self.defaultUpdateCheckChannelComboBox = sHelper.addLabeledControl(
 			# Translators: This is the label for the default update check channel combo box in the Add-on Store Settings dialog.
@@ -3230,9 +3230,9 @@ class AddonStorePanel(SettingsPanel):
 		self.defaultUpdateCheckChannelComboBox.SetSelection(index)
 
 		self.allowIncompatibleUpdates = sHelper.addItem(
-			# Translators: This is the label for the "Allow incompatible add-ons when checking for updates" checkbox
+			# Translators: This is the label for the "Allow updates to add-ons marked as incompatible" checkbox
 			# in the Add-on Store Settings dialog.
-			wx.CheckBox(self, label=_("Allow incompatible add-ons when checking for updates")),
+			wx.CheckBox(self, label=_("Allow updates to add-ons marked as incompatible")),
 		)
 		self.bindHelpEvent("AllowIncompatibleAddonUpdates", self.allowIncompatibleUpdates)
 		self.allowIncompatibleUpdates.SetValue(config.conf["addonStore"]["allowIncompatibleUpdates"])
@@ -3311,8 +3311,8 @@ class AddonStorePanel(SettingsPanel):
 		super().onPanelActivated()
 
 	def onSave(self):
-		index = self.addonsUpdateComboBox.GetSelection()
-		config.conf["addonStore"]["automaticUpdates"] = [x.value for x in AddonsUpdateMode][index]
+		index = self.addonUpdateCheckComboBox.GetSelection()
+		config.conf["addonStore"]["automaticUpdates"] = [x.value for x in AddonUpdateCheck][index]
 		config.conf["addonStore"]["allowIncompatibleUpdates"] = self.allowIncompatibleUpdates.IsChecked()
 		config.conf["addonStore"]["defaultUpdateChannel"] = (
 			self.defaultUpdateCheckChannelComboBox.GetSelection()

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -32,7 +32,7 @@ import installer
 from synthDriverHandler import changeVoice, getSynth, getSynthList, setSynth, SynthDriver
 import config
 from config.configFlags import (
-	AddonsAutomaticUpdate,
+	AddonsUpdateMode,
 	NVDAKey,
 	RemoteConnectionMode,
 	RemoteServerType,
@@ -3204,34 +3204,35 @@ class AddonStorePanel(SettingsPanel):
 
 	def makeSettings(self, settingsSizer: wx.BoxSizer) -> None:
 		sHelper = guiHelper.BoxSizerHelper(self, sizer=settingsSizer)
-		# Translators: This is a label for the automatic updates combo box in the Add-on Store Settings dialog.
-		automaticUpdatesLabelText = _("Automatic &updates:")
-		self.automaticUpdatesComboBox = sHelper.addLabeledControl(
-			automaticUpdatesLabelText,
+		# Translators: This is a label for the add-ons update combo box in the Add-on Store Settings dialog.
+		addonsUpdateLabelText = _("Add-ons &update:")
+		self.addonsUpdateComboBox = sHelper.addLabeledControl(
+			addonsUpdateLabelText,
 			wx.Choice,
-			choices=[mode.displayString for mode in AddonsAutomaticUpdate],
+			choices=[mode.displayString for mode in AddonsUpdateMode],
 		)
-		self.bindHelpEvent("AutomaticAddonUpdates", self.automaticUpdatesComboBox)
-		index = [x.value for x in AddonsAutomaticUpdate].index(config.conf["addonStore"]["automaticUpdates"])
-		self.automaticUpdatesComboBox.SetSelection(index)
+		self.bindHelpEvent("AddonsUpdateMode", self.addonsUpdateComboBox)
+		index = [x.value for x in AddonsUpdateMode].index(config.conf["addonStore"]["automaticUpdates"])
+		self.addonsUpdateComboBox.SetSelection(index)
 
-		self.defaultUpdateChannelComboBox = sHelper.addLabeledControl(
-			# Translators: This is the label for the default update channel combo box in the Add-on Store Settings dialog.
-			_("Default update &channel:"),
+		self.defaultUpdateCheckChannelComboBox = sHelper.addLabeledControl(
+			# Translators: This is the label for the default update check channel combo box in the Add-on Store Settings dialog.
+			_("Default update check &channel:"),
 			wx.Choice,
-			# The default update channel for a specific add-on (UpdateChannel.DEFAULT) refers to this channel,
+			# The default update check channel for a specific add-on (UpdateChannel.DEFAULT) refers to this channel,
 			# so it should be skipped.
 			choices=[
 				channel.displayString for channel in UpdateChannel if channel is not UpdateChannel.DEFAULT
 			],
 		)
-		self.bindHelpEvent("DefaultAddonUpdateChannel", self.defaultUpdateChannelComboBox)
+		self.bindHelpEvent("DefaultAddonUpdateChannel", self.defaultUpdateCheckChannelComboBox)
 		index = config.conf["addonStore"]["defaultUpdateChannel"]
-		self.defaultUpdateChannelComboBox.SetSelection(index)
+		self.defaultUpdateCheckChannelComboBox.SetSelection(index)
 
 		self.allowIncompatibleUpdates = sHelper.addItem(
-			# Translators: Mute other apps checkbox in settings
-			wx.CheckBox(self, label=_("Allow automatic updates to install incompatible add-ons")),
+			# Translators: This is the label for the "Allow incompatible add-ons when checking for updates" checkbox
+			# in the Add-on Store Settings dialog.
+			wx.CheckBox(self, label=_("Allow incompatible add-ons when checking for updates")),
 		)
 		self.bindHelpEvent("AllowIncompatibleAddonUpdates", self.allowIncompatibleUpdates)
 		self.allowIncompatibleUpdates.SetValue(config.conf["addonStore"]["allowIncompatibleUpdates"])
@@ -3310,10 +3311,12 @@ class AddonStorePanel(SettingsPanel):
 		super().onPanelActivated()
 
 	def onSave(self):
-		index = self.automaticUpdatesComboBox.GetSelection()
-		config.conf["addonStore"]["automaticUpdates"] = [x.value for x in AddonsAutomaticUpdate][index]
+		index = self.addonsUpdateComboBox.GetSelection()
+		config.conf["addonStore"]["automaticUpdates"] = [x.value for x in AddonsUpdateMode][index]
 		config.conf["addonStore"]["allowIncompatibleUpdates"] = self.allowIncompatibleUpdates.IsChecked()
-		config.conf["addonStore"]["defaultUpdateChannel"] = self.defaultUpdateChannelComboBox.GetSelection()
+		config.conf["addonStore"]["defaultUpdateChannel"] = (
+			self.defaultUpdateCheckChannelComboBox.GetSelection()
+		)
 
 
 class RemoteSettingsPanel(SettingsPanel):

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -8,7 +8,7 @@ There are many improvements to speech, particularly responsiveness with SAPI 4, 
 Rate boost and automatic language switching is now supported in SAPI 5.
 SAPI 4 voices now support audio ducking, leading silence trimming, and keeping the audio device awake.
 
-The Add-on Store's update system has been improved, allowing you to select channels for update checks, and run automatic updates in the background.
+The Add-on Store's update system has been improved, allowing you to select channels for update and run automatic updates in the background.
 
 It's now easier to manually refresh OCR and toggle automatic refresh, with new commands.
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -8,7 +8,7 @@ There are many improvements to speech, particularly responsiveness with SAPI 4, 
 Rate boost and automatic language switching is now supported in SAPI 5.
 SAPI 4 voices now support audio ducking, leading silence trimming, and keeping the audio device awake.
 
-The Add-on Store's automatic update system has been improved, allowing you to select channels for automatic updates, and run automatic updates in the background.
+The Add-on Store's update system has been improved, allowing you to select channels for update checks, and run automatic updates in the background.
 
 It's now easier to manually refresh OCR and toggle automatic refresh, with new commands.
 
@@ -40,12 +40,12 @@ Please responsibly disclose security issues following NVDA's [security policy](h
 
 * Add-on Store:
   * Automatic updates (#3208):
-    * Automatic update channels for add-ons can now be modified.
-      * Automatic update channels can be selected for installed add-ons via an "Update channel" submenu.
-      * The default automatic update channel can be set from the Add-on Store panel in NVDA's settings.
+    * Update check channels for add-ons can now be modified.
+      * Update check channels can be selected for installed add-ons via an "Update channel" submenu.
+      * The default update check channel can be set from the Add-on Store panel in NVDA's settings.
     * Automatic updates can now happen in the background.
-      * This can be enabled in the Add-on Store panel in NVDA's settings by changing "Automatic updates" to "Update Automatically".
-    * Automatic updates can now update incompatible add-ons to another, newer, incompatible version.
+      * This can be enabled in the Add-on Store panel in NVDA's settings by changing "Addons update" to "Update Automatically".
+    * Update check can now update incompatible add-ons to another, newer, incompatible version.
       * This can be enabled in the Add-on Store panel in NVDA's settings.
   * Added an action to cancel the install of add-ons. (#15578, @hwf1324)
   * Added an action to retry the installation if the download/installation of an add-on fails. (#17090, @hwf1324)

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -365,7 +365,7 @@ The list will display the currently installed version and the available version.
 Press `enter` on the add-on to open the actions list; choose "Update".
 
 By default, after NVDA startup, you will be notified if any add-on updates are available.
-To learn more about and configure this behaviour, refer to ["Update Notifications"](#AutomaticAddonUpdates).
+To learn more about and configure this behaviour, refer to ["Add-ons update"](#AddonsUpdateMode).
 
 ### Community {#Community}
 
@@ -3042,7 +3042,7 @@ You may toggle through the available paragraph styles from anywhere by assigning
 
 This category allows you to adjust the behaviour of the Add-on Store.
 
-##### Automatic updates {#AutomaticAddonUpdates}
+##### Add-ons update {#AddonsUpdateMode}
 
 When this option is set to "Notify", the Add-on Store will notify you after NVDA startup if any add-on updates are available.
 This check is performed every 24 hours.
@@ -3063,12 +3063,12 @@ You will be prompted to restart NVDA when the updates are finished.
 |Update Automatically |Automatically update add-ons in the background |
 |Disabled |Do not automatically check for updates to add-ons |
 
-##### Default Update Channel {#DefaultAddonUpdateChannel}
+##### Default Update Check Channel {#DefaultAddonUpdateChannel}
 
-When [Automatic add-on updates](#AutomaticAddonUpdates) are enabled, by default, add-ons only update to the same [channel](#AddonStoreFilterChannel).
+When [Add-ons update](#AddonsUpdateMode) is enabled ("Notify" or "Update Automatically"),, by default, add-ons only check for update to the same [channel](#AddonStoreFilterChannel).
 For example, an installed beta version will only update to a newer beta version.
-This option sets the default update channel for all add-ons.
-You can also change the update channel for a [specific add-on individually from the Add-on Store](#AddonStoreUpdateChannel).
+This option sets the default update check channel for all add-ons.
+You can also change the update check channel for a [specific add-on individually from the Add-on Store](#AddonStoreUpdateChannel).
 
 | . {.hideHeaderRow} |.|
 |---|---|
@@ -3078,20 +3078,20 @@ You can also change the update channel for a [specific add-on individually from 
 | Option | Behaviour |
 |---|---|
 | Same | Add-ons will remain on their channel |
-| Any | Add-ons will automatically update to the latest version, regardless of channel |
-| Do not update | Add-ons will not automatically update by default, you must enable them individually |
-| Stable | Add-ons will automatically update to stable versions |
-| Beta or dev | Add-ons will automatically update to beta or dev versions |
-| Beta | Add-ons will automatically update to beta versions |
-| Dev | Add-ons will automatically update to dev versions |
+| Any | Add-ons will check for update to the latest version, regardless of channel |
+| Do not update | Add-ons will not check for update by default, you must enable them individually |
+| Stable | Add-ons will check for update to stable versions |
+| Beta or dev | Add-ons will check for update to beta or dev versions |
+| Beta | Add-ons will check for update to beta versions |
+| Dev | Add-ons will check for update to dev versions |
 
-##### Allow automatic updates to install incompatible add-ons {#AllowIncompatibleAddonUpdates}
+##### Allow incompatible add-ons when checking for updates {#AllowIncompatibleAddonUpdates}
 
-This setting enables automatic updates to add-ons that may not be fully compatible with the current version of NVDA.
-By default, this is disabled, meaning automatic updates will only upgrade to add-on versions marked as compatible with the current version of NVDA.
-Automatic updates will still update an incompatible add-on version to a compatible version when it is released.
-Enabling this may be useful for switching over to using add-on breaking releases (the first release of the year).
-This is particularly useful for alpha and beta testers, who are testing compatibility of add-ons during the early stages of an add-on breaking release.
+When NVDA checks for add-on updates, this setting allows to accept updates to add-ons that may not be fully compatible with the current version of NVDA.
+By default, this is disabled, meaning add-ons update will only check for add-on versions marked as compatible with the current version of NVDA.
+Add-on updates check will still allow to update an incompatible add-on version to a compatible version when it is released.
+Enabling this may be useful for switching over to using add-on API breaking releases (the first release of the year).
+This is particularly useful for alpha and beta testers, who are testing compatibility of add-ons during the early stages of an add-on API breaking release.
 
 ##### Mirror server {#AddonStoreMetadataMirror}
 
@@ -3915,7 +3915,7 @@ When an add-on is being installed from an external source, NVDA will ask you to 
 Once the add-on is installed, NVDA must be restarted for the add-on to start running, although you may postpone restarting NVDA if you have other add-ons to install or update.
 
 By default, after NVDA startup, you will be notified if any add-on updates are available.
-To learn more about and configure this behaviour, refer to ["Update Notifications"](#AutomaticAddonUpdates).
+To learn more about and configure this behaviour, refer to ["Add-ons update"](#AddonsUpdateMode).
 
 #### Removing Add-ons {#AddonStoreRemoving}
 
@@ -3945,22 +3945,22 @@ This links to a GitHub Discussion webpage, where you will be able to read and wr
 Please be aware that this doesn't replace direct communication with add-on developers.
 Instead, the purpose of this feature is to share feedback to help users decide if an add-on may be useful for them.
 
-#### Changing the automatic update channel {#AddonStoreUpdateChannel}
+#### Changing the update check channel {#AddonStoreUpdateChannel}
 
-You can manage the automatic update channels for add-ons from the [installed and updatable add-ons tabs](#AddonStoreFilterStatus).
-When [Automatic add-on updates](#AutomaticAddonUpdates) are enabled, add-ons will update to the same [channel](#AddonStoreFilterChannel) they were installed from by [default](#DefaultAddonUpdateChannel).
+You can manage the update check channels for add-ons from the [installed and updatable add-ons tabs](#AddonStoreFilterStatus).
+When [Add-ons update](#AddonsUpdateMode) is enabled ("Notify" or "Update Automatically"), add-ons will check for update to the same [channel](#AddonStoreFilterChannel) they were installed from by [default](#DefaultAddonUpdateChannel).
 From an add-on's actions menu, using the submenu "Update channel", you can modify the channels an add-on will automatically update to.
 
 | Option | Behaviour |
 |---|---|
-| Default | Add-on will follow the [default update channel](#DefaultAddonUpdateChannel) |
+| Default | Add-on will follow the [default update check channel](#DefaultAddonUpdateChannel) |
 | Same | Add-on will remain on the same channel |
-| Any | Add-on will automatically update to the latest version, regardless of channel |
-| Do not update | Add-on will not automatically update |
-| Stable | Add-on will automatically update to stable versions |
-| Beta or dev | Add-on will automatically update to beta or dev versions |
-| Beta | Add-on will automatically update to beta versions |
-| Dev | Add-on will automatically update to dev versions |
+| Any | Add-on will check for update to the latest version, regardless of channel |
+| Do not update | Add-on will not check for update |
+| Stable | Add-on will check for update to stable versions |
+| Beta or dev | Add-on will check for update to beta or dev versions |
+| Beta | Add-on will check for update to beta versions |
+| Dev | Add-on will check for update to dev versions |
 
 ### Incompatible Add-ons {#incompatibleAddonsManager}
 

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -3087,9 +3087,9 @@ You can also change the update check channel for a [specific add-on individually
 
 ##### Allow incompatible add-ons when checking for updates {#AllowIncompatibleAddonUpdates}
 
-When NVDA checks for add-on updates, this setting allows to accept updates to add-ons that may not be fully compatible with the current version of NVDA.
+-This setting allows NVDA to update add-ons to versions that may not be fully compatible with the current version of NVDA when checking for add-on updates.
 By default, this is disabled, meaning add-ons update will only check for add-on versions marked as compatible with the current version of NVDA.
-Add-on updates check will still allow to update an incompatible add-on version to a compatible version when it is released.
+Add-on update checks will still include updates from incompatible add-on versions to compatible versions when they are released.
 Enabling this may be useful for switching over to using add-on API breaking releases (the first release of the year).
 This is particularly useful for alpha and beta testers, who are testing compatibility of add-ons during the early stages of an add-on API breaking release.
 

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -1,3 +1,4 @@
+ons upd
 # NVDA NVDA_VERSION User Guide
 
 [TOC]
@@ -365,7 +366,7 @@ The list will display the currently installed version and the available version.
 Press `enter` on the add-on to open the actions list; choose "Update".
 
 By default, after NVDA startup, you will be notified if any add-on updates are available.
-To learn more about and configure this behaviour, refer to ["Add-ons update"](#AddonsUpdateMode).
+To learn more about and configure this behaviour, refer to ["Add-on update check"](#AddonUpdateCheck).
 
 ### Community {#Community}
 
@@ -3042,7 +3043,7 @@ You may toggle through the available paragraph styles from anywhere by assigning
 
 This category allows you to adjust the behaviour of the Add-on Store.
 
-##### Add-ons update {#AddonsUpdateMode}
+##### Add-on update check {#AddonUpdateCheck}
 
 When this option is set to "Notify", the Add-on Store will notify you after NVDA startup if any add-on updates are available.
 This check is performed every 24 hours.
@@ -3065,7 +3066,7 @@ You will be prompted to restart NVDA when the updates are finished.
 
 ##### Default Update Check Channel {#DefaultAddonUpdateChannel}
 
-When [Add-ons update](#AddonsUpdateMode) is enabled ("Notify" or "Update Automatically"),, by default, add-ons only check for update to the same [channel](#AddonStoreFilterChannel).
+When [Add-on update check](#AddonUpdateCheck) is enabled ("Notify" or "Update Automatically"),, by default, add-ons only check for update to the same [channel](#AddonStoreFilterChannel).
 For example, an installed beta version will only update to a newer beta version.
 This option sets the default update check channel for all add-ons.
 You can also change the update check channel for a [specific add-on individually from the Add-on Store](#AddonStoreUpdateChannel).
@@ -3915,7 +3916,7 @@ When an add-on is being installed from an external source, NVDA will ask you to 
 Once the add-on is installed, NVDA must be restarted for the add-on to start running, although you may postpone restarting NVDA if you have other add-ons to install or update.
 
 By default, after NVDA startup, you will be notified if any add-on updates are available.
-To learn more about and configure this behaviour, refer to ["Add-ons update"](#AddonsUpdateMode).
+To learn more about and configure this behaviour, refer to ["Add-on update check"](#AddonUpdateCheck).
 
 #### Removing Add-ons {#AddonStoreRemoving}
 
@@ -3948,7 +3949,7 @@ Instead, the purpose of this feature is to share feedback to help users decide i
 #### Changing the update check channel {#AddonStoreUpdateChannel}
 
 You can manage the update check channels for add-ons from the [installed and updatable add-ons tabs](#AddonStoreFilterStatus).
-When [Add-ons update](#AddonsUpdateMode) is enabled ("Notify" or "Update Automatically"), add-ons will check for update to the same [channel](#AddonStoreFilterChannel) they were installed from by [default](#DefaultAddonUpdateChannel).
+When [Add-on update check](#AddonUpdateCheck) is enabled ("Notify" or "Update Automatically"), add-ons will check for update to the same [channel](#AddonStoreFilterChannel) they were installed from by [default](#DefaultAddonUpdateChannel).
 From an add-on's actions menu, using the submenu "Update channel", you can modify the channels an add-on will automatically update to.
 
 | Option | Behaviour |


### PR DESCRIPTION
### Link to issue number:
None
### Summary of the issue:
In the GUI and in the documentation, we mention automatic update for parameters that actually only deal with update check. This becomes confusing.

For example in the User Guide:
> When Automatic add-on updates are enabled, by default, add-ons only update to the same channel.

Actually, this behaviour not only describe when automatic updates are enabled, but also when update notifications are enabled (but the user still manually chooses to update or not).


### Description of user facing changes
GUI options renaming:
* In Add-on Store settings:
  * "Automatic updates" becomes "Add-ons update"
  * "Default update channel" becomes "Default update check channel"
  * "Allow automatic updates to install incompatible add-ons" becomes "Allow incompatible add-ons when checking for updates"
* In Add-on Store, context menu: "Update channel" becomes "Update check channel"

Documentation has been updated consequently.

Also:
* speak of "add-on breaking release" rather than "add-on API breaking release".

### Description of development approach
* Changed GUI strings and documentation
* Changed few variable names in `gui\settingsdialog.py`; let me know if I need to change more of them in other files.

### Testing strategy:
Manual checks:
* Check GUI and try to modify parameters
* Check generated documentation.

### Known issues with pull request:
My English wording may be improved if needed. The idea is to avoid using "automatic update" when we actually refer to "update check".

### Code Review Checklist:


- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
