### PR TITLE
Prevent NVDA from announcing non-landmark <header> and <footer> as "grouping"

### DIFF
--- a/source/NVDAObjects/IAccessible/chromium.py
+++ b/source/NVDAObjects/IAccessible/chromium.py
@@ -15,7 +15,7 @@ from NVDAObjects.IAccessible import IAccessible
 from virtualBuffers.gecko_ia2 import Gecko_ia2 as GeckoVBuf, Gecko_ia2_TextInfo as GeckoVBufTextInfo
 from . import ia2Web
 from logHandler import log
-from . import IAccessible, Groupbox
+from . import Groupbox
 
 
 if typing.TYPE_CHECKING:

--- a/source/NVDAObjects/IAccessible/chromium.py
+++ b/source/NVDAObjects/IAccessible/chromium.py
@@ -15,6 +15,8 @@ from NVDAObjects.IAccessible import IAccessible
 from virtualBuffers.gecko_ia2 import Gecko_ia2 as GeckoVBuf, Gecko_ia2_TextInfo as GeckoVBufTextInfo
 from . import ia2Web
 from logHandler import log
+from . import IAccessible, Groupbox
+
 
 if typing.TYPE_CHECKING:
 	# F401 imported but unused, actually used as a string within type annotation (to avoid having to import
@@ -197,6 +199,17 @@ def findExtraOverlayClasses(obj, clsList):
 		clsList.append(PresentationalList)
 	elif obj.role == controlTypes.Role.GROUPING and obj.IA2Attributes.get("tag", "").casefold() == "figure":
 		clsList.append(Figure)
+	# Prevent NVDA from treating <header> or <footer> as "grouping" unless they're landmarks
+	elif (
+		obj.role == controlTypes.Role.GROUPING
+		and obj.IA2Attributes.get("tag", "").casefold() in ("header", "footer")
+		and "container-tag" not in obj.IA2Attributes
+	):
+		try:
+			clsList.remove(Groupbox)
+		except ValueError:
+			pass
+
 	ia2Web.findExtraOverlayClasses(
 		obj,
 		clsList,

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -322,12 +322,7 @@ class SettingsDialog(
 		Sub-classes may extend or override this method.
 		This base method should be called to run the postInit method.
 		"""
-		# Ensure that after applying, focus stays on the Apply button
-		self.setPostInitFocus = lambda: self.FindWindowById(wx.ID_APPLY).SetFocus()
-		# Show a floating message notifying user the settings are applied
-		tip = wx.TipWindow(self, "Settings successfully applied.")
-    	# Auto-close the tooltip after 3 seconds
-		wx.CallLater(3000, tip.Close)
+		self.postInit()
 		self.SetReturnCode(wx.ID_APPLY)
 
 	def _onWindowDestroy(self, evt: wx.WindowDestroyEvent):

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -323,6 +323,12 @@ class SettingsDialog(
 		This base method should be called to run the postInit method.
 		"""
 		self.postInit()
+		# Ensure that after applying, focus stays on the Apply button
+		self.setPostInitFocus = lambda: self.FindWindowById(wx.ID_APPLY).SetFocus()
+		# Show a floating message notifying user the settings are applied
+		tip = wx.TipWindow(self, "Settings successfully applied.")
+    	# Auto-close the tooltip after 3 seconds
+		wx.CallLater(3000, tip.Close)
 		self.SetReturnCode(wx.ID_APPLY)
 
 	def _onWindowDestroy(self, evt: wx.WindowDestroyEvent):

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -322,7 +322,6 @@ class SettingsDialog(
 		Sub-classes may extend or override this method.
 		This base method should be called to run the postInit method.
 		"""
-		self.postInit()
 		# Ensure that after applying, focus stays on the Apply button
 		self.setPostInitFocus = lambda: self.FindWindowById(wx.ID_APPLY).SetFocus()
 		# Show a floating message notifying user the settings are applied


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
<!-- Use Closes/Fixes/Resolves #xxx to link this PR to the issue it is responding to. -->
Fixes [Issue #18186](https://github.com/nvaccess/nvda/issues/18186) 

### Summary of the issue:
For the `<header>` and `<footer>` elements that are children of the main element, but are unnamed, NVDA is correctly not announcing the role for the elements.
For the header and footer elements that are children of the main element, and are named, NVDA is announcing their role as "grouping".

### Description of user facing changes:
NVDA announces `<header>` and `<footer>` elements as they are even when they are not ARIA landmarks.

### Description of developer facing changes:
Updated `findExtraOverlayClasses()` in `NVDAObjects/IAccessible/chromium` to check for `<header>` and `<footer>` elements with the role grouping.
If the IA2 attribute container-tag is main, and the element tag is header or footer, NVDA now prevents the default `Groupbox` class from being applied.

### Description of development approach:
Inspected NVDA’s object overlays to find where the incorrect “grouping” label was applied.
Used IA2 attributes like `"tag"` and `"container-tag"` to identify structural `<headers>`/`<footers>`.
Removed the `Groupbox` overlay class when the element matched conditions indicating a structural (not ARIA landmark) `<header>`/`<footer>`.

### Testing strategy:
Used NVDA’s Python Console and Speech Viewer to inspect how headers and footers are announced across several Chromium-based browsers.
Confirmed that unlabeled `<header>` and `<footer>` elements no longer produce the misleading “grouping” announcement.
Verified that actual ARIA landmarks and meaningful groupings continue to be read as expected.

### Known issues with pull request:
This fix is specific to Chromium objects and may not apply to other rendering engines (like Firefox or EdgeHTML). As not all browers have `<sectionheader>`/`<sectionfooter>`.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [ ] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [ ] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [ ] API is compatible with existing add-ons.
- [ ] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
