### PR TITLE
fix(build): fix Python interpreter calling failure when path contains spaces

### DIFF
--- a/projectDocs/dev/developerGuide/sconscript
+++ b/projectDocs/dev/developerGuide/sconscript
@@ -24,7 +24,7 @@ mdFileSub = env.Substfile(
 htmlFile = env.Command(
 	target=mdFile.abspath.replace(".md", ".html"),
 	source=mdFileSub,
-	action=[f'@{sys.executable} source/md2html.py -t developerGuide "$SOURCE" "$TARGET"'],
+	action=[f'@"{sys.executable}" source/md2html.py -t developerGuide "$SOURCE" "$TARGET"'],
 )
 devGuide = env.Command(
 	target=devDocsOutputDir.File("developerGuide.html"), source=htmlFile, action=Move("$TARGET", "$SOURCE")

--- a/sconstruct
+++ b/sconstruct
@@ -307,7 +307,7 @@ for xliffFile in env.Glob(os.path.join(userDocsDir.path, "*", "*.xliff")):
 	env.Command(
 		mdFile,
 		xliffFile,
-		[f'@{sys.executable} source/markdownTranslate.py generateMarkdown -x "{xliffFile}" -o "{mdFile}"'],
+		[f'@"{sys.executable}" source/markdownTranslate.py generateMarkdown -x "{xliffFile}" -o "{mdFile}"'],
 	)
 # Allow all markdown files to be converted to html in user_docs
 for mdFile in env.Glob(os.path.join(userDocsDir.path, "*", "*.md")):
@@ -326,7 +326,7 @@ for mdFile in env.Glob(os.path.join(userDocsDir.path, "*", "*.md")):
 	htmlFile = env.Command(
 		target=mdFile.abspath.replace(".md", ".html"),
 		source=mdFileSub,
-		action=[f'@{sys.executable} source/md2html.py -l {lang} -t {docType} "$SOURCE" "$TARGET"'],
+		action=[f'@"{sys.executable}" source/md2html.py -l {lang} -t {docType} "$SOURCE" "$TARGET"'],
 	)
 	styleInstallPath = os.path.dirname(mdFile.abspath)
 	installedStyle = env.Install(styleInstallPath, styles)
@@ -351,7 +351,7 @@ for userGuideFileSub in env.Glob(os.path.join(userDocsDir.path, "*", "userGuide.
 	keyCommandsHtmlFile = env.Command(
 		target=userGuideFileSub.abspath.replace("userGuide.md.sub", "keyCommands.html"),
 		source=userGuideFileSub,
-		action=[f'@{sys.executable} source/md2html.py -l {lang} -t keyCommands "$SOURCE" "$TARGET"'],
+		action=[f'@"{sys.executable}" source/md2html.py -l {lang} -t keyCommands "$SOURCE" "$TARGET"'],
 	)
 	env.Depends(keyCommandsHtmlFile, userGuideFileSub)
 


### PR DESCRIPTION
Wraps paths passed to the python interpreter in double quotes to prevent build failures on systems where the build directory contains spaces (e.g., under "My Codes").

This is a follow-up to a previously merged PR #18147 which partially addressed build issues under directories with spaces. This PR fixes an overlooked case involving `sys.executable`. 

<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
<!-- Use Closes/Fixes/Resolves #xxx to link this PR to the issue it is responding to. -->
None

### Summary of the issue:
On systems where the build directory contains spaces (e.g., under "`My Codes`"), NVDA's build process fails due to unquoted executable paths. Previously, this was addressed for `m4.exe` (see #18147) but Python interpreter paths used during SCons builds (such as for building `user_docs`) were not properly quoted, causing continued failures in similar scenarios.

### Description of user facing changes:
None

### Description of developer facing changes:
The build system `SCons` invokes the Python interpreter (e.g., `@{sys.executable}` in building scripts) in several build steps. When the interpreter’s path contains spaces (e.g., in "C:\Users\MyName\Documents\My Codes\nvda\\.venv\Scripts\python.exe"), the command fails unless the path is wrapped in quotes. This PR wraps `{sys.executable}` in double quotes to ensure these paths are parsed correctly by the shell and avoids build errors in such environments.

### Description of development approach:
1. Identified additional unquoted uses of `sys.executable` during the `SCons` build process.
2. Wrapped the affected interpreter path with `"` to ensure correct interpretation when passed to the command line.

### Testing strategy:
Executed the building commands mentioned in [projectDocs/dev/buildingNVDA.md](https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/buildingNVDA.md) to confirm that the build completes successfully under directories with spaces and that there is no regression in builds without spaces.

### Known issues with pull request:
None identified.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
