### PR TITLE
Fix SAPI4

### DIFF
--- a/source/synthDrivers/sapi4.py
+++ b/source/synthDrivers/sapi4.py
@@ -360,7 +360,7 @@ class SynthDriverAudio(COMObject):
 		with self._audioCond:
 			self._audioStopped = True
 			self._audioCond.notify()
-		if self._audioThread is not threading.current_thread():
+		if self._audioThread is not threading.current_thread() and self._audioThread.is_alive():
 			self._audioThread.join()
 		self._notifySink = None
 		self._allowDelete = True

--- a/source/synthDrivers/sapi4.py
+++ b/source/synthDrivers/sapi4.py
@@ -330,6 +330,7 @@ class SynthDriverAudio(COMObject):
 		:param comThread: The COM thread that `IAudioDestNotifySink` methods will be called on."""
 		if isDebugForSynthDriver():
 			log.debug("SAPI4: Initializing WASAPI implementation")
+		self._allowDelete = False
 		self._notifySink: LP_IAudioDestNotifySink | None = None
 		self._deviceState = _AudioState.INVALID
 		self._waveFormat: nvwave.WAVEFORMATEX | None = None
@@ -347,8 +348,13 @@ class SynthDriverAudio(COMObject):
 		self._level = 0xFFFFFFFF  # defaults to maximum value (0xFFFF) for both channels (low and high word)
 		self._comThread = comThread
 
-	def _final_release_(self):
-		"""This will be called automatically when this COM object is being destroyed."""
+	def IUnknown_Release(self, this: int, *args, **kwargs):
+		if not self._allowDelete and self._refcnt.value == 1:
+			log.debugWarning("SynthDriverAudio was released too many times")
+			return 1
+		return super().IUnknown_Release(this, *args, **kwargs)
+
+	def terminate(self):
 		if isDebugForSynthDriver():
 			log.debug("SAPI4: Terminating audio")
 		with self._audioCond:
@@ -357,6 +363,7 @@ class SynthDriverAudio(COMObject):
 		if self._audioThread is not threading.current_thread():
 			self._audioThread.join()
 		self._notifySink = None
+		self._allowDelete = True
 
 	def _queueNotification(self, func: Callable, *args, **kwargs) -> None:
 		"""Queue a notification to be sent to the engine via IAudioDestNotifySink.
@@ -718,13 +725,20 @@ class SynthDriverMMAudio(COMObject):
 	def __init__(self):
 		if isDebugForSynthDriver():
 			log.debug("SAPI4: Initializing WinMM implementation")
+		self._allowDelete = False
 		self.mmdev = CoCreateInstance(CLSID_MMAudioDest, IAudioMultiMediaDevice)
 		self.mmdev.DeviceNumSet(_mmDeviceEndpointIdToWaveOutId(config.conf["audio"]["outputDevice"]))
 		self.audio = self.mmdev.QueryInterface(IAudio)
 		self.audiodest = self.mmdev.QueryInterface(IAudioDest)
 
+	def IUnknown_Release(self, this: int, *args, **kwargs):
+		if not self._allowDelete and self._refcnt.value == 1:
+			log.debugWarning("SynthDriverMMAudio was released too many times")
+			return 1
+		return super().IUnknown_Release(this, *args, **kwargs)
+
 	def terminate(self):
-		pass  # do nothing
+		self._allowDelete = True
 
 	@_logTrace(logAll=True)
 	def IAudio_Flush(self) -> None:
@@ -877,6 +891,7 @@ class SynthDriver(SynthDriver):
 		self._comThread = _ComThread()
 		self._finalIndex: Optional[int] = None
 		self._ttsCentral = None
+		self._ttsAudio = None
 		self._sinkRegKey = DWORD()
 		self._bookmarks = None
 		self._bookmarkLists = deque()
@@ -906,6 +921,9 @@ class SynthDriver(SynthDriver):
 		# Release all COM objects before stopping the COM thread.
 		self._ttsAttrs = None
 		self._ttsCentral = None
+		if self._ttsAudio:
+			self._ttsAudio.terminate()
+			self._ttsAudio = None
 		self._ttsEngines = None
 		self._comThread.stop()
 
@@ -1044,12 +1062,14 @@ class SynthDriver(SynthDriver):
 			# before the next _ttsCentral is created.
 			self._ttsAttrs = None
 			self._ttsCentral = None
+			self._ttsAudio.terminate()
+			self._ttsAudio = None
 		if config.conf["speech"]["useWASAPIForSAPI4"]:
-			ttsAudio = self._comThread.invoke(SynthDriverAudio, self._comThread)
+			self._ttsAudio = self._comThread.invoke(SynthDriverAudio, self._comThread)
 		else:
-			ttsAudio = self._comThread.invoke(SynthDriverMMAudio)
+			self._ttsAudio = self._comThread.invoke(SynthDriverMMAudio)
 		self._ttsCentral = POINTER(ITTSCentralW)()
-		self._ttsEngines.Select(self._currentMode.gModeID, byref(self._ttsCentral), ttsAudio)
+		self._ttsEngines.Select(self._currentMode.gModeID, byref(self._ttsCentral), self._ttsAudio)
 		self._ttsCentral = _ComProxy(self._ttsCentral, self._comThread)
 		self._ttsCentral.Register(self._sinkPtr, ITTSNotifySinkW._iid_, byref(self._sinkRegKey))
 		self._ttsAttrs = _ComProxy(self._ttsCentral.QueryInterface(ITTSAttributes), self._comThread)

--- a/source/synthDrivers/sapi4.py
+++ b/source/synthDrivers/sapi4.py
@@ -348,7 +348,7 @@ class SynthDriverAudio(COMObject):
 		self._level = 0xFFFFFFFF  # defaults to maximum value (0xFFFF) for both channels (low and high word)
 		self._comThread = comThread
 
-	def IUnknown_Release(self, this: int, *args, **kwargs):
+	def IUnknown_Release(self, this: int, *args, **kwargs) -> int:
 		if not self._allowDelete and self._refcnt.value == 1:
 			log.debugWarning("SynthDriverAudio was released too many times")
 			return 1
@@ -731,7 +731,7 @@ class SynthDriverMMAudio(COMObject):
 		self.audio = self.mmdev.QueryInterface(IAudio)
 		self.audiodest = self.mmdev.QueryInterface(IAudioDest)
 
-	def IUnknown_Release(self, this: int, *args, **kwargs):
+	def IUnknown_Release(self, this: int, *args, **kwargs) -> int:
 		if not self._allowDelete and self._refcnt.value == 1:
 			log.debugWarning("SynthDriverMMAudio was released too many times")
 			return 1


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
<!-- Use Closes/Fixes/Resolves #xxx to link this PR to the issue it is responding to. -->
Fixes #18259.

### Summary of the issue:

Digalo 2000 voices (SAPI4) do not work and cause memory access violation errors.

### Description of user facing changes:

The issue should be fixed.

### Description of developer facing changes:

None.

### Description of development approach:

For some reason, the IAudio object was destroyed before it was even being used, causing its COM pointers to be reset to zero and access violations afterwards. So code are added to guard the SAPI4 IAudio object from being released prematurely.

Prevent joining the audio thread if the audio object is destroyed before starting.

### Testing strategy:
Users reported that this works on their system.

### Known issues with pull request:
`SynthDriverAudio was released too many times` might still be logged when working correctly.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [ ] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
