### PR TITLE
Hid feature report

### DIFF
--- a/projectDocs/design/hidBrailleTechnicalNotes.md
+++ b/projectDocs/design/hidBrailleTechnicalNotes.md
@@ -144,9 +144,10 @@ This structure should also be saved off as it is later needed when writing brail
 when the `LinkCollection` member last differed from the previous structure).
 In other words, the index within its collection.
 this is needed in some implementations to work out which routing key a value represents, as the Usage ID for the value will be just ROUTING_KEY and the collection will be one of the ROUTER_SET_* collection Usage IDs.
-* A HID Braille device may optionally define the screen reader identifier usage in its feature report, allowing the screen reader to identify itself when the connection is established. This enables the Braille device to adapt its behavior to the specific screen reader. If this usage is present, NVDA will identify itself through it using the following UUID:
-	0xb0, 0x46, 0x9e, 0x01, 0xe6, 0x59, 0x4b, 0x2a,
-	0xa0, 0xc0, 0x91, 0x5a, 0x9d, 0x04, 0x8f, 0x3f
+* A HID braille device may optionally define the screen reader identifier usage in its feature report, allowing the screen reader to identify itself when the connection is established.
+This enables the braille device to adapt its behavior to the specific screen reader.
+If this usage is present, NVDA will identify itself through it using the following UUID:
+  * `0xb0, 0x46, 0x9e, 0x01, 0xe6, 0x59, 0x4b, 0x2a, 0xa0, 0xc0, 0x91, 0x5a, 0x9d, 0x04, 0x8f, 0x3f`
 
 #### Writing cells to the device
 * Create a HID output report (block of memory), setting the report ID (first byte) to the value of the ReportID member of the Braille cell `HIDP_VALUE_CAPS` structure found at construction time.

--- a/projectDocs/design/hidBrailleTechnicalNotes.md
+++ b/projectDocs/design/hidBrailleTechnicalNotes.md
@@ -144,6 +144,9 @@ This structure should also be saved off as it is later needed when writing brail
 when the `LinkCollection` member last differed from the previous structure).
 In other words, the index within its collection.
 this is needed in some implementations to work out which routing key a value represents, as the Usage ID for the value will be just ROUTING_KEY and the collection will be one of the ROUTER_SET_* collection Usage IDs.
+* A HID Braille device may optionally define the screen reader identifier usage in its feature report, allowing the screen reader to identify itself when the connection is established. This enables the Braille device to adapt its behavior to the specific screen reader. If this usage is present, NVDA will identify itself through it using the following UUID:
+	0xb0, 0x46, 0x9e, 0x01, 0xe6, 0x59, 0x4b, 0x2a,
+	0xa0, 0xc0, 0x91, 0x5a, 0x9d, 0x04, 0x8f, 0x3f
 
 #### Writing cells to the device
 * Create a HID output report (block of memory), setting the report ID (first byte) to the value of the ReportID member of the Braille cell `HIDP_VALUE_CAPS` structure found at construction time.

--- a/source/brailleDisplayDrivers/hidBrailleStandard.py
+++ b/source/brailleDisplayDrivers/hidBrailleStandard.py
@@ -88,7 +88,7 @@ SCREEN_READER_IDENTIFIER = bytes(
 		0x04,
 		0x8F,
 		0x3F,
-	]
+	],
 )
 
 

--- a/source/brailleDisplayDrivers/hidBrailleStandard.py
+++ b/source/brailleDisplayDrivers/hidBrailleStandard.py
@@ -69,10 +69,27 @@ class BraillePageUsageID(enum.IntEnum):
 	BRAILLE_ROCKER_DOWN = 0x21D
 	BRAILLE_ROCKER_PRESS = 0x21E
 
-SCREEN_READER_IDENTIFIER = bytes([
-	0xb0, 0x46, 0x9e, 0x01, 0xe6, 0x59, 0x4b, 0x2a,
-	0xa0, 0xc0, 0x91, 0x5a, 0x9d, 0x04, 0x8f, 0x3f
-])
+
+SCREEN_READER_IDENTIFIER = bytes(
+	[
+		0xB0,
+		0x46,
+		0x9E,
+		0x01,
+		0xE6,
+		0x59,
+		0x4B,
+		0x2A,
+		0xA0,
+		0xC0,
+		0x91,
+		0x5A,
+		0x9D,
+		0x04,
+		0x8F,
+		0x3F,
+	]
+)
 
 
 @dataclass
