### PR TITLE
speech.getControlFieldSpeech: avoid exception which stops a line from being read.

### DIFF
--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -1675,7 +1675,9 @@ def getTextInfoSpeech(  # noqa: C901
 	isWordOrCharUnit = unit in (textInfos.UNIT_CHARACTER, textInfos.UNIT_WORD)
 	firstText = ""
 	if len(textWithFields) > 0:
-		firstText = textWithFields[0].strip() if not textWithFields[0].isspace() else textWithFields[0]
+		firstField = textWithFields[0]
+		if isinstance(firstField, str):
+			firstText = firstField.strip() if not firstField.isspace() else firstField
 	if onlyInitialFields or (
 		isWordOrCharUnit
 		and (len(firstText) == 1 or len(unicodeNormalize(firstText)) == 1)

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -18,6 +18,7 @@
 * Fixed some rare cases where NVDA playing sounds could result in unexpected errors. (#17918, @LeonarddeR)
 * In Microsoft Word, when UIA is enabled, NVDA will no longer braille redundant table end markers when the cursor is in a table cell. (#15828, @LeonarddeR)
 * In Geekbench 6.4, NVDA can again read the ribbon and options within. (#17892, @mzanm)
+* NVDA no longer fails to read check list items in Microsoft Loop when viewed in Google Chrome / Microsoft Edge. (#18130)
 
 ### Changes for Developers
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
None

### Summary of the issue:
When trying to read some lines in Chomium, such as a list item with a checkbox at the start, the following traceback is produced and the line is not read:
```
ERROR - scriptHandler.executeScript (07:47:48.801) - MainThread (22912):
error executing script: <bound method EditableText.script_caret_moveByLine of <NVDAObjects.Dynamic_EditorEditableTextWithAutoSelectDetectionEditorIa2WebIAccessible object at 0x05DBB2F0>> with gesture 'down arrow'
Traceback (most recent call last):
  File "scriptHandler.pyc", line 300, in executeScript
  File "editableText.pyc", line 268, in script_caret_moveByLine
  File "editableText.pyc", line 192, in _caretMovementScriptHelper
  File "NVDAObjects\behaviors.pyc", line 254, in _caretScriptPostMovedHelper
  File "editableText.pyc", line 178, in _caretScriptPostMovedHelper
  File "speech\speech.pyc", line 1483, in speakTextInfo
  File "speech\types.pyc", line 47, in __iter__
  File "speech\speech.pyc", line 1678, in getTextInfoSpeech
AttributeError: 'FieldCommand' object has no attribute 'isspace'
```

The code assumes the next field in the list is a string, but in this case it is a controlEnd (from a checkbox with no content inside).

### Description of user facing changes
NVDA no longer refuses to read a line in Google Chrome / Edge where a list item starts with a checkbox, such as within a check list in Microsoft Loop.
 
### Description of development approach
Ensure the field is an str before calling isspace or strip.

### Testing strategy:
In Google Chrome, read the line produced by:
```
<div contenteditable="true">
<p>Start</p>
<ul style="list-style-type: none">
<li><input contenteditable="false" type="checkbox" /> Item 1</li>
</ul>
<p>end</p>
</div>
```

### Known issues with pull request:
In this case, the specific code here that is meant to speak the string as a single character will not run. But this is a very rare case, and it is arguable that the browser content and or control fields may be wrong here anyway. At least we will still speak the line and not cause an exception. 

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
