### PR TITLE
Bugfix: missing tab in spanish symbols.

### DIFF
--- a/source/locale/es/symbols.dic
+++ b/source/locale/es/symbols.dic
@@ -250,7 +250,7 @@ _	subrayado	most
 ≪	mucho menor a	none
 ≥	mayor o igual a	none
 ≧	mayor o igual a	none
-≫	mucho mayor anone
+≫	mucho mayor a	none
 ≶	menor o mayor que	none
 ≷	mayor o menor que	none
 ≮	no menor que	none


### PR DESCRIPTION
### Link to issue number:

None

### Summary of the issue:

A tab is missing on a symbol in the spanish locale, sending a wrong text to the current speech synthesizer.

### Description of user facing changes

As simple as try to read:

```≫```

With any Spanish voice. The output is questionable:

```mucho mayor anone```

none is the part of the column.

### Description of development approach

Just added the missing tab.

### Testing strategy:

**≫** should be read as **mucho mayor a**.

### Known issues with pull request:

None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
