### PR TITLE
Fix the toggle report CLDR script"

### DIFF
--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -4671,7 +4671,9 @@ class GlobalCommands(ScriptableObject):
 		category=SCRCAT_SPEECH,
 	)
 	def script_toggleReportCLDR(self, gesture):
-		dictionaries: list[str] = config.conf["speech"]["symbolDictionaries"]
+		# We need to save a copy of the symbolDictionaries list
+		# so we can set it back afterwards so configobj knows it's changed.
+		dictionaries: list[str] = config.conf["speech"]["symbolDictionaries"].copy()
 		if "cldr" in dictionaries:
 			# Translators: presented when the report CLDR is toggled.
 			state = _("report CLDR characters off")
@@ -4680,6 +4682,7 @@ class GlobalCommands(ScriptableObject):
 			# Translators: presented when the report CLDR is toggled.
 			state = _("report CLDR characters on")
 			dictionaries.append("cldr")
+		config.conf["speech"]["symbolDictionaries"] = dictionaries
 		characterProcessing.clearSpeechSymbols()
 		ui.message(state)
 


### PR DESCRIPTION
### Link to issue number:

Follow-up to #18102

### Summary of the issue:

When fixing the `GlobalCommands.script_reportCLDR" method, I forgot that you can't just mutate lists in the config, or configobj doesn't know they've changed, so the changes will not be persisted to disc.

### Description of user facing changes

The toggle CLDR script will now be persisted across sessions.

### Description of development approach

Make a copy of `config.conf["speech"]["symbolDictionaries"]`, mutate it, then save it back.
Initially tried just mutating it and then setting it to itself, but this did not work. Presumably there is some check for identity somewhere, and since all empty lists are identicle, `__setitem__` was not called.

### Testing strategy:

1. Assign a gesture to the script
2. Read some text with emojis. Observe the result.
3. Use the gesture.
4. Read some text with emojis. Observe the result is different to that in 2.
5. Save the config. Reload the config.
6. Read some text with emojis. Observe the result is the same as 4.
7. Repeat steps 3-6.

### Known issues with pull request:

None known.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
