### PR TITLE
Fix debugging with VS Code

### DIFF
--- a/sconstruct
+++ b/sconstruct
@@ -13,7 +13,7 @@ from pathlib import Path
 # Ensure we are inside the Python virtual environment, and that it is started with uv
 virtualEnv = os.getenv("VIRTUAL_ENV")
 uv = os.getenv("uv")
-if not virtualEnv or not uv or Path.cwd() not in Path(virtualEnv).resolve().parents:
+if not virtualEnv or not uv or Path.cwd() != Path(virtualEnv).parent:
 	print(
 		"Error: SCons was started outside NVDA's build system Python virtual environment.\n"
 		"SCons must be executed using scons.bat in the root of this repository."

--- a/source/nvda.pyw
+++ b/source/nvda.pyw
@@ -36,11 +36,10 @@ _log.addHandler(logging.NullHandler(level=logging.INFO))
 
 if NVDAState.isRunningAsSource():
 	# We should always change directory to the location of this module (nvda.pyw), don't rely on sys.path[0]
-	appDir = os.path.normpath(os.path.dirname(__file__))
-	# Ensure we are inside the Python virtual environment, and that it is started with uv
+	appDir = os.path.abspath(os.path.dirname(__file__))
+	# Ensure we are inside the Python virtual environment
 	virtualEnv = os.getenv("VIRTUAL_ENV")
-	uv = os.getenv("uv")
-	if not virtualEnv or not uv or Path(appDir).parent.resolve() not in Path(virtualEnv).resolve().parents:
+	if not virtualEnv or Path(appDir).parent != Path(virtualEnv).parent:
 		ctypes.windll.user32.MessageBoxW(
 			0,
 			"NVDA cannot  detect the Python virtual environment. "
@@ -52,9 +51,8 @@ if NVDAState.isRunningAsSource():
 else:
 	# Append the path of the executable to sys so we can import modules from the dist dir.
 	sys.path.append(sys.prefix)
-	appDir = sys.prefix
+	appDir = os.path.abspath(sys.prefix)
 
-appDir = os.path.abspath(appDir)
 os.chdir(appDir)
 globalVars.appDir = appDir
 globalVars.appPid = os.getpid()


### PR DESCRIPTION
### Link to issue number:
Fixes #18154 

### Summary of the issue:
Since using uv, debugging with VS Code is no longer functional.

### Description of user facing changes
Debugging works again.

### Description of development approach
There were actually two issues:

1. When running NVDA from VS Code, it is run from the venv, therefore the `UV` environment variable is not set. Therefore we no longer check for this variable in nvda.pyw.
2. We explicitly check whether the venv we're running in belongs to NVDA. This check didn't work properly in VS Code, as when running in the debugger, `os.path.dirname("nvda.pyw")` resolved to an empty string. This is fixed by retrieving the absolute path earlier in the process. The venv check is changed in such a way that it ensures that the parent folder of `source` and `.venv` is equal. Therefore, the cost of no longer checking uv explicitly is solved by having a stricter venv check.

### Testing strategy:
Tested running from source as well as in the VS Code debugger.

### Known issues with pull request:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
