### PR TITLE
Add documentation for CI/CD set up

### DIFF
--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -155,8 +155,6 @@ jobs:
     runs-on: windows-latest
     needs: [buildNVDA, checkPot]
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/beta' && vars.CROWDIN_PROJECT_ID }}
-    needs: [buildNVDA, checkPot]
-    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/beta' }}
     steps:
     - name: Checkout cached build
       uses: actions/cache/restore@v4

--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -25,19 +25,13 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  START_BUILD_NUMBER: 50000
+  START_BUILD_NUMBER: ${{ vars.BUILD_NUMBER_OFFSET || 0 }}
   pullRequestNumber: ${{ github.event_name == 'pull_request' && github.event.number || 0 }}
-  scons_publisher: NV Access
+  scons_publisher: ${{ vars.PUBLISHER_NAME || github.repository_owner }}
   # Don't send telemetry to Microsoft when using MSVC tooling, avoiding an unnecessary PowerShell script invocation.
   VSCMD_SKIP_SENDTELEMETRY: 1
   # Cache details about available MSVC tooling for subsequent SCons invocations to the provided file.
   SCONS_CACHE_MSVC_CONFIG: ".scons_msvc_cache.json"
-  # Comment out any of the feature_* variables to disable the respective build feature.
-  # They are checked for existence of content, not specific value.
-  feature_uploadSymbolsToMozilla: configured
-  feature_crowdinSync: configured
-  feature_signing: configured
-  # feature_buildAppx: configured
 
 jobs:
   buildNVDA:
@@ -163,17 +157,17 @@ jobs:
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/beta' }}
     steps:
     - name: Checkout cached build
-      if: ${{ env.feature_crowdinSync }}
+      if: ${{ vars.CROWDIN_PROJECT_ID }}
       uses: actions/cache/restore@v4
       with:
         path: ${{ github.workspace }}
         key: ${{ github.ref }}-${{ github.run_id }}
         fail-on-cache-miss: true
     - name: Install the latest version of uv
-      if: ${{ env.feature_crowdinSync }}
+      if: ${{ vars.CROWDIN_PROJECT_ID }}
       uses: astral-sh/setup-uv@v6
     - name: Upload translations to Crowdin
-      if: ${{ env.feature_crowdinSync }}
+      if: ${{ vars.CROWDIN_PROJECT_ID }}
       env:
         crowdinProjectID: ${{ vars.CROWDIN_PROJECT_ID }}
         crowdinAuthToken: ${{ secrets.CROWDIN_AUTH_TOKEN }}
@@ -197,7 +191,7 @@ jobs:
     - name: Set scons args
       run: ci/scripts/setSconsArgs.ps1
       env:
-        apiSigningToken: ${{ (github.event_name == 'push' && env.feature_signing) && secrets.API_SIGNING_TOKEN || '' }}
+        apiSigningToken: ${{ github.event_name == 'push' && secrets.API_SIGNING_TOKEN }}
     - name: Create launcher
       shell: cmd
       run: |
@@ -309,15 +303,15 @@ jobs:
         name: Symbols
         path: output/symbols.zip
     - name: Install the latest version of uv
-      if: ${{ github.event_name == 'push' && env.feature_uploadSymbolsToMozilla }}
+      if: ${{ github.event_name == 'push' && vars.feature_uploadSymbolsToMozilla }}
       uses: astral-sh/setup-uv@v6
     - name: Upload symbols to Mozilla
-      if: ${{ github.event_name == 'push' && env.feature_uploadSymbolsToMozilla }}
+      if: ${{ github.event_name == 'push' && vars.feature_uploadSymbolsToMozilla }}
       continue-on-error: true
       # TODO: this script should be moved to ci/scripts
       run: uv run --with requests --directory appveyor mozillaSyms.py
       env:
-        mozillaSymsAuthToken: ${{ secrets.MOZILLA_SYMS_AUTH_TOKEN }}
+        mozillaSymsAuthToken: ${{ secrets.MOZILLA_SYMS_TOKEN }}
     - name: Warn on failure
       if: ${{ failure() }}
       shell: bash

--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -154,20 +154,17 @@ jobs:
     name: Upload translations to Crowdin
     runs-on: windows-latest
     needs: buildNVDA
-    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/beta' }}
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/beta' && vars.CROWDIN_PROJECT_ID }}
     steps:
     - name: Checkout cached build
-      if: ${{ vars.CROWDIN_PROJECT_ID }}
       uses: actions/cache/restore@v4
       with:
         path: ${{ github.workspace }}
         key: ${{ github.ref }}-${{ github.run_id }}
         fail-on-cache-miss: true
     - name: Install the latest version of uv
-      if: ${{ vars.CROWDIN_PROJECT_ID }}
       uses: astral-sh/setup-uv@v6
     - name: Upload translations to Crowdin
-      if: ${{ vars.CROWDIN_PROJECT_ID }}
       env:
         crowdinProjectID: ${{ vars.CROWDIN_PROJECT_ID }}
         crowdinAuthToken: ${{ secrets.CROWDIN_AUTH_TOKEN }}
@@ -282,8 +279,8 @@ jobs:
         annotate_only: true
         report_paths: testOutput/system/systemTests.xml
 
-  uploadSymbols:
-    name: Upload symbols
+  createSymbols:
+    name: Create symbols
     runs-on: windows-latest
     needs: buildNVDA
     steps:
@@ -302,11 +299,21 @@ jobs:
       with:
         name: Symbols
         path: output/symbols.zip
+
+  uploadSymbols:
+    name: Upload symbols
+    runs-on: windows-latest
+    needs: createSymbols
+    if: ${{ github.event_name == 'push' && vars.feature_uploadSymbolsToMozilla }}
+    steps:
     - name: Install the latest version of uv
-      if: ${{ github.event_name == 'push' && vars.feature_uploadSymbolsToMozilla }}
       uses: astral-sh/setup-uv@v6
+    - name: Get symbols
+      uses: actions/download-artifact@v4
+      with:
+        name: Symbols
+        path: output/symbols.zip
     - name: Upload symbols to Mozilla
-      if: ${{ github.event_name == 'push' && vars.feature_uploadSymbolsToMozilla }}
       continue-on-error: true
       # TODO: this script should be moved to ci/scripts
       run: uv run --with requests --directory appveyor mozillaSyms.py
@@ -328,7 +335,7 @@ jobs:
     name: Cleanup cache
     permissions:
       actions: write
-    needs: [checkPot, licenseCheck, unitTests, systemTests, crowdinUpload, uploadSymbols]
+    needs: [checkPot, licenseCheck, unitTests, systemTests, crowdinUpload, createSymbols]
     if: ${{ always() && (github.event_name == 'push' || github.event.pull_request.head.repo.owner == github.repository_owner) }}
     runs-on: ubuntu-latest
     steps:
@@ -344,7 +351,7 @@ jobs:
     permissions:
       contents: write
     runs-on: ubuntu-latest
-    needs: [checkPot, licenseCheck, unitTests, systemTests, uploadSymbols]
+    needs: [checkPot, licenseCheck, unitTests, systemTests, createSymbols]
     if: startsWith(github.ref_name, 'release-')
     steps:
     - name: Get normalized tag names

--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -153,13 +153,10 @@ jobs:
   crowdinUpload:
     name: Upload translations to Crowdin
     runs-on: windows-latest
-<<<<<<< ghVarConfig
-    needs: buildNVDA
+    needs: [buildNVDA, checkPot]
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/beta' && vars.CROWDIN_PROJECT_ID }}
-=======
     needs: [buildNVDA, checkPot]
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/beta' }}
->>>>>>> master
     steps:
     - name: Checkout cached build
       uses: actions/cache/restore@v4

