### PR TITLE
winVersion: report Windows build revision when winVersion.getWinVer is called and at startup

### DIFF
--- a/source/winVersion.py
+++ b/source/winVersion.py
@@ -188,10 +188,17 @@ def getWinVer():
 			releaseName = f"Windows 10 {_getRunningVersionNameFromWinReg()}"
 	except RuntimeError:
 		releaseName = None
+	# #18266: ask Windows Registry for update build revision (UBR).
+	# UBR is updated whenever cumulative updates are applied.
+	with winreg.OpenKey(
+		winreg.HKEY_LOCAL_MACHINE, r"Software\Microsoft\Windows NT\CurrentVersion"
+	) as currentVersion:
+		buildRevision = winreg.QueryValueEx(currentVersion, "UBR")[0]
 	return WinVersion(
 		major=winVer.major,
 		minor=winVer.minor,
 		build=winVer.build,
+		revision=buildRevision,
 		releaseName=releaseName,
 		servicePack=winVer.service_pack,
 		productType=("workstation", "domain controller", "server")[winVer.product_type - 1],

--- a/source/winVersion.py
+++ b/source/winVersion.py
@@ -83,6 +83,7 @@ class WinVersion(object):
 		major: int = 0,
 		minor: int = 0,
 		build: int = 0,
+		revision: int = 0,
 		releaseName: str | None = None,
 		servicePack: str = "",
 		productType: str = "",
@@ -91,6 +92,7 @@ class WinVersion(object):
 		self.major = major
 		self.minor = minor
 		self.build = build
+		self.revision= revision
 		if releaseName:
 			self.releaseName = releaseName
 		else:
@@ -126,7 +128,7 @@ class WinVersion(object):
 
 	def __repr__(self):
 		winVersionText = [self.releaseName]
-		winVersionText.append(f"({self.major}.{self.minor}.{self.build})")
+		winVersionText.append(f"({self.major}.{self.minor}.{self.build}.{self.revision})")
 		if self.servicePack != "":
 			winVersionText.append(f"service pack {self.servicePack}")
 		if self.productType != "":

--- a/source/winVersion.py
+++ b/source/winVersion.py
@@ -92,7 +92,7 @@ class WinVersion(object):
 		self.major = major
 		self.minor = minor
 		self.build = build
-		self.revision= revision
+		self.revision = revision
 		if releaseName:
 			self.releaseName = releaseName
 		else:
@@ -191,7 +191,8 @@ def getWinVer():
 	# #18266: ask Windows Registry for update build revision (UBR).
 	# UBR is updated whenever cumulative updates are applied.
 	with winreg.OpenKey(
-		winreg.HKEY_LOCAL_MACHINE, r"Software\Microsoft\Windows NT\CurrentVersion"
+		winreg.HKEY_LOCAL_MACHINE,
+		r"Software\Microsoft\Windows NT\CurrentVersion",
 	) as currentVersion:
 		buildRevision = winreg.QueryValueEx(currentVersion, "UBR")[0]
 	return WinVersion(

--- a/source/winVersion.py
+++ b/source/winVersion.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2006-2024 NV Access Limited, Bill Dengler, Joseph Lee
+# Copyright (C) 2006-2025 NV Access Limited, Bill Dengler, Joseph Lee
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -51,6 +51,7 @@ Please refer to [the developer guide](https://www.nvaccess.org/files/nvda/docume
 * The `brailleTables` module is now a package.
 The several built-in table definitions are moved to the `__tables` module in that package. (#18194, @LeonarddeR)
 * Microsoft SQL Server Management Studio now uses the Visual Studio app module, as SSMS is based on Visual Studio. (#18176, @LeonarddeR)
+* NVDA will report Windows release revision number (for example: 10.0.26100.0) when `winVersion.getWinVer` is called and log this information at startup. (#18266, @josephsl)
 
 #### Deprecations
 


### PR DESCRIPTION

### Link to issue number:
Closes #18266 

### Summary of the issue:
NVDA does not report Windows build revision at startup.

### Description of user facing changes:
NVDA will log Windows build revisoin number (e.g. 10.0.26100.0) at startup.

### Description of developer facing changes:
NVDA will report update build revision (UBR) number when winVersion.getWinVer function is called. In addition, "revisoin" was added as an argument to winVersion.WinVersion class constructor (default: 0).

### Description of development approach:
Added "revisoin" to winVersion.WinVersion constructor. In winVersion.getWinVer, this value is obtained from Windows Registry and is reported at NVDA startup.

### Testing strategy:
Manual: make sure the four part number for a Windows build (e.g. 10.0.26100.4351) is whon in the log viewer at startup and from winVersion.getWinVer function.

### Known issues with pull request:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
