### PR TITLE
Fix: Correct context help navigation for Remote Access dialog

### DIFF
--- a/source/_remoteClient/dialogs.py
+++ b/source/_remoteClient/dialogs.py
@@ -25,7 +25,7 @@ from .protocol import SERVER_PORT, RemoteMessageType
 
 
 class ClientPanel(ContextHelpMixin, wx.Panel):
-	helpId = "RemoteAccessConnectExisting"
+	helpId = "RemoteAccessJoin"
 	host: wx.ComboBox
 	key: wx.TextCtrl
 	_generateKeyButton: wx.Button
@@ -170,7 +170,7 @@ class PortCheckResponse(TypedDict):
 
 
 class ServerPanel(ContextHelpMixin, wx.Panel):
-	helpId = "RemoteAccessConnectLocal"
+	helpId = "RemoteAccessConnectSelfHosted"
 	_getIPButton: wx.Button
 	_externalIPControl: wx.TextCtrl
 	port: wx.TextCtrl
@@ -306,7 +306,7 @@ class ServerPanel(ContextHelpMixin, wx.Panel):
 
 
 class DirectConnectDialog(ContextHelpMixin, wx.Dialog):
-	helpId = "RemoteAccessConnect"
+	helpId = "RemoteAccessSetup"
 	_selectedPanel: ClientPanel | ServerPanel
 
 	def __init__(self, parent: wx.Window, id: int, title: str, hostnames: list[str] | None = None):


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
The context help (invoked by F1) for remote access dialogs was not functioning correctly. The `helpId` attributes associated with these dialogs were pointing to outdated anchor links within the NVDA User Guide. This pull request corrects these `helpId`s to ensure users are directed to the appropriate and current help sections.

### Description of user facing changes
When users activate context help while focused on elements within the "Remote Access" dialogs, they will now be navigated to the correct and relevant topic in the NVDA User Guide.

### Description of development approach
The `helpId` class attributes for `ClientPanel`, `ServerPanel`, and `DirectConnectDialog` within the `_remoteClient/dialogs.py` module were reviewed and updated.

These changes ensure that the context help system maps these dialog components to their intended sections in the user guide. No other logic changes were made.

### Testing strategy:
Manual testing.

### Known issues with pull request:
None.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [X] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [X] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [X] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [ ] API is compatible with existing add-ons.
- [ ] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
