### PR TITLE
Minor fixups to projectDocs

### DIFF
--- a/projectDocs/issues/triage.md
+++ b/projectDocs/issues/triage.md
@@ -220,12 +220,15 @@ Community members are welcome and encouraged to interact with staff tickets in t
 By refraining from closing or consolidating staff tickets, we can ensure that the NV Access team maintains control over their internal workflow and prioritisation, while still benefiting from the valuable insights and contributions of the community.
 
 ## Extra permissions for triage
+
 GitHub allows NV Access to grant "triage" permissions to active contributors in the repository.
 This grants the ability to manage issues, pull requests and discussions, such as closing/opening, labeling, and assigning.
 Refer to [GitHub documentation](https://docs.github.com/en/organizations/managing-user-access-to-your-organizations-repositories/managing-repository-roles/repository-roles-for-an-organization) for more information on triage permissions.
 
-To request triage permissions, email info@nvaccess.org.
+To request triage permissions, email <info@nvaccess.org>.
 A consistent history of helpful activity in the repository is expected, for example helping debug issues, asking for missing information, providing constructive feedback on pull requests, submitting well-documented pull requests, constructively participating in discussions, mentoring new contributors or improving documentation.
 Candidates will be considered on a case by case basis.
 
 If conflict arises between how best to triage an issue, please defer to NV Access and keep the issue in an open, untriaged state i.e. with the labels "needs triage" and "blocked/needs-product-decision".
+Please do not close feature requests on the grounds of rejecting a feature.
+Allow the community to discuss the proposed feature and NV Access to make the decision on accepting it.

--- a/projectDocs/translating/github.md
+++ b/projectDocs/translating/github.md
@@ -72,6 +72,8 @@ New gestures will be announced there, and localisations can be added to `gesture
     - `gestures.ini`: This file doesn't require a base file, gestures can be added as needed.
 1. Edit the relevant file
     - Tab to the "edit file" button to open the editor for the file.
+    - If it's your first time doing this, GitHub will ask you to fork this repository.
+    Click "Fork this repository".
     - English example: <https://github.com/nvaccess/nvda/edit/beta/source/locale/en/symbols.dic>
     - Format (replace `{lang}` and `{fileName}`): `https://github.com/nvaccess/nvda/edit/beta/source/locale/{lang}/{fileName}`
     - Refer to [background](#background) for more information on the format of the files


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
None

### Summary of the issue:

- [Translators on the mailing list were confused about the need to create a fork when translating files on GitHub](https://groups.io/g/nvda-translations/topic/can_t_edit_the_bulgarian/113891310).
- NV Access wishes to avoid feature requests being closed prematurely, before a feature gets a chance to be considered or discussed

### Description of user facing changes:

- Clarified the need to fork the repository to translate files
- Clarified the request to not close feature requests
