### PR TITLE
Fix Korean add-on store string

### DIFF
--- a/source/locale/ko/LC_MESSAGES/nvda.po
+++ b/source/locale/ko/LC_MESSAGES/nvda.po
@@ -15311,7 +15311,7 @@ msgstr "날짜"
 #, python-brace-format
 msgctxt "addonStore"
 msgid "{column} (ascending)"
-msgstr "{column} {오름차순)"
+msgstr "{column} (오름차순)"
 
 #. Translators: An option of a combo box to sort columns in the add-on store, in descending order.
 #. {column} will be replaced with the column display string.

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -1,5 +1,13 @@
 # What's New in NVDA
 
+## 2025.1.1
+
+This is a patch release to fix a bug.
+
+### Bug fixes
+
+* Fixed bug where the Add-on Store would not open when using the Korean language for the NVDA interface. (#18250)
+
 ## 2025.1
 
 This release introduces NVDA Remote Access, allowing you to control a remote computer running NVDA from another device running NVDA.


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Fixes #18250 

### Summary of the issue:
There was syntax error in the korean translations, which cause the add-on store to fail to open

### Description of user facing changes:
Add-on store now opens correctly when NVDA uses korean localisations

### Description of developer facing changes:
None

### Description of development approach:
Fix string

### Testing strategy:
Tested opening the add-on store using korean localisations

### Known issues with pull request:

We should be validating these files on commit to NVDA - see also #17289 

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
