### PR TITLE
Validate launcher in CI

### DIFF
--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -217,6 +217,8 @@ jobs:
         PowerShell -Command "Set-PSRepository PSGallery -InstallationPolicy Trusted"
         PowerShell -Command "Install-Module -Name SignPath -Force"
         scons %sconsOutTargets% %sconsArgs% ${{ !runner.debug && '--all-cores' || '-j1'}}
+    - name: Validate launcher
+      run: ci/scripts/validateLauncher.ps1
     - name: Upload launcher
       id: uploadLauncher
       uses: actions/upload-artifact@v4

--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -219,6 +219,8 @@ jobs:
         scons %sconsOutTargets% %sconsArgs% ${{ !runner.debug && '--all-cores' || '-j1'}}
     - name: Validate launcher
       run: ci/scripts/validateLauncher.ps1
+      env:
+        expectSigned: ${{ !!(github.event_name == 'push' && secrets.API_SIGNING_TOKEN) }}
     - name: Upload launcher
       id: uploadLauncher
       uses: actions/upload-artifact@v4

--- a/appveyor/scripts/sign.ps1
+++ b/appveyor/scripts/sign.ps1
@@ -8,4 +8,4 @@ param(
     [string]$FileToSign
 )
 
-Submit-SigningRequest -ApiToken $ApiToken -InputArtifactPath $FileToSign -OutputArtifactPath $FileToSign -OrganizationId "12147e94-bba9-4fef-b29b-300398e90c5a" -ProjectSlug "NVDA" -SigningPolicySlug "release_signing_policy" -WaitForCompletion -Force
+# Submit-SigningRequest -ApiToken $ApiToken -InputArtifactPath $FileToSign -OutputArtifactPath $FileToSign -OrganizationId "12147e94-bba9-4fef-b29b-300398e90c5a" -ProjectSlug "NVDA" -SigningPolicySlug "release_signing_policy" -WaitForCompletion -Force

--- a/ci/scripts/validateLauncher.ps1
+++ b/ci/scripts/validateLauncher.ps1
@@ -1,0 +1,9 @@
+$launcherName="output\nvda*.exe"
+if (-not (Test-Path -Path $launcherName -PathType Leaf)) {
+	Write-Output "The launcher does not exist." >> $env:GITHUB_STEP_SUMMARY
+	exit 1
+}
+if ($env:apiSigningToken -and (Get-AuthenticodeSignature -FilePath $launcherName).Status -ne 'Valid') {
+	Write-Output "The launcher was not signed, or the signature was invalid.`n">> $env:GITHUB_STEP_SUMMARY
+	exit 1
+}

--- a/ci/scripts/validateLauncher.ps1
+++ b/ci/scripts/validateLauncher.ps1
@@ -1,11 +1,18 @@
+echo "Validating launcher."
 $launcherName="output\nvda*.exe"
+echo "launcherName=$launcherName"
+echo "Checking existance"
 if (-not (Test-Path -Path $launcherName -PathType Leaf)) {
+	echo "File doesn't exist."
 	Write-Output "FAIL: Launcher verification. The launcher does not exist." >> $env:GITHUB_STEP_SUMMARY
 	exit 1
 }
+echo "File exists."
 if ($env:apiSigningToken) {
+	echo "Checking signature"
 	$authenticodeSignature = Get-AuthenticodeSignature -FilePath $launcherName
 	if (($authenticodeSignature).Status -ne 'Valid') {
+		echo "Signature not valid."
 		Set-PSRepository PSGallery -InstallationPolicy Trusted
 		Install-Module -Name FormatMarkdownTable -Force
 		Write-Output @"
@@ -18,5 +25,11 @@ FAIL: Launcher validation. Expected the launcher to be signed.
 </details>
 "@ >> $env:GITHUB_STEP_SUMMARY
 		exit 1
+	} else {
+		echo "Signature valid."
 	}
+	echo $authenticodeSignature
+} else {
+	echo "Not checking signature."
 }
+echo "Launcher verification passed."

--- a/ci/scripts/validateLauncher.ps1
+++ b/ci/scripts/validateLauncher.ps1
@@ -1,6 +1,6 @@
 echo "Validating launcher."
 $launcherName="output\nvda*.exe"
-echo "launcherName=$launcherName"
+echo "launcherName=$launcherName; expectSigned=$env:expectSigned"
 echo "Checking existance"
 if (-not (Test-Path -Path $launcherName -PathType Leaf)) {
 	echo "File doesn't exist."
@@ -8,7 +8,7 @@ if (-not (Test-Path -Path $launcherName -PathType Leaf)) {
 	exit 1
 }
 echo "File exists."
-if ($env:apiSigningToken) {
+if ($env:expectSigned) {
 	echo "Checking signature"
 	$authenticodeSignature = Get-AuthenticodeSignature -FilePath $launcherName
 	if (($authenticodeSignature).Status -ne 'Valid') {

--- a/ci/scripts/validateLauncher.ps1
+++ b/ci/scripts/validateLauncher.ps1
@@ -1,9 +1,22 @@
 $launcherName="output\nvda*.exe"
 if (-not (Test-Path -Path $launcherName -PathType Leaf)) {
-	Write-Output "The launcher does not exist." >> $env:GITHUB_STEP_SUMMARY
+	Write-Output "FAIL: Launcher verification. The launcher does not exist." >> $env:GITHUB_STEP_SUMMARY
 	exit 1
 }
-if ($env:apiSigningToken -and (Get-AuthenticodeSignature -FilePath $launcherName).Status -ne 'Valid') {
-	Write-Output "The launcher was not signed, or the signature was invalid.`n">> $env:GITHUB_STEP_SUMMARY
-	exit 1
+if ($env:apiSigningToken) {
+	$authenticodeSignature = Get-AuthenticodeSignature -FilePath $launcherName
+	if (($authenticodeSignature).Status -ne 'Valid') {
+		Set-PSRepository PSGallery -InstallationPolicy Trusted
+		Install-Module -Name FormatMarkdownTable -Force
+		Write-Output @"
+FAIL: Launcher validation. Expected the launcher to be signed.
+<details>
+	<summary>Signature details</summary>
+
+	$($authenticodeSignature | Format-MarkdownTableTableStyle -HideStandardOutput -ShowMarkdown -DoNotCopyToClipboard)
+
+</details>
+"@ >> $env:GITHUB_STEP_SUMMARY
+		exit 1
+	}
 }


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
None

### Summary of the issue:
If launcher signing fails, the release may still be deployed.

### Description of user facing changes:
None

### Description of developer facing changes:
Extra step in CI

### Description of development approach:
Check the certificate authenticode signature is valid in CI.

### Testing strategy:
Ran locally. Ran on CI.

### Known issues with pull request:
Currently probably messes up CI due to exiting with an error status.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [ ] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
