### PR TITLE
Fix deprecation warning for bdDetect.DeviceType

### DIFF
--- a/source/brailleDisplayDrivers/nlseReaderZoomax.py
+++ b/source/brailleDisplayDrivers/nlseReaderZoomax.py
@@ -92,7 +92,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 	@classmethod
 	def registerAutomaticDetection(cls, driverRegistrar: bdDetect.DriverRegistrar):
 		driverRegistrar.addUsbDevices(
-			bdDetect.DeviceType.SERIAL,
+			bdDetect.ProtocolType.SERIAL,
 			{
 				"VID_1A86&PID_7523",  # CH340 USB to serial chip
 			},


### PR DESCRIPTION
`bdDetect.DeviceType` is deprecated, we should use `bdDetect.ProtocolType` instead.
Fixup of #18332 