### PR TITLE
MS Word with UIA: only fetch expandCollapseState for headings   on Word version 16.0.18226 or higher.

### DIFF
--- a/source/NVDAObjects/UIA/wordDocument.py
+++ b/source/NVDAObjects/UIA/wordDocument.py
@@ -501,7 +501,7 @@ class WordDocumentTextInfo(UIATextInfo):
 			try:
 				officeVersion = tuple(int(x) for x in self.obj.appModule.productVersion.split(".")[:3])
 			except Exception:
-				log.debugWarning("Unable to parse Office version", exc_info=True)
+				log.error("Unable to parse Office version", exc_info=True)
 				officeVersion = (0, 0, 0)
 			if officeVersion >= (16, 0, 18226):
 				expandCollapseState = UIARemote.msWord_getCustomAttributeValue(

--- a/source/NVDAObjects/UIA/wordDocument.py
+++ b/source/NVDAObjects/UIA/wordDocument.py
@@ -496,15 +496,23 @@ class WordDocumentTextInfo(UIATextInfo):
 					)
 					if isinstance(textColumnNumber, int):
 						formatField.field["text-column-number"] = textColumnNumber
-			expandCollapseState = UIARemote.msWord_getCustomAttributeValue(
-				docElement,
-				textRange,
-				UIACustomAttributeID.EXPAND_COLLAPSE_STATE,
-			)
-			if expandCollapseState == EXPAND_COLLAPSE_STATE.COLLAPSED:
-				formatField.field["collapsed"] = True
-			elif expandCollapseState == EXPAND_COLLAPSE_STATE.EXPANDED:
-				formatField.field["collapsed"] = False
+			# #18279: It is only safe to fetch the expand/collapse state in MS Word 16.0.18226 or later,
+			# as earlier versions that support Custom attribute Values but not this particular argument will crash.
+			try:
+				officeVersion = tuple(int(x) for x in self.obj.appModule.productVersion.split(".")[:3])
+			except Exception:
+				log.debugWarning("Unable to parse Office version", exc_info=True)
+				officeVersion = (0, 0, 0)
+			if officeVersion >= (16, 0, 18226):
+				expandCollapseState = UIARemote.msWord_getCustomAttributeValue(
+					docElement,
+					textRange,
+					UIACustomAttributeID.EXPAND_COLLAPSE_STATE,
+				)
+				if expandCollapseState == EXPAND_COLLAPSE_STATE.COLLAPSED:
+					formatField.field["collapsed"] = True
+				elif expandCollapseState == EXPAND_COLLAPSE_STATE.EXPANDED:
+					formatField.field["collapsed"] = False
 		return formatField
 
 	def _getIndentValueDisplayString(self, val: float) -> str:

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -6,7 +6,7 @@ This is a patch release to fix a bug.
 
 ### Bug fixes
 
-* Certain Microsoft Word versions before version 16.0.18226   will no longer crash on opening. (#18280)
+* Certain Microsoft Word versions before version 16.0.18226 will no longer crash on opening. (#18280)
 
 ## 2025.1.1
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -1,5 +1,13 @@
 # What's New in NVDA
 
+## 2025.1.2
+
+This is a patch release to fix a bug.
+
+### Bug fixes
+
+* Certain Microsoft Word versions before version 16.0.18226   will no longer crash on opening. (#18280)
+
 ## 2025.1.1
 
 This is a patch release to fix a bug.


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
<!-- Use Closes/Fixes/Resolves #xxx to link this PR to the issue it is responding to. -->
Fixes #18279

### Summary of the issue:
PR #17499 added support for reporting if a heading is collapsed in MS word.
However, this crashes some versions of MS Word before this feature was supported.
For example, MS word version16.0.17932.20396 supports custom attribute values, but crashes if given this specific expandCollapseState constant.
 NVDA should limit fetching this data to when it was officially supported in MS Word.

### Description of user facing changes:
Microsoft Word 2024 will no longer crash when NVDA tries to fetch the collapsed state of headings.
 
### Description of developer facing changes:

### Description of development approach:
Limit fetching of expandcollapseState to MS Word 16.0.18226 and higher.

### Testing strategy:
* [x] Open a document in MS Word version 16.0.19200, read a collapsed heading ensuring that NDA reports it as collapsed.
* [x] Open a document in MicrosoftWord version 16.0.17932.20396. Confirm that MS Word does not crash, and that collapsed state of headings is not reported.

### Known issues with pull request:

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
