### PR TITLE
Disable Appveyor Crowdin sync

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,7 +34,7 @@ environment:
  feature_buildSymbols: configured
  feature_uploadSymbolsToMozilla: configured
  #feature_buildAppx: configured
- feature_crowdinSync: configured
+ #feature_crowdinSync: configured
  feature_signing: configured
 
 # scripts that are called at very beginning, before repo cloning


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Part of #17878 

### Summary of the issue:
Crowdin synchronization is now ready to happen via GitHub actions.
As such, we don't want AppVeyor conflicting with GitHub actions synchronizing.

### Description of user facing changes:
none

### Description of developer facing changes:
Disable AppVeyor crowdin sync. 2025.2 betas will sync with Crowdin via GitHub actions

### Description of development approach:
comment out line

### Testing strategy:
Test after we merge master to beta