### PR TITLE
fix up features for github actions

### DIFF
--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -34,7 +34,6 @@ env:
   SCONS_CACHE_MSVC_CONFIG: ".scons_msvc_cache.json"
   # Comment out any of the feature_* variables to disable the respective build feature.
   # They are checked for existence of content, not specific value.
-  feature_buildSymbols: configured
   feature_uploadSymbolsToMozilla: configured
   feature_crowdinSync: configured
   # feature_signing: configured
@@ -163,10 +162,8 @@ jobs:
     needs: buildNVDA
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/beta' }}
     steps:
-    - name: Skip if feature disabled
-      if: ${{ !env.feature_crowdinSync }}
-      run: exit 0
     - name: Checkout cached build
+      if: ${{ env.feature_crowdinSync }}
       uses: actions/cache/restore@v4
       with:
         path: ${{ github.workspace }}
@@ -175,6 +172,7 @@ jobs:
     - name: Install the latest version of uv
       uses: astral-sh/setup-uv@v6
     - name: Upload translations to Crowdin
+      if: ${{ env.feature_crowdinSync }}
       env:
         crowdinProjectID: ${{ vars.CROWDIN_PROJECT_ID }}
         crowdinAuthToken: ${{ secrets.CROWDIN_AUTH_TOKEN }}
@@ -288,10 +286,6 @@ jobs:
     runs-on: windows-latest
     needs: buildNVDA
     steps:
-    - name: Cancel if feature disabled
-      if: ${{ !env.feature_buildSymbols }}
-      shell: bash
-      run: exit 0
     - name: Checkout cached build
       uses: actions/cache/restore@v4
       with:

--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -170,6 +170,7 @@ jobs:
         key: ${{ github.ref }}-${{ github.run_id }}
         fail-on-cache-miss: true
     - name: Install the latest version of uv
+      if: ${{ env.feature_crowdinSync }}
       uses: astral-sh/setup-uv@v6
     - name: Upload translations to Crowdin
       if: ${{ env.feature_crowdinSync }}

--- a/ci/scripts/tests/systemTests.ps1
+++ b/ci/scripts/tests/systemTests.ps1
@@ -29,7 +29,7 @@ $tagsForTest = "installer NVDA"  # include the tests tagged with installer, or N
 if ($env:INCLUDE_SYSTEM_TEST_TAGS) {
 	if ($env:INCLUDE_SYSTEM_TEST_TAGS -eq $SKIP_SYS_TESTS) {
 		# Indicate the tests were skipped, and exit early.
-		"Skipped: System tests." >> $env:GITHUB_STEP_SUMMARY
+		Write-Output "Skipped: System tests." >> $env:GITHUB_STEP_SUMMARY
 		return
 	}
 	$tagsForTest = $env:INCLUDE_SYSTEM_TEST_TAGS


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Part of #17878 

### Summary of the issue:
GitHub actions CI/CD uses feature flags to disable parts of the build.

`exit 0` was not cancelling builds if features were disabled.

Additionally, the reasoning for a "symbols" feature isn't clear. Other feature flags are for aspects of the build which integrate with NV Access owned APIs such as Crowdin, Code signing and uploading symbols. Building symbols has no negative side affects other than a slight time increase of the build. Disabling symbols with github actions should be as easy as an `if` statement in the job.

When system tests are cancelled, the warning message is not correctly posted to the github step summary.


### Description of developer facing changes:

When system tests are cancelled, the warning message is now correctly posted to the github step summary.

the symbols feature was removed.

feature_crowdinSync  was fixed to check on each step rather than using `exit 0`
