### PR TITLE
Only create GH summaries on failure

### DIFF
--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -98,7 +98,7 @@ jobs:
     - name: Check comments for translators
       run: ci/scripts/tests/translationCheck.ps1
     - name: Upload artifact
-      if: ${{ success() || failure() }}
+      if: ${{ failure() }}
       uses: actions/upload-artifact@v4
       with:
         name: makePot results
@@ -138,19 +138,19 @@ jobs:
     - name: Run unit tests
       run: ci/scripts/tests/unitTests.ps1
     - name: Replace relative paths in unit test results
-      if: ${{ success() || failure() }}
+      if: ${{ failure() }}
       # Junit reports fail on these
       shell: bash
       run: sed -i 's|file="..\\|file="|g' testOutput/unit/unitTests.xml
     - name: Upload artifact
-      if: ${{ success() || failure() }}
+      if: ${{ failure() }}
       uses: actions/upload-artifact@v4
       with:
         name: Unit tests results
         path: testOutput/unit/unitTests.xml
     - name: Publish unit test report
       uses: mikepenz/action-junit-report@v5
-      if: ${{ success() || failure() }}
+      if: ${{ failure() }}
       with:
         check_name: Unit tests
         detailed_summary: true

--- a/ci/scripts/tests/licenseCheck.ps1
+++ b/ci/scripts/tests/licenseCheck.ps1
@@ -4,10 +4,8 @@ cmd.exe /c "runlicensecheck.bat $licenseOutput"
 if ($LastExitCode -ne 0) {
 	Write-Output "FAIL: License check.`n" >> $env:GITHUB_STEP_SUMMARY
 	Write-Output "testFailExitCode=$LastExitCode" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-} else {
-	Write-Output "PASS: License check.`n" >> $env:GITHUB_STEP_SUMMARY
+	Write-Output "<details>`n<summary>License check summary</summary>`n" >> $env:GITHUB_STEP_SUMMARY
+	Get-Content $licenseOutput >> $env:GITHUB_STEP_SUMMARY
+	Write-Output "`n</details>`n" >> $env:GITHUB_STEP_SUMMARY
 }
-Write-Output "<details>`n<summary>License check summary</summary>`n" >> $env:GITHUB_STEP_SUMMARY
-Get-Content $licenseOutput >> $env:GITHUB_STEP_SUMMARY
-Write-Output "`n</details>`n" >> $env:GITHUB_STEP_SUMMARY
 exit $LastExitCode

--- a/ci/scripts/tests/systemTests.ps1
+++ b/ci/scripts/tests/systemTests.ps1
@@ -51,10 +51,7 @@ $nvdaLauncherFile=$(Resolve-Path "$env:nvdaLauncherDir\nvda*.exe")
 @includeTags `
 # last line intentionally blank, allowing all lines to have line continuations.
 if ($LastExitCode -ne 0) {
-	$MESSAGE = "FAIL: System tests (tags: ${tagsForTest}). See test results for more information."
+	Write-Output "FAIL: System tests (tags: ${tagsForTest}). See test results for more information."  >> $env:GITHUB_STEP_SUMMARY
 	Write-Output "testFailExitCode=$LastExitCode" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-} else {
-	$MESSAGE = "PASS: System tests (tags: ${tagsForTest})."
 }
-$MESSAGE >> $env:GITHUB_STEP_SUMMARY
 exit $LastExitCode

--- a/ci/scripts/tests/translationCheck.ps1
+++ b/ci/scripts/tests/translationCheck.ps1
@@ -12,7 +12,5 @@ if ($LastExitCode -ne 0) {
 	Get-Content testOutput\translationCheckResults.log >> $env:GITHUB_STEP_SUMMARY
 	Write-Output "```````n</details>`n" >> $env:GITHUB_STEP_SUMMARY
 	Write-Output "testFailExitCode=$LastExitCode" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-} else {
-	Write-Output "PASS: Translation comments check." >> $env:GITHUB_STEP_SUMMARY
 }
 exit $LastExitCode

--- a/ci/scripts/tests/unitTests.ps1
+++ b/ci/scripts/tests/unitTests.ps1
@@ -2,10 +2,7 @@ $outDir = (Resolve-Path .\testOutput\unit\)
 $unitTestsXml = "$outDir\unitTests.xml"
 .\rununittests.bat --output-file "$unitTestsXml" -v
 if ($LastExitCode -ne 0) {
-	$message = "FAIL: Unit tests. See test results for more information."
+	Write-Output "FAIL: Unit tests. See test results for more information." >> $env:GITHUB_STEP_SUMMARY
 	Write-Output "testFailExitCode=$LastExitCode" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-} else {
-	$message = "PASS: Unit tests."
-}
-$message >> $env:GITHUB_STEP_SUMMARY
+} 
 exit $LastExitCode

--- a/ci/scripts/tests/unitTests.ps1
+++ b/ci/scripts/tests/unitTests.ps1
@@ -4,5 +4,5 @@ $unitTestsXml = "$outDir\unitTests.xml"
 if ($LastExitCode -ne 0) {
 	Write-Output "FAIL: Unit tests. See test results for more information." >> $env:GITHUB_STEP_SUMMARY
 	Write-Output "testFailExitCode=$LastExitCode" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-} 
+}
 exit $LastExitCode


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Part of #17878 

### Summary of the issue:
GH Actions for CI/CD creates many step summary messages when tests succeed. This adds noise to the summaries. Test success can easily be checked in the workflow summary.


### Description of developer facing changes:
Only report test failures in step summaries
