### PR TITLE
Fix TextInfo.collapse() in Notepad++

### DIFF
--- a/source/NVDAObjects/window/scintilla.py
+++ b/source/NVDAObjects/window/scintilla.py
@@ -313,7 +313,7 @@ class ScintillaTextInfo(textInfos.offsets.OffsetsTextInfo):
 				tempOffset -= 1
 		return [start, end]
 
-	def collapse(self, end: bool = False):
+	def collapseAndMaybeMoveToNextParagraph(self, end: bool = False):
 		"""Before collapsing to end, if no text is selected, TextInfo is expanded to line.
 		This fixes a bug where next braille line command didn't move the cursor to the last empty line
 		in Notepad++ documents.

--- a/source/NVDAObjects/window/scintilla.py
+++ b/source/NVDAObjects/window/scintilla.py
@@ -313,7 +313,7 @@ class ScintillaTextInfo(textInfos.offsets.OffsetsTextInfo):
 				tempOffset -= 1
 		return [start, end]
 
-	def collapseAndMaybeMoveToNextParagraph(self, end: bool = False):
+	def _collapseAndMaybeMoveToNextParagraph(self, end: bool = False):
 		"""Before collapsing to end, if no text is selected, TextInfo is expanded to line.
 		This fixes a bug where next braille line command didn't move the cursor to the last empty line
 		in Notepad++ documents.

--- a/source/braille.py
+++ b/source/braille.py
@@ -1661,7 +1661,7 @@ class TextInfoRegion(Region):
 					dest = dest.obj.makeTextInfo(textInfos.POSITION_FIRST)
 			else:  # no page turn support
 				shouldCollapseToEnd = True
-		dest.collapseAndMaybeMoveToNextParagraph(shouldCollapseToEnd)
+		dest._collapseAndMaybeMoveToNextParagraph(shouldCollapseToEnd)
 		self._setCursor(dest)
 		_speakOnNavigatingByUnit(dest, self._getReadingUnit())
 

--- a/source/braille.py
+++ b/source/braille.py
@@ -1661,7 +1661,7 @@ class TextInfoRegion(Region):
 					dest = dest.obj.makeTextInfo(textInfos.POSITION_FIRST)
 			else:  # no page turn support
 				shouldCollapseToEnd = True
-		dest.collapse(shouldCollapseToEnd)
+		dest.collapseAndMaybeMoveToNextParagraph(shouldCollapseToEnd)
 		self._setCursor(dest)
 		_speakOnNavigatingByUnit(dest, self._getReadingUnit())
 

--- a/source/textInfos/__init__.py
+++ b/source/textInfos/__init__.py
@@ -519,6 +519,9 @@ class TextInfo(baseObject.AutoPropertyObject):
 		"""
 		raise NotImplementedError
 
+	def collapseAndMaybeMoveToNextParagraph(self, end: bool = False):
+		return self.collapse(end)
+
 	@abstractmethod
 	def copy(self):
 		"""duplicates this text info object so that changes can be made to either one with out afecting the other"""

--- a/source/textInfos/__init__.py
+++ b/source/textInfos/__init__.py
@@ -519,7 +519,7 @@ class TextInfo(baseObject.AutoPropertyObject):
 		"""
 		raise NotImplementedError
 
-	def collapseAndMaybeMoveToNextParagraph(self, end: bool = False):
+	def _collapseAndMaybeMoveToNextParagraph(self, end: bool = False) -> None:
 		self.collapse(end)
 
 	@abstractmethod

--- a/source/textInfos/__init__.py
+++ b/source/textInfos/__init__.py
@@ -520,7 +520,7 @@ class TextInfo(baseObject.AutoPropertyObject):
 		raise NotImplementedError
 
 	def collapseAndMaybeMoveToNextParagraph(self, end: bool = False):
