### PR TITLE
If the text of a control is not navigable, use NVDAObjectTextInfo for object review and read line.

### DIFF
--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -259,15 +259,22 @@ class GlobalCommands(ScriptableObject):
 	def script_reportCurrentLine(self, gesture):
 		obj = api.getFocusObject()
 		treeInterceptor = obj.treeInterceptor
+		isNavigable: bool = False
 		if (
 			isinstance(treeInterceptor, treeInterceptorHandler.DocumentTreeInterceptor)
 			and not treeInterceptor.passThrough
 		):
 			obj = treeInterceptor
-		try:
-			info = obj.makeTextInfo(textInfos.POSITION_CARET)
-		except (NotImplementedError, RuntimeError):
-			info = obj.makeTextInfo(textInfos.POSITION_FIRST)
+			isNavigable = True
+		else:
+			isNavigable = obj._hasNavigableText
+		if isNavigable:
+			try:
+				info = obj.makeTextInfo(textInfos.POSITION_CARET)
+			except (NotImplementedError, RuntimeError):
+				info = obj.makeTextInfo(textInfos.POSITION_FIRST)
+		else:
+			info = NVDAObjectTextInfo(obj, textInfos.POSITION_FIRST)
 		info.expand(textInfos.UNIT_LINE)
 		scriptCount = scriptHandler.getLastScriptRepeatCount()
 		if scriptCount == 0:

--- a/source/review.py
+++ b/source/review.py
@@ -28,18 +28,22 @@ def getObjectPosition(obj):
 	@return: the TextInfo instance and the Scriptable object the TextInfo instance is referencing, or None on error.
 	@rtype: (L{TextInfo},L{ScriptableObject})
 	"""
-	try:
-		pos = obj.makeTextInfo(textInfos.POSITION_CARET)
-	except (NotImplementedError, RuntimeError):
-		# No caret supported, try first position instead
+	isNavigable: bool = obj._hasNavigableText
+	if isNavigable:
 		try:
-			pos = obj.makeTextInfo(textInfos.POSITION_FIRST)
+			pos = obj.makeTextInfo(textInfos.POSITION_CARET)
 		except (NotImplementedError, RuntimeError):
-			log.debugWarning(
-				"%s does not support POSITION_FIRST, falling back to NVDAObjectTextInfo" % obj.TextInfo,
-			)
-			# First position not supported either, return first position from a generic NVDAObjectTextInfo
-			return NVDAObjectTextInfo(obj, textInfos.POSITION_FIRST), obj
+			# No caret supported, try first position instead
+			try:
+				pos = obj.makeTextInfo(textInfos.POSITION_FIRST)
+			except (NotImplementedError, RuntimeError):
+				log.debugWarning(
+					"%s does not support POSITION_FIRST, falling back to NVDAObjectTextInfo" % obj.TextInfo,
+				)
+				# First position not supported either, return first position from a generic NVDAObjectTextInfo
+				isNavigable = False
+	if not isNavigable:
+		return NVDAObjectTextInfo(obj, textInfos.POSITION_FIRST), obj
 	return pos, pos.obj
 
 

--- a/source/review.py
+++ b/source/review.py
@@ -38,7 +38,7 @@ def getObjectPosition(obj):
 				pos = obj.makeTextInfo(textInfos.POSITION_FIRST)
 			except (NotImplementedError, RuntimeError):
 				log.debugWarning(
-					"%s does not support POSITION_FIRST, falling back to NVDAObjectTextInfo" % obj.TextInfo,
+					f"{obj.TextInfo} does not support POSITION_FIRST, falling back to NVDAObjectTextInfo",
 				)
 				# First position not supported either, return first position from a generic NVDAObjectTextInfo
 				isNavigable = False

--- a/source/review.py
+++ b/source/review.py
@@ -5,7 +5,6 @@
 
 from typing import (
 	Optional,
-	Tuple,
 	Union,
 )
 
@@ -21,11 +20,11 @@ import textInfos
 import config
 
 
-def getObjectPosition(obj: NVDAObject) -> Optional[Tuple[textInfos.TextInfo, ScriptableObject]]:
+def getObjectPosition(obj: NVDAObject) -> tuple[textInfos.TextInfo, ScriptableObject] | None:
 	"""
 	Fetches a TextInfo instance suitable for reviewing the text in  the given object.
-	@param obj: the NVDAObject to review
-	@return: the TextInfo instance and the Scriptable object the TextInfo instance is referencing, or None on error.
+	:param obj: the NVDAObject to review
+	:return: the TextInfo instance and the Scriptable object the TextInfo instance is referencing, or None on error.
 	"""
 	isNavigable: bool = obj._hasNavigableText
 	if isNavigable:

--- a/source/review.py
+++ b/source/review.py
@@ -5,6 +5,7 @@
 
 from typing import (
 	Optional,
+	Tuple,
 	Union,
 )
 
@@ -20,13 +21,11 @@ import textInfos
 import config
 
 
-def getObjectPosition(obj):
+def getObjectPosition(obj: NVDAObject) -> Optional[Tuple[textInfos.TextInfo, ScriptableObject]]:
 	"""
 	Fetches a TextInfo instance suitable for reviewing the text in  the given object.
 	@param obj: the NVDAObject to review
