### PR TITLE
Fix for issue #18406 - NLS eReader Zoomax driver does not work with all units

### DIFF
--- a/source/brailleDisplayDrivers/nlseReaderZoomax.py
+++ b/source/brailleDisplayDrivers/nlseReaderZoomax.py
@@ -23,13 +23,15 @@ COMMUNICATION_ESCAPE_BYTE = b"\x1b"
 So each command starts with the escape character.
 When part of the command payload, the escape character is duplicated. """
 
+PROTOCOL_NVDA = b"\x03"
+"""The device has a command 0x15 for setting protocol type, the parameter value 0x03 is specifying that the screen reader is NVDA."""
 
 class DeviceCommand(bytes, Enum):
 	DISPLAY_DATA = b"\x01"
 	REQUEST_INFO = b"\x02"
 	REQUEST_VERSION = b"\x05"
 	REPEAT_ALL = b"\x08"
-	PROTOCOL_ONOFF = b"\x15"
+	PROTOCOL_TYPE = b"\x15"
 	ROUTING_KEYS = b"\x22"
 	DISPLAY_KEYS = b"\x24"
 	BRAILLE_KEYS = b"\x33"
@@ -117,8 +119,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 				log.debugWarning("Port not yet available.", exc_info=True)
 				continue
 
-			self._sendRequest(DeviceCommand.PROTOCOL_ONOFF.value, False)
-			self._sendRequest(DeviceCommand.PROTOCOL_ONOFF.value, True)
+			self._sendRequest(DeviceCommand.PROTOCOL_TYPE.value, PROTOCOL_NVDA)
 			self._sendRequest(DeviceCommand.REPEAT_ALL.value)
 
 			for i in range(CONNECT_RETRIES):
@@ -148,7 +149,6 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 	def terminate(self):
 		try:
 			super().terminate()
-			self._sendRequest(DeviceCommand.PROTOCOL_ONOFF, False)
 		except EnvironmentError:
 			pass
 		finally:

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -70,6 +70,7 @@ There have also been a number of other fixes and improvements, including to mous
 * In focus mode in web browsers, it is now possible to review and spell the labels of controls when those labels are specifically provided for accessibility; e.g. via `aria-label` or `aria-labelledby`. (#15159, @jcsteh)
 * It is now possible to review and spell the labels of controls in Google Chrome menus and dialogs. (#11285, @jcsteh)
 * When typing into a cell in Microsoft Excel, the braille display is now correctly updated to show the new content. (#18391)
+* Fixed NLS eReader Zoomax driver does not work with all units (#18406, @florin-trutiu)
 
 ### Changes for Developers
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
<!-- Use Closes/Fixes/Resolves #xxx to link this PR to the issue it is responding to. -->
Resolves #18406
### Summary of the issue:
NLS eReader Zoomax driver does not work with all units.
The issue was detected only in the 2025.2beta1, as the NLS eReader Zoomax driver has now support for autodetection. Previously, the versions of the NLS eReader Zoomax driver were provided as an add-on file, and the autodetection feature was not implemented in that versions.
### Description of user facing changes:

### Description of developer facing changes:

### Description of development approach:

### Testing strategy:

### Known issues with pull request:

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
