### PR TITLE
Don't trigger a different configuration profile when Elements list or find dialogs are opened

### DIFF
--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -1252,6 +1252,8 @@ class ElementsListDialog(
 
 	lastSelectedElementType = 0
 
+	shouldSuspendConfigProfileTriggers = True
+
 	def __init__(self, document):
 		super().__init__(
 			parent=gui.mainFrame,

--- a/source/cursorManager.py
+++ b/source/cursorManager.py
@@ -42,6 +42,8 @@ class FindDialog(
 
 	helpId = "SearchingForText"
 
+	shouldSuspendConfigProfileTriggers = True
+
 	def __init__(self, parent, cursorManager, text, caseSensitivity, reverse=False):
 		# Translators: Title of a dialog to find text.
 		super().__init__(parent, title=_("Find"))

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -11,6 +11,7 @@
 ### Changes
 
 * In browse mode, it is now possible to use number keys 1 to 9 (previously 1 to 6), to navigate to the corresponding heading. (#18014, @CyrilleB79)
+* When Elements List or Find dialogs are opened, NVDA won't change the configuration profile, similar to the behavior in other NVDA dialogs. (#18160, @nvdaes)
 
 ### Bug Fixes
 


### PR DESCRIPTION
- **Suspend profile triggers when Element list, and Find dialogs are opened**
- **Update changelog**

<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Fixes issue #18160.
### Summary of the issue:
When the Elements list dialog, or the Find dialog are opened, NVDA may change the configuration profile, instead of using the current profile, for example, a profile created for the web browser. This behavior doesn't match other NVDA's dialogs, where profile triggers are suspended.
### Description of user facing changes
NVDA Will use the current profile when Elements list or Find dialogs are opened.
### Description of development approach
`shouldSuspendConfigProfileTriggers` is set to True for Elements list and Find dialogs.
### Testing strategy:
1. Create a configuration profile triggered in Firefox.
1. Open the Elements list dialog.
1. Check that Firefox profile is active.
1. Close the dialog.
1. Check that Firefox profile is active.
1. Press `Windows+m`to go to the desktop.
1. Check that the normal configuration is active.
1. Repeat same steps for Find dialog.

### Known issues with pull request:
None.
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
