### PR TITLE
Add NVDA logo to installer and uninstaller

### DIFF
--- a/launcher/nvdaLauncher.nsi
+++ b/launcher/nvdaLauncher.nsi
@@ -1,6 +1,6 @@
 !include "fileFunc.nsh"
 !include "LogicLib.nsh"
-!include "mui2.nsh"
+!include "MUI2.nsh"
 
 !define launcher_appExe "nvdaLauncher.exe"
 !define MUI_ICON ..\source\images\nvda.ico

--- a/launcher/nvdaLauncher.nsi
+++ b/launcher/nvdaLauncher.nsi
@@ -3,6 +3,7 @@
 !include "mui2.nsh"
 
 !define launcher_appExe "nvdaLauncher.exe"
+!define MUI_ICON ..\source\images\nvda.ico
 
 SetCompressor /SOLID LZMA
 SilentInstall silent

--- a/uninstaller/uninst.nsi
+++ b/uninstaller/uninst.nsi
@@ -1,6 +1,7 @@
 !include "MUI2.nsh"
 
 !define appName "NVDA"
+!define MUI_UNICON ..\source\images\nvda.ico
 
 !define INSTDIR_REG_ROOT "HKLM"
 !define INSTDIR_REG_KEY "Software\Microsoft\Windows\CurrentVersion\Uninstall\${appName}"


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
None

### Summary of the issue:

The installer and uninstaller use the default NSIS logos, which are bad for branding. Logos are a useful visual cue for identifying the right program in menus and searches.

### Description of user facing changes:

NVDA `N` icon is used for installer and uninstaller.

### Description of developer facing changes:

None

### Description of development approach:

Added referents to icons in installer and uninstaller script

### Testing strategy:

Performing `scons dist` and checking if the files were built with the right logos.
Performing `scons launcher` and ensuring the installer has the right logo. Installed the launcher and ensured NVDA used the logo for the uninstaller.

### Known issues with pull request:

None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
