### PR TITLE
Use devenv app module for SQL Server Management Studio

### DIFF
--- a/source/appModuleHandler.py
+++ b/source/appModuleHandler.py
@@ -1,6 +1,6 @@
 # -*- coding: UTF-8 -*-
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2006-2024 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Patrick Zajda, Joseph Lee,
+# Copyright (C) 2006-2025 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Patrick Zajda, Joseph Lee,
 # Babbage B.V., Mozilla Corporation, Julien Cochuyt, Leonard de Ruijter, Cyrille Bougot
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.

--- a/source/appModuleHandler.py
+++ b/source/appModuleHandler.py
@@ -489,10 +489,10 @@ class AppModule(baseObject.ScriptableObject):
 
 		self._inprocRegistrationHandle = None
 
-	def _getExecutableFileInfo(self):
-		# Used for obtaining file name and version for the executable.
-		# This is needed in case immersive app package returns an error,
-		# dealing with a native app, or a converted desktop app.
+	processExecutablePath: str
+	"""The path to the executable of the current process."""
+
+	def _get_processExecutablePath(self) -> str:
 		# Create the buffer to get the executable name
 		exeFileName = ctypes.create_unicode_buffer(ctypes.wintypes.MAX_PATH)
 		length = ctypes.wintypes.DWORD(ctypes.wintypes.MAX_PATH)
@@ -503,8 +503,13 @@ class AppModule(baseObject.ScriptableObject):
 			ctypes.byref(length),
 		):
 			raise ctypes.WinError()
-		fileName = exeFileName.value
-		fileinfo = getFileVersionInfo(fileName, "ProductName", "ProductVersion")
+		return exeFileName.value
+
+	def _getExecutableFileInfo(self):
+		# Used for obtaining file name and version for the executable.
+		# This is needed in case immersive app package returns an error,
+		# dealing with a native app, or a converted desktop app.
+		fileinfo = getFileVersionInfo(self.processExecutablePath, "ProductName", "ProductVersion")
 		return (fileinfo["ProductName"], fileinfo["ProductVersion"])
 
 	def _getImmersivePackageInfo(self):

--- a/source/appModules/__init__.py
+++ b/source/appModules/__init__.py
@@ -1,7 +1,7 @@
 # A part of NonVisual Desktop Access (NVDA)
 # Copyright (C) 2009-2024 NV Access Limited, Łukasz Golonka, Joseph Lee
