### PR TITLE
Fix pronunciation of combining circumflex

### DIFF
--- a/source/locale/en/symbols.dic
+++ b/source/locale/en/symbols.dic
@@ -270,7 +270,7 @@ _	line	most
 ⊥	perpendicular to	none
 ⟂	ortogonal to	none
 ‖	norm of vector	none
-̂	normalizes	none
+̂	hat	none
 ∿	sine wave	none
 ∡	measured Angle	none
 ∢	spherical Angle	none


### PR DESCRIPTION
### Link to issue number:
Closes #17725

### Summary of the issue:
NVDA speaks the combining circumflex character (U+0302) as "normalizes". While this is its Unicode name, it is unintuitive to users.

### Description of user facing changes:
U+0302 is now pronounced as "hat" in English.

### Description of developer facing changes:
None

### Description of development approach:
Replaced "normalizes" with "hat" in `source/locale/en/symbols.dic`.

### Testing strategy:
Ran NVDA and had it read "ê or ô".

### Known issues with pull request:
"Hat" was chosen as a suitable replacement for "normalizes" as it is brief but part of established nomenclature (similar to the choice of "bang" for "!"). However, this may confuse users, as, when unicode normalization is enabled, when reading by character, the speech output will most likely not match that when navigating by a larger unit. For instance:

* eSpeak (Max): "e circumflex normalized"
* SAPI4 (Microsoft Mary/Mike/Sam): "e normalized"
* SAPI5 (Microsoft Hazel/David/Zira): "e with circumflex normalized"
* OneCore (Microsoft George/David/Catherine/Hazel/Zira/Susan/Mark/James): "e normalized"

Using "circumflex" could be a viable alternative that would partially mitigate this potential confusion.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
