### PR TITLE
fix(build): fix m4 invocation failure when path contains spaces

### DIFF
--- a/nvdaHelper/liblouis/sconscript
+++ b/nvdaHelper/liblouis/sconscript
@@ -60,7 +60,7 @@ if len(clangDirs) == 0:
 		"Perhaps the C++ Clang tools for Windows component in visual Studio is not installed"
 	)
 env["CC"] = "clang-cl"
-env["M4"] = str(env.File("#miscdeps/tools/m4.exe"))
+env["M4"] = f'"{str(env.File("#miscdeps/tools/m4.exe"))}"'
 # Liblouis disables GNU extensions for m4
 env.Append(M4FLAGS="-G")
 # Don't analyze the code as not our project


### PR DESCRIPTION
Wraps paths passed to `m4.exe` in double quotes to prevent build failures on systems where the build directory contains spaces (e.g., under `My Codes`).

<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
None
### Summary of the issue:
When building NVDA's liblouis component, the build system invokes `m4.exe` using a path that may include spaces (e.g., in `My Codes`). However, the path was not wrapped in quotes, causing the command to fail when executed via shell. This resulted in build errors on systems where the path to `m4.exe` includes spaces.
### Description of user facing changes

### Description of development approach
Updated the varible `env["M4"]` in `nvdaHelper\liblouis\sconscript` to ensure that the path to m4.exe is properly quoted when passed to the shell. 
### Testing strategy:
- Verified the build process on a Windows system where the NVDA source path includes spaces (e.g., `C:\Users\MyName\Documents\\My Codes\nvda`).
- Confirmed that `m4.exe` is invoked successfully and completes preprocessing without errors.
- Checked that the expected output files from the m4 step are correctly generated.
- Ensured the overall NVDA build completes without regressions.
### Known issues with pull request:

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