--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -188,7 +188,7 @@ jobs:
     - name: Set scons args
       run: ci/scripts/setSconsArgs.ps1
       env:
-        apiSigningToken: ${{ github.event_name == 'push' && secrets.API_SIGNING_TOKEN }}
+        apiSigningToken: ${{ github.event_name == 'push' && secrets.API_SIGNING_TOKEN || '' }}
     - name: Create launcher
       shell: cmd
       run: |

--- a/ci/README.md
+++ b/ci/README.md
@@ -19,22 +19,22 @@ These are signed and deployed to the NV Access server.
 The build process is non-linear.
 Some of these steps run concurrently.
 
-1. Prepare source code and cache:
-    1. Checkout NVDA repository with submodules.
-    1. Install dependencies (or use cache).
-    1. Set version and scons variables.
-    1. Build NVDA source.
-1. Build and test:
-    1. Run static tests
-    1. Build launcher
-    1. Install NVDA
-    1. Run systems tests
-1. Deploy (not fully active currently):
-    1. On tagged/snapshot builds, upload symbols to Mozilla
-    1. On beta branch builds, upload translation to Crowdin.
-    1. On snapshot builds, deploy to the server.
-    1. On release builds, publish the release in GitHub and deploy to the server.
-1. Clean up build cache.
+* Prepare source code and cache:
+  * Checkout NVDA repository with submodules.
+  * Install dependencies (or use cache).
+  * Set version and scons variables.
+  * Build NVDA source.
+* Build and test:
+  * Run static tests
+  * Build launcher
+  * Install NVDA
+  * Run systems tests
+* Deploy (not fully active currently):
+  * On tagged/snapshot builds, upload symbols to Mozilla
+  * On beta branch builds, upload translation to Crowdin.
+  * On snapshot builds, deploy to the server.
+  * On release builds, publish the release in GitHub and deploy to the server.
+* Clean up build cache.
 
 ### Build behaviours
 
@@ -56,7 +56,7 @@ It currently defaults to the repository owner (e.g. `nvaccess`).
 ### Build number offset
 
 To offset from our previous build system, we start the sequential build count at a higher number than 0.
-This means our first build will be numbered something like 100,001 not 1.
+This means our first build will be numbered something like 100,001 not *
 
 To offset build numbers, set;
 
@@ -133,7 +133,9 @@ Ensure a secret is set and SSL is enabled.
 
 NV Access scans tagged builds with VirusTotal.
 
-Set `VT_API_KEY` as a secret to perform tagged builds.
+To ensure this step of tagged builds succeed, set:
+
+* `VT_API_KEY` as a secret.
 
 ### GitHub Discussions category
 

--- a/ci/README.md
+++ b/ci/README.md
@@ -1,43 +1,143 @@
 # Continuous Integration with GitHub Actions
 