@@ -142,7 +159,7 @@ class HidBrailleDriver(braille.BrailleDisplayDriver):
 						HID_USAGE_PAGE_BRAILLE,
 						0,
 						BraillePageUsageID.SCREEN_READER_IDENTIFIER,
-						SCREEN_READER_IDENTIFIER
+						SCREEN_READER_IDENTIFIER,
 					)
 					self._dev.setFeature(report.data)
 				break

--- a/source/hwIo/hid.py
+++ b/source/hwIo/hid.py
@@ -119,6 +119,35 @@ class HidOutputReport(HidReport):
 		)
 
 
+class HidFeatureReport(HidReport):
+	_reportType = hidpi.HIDP_REPORT_TYPE.FEATURE
+
+	def __init__(self, device, reportID=0):
+		self._reportSize = device.caps.FeatureReportByteLength
+		self._reportBuf = ctypes.c_buffer(self._reportSize)
+		self._reportBuf[0] = reportID
+		super().__init__(device)
+
+	@property
+	def data(self):
+		return self._reportBuf.raw
+
+	def setUsageValueArray(self, usagePage, linkCollection, usage, data):
+		dataBuf = ctypes.c_buffer(data)
+		check_HidP_status(
+			hidDll.HidP_SetUsageValueArray,
+			self._reportType,
+			hidpi.USAGE(usagePage),
+			ctypes.c_ushort(linkCollection),
+			hidpi.USAGE(usage),
+			dataBuf,
+			len(dataBuf),
+			self._dev._pd,
+			self._reportBuf,
+			self._reportSize,
+		)
+
+
 class Hid(IoBase):
 	"""Raw I/O for HID devices."""
 

--- a/source/hwIo/hid.py
+++ b/source/hwIo/hid.py
@@ -280,6 +280,24 @@ class Hid(IoBase):
 		self._outputValueCaps = valueCapsList
 		return self._outputValueCaps
 
+	@property
+	def featureValueCaps(self) -> ctypes.Array[hidpi.HIDP_VALUE_CAPS]:
+		if hasattr(self, "_featureValueCaps"):
+			return self._featureValueCaps
+		valueCapsList = (hidpi.HIDP_VALUE_CAPS * self.caps.NumberFeatureValueCaps)()
+		numValueCaps = ctypes.c_long(self.caps.NumberFeatureValueCaps)
+		if numValueCaps.value == 0:
+			return valueCapsList
+		check_HidP_status(
+			hidDll.HidP_GetValueCaps,
+			hidpi.HIDP_REPORT_TYPE.FEATURE,
+			ctypes.byref(valueCapsList),
+			ctypes.byref(numValueCaps),
+			self._pd,
+		)
+		self._featureValueCaps = valueCapsList
+		return self._featureValueCaps
+
 	def _prepareWriteBuffer(self, data: bytes) -> Tuple[int, ctypes.c_char_p]:
 		"""For HID devices, the buffer to be written must match the
 		OutputReportByteLength fetched from HIDP_CAPS, to ensure this is the case

--- a/source/hwIo/hid.py
+++ b/source/hwIo/hid.py
@@ -122,17 +122,17 @@ class HidOutputReport(HidReport):
 class HidFeatureReport(HidReport):
 	_reportType = hidpi.HIDP_REPORT_TYPE.FEATURE
 
-	def __init__(self, device, reportID=0):
+	def __init__(self, device, reportID: int = 0):
 		self._reportSize = device.caps.FeatureReportByteLength
 		self._reportBuf = ctypes.c_buffer(self._reportSize)
 		self._reportBuf[0] = reportID
 		super().__init__(device)
 
 	@property
-	def data(self):
+	def data(self) -> bytes:
 		return self._reportBuf.raw
 
-	def setUsageValueArray(self, usagePage, linkCollection, usage, data):
+	def setUsageValueArray(self, usagePage: int, linkCollection: int, usage: int, data: bytes) -> None:
 		dataBuf = ctypes.c_buffer(data)
 		check_HidP_status(
 			hidDll.HidP_SetUsageValueArray,


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Does not apply
### Summary of the issue:
A HID Braille device can expect a screen reader identifier that signifies to the device what screen reader has initiated communication. Currently, NVDA ignores this.
### Description of user facing changes
No immediate changes of behavior.
### Description of development approach
The HID Braille driver queries the report descriptor for the presence of the screen reader identifier usage in the feature report. If the usage is found, then as part of initialization, a UUID signifying NVDA (newly generated from a source of random numbers) is sent as the screen reader identifier.
### Testing strategy:
Tested against Help Tech HID devices with and without this usage in their report descriptors.
### Known issues with pull request:
None.
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
