### PR TITLE
Fix issues when connecting to an untrusted relay server

### DIFF
--- a/source/_remoteClient/client.py
+++ b/source/_remoteClient/client.py
@@ -206,15 +206,8 @@ class RemoteClient:
 			self.connectAsFollower(connectionInfo)
 
 	@alwaysCallAfter
-	def disconnect(self):
-		"""Close all active connections and clean up resources.
-
-		:note: Closes local control server and both leader/follower sessions if active
-		"""
-		if self.leaderSession is None and self.followerSession is None:
-			log.debug("Disconnect called but no active sessions")
-			return
-
+	def doDisconnect(self) -> None:
+		"""Seek confirmation from the user before disconnecting."""
 		if (
 			self.followerSession is not None
 			and configuration.getRemoteConfig()["ui"]["confirmDisconnectAsFollower"]
@@ -243,7 +236,16 @@ class RemoteClient:
 				if dialog.ShowModal() != ReturnCode.YES:
 					log.info("Remote disconnection cancelled by user.")
 					return
+		self.disconnect()
 
+	def disconnect(self):
+		"""Close all active connections and clean up resources.
+
+		:note: Closes local control server and both leader/follower sessions if active
+		"""
+		if self.leaderSession is None and self.followerSession is None:
+			log.debug("Disconnect called but no active sessions")
+			return
 		log.info("Disconnecting from remote session")
 		if self.localControlServer is not None:
 			self.localControlServer.close()

--- a/source/_remoteClient/client.py
+++ b/source/_remoteClient/client.py
@@ -238,7 +238,7 @@ class RemoteClient:
 					return
 		self.disconnect()
 
-	def disconnect(self):
+	def disconnect(self, *, _silent: bool = False):
 		"""Close all active connections and clean up resources.
 
 		:note: Closes local control server and both leader/follower sessions if active
@@ -254,7 +254,8 @@ class RemoteClient:
 			self.disconnectAsLeader()
 		if self.followerSession is not None:
 			self.disconnectAsFollower()
-		cues.disconnected()
+		if not _silent:
+			cues.disconnected()
 
 	def disconnectAsLeader(self):
 		"""Close leader session and clean up related resources."""
@@ -407,7 +408,7 @@ class RemoteClient:
 		log.warning(f"Certificate validation failed for {transport.address}")
 		self.lastFailAddress = transport.address
 		self.lastFailKey = transport.channel
-		self.disconnect()
+		self.disconnect(_silent=True)
 		try:
 			certHash = transport.lastFailFingerprint
 

--- a/source/_remoteClient/dialogs.py
+++ b/source/_remoteClient/dialogs.py
@@ -142,7 +142,7 @@ class ClientPanel(ContextHelpMixin, wx.Panel):
 		5. Close the key connector and reset it.
 		6. Generate a new key from the server.
 		"""
-		self._keyGenerationProgressDialog.Done()
+		self._keyGenerationProgressDialog.done()
 		self._keyGenerationProgressDialog = None
 		try:
 			certHash = self._keyConnector.lastFailFingerprint

--- a/source/_remoteClient/menu.py
+++ b/source/_remoteClient/menu.py
@@ -113,7 +113,7 @@ class RemoteMenu(wx.Menu):
 
 	def doDisconnect(self, evt: wx.CommandEvent) -> None:
 		evt.Skip()
-		self.client.disconnect()
+		self.client.doDisconnect()
 
 	def onMuteItem(self, evt: wx.CommandEvent) -> None:
 		evt.Skip()

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -4927,7 +4927,7 @@ class GlobalCommands(ScriptableObject):
 			# Translators: A message indicating that the remote client is not connected.
 			ui.message(pgettext("remote", "Not connected"))
 			return
-		_remoteClient._remoteClient.disconnect()
+		_remoteClient._remoteClient.doDisconnect()
 
 	@script(
 		# Translators: Documentation string for the script that starts a new Remote Access session.

--- a/tests/unit/test_remote/test_remoteClient.py
+++ b/tests/unit/test_remote/test_remoteClient.py
@@ -218,7 +218,7 @@ class TestRemoteClient(unittest.TestCase):
 		with patch("_remoteClient.client.log.debug") as mockLogDebug:
 			# `disconnect` is decorated with `alwaysCallAfter`, which causes it to be executed on the GUI thread.
 			# Unwrap it since we want it to run on this thread.
-			rcClient.RemoteClient.disconnect.__wrapped__(self.client)
+			self.client.disconnect()
 			mockLogDebug.assert_called()
 		# Test disconnect with an active localControlServer.
 		fakeControl = MagicMock()
@@ -226,9 +226,7 @@ class TestRemoteClient(unittest.TestCase):
 		self.client.leaderSession = MagicMock()
 		self.client.followerSession = MagicMock()
 		with patch.object(rcClient.MessageDialog, "ShowModal", lambda *a, **k: ReturnCode.YES):
-			# `disconnect` is decorated with `alwaysCallAfter`, which causes it to be executed on the GUI thread.
-			# Unwrap it since we want it to run on this thread.
-			rcClient.RemoteClient.disconnect.__wrapped__(self.client)
+			self.client.disconnect()
 		fakeControl.close.assert_called_once()
 
 


### PR DESCRIPTION
### Link to issue number:

None

### Summary of the issue:

1. When requesting for a relay server to generate a key, if the server's certificate is not trusted, the process fails and the indeterminate progress dialog stays open indefinitely.
2. When connecting to a server with an untrusted certificate, NVDA asks the user if they want to disconnect before asking them whether to trust the server's certificate. It also plays the disconnection sound.

### Description of user facing changes

1. Requesting a key from a server with an untrusted certificate asks the user if they want to continue.
2. Connecting to a server with an untrusted certificate no-longer asks the user if they want to disconnect before asking them to confirm, and no longer plays the disconnection sound.

### Description of development approach

1. Fixed a typo where `IndeterminateProgressDialog.Done` was being called instead of `IndeterminateProgressDialog.done`.
2. Refactored `RemoteClient.close`.
   1. The business logic of disconnecting is still in `RemoteClient.disconnect`.
   2. The logic for asking the user to disconnect is in `RemoteClient.doDisconnect`. This is similar to the pattern for `doConnect`.
   3. Fixed associated unit tests, by removing the unwrapping of `RemoteClient.disconnect`, as `doDisconnect` is now wrapped in `alwaysCallAfter`.
3. Added an internal-use keyword-only parameter, `_silent`, to `RemoteClient.disconnect`, which defaults to `False`. If `True`, this bypasses calling `cues.disconnected`.

### Testing strategy:

Generated certificates using nvdaremote.com and a self-hosted relay server with a self-signed certificate.

Connected to and disconnected from nvdaremote.com and the same self-signed server.

### Known issues with pull request:

None

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
