### PR TITLE
Update mailing list links

### DIFF
--- a/projectDocs/community/readme.md
+++ b/projectDocs/community/readme.md
@@ -39,7 +39,7 @@ This website is considered legacy software, using the NVDA Add-on Store instead 
 
 #### NVDA Community
 
-* [NVDA Users Mailing List](https://nvda.groups.io/g/nvda)
+* [NVDA Users Mailing List](https://groups.google.com/a/nvaccess.org/g/nvda-users)
 * [NVDA Developers Mailing List](https://groups.io/g/nvda-devel)
 * [NVDA Translators list](https://groups.io/g/nvda-translations)
 * [NVDA Add-ons Mailing List](https://groups.io/g/nvda-addons)

--- a/projectDocs/issues/githubIssueTemplateExplanationAndExamples.md
+++ b/projectDocs/issues/githubIssueTemplateExplanationAndExamples.md
@@ -12,14 +12,14 @@ Your issue will likely be closed if a template has not been followed.
 
 We currently have the following templates:
 
-- For [feature requests](#feature-request-template)
-- For [bug reports](#bug-report-template)
-- For [special case issues](#special-case-issue-template) that cannot easily be categorised as either a bug report or a feature request
-- For security vulnerabilities (please note that these are reported differently, for more information see https://github.com/nvaccess/nvda/blob/master/security.md)
-- For developer facing changes:
-  - This template is intended for developers to document improvements or maintenance to NVDA's code base that do not have user facing changes.
-  - This may include API changes, technical debt removal, refactoring and maintenance tasks.
-  - Note there is no further guide for this - it is expected that developers can use the template appropriately.
+* For [feature requests](#feature-request-template)
+* For [bug reports](#bug-report-template)
+* For [special case issues](#special-case-issue-template) that cannot easily be categorised as either a bug report or a feature request
+* For security vulnerabilities (please note that these are reported differently, for more information see https://github.com/nvaccess/nvda/blob/master/security.md)
+* For developer facing changes:
+  * This template is intended for developers to document improvements or maintenance to NVDA's code base that do not have user facing changes.
+  * This may include API changes, technical debt removal, refactoring and maintenance tasks.
+  * Note there is no further guide for this - it is expected that developers can use the template appropriately.
 
 ## General information
 The following information applies to all issues and pull requests.
@@ -48,12 +48,9 @@ developers of NVDA are blind and will greatly appreciate this image being descri
 Most tools allow you to copy text out of them.
 
 ### Tips
-* Consider swapping to the preview tab in order to read through your issue at any stage to confirm
-  the issue reads as expected.
-* If you have trouble following this template, or with the initial investigation that is required,
-  please politely ask for assistance from the fantastic community of people on the
-  [NVDA users mailing list](https://github.com/nvaccess/nvda/wiki/Connect#international-users-mailing-list-english)
 
+* Consider swapping to the preview tab in order to read through your issue at any stage to confirm the issue reads as expected.
+* If you have trouble following this template, or with the initial investigation that is required, please politely ask for assistance from the fantastic community of people on the [NVDA users mailing list](https://groups.google.com/a/nvaccess.org/g/nvda-users)
 
 ## Feature Request template
 
@@ -221,10 +218,12 @@ Include specific details to help us understand the context.
 Explain why this issue cannot be addressed using the standard bug report or feature request templates.
 
 ### Have you asked for advice on how to report this issue via a community discussion? If so, please link to the discussion
+
 Mention if you have sought advice or shared this issue in community discussions before creating this issue ticket.
 Include links to discussion threads if applicable, for example:
-- https://github.com/nvaccess/nvda/discussions
-- https://nvda.groups.io/g/nvda
+
+* <https://github.com/nvaccess/nvda/discussions>
+* <https://groups.google.com/a/nvaccess.org/g/nvda-users>
 
 ### Steps to reproduce or illustrate the issue (if applicable)
 If possible, provide steps to demonstrate or reproduce the issue.

--- a/projectDocs/testing/readme.md
+++ b/projectDocs/testing/readme.md
@@ -16,6 +16,6 @@
 
 ### Community communication channels
 
-* [NVDA Users Mailing List](https://nvda.groups.io/g/nvda)
+* [NVDA Users Mailing List](https://groups.google.com/a/nvaccess.org/g/nvda-users)
 * [NVDA Developers Mailing List](https://groups.io/g/nvda-devel)
 * [Other sources including groups and profiles on social media channels, language-specific websites and mailing lists etc.](https://github.com/nvaccess/nvda/wiki/Connect)

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -371,7 +371,7 @@ To learn more about and configure this behaviour, refer to ["Update Notification
 ### Community {#Community}
 
 NVDA has a vibrant user community.
-NV Access, makers of NVDA, are active on [Twitter](https://twitter.com/nvaccess) and [Facebook](https://www.facebook.com/NVAccess).
+NV Access, makers of NVDA, are active on [Mastodon](https://fosstodon.org/@NVAccess), [Twitter/X](https://x.com/nvaccess) and [Facebook](https://www.facebook.com/NVAccess).
 NV Access also have a regular [In-Process blog](https://www.nvaccess.org/category/in-process/).
 There is a main [NV Access owned email list](https://groups.google.com/a/nvaccess.org/g/nvda-users) and a page full of [other community groups](https://github.com/nvaccess/nvda/wiki/Connect).
 

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -371,9 +371,9 @@ To learn more about and configure this behaviour, refer to ["Update Notification
 ### Community {#Community}
 
 NVDA has a vibrant user community.
-There is a main [English language email list](https://nvda.groups.io/g/nvda) and a page full of [local language groups](https://github.com/nvaccess/nvda/wiki/Connect).
 NV Access, makers of NVDA, are active on [Twitter](https://twitter.com/nvaccess) and [Facebook](https://www.facebook.com/NVAccess).
 NV Access also have a regular [In-Process blog](https://www.nvaccess.org/category/in-process/).
+There is a main [NV Access owned email list](https://groups.google.com/a/nvaccess.org/g/nvda-users) and a page full of [other community groups](https://github.com/nvaccess/nvda/wiki/Connect).
 
 There is also an [NVDA Certified Expert](https://certification.nvaccess.org/) program.
 This is an online exam you can complete to demonstrate your skills in NVDA.


### PR DESCRIPTION
NV Access has started an [official user group](https://groups.google.com/a/nvaccess.org/g/nvda-users) which follows the NVDA Code of Conduct.

As such, references to the group in documentation needs to be added