### PR TITLE
UIA notification event handler: NotificationKind -> notificationKind, NotificationProcessing -> notificationProcessing (argument name consistency)

### DIFF
--- a/source/UIAHandler/__init__.py
+++ b/source/UIAHandler/__init__.py
@@ -1054,8 +1054,8 @@ class UIAHandler(COMObject):
 			appMod = appModuleHandler.getAppModuleFromProcessID(processId)
 			if not appMod.shouldProcessUIANotificationEvent(
 				sender,
-				NotificationKind=NotificationKind,
-				NotificationProcessing=NotificationProcessing,
+				notificationKind=NotificationKind,
+				notificationProcessing=NotificationProcessing,
 				displayString=displayString,
 				activityId=activityId,
 			):

--- a/source/appModuleHandler.py
+++ b/source/appModuleHandler.py
@@ -769,8 +769,8 @@ class AppModule(baseObject.ScriptableObject):
 	def shouldProcessUIANotificationEvent(
 		self,
 		sender: UIA.IUIAutomationElement,
-		NotificationKind: int | None = None,
-		NotificationProcessing: int | None = None,
+		notificationKind: int | None = None,
+		notificationProcessing: int | None = None,
 		displayString: str = "",
 		activityId: str = "",
 	) -> bool:
@@ -785,8 +785,8 @@ class AppModule(baseObject.ScriptableObject):
 		shouldAcceptEvent returns False, etc.
 
 		:param sender: UIA element raising the notification event.
-		:param NotificationKind: notification kind such as activity completion.
-		:param NotificationProcessing: how NVDA should process notifications such as canceling speech.
+		:param notificationKind: notification kind such as activity completion.
+		:param notificationProcessing: how NVDA should process notifications such as canceling speech.
 		:param displayString: notification content/text.
 		:param activityId: notification description.
 		:return: Whether NVDA components including ap modules and NVDA objects should process notification events.

--- a/source/appModules/explorer.py
+++ b/source/appModules/explorer.py
@@ -585,8 +585,8 @@ class AppModule(appModuleHandler.AppModule):
 		self,
 		obj: NVDAObject,
 		nextHandler: Callable[[], None],
-		NotificationKind: int | None = None,
-		NotificationProcessing: int | None = None,
+		notificationKind: int | None = None,
+		notificationProcessing: int | None = None,
 		displayString: str = "",
 		activityId: str = "",
 	) -> None:

--- a/source/appModules/explorer.py
+++ b/source/appModules/explorer.py
@@ -566,8 +566,8 @@ class AppModule(appModuleHandler.AppModule):
 	def shouldProcessUIANotificationEvent(
 		self,
 		sender: UIAutomationClient.IUIAutomationElement,
-		NotificationKind: int | None = None,
-		NotificationProcessing: int | None = None,
+		notificationKind: int | None = None,
+		notificationProcessing: int | None = None,
 		displayString: str = "",
 		activityId: str = "",
 	) -> bool:
@@ -575,8 +575,8 @@ class AppModule(appModuleHandler.AppModule):
 			return True
 		return super().shouldProcessUIANotificationEvent(
 			sender,
-			NotificationKind=NotificationKind,
-			NotificationProcessing=NotificationProcessing,
+			notificationKind=NotificationKind,
+			notificationProcessing=NotificationProcessing,
 			displayString=displayString,
 			activityId=activityId,
 		)

--- a/source/appModules/explorer.py
+++ b/source/appModules/explorer.py
@@ -575,8 +575,8 @@ class AppModule(appModuleHandler.AppModule):
 			return True
 		return super().shouldProcessUIANotificationEvent(
 			sender,
-			notificationKind=NotificationKind,
-			notificationProcessing=NotificationProcessing,
+			notificationKind=notificationKind,
+			notificationProcessing=notificationProcessing,
 			displayString=displayString,
 			activityId=activityId,
 		)


### PR DESCRIPTION
Quick follow-up to #18229:

### Link to issue number:
None

### Summary of the issue:
UIA notification argument names are inconsistent across UIA handler, app modules, and UIA NVDA objects.

### Description of user facing changes:
None

### Description of developer facing changes:
None, as the app module API was just merged.

### Description of development approach:
Change the follwoing argument names in app module version of shouldProcessUIANotificationEvent:

* NotificationKind -> notificationKind
* NotificationProcessing -> notificationProcessing

### Testing strategy:
Manual: make sure UIA notifications such as volume changes and window style changes are announced.

### Known issues with pull request:
We may need to revisit UIA handler notification event handler argument names in 2026.1 dev cycle - this PR attempts to correct part of the inconsistency issue, with the event handler change proposed for 2026.1.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
