### PR TITLE
Make the report language command consistent across settings

### DIFF
--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -4942,6 +4942,9 @@ class GlobalCommands(ScriptableObject):
 	)
 	def script_reportCaretLanguage(self, gesture: "inputCore.InputGesture"):
 		info = self._getTIAtCaret()
+		if info is None:
+			log.debugWarning("No caret")
+			return
 		info.expand(textInfos.UNIT_CHARACTER)
 		curLanguage = self._getCurrentLanguageForTextInfo(info)
 		languageDescription = languageHandler.getLanguageDescription(curLanguage)

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -2335,7 +2335,8 @@ class GlobalCommands(ScriptableObject):
 			if isinstance(field, textInfos.FieldCommand) and field.command == "formatChange":
 				curLanguage = field.field.get("language")
 		if curLanguage is None:
-			curLanguage = speech.getCurrentLanguage()
+			# Translators: Reported when the language of the text at caret is not defined.
+			_("Not defined")
 		return curLanguage
 
 	@script(

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -2329,7 +2329,7 @@ class GlobalCommands(ScriptableObject):
 		else:
 			ui.reviewMessage(gui.blockAction.Context.WINDOWS_LOCKED.translatedMessage)
 
-	def _getCurrentLanguageForTextInfo(self, info):
+	def _getCurrentLanguageForTextInfo(self, info: textInfos.TextInfo):
 		curLanguage = None
 		for field in info.getTextWithFields({}):
 			if isinstance(field, textInfos.FieldCommand) and field.command == "formatChange":

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -2349,6 +2349,8 @@ class GlobalCommands(ScriptableObject):
 		info = api.getReviewPosition().copy()
 		info.expand(textInfos.UNIT_CHARACTER)
 		curLanguage = self._getCurrentLanguageForTextInfo(info)
+		if curLanguage is None:
+			curLanguage = speech.getCurrentLanguage()
 		text = info.text
 		expandedSymbol = characterProcessing.processSpeechSymbol(curLanguage, text)
 		if expandedSymbol == text:

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -2334,9 +2334,6 @@ class GlobalCommands(ScriptableObject):
 		for field in info.getTextWithFields({}):
 			if isinstance(field, textInfos.FieldCommand) and field.command == "formatChange":
 				curLanguage = field.field.get("language")
-		if curLanguage is None:
-			# Translators: Reported when the language of the text at caret is not defined.
-			_("Not defined")
 		return curLanguage
 
 	@script(
@@ -4948,7 +4945,11 @@ class GlobalCommands(ScriptableObject):
 			return
 		info.expand(textInfos.UNIT_CHARACTER)
 		curLanguage = self._getCurrentLanguageForTextInfo(info)
-		languageDescription = languageHandler.getLanguageDescription(curLanguage)
+		if curLanguage is None:
+			# Translators: Reported when the language of the text at caret is not defined.
+			languageDescription = _("Not defined")
+		else:
+			languageDescription = languageHandler.getLanguageDescription(curLanguage)
 		if languageDescription is None:
 			languageDescription = curLanguage
 		message = languageDescription

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -2332,10 +2332,9 @@ class GlobalCommands(ScriptableObject):
 
 	def _getCurrentLanguageForTextInfo(self, info):
 		curLanguage = None
-		if languageHandling.shouldMakeLangChangeCommand():
-			for field in info.getTextWithFields({}):
-				if isinstance(field, textInfos.FieldCommand) and field.command == "formatChange":
-					curLanguage = field.field.get("language")
+		for field in info.getTextWithFields({}):
+			if isinstance(field, textInfos.FieldCommand) and field.command == "formatChange":
+				curLanguage = field.field.get("language")
 		if curLanguage is None:
 			curLanguage = speech.getCurrentLanguage()
 		return curLanguage
@@ -4946,21 +4945,19 @@ class GlobalCommands(ScriptableObject):
 		info = self._getTIAtCaret()
 		info.expand(textInfos.UNIT_CHARACTER)
 		curLanguage = self._getCurrentLanguageForTextInfo(info)
-		langToReport = languageHandling.getLangToReport(curLanguage)
-		languageDescription = languageHandler.getLanguageDescription(langToReport)
+		languageDescription = languageHandler.getLanguageDescription(curLanguage)
 		if languageDescription is None:
-			languageDescription = langToReport
+			languageDescription = curLanguage
 		message = languageDescription
-		if languageHandling.shouldReportNotSupported():
-			curSynth = synthDriverHandler.getSynth()
-			if not curSynth.languageIsSupported(langToReport):
-				message = pgettext(
-					"reportLanguage",
-					# Translators: Language of the character at caret position when it's not supported by the current synthesizer.
-					"{languageDescription} (not supported)",
-				).format(
-					languageDescription=languageDescription,
-				)
+		curSynth = synthDriverHandler.getSynth()
+		if not curSynth.languageIsSupported(curLanguage):
+			message = pgettext(
+				"reportLanguage",
+				# Translators: Language of the character at caret position when it's not supported by the current synthesizer.
+				"{languageDescription} (not supported)",
+			).format(
+				languageDescription=languageDescription,
+			)
 		repeats = scriptHandler.getLastScriptRepeatCount()
 		if repeats == 0:
 			ui.message(message)

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -4949,7 +4949,7 @@ class GlobalCommands(ScriptableObject):
 		curLanguage = self._getCurrentLanguageForTextInfo(info)
 		if curLanguage is None:
 			# Translators: Reported when the language of the text at caret is not defined.
-			languageDescription = _("Not defined")
+			languageDescription = pgettext("reportLanguage", "Unknown language")
 		else:
 			languageDescription = languageHandler.getLanguageDescription(curLanguage)
 		if languageDescription is None:

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -31,7 +31,6 @@ import speech
 from speech import (
 	sayAll,
 	shortcutKeys,
-	languageHandling,
 )
 from NVDAObjects import NVDAObject, NVDAObjectTextInfo
 import globalVars

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -1709,7 +1709,7 @@ class VoiceSettingsPanel(AutoSettingsMixin, SettingsPanel):
 			config.conf["speech"]["autoDialectSwitching"],
 		)
 		# Translators: This is the label for a checkbox in the voice settings panel. If checked, the language of the text been read will be reported.
-		reportLanguageText = pgettext("reportLanguage", "Report lan&guage changes")
+		reportLanguageText = pgettext("reportLanguage", "Report lan&guage changes while reading")
 		self.reportLanguageCheckbox = settingsSizerHelper.addItem(
 			wx.CheckBox(
 				self,

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -1932,7 +1932,7 @@ This checkbox allows you to toggle whether or not dialect changes should be made
 For example, if reading in an English U.S. voice but a document specifies that some text is in English U.K., then the synthesizer will switch accents if this option is enabled.
 This option is disabled by default.
 
-##### Report language changes {#ReportLanguage}
+##### Report language changes while reading {#ReportLanguage}
 
 This checkbox allows you to toggle whether NVDA should report the detected language of the text being read, when the language changes from the default language.
 The language configured to be used by default won't be reported.


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
<!-- Use Closes/Fixes/Resolves #xxx to link this PR to the issue it is responding to. -->

Fixes #18408

### Summary of the issue:
The report language command Works in a different way deppending on certain NVDA's settings. This makes the command les useful. In contrast, it's desirable that the command Works in a consistent way, so that users can change NVDA's settings deppending on the result of this command. For example, they may enable automatic language switching if the language of the text is supported by the current synthesizer, or if it is set correctly in a webpage or document.

### Description of user facing changes:
The command to report the current language at caretworks consistently regardless of NVDA's settings.
### Description of developer facing changes:
N/A
### Description of development approach:
In the `globalCommands` module, function to get language at caret and script to report it have been updated, removing condition which made them to be based on NVDA's settings.

### Testing strategy:
Tested on this [Codepen sample](https://codepen.io/nvdaes/pen/KwKyVpR)

### Known issues with pull request:
None.
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
