### PR TITLE
Fix naming of snapshot builds

### DIFF
--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -26,7 +26,7 @@ concurrency:
 
 env:
   START_BUILD_NUMBER: ${{ vars.BUILD_NUMBER_OFFSET || 0 }}
-  pullRequestNumber: ${{ github.event_name == 'pull_request' && github.event.number || '' }}
+  pullRequestNumber: ${{ github.event_name == 'pull_request' && github.event.number || 0 }}
   scons_publisher: ${{ vars.PUBLISHER_NAME || github.repository_owner }}
   # Don't send telemetry to Microsoft when using MSVC tooling, avoiding an unnecessary PowerShell script invocation.
   VSCMD_SKIP_SENDTELEMETRY: 1

--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -26,7 +26,7 @@ concurrency:
 
 env:
   START_BUILD_NUMBER: ${{ vars.BUILD_NUMBER_OFFSET || 0 }}
-  pullRequestNumber: ${{ github.event_name == 'pull_request' && github.event.number || 0 }}
+  pullRequestNumber: ${{ github.event_name == 'pull_request' && github.event.number || '' }}
   scons_publisher: ${{ vars.PUBLISHER_NAME || github.repository_owner }}
   # Don't send telemetry to Microsoft when using MSVC tooling, avoiding an unnecessary PowerShell script invocation.
   VSCMD_SKIP_SENDTELEMETRY: 1

--- a/ci/scripts/setBuildVersionVars.ps1
+++ b/ci/scripts/setBuildVersionVars.ps1
@@ -14,7 +14,7 @@ if ($env:GITHUB_REF_TYPE -eq "tag" -and $env:GITHUB_REF_NAME.StartsWith("release
 } else {
 	$commitVersion = $env:GITHUB_SHA.Substring(0, 8)
 	$BUILD_NUMBER = [int]$env:GITHUB_RUN_NUMBER + [int]$env:START_BUILD_NUMBER
-	if ($env:pullRequestNumber) {
+	if ([int]$env:pullRequestNumber) {
 		$version = "pr$env:pullRequestNumber-$BUILD_NUMBER,$commitVersion"
 	} elseif ($env:GITHUB_REF_NAME -eq "master") {
 		$version = "alpha-$BUILD_NUMBER,$commitVersion"
@@ -28,7 +28,7 @@ if ($env:GITHUB_REF_TYPE -eq "tag" -and $env:GITHUB_REF_NAME.StartsWith("release
 if (!$release) {
 	if ($env:GITHUB_REF_NAME -eq "master") {
 		$versionType = "snapshot:alpha"
-	} elseif (!$env:GITHUB_REF_NAME.StartsWith("try-") -and !$env:pullRequestNumber) {
+	} elseif (!$env:GITHUB_REF_NAME.StartsWith("try-") -and ![int]$env:pullRequestNumber) {
 		$versionType = "snapshot:$env:GITHUB_REF_NAME"
 	}
 }


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
None

### Summary of the issue:
Snapshot builds (i.e. pushes) are incorrectly being labelled as PR builds on GitHub actions.

### Description of development approach:
Cast strings to integer