-		return self.collapse(end)
+		self.collapse(end)
 
 	@abstractmethod
 	def copy(self):

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -47,6 +47,7 @@
 * It is now possible to route to any braille cell on the Humanware Monarch multiline braille device, using their point and click action. (#18248)
 * In focus mode in web browsers, it is now possible to review and spell the labels of controls when those labels are specifically provided for accessibility; e.g. via `aria-label` or `aria-labelledby`. (#15159, @jcsteh)
 * It is now possible to review and spell the labels of controls in Google Chrome menus and dialogs. (#11285, @jcsteh)
+* Fixed behavior of `TextInfo.collapse()` - previously it was moving TextInfo to the next paragraph in some cases. (#18320, @mltony).
 
 ### Changes for Developers
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -47,7 +47,6 @@
 * It is now possible to route to any braille cell on the Humanware Monarch multiline braille device, using their point and click action. (#18248)
 * In focus mode in web browsers, it is now possible to review and spell the labels of controls when those labels are specifically provided for accessibility; e.g. via `aria-label` or `aria-labelledby`. (#15159, @jcsteh)
 * It is now possible to review and spell the labels of controls in Google Chrome menus and dialogs. (#11285, @jcsteh)
-* Fixed behavior of `TextInfo.collapse()` - previously it was moving TextInfo to the next paragraph in some cases. (#18320, @mltony).
 
 ### Changes for Developers
 
@@ -70,6 +69,7 @@ Please refer to [the developer guide](https://www.nvaccess.org/files/nvda/docume
 The several built-in table definitions are moved to the `__tables` module in that package. (#18194, @LeonarddeR)
 * Microsoft SQL Server Management Studio now uses the Visual Studio app module, as SSMS is based on Visual Studio. (#18176, @LeonarddeR)
 * NVDA will report Windows release revision number (for example: 10.0.26100.0) when `winVersion.getWinVer` is called and log this information at startup. (#18266, @josephsl)
+* Fixed behavior of `TextInfo.collapse()` - previously it was moving TextInfo to the next paragraph in some cases. (#18320, @mltony)
 
 #### Deprecations
 


### PR DESCRIPTION
### Link to issue number:
Fixes #18320.

### Summary of the issue:
Commit 70cd311 by @nvdaes introduced a bug in TextInfo API: `TextInfo.collapse()` now unnecessarily jumps to the next paragraph in Notepad++. This bug also made its way into 2025.1 release.  There are several problems with this:
1. It breaks a bunch of add-ons that make use of TextInfo API. In particular, my WordNav add-on is broken as reported by my users. Probably more are broken - since `collapse` is frequently used method.
2. With this commit in place there is no way to actually collapse a TextInfo in place. This severely impacts the entire TextInfo API as many actions are now impossible to perform.
3. This is not intuitive: the name `collapse()` doesn't reflect that the TextInfo would also jump.
4. This is inconsistent across different apps - it only jumps in Notepad++.

@nvdaes tried to fix #17430 with this commit.

I propose this PR as a way to fix TextInfo API without breaking #17430.

### Description of user facing changes:
N/A
### Description of developer facing changes:
`TextInfo.collapse()` now works correctly in Notepad++.
### Description of development approach:
Created a new method `TextInfo.collapseAndMaybeMoveToNextParagraph` so that the logic implemented by @nvdaes can stay in place, but not affect other users of TextInfo API.

TBH I would rather not pollute TextInfo API, but I don't have visibility into braille subsystem - and I don't have a Braille display to test any changes - and @nvdaes claims there is no other way to fix #17430. So This PR is a compromise: I kept @nvdaes's logic in place at the cost of introducing a new unnecessary method in TextInfo API. I think a cleaner way would be for @nvdaes to dfix the issue in `def nextLine` and `def previousLine` in braille.py., but @nvdaes claims that's impossible (see the discussion in #18320).

### Testing strategy:
Tested with use case provided in #18320.

@nvdaes, can you test that this PR doesn't break #17430? I don't have a Braille display to test it on my end.

### Known issues with pull request:
N/A
### Code Review Checklist:


- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