-[Documentation about GitHub Actions](https://docs.github.com/en/actions)
+## Background
+
+GitHub Actions builds the following types of NVDA installers through a CI/CD pipeline:
+
+* Pull Request builds: Generated from the pull requests.
+Pull requests initiated from `nvaccess/nvda` rather than a fork have extra permissions than standard PRs.
+* Snapshot builds: Generated from pushes to master/beta/rc or branch names prefixed with `try-`.
+These are signed and deployed to the NV Access server.
+* Tagged builds: Generated from pushes to tags prefixed with `release-`.
+Official beta, rc and stable releases.
+These are signed and deployed to the NV Access server.
 
 ## Builds
+
+### Build process
+
+The build process is non-linear.
+Some of these steps run concurrently.
+
+1. Prepare source code and cache:
+    1. Checkout NVDA repository with submodules.
+    1. Install dependencies (or use cache).
+    1. Set version and scons variables.
+    1. Build NVDA source.
+1. Build and test:
+    1. Run static tests
+    1. Build launcher
+    1. Install NVDA
+    1. Run systems tests
+1. Deploy (not fully active currently):
+    1. On tagged/snapshot builds, upload symbols to Mozilla
+    1. On beta branch builds, upload translation to Crowdin.
+    1. On snapshot builds, deploy to the server.
+    1. On release builds, publish the release in GitHub and deploy to the server.
+1. Clean up build cache.
+
+### Build behaviours
 
 Builds will fail if any command has a non-zero exit code.
 PowerShell scripts continue on non-terminating errors unless the file is prefixed with `$ErrorActionPreference = "Stop";`.
 
-### Build process
+## Setup requirements
 
-1. Checkout NVDA repository with submodules.
-1. Install dependencies (or use cache).
-1. Set version and scons variables.
-1. Prepare source code.
-1. Build launcher.
-1. Install NVDA.
-1. Prepare for tests.
-1. Run tests.
-1. Clean up build cache.
-1. Release NVDA if this is a tagged release.
+The repository hosting GitHub Actions must be configured correctly for different parts of the build process.
 
-## Testing
+### Publisher name
 
-Before testing we:
+Our releases are packaged with a publisher name.
+To customise this, set:
 
-* Create directories to store results.
-* Install NVDA for system tests
+* `PUBLISHER_NAME` as a variable.
+It currently defaults to the repostiory owner (e.g. `nvaccess`).
 
-The tests we perform are:
+### Build number offset
 
-* check translation comments
-* license checks
-* unit tests
-* system tests
-  * each test suite (i.e. .robot file) must be manually included by:
-    * adding a tag to `Force Tags` in the suite
-    * adding the tag to `systemTests.strategy.matrix.testSuite` in the [CI script](../.github/workflows/testAndPublish.yml)
+To offset from our previous build system, we start the sequential build count at a higher number than 0.
+This means our first build will be numbered something like 100,001 not 1.
 
-## Artifacts
+To offset build numbers, set;
 
-* NVDA launcher.
-* Test results.
+* `BUILD_NUMBER_OFFSET` as a variable.
+It currently defaults to 0.
+
+### Crowdin
+
+NVDA translations are synced with Crowdin on the beta branch.
+
+To enable, set:
+
+* `CROWDIN_PROJECT_ID` as a variable.
+* `CROWDIN_AUTH_TOKEN` as a secret.
+
+### Code signing
+
+NV Access signs snapshot/tagged builds with SignPath.
+
+To enable, set:
+
+* `API_SIGNING_TOKEN` as a secret with your SignPath token.
+
+### Uploading symbols
+
+NVDA uploads its build symbols to Mozilla to help them with debugging on snapshot/tagged builds.
+
+To enable, set:
+
+* `MOZILLA_SYMS_TOKEN` as a secret.
+* `feature_uploadSymbolsToMozilla` as a variable with any non-empty string.
+
+Generating this requires direct co-ordination with Mozilla.
+
+### GitHub Environments
+
+GitHub Environments are used to protect deployments of snapshot/tagged builds.
+
+Create two GitHub Environments, one called `production`, the other `snapshot`.
+
+#### production
+
+Used for tagged releases of NVDA.
+It's recommended to enable deployment protection rules so that a human can confirm the deployment of a built tagged release staged for deployment.
+This is so any desired testing can get manually confirmed, and communications for the release can be prepared.
+
+Configuration:
+
+* Name: `production`
+* Enable required reviewers: this ensures a human must confirm deployment of a staged release
+* Under "Deployment branches and tags", create a tag rule: `release-*`
+
+#### snapshot
+
+Configuration:
+
+* Name: `snapshot`
+* Do not enable required reviewers: this is not needed for snapshots.
+* Under "Deployment branches and tags", create these branch rules:
+  * `master`
+  * `beta`
+  * `rc`
+  * `try-**`
+
+### Deployment webhook
+
+Create a GitHub webhook to subscribe to snapshot/tagged builds of NVDA, and use it to deploy to a server.
+
+Under events, only subscribe to the Deployments event.
+
+Ensure a secret is set and SSL is enabled.
+
+### VirusTotal scanning
+
+NV Access scans tagged builds with VirusTotal.
+
+Set `VT_API_KEY` as a secret to perform tagged builds.
+
+### GitHub Discussions category
+
+This is only used when building tagged builds.
+GitHub Discussions created for stable releases must go into a "Releases" category.
+Discussions must be enabled in the repository.
+Create a new discussion category with an "Announcement" type, and a category name of "Releases".

--- a/ci/README.md
+++ b/ci/README.md
@@ -33,7 +33,7 @@ Some of these steps run concurrently.
   * On tagged/snapshot builds, upload symbols to Mozilla
   * On beta branch builds, upload translation to Crowdin.
   * On snapshot builds, deploy to the server.
-  * On release builds, publish the release in GitHub and deploy to the server.
+  * On release builds, publish the release on GitHub and deploy to the server.
 * Clean up build cache.
 
 ### Build behaviours

--- a/ci/README.md
+++ b/ci/README.md
@@ -51,7 +51,7 @@ Our releases are packaged with a publisher name.
 To customise this, set:
 
 * `PUBLISHER_NAME` as a variable.
-It currently defaults to the repostiory owner (e.g. `nvaccess`).
+It currently defaults to the repository owner (e.g. `nvaccess`).
 
 ### Build number offset
 

--- a/ci/README.md
+++ b/ci/README.md
@@ -56,7 +56,7 @@ It currently defaults to the repository owner (e.g. `nvaccess`).
 ### Build number offset
 
 To offset from our previous build system, we start the sequential build count at a higher number than 0.
-This means our first build will be numbered something like 100,001 not *
+This means our first build will be numbered something like 100,001 not 1.
 
 To offset build numbers, set;
 

--- a/ci/scripts/setSconsArgs.ps1
+++ b/ci/scripts/setSconsArgs.ps1
@@ -1,5 +1,6 @@
 $ErrorActionPreference = "Stop";
 $sconsOutTargets = "launcher developerGuide changes userGuide keyCommands client moduleList"
+# AppX is currently unmaintained and not built by default.
 if ($env:GITHUB_EVENT_NAME -eq "push" -and $env:feature_buildAppx) {
 	$sconsOutTargets += " appx"
 }


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Part of #17878 

### Summary of the issue:
Forks of NVDA cannot customise parts of the CI/CD pipeline without committing to code.
This allows forks to maintain a clean diff with `nvaccess/nvda`.
Right now several environment variables and feature flags are set in `testAndPublish.yml`, the CI/CD script.
Forks should be able to maintain their CI/CD pipeline without making commits, as commits dirty the fork and make merging upstream harder.
For AppVeyor, developers [could create a gist](https://github.com/nvaccess/nvda/blob/HEAD/projectDocs/dev/buildingNVDAOnAppVeyor.md) for appveyor.yml, point AppVeyors UX towards it, and host it separately to their repo fork.
This can't be done with GitHub actions.
As such, all variables which need to be customizable by forks should be able to be set from GitHub variable contexts.
such as:

- setting a publisher name
- enabling/configuring signing
- enabling/configuring crowdin sync
- enabling/configuring uploading symbols to mozilla

The current GitHub actions design doesn't allow for a separate environment to override `.github/workflows/testAndPublish.yml`.


### Description of user facing changes:

None

### Description of developer facing changes:

Forks can now more easily maintain a custom build set up.
Documentation has been added on how to do this. 
Forks should work clean out of the gate, with features disabled by default, for everything except tagged releases.

We also have more clear documentation on how to set up the NVDA repository for builds

### Description of development approach:

Config is moved out of source control into github variables. sensible defaults are provided for forks

### Testing strategy:

Test builds

### Known issues with pull request:

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
