### PR TITLE
NLS eReader Zoomax braille driver

### DIFF
--- a/source/brailleDisplayDrivers/nlseReaderZoomax.py
+++ b/source/brailleDisplayDrivers/nlseReaderZoomax.py
@@ -1,0 +1,276 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2025 NV Access Limited, Zoomax
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+# NLS eReader Zoomax driver for NVDA.
+
+import bdDetect
+import braille
+import brailleInput
+import hwIo
+import inputCore
+import serial
+from dataclasses import dataclass
+from enum import Enum
+from logHandler import log
+
+TIMEOUT_SEC = 0.2
+BAUD_RATE = 19200
+CONNECT_RETRIES = 5
+
+COMMUNICATION_ESCAPE_BYTE = b"\x1b"
+""" The device communication protocol is escape ASCII character based.
+So each command starts with the escape character.
+When part of the command payload, the escape character is duplicated. """
+
+
+class DeviceCommand(bytes, Enum):
+	DISPLAY_DATA = b"\x01"
+	REQUEST_INFO = b"\x02"
+	REQUEST_VERSION = b"\x05"
+	REPEAT_ALL = b"\x08"
+	PROTOCOL_ONOFF = b"\x15"
+	ROUTING_KEYS = b"\x22"
+	DISPLAY_KEYS = b"\x24"
+	BRAILLE_KEYS = b"\x33"
+	JOYSTICK_KEYS = b"\x34"
+	DEVICE_ID = b"\x84"
+	SERIAL_NUMBER = b"\x8a"
+
+
+@dataclass(frozen=True)
+class DeviceResponseInfo:
+	length: int
+	keys: tuple[str, ...] | None = None
+
+
+COMMAND_RESPONSE_INFO: dict[DeviceCommand, DeviceResponseInfo] = {
+	DeviceCommand.DISPLAY_DATA: DeviceResponseInfo(1),
+	DeviceCommand.DISPLAY_KEYS: DeviceResponseInfo(
+		1,
+		("d1", "d2", "d3", "d4", "d5", "d6"),
+	),
+	DeviceCommand.BRAILLE_KEYS: DeviceResponseInfo(
+		2,
+		(
+			"bl",
+			"br",
+			"bs",
+			None,
+			"s1",
+			"s2",
+			"s3",
+			"s4",  # byte 1
+			"b1",
+			"b2",
+			"b3",
+			"b4",
+			"b5",
+			"b6",
+			"b7",
+			"b8",  # byte 2
+		),
+	),
+	DeviceCommand.JOYSTICK_KEYS: DeviceResponseInfo(
+		1,
+		("up", "left", "down", "right", "select"),
+	),
+	DeviceCommand.ROUTING_KEYS: DeviceResponseInfo(5),
+	DeviceCommand.DEVICE_ID: DeviceResponseInfo(16),
+	DeviceCommand.SERIAL_NUMBER: DeviceResponseInfo(8),
+}
+
+
+class BrailleDisplayDriver(braille.BrailleDisplayDriver):
+	_dev: hwIo.IoBase
+	name = "nlseReaderZoomax"
+	# Translators: Names of braille displays.
+	description = _("NLS eReader Zoomax")
+	isThreadSafe = True
+	supportsAutomaticDetection = True
+
+	@classmethod
+	def registerAutomaticDetection(cls, driverRegistrar: bdDetect.DriverRegistrar):
+		driverRegistrar.addUsbDevices(
+			bdDetect.DeviceType.SERIAL,
+			{
+				"VID_1A86&PID_7523",  # CH340 USB to serial chip
+			},
+		)
+
+		driverRegistrar.addBluetoothDevices(lambda m: m.id.startswith("NLS eReader Z"))
+
+	def _connect(self, port: str) -> bool:
+		for portType, portId, port, portInfo in self._getTryPorts(port):
+			try:
+				self._dev = hwIo.Serial(
+					port,
+					baudrate=BAUD_RATE,
+					bytesize=serial.EIGHTBITS,
+					parity=serial.PARITY_NONE,
+					stopbits=serial.STOPBITS_ONE,
+					timeout=TIMEOUT_SEC,
+					writeTimeout=TIMEOUT_SEC,
+					onReceive=self._onReceive,
+				)
+			except EnvironmentError:
+				log.debugWarning("Port not yet available.", exc_info=True)
+				continue
+
+			self._sendRequest(DeviceCommand.PROTOCOL_ONOFF.value, False)
+			self._sendRequest(DeviceCommand.PROTOCOL_ONOFF.value, True)
+			self._sendRequest(DeviceCommand.REPEAT_ALL.value)
+
+			for i in range(CONNECT_RETRIES):
+				self._dev.waitForRead(TIMEOUT_SEC)
+				if self.numCells:
+					break
+
+			if self.numCells:
+				log.info(f"Device connected via {portType} ({port})")
+				return True
+			log.info("Device arrival timeout")
+			self._dev.close()
+		return False
+
+	def __init__(self, port: str = "auto"):
+		log.info("Initializing nlseReaderZoomax driver")
+		super().__init__()
+		self.numCells = 0
+		self._dev = None
+
+		if not self._connect(port):
+			raise RuntimeError("Could not connect to device")
+
+		self._keysDown: dict[bytes, bytes] = {}
+		self._ignoreKeyReleases = False
+
+	def terminate(self):
+		try:
+			super().terminate()
+			self._sendRequest(DeviceCommand.PROTOCOL_ONOFF, False)
+		except EnvironmentError:
+			pass
+		finally:
+			self._dev.close()
+
+	def _sendRequest(self, command: bytes, arg: bytes | bool | int = b""):
+		typeErrorString = "Expected param '{}' to be of type '{}', got '{}'"
+		if not isinstance(arg, bytes):
+			if isinstance(arg, bool):
+				arg = hwIo.boolToByte(arg)
+			elif isinstance(arg, int):
+				arg = hwIo.intToByte(arg)
+			else:
+				raise TypeError(typeErrorString.format("arg", "bytes, bool, or int", type(arg).__name__))
+
+		if not isinstance(command, bytes):
+			raise TypeError(typeErrorString.format("command", "bytes", type(command).__name__))
+
+		# doubling the escape characters in the data (arg) part
+		# as required by the device communication protocol
+		arg = arg.replace(COMMUNICATION_ESCAPE_BYTE, COMMUNICATION_ESCAPE_BYTE * 2)
+
+		data = b"".join(
+			[
+				COMMUNICATION_ESCAPE_BYTE,
+				command,
+				arg,
+			],
+		)
+		self._dev.write(data)
+
+	def _onReceive(self, data: bytes):
+		if data != COMMUNICATION_ESCAPE_BYTE:
+			log.debugWarning(f"Ignoring byte before escape: {data!r}")
+			return
+		# data only contained the escape. Read the rest from the device.
+		stream = self._dev
+		command = stream.read(1)
+		length = COMMAND_RESPONSE_INFO.get(command, DeviceResponseInfo(0)).length
+		arg = stream.read(length)
+		self._handleResponse(command, arg)
+
+	def _handleResponse(self, command: bytes, arg: bytes):
+		if command == DeviceCommand.DISPLAY_DATA:
+			self.numCells = ord(arg)
+		elif command in COMMAND_RESPONSE_INFO:
+			arg = int.from_bytes(reversed(arg))
+			if arg < self._keysDown.get(command, 0):
+				# Release.
+				if not self._ignoreKeyReleases:
+					# The first key released executes the key combination.
+					try:
+						inputCore.manager.executeGesture(InputGesture(self._keysDown))
+					except inputCore.NoInputGestureAction:
+						pass
+					# Any further releases are just the rest of the keys in the combination being released,
+					# so they should be ignored.
+					self._ignoreKeyReleases = True
+			else:
+				# Press.
+				# This begins a new key combination.
+				self._ignoreKeyReleases = False
+			if arg > 0:
+				self._keysDown[command] = arg
+			elif command in self._keysDown:
+				# All keys in this group have been released.
+				# Remove this group so it doesn't count as a group with keys down.
+				del self._keysDown[command]
+		else:
+			log.debugWarning(f"Unknown command {command!r}, arg {arg!r}")
+
+	def display(self, cells: list[int]):
+		# cells will already be padded up to numCells.
+		arg = bytes(cells)
+		self._sendRequest(DeviceCommand.DISPLAY_DATA, arg)
+
+	gestureMap = inputCore.GlobalGestureMap(
+		{
+			"globalCommands.GlobalCommands": {
+				"braille_scrollBack": ("br(nlseReaderZoomax):d2",),
+				"braille_scrollForward": ("br(nlseReaderZoomax):d5",),
+				"braille_previousLine": ("br(nlseReaderZoomax):d1",),
+				"braille_nextLine": ("br(nlseReaderZoomax):d3",),
+				"braille_routeTo": ("br(nlseReaderZoomax):routing",),
+				"kb:upArrow": ("br(nlseReaderZoomax):up",),
+				"kb:downArrow": ("br(nlseReaderZoomax):down",),
+				"kb:leftArrow": ("br(nlseReaderZoomax):left",),
+				"kb:rightArrow": ("br(nlseReaderZoomax):right",),
+				"kb:enter": ("br(nlseReaderZoomax):select",),
+			},
+		},
+	)
+
+
+class InputGesture(braille.BrailleDisplayGesture, brailleInput.BrailleInputGesture):
+	source = BrailleDisplayDriver.name
+
+	def __init__(self, keysDown: dict[bytes, bytes]):
+		super().__init__()
+		self.keysDown = keysDown
+
+		SYSTEM_KEYS_MASK = 0xF8
+		SPACEBAR_KEYS_MASK = 0x07
+
+		self.keyNames = names = []
+		for group, groupKeysDown in keysDown.items():
+			if (
+				group == DeviceCommand.BRAILLE_KEYS
+				and len(keysDown) == 1
+				and not groupKeysDown & SYSTEM_KEYS_MASK
+			):
+				self.dots = groupKeysDown >> 8
+				self.space = groupKeysDown & SPACEBAR_KEYS_MASK
+			if group == DeviceCommand.ROUTING_KEYS:
+				for index in range(braille.handler.display.numCells):
+					if groupKeysDown & (1 << index):
+						self.routingIndex = index
+						names.append("routing")
+						break
+			else:
+				for index, name in enumerate(COMMAND_RESPONSE_INFO.get(group).keys):
+					if groupKeysDown & (1 << index):
+						names.append(name)
+
+		self.id = "+".join(names)

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -15,6 +15,7 @@
 * In Windows 11 2024 Update and Server 2025 and later, NVDA will announce foreground window states such as restore, maximize, and snap when changing window position by pressing `windows+arrow` keys. (#17841, #18175, @josephsl)
 * Unassigned commands have been added to open the NVDA settings dialog in the following categories: Vision, Windows OCR, Add-on Store and Advanced. (#18313, @CyrilleB79)
 * Introduced support for Windows 11 Voice Access, including reporting dictated text and microphone status from everywhere (requires NVDA to be installed). (#16862, #17384, @josephsl)
+* Support for the NLS eReader Zoomax braille display has been added. (#15863, @florin-trutiu)
 
 ### Changes
 

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -4197,6 +4197,7 @@ The following displays support this automatic detection functionality.
 * Nattiq nBraille displays
 * Seika Notetaker: MiniSeika (16, 24 cells), V6, and V6Pro (40 cells)
 * Tivomatic Caiku Albatross 46/80 displays
+* NLS eReader Zoomax
 * Any Display that supports the Standard HID Braille protocol
 
 ### Freedom Scientific Focus/PAC Mate Series {#FreedomScientificFocus}
@@ -4509,8 +4510,7 @@ The following extra devices are also supported (and do not require any special d
 * APH Mantis Q40
 * APH Chameleon 20
 * Humanware BrailleOne
-* NLS eReader
-  * Note that the Zoomax is currently not supported without external drivers
+* NLS eReader HumanWare
 
 Following are the key assignments for the Brailliant BI/B and BrailleNote touch displays with NVDA.
 Please see the display's documentation for descriptions of where these keys can be found.
@@ -5370,6 +5370,34 @@ Please see the display's documentation for descriptions of where these keys can 
 |`Windows+e` key (this computer) |`attribute2`|
 |`Windows+b` key (focus system tray) |`attribute3`|
 |`Windows+i` key (Windows settings) |`attribute4`|
+
+<!-- KC:endInclude -->
+
+### NLS eReader Zoomax {#Zoomax}
+
+The NLS eReader Zoomax device supports USB or bluetooth connections.
+The Windows 10 and Windows 11 operating systems will automatically detect and install the necessary drivers for this display.
+For computers where the Internet connection is disabled or not available, you can manually [download and install the USB to serial CH340 chip driver](https://www.wch-ic.com/downloads/CH341SER_EXE.html) to support this display over USB.
+
+By default, NVDA can automatically detect and connect to this display via USB or bluetooth.
+However, when configuring the display, you can also explicitly select "USB" or "Bluetooth" ports to restrict the connection type to be used.
+
+Following are the key assignments for this display with NVDA.
+Please see the display's documentation for descriptions of where these keys can be found.
+<!-- KC:beginInclude -->
+
+| Name |Key|
+|---|---|
+|Scroll braille display back |`d2`|
+|Scroll braille display forward |`d5`|
+|Move braille display to previous line |`d1`|
+|Move braille display to next line |`d3`|
+|Route to braille cell |`routing`|
+|Up arrow key |`up`|
+|Down arrow key |`down`|
+|Left arrow key |`left`|
+|Right arrow key |`right`|
+|Enter key |`select`|
 
 <!-- KC:endInclude -->
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
<!-- Use Closes/Fixes/Resolves #xxx to link this PR to the issue it is responding to. -->
Closes https://github.com/nvaccess/nvda/issues/15863
Copy of #18260
### Summary of the issue:
This is the NVDA driver for the NLS eReader Zoomax braille display.
It supports both USB and Bluetooth automatic detection.
### Description of user facing changes:
With this driver the user can use directly the NLS eReader Zoomax display without the need to manually install it as an addon.
### Description of developer facing changes:

### Description of development approach:
The driver is similar with the existing braille display drivers for NVDA.
### Testing strategy:

### Known issues with pull request:

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
