### PR TITLE
Remove Add-on Store panel in secure mode

### DIFF
--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -5473,9 +5473,12 @@ class NVDASettingsDialog(MultiCategorySettingsDialog):
 		BrowseModePanel,
 		DocumentFormattingPanel,
 		DocumentNavigationPanel,
-		AddonStorePanel,
 		RemoteSettingsPanel,
 	]
+	# In secure mode, add-on update is disabled, so AddonStorePanel should not appear since it only contains
+	# add-on update related controls.
+	if not globalVars.appArgs.secure:
+		categoryClasses.append(AddonStorePanel)
 	if touchHandler.touchSupported():
 		categoryClasses.append(TouchInteractionPanel)
 	if winVersion.isUwpOcrAvailable():


### PR DESCRIPTION
### Link to issue number:
Closes #17974

### Summary of the issue:
The Add-on Store is not available in secure mode and add-ons are not updated in this mode.
Keeping the Add-on Store panel visible with modifiable controls in secure mode is confusing for users.

Moreover, being allow to test an Add-on Store mirror from the logon screen allows to send any GET request from the logon screen, what make these requests not traceable and even maybe insecure.

### Description of user facing changes
The add-on store panel is not visible anymore in NVDA's settings window in secure mode.

### Description of development approach
Same approach as advanced settings panel.

### Testing strategy:
Manuel test from source with and without `-s` flag.
### Known issues with pull request:
None.
### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