-	@type obj: L{NVDAObject}
 	@return: the TextInfo instance and the Scriptable object the TextInfo instance is referencing, or None on error.
-	@rtype: (L{TextInfo},L{ScriptableObject})
 	"""
 	isNavigable: bool = obj._hasNavigableText
 	if isNavigable:

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -35,6 +35,7 @@
 * In Windows 11, NVDA will no longer announce emoji panel items twice while browsing them. (#18236, @josephsl)
 * It is now possible to route to any braille cell on the Humanware Monarch multiline braille device, using their point and click action. (#18248)
 * In focus mode in web browsers, it is now possible to review and spell the labels of controls when those labels are specifically provided for accessibility; e.g. via `aria-label` or `aria-labelledby`. (#15159, @jcsteh)
+* It is now possible to review and spell the labels of controls in Google Chrome menus and dialogs. (#11285, @jcsteh)
 
 ### Changes for Developers
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -34,7 +34,7 @@
   * Search suggestions are now reported reliably.
 * In Windows 11, NVDA will no longer announce emoji panel items twice while browsing them. (#18236, @josephsl)
 * It is now possible to route to any braille cell on the Humanware Monarch multiline braille device, using their point and click action. (#18248)
-* In focus mode in web browsers, it is now possible to review and spell the labels of controls when those labels are specifically provided for accessibility; e.g. via aria-label or aria-labelledby. (#15159, @jcsteh)
+* In focus mode in web browsers, it is now possible to review and spell the labels of controls when those labels are specifically provided for accessibility; e.g. via `aria-label` or `aria-labelledby`. (#15159, @jcsteh)
 
 ### Changes for Developers
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -34,6 +34,7 @@
   * Search suggestions are now reported reliably.
 * In Windows 11, NVDA will no longer announce emoji panel items twice while browsing them. (#18236, @josephsl)
 * It is now possible to route to any braille cell on the Humanware Monarch multiline braille device, using their point and click action. (#18248)
+* In focus mode in web browsers, it is now possible to review and spell the labels of controls when those labels are specifically provided for accessibility; e.g. via aria-label or aria-labelledby. (#15159, @jcsteh)
 
 ### Changes for Developers
 


### PR DESCRIPTION
### Link to issue number:
Fixes #15159. Fixes #11285.

### Summary of the issue:
In focus mode in web browsers, when a control specifies a label using aria-label or aria-labelledby, it is impossible to review or spell that label; e.g. using read current line or the review cursor. This is particularly annoying and detrimental to efficiency when using web apps such as Gmail and Slack, among others, where you have to switch to browse mode to work around this even though it might be more efficient to use focus mode for navigation.

The same bug also applies in Google Chrome menus and dialogs where UIA is not used, such as in Chrome 137.

### Description of user facing changes:
In focus mode in web browsers, it is now possible to review and spell the labels of controls when those labels are specifically provided for accessibility; e.g. via aria-label or aria-labelledby.

### Description of development approach:
When in focus mode, for non-editable controls, both speech and braille report the name, description, value, etc. of the control; they don't use the TextInfo. However, previously, the review cursor and the read line command always used the TextInfo. Since IA2TextTextInfo is used for all objects supporting IAccessibleText, this meant that if the content wasn't a flat piece of text equal to the label, the review cursor and read line command would report something different, often nothing at all. To fix this, use NVDAObjectTextInfo instead of the object's TextInfo for object review and the read line command.

### Testing strategy:
In both Firefox and Edge:

1. Followed and verified the steps to reproduce in https://github.com/nvaccess/nvda/issues/15159#issue-1808844106.
2. Also tested with the review cursor in the Gmail message list, where previously, the review cursor couldn't read the message details. With this change, it can. Same for read current line.
3. Verified that braille remains the same as before (the expected behaviour) in all of these scenarios.
4. Also tested this test case:
    `data:text/html,<textarea>ab`
    Verified that in focus mode, formatting info is still reported for the review cursor, indicating that the correct TextInfo is being used. Also verified that the review cursor tracks the caret.
5. With a multi line message in Gmail, verified that read current line reports the correct line when on the second or subsequent lines.
6. I wasn't able to reproduce #11285 myself. However, @amirsol81 [verified that this change fixes that too](https://github.com/nvaccess/nvda/issues/11285#issuecomment-2996421115).

### Known issues with pull request:
Although this fix is primarily about focus mode in web browsers, the code paths it touches are more generic than that. Anything that has a specific TextInfo but for which `_hasNavigableText` returns False will be impacted. This is consistent with how we report the focus with speech and what is shown in braille, and thus I think this makes sense. Nevertheless, this potential broader impact is worth noting.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
