### PR TITLE
Fix to case where alt text for math in PDF contains `&` and `<`

### DIFF
--- a/source/NVDAObjects/IAccessible/adobeAcrobat.py
+++ b/source/NVDAObjects/IAccessible/adobeAcrobat.py
@@ -212,7 +212,8 @@ class AcrobatNode(IAccessible):
 			return mathMl.replace('xmlns:mml="http://www.w3.org/1998/Math/MathML"', "")
 
 		# not MathML -- fall back to return the contents, which is hopefully alt text, inside an <mtext>
-		answer = f"<math><mtext>{mathMl.replace('<', '&lt;').replace('&', '&amp;')}</mtext></math>"
+		# note: we need to convert '<' and '%' to entity names; order of replacement is important
+		answer = f"<math><mtext>{mathMl.replace('&', '&amp;').replace('<', '&lt;')}</mtext></math>"
 		log.debug(f"_get_mathMl: didn't find MathML -- returning value as mtext: {answer}")
 		return answer
 

--- a/source/NVDAObjects/IAccessible/adobeAcrobat.py
+++ b/source/NVDAObjects/IAccessible/adobeAcrobat.py
@@ -9,6 +9,7 @@ import api
 import controlTypes
 import eventHandler
 import winUser
+import html  # for escape
 from . import IAccessible, getNVDAObjectFromEvent
 from NVDAObjects import NVDAObjectTextInfo
 from NVDAObjects.behaviors import EditableText
@@ -212,8 +213,8 @@ class AcrobatNode(IAccessible):
 			return mathMl.replace('xmlns:mml="http://www.w3.org/1998/Math/MathML"', "")
 
 		# not MathML -- fall back to return the contents, which is hopefully alt text, inside an <mtext>
-		# note: we need to convert '<' and '&' to entity names; order of replacement is important
-		answer = f"<math><mtext>{mathMl.replace('&', '&amp;').replace('<', '&lt;')}</mtext></math>"
+		# note: we need to convert '<' and '%' to entity names
+		answer = f"<math><mtext>{html.escape(mathMl)}</mtext></math>"
 		log.debug(f"_get_mathMl: didn't find MathML -- returning value as mtext: {answer}")
 		return answer
 

--- a/source/NVDAObjects/IAccessible/adobeAcrobat.py
+++ b/source/NVDAObjects/IAccessible/adobeAcrobat.py
@@ -212,7 +212,7 @@ class AcrobatNode(IAccessible):
 			return mathMl.replace('xmlns:mml="http://www.w3.org/1998/Math/MathML"', "")
 
 		# not MathML -- fall back to return the contents, which is hopefully alt text, inside an <mtext>
-		answer = f"<math><mtext>{mathMl}</mtext></math>"
+		answer = f"<math><mtext>{mathMl.replace('<', '&lt;').replace('&', '&amp;')}</mtext></math>"
 		log.debug(f"_get_mathMl: didn't find MathML -- returning value as mtext: {answer}")
 		return answer
 

--- a/source/NVDAObjects/IAccessible/adobeAcrobat.py
+++ b/source/NVDAObjects/IAccessible/adobeAcrobat.py
@@ -212,7 +212,7 @@ class AcrobatNode(IAccessible):
 			return mathMl.replace('xmlns:mml="http://www.w3.org/1998/Math/MathML"', "")
 
 		# not MathML -- fall back to return the contents, which is hopefully alt text, inside an <mtext>
-		# note: we need to convert '<' and '%' to entity names; order of replacement is important
+		# note: we need to convert '<' and '&' to entity names; order of replacement is important
 		answer = f"<math><mtext>{mathMl.replace('&', '&amp;').replace('<', '&lt;')}</mtext></math>"
 		log.debug(f"_get_mathMl: didn't find MathML -- returning value as mtext: {answer}")
 		return answer

--- a/source/NVDAObjects/IAccessible/adobeAcrobat.py
+++ b/source/NVDAObjects/IAccessible/adobeAcrobat.py
@@ -9,7 +9,7 @@ import api
 import controlTypes
 import eventHandler
 import winUser
-import html  # for escape
+import html
 from . import IAccessible, getNVDAObjectFromEvent
 from NVDAObjects import NVDAObjectTextInfo
 from NVDAObjects.behaviors import EditableText


### PR DESCRIPTION
### Link to issue number:
Fixes #18133 

### Summary of the issue:
In https://github.com/nvaccess/nvda/pull/17276, support was added for alt text in a formula (a fallback when MathML is not detected) by wrapping the alt text inside of MathML's mtext tag. That text might have `<` and `&` characters which should be "escaped" but were not. 

The PDF support was added to 2025.1 beta.

The fix is trivial: `<` -> `&lt;` and `&` -> `&amp;` (in that order).

In #18133 I said that the punctuation was not being spoken, but it turns out that MathCAT actually does convert the punctuation in strings, so LaTeX is spoken sensibly (but it is still hard to understand when read quickly).

### Description of user facing changes
In Adobe Acrobat, NVDA now properly reads alt text inside of Formula tags when no MathML is present (in various forms).

### Description of development approach
Simple string `replace()` calls to do the substitutions.

### Testing strategy:
I opened the test file [alt.pdf](https://github.com/user-attachments/files/20325821/alt.pdf) and listened what it said. I checked that in the speech viewer.

### Known issues with pull request:
None

### Code Review Checklist:

- [ ] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
