### PR TITLE
Keep focus on Apply button and show confirmation after applying settings

### DIFF
--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -322,9 +322,11 @@ class SettingsDialog(
 		Sub-classes may extend or override this method.
 		This base method should be called to run the postInit method.
 		"""
+		# Ensure that after applying, focus stays on the Apply button
+		self.setPostInitFocus = lambda: self.FindWindowById(wx.ID_APPLY).SetFocus()
 		self.postInit()
 		# Translators: confirmation message for when settings are applied
-		tip = ui.message(_("Settings successfully applied."))
+		core.callLater(500, ui.message, _("Settings successfully applied."))
 		self.SetReturnCode(wx.ID_APPLY)
 
 	def _onWindowDestroy(self, evt: wx.WindowDestroyEvent):

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -327,7 +327,7 @@ class SettingsDialog(
 		self.setPostInitFocus = lambda: self.FindWindowById(wx.ID_APPLY).SetFocus()
 		# Show a floating message notifying user the settings are applied
 		tip = wx.TipWindow(self, "Settings successfully applied.")
-    	# Auto-close the tooltip after 3 seconds
+		# Auto-close the tooltip after 3 seconds
 		wx.CallLater(3000, tip.Close)
 		self.SetReturnCode(wx.ID_APPLY)
 

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -88,6 +88,7 @@ import winVersion
 import weakref
 import time
 from .dpiScalingHelper import DpiScalingHelperMixinWithoutInit
+import ui
 
 #: The size that settings panel text descriptions should be wrapped at.
 # Ensure self.scaleSize is used to adjust for OS scaling adjustments.

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -323,6 +323,12 @@ class SettingsDialog(
 		This base method should be called to run the postInit method.
 		"""
 		self.postInit()
+		# Ensure that after applying, focus stays on the Apply button
+		self.setPostInitFocus = lambda: self.FindWindowById(wx.ID_APPLY).SetFocus()
+		# Show a floating message notifying user the settings are applied
+		tip = wx.TipWindow(self, "Settings successfully applied.")
+    	# Auto-close the tooltip after 3 seconds
+		wx.CallLater(3000, tip.Close)
 		self.SetReturnCode(wx.ID_APPLY)
 
 	def _onWindowDestroy(self, evt: wx.WindowDestroyEvent):

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -323,12 +323,8 @@ class SettingsDialog(
 		This base method should be called to run the postInit method.
 		"""
 		self.postInit()
-		# Ensure that after applying, focus stays on the Apply button
-		self.setPostInitFocus = lambda: self.FindWindowById(wx.ID_APPLY).SetFocus()
-		# Show a floating message notifying user the settings are applied
-		tip = wx.TipWindow(self, "Settings successfully applied.")
-		# Auto-close the tooltip after 3 seconds
-		wx.CallLater(3000, tip.Close)
+		# Translators: confirmation message for when settings are applied
+		tip = ui.message(_("Settings successfully applied."))
 		self.SetReturnCode(wx.ID_APPLY)
 
 	def _onWindowDestroy(self, evt: wx.WindowDestroyEvent):


### PR DESCRIPTION


<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
<!-- Use Closes/Fixes/Resolves #xxx to link this PR to the issue it is responding to. -->
Fixes [Issue #18029](https://github.com/nvaccess/nvda/issues/18029).

### Summary of the issue:
Previously, pressing Alt + A (Apply) would shift focus back to the Categories List, which confused users and made it unclear whether settings were saved. The original post proposed to add a notification for the user to confirm.

### Description of user facing changes:
- Keeps focus on the Apply button after pressing it.
- Shows a non-blocking Window with the message “Settings successfully applied”.
- The message automatically disappears after 3 seconds.

### Description of developer facing changes:
- Uses setPostInitFocus to override the default behavior in postInit, avoiding focus reset to the category list.
- Uses wx.TipWindow with wx.CallLater for lightweight, temporary visual feedback.
- No changes to dialog layout or event handling flow.

### Description of development approach:
- Looked into the onApply() method of the base settings dialog.
- Used setPostInitFocus to maintain focus on the Apply button — leveraging NVDA’s existing design.
- Used wx.TipWindow instead of wx.MessageBox to avoid taking focus or requiring user interaction.
- Added a timer (wx.CallLater) to auto-close the message after 3 seconds for minimal user impact.

### Testing strategy:
-Verified that pressing Alt + A (Apply):
    - Applies settings as expected.
    - Keeps focus on the Apply button.
    - Triggers a tooltip that disappears automatically.

Ensured the fix does not affect other behavior or initial dialog focus.

### Known issues with pull request:
The tooltip does not offer an audio cue unless screen reader focus reaches it (expected for a TipWindow).
No localisation added for the message string ("Settings successfully applied.") — could be added in future.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [ ] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [ ] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [ ] API is compatible with existing add-ons.
- [ ] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
