### PR TITLE
More conservatively add EditableText support to UIA objects

### DIFF
--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -1740,7 +1740,14 @@ class UIA(Window):
 	_cache_TextInfo = False
 
 	def _get_TextInfo(self):
-		if self.UIATextPattern:
+		if self.UIATextPattern and (
+			(
+				self.role
+				in (controlTypes.Role.EDITABLETEXT, controlTypes.Role.TERMINAL, controlTypes.Role.DOCUMENT)
+			)
+			or controlTypes.State.EDITABLE in self.states
+			or self.UIATextPattern.SupportedTextSelection != UIAHandler.UIA.SupportedTextSelection_None
+		):
 			return self._TextInfo
 		textInfo = super(UIA, self).TextInfo
 		if (

--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -1438,8 +1438,11 @@ class UIA(Window):
 
 			sysListView32.findExtraOverlayClasses(self, clsList)
 
-		# Add editableText support if UIA supports a text pattern
-		if self.TextInfo == UIATextInfo:
+		# Add editableText support if UIA supports a text pattern and the control either has navigable text or supports selection.
+		if self.TextInfo == UIATextInfo and (
+			self._hasNavigableText
+			or self.UIATextPattern.SupportedTextSelection != UIAHandler.UIA.SupportedTextSelection_None
+		):
 			if self.UIAFrameworkId == "XAML":
 				# This UIA element is being exposed by the XAML framework.
 				clsList.append(XamlEditableText)
@@ -1740,14 +1743,7 @@ class UIA(Window):
 	_cache_TextInfo = False
 
 	def _get_TextInfo(self):
-		if self.UIATextPattern and (
-			(
-				self.role
-				in (controlTypes.Role.EDITABLETEXT, controlTypes.Role.TERMINAL, controlTypes.Role.DOCUMENT)
-			)
-			or controlTypes.State.EDITABLE in self.states
-			or self.UIATextPattern.SupportedTextSelection != UIAHandler.UIA.SupportedTextSelection_None
-		):
+		if self.UIATextPattern:
 			return self._TextInfo
 		textInfo = super(UIA, self).TextInfo
 		if (


### PR DESCRIPTION
### Link to issue number:
Fixes #18399 
Fixup regression caused by #18271

### Summary of the issue:
Since #18271, object navigation might cause errors with braille in XAML static text controls.

### Description of user facing changes:
No errors, working braille.

### Description of developer facing changes:
N/a

### Description of development approach:
Be more conservative in applying an EditableText overlay class to UIA objects. Before this change, objects only needed to have UIATextInfo, implicitly meaning that it ought to have a text pattern. With this, we only add EditableText if either:
a. The object has navigable text; or
b. The objects text pattern reports that selection is supported.

### Testing strategy:
Tested str from #18399 

### Known issues with pull request:
I can't think of any reason why this is too conservative. May be in severely broken TextPattern implementations that don't implement `SupportedTextSelection`. I only just discovered this property.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
