### PR TITLE
Fix bad HTML filtering regexp

### DIFF
--- a/source/markdownTranslate.py
+++ b/source/markdownTranslate.py
@@ -20,7 +20,8 @@ import subprocess
 RAW_GITHUB_REPO_URL = "https://raw.githubusercontent.com/nvaccess/nvda"
 re_kcTitle = re.compile(r"^(<!--\s+KC:title:\s*)(.+?)(\s*-->)$")
 re_kcSettingsSection = re.compile(r"^(<!--\s+KC:settingsSection:\s*)(.+?)(\s*-->)$")
-re_comment = re.compile(r"^<!--.*?-->$", flags=re.DOTALL)
+# Comments that span a single line in their entirety
+re_comment = re.compile(r"^<!--.+-->$")
 re_heading = re.compile(r"^(#+\s+)(.+?)((?:\s+\{#.+\})?)$")
 re_bullet = re.compile(r"^(\s*\*\s+)(.+)$")
 re_number = re.compile(r"^(\s*[0-9]+\.\s+)(.+)$")

--- a/source/markdownTranslate.py
+++ b/source/markdownTranslate.py
@@ -20,7 +20,7 @@ import subprocess
 RAW_GITHUB_REPO_URL = "https://raw.githubusercontent.com/nvaccess/nvda"
 re_kcTitle = re.compile(r"^(<!--\s+KC:title:\s*)(.+?)(\s*-->)$")
 re_kcSettingsSection = re.compile(r"^(<!--\s+KC:settingsSection:\s*)(.+?)(\s*-->)$")
-re_comment = re.compile(r"^<!--.+-->$")
+re_comment = re.compile(r"^<!--.*?-->$", flags=re.DOTALL)
 re_heading = re.compile(r"^(#+\s+)(.+?)((?:\s+\{#.+\})?)$")
 re_bullet = re.compile(r"^(\s*\*\s+)(.+)$")
 re_number = re.compile(r"^(\s*[0-9]+\.\s+)(.+)$")


### PR DESCRIPTION
### Link to issue number:
Closes #17753 

### Summary of the issue:
The `re_comment` regular expression doesn't account for multi-line HTML comments.

### Description of user facing changes:
None.

### Description of developer facing changes:
None.

### Description of development approach:
Update the expression to use the `re.DOTALL` flag, which expands `.` to match characters including newlines. As this would match from the start of the first comment in the file to the end of the last, switch to matching minimally between `<!--` and `-->`.

### Testing strategy:
CI

### Known issues with pull request:
None known

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary