### PR TITLE
Fix for issue #18406 - NLS eReader Zoomax driver does not work with all units

### DIFF
--- a/source/brailleDisplayDrivers/nlseReaderZoomax.py
+++ b/source/brailleDisplayDrivers/nlseReaderZoomax.py
@@ -23,12 +23,15 @@ COMMUNICATION_ESCAPE_BYTE = b"\x1b"
 So each command starts with the escape character.
 When part of the command payload, the escape character is duplicated. """
 
+PROTOCOL_NVDA = b"\x03"
+"""There is a command, 0x15, for setting a device protocol type, the parameter value 0x03 is specifying that the screen reader is NVDA."""
 
 class DeviceCommand(bytes, Enum):
 	DISPLAY_DATA = b"\x01"
 	REQUEST_INFO = b"\x02"
 	REQUEST_VERSION = b"\x05"
 	REPEAT_ALL = b"\x08"
+	PROTOCOL_TYPE = b"\x15"
 	ROUTING_KEYS = b"\x22"
 	DISPLAY_KEYS = b"\x24"
 	BRAILLE_KEYS = b"\x33"
@@ -116,6 +119,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 				log.debugWarning("Port not yet available.", exc_info=True)
 				continue
 
+			self._sendRequest(DeviceCommand.PROTOCOL_TYPE.value, PROTOCOL_NVDA)
 			self._sendRequest(DeviceCommand.REPEAT_ALL.value)
 
 			for i in range(CONNECT_RETRIES):

--- a/source/brailleDisplayDrivers/nlseReaderZoomax.py
+++ b/source/brailleDisplayDrivers/nlseReaderZoomax.py
@@ -26,6 +26,7 @@ When part of the command payload, the escape character is duplicated. """
 PROTOCOL_NVDA = b"\x03"
 """There is a command, 0x15, for setting a device protocol type, the parameter value 0x03 is specifying that the screen reader is NVDA."""
 
+
 class DeviceCommand(bytes, Enum):
 	DISPLAY_DATA = b"\x01"
 	REQUEST_INFO = b"\x02"

--- a/source/brailleDisplayDrivers/nlseReaderZoomax.py
+++ b/source/brailleDisplayDrivers/nlseReaderZoomax.py
@@ -29,7 +29,6 @@ class DeviceCommand(bytes, Enum):
 	REQUEST_INFO = b"\x02"
 	REQUEST_VERSION = b"\x05"
 	REPEAT_ALL = b"\x08"
-	PROTOCOL_ONOFF = b"\x15"
 	ROUTING_KEYS = b"\x22"
 	DISPLAY_KEYS = b"\x24"
 	BRAILLE_KEYS = b"\x33"
@@ -117,8 +116,6 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 				log.debugWarning("Port not yet available.", exc_info=True)
 				continue
 
-			self._sendRequest(DeviceCommand.PROTOCOL_ONOFF.value, False)
-			self._sendRequest(DeviceCommand.PROTOCOL_ONOFF.value, True)
 			self._sendRequest(DeviceCommand.REPEAT_ALL.value)
 
 			for i in range(CONNECT_RETRIES):
@@ -148,7 +145,6 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 	def terminate(self):
 		try:
 			super().terminate()
-			self._sendRequest(DeviceCommand.PROTOCOL_ONOFF, False)
 		except EnvironmentError:
 			pass
 		finally:

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -13,7 +13,7 @@
 ### Bug Fixes
 
 * Fixed support for paragraph mouse text unit in Java applications. (#18231, @hwf1324)
-
+* Fixed NLS eReader Zoomax driver does not work with all units (#18406, @florin-trutiu)
 ### Changes for Developers
 
 Please refer to [the developer guide](https://download.nvaccess.org/documentation/developerGuide.html#API) for information on NVDA's API deprecation and removal process.


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
<!-- Use Closes/Fixes/Resolves #xxx to link this PR to the issue it is responding to. -->
Resolves #18406
### Summary of the issue:
NLS eReader Zoomax driver does not work with all units.
The issue was detected only in the 2025.2beta1, as the NLS eReader Zoomax driver has now support for autodetection. Previously, the versions of the NLS eReader Zoomax driver were provided as an add-on file, and the autodetection feature was not implemented in that versions.
### Description of user facing changes:

### Description of developer facing changes:

### Description of development approach:
Because the issue appears on units that run different firmware versions and we cannot enforce changes to those units, we found the optimal solution.
We removed from the driver the sending of the PROTOCOL_ONOFF command as it was the one causing the issues and it anyway was redundant.
Sending the REPEAT_ALL command to the device is enough for triggering a device response that is used for autodetection. 

### Testing strategy:

### Known issues with pull request:

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