-# This file may be used under the terms of the GNU General Public License, version 2 or later.
-# For more details see: https://www.gnu.org/licenses/gpl-2.0.html
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
 
 
 EXECUTABLE_NAMES_TO_APP_MODS: dict[str, str] = {
@@ -43,6 +43,8 @@ EXECUTABLE_NAMES_TO_APP_MODS: dict[str, str] = {
 	# Spring Tool Suite is based on Eclipse and should use its appModule.
 	"springtoolsuite4": "eclipse",
 	"sts": "eclipse",
+	# Microsoft SQL Server Management Studio is based on Visual Studio
+	"ssms": "devenv",
 	# Various versions of Teamtalk.
 	"teamtalk3": "teamtalk4classic",
 	# App module for Windows 10/11 Modern Keyboard aka new touch keyboard panel

--- a/source/appModules/__init__.py
+++ b/source/appModules/__init__.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2009-2024 NV Access Limited, Łukasz Golonka, Joseph Lee
+# Copyright (C) 2009-2025 NV Access Limited, Łukasz Golonka, Joseph Lee, Leonard de Ruijter
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 

--- a/source/appModules/devenv.py
+++ b/source/appModules/devenv.py
@@ -1,8 +1,10 @@
 # A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2010-2025 NV Access Limited, Soronel Haetir, Babbage B.V., Francisco Del Roio,
+# Leonard de Ruijter
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-# Copyright (C) 2010-2022 NV Access Limited, Soronel Haetir, Babbage B.V., Francisco Del Roio,
-# Leonard de Ruijter
+
+"""App module for Microsoft Visual Studio and Microsoft SQL Server Management Studio."""
 
 import os.path
 import objbase

--- a/source/appModules/devenv.py
+++ b/source/appModules/devenv.py
@@ -46,6 +46,8 @@ class AppModule(appModuleHandler.AppModule):
 		self._DTECache = {}
 		slnDllPath = os.path.join(os.path.dirname(self.processExecutablePath), "vssln.dll")
 		if self.appName.lower() == "ssms" and os.path.exists(slnDllPath):
+			# Use the underlying Visual Studio version number,
+			# Not the SQL Server Management Studio version number.
 			fileinfo = getFileVersionInfo(slnDllPath, "ProductVersion")
 			productVersion = fileinfo["ProductVersion"]
 		else:

--- a/source/appModules/devenv.py
+++ b/source/appModules/devenv.py
@@ -4,12 +4,14 @@
 # Copyright (C) 2010-2022 NV Access Limited, Soronel Haetir, Babbage B.V., Francisco Del Roio,
 # Leonard de Ruijter
 
+import os.path
 import objbase
 import comtypes
 from locationHelper import RectLTWH
 from logHandler import log
 import textInfos.offsets
 
+from fileUtils import getFileVersionInfo
 from NVDAObjects.behaviors import EditableText, EditableTextWithoutAutoSelectDetection
 from NVDAObjects.window import Window
 from comtypes.automation import IDispatch
@@ -40,7 +42,13 @@ class AppModule(appModuleHandler.AppModule):
 	def __init__(self, *args, **kwargs):
 		super().__init__(*args, **kwargs)
 		self._DTECache = {}
-		vsMajor, vsMinor, rest = self.productVersion.split(".", 2)
+		slnDllPath = os.path.join(os.path.dirname(self.processExecutablePath), "vssln.dll")
+		if self.appName.lower() == "ssms" and os.path.exists(slnDllPath):
+			fileinfo = getFileVersionInfo(slnDllPath, "ProductVersion")
+			productVersion = fileinfo["ProductVersion"]
+		else:
+			productVersion = self.productVersion
+		vsMajor, vsMinor, rest = productVersion.split(".", 2)
 		self.vsMajor, self.vsMinor = int(vsMajor), int(vsMinor)
 
 	def chooseNVDAObjectOverlayClasses(self, obj, clsList):

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -19,7 +19,7 @@
 * In Microsoft Word, when UIA is enabled, NVDA will no longer braille redundant table end markers when the cursor is in a table cell. (#15828, @LeonarddeR)
 * In Geekbench 6.4, NVDA can again read the ribbon and options within. (#17892, @mzanm)
 * NVDA no longer fails to read check list items in Microsoft Loop when viewed in Google Chrome / Microsoft Edge. (#18130)
-* NVDA now respects its line number reporting setting in Microsoft SQL Server Management Studio 21. (#?, @LeonarddeR)
+* NVDA now respects its line number reporting setting in Microsoft SQL Server Management Studio 21. (#18176, @LeonarddeR)
 
 ### Changes for Developers
 
@@ -28,7 +28,7 @@ Please refer to [the developer guide](https://www.nvaccess.org/files/nvda/docume
 * NVDA now uses [uv](https://docs.astral.sh/uv/) as Python package/project manager. (#17935, #17978, @LeonarddeR)
   * Running `scons` from the source repository will automatically suggest a strategy to install uv when it is not yet available.
 * Added the "externalPythonDependencies" category as an extra debug logging category. When enabled, debug logging messages from external dependencies (such as comtypes) will be delivered to NVDA's log. (#18067, @LeonarddeR)
-* Microsoft SQL Server Management Studio now uses the Visual Studio app module, as SSMS is based on Visual Studio. (#?, @LeonarddeR)
+* Microsoft SQL Server Management Studio now uses the Visual Studio app module, as SSMS is based on Visual Studio. (#18176, @LeonarddeR)
 
 #### Deprecations
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -19,6 +19,7 @@
 * In Microsoft Word, when UIA is enabled, NVDA will no longer braille redundant table end markers when the cursor is in a table cell. (#15828, @LeonarddeR)
 * In Geekbench 6.4, NVDA can again read the ribbon and options within. (#17892, @mzanm)
 * NVDA no longer fails to read check list items in Microsoft Loop when viewed in Google Chrome / Microsoft Edge. (#18130)
+* NVDA now respects its line number reporting setting in Microsoft SQL Server Management Studio 21. (#?, @LeonarddeR)
 
 ### Changes for Developers
 
@@ -27,6 +28,7 @@ Please refer to [the developer guide](https://www.nvaccess.org/files/nvda/docume
 * NVDA now uses [uv](https://docs.astral.sh/uv/) as Python package/project manager. (#17935, #17978, @LeonarddeR)
   * Running `scons` from the source repository will automatically suggest a strategy to install uv when it is not yet available.
 * Added the "externalPythonDependencies" category as an extra debug logging category. When enabled, debug logging messages from external dependencies (such as comtypes) will be delivered to NVDA's log. (#18067, @LeonarddeR)
+* Microsoft SQL Server Management Studio now uses the Visual Studio app module, as SSMS is based on Visual Studio. (#?, @LeonarddeR)
 
 #### Deprecations
 


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
Microsoft SQL Server Management Studio has always been based on Visual Studio, though this was never reflected in NVDA"s use of the devenv submodule. This becomes more prevalent since SSMS version 21, which upgrades its internals from VS 2017 to VS 2022. NVDA requires a Visual Studio specific tweak to properly respect the line number reporting setting in the query editor.

### Description of user facing changes
NVDA no longer ignores the line number reporting setting in SSMS 21.

### Description of development approach
1. Add a mapping to `EXECUTABLE_NAMES_TO_APP_MODS`
2. Refactored `_getExecutableFileInfo` in such a way that the executable path of the current process can now be fetched separately.
3. When using SSMS, base VS Major and VS Minor on the product version of vssln.dll, which has been found in installations of SSMS 20 and 21. If we don't, the product version of SSMS is used, which differs from the internal VS version.

### Testing strategy:
1. Tested that vsMajor and vsMinor are properly recognised and that the app module can access the Visual Studio object model in SSMS.
2. Tested that line numbers are no longer reported erroneously.

### Known issues with pull request:
None known

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
