### PR TITLE
Windows 11 emoji panel: prevent speech repetition while browsing panel items

### DIFF
--- a/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
+++ b/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
@@ -171,7 +171,7 @@ class AppModule(appModuleHandler.AppModule):
 	# Turn off browse mode by default so clipboard history entry menu items can be announced when tabbed to.
 	disableBrowseModeByDefault: bool = True
 
-	def event_UIA_elementSelected(self, obj, nextHandler):
+	def event_UIA_elementSelected(self, obj: NVDAObject, nextHandler: Callable[[], None]):
 		# Logic for the following items is handled by overlay classes
 		# #18236: for others, event_selection method from base NVDA object will be invoked,
 		# and on Windows 11, this causes speech repetitions because emoji panel takes system focus

--- a/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
+++ b/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
@@ -173,13 +173,18 @@ class AppModule(appModuleHandler.AppModule):
 
 	def event_UIA_elementSelected(self, obj, nextHandler):
 		# Logic for the following items is handled by overlay classes
+		# #18236: for others, event_selection method from base NVDA object will be invoked,
+		# and on Windows 11, this causes speech repetitions because emoji panel takes system focus
+		# if the event handler is allowed to run through its course.
 		# Therefore pass these events straight on.
-		if isinstance(
-			obj,
-			(
-				ImeCandidateItem,  # IME candidate items
-				NavigationMenuItem,  # Windows 11 emoji panel navigation menu items
-			),
+		if (
+			isinstance(
+				obj,
+				(
+					ImeCandidateItem,  # IME candidate items
+					NavigationMenuItem,  # Windows 11 emoji panel navigation menu items
+				),
+			) or api.getFocusObject().appModule == self
 		):
 			return nextHandler()
 		# #7273: When this is fired on categories,

--- a/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
+++ b/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
@@ -184,7 +184,8 @@ class AppModule(appModuleHandler.AppModule):
 					ImeCandidateItem,  # IME candidate items
 					NavigationMenuItem,  # Windows 11 emoji panel navigation menu items
 				),
-			) or api.getFocusObject().appModule == self
+			)
+			or api.getFocusObject().appModule == self
 		):
 			return nextHandler()
 		# #7273: When this is fired on categories,

--- a/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
+++ b/source/appModules/windowsinternal_composableshell_experiences_textinput_inputapp.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2017-2024 NV Access Limited, Joseph Lee
+# Copyright (C) 2017-2025 NV Access Limited, Joseph Lee
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -30,6 +30,7 @@
   * NVDA no longer sometimes incorrectly switches to browse mode soon after entering the Start Menu.
   * NVDA no longer sometimes freezes when navigating in browse mode.
   * Search suggestions are now reported reliably.
+* In Windows 11, NVDA will no longer announce emoji panel items twice while browsing them. (#18236, @josephsl)
 
 ### Changes for Developers
 


### PR DESCRIPTION

### Link to issue number:
Fixes #18236 

### Summary of the issue:
NVDA repeats Windows 11 emoji panel items twice while browsing them.

### Description of user facing changes:
NVDA will no longer speak Windows 11 emoji panel items twice.

### Description of developer facing changes:
NVDA will call nextHandler() when handling UIA element selected event while focused on the emoji panel.

### Description of development approach:
When handling element selected event, call nextHandler() if focused on the emoji panel. This also improves element selected event performance as emoji panel item selection announcement will not involve traversing the event handler to the end.

### Testing strategy:
Manual: open Windows 11 emoji panel (Windows+Period) and make sure NVDA is announcing selected item once.

### Known issues with pull request:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
