### PR TITLE
WasapiPlayer: Call IAudioClient::Reset in completeStop() rather than in stop().

### DIFF
--- a/nvdaHelper/local/wasapi.cpp
+++ b/nvdaHelper/local/wasapi.cpp
@@ -608,7 +608,9 @@ HRESULT WasapiPlayer::stop() {
 void WasapiPlayer::completeStop() {
 	HRESULT hr = client->Reset();
 	if (FAILED(hr)) {
-		LOG_ERROR(L"Couldn't reset stream: " << hr);
+		// We must not use LOG_ERROR here because that plays a sound and we might be
+		// in the middle of stopping our sound player.
+		LOG_DEBUGWARNING(L"Couldn't reset stream: " << hr);
 		// We deliberately continue here. If Reset failed, the stream is probably
 		// already cleared or unusable anyway. We should always reset our state.
 	}

--- a/nvdaHelper/local/wasapi.cpp
+++ b/nvdaHelper/local/wasapi.cpp
@@ -587,8 +587,12 @@ bool WasapiPlayer::didPreferredDeviceBecomeAvailable() {
 }
 
 HRESULT WasapiPlayer::stop() {
-	playState = PlayState::stopping;
 	HRESULT hr = client->Stop();
+	// It's important that we set playState *after*
+	// calling client->Stop() because otherwise, the feeder thread might see the
+	// playState change and call client->Reset() before client->Stop() runs,
+	// causing AUDCLNT_E_NOT_STOPPED.
+	playState = PlayState::stopping;
 	// If the device has been invalidated, it has already stopped. Just ignore
 	// this and behave as if we were successful to avoid a cascade of breakage.
 	// feed() will attempt to reopen the device next time it is called.

--- a/nvdaHelper/local/wasapi.cpp
+++ b/nvdaHelper/local/wasapi.cpp
@@ -202,7 +202,8 @@ class WasapiPlayer {
 
 	// Reset our state due to being stopped. This runs on the feeder thread
 	// rather than on the thread which called stop() because writing to a vector
-	// isn't thread safe.
+	// isn't thread safe. We also reset the stream here because this can't be done
+	// in stop() if the feeder thread is currently writing to the buffer.
 	void completeStop();
 
 	// Convert frames into ms.
@@ -594,14 +595,9 @@ HRESULT WasapiPlayer::stop() {
 	if (
 		hr != AUDCLNT_E_DEVICE_INVALIDATED
 		&& hr != AUDCLNT_E_NOT_INITIALIZED
+		&& FAILED(hr)
 	) {
-		if (FAILED(hr)) {
-			return hr;
-		}
-		hr = client->Reset();
-		if (FAILED(hr)) {
-			return hr;
-		}
+		return hr;
 	}
 	// If there is a feed/sync call waiting, wake it up so it can immediately
 	// return to the caller.
@@ -610,6 +606,12 @@ HRESULT WasapiPlayer::stop() {
 }
 
 void WasapiPlayer::completeStop() {
+	HRESULT hr = client->Reset();
+	if (FAILED(hr)) {
+		LOG_ERROR(L"Couldn't reset stream: " << hr);
+		// We deliberately continue here. If Reset failed, the stream is probably
+		// already cleared or unusable anyway. We should always reset our state.
+	}
 	nextFeedId = 0;
 	sentFrames = 0;
 	feedEnds.clear();

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -71,6 +71,7 @@ There have also been a number of other fixes and improvements, including to mous
 * It is now possible to review and spell the labels of controls in Google Chrome menus and dialogs. (#11285, @jcsteh)
 * When typing into a cell in Microsoft Excel, the braille display is now correctly updated to show the new content. (#18391)
 * Fixed bug where NLS eReader Zoomax driver did not work with all devices. (#18406, @florin-trutiu)
+* When using NVDA Remote Access, speech from User Account Control screens on the remote computer now works reliably. (#18101, @jcsteh)
 
 ### Changes for Developers
 


### PR DESCRIPTION
### Link to issue number:
Fixes #18101
May address #17131, though I'm not sure and I think there's still a thread safety bug in that third party synth driver even if it does.

### Summary of the issue:
Sometimes, speech is silent on the local computer when using NVDA Remote Access and a UAC screen appears on the remote computer. This occurs because NVDA tries to play a sound, which calls WavePlayer.stop, which throws an AUDCLNT_E_BUFFER_OPERATION_PENDING exception. That exception isn't caught, so it prevents speech handlers from being registered.

### Description of user facing changes:
When using NVDA Remote Access, speech from User Account Control screens on the remote computer now works reliably.

### Description of development approach:
AUDCLNT_E_BUFFER_OPERATION_PENDING is being returned from IAudioClient::Reset() called by WasapiPlayer::stop(). Per [the documentation](https://learn.microsoft.com/en-us/windows/win32/api/audioclient/nf-audioclient-iaudioclient-reset#return-value), Reset can return AUDCLNT_E_BUFFER_OPERATION_PENDING if "The client is currently writing to or reading from the buffer."

It's indeed slightly possible that the feeder thread is still in WasapiPlayer::feed() when we call WasapiPlayer::stop() on the main thread. This is why stopping is split into two phases: the stop() call itself, generally called on the main thread, and completeStop(), called by the feeder thread when it sees that stop() has been called.

Thus, we fix this problem by moving the IAudioClient::Reset() call from WasapiPlayer::stop() to WasapiPlayer::completeStop(), ensuring that it is called on the feeder thread and therefore not while the buffer is being written to. Audio still stops immediately when WasapiPlayer::stop() is called due to the call to IAudioClient::Stop(), which does not care about whether another thread is writing to the buffer.

We also call IAudioClient::Stop() before setting playState. Otherwise, the feeder thread might see the playState change and call client->Reset() before client->Stop() runs, causing AUDCLNT_E_NOT_STOPPED.

### Testing strategy:
Followed steps in #18101. Verified the expected result 30 times.

### Known issues with pull request:
None.

### Code Review Checklist:
- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
