### PR TITLE
If a virtual buffer caret moves due to a buffer update, update the review cursor if appropriate.

### DIFF
--- a/nvdaHelper/interfaces/nvdaControllerInternal/nvdaControllerInternal.idl
+++ b/nvdaHelper/interfaces/nvdaControllerInternal/nvdaControllerInternal.idl
@@ -78,7 +78,7 @@ interface NvdaControllerInternal {
 /**
  * Notifies NVDA that a virtual buffer has changed.
  */
-	error_status_t __stdcall vbufChangeNotify([in] const int rootDocHandle, [in] const int rootID);
+	error_status_t __stdcall vbufChangeNotify([in] const int rootDocHandle, [in] const int rootID, [in] const boolean selectionChanged);
 
 /**
 * Requests for installation of the add-on package from specified path.

--- a/nvdaHelper/local/nvdaControllerInternal.c
+++ b/nvdaHelper/local/nvdaControllerInternal.c
@@ -62,7 +62,7 @@ error_status_t __stdcall nvdaControllerInternal_inputConversionModeUpdate(const 
 
 error_status_t(__stdcall *_nvdaControllerInternal_vbufChangeNotify)(const int, const int, const unsigned char);
 error_status_t __stdcall nvdaControllerInternal_vbufChangeNotify(const int rootDocHandle, const int rootID, const unsigned char selectionChanged) {
-	return _nvdaControllerInternal_vbufChangeNotify(rootDocHandle,rootID,selectionChanged);
+	return _nvdaControllerInternal_vbufChangeNotify(rootDocHandle, rootID, selectionChanged);
 }
 
 error_status_t(__stdcall *_nvdaControllerInternal_installAddonPackageFromPath)(const wchar_t *);

--- a/nvdaHelper/local/nvdaControllerInternal.c
+++ b/nvdaHelper/local/nvdaControllerInternal.c
@@ -60,9 +60,9 @@ error_status_t __stdcall nvdaControllerInternal_inputConversionModeUpdate(const 
 	return _nvdaControllerInternal_inputConversionModeUpdate(oldFlags,newFlags,lcid);
 }
 
-error_status_t(__stdcall *_nvdaControllerInternal_vbufChangeNotify)(const int, const int);
-error_status_t __stdcall nvdaControllerInternal_vbufChangeNotify(const int rootDocHandle, const int rootID) {
-	return _nvdaControllerInternal_vbufChangeNotify(rootDocHandle,rootID);
+error_status_t(__stdcall *_nvdaControllerInternal_vbufChangeNotify)(const int, const int, const unsigned char);
+error_status_t __stdcall nvdaControllerInternal_vbufChangeNotify(const int rootDocHandle, const int rootID, const unsigned char selectionChanged) {
+	return _nvdaControllerInternal_vbufChangeNotify(rootDocHandle,rootID,selectionChanged);
 }
 
 error_status_t(__stdcall *_nvdaControllerInternal_installAddonPackageFromPath)(const wchar_t *);

--- a/nvdaHelper/vbufBase/backend.cpp
+++ b/nvdaHelper/vbufBase/backend.cpp
@@ -211,11 +211,13 @@ void VBufBackend_t::update() {
 		workingInvalidSubtreesList.clear();
 		this->lock.acquire();
 		LOG_DEBUG(L"Replacing nodes with content of temp buffers");
+		int oldSel = this->selectionStart;
 		if(!this->replaceSubtrees(replacementSubtreeMap)) {
 			LOG_DEBUGWARNING(L"Error replacing one or more subtrees");
 		}
 		this->lock.release();
-		nvdaControllerInternal_vbufChangeNotify(this->rootDocHandle,this->rootID);
+		nvdaControllerInternal_vbufChangeNotify(this->rootDocHandle, this->rootID,
+			this->selectionStart != oldSel);
 	} else {
 		LOG_DEBUG(L"Initial render");
 		this->lock.acquire();

--- a/source/NVDAHelper.py
+++ b/source/NVDAHelper.py
@@ -654,7 +654,9 @@ def _nvdaControllerInternal_vbufChangeNotify(rootDocHandle: int, rootID: int, se
 	return 0
 
 
-def nvdaControllerInternal_vbufChangeNotify(rootDocHandle: int, rootID: int, selectionChanged: bool = False) -> int:
+def nvdaControllerInternal_vbufChangeNotify(
+	rootDocHandle: int, rootID: int, selectionChanged: bool = False
+) -> int:
 	"""API compatibility wrapper. This is necessary because default argument values
 	are discarded for ctypes callbacks.
 	"""

--- a/source/NVDAHelper.py
+++ b/source/NVDAHelper.py
@@ -655,7 +655,9 @@ def _nvdaControllerInternal_vbufChangeNotify(rootDocHandle: int, rootID: int, se
 
 
 def nvdaControllerInternal_vbufChangeNotify(
-	rootDocHandle: int, rootID: int, selectionChanged: bool = False
+	rootDocHandle: int,
+	rootID: int,
+	selectionChanged: bool = False,
 ) -> int:
 	"""API compatibility wrapper. This is necessary because default argument values
 	are discarded for ctypes callbacks.

--- a/source/NVDAHelper.py
+++ b/source/NVDAHelper.py
@@ -647,11 +647,18 @@ def nvdaControllerInternal_typedCharacterNotify(ch):
 
 
 @WINFUNCTYPE(c_long, c_int, c_int, c_bool)
-def nvdaControllerInternal_vbufChangeNotify(rootDocHandle: int, rootID: int, selectionChanged: bool) -> int:
+def _nvdaControllerInternal_vbufChangeNotify(rootDocHandle: int, rootID: int, selectionChanged: bool) -> int:
 	import virtualBuffers
 
 	virtualBuffers.VirtualBuffer.changeNotify(rootDocHandle, rootID, selectionChanged)
 	return 0
+
+
+def nvdaControllerInternal_vbufChangeNotify(rootDocHandle: int, rootID: int, selectionChanged: bool = False) -> int:
+	"""API compatibility wrapper. This is necessary because default argument values
+	are discarded for ctypes callbacks.
+	"""
+	return _nvdaControllerInternal_vbufChangeNotify(rootDocHandle, rootID, selectionChanged)
 
 
 @WINFUNCTYPE(c_long, c_wchar_p)
@@ -794,7 +801,7 @@ def initialize() -> None:
 			"nvdaControllerInternal_inputConversionModeUpdate",
 			nvdaControllerInternal_inputConversionModeUpdate,
 		),
-		("nvdaControllerInternal_vbufChangeNotify", nvdaControllerInternal_vbufChangeNotify),
+		("nvdaControllerInternal_vbufChangeNotify", _nvdaControllerInternal_vbufChangeNotify),
 		(
 			"nvdaControllerInternal_installAddonPackageFromPath",
 			nvdaControllerInternal_installAddonPackageFromPath,

--- a/source/NVDAHelper.py
+++ b/source/NVDAHelper.py
@@ -646,11 +646,11 @@ def nvdaControllerInternal_typedCharacterNotify(ch):
 	return 0
 
 
-@WINFUNCTYPE(c_long, c_int, c_int)
-def nvdaControllerInternal_vbufChangeNotify(rootDocHandle, rootID):
+@WINFUNCTYPE(c_long, c_int, c_int, c_bool)
+def nvdaControllerInternal_vbufChangeNotify(rootDocHandle: int, rootID: int, selectionChanged: bool) -> int:
 	import virtualBuffers
 
-	virtualBuffers.VirtualBuffer.changeNotify(rootDocHandle, rootID)
+	virtualBuffers.VirtualBuffer.changeNotify(rootDocHandle, rootID, selectionChanged)
 	return 0
 
 

--- a/source/virtualBuffers/__init__.py
+++ b/source/virtualBuffers/__init__.py
@@ -868,7 +868,7 @@ class VirtualBuffer(browseMode.BrowseModeDocumentTreeInterceptor):
 		return self.makeTextInfo(textInfos.offsets.Offsets(*offsets))
 
 	@classmethod
-	def changeNotify(cls, rootDocHandle: int, rootID: int, selectionChanged: bool):
+	def changeNotify(cls, rootDocHandle: int, rootID: int, selectionChanged: bool = False):
 		try:
 			queueHandler.queueFunction(
 				queueHandler.eventQueue,

--- a/source/virtualBuffers/__init__.py
+++ b/source/virtualBuffers/__init__.py
@@ -868,20 +868,23 @@ class VirtualBuffer(browseMode.BrowseModeDocumentTreeInterceptor):
 		return self.makeTextInfo(textInfos.offsets.Offsets(*offsets))
 
 	@classmethod
-	def changeNotify(cls, rootDocHandle, rootID):
+	def changeNotify(cls, rootDocHandle: int, rootID: int, selectionChanged: bool):
 		try:
 			queueHandler.queueFunction(
 				queueHandler.eventQueue,
 				cls.rootIdentifiers[rootDocHandle, rootID]._handleUpdate,
+				selectionChanged,
 			)
 		except KeyError:
 			pass
 
-	def _handleUpdate(self):
+	def _handleUpdate(self, selectionChanged: bool):
 		"""Handle an update to this buffer."""
 		if not self.VBufHandle:
 			# #4859: The buffer was unloaded after this method was queued.
 			return
+		if selectionChanged:
+			review.handleCaretMove(self.makeTextInfo(textInfos.POSITION_CARET))
 		braille.handler.handleUpdate(self)
 
 	def getControlFieldForNVDAObject(self, obj):

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -43,6 +43,7 @@
 * It is now possible to route to any braille cell on the Humanware Monarch multiline braille device, using their point and click action. (#18248)
 * In focus mode in web browsers, it is now possible to review and spell the labels of controls when those labels are specifically provided for accessibility; e.g. via `aria-label` or `aria-labelledby`. (#15159, @jcsteh)
 * It is now possible to review and spell the labels of controls in Google Chrome menus and dialogs. (#11285, @jcsteh)
+* In browse mode in web browsers, if scrolling causes content to be removed earlier in the document, the review cursor correctly follows the caret if configured to do so. (#17379, @jcsteh)
 
 ### Changes for Developers
 


### PR DESCRIPTION
### Link to issue number:
Fixes #17379.

### Summary of the issue:
Scrolling can be triggered by moving the browse mode cursor. In some web documents, scrolling can cause content earlier in the document to be removed. This changes the offsets of content later in the document. When this happens, the C++ buffer updates the selection start offset to compensate, so the browse mode caret (which is always queried via C++) is correct. However, NVDA's Python code isn't notified about this change. This means the review cursor isn't updated appropriately.

### Description of user facing changes:
In browse mode in web browsers, if scrolling causes content to be removed earlier in the document, the review cursor correctly follows the caret if configured to do so.

### Description of development approach:
1. Added a boolean `selectionChanged` argument to `nvdaControllerInternal_vbufChangeNotify` and plumbed it through the 17000 different locations required by an RPC interface change.
2. In `VBufBackend_t::update`, before calling `replaceSubtrees`, save the old selection start.
3. After `replaceSubtrees`, when calling `nvdaControllerInternal_vbufChangeNotify`, pass `selectionChanged = true` if the old selection start (from 2) is different to the current selection start.
4. In `VirtualBuffer._handleUpdate`, if `selectionChanged` is true, notify the review module about the update.

### Testing strategy:
Tested as per https://github.com/nvaccess/nvda/issues/17379#issue-2646037153 and https://github.com/nvaccess/nvda/issues/17379#issuecomment-3002173624.

### Known issues with pull request:
None.

### Code Review Checklist:
- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [ ] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
