### PR TITLE
File Explorer app module: correct notification event argument names

### DIFF
--- a/source/appModules/explorer.py
+++ b/source/appModules/explorer.py
@@ -585,8 +585,8 @@ class AppModule(appModuleHandler.AppModule):
 		self,
 		obj: NVDAObject,
 		nextHandler: Callable[[], None],
-		NotificationKind: int | None = None,
-		NotificationProcessing: int | None = None,
+		notificationKind: int | None = None,
+		notificationProcessing: int | None = None,
 		displayString: str = "",
 		activityId: str = "",
 	) -> None:


### PR DESCRIPTION
Quick follow-up:

### Link to issue number:
None

### Summary of the issue:
File Explorer app module uses title case for notification event handler argument names.

### Description of user facing changes:
None

### Description of developer facing changes:
File Explorer's notification event argument names are corrected.

### Description of development approach:
Argument name corrections:

* NotificationKind -> notificationKind
* NotificationProcessing -> notificationProcessing

### Testing strategy:
Manual: make sure UIA notification events are raised without TypeError tracebacks.

### Known issues with pull request:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
