### PR TITLE
Fix Remote Access settings in secure mode

### DIFF
--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -3327,25 +3327,20 @@ class RemoteSettingsPanel(SettingsPanel):
 		self.config = config.conf["remote"]
 		sHelper = guiHelper.BoxSizerHelper(self, sizer=sizer)
 
-		remoteControlsGroupSizer = wx.StaticBoxSizer(wx.VERTICAL, self)
-		remoteControlsGroupBox: wx.StaticBox = remoteControlsGroupSizer.GetStaticBox()
-		remoteControlsGroupHelper = guiHelper.BoxSizerHelper(self, sizer=remoteControlsGroupSizer)
-		sHelper.addItem(remoteControlsGroupHelper)
-
-		self.enableRemote = remoteControlsGroupHelper.addItem(
+		self.enableRemote = sHelper.addItem(
 			# Translators: Label of a checkbox in Remote Access settings
-			wx.CheckBox(remoteControlsGroupBox, label=pgettext("remote", "Enable Remote Access")),
+			wx.CheckBox(self, label=pgettext("remote", "Enable Remote Access")),
 		)
 		self.enableRemote.Bind(wx.EVT_CHECKBOX, self._onEnableRemote)
 		self.bindHelpEvent("RemoteEnable", self.enableRemote)
 
 		remoteSettingsGroupSizer = wx.StaticBoxSizer(
 			wx.VERTICAL,
-			remoteControlsGroupBox,
+			self,
 		)
 		self.remoteSettingsGroupBox = remoteSettingsGroupSizer.GetStaticBox()
 		remoteSettingsGroupHelper = guiHelper.BoxSizerHelper(self, sizer=remoteSettingsGroupSizer)
-		remoteControlsGroupHelper.addItem(remoteSettingsGroupHelper)
+		sHelper.addItem(remoteSettingsGroupHelper)
 
 		self.confirmDisconnectAsFollower = remoteSettingsGroupHelper.addItem(
 			wx.CheckBox(
@@ -3434,9 +3429,9 @@ class RemoteSettingsPanel(SettingsPanel):
 		)
 		self.bindHelpEvent("RemoteAutoconnectKey", self.key)
 
-		self.deleteFingerprints = remoteControlsGroupHelper.addItem(
+		self.deleteFingerprints = sHelper.addItem(
 			# Translators: A button in Remote Access settings to delete all fingerprints of unauthorized certificates.
-			wx.Button(remoteControlsGroupBox, label=_("Delete all trusted fingerprints")),
+			wx.Button(self, label=_("Delete all trusted fingerprints")),
 		)
 		self.deleteFingerprints.Bind(wx.EVT_BUTTON, self.onDeleteFingerprints)
 		self.bindHelpEvent("RemoteDeleteFingerprints", self.deleteFingerprints)

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -3442,6 +3442,13 @@ class RemoteSettingsPanel(SettingsPanel):
 			self._disableDescendants(sizer, enabledInSecureMode)
 
 	def _disableDescendants(self, sizer: wx.Sizer, excluded: Container[wx.Window]):
+		"""Disable all but the specified discendant windows of this sizer.
+
+		Disables all child windows, and recursively calls itself for all child sizers.
+
+		:param sizer: Root sizer whose descendents should be disabled.
+		:param excluded: Container of windows that should remain enabled.
+		"""
 		for child in sizer.GetChildren():
 			if (window := child.GetWindow()) is not None and window not in excluded:
 				window.Disable()

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -3444,7 +3444,6 @@ class RemoteSettingsPanel(SettingsPanel):
 		self._setFromConfig()
 
 		if globalVars.appArgs.secure:
-			self._insertReadOnlyNotice(sizer)
 			self._disableDescendants(sizer, enabledInSecureMode)
 
 	def _disableDescendants(self, sizer: wx.Sizer, excluded: Container[wx.Window]):
@@ -3453,18 +3452,6 @@ class RemoteSettingsPanel(SettingsPanel):
 				window.Disable()
 			elif (subsizer := child.GetSizer()) is not None:
 				self._disableDescendants(subsizer, excluded)
-
-	def _insertReadOnlyNotice(self, sizer: wx.BoxSizer):
-		banner = wx.adv.BannerWindow(self, dir=wx.TOP)
-		banner.SetText(
-			# Translators: Title of a message presented to users when viewing Remote Access settings in secure mode.
-			pgettext("remote", "Read only"),
-			# Translators: Message presented to users when viewing Remote Access settings in secure mode.
-			pgettext("remote", "Remote Access settings are read only as NVDA is running in secure mode."),
-		)
-		normalBgColour = self.GetBackgroundColour()
-		banner.SetGradient(normalBgColour, normalBgColour)
-		sizer.Insert(0, banner)
 
 	def _setControls(self) -> None:
 		"""Ensure the state of the GUI is internally consistent, as well as consistent with the state of the config.


### PR DESCRIPTION
### Link to issue number:

Closes #18107

### Summary of the issue:

Remote Access's settings were improperly disabled in secure mode, including disabling options that could be useful in secure mode.

### Description of user facing changes

* Most of Remote Access's settings are visibly disabled in secure mode, and cannot be activated with object navigation.
* The "Confirm before disconnecting when controlled" option is still enabled in secure mode.
* There is no banner notice on Remote Access's settings page when in secure mode.

### Description of development approach

* Change the approach for disabling the config items. Rather then them all being in a parent grouping, recursively disable the children of the containing sizer.
* To keep some options enabled, maintain a set of options that make sense in secure mode, and exclude those options when disabling everything.
* Remove the method to create the read only banner.
* Refactor things to remove the no-longer needed containing static box sizer helper.

### Testing strategy:

Used the settings in secure and regular modes to make sure they work as expected.

### Known issues with pull request:

None.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
