### PR TITLE
Only automatically assign milestone on merge of PRs

### DIFF
--- a/.github/workflows/assign-milestone-on-close.yml
+++ b/.github/workflows/assign-milestone-on-close.yml
@@ -4,13 +4,10 @@ env:
   MILESTONE_ID: ${{ vars.MILESTONE_ID }}
 
 on:
-  issues:
-    types: [closed]
   pull_request_target:
     types: [closed]
 
 permissions:
-  issues: write
   pull-requests: write
 
 jobs:
@@ -23,21 +20,20 @@ jobs:
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            const issueOrPr = context.payload.issue || context.payload.pull_request;
-            if (!issueOrPr.milestone) {
+            const pr = context.payload.pull_request;
+            if (!pr.milestone) {
               core.setOutput('milestoneNotSet', 'true');
             } else {
               core.setOutput('milestoneNotSet', 'false');
             }
 
-      - name: Check completed or merged
+      - name: Check merged
         id: check-done
         uses: actions/github-script@v7
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            if ((context.payload.issue && context.payload.issue.state_reason === "completed")
-                || (context.payload.pull_request && context.payload.pull_request.merged === true)) {
+            if (context.payload.pull_request.merged === true) {
               core.setOutput('isDone', 'true');
             } else {
               core.setOutput('isDone', 'false');
@@ -49,10 +45,10 @@ jobs:
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            const issueOrPrNumber = (context.payload.issue || context.payload.pull_request).number;
+            const prNumber = context.payload.pull_request.number;
             const repository = context.repo;
             await github.rest.issues.update({
               ...repository,
-              issue_number: issueOrPrNumber,
+              issue_number: prNumber,
               milestone: process.env.MILESTONE_ID
             });


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
NV Access has a workflow set up to automatically apply a milestone to closed issues and merged pull requests. While this script only applies a milestone to issues closed as completed, many issues get closed as completed even when not planned or duplicates. This results in unnecessary work for staff.

### Description of user facing changes:
None

### Description of developer facing changes:
Only merged PRs are automatically given a milestone.

This matches our approach of applying milestones manually to issues planned for inclusion in particular releases.

### Description of development approach:
Updated `.github/workflows/apply-milestone-on-close.yml` to remove the code for applying milestones to issues.

### Testing strategy:

### Known issues with pull request:
It would be nice if we recorded the alpha, beta, and stable/rc milestones, and applied the correct milestone based on the branch into which the PR was merged.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
