### PR TITLE
Only call `_getIA2RelationFirstTarget` for IA2 objects

### DIFF
--- a/source/NVDAObjects/IAccessible/__init__.py
+++ b/source/NVDAObjects/IAccessible/__init__.py
@@ -1989,17 +1989,17 @@ class IAccessible(Window):
 		return super().controllerFor
 
 	#: Type definition for auto prop '_get_flowsTo'
-	flowsTo: typing.Optional["IAccessible"]
+	flowsTo: "IAccessible | None"
 
-	def _get_flowsTo(self) -> typing.Optional["IAccessible"]:
+	def _get_flowsTo(self) -> "IAccessible | None":
 		if isinstance(self.IAccessibleObject, IA2.IAccessible2):
 			return self._getIA2RelationFirstTarget(IAccessibleHandler.RelationType.FLOWS_TO)
 		return super().flowsTo
 
 	#: Type definition for auto prop '_get_flowsFrom'
-	flowsFrom: typing.Optional["IAccessible"]
+	flowsFrom: "IAccessible | None"
 
-	def _get_flowsFrom(self) -> typing.Optional["IAccessible"]:
+	def _get_flowsFrom(self) -> "IAccessible | None":
 		if isinstance(self.IAccessibleObject, IA2.IAccessible2):
 			return self._getIA2RelationFirstTarget(IAccessibleHandler.RelationType.FLOWS_FROM)
 		return super().flowsFrom

--- a/source/NVDAObjects/IAccessible/__init__.py
+++ b/source/NVDAObjects/IAccessible/__init__.py
@@ -1200,9 +1200,10 @@ class IAccessible(Window):
 		return True
 
 	def _get_labeledBy(self) -> "IAccessible | None":
-		label = self._getIA2RelationFirstTarget(IAccessibleHandler.RelationType.LABELLED_BY)
-		if label:
-			return label
+		if isinstance(self.IAccessibleObject, IA2.IAccessible2):
+			label = self._getIA2RelationFirstTarget(IAccessibleHandler.RelationType.LABELLED_BY)
+			if label:
+				return label
 
 		try:
 			ret = IAccessibleHandler.accNavigate(
@@ -1981,27 +1982,34 @@ class IAccessible(Window):
 		return tuple(detailsRelsGen)
 
 	def _get_controllerFor(self) -> list[NVDAObject]:
-		control = self._getIA2RelationFirstTarget(IAccessibleHandler.RelationType.CONTROLLER_FOR)
-		if control:
-			return [control]
-		return []
+		if isinstance(self.IAccessibleObject, IA2.IAccessible2):
+			control = self._getIA2RelationFirstTarget(IAccessibleHandler.RelationType.CONTROLLER_FOR)
+			if control:
+				return [control]
+		return super().controllerFor
 
 	#: Type definition for auto prop '_get_flowsTo'
 	flowsTo: typing.Optional["IAccessible"]
 
 	def _get_flowsTo(self) -> typing.Optional["IAccessible"]:
-		return self._getIA2RelationFirstTarget(IAccessibleHandler.RelationType.FLOWS_TO)
+		if isinstance(self.IAccessibleObject, IA2.IAccessible2):
+			return self._getIA2RelationFirstTarget(IAccessibleHandler.RelationType.FLOWS_TO)
+		return super().flowsTo
 
 	#: Type definition for auto prop '_get_flowsFrom'
 	flowsFrom: typing.Optional["IAccessible"]
 
 	def _get_flowsFrom(self) -> typing.Optional["IAccessible"]:
-		return self._getIA2RelationFirstTarget(IAccessibleHandler.RelationType.FLOWS_FROM)
+		if isinstance(self.IAccessibleObject, IA2.IAccessible2):
+			return self._getIA2RelationFirstTarget(IAccessibleHandler.RelationType.FLOWS_FROM)
+		return super().flowsFrom
 
 	def _get_errorMessage(self) -> str | None:
-		errorNode = self._getIA2RelationFirstTarget(IAccessibleHandler.RelationType.ERROR)
-		if errorNode is not None:
-			return errorNode.summarizeInProcess()
+		if isinstance(self.IAccessibleObject, IA2.IAccessible2):
+			errorNode = self._getIA2RelationFirstTarget(IAccessibleHandler.RelationType.ERROR)
+			if errorNode is not None:
+				return errorNode.summarizeInProcess()
+		return super().errorMessage
 
 	def event_valueChange(self):
 		if isinstance(self, EditableTextWithAutoSelectDetection):

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -18,6 +18,8 @@
 
 Please refer to [the developer guide](https://download.nvaccess.org/documentation/developerGuide.html#API) for information on NVDA's API deprecation and removal process.
 
+* For `IAccessible` objects, the `flowsFrom` and `flowsTo` properties will now raise a `NotImplementedError` for MSAA (non-IA2) objects. (#18416, @LeonarddeR)
+
 #### Deprecations
 
 ## 2025.2


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
Several properties on IAccessible objects call the `_getIA2RelationFirstTarget` method without checking whether we're really dealing with an IA2 object. This results in unnecessary and verbose debug warnings:
```log
DEBUGWARNING - NVDAObjects.IAccessible.IAccessible._getIA2RelationFirstTarget (14:36:37.817) - MainThread (14260):
Unable to use _getIA2TargetsForRelationsOfType, fallback to _IA2Relations.
```

### Description of user facing changes:
Less debug warnings.

### Description of developer facing changes:
None

### Description of development approach:
1. For every property that calls `_getIA2RelationFirstTarget`, check whether the object is IA2
2. Call `super` when not IA2. This changes behavior for the `flowsFrom` and `flowsTo` properties on MSAA objects. These will now raise a `NotImplementedError`, which is in line with what `NVDAObject` does by default. Therefore I don't think this can be considered API breaking, rather the behavior of the `IAccessible` implementation was inconsistent and misleading. Note that `flowsFrom` and `flowsTo` raise `NotImplementedError` for UIA objects, too.

### Testing strategy:
Ran from source, called the several properties. Ensured no obnoxious debug warnings were logged.

### Known issues with pull request:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
