### PR TITLE
Support multiline braille routing on Humanware Monarch

### DIFF
--- a/source/brailleDisplayDrivers/hidBrailleStandard.py
+++ b/source/brailleDisplayDrivers/hidBrailleStandard.py
@@ -78,6 +78,7 @@ class ButtonCapsInfo:
 
 class HidBrailleDriver(braille.BrailleDisplayDriver):
 	_dev: hwIo.hid.Hid
+	_numberOfCellsValueCaps: hidpi.HIDP_VALUE_CAPS | None = None
 	name = "hidBrailleStandard"
 	# Translators: The name of a series of braille displays.
 	description = _("Standard HID Braille Display")
@@ -190,6 +191,7 @@ class HidBrailleDriver(braille.BrailleDisplayDriver):
 						buttonCaps,
 						relativeIndexInCollection=relativeIndexInCollection,
 					)
+					relativeIndexInCollection += 1
 			else:
 				nr = buttonCaps.u1.NotRange
 				index = nr.DataIndex
@@ -348,8 +350,12 @@ class InputGesture(braille.BrailleDisplayGesture, brailleInput.BrailleInputGestu
 				isBrailleInput = False
 				self.dots = 0
 				self.space = False
-			if usagePage == HID_USAGE_PAGE_BRAILLE and usageID == BraillePageUsageID.ROUTER_KEY:
+			if usagePage == HID_USAGE_PAGE_BRAILLE and linkUsageID == BraillePageUsageID.ROUTER_SET_1:
+				# We must assume that any input in the router set is a routing key,
+				# Because some devices expose the routing keys as 1-bit values
+				# which Windows then combines into a usage range.
 				self.routingIndex = buttonCapsInfo.relativeIndexInCollection
+				usageID = BraillePageUsageID.ROUTER_KEY
 				# Prefix the gesture name with the specific routing collection name (E.g. routerSet1)
 				namePrefix = self._usageIDToGestureName(linkUsagePage, linkUsageID)
 			name = self._usageIDToGestureName(usagePage, usageID)

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -34,7 +34,6 @@
 * In Windows 11, NVDA will no longer announce emoji panel items twice while browsing them. (#18236, @josephsl)
 * It is now possible to route to any braille cell on the Humanware Monarch multiline braille device, using their point and click action. (#18248)
 
-
 ### Changes for Developers
 
 Please refer to [the developer guide](https://www.nvaccess.org/files/nvda/documentation/developerGuide.html#API) for information on NVDA's API deprecation and removal process.

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -32,6 +32,8 @@
   * NVDA no longer sometimes freezes when navigating in browse mode.
   * Search suggestions are now reported reliably.
 * In Windows 11, NVDA will no longer announce emoji panel items twice while browsing them. (#18236, @josephsl)
+* It is now possible to route to any braille cell on the Humanware Monarch multiline braille device, using their point and click action. (#18248)
+
 
 ### Changes for Developers
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
<!-- Use Closes/Fixes/Resolves #xxx to link this PR to the issue it is responding to. -->
None.

### Summary of the issue:
The Humanware Monarch multiline braille / tactile graphics device is adding support for multiline braille routing in its Braille Terminal.
NVDA should support this in its HID Braille driver, so that it is possible to route to any character within the multiline display.
Humanware Monarch currently supports two means of routing: 1. place your finger where you want to route, and press the select button. Or, 2. do a single tap on the cell you wish to route to. Though this seems a little less accurate.

NVDA's current support for routing works by simply looking for any data index for wsitched on inputs, that has been mapped to a router_key usage. The cell index of the router  is based on the index of the specific routerkey within its linked collection (presumably routerSet1).
However, as multiline devices like the Monarch will have so many routers (E.g. 256 for the Monarch), they it would be inefficient to to expose them all as individual router_key sages, and instead may be exposed as a usage range, with custom usage values, but all within the routerSet1 collection. This is what the Monarch does.
  Therefore, NVDA's HID braille driver  needs to ensure it can support usage ranges for routing.

### Description of user facing changes:
It is possible to route to any braille cell on the Humanware Monarch multiline braille device.

### Description of developer facing changes:
HID Braille driver:
* _collectInputButtonCapsByDataIndex: ensure to increment the data index for evry usage in a useage range, otherwise data indexes will be wrong during / past a usage range. An example usage range might be  a router set where each usage is 1 bit. Windows will force this into a usage range.
* _numberOfCellsValueCaps: this must be initially set to None. Otherwise on multiline devices that don't set this, we get an attribute error.
* InputGesture: rather than detecting routing keys as the specific router_key usage, instead, just treat any usage from the routerSet1 collection as a router_key. As if these are 1 bit usages, such as for a multiline devices with 256 cells say, each usage will be some custom value and not specifically all router_key.

### Description of development approach:

### Testing strategy:
Using a Humanware Monarch with the latest beta firmware:
* Connected NvDA to the Monarch.
* Opened a document in MS Word, displaying a line that took up more than one braill line on the Monarch.
* Tried routing to various positions on each line, verifying the cursor landed in the correct position.

### Known issues with pull request:
None known.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
