### PR TITLE
Replace `typing.Optional[type]` with `type | None`

### DIFF
--- a/source/IAccessibleHandler/__init__.py
+++ b/source/IAccessibleHandler/__init__.py
@@ -308,7 +308,7 @@ def calculateNvdaStates(IARole: int, IAStates: int) -> Set[State]:
 	return states
 
 
-def NVDARoleFromAttr(accRole: Optional[str]) -> Role:
+def NVDARoleFromAttr(accRole: str | None) -> Role:
 	if not accRole:  # empty string or None
 		return controlTypes.Role.UNKNOWN
 	assert isinstance(accRole, str)
@@ -519,7 +519,7 @@ def winEventToNVDAEvent(  # noqa: C901
 	objectID: int,
 	childID: int,
 	useCache: bool = True,
-) -> Optional[Tuple[str, NVDAObjects.IAccessible.IAccessible]]:
+) -> Tuple[str, NVDAObjects.IAccessible.IAccessible] | None:
 	"""Tries to convert a win event ID to an NVDA event name, and instantiate or fetch an NVDAObject for
 	 the win event parameters.
 	@param eventID: the win event ID (type)

--- a/source/IAccessibleHandler/__init__.py
+++ b/source/IAccessibleHandler/__init__.py
@@ -12,7 +12,6 @@ from .types import RelationType  # noqa: F401
 import re
 import struct
 from typing import (
-	Optional,
 	Tuple,
 	Dict,
 	Union,

--- a/source/IAccessibleHandler/orderedWinEventLimiter.py
+++ b/source/IAccessibleHandler/orderedWinEventLimiter.py
@@ -1,4 +1,4 @@
-from typing import Optional, List
+from typing import List
 import heapq
 import itertools
 

--- a/source/IAccessibleHandler/orderedWinEventLimiter.py
+++ b/source/IAccessibleHandler/orderedWinEventLimiter.py
@@ -82,7 +82,7 @@ class OrderedWinEventLimiter(object):
 
 	def flushEvents(
 		self,
-		alwaysAllowedObjects: Optional[List[IAccessibleObjectIdentifierType]] = None,
+		alwaysAllowedObjects: List[IAccessibleObjectIdentifierType] | None = None,
 	) -> List:
 		"""Returns a list of winEvents that have been added.
 		Due to limiting, it will not necessarily be all the winEvents that were originally added.

--- a/source/NVDAHelper.py
+++ b/source/NVDAHelper.py
@@ -4,7 +4,6 @@
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
-from typing import Optional
 import typing
 import os
 import winreg

--- a/source/NVDAHelper.py
+++ b/source/NVDAHelper.py
@@ -55,8 +55,8 @@ if not NVDAState.isRunningAsSource():
 
 
 _remoteLib = None
-_remoteLoaderAMD64: "Optional[_RemoteLoader]" = None
-_remoteLoaderARM64: "Optional[_RemoteLoader]" = None
+_remoteLoaderAMD64: "_RemoteLoader | None" = None
+_remoteLoaderARM64: "_RemoteLoader | None" = None
 localLib = None
 generateBeep = None
 onSsmlMarkReached = None

--- a/source/NVDAObjects/IAccessible/__init__.py
+++ b/source/NVDAObjects/IAccessible/__init__.py
@@ -772,9 +772,9 @@ class IAccessible(Window):
 	# C901: 'IAccessible.__init__' is too complex
 	def __init__(  # noqa: C901
 		self,
-		windowHandle: Optional[int] = None,
-		IAccessibleObject: Optional[Union[IUnknown, IA.IAccessible, IA2.IAccessible2]] = None,
-		IAccessibleChildID: Optional[int] = None,
+		windowHandle: int | None = None,
+		IAccessibleObject: Union[IUnknown, IA.IAccessible, IA2.IAccessible2] | None = None,
+		IAccessibleChildID: int | None = None,
 		event_windowHandle: Optional = None,
 		event_objectID: Optional = None,
 		event_childID: Optional = None,

--- a/source/NVDAObjects/IAccessible/__init__.py
+++ b/source/NVDAObjects/IAccessible/__init__.py
@@ -1881,7 +1881,7 @@ class IAccessible(Window):
 	def _getIA2RelationFirstTarget(
 		self,
 		relationType: typing.Union[str, "IAccessibleHandler.RelationType"],
-	) -> typing.Optional["IAccessible"]:
+	) -> "IAccessible | None":
 		"""Get the first target for the relation of type.
 		@param relationType: The type of relation to fetch.
 		"""

--- a/source/NVDAObjects/IAccessible/adobeAcrobat.py
+++ b/source/NVDAObjects/IAccessible/adobeAcrobat.py
@@ -41,7 +41,7 @@ stdNamesToRoles = {
 }
 
 
-def normalizeStdName(stdName: str) -> typing.Tuple[controlTypes.Role, typing.Optional[str]]:
+def normalizeStdName(stdName: str) -> typing.Tuple[controlTypes.Role, str | None]:
 	"""
 	@param stdName:
 	@return: Tuple with the NVDA role and optionally the level number of the heading as a string, E.G.:

--- a/source/NVDAObjects/IAccessible/chromium.py
+++ b/source/NVDAObjects/IAccessible/chromium.py
@@ -21,7 +21,7 @@ if typing.TYPE_CHECKING:
 	# at run time)
 	from treeInterceptorHandler import TreeInterceptor  # noqa: F401
 
-supportedAriaDetailsRoles: Dict[str, Optional[controlTypes.Role]] = {
+supportedAriaDetailsRoles: Dict[str, controlTypes.Role | None] = {
 	"unknown": None,  # no explicit role, should be reported as "details"
 	"comment": controlTypes.Role.COMMENT,
 	"doc-footnote": controlTypes.Role.FOOTNOTE,

--- a/source/NVDAObjects/IAccessible/chromium.py
+++ b/source/NVDAObjects/IAccessible/chromium.py
@@ -6,7 +6,7 @@
 """NVDAObjects for the Chromium browser project"""
 
 import typing
-from typing import Dict, Optional
+from typing import Dict
 from comtypes import COMError
 
 import config

--- a/source/NVDAObjects/IAccessible/ia2TextMozilla.py
+++ b/source/NVDAObjects/IAccessible/ia2TextMozilla.py
@@ -7,9 +7,7 @@
 This is now used by other applications as well.
 """
 
-import typing
 from typing import (
-	Optional,
 	Dict,
 	Type,
 )

--- a/source/NVDAObjects/IAccessible/ia2TextMozilla.py
+++ b/source/NVDAObjects/IAccessible/ia2TextMozilla.py
@@ -34,7 +34,7 @@ def _getRawTextInfo(obj) -> Type[offsets.OffsetsTextInfo]:
 	return IA2TextTextInfo
 
 
-def _getEmbedded(obj, offset) -> typing.Optional[IAccessible]:
+def _getEmbedded(obj, offset) -> IAccessible | None:
 	if not hasattr(obj, "IAccessibleTextObject"):
 		return obj.getChild(offset)
 	# Mozilla uses IAccessibleHypertext to facilitate quick retrieval of embedded objects.
@@ -319,7 +319,7 @@ class MozillaCompoundTextInfo(CompoundTextInfo):
 			elif isinstance(item, str):
 				yield item
 			elif isinstance(item, int):  # Embedded object.
-				embedded: typing.Optional[IAccessible] = _getEmbedded(ti.obj, item)
+				embedded: IAccessible | None = _getEmbedded(ti.obj, item)
 				if embedded is None:
 					continue
 				notText = _getRawTextInfo(embedded) is NVDAObjectTextInfo
@@ -453,7 +453,7 @@ class MozillaCompoundTextInfo(CompoundTextInfo):
 	def _get_text(self):
 		return "".join(self._getText(False))
 
-	def getTextWithFields(self, formatConfig: Optional[Dict] = None) -> textInfos.TextInfo.TextWithFieldsT:
+	def getTextWithFields(self, formatConfig: Dict | None = None) -> textInfos.TextInfo.TextWithFieldsT:
 		return self._getText(True, formatConfig)
 
 	def _adjustIfEndOfLine(

--- a/source/NVDAObjects/IAccessible/ia2Web.py
+++ b/source/NVDAObjects/IAccessible/ia2Web.py
@@ -7,7 +7,6 @@
 
 from typing import (
 	Generator,
-	Optional,
 	Tuple,
 )
 from ctypes import c_short

--- a/source/NVDAObjects/IAccessible/ia2Web.py
+++ b/source/NVDAObjects/IAccessible/ia2Web.py
@@ -74,7 +74,7 @@ class IA2WebAnnotation(AnnotationOrigin):
 		return tuple(self._rolesGenerator)
 
 	@property
-	def _rolesGenerator(self) -> Generator[Optional[controlTypes.Role], None, None]:
+	def _rolesGenerator(self) -> Generator[controlTypes.Role | None, None, None]:
 		"""
 		Since Chromium exposes the roles via the "details-roles" IA2Attributes, an optimisation can be used
 		to return them.
@@ -127,7 +127,7 @@ class Ia2Web(IAccessible):
 		return info
 
 	def _get_descriptionFrom(self) -> controlTypes.DescriptionFrom:
-		ia2attrDescriptionFrom: Optional[str] = self.IA2Attributes.get("description-from")
+		ia2attrDescriptionFrom: str | None = self.IA2Attributes.get("description-from")
 		try:
 			return controlTypes.DescriptionFrom(ia2attrDescriptionFrom)
 		except ValueError:
@@ -143,7 +143,7 @@ class Ia2Web(IAccessible):
 		annotationOrigin = IA2WebAnnotation(self)
 		return annotationOrigin
 
-	def _get_detailsSummary(self) -> Optional[str]:
+	def _get_detailsSummary(self) -> str | None:
 		log.warning(
 			"NVDAObject.detailsSummary is deprecated. Use NVDAObject.annotations instead.",
 			stack_info=True,
@@ -159,7 +159,7 @@ class Ia2Web(IAccessible):
 		)
 		return bool(self.annotations)
 
-	def _get_detailsRole(self) -> Optional[controlTypes.Role]:
+	def _get_detailsRole(self) -> controlTypes.Role | None:
 		log.warning(
 			"NVDAObject.detailsRole is deprecated. Use NVDAObject.annotations instead.",
 			stack_info=True,

--- a/source/NVDAObjects/IAccessible/mozilla.py
+++ b/source/NVDAObjects/IAccessible/mozilla.py
@@ -36,7 +36,7 @@ class MozAnnotationTarget(AnnotationTarget):
 		return self._target.summarizeInProcess()
 
 	@property
-	def role(self) -> Optional[controlTypes.Role]:
+	def role(self) -> controlTypes.Role | None:
 		# details-roles is currently only defined in Chromium
 		# this may diverge in Firefox in the future.
 		from .chromium import supportedAriaDetailsRoles
@@ -83,7 +83,7 @@ class MozAnnotation(AnnotationOrigin):
 		return tuple(self._rolesGenerator)
 
 	@property
-	def _rolesGenerator(self) -> Generator[Optional[controlTypes.Role], None, None]:
+	def _rolesGenerator(self) -> Generator[controlTypes.Role | None, None, None]:
 		# Unlike base Ia2Web implementation, the details-roles
 		# IA2 attribute is not exposed in Firefox.
 		# Although slower, we have to fetch the details relations instead.
@@ -145,7 +145,7 @@ class Mozilla(ia2Web.Ia2Web):
 		annotationOrigin = MozAnnotation(self)
 		return annotationOrigin
 
-	def _get_detailsSummary(self) -> Optional[str]:
+	def _get_detailsSummary(self) -> str | None:
 		log.warning(
 			"NVDAObject.detailsSummary is deprecated. Use NVDAObject.annotations instead.",
 			stack_info=True,
@@ -153,7 +153,7 @@ class Mozilla(ia2Web.Ia2Web):
 		# just take the first for now.
 		return self.annotations.targets[0].summary
 
-	def _get_detailsRole(self) -> Optional[controlTypes.Role]:
+	def _get_detailsRole(self) -> controlTypes.Role | None:
 		log.warning(
 			"NVDAObject.detailsRole is deprecated. Use NVDAObject.annotations instead.",
 			stack_info=True,

--- a/source/NVDAObjects/IAccessible/mozilla.py
+++ b/source/NVDAObjects/IAccessible/mozilla.py
@@ -6,7 +6,6 @@
 
 from typing import (
 	Generator,
-	Optional,
 	Tuple,
 )
 

--- a/source/NVDAObjects/IAccessible/sysListView32.py
+++ b/source/NVDAObjects/IAccessible/sysListView32.py
@@ -249,7 +249,7 @@ class List(List):
 			return 1
 		return count
 
-	def _getColumnOrderArrayRawInProc(self, columnCount: int) -> Optional[ctypes.Array]:
+	def _getColumnOrderArrayRawInProc(self, columnCount: int) -> ctypes.Array | None:
 		"""Retrieves a list of column indexes for a given list control.
 		See `_getColumnOrderArrayRaw` for more comments.
 		Note that this method operates in process and cannot be used in situations where NVDA cannot inject
@@ -267,7 +267,7 @@ class List(List):
 			return None
 		return columnOrderArray
 
-	def _getColumnOrderArrayRawOutProc(self, columnCount: int) -> Optional[ctypes.Array]:
+	def _getColumnOrderArrayRawOutProc(self, columnCount: int) -> ctypes.Array | None:
 		"""Retrieves a list of column indexes for a given list control.
 		See `_getColumnOrderArrayRaw` for more comments.
 		Note that this method operates out of process and has to reserve memory inside a given application.
@@ -307,7 +307,7 @@ class List(List):
 			winKernel.virtualFreeEx(processHandle, internalCoa, 0, winKernel.MEM_RELEASE)
 		return coa
 
-	def _getColumnOrderArrayRaw(self, columnCount: int) -> Optional[ctypes.Array]:
+	def _getColumnOrderArrayRaw(self, columnCount: int) -> ctypes.Array | None:
 		"""Retrieves an array of column indexes for a given list.
 		The indexes are placed in order in which columns are displayed on screen from left to right.
 		Note that when columns are reordered the indexes remain the same - only their order differs.
@@ -316,7 +316,7 @@ class List(List):
 			return self._getColumnOrderArrayRawOutProc(columnCount)
 		return self._getColumnOrderArrayRawInProc(columnCount)
 
-	def _getMappedColumn(self, presentationIndex: int) -> Optional[int]:
+	def _getMappedColumn(self, presentationIndex: int) -> int | None:
 		"""
 		Multi-column SysListViews can have their columns re-ordered.
 		To keep a consistent internal mapping, a column order array is used
@@ -493,7 +493,7 @@ class ListItem(RowWithFakeNavigation, RowWithoutCellObjects, ListItemWithoutColu
 			return None
 		return localRect
 
-	def _getColumnLocationRaw(self, index: int) -> Optional[RectLTRB]:
+	def _getColumnLocationRaw(self, index: int) -> RectLTRB | None:
 		if not self.appModule.helperLocalBindingHandle:
 			rect = self._getColumnLocationRawOutProc(index)
 		else:
@@ -514,13 +514,13 @@ class ListItem(RowWithFakeNavigation, RowWithoutCellObjects, ListItemWithoutColu
 			top = bottom
 		return RectLTRB(left, top, right, bottom).toScreen(self.windowHandle).toLTWH()
 
-	def _getColumnLocation(self, column: int) -> Optional[RectLTRB]:
+	def _getColumnLocation(self, column: int) -> RectLTRB | None:
 		mappedColumn = self.parent._getMappedColumn(column)
 		if mappedColumn is None:
 			return None
 		return self._getColumnLocationRaw(mappedColumn)
 
-	def _getColumnContentRawInProc(self, index: int) -> Optional[str]:
+	def _getColumnContentRawInProc(self, index: int) -> str | None:
 		"""Retrieves text for a given column.
 		Note that this method operates in process and cannot be used in situations where NVDA cannot inject
 		i.e when running as a Windows Store application or when no focus event was received on startup.
@@ -542,7 +542,7 @@ class ListItem(RowWithFakeNavigation, RowWithoutCellObjects, ListItemWithoutColu
 			return None
 		return text.value
 
-	def _getColumnContentRawOutProc(self, index: int) -> Optional[str]:
+	def _getColumnContentRawOutProc(self, index: int) -> str | None:
 		"""Retrieves text for a given column.
 		Note that this method operates out of process and has to reserve memory inside a given application.
 		As a consequence it may fail when reserved memory is above the range available
@@ -603,12 +603,12 @@ class ListItem(RowWithFakeNavigation, RowWithoutCellObjects, ListItemWithoutColu
 			winKernel.virtualFreeEx(processHandle, internalItem, 0, winKernel.MEM_RELEASE)
 		return buffer.value if buffer else None
 
-	def _getColumnContentRaw(self, index: int) -> Optional[str]:
+	def _getColumnContentRaw(self, index: int) -> str | None:
 		if not self.appModule.helperLocalBindingHandle:
 			return self._getColumnContentRawOutProc(index)
 		return self._getColumnContentRawInProc(index)
 
-	def _getColumnContent(self, column: int) -> Optional[str]:
+	def _getColumnContent(self, column: int) -> str | None:
 		mappedColumn = self.parent._getMappedColumn(column)
 		if mappedColumn is None:
 			return None
@@ -644,7 +644,7 @@ class ListItem(RowWithFakeNavigation, RowWithoutCellObjects, ListItemWithoutColu
 			return None
 		return self._getColumnImageIDRaw(mappedColumn)
 
-	def _getColumnHeaderRawOutProc(self, index: int) -> Optional[str]:
+	def _getColumnHeaderRawOutProc(self, index: int) -> str | None:
 		"""Retrieves text of the header for the given column.
 		Note that this method operates out of process and has to reserve memory inside a given application.
 		As a consequence it may fail when reserved memory is above the range available
@@ -704,7 +704,7 @@ class ListItem(RowWithFakeNavigation, RowWithoutCellObjects, ListItemWithoutColu
 			winKernel.virtualFreeEx(processHandle, internalColumn, 0, winKernel.MEM_RELEASE)
 		return buffer.value if buffer else None
 
-	def _getColumnHeaderRawInProc(self, index: int) -> Optional[str]:
+	def _getColumnHeaderRawInProc(self, index: int) -> str | None:
 		"""Retrieves text of the header for the given column.
 		Note that this method operates in process and cannot be used in situations where NVDA cannot inject
 		i.e when running as a Windows Store application or when no focus event was received on startup.
@@ -724,12 +724,12 @@ class ListItem(RowWithFakeNavigation, RowWithoutCellObjects, ListItemWithoutColu
 			return None
 		return text.value
 
-	def _getColumnHeaderRaw(self, index: int) -> Optional[str]:
+	def _getColumnHeaderRaw(self, index: int) -> str | None:
 		if not self.appModule.helperLocalBindingHandle:
 			return self._getColumnHeaderRawOutProc(index)
 		return self._getColumnHeaderRawInProc(index)
 
-	def _getColumnHeader(self, column: int) -> Optional[str]:
+	def _getColumnHeader(self, column: int) -> str | None:
 		mappedColumn = self.parent._getMappedColumn(column)
 		if mappedColumn is None:
 			return None

--- a/source/NVDAObjects/IAccessible/sysListView32.py
+++ b/source/NVDAObjects/IAccessible/sysListView32.py
@@ -21,7 +21,6 @@ import config
 from config.configFlags import ReportTableHeaders
 from locationHelper import RectLTRB
 from logHandler import log
-from typing import Optional
 
 # Window messages
 LVM_FIRST = 0x1000

--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -469,7 +469,7 @@ class UIATextInfo(textInfos.TextInfo):
 		self,
 		obj: NVDAObject,
 		position: str,
-		_rangeObj: Optional[IUIAutomationTextRangeT] = None,
+		_rangeObj: IUIAutomationTextRangeT | None = None,
 	):
 		super(UIATextInfo, self).__init__(obj, position)
 		if _rangeObj:
@@ -508,7 +508,7 @@ class UIATextInfo(textInfos.TextInfo):
 			if isinstance(position, UIA):
 				position = position.UIAElement
 			try:
-				self._rangeObj: Optional[IUIAutomationTextRangeT] = self.obj.UIATextPattern.rangeFromChild(
+				self._rangeObj: IUIAutomationTextRangeT | None = self.obj.UIATextPattern.rangeFromChild(
 					position,
 				)
 			except COMError:
@@ -655,7 +655,7 @@ class UIATextInfo(textInfos.TextInfo):
 		self,
 		textRange: IUIAutomationTextRangeT,
 		formatConfig: Dict,
-		UIAFormatUnits: Optional[List[int]] = None,
+		UIAFormatUnits: List[int] | None = None,
 	) -> Generator[textInfos.FieldCommand, None, None]:
 		"""
 		Yields format fields and text for the given UI Automation text range, split up by the first available UI Automation text unit that does not result in mixed attribute values.
@@ -1028,7 +1028,7 @@ class UIATextInfo(textInfos.TextInfo):
 		if debug:
 			log.debug("_getTextWithFieldsForUIARange end")
 
-	def getTextWithFields(self, formatConfig: Optional[Dict] = None) -> textInfos.TextInfo.TextWithFieldsT:
+	def getTextWithFields(self, formatConfig: Dict | None = None) -> textInfos.TextInfo.TextWithFieldsT:
 		if not formatConfig:
 			formatConfig = config.conf["documentFormatting"]
 		fields = list(self._getTextWithFieldsForUIARange(self.obj.UIAElement, self._rangeObj, formatConfig))
@@ -1063,7 +1063,7 @@ class UIATextInfo(textInfos.TextInfo):
 		self,
 		unit: str,
 		direction: int,
-		endPoint: Optional[str] = None,
+		endPoint: str | None = None,
 	):
 		UIAUnit = UIAHandler.NVDAUnitsToUIAUnits[unit]
 		if endPoint == "start":
@@ -1671,9 +1671,9 @@ class UIA(Window):
 		return 0
 
 	#: Typing information for auto-property: _get_selectionContainer
-	selectionContainer: "typing.Optional[UIA]"
+	selectionContainer: "UIA | None"
 
-	def _get_selectionContainer(self) -> "typing.Optional[UIA]":
+	def _get_selectionContainer(self) -> "UIA | None":
 		p = self.UIASelectionItemPattern
 		if not p:
 			return None
@@ -2071,9 +2071,9 @@ class UIA(Window):
 		return self.correctAPIForRelation(UIA(UIAElement=previousElement))
 
 	#: Typing information for auto-property: _get_next
-	next: "typing.Optional[UIA]"
+	next: "UIA | None"
 
-	def _get_next(self) -> "typing.Optional[UIA]":
+	def _get_next(self) -> "UIA | None":
 		try:
 			nextElement = UIAHandler.handler.baseTreeWalker.GetNextSiblingElementBuildCache(
 				self.UIAElement,
@@ -2158,7 +2158,7 @@ class UIA(Window):
 			return val
 		return 1
 
-	def _getTextFromHeaderElement(self, element: UIAHandler.IUIAutomationElement) -> typing.Optional[str]:
+	def _getTextFromHeaderElement(self, element: UIAHandler.IUIAutomationElement) -> str | None:
 		obj = UIA(
 			windowHandle=self.windowHandle,
 			UIAElement=element.buildUpdatedCache(UIAHandler.handler.baseCacheRequest),
@@ -2259,19 +2259,19 @@ class UIA(Window):
 		# r is a tuple of floats representing left, top, width and height.
 		return locationHelper.RectLTWH.fromFloatCollection(*r)
 
-	def _get_UIAValue(self) -> typing.Optional[str]:
+	def _get_UIAValue(self) -> str | None:
 		val = self._getUIACacheablePropertyValue(UIAHandler.UIA.UIA_ValueValuePropertyId, True)
 		if val != UIAHandler.handler.reservedNotSupportedValue:
 			return val
 		return None
 
-	def _get_UIARangeValue(self) -> typing.Optional[float]:
+	def _get_UIARangeValue(self) -> float | None:
 		val = self._getUIACacheablePropertyValue(UIAHandler.UIA.UIA_RangeValueValuePropertyId, True)
 		if val != UIAHandler.handler.reservedNotSupportedValue:
 			return val
 		return None
 
-	def _get_value(self) -> typing.Optional[str]:
+	def _get_value(self) -> str | None:
 		if self.UIAValue is not None:
 			return self.UIAValue
 		if self.UIARangeValue is not None:
@@ -2777,7 +2777,7 @@ class ProgressBar(UIA, ProgressBar):
 	This overlay class ensures that the reported value wil be between the accepted range of progress bar values.
 	"""
 
-	def _get_value(self) -> typing.Optional[str]:
+	def _get_value(self) -> str | None:
 		val = self.UIARangeValue
 		if val is None:
 			return self.UIAValue

--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -11,7 +11,6 @@ import typing
 from typing import (
 	Generator,
 	List,
-	Optional,
 	Dict,
 	Tuple,
 	Callable,

--- a/source/NVDAObjects/UIA/excel.py
+++ b/source/NVDAObjects/UIA/excel.py
@@ -133,36 +133,36 @@ class ExcelCell(ExcelObject):
 			return False
 
 	#: Typing information for auto-property: _get_outlineColor
-	outlineColor: Optional[Tuple[colors.RGB]]
+	outlineColor: Tuple[colors.RGB] | None
 
-	def _get_outlineColor(self) -> Optional[Tuple[colors.RGB]]:
+	def _get_outlineColor(self) -> Tuple[colors.RGB] | None:
 		val = self._getUIACacheablePropertyValue(UIAHandler.UIA_OutlineColorPropertyId, True)
 		if isinstance(val, tuple):
 			return tuple(colors.RGB.fromCOLORREF(v) for v in val)
 		return None
 
 	#: Typing information for auto-property: _get_outlineThickness
-	outlineThickness: Optional[Tuple[float]]
+	outlineThickness: Tuple[float] | None
 
-	def _get_outlineThickness(self) -> Optional[Tuple[float]]:
+	def _get_outlineThickness(self) -> Tuple[float] | None:
 		val = self._getUIACacheablePropertyValue(UIAHandler.UIA_OutlineThicknessPropertyId, True)
 		if isinstance(val, tuple):
 			return val
 		return None
 
 	#: Typing information for auto-property: _get_fillColor
-	fillColor: Optional[colors.RGB]
+	fillColor: colors.RGB | None
 
-	def _get_fillColor(self) -> Optional[colors.RGB]:
+	def _get_fillColor(self) -> colors.RGB | None:
 		val = self._getUIACacheablePropertyValue(UIAHandler.UIA_FillColorPropertyId, True)
 		if isinstance(val, int):
 			return colors.RGB.fromCOLORREF(val)
 		return None
 
 	#: Typing information for auto-property: _get_fillType
-	fillType: Optional[UIAHandler.constants.FillType]
+	fillType: UIAHandler.constants.FillType | None
 
-	def _get_fillType(self) -> Optional[UIAHandler.constants.FillType]:
+	def _get_fillType(self) -> UIAHandler.constants.FillType | None:
 		val = self._getUIACacheablePropertyValue(UIAHandler.UIA_FillTypePropertyId, True)
 		if isinstance(val, int):
 			try:
@@ -172,9 +172,9 @@ class ExcelCell(ExcelObject):
 		return None
 
 	#: Typing information for auto-property: _get_rotation
-	rotation: Optional[float]
+	rotation: float | None
 
-	def _get_rotation(self) -> Optional[float]:
+	def _get_rotation(self) -> float | None:
 		val = self._getUIACacheablePropertyValue(UIAHandler.UIA_RotationPropertyId, True)
 		if isinstance(val, float):
 			return val

--- a/source/NVDAObjects/UIA/excel.py
+++ b/source/NVDAObjects/UIA/excel.py
@@ -3,7 +3,7 @@
 # See the file COPYING for more details.
 # Copyright (C) 2018-2021 NV Access Limited, Leonard de Ruijter
 
-from typing import Optional, Tuple
+from typing import Tuple
 from comtypes import COMError
 import winVersion
 import UIAHandler

--- a/source/NVDAObjects/UIA/sysListView32.py
+++ b/source/NVDAObjects/UIA/sysListView32.py
@@ -6,7 +6,7 @@
 
 """Module for native UIA implementations of SysListView32, e.g. in Windows Forms."""
 
-from typing import Dict, List, Optional, Type
+from typing import Dict, List, Type
 from comtypes import COMError
 import config
 from logHandler import log

--- a/source/NVDAObjects/UIA/sysListView32.py
+++ b/source/NVDAObjects/UIA/sysListView32.py
@@ -83,7 +83,7 @@ class SysListViewItem(ListItem):
 			textList.append(text)
 		return "; ".join(textList)
 
-	def _get_indexInParent(self) -> Optional[int]:
+	def _get_indexInParent(self) -> int | None:
 		parent = self.parent
 		if not isinstance(parent, SysListViewList) or self.childCount == 0:
 			return super().indexInParent

--- a/source/NVDAObjects/UIA/web.py
+++ b/source/NVDAObjects/UIA/web.py
@@ -270,7 +270,7 @@ class UIAWebTextInfo(UIATextInfo):
 	# and move logic out into smaller helper functions.
 	def getTextWithFields(  # noqa: C901
 		self,
-		formatConfig: Optional[Dict] = None,
+		formatConfig: Dict | None = None,
 	) -> textInfos.TextInfo.TextWithFieldsT:
 		# We don't want fields for collapsed ranges.
 		# This would normally be a general rule, but MS Word currently needs fields for collapsed ranges,

--- a/source/NVDAObjects/UIA/web.py
+++ b/source/NVDAObjects/UIA/web.py
@@ -3,7 +3,6 @@
 # See the file COPYING for more details.
 # Copyright (C) 2015-2021 NV Access Limited, Babbage B.V., Leonard de Ruijter
 from typing import (
-	Optional,
 	Dict,
 )
 

--- a/source/NVDAObjects/UIA/winConsoleUIA.py
+++ b/source/NVDAObjects/UIA/winConsoleUIA.py
@@ -17,9 +17,6 @@ import UIAHandler
 from comtypes import COMError
 from diffHandler import prefer_difflib
 from logHandler import log
-from typing import (
-	Optional,
-)
 from UIAHandler.utils import _getConhostAPILevel
 from UIAHandler.constants import WinConsoleAPILevel
 from . import UIA, UIATextInfo

--- a/source/NVDAObjects/UIA/winConsoleUIA.py
+++ b/source/NVDAObjects/UIA/winConsoleUIA.py
@@ -473,10 +473,10 @@ class _NotificationsBasedWinTerminalUIA(UIA):
 
 	def event_UIA_notification(
 		self,
-		notificationKind: Optional[int] = None,
-		notificationProcessing: Optional[int] = UIAHandler.NotificationProcessing_CurrentThenMostRecent,
-		displayString: Optional[str] = None,
-		activityId: Optional[str] = None,
+		notificationKind: int | None = None,
+		notificationProcessing: int | None = UIAHandler.NotificationProcessing_CurrentThenMostRecent,
+		displayString: str | None = None,
+		activityId: str | None = None,
 	):
 		# Do not announce output from background terminals.
 		if self.appModule != api.getFocusObject().appModule:

--- a/source/NVDAObjects/UIA/wordDocument.py
+++ b/source/NVDAObjects/UIA/wordDocument.py
@@ -4,7 +4,6 @@
 # Copyright (C) 2016-2025 NV Access Limited, Joseph Lee, Jakub Lukowicz, Cyrille Bougot
 
 from typing import (
-	Optional,
 	Dict,
 	Generator,
 )

--- a/source/NVDAObjects/UIA/wordDocument.py
+++ b/source/NVDAObjects/UIA/wordDocument.py
@@ -328,7 +328,7 @@ class WordDocumentTextInfo(UIATextInfo):
 	# and move logic out into smaller helper functions.
 	def getTextWithFields(  # noqa: C901
 		self,
-		formatConfig: Optional[Dict] = None,
+		formatConfig: Dict | None = None,
 	) -> textInfos.TextInfo.TextWithFieldsT:
 		fields = None
 		# #11043: when a non-collapsed text range is positioned within a blank table cell

--- a/source/NVDAObjects/__init__.py
+++ b/source/NVDAObjects/__init__.py
@@ -12,7 +12,6 @@ import time
 import typing
 from typing import (
 	Dict,
-	Optional,
 	TYPE_CHECKING,
 )
 import weakref

--- a/source/NVDAObjects/__init__.py
+++ b/source/NVDAObjects/__init__.py
@@ -670,10 +670,10 @@ class NVDAObject(
 		).format(left=percentFromLeft, top=percentFromTop, width=percentWidth, height=percentHeight)
 
 	#: Typing information for auto-property: _get_parent
-	parent: typing.Optional["NVDAObject"]
+	parent: "NVDAObject | None"
 	"This object's parent (the object that contains this object)."
 
-	def _get_parent(self) -> typing.Optional["NVDAObject"]:
+	def _get_parent(self) -> "NVDAObject | None":
 		"""Retrieves this object's parent (the object that contains this object).
 		@return: the parent object if it exists else None.
 		"""
@@ -689,38 +689,38 @@ class NVDAObject(
 		return parent
 
 	#: Typing information for auto-property: _get_next
-	next: typing.Optional["NVDAObject"]
+	next: "NVDAObject | None"
 	"The object directly after this object with the same parent."
 
-	def _get_next(self) -> typing.Optional["NVDAObject"]:
+	def _get_next(self) -> "NVDAObject | None":
 		"""Retrieves the object directly after this object with the same parent.
 		@return: the next object if it exists else None.
 		"""
 		return None
 
 	#: Typing information for auto-property: _get_previous
-	previous: typing.Optional["NVDAObject"]
+	previous: "NVDAObject | None"
 	"The object directly before this object with the same parent."
 
-	def _get_previous(self) -> typing.Optional["NVDAObject"]:
+	def _get_previous(self) -> "NVDAObject | None":
 		"""Retrieves the object directly before this object with the same parent.
 		@return: the previous object if it exists else None.
 		"""
 		return None
 
 	#: Type definition for auto prop '_get_firstChild'
-	firstChild: typing.Optional["NVDAObject"]
+	firstChild: "NVDAObject | None"
 
-	def _get_firstChild(self) -> typing.Optional["NVDAObject"]:
+	def _get_firstChild(self) -> "NVDAObject | None":
 		"""Retrieves the first object that this object contains.
 		@return: the first child object if it exists else None.
 		"""
 		return None
 
 	#: Type definition for auto prop '_get_lastChild'
-	lastChild: typing.Optional["NVDAObject"]
+	lastChild: "NVDAObject | None"
 
-	def _get_lastChild(self) -> typing.Optional["NVDAObject"]:
+	def _get_lastChild(self) -> "NVDAObject | None":
 		"""Retrieves the last object that this object contains.
 		@return: the last child object if it exists else None.
 		"""
@@ -1177,9 +1177,9 @@ class NVDAObject(
 		return True
 
 	#: Type definition for auto prop '_get_statusBar'
-	statusBar: Optional["NVDAObject"]
+	statusBar: "NVDAObject | None"
 
-	def _get_statusBar(self) -> Optional["NVDAObject"]:
+	def _get_statusBar(self) -> "NVDAObject | None":
 		"""Finds the closest status bar in relation to this object.
 		@return: the found status bar else None
 		"""

--- a/source/NVDAObjects/__init__.py
+++ b/source/NVDAObjects/__init__.py
@@ -434,10 +434,10 @@ class NVDAObject(
 	#: @type: bool
 	shouldCreateTreeInterceptor = True
 
-	treeInterceptor: typing.Optional[TreeInterceptor]
+	treeInterceptor: TreeInterceptor | None
 	"""Type definition for auto prop '_get_treeInterceptor'"""
 
-	def _get_treeInterceptor(self) -> typing.Optional[TreeInterceptor]:
+	def _get_treeInterceptor(self) -> TreeInterceptor | None:
 		"""Retrieves the treeInterceptor associated with this object.
 		If a treeInterceptor has not been specifically set,
 		the L{treeInterceptorHandler} is asked if it can find a treeInterceptor containing this object.
@@ -458,7 +458,7 @@ class NVDAObject(
 				self._treeInterceptor = weakref.ref(ti)
 			return ti
 
-	def _set_treeInterceptor(self, obj: typing.Optional[TreeInterceptor]):
+	def _set_treeInterceptor(self, obj: TreeInterceptor | None):
 		"""Specifically sets a treeInterceptor to be associated with this object."""
 		if obj:
 			self._treeInterceptor = weakref.ref(obj)
@@ -496,9 +496,9 @@ class NVDAObject(
 		return controlTypes.Role.UNKNOWN
 
 	#: Type definition for auto prop '_get_roleText'
-	roleText: typing.Optional[str]
+	roleText: str | None
 
-	def _get_roleText(self) -> typing.Optional[str]:
+	def _get_roleText(self) -> str | None:
 		"""
 		A custom role string for this object, which is used for braille and speech presentation, which will override the standard label for this object's role property.
 		No string is provided by default, meaning that NVDA will fall back to using role.
@@ -544,20 +544,20 @@ class NVDAObject(
 	"""Typing information for auto property _get_annotations
 	"""
 
-	def _get_annotations(self) -> typing.Optional[AnnotationOrigin]:
+	def _get_annotations(self) -> AnnotationOrigin | None:
 		if config.conf["debugLog"]["annotations"]:
 			log.debugWarning(
 				f"Fetching annotations not supported on: {self.__class__.__qualname__}",
 			)
 		return None
 
-	detailsSummary: typing.Optional[str]
+	detailsSummary: str | None
 	"""
 	Typing information for auto property _get_detailsSummary
 	Deprecated, use self.annotations.targets instead.
 	"""
 
-	def _get_detailsSummary(self) -> typing.Optional[str]:
+	def _get_detailsSummary(self) -> str | None:
 		log.warning(
 			"NVDAObject.detailsSummary is deprecated. Use NVDAObject.annotations instead.",
 			stack_info=True,
@@ -575,12 +575,12 @@ class NVDAObject(
 		)
 		return bool(self.annotations)
 
-	detailsRole: typing.Optional[controlTypes.Role]
+	detailsRole: controlTypes.Role | None
 	"""Typing information for auto property _get_detailsRole
 	Deprecated, use self.annotations.roles instead.
 	"""
 
-	def _get_detailsRole(self) -> typing.Optional[controlTypes.Role]:
+	def _get_detailsRole(self) -> controlTypes.Role | None:
 		log.warning(
 			"NVDAObject.detailsRole is deprecated. Use NVDAObject.annotations instead.",
 			stack_info=True,
@@ -798,9 +798,9 @@ class NVDAObject(
 		raise NotImplementedError
 
 	#: Typing information for auto-property: _get_cellCoordsText
-	cellCoordsText: typing.Optional[str]
+	cellCoordsText: str | None
 
-	def _get_cellCoordsText(self) -> typing.Optional[str]:
+	def _get_cellCoordsText(self) -> str | None:
 		"""
 		An alternative text representation of cell coordinates e.g. "a1". Will override presentation of rowNumber and columnNumber.
 		Only implement if the representation is really different.
@@ -1135,9 +1135,9 @@ class NVDAObject(
 		return isProtected
 
 	#: Type definition for auto prop '_get_indexInParent'
-	indexInParent: Optional[int]
+	indexInParent: int | None
 
-	def _get_indexInParent(self) -> Optional[int]:
+	def _get_indexInParent(self) -> int | None:
 		"""The index of this object in its parent object.
 		@return: The 0 based index, C{None} if there is no parent.
 		@raise NotImplementedError: If not supported by the underlying object.
@@ -1217,11 +1217,11 @@ class NVDAObject(
 		log.debug("Potential unimplemented child class: %r" % self)
 		return None
 
-	landmark: typing.Optional[str]
+	landmark: str | None
 	"""Typing information for auto property _get_landmark
 	"""
 
-	def _get_landmark(self) -> typing.Optional[str]:
+	def _get_landmark(self) -> str | None:
 		"""If this object represents an ARIA landmark, fetches the ARIA landmark role.
 		@return: ARIA landmark role else None
 		"""

--- a/source/NVDAObjects/lockscreen.py
+++ b/source/NVDAObjects/lockscreen.py
@@ -17,19 +17,19 @@ class LockScreenObject(NVDAObject):
 	the user from moving to the object, this overlay class prevents reading neighbouring objects.
 	"""
 
-	def _get_next(self) -> Optional[NVDAObject]:
+	def _get_next(self) -> NVDAObject | None:
 		nextObject = super()._get_next()
 		if nextObject and nextObject.appModule.appName == self.appModule.appName:
 			return nextObject
 		return None
 
-	def _get_previous(self) -> Optional[NVDAObject]:
+	def _get_previous(self) -> NVDAObject | None:
 		previousObject = super()._get_previous()
 		if previousObject and previousObject.appModule.appName == self.appModule.appName:
 			return previousObject
 		return None
 
-	def _get_parent(self) -> Optional[NVDAObject]:
+	def _get_parent(self) -> NVDAObject | None:
 		parentObject = super()._get_parent()
 		if parentObject and parentObject.appModule.appName == self.appModule.appName:
 			return parentObject

--- a/source/NVDAObjects/lockscreen.py
+++ b/source/NVDAObjects/lockscreen.py
@@ -3,9 +3,6 @@
 # See the file COPYING for more details.
 # Copyright (C) 2022 NV Access Limited
 
-from typing import (
-	Optional,
-)
 
 from NVDAObjects import NVDAObject
 

--- a/source/NVDAObjects/window/edit.py
+++ b/source/NVDAObjects/window/edit.py
@@ -911,7 +911,7 @@ class ITextDocumentTextInfo(textInfos.TextInfo):
 		else:
 			raise NotImplementedError("position: %s" % position)
 
-	def getTextWithFields(self, formatConfig: Optional[Dict] = None) -> textInfos.TextInfo.TextWithFieldsT:
+	def getTextWithFields(self, formatConfig: Dict | None = None) -> textInfos.TextInfo.TextWithFieldsT:
 		if not formatConfig:
 			formatConfig = config.conf["documentFormatting"]
 		textRange = self._rangeObj.duplicate

--- a/source/NVDAObjects/window/edit.py
+++ b/source/NVDAObjects/window/edit.py
@@ -5,7 +5,6 @@
 
 from typing import (
 	Dict,
-	Optional,
 	Union,
 )
 

--- a/source/NVDAObjects/window/excel.py
+++ b/source/NVDAObjects/window/excel.py
@@ -1571,10 +1571,10 @@ class FormulaExcelCellInfoQuicknavIterator(ExcelCellInfoQuicknavIterator):
 
 
 class ExcelCell(ExcelBase):
-	excelCellInfo: Optional[ExcelCellInfo]
+	excelCellInfo: ExcelCellInfo | None
 	"""Type info for auto property: _get_excelCellInfo"""
 
-	def _get_excelCellInfo(self) -> Optional[ExcelCellInfo]:
+	def _get_excelCellInfo(self) -> ExcelCellInfo | None:
 		if not self.appModule.helperLocalBindingHandle:
 			return None
 		ci = ExcelCellInfo()

--- a/source/NVDAObjects/window/excel.py
+++ b/source/NVDAObjects/window/excel.py
@@ -10,7 +10,6 @@ import enum
 from typing import (
 	Any,
 	Dict,
-	Optional,
 )
 
 from comtypes import COMError, BSTR

--- a/source/NVDAObjects/window/winword.py
+++ b/source/NVDAObjects/window/winword.py
@@ -1004,7 +1004,7 @@ class WordDocumentTextInfo(textInfos.TextInfo):
 	# and move logic out into smaller helper functions.
 	def getTextWithFields(  # noqa: C901
 		self,
-		formatConfig: Optional[Dict] = None,
+		formatConfig: Dict | None = None,
 	) -> textInfos.TextInfo.TextWithFieldsT:
 		if self.isCollapsed:
 			return []

--- a/source/NVDAObjects/window/winword.py
+++ b/source/NVDAObjects/window/winword.py
@@ -8,7 +8,6 @@
 import ctypes
 import time
 from typing import (
-	Optional,
 	Dict,
 	Generator,
 	Self,

--- a/source/UIAHandler/__init__.py
+++ b/source/UIAHandler/__init__.py
@@ -1512,7 +1512,7 @@ class UIAHandler(COMObject):
 		return False
 
 
-handler: Optional[UIAHandler] = None
+handler: UIAHandler | None = None
 
 
 def initialize():

--- a/source/UIAHandler/__init__.py
+++ b/source/UIAHandler/__init__.py
@@ -3,7 +3,6 @@
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
-from typing import Optional
 import ctypes
 import ctypes.wintypes
 from ctypes import (

--- a/source/UIAHandler/browseMode.py
+++ b/source/UIAHandler/browseMode.py
@@ -3,7 +3,6 @@
 # See the file COPYING for more details.
 # Copyright (C) 2015-2020 NV Access Limited, Babbage B.V., Accessolutions, Julien Cochuyt
 
-from typing import Optional
 from ctypes import byref
 from comtypes import COMError
 from comtypes.automation import VARIANT, VT_EMPTY

--- a/source/UIAHandler/browseMode.py
+++ b/source/UIAHandler/browseMode.py
@@ -177,7 +177,7 @@ class HeadingUIATextInfoQuickNavItem(browseMode.TextInfoQuickNavItem):
 def UIAHeadingQuicknavIterator(
 	itemType: str,
 	document: "UIABrowseModeDocument",
-	position: Optional["UIABrowseModeDocumentTextInfo"],
+	position: "UIABrowseModeDocumentTextInfo | None",
 	direction: str = "next",
 ):
 	reverse = bool(direction == "previous")

--- a/source/UIAHandler/remote.py
+++ b/source/UIAHandler/remote.py
@@ -5,7 +5,6 @@
 
 
 from typing import (
-	Optional,
 	Any,
 	Generator,
 	cast,

--- a/source/UIAHandler/remote.py
+++ b/source/UIAHandler/remote.py
@@ -60,7 +60,7 @@ def msWord_getCustomAttributeValue(
 	docElement: UIA.IUIAutomationElement,
 	textRange: UIA.IUIAutomationTextRange,
 	customAttribID: int,
-) -> Optional[Any]:
+) -> Any | None:
 	guid_msWord_extendedTextRangePattern = GUID("{93514122-FF04-4B2C-A4AD-4AB04587C129}")
 	guid_msWord_getCustomAttributeValue = GUID("{081ACA91-32F2-46F0-9FB9-017038BC45F8}")
 	op = operation.Operation()

--- a/source/XMLFormatting.py
+++ b/source/XMLFormatting.py
@@ -10,7 +10,7 @@ import textUtils
 from logHandler import log
 from textUtils import WCHAR_ENCODING, isLowSurrogate
 
-CommandsT = typing.Union[textInfos.FieldCommand, typing.Optional[str]]
+CommandsT = typing.Union[textInfos.FieldCommand, str | None]
 CommandListT = typing.List[CommandsT]
 
 
@@ -65,7 +65,7 @@ class XMLTextParser(object):
 		else:
 			raise ValueError("unknown tag name: %s" % tagName)
 
-	def _CharacterDataHandler(self, data: typing.Optional[str], processBufferedSurrogates=False):
+	def _CharacterDataHandler(self, data: str | None, processBufferedSurrogates=False):
 		cmdList = self._commandList
 		if not isinstance(data, str):
 			dataStr = repr(data)

--- a/source/_remoteClient/client.py
+++ b/source/_remoteClient/client.py
@@ -42,14 +42,14 @@ Address = Tuple[str, int]  # (hostname, port)
 class RemoteClient:
 	localScripts: Set[scriptHandler._ScriptFunctionT]
 	localMachine: LocalMachine
-	leaderSession: Optional[LeaderSession]
-	followerSession: Optional[FollowerSession]
+	leaderSession: LeaderSession | None
+	followerSession: FollowerSession | None
 	keyModifiers: Set[KeyModifier]
 	hostPendingModifiers: Set[KeyModifier]
 	connecting: bool
-	leaderTransport: Optional[RelayTransport]
-	followerTransport: Optional[RelayTransport]
-	localControlServer: Optional[server.LocalRelayServer]
+	leaderTransport: RelayTransport | None
+	followerTransport: RelayTransport | None
+	localControlServer: server.LocalRelayServer | None
 	sendingKeys: bool
 
 	def __init__(
@@ -62,9 +62,9 @@ class RemoteClient:
 		self.localMachine = LocalMachine()
 		self.followerSession = None
 		self.leaderSession = None
-		self.menu: Optional[RemoteMenu] = None
+		self.menu: RemoteMenu | None = None
 		if not isRunningOnSecureDesktop():
-			self.menu: Optional[RemoteMenu] = RemoteMenu(self)
+			self.menu: RemoteMenu | None = RemoteMenu(self)
 		self.connecting = False
 		urlHandler.registerURLHandler()
 		self.leaderTransport = None

--- a/source/_remoteClient/client.py
+++ b/source/_remoteClient/client.py
@@ -4,7 +4,7 @@
 # See the file COPYING for more details.
 
 import threading
-from typing import Optional, Set, Tuple
+from typing import Set, Tuple
 
 import api
 import braille

--- a/source/_remoteClient/localMachine.py
+++ b/source/_remoteClient/localMachine.py
@@ -21,7 +21,7 @@ muting and uses wxPython's CallAfter for thread synchronization.
 import ctypes
 from enum import IntEnum, nonmember
 import os
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 import winreg
 
 import api

--- a/source/_remoteClient/localMachine.py
+++ b/source/_remoteClient/localMachine.py
@@ -108,7 +108,7 @@ class LocalMachine:
 		self.receivingBraille: bool = False
 		"""When True, braille output comes from remote"""
 
-		self._cachedSizes: Optional[List[int]] = None
+		self._cachedSizes: List[int] | None = None
 		"""Cached braille display sizes from remote machines"""
 
 		braille.decide_enabled.register(self.handleDecideEnabled)
@@ -257,9 +257,9 @@ class LocalMachine:
 
 	def sendKey(
 		self,
-		vk_code: Optional[int] = None,
-		extended: Optional[bool] = None,
-		pressed: Optional[bool] = None,
+		vk_code: int | None = None,
+		extended: bool | None = None,
+		pressed: bool | None = None,
 	) -> None:
 		"""Simulate a keyboard event on the local machine.
 

--- a/source/_remoteClient/secureDesktop.py
+++ b/source/_remoteClient/secureDesktop.py
@@ -71,10 +71,10 @@ class SecureDesktopHandler:
 		self.IPCFile = self.IPCPath / "remote.ipc"
 		log.debug("Initialized SecureDesktopHandler with IPC file: %s", self.IPCFile)
 
-		self._followerSession: Optional[FollowerSession] = None
-		self.sdServer: Optional[server.LocalRelayServer] = None
-		self.sdRelay: Optional[RelayTransport] = None
-		self.sdBridge: Optional[bridge.BridgeTransport] = None
+		self._followerSession: FollowerSession | None = None
+		self.sdServer: server.LocalRelayServer | None = None
+		self.sdRelay: RelayTransport | None = None
+		self.sdBridge: bridge.BridgeTransport | None = None
 
 		post_secureDesktopStateChange.register(self._onSecureDesktopChange)
 
@@ -91,11 +91,11 @@ class SecureDesktopHandler:
 		log.info("Secure desktop cleanup completed")
 
 	@property
-	def followerSession(self) -> Optional[FollowerSession]:
+	def followerSession(self) -> FollowerSession | None:
 		return self._followerSession
 
 	@followerSession.setter
-	def followerSession(self, session: Optional[FollowerSession]) -> None:
+	def followerSession(self, session: FollowerSession | None) -> None:
 		"""Update follower session reference and handle necessary cleanup/setup."""
 		if self._followerSession == session:
 			log.debug("Follower session unchanged, skipping update")
@@ -115,7 +115,7 @@ class SecureDesktopHandler:
 				self._onLeaderDisplayChange,
 			)
 
-	def _onSecureDesktopChange(self, isSecureDesktop: Optional[bool] = None) -> None:
+	def _onSecureDesktopChange(self, isSecureDesktop: bool | None = None) -> None:
 		"""Internal callback for secure desktop state changes.
 
 		:param isSecureDesktop: True if transitioning to secure desktop, False otherwise
@@ -201,7 +201,7 @@ class SecureDesktopHandler:
 		except FileNotFoundError:
 			pass
 
-	def initializeSecureDesktop(self) -> Optional[ConnectionInfo]:
+	def initializeSecureDesktop(self) -> ConnectionInfo | None:
 		"""Initialize connection when starting in secure desktop.
 
 		:return: Connection information if successful, None on failure

--- a/source/_remoteClient/secureDesktop.py
+++ b/source/_remoteClient/secureDesktop.py
@@ -24,7 +24,7 @@ import socket
 import threading
 import uuid
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 from ctypes import c_bool, windll, c_wchar_p, c_ushort, create_unicode_buffer
 from ctypes.wintypes import DWORD, HANDLE
 

--- a/source/_remoteClient/serializer.py
+++ b/source/_remoteClient/serializer.py
@@ -23,7 +23,7 @@ Supported Data Types
 import json
 from abc import ABCMeta, abstractmethod
 from enum import Enum
-from typing import Any, Dict, Optional, Type, TypeVar, Union
+from typing import Any, Dict, Type, TypeVar, Union
 
 import speech.commands
 from logHandler import log

--- a/source/_remoteClient/serializer.py
+++ b/source/_remoteClient/serializer.py
@@ -47,7 +47,7 @@ class Serializer(metaclass=ABCMeta):
 	"""
 
 	@abstractmethod
-	def serialize(self, type: Optional[str] = None, **obj: Any) -> bytes:
+	def serialize(self, type: str | None = None, **obj: Any) -> bytes:
 		"""Convert a message to bytes for transmission.
 
 		:param type: Message type identifier, used for routing
@@ -79,7 +79,7 @@ class JSONSerializer(Serializer):
 	SEP: bytes = b"\n"
 	"""Message separator for streaming protocols"""
 
-	def serialize(self, type: Optional[str] = None, **obj: Any) -> bytes:
+	def serialize(self, type: str | None = None, **obj: Any) -> bytes:
 		"""Serialize a message to JSON bytes.
 
 		Converts message type and payload to JSON format, handling Enum types

--- a/source/_remoteClient/transport.py
+++ b/source/_remoteClient/transport.py
@@ -63,7 +63,7 @@ class RemoteExtensionPoint:
 	messageType: RemoteMessageType
 	"""The remote message type to send"""
 
-	filter: Optional[Callable[..., dict[str, Any]]] = None
+	filter: Callable[..., dict[str, Any]] | None = None
 	"""Optional function to transform arguments before sending"""
 
 	transport: Optional["Transport"] = None
@@ -214,7 +214,7 @@ class Transport(ABC):
 		self,
 		extensionPoint: HandlerRegistrar,
 		messageType: RemoteMessageType,
-		filter: Optional[Callable[..., dict[str, Any]]] = None,
+		filter: Callable[..., dict[str, Any]] | None = None,
 	) -> None:
 		"""Register an extension point to a message type.
 

--- a/source/_remoteClient/transport.py
+++ b/source/_remoteClient/transport.py
@@ -35,7 +35,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from logHandler import log
 from queue import Queue
-from typing import Any, Literal, Optional, Self
+from typing import Any, Literal, Self
 
 import wx
 from extensionPoints import Action, HandlerRegistrar

--- a/source/_remoteClient/transport.py
+++ b/source/_remoteClient/transport.py
@@ -66,7 +66,7 @@ class RemoteExtensionPoint:
 	filter: Callable[..., dict[str, Any]] | None = None
 	"""Optional function to transform arguments before sending"""
 
-	transport: Optional["Transport"] = None
+	transport: "Transport | None" = None
 	"""The transport instance (set on registration)"""
 
 	def remoteBridge(self, *args: Any, **kwargs: Any) -> Literal[True]:

--- a/source/addonHandler/__init__.py
+++ b/source/addonHandler/__init__.py
@@ -410,7 +410,7 @@ _availableAddons = collections.OrderedDict()
 
 def getAvailableAddons(
 	refresh: bool = False,
-	filterFunc: Optional[Callable[["Addon"], bool]] = None,
+	filterFunc: Callable[["Addon"], bool] | None = None,
 	isFirstLoad: bool = False,
 ) -> "AddonHandlerModelGeneratorT":
 	"""Gets all available addons on the system.
@@ -507,7 +507,7 @@ class AddonBase(SupportsAddonState, SupportsVersionCheck, ABC):
 	def manifest(self) -> "AddonManifest": ...
 
 	@property
-	def _addonStoreData(self) -> Optional["InstalledAddonStoreModel"]:
+	def _addonStoreData(self) -> "InstalledAddonStoreModel" | None:
 		from addonStore.dataManager import addonDataManager
 
 		assert addonDataManager
@@ -549,7 +549,7 @@ class Addon(AddonBase):
 				_report_manifest_errors(self.manifest)
 				raise AddonError("Manifest file has errors.")
 
-	def completeInstall(self) -> Optional[str]:
+	def completeInstall(self) -> str | None:
 		if not os.path.exists(self.pendingInstallPath):
 			log.error(f"Pending install path {self.pendingInstallPath} does not exist")
 			return None
@@ -792,7 +792,7 @@ class Addon(AddonBase):
 				log.debug(f"Removing module {module} from cache of imported modules")
 				del sys.modules[modName]
 
-	def getDocFilePath(self, fileName: Optional[str] = None) -> Optional[str]:
+	def getDocFilePath(self, fileName: str | None = None) -> str | None:
 		r"""Get the path to a documentation file for this add-on.
 		The file should be located in C{doc\lang\file} inside the add-on,
 		where C{lang} is the language code and C{file} is the requested file name.
@@ -936,7 +936,7 @@ class AddonBundle(AddonBase):
 				_report_manifest_errors(self.manifest)
 				raise AddonError("Manifest file has errors.")
 
-	def extract(self, addonPath: Optional[str] = None):
+	def extract(self, addonPath: str | None = None):
 		"""Extracts the bundle content to the specified path.
 		The addon will be extracted to L{addonPath}
 		@param addonPath: Path where to extract contents.

--- a/source/addonHandler/__init__.py
+++ b/source/addonHandler/__init__.py
@@ -22,7 +22,6 @@ from typing import (
 	Dict,
 	IO,
 	Literal,
-	Optional,
 	Set,
 	TYPE_CHECKING,
 	Tuple,

--- a/source/addonHandler/__init__.py
+++ b/source/addonHandler/__init__.py
@@ -507,7 +507,7 @@ class AddonBase(SupportsAddonState, SupportsVersionCheck, ABC):
 	def manifest(self) -> "AddonManifest": ...
 
 	@property
-	def _addonStoreData(self) -> "InstalledAddonStoreModel" | None:
+	def _addonStoreData(self) -> "InstalledAddonStoreModel | None":
 		from addonStore.dataManager import addonDataManager
 
 		assert addonDataManager

--- a/source/addonHandler/packaging.py
+++ b/source/addonHandler/packaging.py
@@ -35,7 +35,7 @@ def initializeModulePackagePaths():
 		addDirsToPythonPackagePath(module)
 
 
-def addDirsToPythonPackagePath(module: ModuleType, subdir: Optional[str] = None):
+def addDirsToPythonPackagePath(module: ModuleType, subdir: str | None = None):
 	"""Add add-on and scratchpath directories for a module to the search path (__path__) of a Python package.
 	C{subdir} is added to each directory. It defaults to the name of the Python package.
 	@param module: The root module of the package.

--- a/source/addonHandler/packaging.py
+++ b/source/addonHandler/packaging.py
@@ -6,7 +6,6 @@
 """Functions to add python modules within addon directories to python module paths."""
 
 import os.path
-from typing import Optional
 from types import ModuleType
 import globalVars
 import config

--- a/source/addonStore/dataManager.py
+++ b/source/addonStore/dataManager.py
@@ -57,7 +57,7 @@ if TYPE_CHECKING:
 	from gui.message import DisplayableError  # noqa: F401
 
 
-addonDataManager: Optional["_DataManager"] = None
+addonDataManager: "_DataManager | None" = None
 FETCH_TIMEOUT_S = 120  # seconds
 
 
@@ -226,7 +226,7 @@ class _DataManager:
 
 	def getLatestCompatibleAddons(
 		self,
-		onDisplayableError: Optional["DisplayableError.OnDisplayableErrorT"] = None,
+		onDisplayableError: "DisplayableError.OnDisplayableErrorT | None" = None,
 	) -> "AddonGUICollectionT":
 		cacheHash = self._getCacheHash()
 		shouldRefreshData = (
@@ -263,7 +263,7 @@ class _DataManager:
 
 	def getLatestAddons(
 		self,
-		onDisplayableError: Optional["DisplayableError.OnDisplayableErrorT"] = None,
+		onDisplayableError: "DisplayableError.OnDisplayableErrorT | None" = None,
 	) -> "AddonGUICollectionT":
 		cacheHash = self._getCacheHash()
 		shouldRefreshData = (

--- a/source/addonStore/dataManager.py
+++ b/source/addonStore/dataManager.py
@@ -10,7 +10,6 @@ import pathlib
 import threading
 from typing import (
 	TYPE_CHECKING,
-	Optional,
 	Set,
 	Tuple,
 )

--- a/source/addonStore/dataManager.py
+++ b/source/addonStore/dataManager.py
@@ -121,7 +121,7 @@ class _DataManager:
 		if self._initialiseAvailableAddonsThread.is_alive():
 			log.debugWarning("initialiseAvailableAddons thread did not terminate immediately")
 
-	def _getLatestAddonsDataForVersion(self, apiVersion: str) -> Optional[bytes]:
+	def _getLatestAddonsDataForVersion(self, apiVersion: str) -> bytes | None:
 		url = _getAddonStoreURL(self._preferredChannel, self._lang, apiVersion)
 		try:
 			log.debug(f"Fetching add-on data from {url}")
@@ -152,7 +152,7 @@ class _DataManager:
 		cacheHash = response.json()
 		return cacheHash
 
-	def _cacheCompatibleAddons(self, addonData: str, cacheHash: Optional[str]):
+	def _cacheCompatibleAddons(self, addonData: str, cacheHash: str | None):
 		if not NVDAState.shouldWriteToDisk():
 			return
 		if not addonData or not cacheHash:
@@ -166,7 +166,7 @@ class _DataManager:
 		with open(self._cacheCompatibleFile, "w", encoding="utf-8") as cacheFile:
 			json.dump(cacheData, cacheFile, ensure_ascii=False)
 
-	def _cacheLatestAddons(self, addonData: str, cacheHash: Optional[str]):
+	def _cacheLatestAddons(self, addonData: str, cacheHash: str | None):
 		if not NVDAState.shouldWriteToDisk():
 			return
 		if not addonData or not cacheHash:
@@ -180,7 +180,7 @@ class _DataManager:
 		with open(self._cacheLatestFile, "w", encoding="utf-8") as cacheFile:
 			json.dump(cacheData, cacheFile, ensure_ascii=False)
 
-	def _getCachedAddonData(self, cacheFilePath: str) -> Optional[CachedAddonsModel]:
+	def _getCachedAddonData(self, cacheFilePath: str) -> CachedAddonsModel | None:
 		if not os.path.exists(cacheFilePath):
 			return None
 		try:
@@ -338,7 +338,7 @@ class _DataManager:
 		with open(addonCachePath, "w", encoding="utf-8") as cacheFile:
 			json.dump(addonData.asdict(), cacheFile, ensure_ascii=False)
 
-	def _getCachedInstalledAddonData(self, addonId: str) -> Optional[InstalledAddonStoreModel]:
+	def _getCachedInstalledAddonData(self, addonId: str) -> InstalledAddonStoreModel | None:
 		addonCachePath = os.path.join(self._installedAddonDataCacheDir, f"{addonId}.json")
 		if not os.path.exists(addonCachePath):
 			return None

--- a/source/addonStore/install.py
+++ b/source/addonStore/install.py
@@ -60,7 +60,7 @@ def _getAddonBundleToInstallIfValid(addonPath: str) -> "AddonBundle":
 	return bundle
 
 
-def _getPreviouslyInstalledAddonById(addon: "AddonBundle") -> Optional["AddonHandlerModel"]:
+def _getPreviouslyInstalledAddonById(addon: "AddonBundle") -> "AddonHandlerModel | None":
 	assert addonDataManager
 	installedAddon = addonDataManager._installedAddonsCache.installedAddons.get(addon.name)
 	if installedAddon is None or installedAddon.isPendingRemove:

--- a/source/addonStore/install.py
+++ b/source/addonStore/install.py
@@ -9,7 +9,6 @@ from os import (
 from typing import (
 	TYPE_CHECKING,
 	cast,
-	Optional,
 )
 
 import systemUtils

--- a/source/addonStore/models/addon.py
+++ b/source/addonStore/models/addon.py
@@ -78,7 +78,7 @@ class _AddonGUIModel(SupportsAddonState, SupportsVersionCheck, Protocol):
 		return self.lastTestedVersion
 
 	@property
-	def _addonHandlerModel(self) -> Optional["AddonHandlerModel"]:
+	def _addonHandlerModel(self) -> "AddonHandlerModel | None":
 		"""Returns the Addon model tracked in addonHandler, if it exists."""
 		from ..dataManager import addonDataManager
 

--- a/source/addonStore/models/addon.py
+++ b/source/addonStore/models/addon.py
@@ -13,7 +13,6 @@ from typing import (
 	Dict,
 	Generator,
 	List,
-	Optional,
 	Protocol,
 	Union,
 )

--- a/source/addonStore/models/addon.py
+++ b/source/addonStore/models/addon.py
@@ -58,7 +58,7 @@ class _AddonGUIModel(SupportsAddonState, SupportsVersionCheck, Protocol):
 	description: str
 	addonVersionName: str
 	channel: Channel
-	homepage: Optional[str]
+	homepage: str | None
 	minNVDAVersion: MajorMinorPatch
 	lastTestedVersion: MajorMinorPatch
 	legacy: bool
@@ -114,18 +114,18 @@ class _AddonStoreModel(_AddonGUIModel):
 	description: str
 	addonVersionName: str
 	channel: Channel
-	homepage: Optional[str]
+	homepage: str | None
 	minNVDAVersion: MajorMinorPatch
 	lastTestedVersion: MajorMinorPatch
 	legacy: bool
 	publisher: str
 	license: str
-	licenseURL: Optional[str]
+	licenseURL: str | None
 	sourceURL: str
 	URL: str
 	sha256: str
 	addonVersionNumber: MajorMinorPatch
-	reviewURL: Optional[str]
+	reviewURL: str | None
 	submissionTime: int | None
 
 	@property
@@ -200,7 +200,7 @@ class _AddonManifestModel(_AddonGUIModel):
 	addonId: str
 	addonVersionName: str
 	channel: Channel
-	homepage: Optional[str]
+	homepage: str | None
 	minNVDAVersion: MajorMinorPatch
 	lastTestedVersion: MajorMinorPatch
 	manifest: "AddonManifest"
@@ -216,7 +216,7 @@ class _AddonManifestModel(_AddonGUIModel):
 
 	@property
 	def description(self) -> str:
-		description: Optional[str] = self.manifest.get("description")
+		description: str | None = self.manifest.get("description")
 		if description is None:
 			return ""
 		return description
@@ -239,7 +239,7 @@ class AddonManifestModel(_AddonManifestModel):
 	addonId: str
 	addonVersionName: str
 	channel: Channel
-	homepage: Optional[str]
+	homepage: str | None
 	minNVDAVersion: MajorMinorPatch
 	lastTestedVersion: MajorMinorPatch
 	manifest: "AddonManifest"
@@ -260,16 +260,16 @@ class InstalledAddonStoreModel(_AddonManifestModel, _AddonStoreModel):
 	publisher: str
 	addonVersionName: str
 	channel: Channel
-	homepage: Optional[str]
+	homepage: str | None
 	license: str
-	licenseURL: Optional[str]
+	licenseURL: str | None
 	sourceURL: str
 	URL: str
 	sha256: str
 	addonVersionNumber: MajorMinorPatch
 	minNVDAVersion: MajorMinorPatch
 	lastTestedVersion: MajorMinorPatch
-	reviewURL: Optional[str]
+	reviewURL: str | None
 	submissionTime: int | None
 	legacy: bool = False
 	"""
@@ -297,16 +297,16 @@ class AddonStoreModel(_AddonStoreModel):
 	publisher: str
 	addonVersionName: str
 	channel: Channel
-	homepage: Optional[str]
+	homepage: str | None
 	license: str
-	licenseURL: Optional[str]
+	licenseURL: str | None
 	sourceURL: str
 	URL: str
 	sha256: str
 	addonVersionNumber: MajorMinorPatch
 	minNVDAVersion: MajorMinorPatch
 	lastTestedVersion: MajorMinorPatch
-	reviewURL: Optional[str]
+	reviewURL: str | None
 	submissionTime: int | None
 	legacy: bool = False
 	"""
@@ -318,7 +318,7 @@ class AddonStoreModel(_AddonStoreModel):
 @dataclasses.dataclass
 class CachedAddonsModel:
 	cachedAddonData: "AddonGUICollectionT"
-	cacheHash: Optional[str]
+	cacheHash: str | None
 	cachedLanguage: str
 	# AddonApiVersionT or the string .network._LATEST_API_VER
 	nvdaAPIVersion: Union[addonAPIVersion.AddonApiVersionT, str]
@@ -369,7 +369,7 @@ def _createStoreModelFromData(addon: Dict[str, Any]) -> AddonStoreModel:
 
 
 def _createGUIModelFromManifest(addon: "AddonHandlerBaseModel") -> AddonManifestModel:
-	homepage: Optional[str] = addon.manifest.get("url")
+	homepage: str | None = addon.manifest.get("url")
 	if homepage == "None":
 		# Manifest strings can be set to "None"
 		homepage = None

--- a/source/addonStore/models/status.py
+++ b/source/addonStore/models/status.py
@@ -8,7 +8,6 @@ import os
 from pathlib import Path
 from typing import (
 	Dict,
-	Optional,
 	OrderedDict,
 	Protocol,
 	Set,

--- a/source/addonStore/models/status.py
+++ b/source/addonStore/models/status.py
@@ -217,7 +217,7 @@ class _StatusFilterKey(DisplayStringEnum):
 			raise e
 
 
-def _getDownloadableStatus(model: "_AddonGUIModel") -> Optional[AvailableAddonStatus]:
+def _getDownloadableStatus(model: "_AddonGUIModel") -> AvailableAddonStatus | None:
 	from ..dataManager import addonDataManager
 
 	assert addonDataManager is not None
@@ -330,7 +330,7 @@ def _getUpdateStatus(model: "_AddonGUIModel") -> AvailableAddonStatus | None:
 			raise ValueError(f"Unexpected value: {canUpdateAddon}")
 
 
-def _getInstalledStatus(model: "_AddonGUIModel") -> Optional[AvailableAddonStatus]:
+def _getInstalledStatus(model: "_AddonGUIModel") -> AvailableAddonStatus | None:
 	from addonHandler import state as addonHandlerState
 	from ..dataManager import addonDataManager
 

--- a/source/addonStore/models/version.py
+++ b/source/addonStore/models/version.py
@@ -6,7 +6,6 @@
 
 from typing import (
 	NamedTuple,
-	Optional,
 	Protocol,
 )
 import addonAPIVersion

--- a/source/addonStore/models/version.py
+++ b/source/addonStore/models/version.py
@@ -106,7 +106,7 @@ class SupportsVersionCheck(Protocol):
 		self,
 		backwardsCompatToVersion: addonAPIVersion.AddonApiVersionT = addonAPIVersion.BACK_COMPAT_TO,
 		currentAPIVersion: addonAPIVersion.AddonApiVersionT = addonAPIVersion.CURRENT,
-	) -> Optional[str]:
+	) -> str | None:
 		from addonHandler.addonVersionCheck import hasAddonGotRequiredSupport, isAddonTested
 
 		if not hasAddonGotRequiredSupport(self, currentAPIVersion):

--- a/source/addonStore/network.py
+++ b/source/addonStore/network.py
@@ -15,7 +15,6 @@ from typing import (
 	cast,
 	Callable,
 	Dict,
-	Optional,
 	Tuple,
 )
 

--- a/source/annotation.py
+++ b/source/annotation.py
@@ -14,7 +14,6 @@ from dataclasses import dataclass
 from typing import (
 	TYPE_CHECKING,
 	List,
-	Optional,
 	Tuple,
 )
 

--- a/source/annotation.py
+++ b/source/annotation.py
@@ -30,7 +30,7 @@ __all__ = [
 	"_AnnotationRolesT",
 ]
 
-_AnnotationRolesT = Tuple[Optional["controlTypes.Role"]]
+_AnnotationRolesT = Tuple["controlTypes.Role | None"]
 
 
 class AnnotationTarget:
@@ -40,7 +40,7 @@ class AnnotationTarget:
 	"""
 
 	@property
-	def role(self) -> Optional["controlTypes.Role"]:
+	def role(self) -> "controlTypes.Role | None":
 		raise NotImplementedError
 
 	@property

--- a/source/annotation.py
+++ b/source/annotation.py
@@ -83,7 +83,7 @@ class _AnnotationNavigationNode:
 
 	_TargetIndex = int  # Type for target index
 	origin: "NVDAObject"  # this is the last known location
-	indexOfLastReportedSummary: Optional[_TargetIndex] = None  # this would be the next destination
+	indexOfLastReportedSummary: _TargetIndex | None = None  # this would be the next destination
 
 
 class _AnnotationNavigation:
@@ -92,5 +92,5 @@ class _AnnotationNavigation:
 	For example, reporting a summary of each comment for an object with multiple comment annotation targets.
 	"""
 
-	lastReported: Optional[_AnnotationNavigationNode] = None
+	lastReported: _AnnotationNavigationNode | None = None
 	priorOrigins: List["NVDAObject"] = []

--- a/source/api.py
+++ b/source/api.py
@@ -28,7 +28,7 @@ import watchdog
 import exceptions
 import appModuleHandler
 import cursorManager
-from typing import Any, Optional
+from typing import Any
 from utils.security import objectBelowLockScreenAndWindowsIsLocked
 
 if typing.TYPE_CHECKING:

--- a/source/api.py
+++ b/source/api.py
@@ -395,7 +395,7 @@ def processPendingEvents(processEventQueue=True):
 		queueHandler.flushQueue(queueHandler.eventQueue)
 
 
-def copyToClip(text: str, notify: Optional[bool] = False) -> bool:
+def copyToClip(text: str, notify: bool | None = False) -> bool:
 	"""Copies the given text to the windows clipboard.
 	@returns: True if it succeeds, False otherwise.
 	@param text: the text which will be copied to the clipboard
@@ -434,7 +434,7 @@ def getClipData():
 		return winUser.getClipboardData(winUser.CF_UNICODETEXT) or ""
 
 
-def getStatusBar() -> Optional[NVDAObjects.NVDAObject]:
+def getStatusBar() -> NVDAObjects.NVDAObject | None:
 	"""Obtain the status bar for the current foreground object.
 	@return: The status bar object or C{None} if no status bar was found.
 	"""

--- a/source/appModuleHandler.py
+++ b/source/appModuleHandler.py
@@ -150,7 +150,7 @@ def doesAppModuleExist(name: str) -> bool:
 	return True
 
 
-def _importAppModuleForExecutable(executableName: str) -> Optional[ModuleType]:
+def _importAppModuleForExecutable(executableName: str) -> ModuleType | None:
 	"""Import and return appModule for a given executable or `None` if there is no module."""
 	for possibleModName in _getPossibleAppModuleNamesForExecutable(executableName):
 		# First, check whether the module exists.
@@ -485,7 +485,7 @@ class AppModule(baseObject.ScriptableObject):
 			False,
 			processID,
 		)
-		self.helperLocalBindingHandle: Optional[ctypes.c_long] = None
+		self.helperLocalBindingHandle: ctypes.c_long | None = None
 		"""RPC binding handle pointing to the RPC server for this process"""
 
 		self._inprocRegistrationHandle = None

--- a/source/appModuleHandler.py
+++ b/source/appModuleHandler.py
@@ -20,7 +20,6 @@ from typing import (
 	Any,
 	Dict,
 	List,
-	Optional,
 	Tuple,
 )
 

--- a/source/appModules/foobar2000.py
+++ b/source/appModules/foobar2000.py
@@ -118,7 +118,7 @@ class _StatusBarTimes(NamedTuple):
 
 
 class AppModule(appModuleHandler.AppModule):
-	_statusBar: Optional["NVDAObject"] = None
+	_statusBar: "NVDAObject | None" = None
 
 	def event_gainFocus(self, obj, nextHandler):
 		if not self._statusBar:

--- a/source/appModules/foobar2000.py
+++ b/source/appModules/foobar2000.py
@@ -36,7 +36,7 @@ _timeOutputToParsingFormats: Dict[TimeOutputFormat, str] = {
 }
 
 
-def _getTimeOutputFormat(timeStr: str) -> Optional[TimeOutputFormat]:
+def _getTimeOutputFormat(timeStr: str) -> TimeOutputFormat | None:
 	"""
 	Attempts to find a suitable output format for a
 	D HH:MM:SS, HH:MM:SS, MM:SS or SS -style interval.
@@ -69,7 +69,7 @@ def _getTimeOutputFormat(timeStr: str) -> Optional[TimeOutputFormat]:
 		return None
 
 
-def _parseTimeStrToTimeDelta(timeStr: str) -> Optional[timedelta]:
+def _parseTimeStrToTimeDelta(timeStr: str) -> timedelta | None:
 	"""
 	Attempts to convert a time string to a timedelta for a
 	D HH:MM:SS, HH:MM:SS, MM:SS or SS -style interval.
@@ -101,7 +101,7 @@ def _parseTimeStrToTimeDelta(timeStr: str) -> Optional[timedelta]:
 	)
 
 
-def _parseTimeStrToOutputFormatted(timeStr: str) -> Optional[str]:
+def _parseTimeStrToOutputFormatted(timeStr: str) -> str | None:
 	td = _parseTimeStrToTimeDelta(timeStr)
 	if td is None:
 		return td
@@ -113,8 +113,8 @@ class _StatusBarTimes(NamedTuple):
 	A named tuple for holding the elapsed and total playing times from Foobar2000's status bar
 	"""
 
-	elapsed: Optional[str]
-	total: Optional[str]
+	elapsed: str | None
+	total: str | None
 
 
 class AppModule(appModuleHandler.AppModule):

--- a/source/appModules/foobar2000.py
+++ b/source/appModules/foobar2000.py
@@ -9,7 +9,6 @@ import re
 from typing import (
 	Dict,
 	NamedTuple,
-	Optional,
 	TYPE_CHECKING,
 )
 

--- a/source/appModules/kindle.py
+++ b/source/appModules/kindle.py
@@ -3,7 +3,6 @@
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 from typing import (
-	Optional,
 	Dict,
 )
 

--- a/source/appModules/kindle.py
+++ b/source/appModules/kindle.py
@@ -286,7 +286,7 @@ class BookPageViewTextInfo(MozillaCompoundTextInfo):
 			text += ", " + _("Page {pageNumber}").format(pageNumber=pageNumber)
 		return text
 
-	def getTextWithFields(self, formatConfig: Optional[Dict] = None) -> textInfos.TextInfo.TextWithFieldsT:
+	def getTextWithFields(self, formatConfig: Dict | None = None) -> textInfos.TextInfo.TextWithFieldsT:
 		if not formatConfig:
 			formatConfig = config.conf["documentFormatting"]
 		items = super(BookPageViewTextInfo, self).getTextWithFields(formatConfig=formatConfig)
@@ -306,10 +306,10 @@ class BookPageViewTextInfo(MozillaCompoundTextInfo):
 	def getFormatFieldSpeech(
 		self,
 		attrs: textInfos.Field,
-		attrsCache: Optional[textInfos.Field] = None,
-		formatConfig: Optional[Dict[str, bool]] = None,
-		reason: Optional[OutputReason] = None,
-		unit: Optional[str] = None,
+		attrsCache: textInfos.Field | None = None,
+		formatConfig: Dict[str, bool] | None = None,
+		reason: OutputReason | None = None,
+		unit: str | None = None,
 		extraDetail: bool = False,
 		initialFormat: bool = False,
 	) -> SpeechSequence:

--- a/source/appModules/powerpnt.py
+++ b/source/appModules/powerpnt.py
@@ -1370,7 +1370,7 @@ class SlideShowTreeInterceptorTextInfo(NVDAObjectTextInfo):
 			return (0, self._getStoryLength())
 		raise LookupError
 
-	def getTextWithFields(self, formatConfig: Optional[Dict] = None) -> textInfos.TextInfo.TextWithFieldsT:
+	def getTextWithFields(self, formatConfig: Dict | None = None) -> textInfos.TextInfo.TextWithFieldsT:
 		fields = self.obj.rootNVDAObject.basicTextFields
 		text = self.obj.rootNVDAObject.basicText
 		out = []

--- a/source/appModules/powerpnt.py
+++ b/source/appModules/powerpnt.py
@@ -5,7 +5,6 @@
 
 from typing import (
 	Any,
-	Optional,
 	Dict,
 )
 

--- a/source/appModules/soffice.py
+++ b/source/appModules/soffice.py
@@ -4,7 +4,6 @@
 # Copyright (C) 2006-2025 NV Access Limited, Bill Dengler, Leonard de Ruijter, Cyrille Bougot
 
 from typing import (
-	Optional,
 	Union,
 )
 

--- a/source/appModules/soffice.py
+++ b/source/appModules/soffice.py
@@ -144,7 +144,7 @@ class SymphonyTextInfo(IA2TextTextInfo):
 	def _getFormatFieldAndOffsetsFromAttributes(
 		self,
 		offset: int,
-		formatConfig: Optional[dict],
+		formatConfig: dict | None,
 		calculateOffsets: bool,
 	) -> tuple[textInfos.FormatField, tuple[int, int]]:
 		"""Get format field and offset information from either
@@ -190,7 +190,7 @@ class SymphonyTextInfo(IA2TextTextInfo):
 	def _getFormatFieldAndOffsets(
 		self,
 		offset: int,
-		formatConfig: Optional[dict],
+		formatConfig: dict | None,
 		calculateOffsets: bool = True,
 	) -> tuple[textInfos.FormatField, tuple[int, int]]:
 		formatField, (startOffset, endOffset) = self._getFormatFieldAndOffsetsFromAttributes(
@@ -621,7 +621,7 @@ class AppModule(appModuleHandler.AppModule):
 			obj.description = None
 			obj.treeInterceptorClass = SymphonyDocument
 
-	def searchStatusBar(self, obj: NVDAObject, max_depth: int = 5) -> Optional[NVDAObject]:
+	def searchStatusBar(self, obj: NVDAObject, max_depth: int = 5) -> NVDAObject | None:
 		"""Searches for and returns the status bar object
 		if either the object itself or one of its recursive children
 		(up to the given depth) has the corresponding role."""
@@ -641,7 +641,7 @@ class AppModule(appModuleHandler.AppModule):
 				return status_bar
 		return None
 
-	def _get_statusBar(self) -> Optional[NVDAObject]:
+	def _get_statusBar(self) -> NVDAObject | None:
 		return self.searchStatusBar(api.getForegroundObject())
 
 	def getStatusBarText(self, obj: NVDAObject) -> str:

--- a/source/appModules/tween.py
+++ b/source/appModules/tween.py
@@ -5,7 +5,6 @@
 
 """App module for Tween"""
 
-from typing import Optional
 import appModuleHandler
 import controlTypes
 from NVDAObjects.window import Window

--- a/source/appModules/tween.py
+++ b/source/appModules/tween.py
@@ -26,7 +26,7 @@ class TweetListItem(ListItem):
 		finally:
 			self._isGettingName = False
 
-	def _getColumnHeaderRaw(self, index: int) -> Optional[str]:
+	def _getColumnHeaderRaw(self, index: int) -> str | None:
 		if self._isGettingName and index in (1, 2):
 			# If this is for use in the name property,
 			# don't include the headers for the Name and Post columns.
@@ -36,7 +36,7 @@ class TweetListItem(ListItem):
 			res = res.replace("▾", "")
 		return res
 
-	def _getColumnContentRaw(self, index: int) -> Optional[str]:
+	def _getColumnContentRaw(self, index: int) -> str | None:
 		if controlTypes.State.INVISIBLE not in self.states and index == 3:
 			# This is the date column.
 			# Its content is overridden on screen,

--- a/source/autoSettingsUtils/driverSetting.py
+++ b/source/autoSettingsUtils/driverSetting.py
@@ -9,7 +9,6 @@
 Naming of these classes is historical, kept for backwards compatibility purposes.
 """
 
-from typing import Optional
 from baseObject import AutoPropertyObject
 
 

--- a/source/autoSettingsUtils/driverSetting.py
+++ b/source/autoSettingsUtils/driverSetting.py
@@ -44,7 +44,7 @@ class DriverSetting(AutoPropertyObject):
 		displayNameWithAccelerator: str,
 		availableInSettingsRing: bool = False,
 		defaultVal: object = None,
-		displayName: Optional[str] = None,
+		displayName: str | None = None,
 		useConfig: bool = True,
 	):
 		"""
@@ -94,7 +94,7 @@ class NumericDriverSetting(DriverSetting):
 		minStep: int = 1,
 		normalStep: int = 5,
 		largeStep: int = 10,
-		displayName: Optional[str] = None,
+		displayName: str | None = None,
 		useConfig: bool = True,
 	):
 		"""
@@ -136,7 +136,7 @@ class BooleanDriverSetting(DriverSetting):
 		id: str,
 		displayNameWithAccelerator: str,
 		availableInSettingsRing: bool = False,
-		displayName: Optional[str] = None,
+		displayName: str | None = None,
 		defaultVal: bool = False,
 		useConfig: bool = True,
 	):

--- a/source/baseObject.py
+++ b/source/baseObject.py
@@ -155,7 +155,7 @@ class AutoPropertyObject(garbageHandler.TrackedObject, metaclass=AutoPropertyTyp
 		self.__instances[self] = None
 		return self
 
-	def _getPropertyViaCache(self, getterMethod: Optional[GetterMethodT] = None) -> GetterReturnT:
+	def _getPropertyViaCache(self, getterMethod: GetterMethodT | None = None) -> GetterReturnT:
 		if not getterMethod:
 			raise ValueError("getterMethod is None")
 		missing = False

--- a/source/baseObject.py
+++ b/source/baseObject.py
@@ -8,7 +8,6 @@
 from typing import (
 	Any,
 	Callable,
-	Optional,
 	Set,
 	Union,
 )

--- a/source/bdDetect.py
+++ b/source/bdDetect.py
@@ -189,7 +189,7 @@ def _isDebug():
 
 
 def getDriversForConnectedUsbDevices(
-	limitToDevices: Optional[List[str]] = None,
+	limitToDevices: List[str] | None = None,
 ) -> Iterator[Tuple[str, DeviceMatch]]:
 	"""Get any matching drivers for connected USB devices.
 	Looks for (and yields) custom drivers first, then considers if the device is may be compatible with the
@@ -271,7 +271,7 @@ def HIDUsagePageMatchFuncFactory(usagePage: int) -> MatchFuncT:
 
 
 def getDriversForPossibleBluetoothDevices(
-	limitToDevices: Optional[List[str]] = None,
+	limitToDevices: List[str] | None = None,
 ) -> Iterator[Tuple[str, DeviceMatch]]:
 	"""Get any matching drivers for possible Bluetooth devices.
 	Looks for (and yields) custom drivers first, then considers if the device is may be compatible with the
@@ -380,7 +380,7 @@ class _DeviceInfoFetcher(AutoPropertyObject):
 		return list(hwPortUtils.listHidDevices(onlyAvailable=True))
 
 
-deviceInfoFetcher: Optional[_DeviceInfoFetcher] = None
+deviceInfoFetcher: _DeviceInfoFetcher | None = None
 
 
 class _Detector:
@@ -393,19 +393,19 @@ class _Detector:
 		After construction, a scan should be queued with L{queueBgScan}.
 		"""
 		self._executor = ThreadPoolExecutor(1)
-		self._queuedFuture: Optional[Future] = None
+		self._queuedFuture: Future | None = None
 		messageWindow.pre_handleWindowMessage.register(self.handleWindowMessage)
 		appModuleHandler.post_appSwitch.register(self.pollBluetoothDevices)
 		self._stopEvent = threading.Event()
 		self._detectUsb = True
 		self._detectBluetooth = True
-		self._limitToDevices: Optional[List[str]] = None
+		self._limitToDevices: List[str] | None = None
 
 	def _queueBgScan(
 		self,
 		usb: bool = False,
 		bluetooth: bool = False,
-		limitToDevices: Optional[List[str]] = None,
+		limitToDevices: List[str] | None = None,
 	):
 		"""Queues a scan for devices.
 		If a scan is already in progress, a new scan will be queued after the current scan.
@@ -438,7 +438,7 @@ class _Detector:
 	@staticmethod
 	def _bgScanUsb(
 		usb: bool = True,
-		limitToDevices: Optional[List[str]] = None,
+		limitToDevices: List[str] | None = None,
 	):
 		"""Handler for L{scanForDevices} that yields USB devices.
 		See the L{scanForDevices} documentation for information about the parameters.
@@ -451,14 +451,14 @@ class _Detector:
 	@staticmethod
 	def _bgScanBluetooth(
 		bluetooth: bool = True,
-		limitToDevices: Optional[List[str]] = None,
+		limitToDevices: List[str] | None = None,
 	):
 		"""Handler for L{scanForDevices} that yields Bluetooth devices and keeps an internal cache of devices.
 		See the L{scanForDevices} documentation for information about the parameters.
 		"""
 		if not bluetooth:
 			return
-		btDevs: Optional[Iterable[Tuple[str, DeviceMatch]]] = deviceInfoFetcher.btDevsCache
+		btDevs: Iterable[Tuple[str, DeviceMatch]] | None = deviceInfoFetcher.btDevsCache
 		if btDevs is None:
 			btDevs = getDriversForPossibleBluetoothDevices(limitToDevices)
 			# Cache Bluetooth devices for next time.
@@ -476,7 +476,7 @@ class _Detector:
 		self,
 		usb: bool,
 		bluetooth: bool,
-		limitToDevices: Optional[List[str]],
+		limitToDevices: List[str] | None,
 	):
 		"""Performs the actual background scan.
 		this function should be run on a background thread.
@@ -505,7 +505,7 @@ class _Detector:
 		self,
 		usb: bool = True,
 		bluetooth: bool = True,
-		limitToDevices: Optional[List[str]] = None,
+		limitToDevices: List[str] | None = None,
 	):
 		"""Stop a current scan when in progress, and start scanning from scratch.
 		@param usb: Whether USB devices should be detected for this and subsequent scans.

--- a/source/bdDetect.py
+++ b/source/bdDetect.py
@@ -27,7 +27,6 @@ from typing import (
 	Iterator,
 	List,
 	NamedTuple,
-	Optional,
 	OrderedDict,
 	Tuple,
 	Type,

--- a/source/bdDetect.py
+++ b/source/bdDetect.py
@@ -318,7 +318,7 @@ def getDriversForPossibleBluetoothDevices(
 			yield (hidName, match)
 
 
-btDevsCacheT = Optional[List[Tuple[str, DeviceMatch]]]
+btDevsCacheT = List[Tuple[str, DeviceMatch]] | None
 
 
 class _DeviceInfoFetcher(AutoPropertyObject):

--- a/source/braille.py
+++ b/source/braille.py
@@ -16,7 +16,6 @@ from typing import (
 	Iterable,
 	List,
 	NamedTuple,
-	Optional,
 	Set,
 	Tuple,
 	Union,

--- a/source/braille.py
+++ b/source/braille.py
@@ -2692,7 +2692,7 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 
 	def _switchDisplay(
 		self,
-		oldDisplay: Optional["BrailleDisplayDriver"],
+		oldDisplay: "BrailleDisplayDriver | None",
 		newDisplayClass: Type["BrailleDisplayDriver"],
 		**kwargs,
 	) -> "BrailleDisplayDriver":

--- a/source/braille.py
+++ b/source/braille.py
@@ -539,7 +539,7 @@ class Region(object):
 		#: @type: [int, ...]
 		self.brailleToRawPos = []
 		#: The position of the cursor in L{brailleCells}, C{None} if the cursor is not in this region.
-		self.brailleCursorPos: Optional[int] = None
+		self.brailleCursorPos: int | None = None
 		#: The position of the selection start in L{brailleCells}, C{None} if there is no selection in this region.
 		#: @type: int
 		self.brailleSelectionStart = None
@@ -680,7 +680,7 @@ def getPropertiesBraille(**propertyValues) -> str:  # noqa: C901
 	name = propertyValues.get("name")
 	if name:
 		textList.append(name)
-	role: Optional[Union[controlTypes.Role, int]] = propertyValues.get("role")
+	role: Union[controlTypes.Role, int] | None = propertyValues.get("role")
 	roleText = propertyValues.get("roleText")
 	states = propertyValues.get("states")
 	positionInfo = propertyValues.get("positionInfo")
@@ -903,7 +903,7 @@ def getControlFieldBraille(
 	ancestors: typing.List[textInfos.Field],
 	reportStart: bool,
 	formatConfig: config.AggregatedSection,
-) -> Optional[str]:
+) -> str | None:
 	presCat = field.getPresentationCategory(ancestors, formatConfig)
 	# Cache this for later use.
 	field._presCat = presCat
@@ -1010,13 +1010,13 @@ def getControlFieldBraille(
 
 
 def _getControlFieldForLayoutPresentation(
-	description: Optional[str],
+	description: str | None,
 	current: controlTypes.IsCurrent,
 	hasDetails: bool,
 	detailsRoles: _AnnotationRolesT,
 	role: controlTypes.Role,
-	content: Optional[str],
-) -> Optional[str]:
+	content: str | None,
+) -> str | None:
 	text = []
 	if description:
 		text.append(getPropertiesBraille(description=description))
@@ -1033,7 +1033,7 @@ def _getControlFieldForLayoutPresentation(
 
 
 def _getControlFieldForTableCell(
-	description: Optional[str],
+	description: str | None,
 	current: controlTypes.IsCurrent,
 	hasDetails: bool,
 	detailsRoles: _AnnotationRolesT,
@@ -1061,18 +1061,18 @@ def _getControlFieldForTableCell(
 
 
 def _getControlFieldForReportStart(
-	description: Optional[str],
+	description: str | None,
 	current: controlTypes.IsCurrent,
 	hasDetails: bool,
 	detailsRoles: _AnnotationRolesT,
 	field: textInfos.Field,
 	role: controlTypes.Role,
 	states: Set[controlTypes.State],
-	content: Optional[str],
+	content: str | None,
 	info: textInfos.TextInfo,
-	value: Optional[str],
+	value: str | None,
 	roleText: str,
-	placeholder: Optional[str],
+	placeholder: str | None,
 	errorMessage: str | None,
 ) -> str:
 	props = {
@@ -2147,7 +2147,7 @@ def invalidateCachedFocusAncestors(index):
 
 def getFocusContextRegions(
 	obj: "NVDAObject",
-	oldFocusRegions: Optional[List[Region]] = None,
+	oldFocusRegions: List[Region] | None = None,
 ) -> Generator[Region, None, None]:
 	if objectBelowLockScreenAndWindowsIsLocked(obj):
 		return
@@ -2369,7 +2369,7 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 	TETHER_REVIEW = TetherTo.REVIEW.value
 	tetherValues = [(v.value, v.displayString) for v in TetherTo]
 
-	queuedWrite: Optional[List[int]] = None
+	queuedWrite: List[int] | None = None
 	queuedWriteLock: threading.Lock
 	ackTimerHandle: int
 	_regionsPendingUpdate: Set[Union[NVDAObjectRegion, TextInfoRegion]]
@@ -2381,7 +2381,7 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 	def __init__(self):
 		louisHelper.initialize()
 		self._table: brailleTables.BrailleTable = brailleTables.getTable(FALLBACK_TABLE)
-		self.display: Optional[BrailleDisplayDriver] = None
+		self.display: BrailleDisplayDriver | None = None
 		self._displayDimensions: DisplayDimensions = DisplayDimensions(1, 0)
 		"""
 		Internal cache for the displayDimensions property.
@@ -2649,7 +2649,7 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 		self,
 		name: str,
 		isFallback: bool = False,
-		detected: typing.Optional[bdDetect.DeviceMatch] = None,
+		detected: bdDetect.DeviceMatch | None = None,
 	) -> bool:
 		if name == AUTO_DISPLAY_NAME:
 			# Calling _enableDetection will set the display to noBraille until a display is detected.
@@ -2719,7 +2719,7 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 		self,
 		newDisplayClass: Type["BrailleDisplayDriver"],
 		isFallback: bool = False,
-		detected: typing.Optional[bdDetect.DeviceMatch] = None,
+		detected: bdDetect.DeviceMatch | None = None,
 	):
 		kwargs = {}
 		if detected:
@@ -2823,7 +2823,7 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 				self.handleDisplayUnavailable()
 			return
 		with self.queuedWriteLock:
-			alreadyQueued: Optional[List[int]] = self.queuedWrite
+			alreadyQueued: List[int] | None = self.queuedWrite
 			self.queuedWrite = cells
 		# If a write was already queued, we don't need to queue another;
 		# we just replace the data.
@@ -3013,7 +3013,7 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 		if not self._regionsPendingUpdate:
 			return
 		try:
-			scrollTo: Optional[TextInfoRegion] = None
+			scrollTo: TextInfoRegion | None = None
 			self.mainBuffer.saveWindow()
 			for region in self._regionsPendingUpdate:
 				from treeInterceptorHandler import TreeInterceptor
@@ -3206,7 +3206,7 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 		self,
 		usb: bool = True,
 		bluetooth: bool = True,
-		limitToDevices: Optional[List[str]] = None,
+		limitToDevices: List[str] | None = None,
 	):
 		"""Enables automatic detection of braille displays.
 		When auto detection is already active, this will force a rescan for devices.
@@ -3244,7 +3244,7 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 			# Do not write cells when we are awaiting an ACK
 			return
 		with self.queuedWriteLock:
-			data: Optional[List[int]] = self.queuedWrite
+			data: List[int] | None = self.queuedWrite
 			self.queuedWrite = None
 		if not data:
 			return
@@ -3282,7 +3282,7 @@ RENAMED_DRIVERS = {
 	"hid": "hidBrailleStandard",
 }
 
-handler: Optional[BrailleHandler] = None
+handler: BrailleHandler | None = None
 
 
 def initialize():
@@ -3566,7 +3566,7 @@ class BrailleDisplayDriver(driverHandler.Driver):
 					yield match
 
 	#: Global input gesture map for this display driver.
-	gestureMap: Optional[inputCore.GlobalGestureMap] = None
+	gestureMap: inputCore.GlobalGestureMap | None = None
 
 	@classmethod
 	def _getModifierGestures(cls, model=None):
@@ -3782,7 +3782,7 @@ class BrailleDisplayGesture(inputCore.InputGesture):
 		"""
 		return self.id.split("+")
 
-	def _get_speechEffectWhenExecuted(self) -> Optional[str]:
+	def _get_speechEffectWhenExecuted(self) -> str | None:
 		from globalCommands import commands
 
 		if not config.conf["braille"]["interruptSpeechWhileScrolling"] and self.script in {
@@ -3855,7 +3855,7 @@ def getSerialPorts(filterFunc=None) -> typing.Iterator[typing.Tuple[str, str]]:
 
 
 def getDisplayDrivers(
-	filterFunc: Optional[Callable[[Type[BrailleDisplayDriver]], bool]] = None,
+	filterFunc: Callable[[Type[BrailleDisplayDriver]], bool] | None = None,
 ) -> Generator[Type[BrailleDisplayDriver], Any, Any]:
 	"""Gets an iterator of braille display drivers meeting the given filter callable.
 	@param filterFunc: an optional callable that receives a driver as its only argument and returns

--- a/source/brailleDisplayDrivers/albatross/driver.py
+++ b/source/brailleDisplayDrivers/albatross/driver.py
@@ -27,7 +27,6 @@ from threading import (
 )
 from typing import (
 	List,
-	Optional,
 )
 
 import braille

--- a/source/brailleDisplayDrivers/albatross/driver.py
+++ b/source/brailleDisplayDrivers/albatross/driver.py
@@ -430,7 +430,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 			return
 		self._handleReadQueue()
 
-	def _somethingToRead(self) -> Optional[bytes]:
+	def _somethingToRead(self) -> bytes | None:
 		"""All but connecting/reconnecting related read operations.
 		@return: on success returns data, on failure C{None}
 		"""

--- a/source/brailleDisplayDrivers/albatross/gestures.py
+++ b/source/brailleDisplayDrivers/albatross/gestures.py
@@ -110,7 +110,7 @@ class InputGestureKeys(braille.BrailleDisplayGesture):
 		if self.id and not self.script:
 			self.script = self._get_script()
 
-	def _getRoutingIndex(self, key: int) -> Optional[Tuple[str, int]]:
+	def _getRoutingIndex(self, key: int) -> Tuple[str, int] | None:
 		"""Get the routing index, if the key is in a routing index range,
 		returns the name of the range and the index within that range.
 		See L{ROUTING_KEY_RANGES}.

--- a/source/brailleDisplayDrivers/albatross/gestures.py
+++ b/source/brailleDisplayDrivers/albatross/gestures.py
@@ -7,7 +7,6 @@
 
 from logHandler import log
 from typing import (
-	Optional,
 	Set,
 	Tuple,
 )

--- a/source/brailleDisplayDrivers/baum.py
+++ b/source/brailleDisplayDrivers/baum.py
@@ -159,7 +159,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 	def __init__(self, port="auto"):
 		super(BrailleDisplayDriver, self).__init__()
 		self.numCells = 0
-		self._deviceID: Optional[str] = None
+		self._deviceID: str | None = None
 
 		for portType, portId, port, portInfo in self._getTryPorts(port):
 			# At this point, a port bound to this display has been found.

--- a/source/brailleDisplayDrivers/baum.py
+++ b/source/brailleDisplayDrivers/baum.py
@@ -6,7 +6,7 @@
 # Copyright (C) 2010-2017 NV Access Limited, Babbage B.V.
 
 from io import BytesIO
-from typing import Union, List, Optional
+from typing import Union, List
 
 import braille
 from hwIo import intToByte, boolToByte

--- a/source/brailleDisplayDrivers/brailleNote.py
+++ b/source/brailleDisplayDrivers/brailleNote.py
@@ -9,7 +9,7 @@ QWERTY keyboard input using basic terminal mode (no PC keyboard emulation) and s
 See Brailliant B module for BrailleNote Touch support routines.
 """
 
-from typing import List, Optional
+from typing import List
 
 import serial
 import bdDetect

--- a/source/brailleDisplayDrivers/brailleNote.py
+++ b/source/brailleDisplayDrivers/brailleNote.py
@@ -218,7 +218,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 		self,
 		command: int,
 		arg: int,
-		arg2: Optional[str] = None,
+		arg2: str | None = None,
 	):
 		space = False
 		if command == THUMB_KEYS_TAG:
@@ -313,13 +313,13 @@ class InputGesture(braille.BrailleDisplayGesture, brailleInput.BrailleInputGestu
 
 	def __init__(
 		self,
-		keys: Optional[int] = None,
-		dots: Optional[int] = None,
+		keys: int | None = None,
+		dots: int | None = None,
 		space: bool = False,
-		routing: Optional[int] = None,
-		wheel: Optional[int] = None,
-		qtMod: Optional[int] = None,
-		qtData: Optional[str] = None,
+		routing: int | None = None,
+		wheel: int | None = None,
+		qtMod: int | None = None,
+		qtData: str | None = None,
 	):
 		super(braille.BrailleDisplayGesture, self).__init__()
 		# Denotes if we're dealing with a QT model.

--- a/source/brailleDisplayDrivers/freedomScientific.py
+++ b/source/brailleDisplayDrivers/freedomScientific.py
@@ -229,9 +229,9 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver, ScriptableObject):
 		self._keyBits = 0
 		self._extendedKeyBits = 0
 		self._ignoreKeyReleases = False
-		self._model: Optional[str] = None
-		self._manufacturer: Optional[str] = None
-		self._firmwareVersion: Optional[str] = None
+		self._model: str | None = None
+		self._manufacturer: str | None = None
+		self._firmwareVersion: str | None = None
 		self.translationTable = None
 		self.leftWizWheelActionCycle = itertools.cycle(self.wizWheelActions)
 		action = next(self.leftWizWheelActionCycle)

--- a/source/brailleDisplayDrivers/freedomScientific.py
+++ b/source/brailleDisplayDrivers/freedomScientific.py
@@ -10,7 +10,7 @@ A c(lang) reference implementation is available in brltty.
 
 from io import BytesIO
 import itertools
-from typing import List, Optional
+from typing import List
 
 import braille
 import inputCore

--- a/source/brailleDisplayDrivers/handyTech.py
+++ b/source/brailleDisplayDrivers/handyTech.py
@@ -753,7 +753,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver, ScriptableObject):
 	def getManualPorts(cls):
 		return braille.getSerialPorts()
 
-	_dev: Optional[Union[hwIo.Hid, hwIo.Serial]]
+	_dev: Union[hwIo.Hid, hwIo.Serial] | None
 
 	def __new__(cls, *args, **kwargs):
 		obj = super().__new__(cls, *args, **kwargs)

--- a/source/brailleDisplayDrivers/handyTech.py
+++ b/source/brailleDisplayDrivers/handyTech.py
@@ -12,7 +12,6 @@ from collections import OrderedDict
 from typing import (
 	Dict,
 	List,
-	Optional,
 	Union,
 )
 

--- a/source/brailleDisplayDrivers/lilli.py
+++ b/source/brailleDisplayDrivers/lilli.py
@@ -139,7 +139,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 
 	def _handleKeyPresses(self):
 		while True:
-			key: Optional[int] = None
+			key: int | None = None
 			try:
 				# Python 3: review required
 				# The code seems to assume this returns an int.

--- a/source/brailleDisplayDrivers/lilli.py
+++ b/source/brailleDisplayDrivers/lilli.py
@@ -3,7 +3,7 @@
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 # Copyright (C) 2008-2017 NV Access Limited, Gianluca Casalino, Alberto Benassati, Babbage B.V.
-from typing import Optional, List
+from typing import List
 
 import os
 import globalVars

--- a/source/brailleDisplayDrivers/papenmeier.py
+++ b/source/brailleDisplayDrivers/papenmeier.py
@@ -7,7 +7,7 @@
 # minor changes by Halim Sahin (nvda@lists.thm.de), Ali-Riza Ciftcioglu <aliminator83@googlemail.com>, James Teh and Davy Kager
 
 import time
-from typing import List, Union, Optional
+from typing import List, Union
 
 import wx
 import braille

--- a/source/brailleDisplayDrivers/papenmeier.py
+++ b/source/brailleDisplayDrivers/papenmeier.py
@@ -621,7 +621,7 @@ class InputGesture(braille.BrailleDisplayGesture, brailleInput.BrailleInputGestu
 
 	source = BrailleDisplayDriver.name
 
-	def __init__(self, keys: Optional[Union[bytes, int]], driver: BrailleDisplayDriver):
+	def __init__(self, keys: Union[bytes, int] | None, driver: BrailleDisplayDriver):
 		"""create an input gesture and decode keys"""
 		super(InputGesture, self).__init__()
 		self.id = ""

--- a/source/brailleDisplayDrivers/papenmeier_serial.py
+++ b/source/brailleDisplayDrivers/papenmeier_serial.py
@@ -9,7 +9,7 @@
 
 from collections import OrderedDict
 import time
-from typing import List, Optional
+from typing import List
 
 import wx
 import braille

--- a/source/brailleDisplayDrivers/papenmeier_serial.py
+++ b/source/brailleDisplayDrivers/papenmeier_serial.py
@@ -294,9 +294,9 @@ class InputGesture(braille.BrailleDisplayGesture):
 
 	def __init__(
 		self,
-		keyindex: Optional[int],
-		pressed: Optional[int],
-		keys: Optional[int],
+		keyindex: int | None,
+		pressed: int | None,
+		keys: int | None,
 		driver: BrailleDisplayDriver,
 	):
 		super(InputGesture, self).__init__()

--- a/source/brailleDisplayDrivers/seikantk.py
+++ b/source/brailleDisplayDrivers/seikantk.py
@@ -11,7 +11,7 @@ see www.seika-braille.com for more details
 import re
 from io import BytesIO
 import typing
-from typing import Dict, List, Optional, Set
+from typing import Dict, List, Set
 
 import serial
 

--- a/source/brailleDisplayDrivers/seikantk.py
+++ b/source/brailleDisplayDrivers/seikantk.py
@@ -127,12 +127,12 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 		self.numRoutingKeys = 0
 		self.handle = None
 		self._hidBuffer = b""
-		self._command: typing.Optional[bytes] = None
-		self._argsLen: typing.Optional[int] = None
-		self._dev: Optional[hwIo.IoBase] = None
+		self._command: bytes | None = None
+		self._argsLen: int | None = None
+		self._dev: hwIo.IoBase | None = None
 
 		log.debug(f"Seika Notetaker braille driver: ({port!r})")
-		dev: typing.Optional[typing.Union[hwIo.Hid, hwIo.Serial]] = None
+		dev: typing.Union[hwIo.Hid, hwIo.Serial] | None = None
 		for match in self._getTryPorts(port):
 			self.isHid = match.type == bdDetect.ProtocolType.HID
 			self.isSerial = match.type == bdDetect.ProtocolType.SERIAL

--- a/source/brailleInput.py
+++ b/source/brailleInput.py
@@ -4,7 +4,7 @@
 # Copyright (C) 2012-2024 NV Access Limited, Rui Batista, Babbage B.V., Julien Cochuyt, Leonard de Ruijter
 
 import time
-from typing import Optional, List, Set
+from typing import List, Set
 
 import louis
 import brailleTables

--- a/source/brailleInput.py
+++ b/source/brailleInput.py
@@ -51,7 +51,7 @@ class BrailleInputHandler(AutoPropertyObject):
 	untranslatedBraille: str
 	untranslatedStart: int
 	untranslatedCursorPos: int
-	_uncontSentTime: Optional[float]
+	_uncontSentTime: float | None
 	currentModifiers: Set[str]
 
 	def __init__(self):
@@ -471,7 +471,7 @@ class BrailleInputHandler(AutoPropertyObject):
 
 
 #: The singleton BrailleInputHandler instance.
-handler: Optional[BrailleInputHandler] = None
+handler: BrailleInputHandler | None = None
 
 
 def initialize():

--- a/source/brailleViewer/brailleViewerGui.py
+++ b/source/brailleViewer/brailleViewerGui.py
@@ -31,7 +31,7 @@ def _linearInterpolate(value, start, end):
 	return tuple(map(lambda i, j: i + value * j, start, difference))
 
 
-def _getCharIndexUnderMouse(ctrl: wx.TextCtrl) -> Optional[int]:
+def _getCharIndexUnderMouse(ctrl: wx.TextCtrl) -> int | None:
 	"""Get the index of the character under the mouse.
 	@note: Assumes all characters are on one line
 	"""
@@ -133,7 +133,7 @@ class TextCellHover:
 		self._normalBGColor = textCtrl.GetBackgroundColour()
 		self._charIndex = None
 		self._doneRouteCall = False
-		self._cellAnimation: Optional[CharCellBackgroundColorAnimation] = None
+		self._cellAnimation: CharCellBackgroundColorAnimation | None = None
 		self._setStage(self.Stage.NOT_STARTED)
 
 	def isInProgress(self) -> bool:
@@ -148,7 +148,7 @@ class TextCellHover:
 		self._stageStartTime = time.time()
 
 	def cancelPendingHover(self):
-		self._charIndex: Optional[int] = None  # cancels a pending hover action
+		self._charIndex: int | None = None  # cancels a pending hover action
 		self._setStage(self.Stage.CANCELLED)
 
 	def startPendingHover(self, index):
@@ -272,9 +272,9 @@ class BrailleViewerFrame(
 			log.debug("Setting brailleViewer window position")
 			brailleViewSection = config.conf["brailleViewer"]
 			dialogPos = wx.Point(x=brailleViewSection["x"], y=brailleViewSection["y"])
-		self._newBraille: Optional[str] = None
-		self._newRawText: Optional[str] = None
-		self._newCellCount: Optional[int] = None
+		self._newBraille: str | None = None
+		self._newRawText: str | None = None
+		self._newCellCount: int | None = None
 
 		super().__init__(
 			gui.mainFrame,

--- a/source/brailleViewer/brailleViewerGui.py
+++ b/source/brailleViewer/brailleViewerGui.py
@@ -7,7 +7,6 @@ import time
 from typing import (
 	Callable,
 	List,
-	Optional,
 )
 
 import wx

--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -247,7 +247,7 @@ class TextInfoQuickNavItem(QuickNavItem):
 		caret = self.document.makeTextInfo(textInfos.POSITION_CARET)
 		return self.textInfo.compareEndPoints(caret, "startToStart") > 0
 
-	def _getLabelForProperties(self, labelPropertyGetter: Callable[[str], Optional[Any]]):
+	def _getLabelForProperties(self, labelPropertyGetter: Callable[[str], Any | None]):
 		"""
 		Fetches required properties for this L{TextInfoQuickNavItem} and constructs a label to be shown in an elements list.
 		This can be used by subclasses to implement the L{label} property.
@@ -368,7 +368,7 @@ class BrowseModeTreeInterceptor(treeInterceptorHandler.TreeInterceptor):
 		},
 	)
 
-	def shouldPassThrough(self, obj, reason: Optional[OutputReason] = None):
+	def shouldPassThrough(self, obj, reason: OutputReason | None = None):
 		"""Determine whether pass through mode should be enabled (focus mode) or disabled (browse mode) for a given object.
 		@param obj: The object in question.
 		@type obj: L{NVDAObjects.NVDAObject}
@@ -504,8 +504,8 @@ class BrowseModeTreeInterceptor(treeInterceptorHandler.TreeInterceptor):
 	def _iterSimilarParagraph(
 		self,
 		kind: str,
-		paragraphFunction: Callable[[textInfos.TextInfo], Optional[Any]],
-		desiredValue: Optional[Any],
+		paragraphFunction: Callable[[textInfos.TextInfo], Any | None],
+		desiredValue: Any | None,
 		direction: _Movement,
 		pos: textInfos.TextInfo,
 	) -> Generator[TextInfoQuickNavItem, None, None]:
@@ -582,12 +582,12 @@ class BrowseModeTreeInterceptor(treeInterceptorHandler.TreeInterceptor):
 	def addQuickNav(
 		cls,
 		itemType: str,
-		key: Optional[str],
+		key: str | None,
 		nextDoc: str,
 		nextError: str,
 		prevDoc: str,
 		prevError: str,
-		readUnit: Optional[str] = None,
+		readUnit: str | None = None,
 	):
 		"""Adds a script for the given quick nav item.
 		@param itemType: The type of item, I.E. "heading" "Link" ...
@@ -1301,7 +1301,7 @@ class ElementsListDialog(
 		filterText = _("Filter b&y:")
 		labeledCtrl = gui.guiHelper.LabeledControlHelper(self, filterText, wx.TextCtrl)
 		self.filterEdit = labeledCtrl.control
-		self.filterTimer: Optional[wx.CallLater] = None
+		self.filterTimer: wx.CallLater | None = None
 		self.filterEdit.Bind(wx.EVT_TEXT, self.onFilterEditTextChange)
 		contentsSizer.Add(labeledCtrl.sizer)
 		contentsSizer.AddSpacer(gui.guiHelper.SPACE_BETWEEN_VERTICAL_DIALOG_ITEMS)
@@ -1600,7 +1600,7 @@ class BrowseModeDocumentTreeInterceptor(
 		self._lastProgrammaticScrollTime = None
 		# Cache the document constant identifier so it can be saved with the last caret position on termination.
 		# As the original property may not be available as the document will be already dead.
-		self._lastCachedDocumentConstantIdentifier: Optional[str] = self.documentConstantIdentifier
+		self._lastCachedDocumentConstantIdentifier: str | None = self.documentConstantIdentifier
 		self._lastFocusObj = None
 		self._objPendingFocusBeforeActivate = None
 		self._hadFirstGainFocus = False
@@ -2172,13 +2172,13 @@ class BrowseModeDocumentTreeInterceptor(
 			obj = container
 		return doResult(False)
 
-	documentConstantIdentifier: Optional[str]
+	documentConstantIdentifier: str | None
 	""" Typing information for auto-property: _get_documentConstantIdentifier"""
 
 	# Mark documentConstantIdentifier property for caching during the current core cycle
 	_cache_documentConstantIdentifier = True
 
-	def _get_documentConstantIdentifier(self) -> Optional[str]:
+	def _get_documentConstantIdentifier(self) -> str | None:
 		"""Get the constant identifier for this document.
 		This identifier should uniquely identify all instances (not just one instance) of a document for at least the current session of the hosting application.
 		Generally, the document URL should be used.
@@ -2670,8 +2670,8 @@ class BrowseModeDocumentTreeInterceptor(
 	def _iterSimilarParagraph(
 		self,
 		kind: str,
-		paragraphFunction: Callable[[textInfos.TextInfo], Optional[Any]],
-		desiredValue: Optional[Any],
+		paragraphFunction: Callable[[textInfos.TextInfo], Any | None],
+		desiredValue: Any | None,
 		direction: _Movement,
 		pos: textInfos.TextInfo,
 	) -> Generator[TextInfoQuickNavItem, None, None]:

--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -55,7 +55,6 @@ import gui.contextHelp
 from abc import ABCMeta, abstractmethod
 import globalVars
 from utils import urlUtils
-from typing import Optional
 
 
 def reportPassThrough(treeInterceptor, onlyIfChanged=True):

--- a/source/characterProcessing.py
+++ b/source/characterProcessing.py
@@ -18,7 +18,6 @@ from typing import (
 	Dict,
 	Generic,
 	List,
-	Optional,
 	TypeVar,
 )
 

--- a/source/characterProcessing.py
+++ b/source/characterProcessing.py
@@ -122,7 +122,7 @@ class CharacterDescriptions(object):
 		log.debug("Loaded %d entries." % len(self._entries))
 		f.close()
 
-	def getCharacterDescription(self, character: str) -> Optional[List[str]]:
+	def getCharacterDescription(self, character: str) -> List[str] | None:
 		"""
 		Looks up the given character and returns a list containing all the description strings found.
 		"""
@@ -132,7 +132,7 @@ class CharacterDescriptions(object):
 _charDescLocaleDataMap: LocaleDataMap[CharacterDescriptions] = LocaleDataMap(CharacterDescriptions)
 
 
-def getCharacterDescription(locale: str, character: str) -> Optional[List[str]]:
+def getCharacterDescription(locale: str, character: str) -> List[str] | None:
 	"""
 	Finds a description or examples for the given character, which makes sense in the given locale.
 	@param locale: the locale (language[_COUNTRY]) the description should be for.

--- a/source/compoundDocuments.py
+++ b/source/compoundDocuments.py
@@ -4,7 +4,6 @@
 # Copyright (C) 2010-2024 NV Access Limited, Bram Duvigneau
 
 from typing import (
-	Optional,
 	Dict,
 	Self,
 )

--- a/source/compoundDocuments.py
+++ b/source/compoundDocuments.py
@@ -331,7 +331,7 @@ class TreeCompoundTextInfo(CompoundTextInfo):
 		text = info._getTextRange(0, info._startOffset)
 		return text.count(textUtils.OBJ_REPLACEMENT_CHAR)
 
-	def getTextWithFields(self, formatConfig: Optional[Dict] = None) -> textInfos.TextInfo.TextWithFieldsT:
+	def getTextWithFields(self, formatConfig: Dict | None = None) -> textInfos.TextInfo.TextWithFieldsT:
 		# Get the initial control fields.
 		fields = []
 		rootObj = self.obj.rootNVDAObject

--- a/source/config/__init__.py
+++ b/source/config/__init__.py
@@ -186,7 +186,7 @@ def isInstalledCopy() -> bool:
 		return False
 
 
-def getInstalledUserConfigPath() -> Optional[str]:
+def getInstalledUserConfigPath() -> str | None:
 	try:
 		winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, RegistryKey.NVDA.value)
 	except FileNotFoundError:
@@ -254,7 +254,7 @@ def getScratchpadDir(ensureExists: bool = False) -> str:
 	return path
 
 
-def initConfigPath(configPath: Optional[str] = None) -> None:
+def initConfigPath(configPath: str | None = None) -> None:
 	"""
 	Creates the current configuration path if it doesn't exist. Also makes sure that various sub directories also exist.
 	@param configPath: an optional path which should be used instead (only useful when being called from outside of NVDA)
@@ -536,7 +536,7 @@ class ConfigManager(object):
 		self.spec = confspec
 		_transformSpec(self.spec)
 		#: All loaded profiles by name.
-		self._profileCache: Optional[Dict[Optional[str], ConfigObj]] = {}
+		self._profileCache: Dict[str | None, ConfigObj] | None = {}
 		#: The active profiles.
 		self.profiles: List[ConfigObj] = []
 		#: Whether profile triggers are enabled (read-only).
@@ -546,13 +546,13 @@ class ConfigManager(object):
 				"_featureFlag": _validateConfig_featureFlag,
 			},
 		)
-		self.rootSection: Optional[AggregatedSection] = None
+		self.rootSection: AggregatedSection | None = None
 		self._shouldHandleProfileSwitch: bool = True
 		self._pendingHandleProfileSwitch: bool = False
-		self._suspendedTriggers: Optional[List[ProfileTrigger]] = None
+		self._suspendedTriggers: List[ProfileTrigger] | None = None
 		self._initBaseConf()
 		#: Maps triggers to profiles.
-		self.triggersToProfiles: Optional[Dict[ProfileTrigger, ConfigObj]] = None
+		self.triggersToProfiles: Dict[ProfileTrigger, ConfigObj] | None = None
 		self._loadProfileTriggers()
 		#: The names of all profiles that have been modified since they were last saved.
 		self._dirtyProfiles: Set[str] = set()

--- a/source/config/__init__.py
+++ b/source/config/__init__.py
@@ -44,7 +44,6 @@ from typing import (
 	Any,
 	Dict,
 	List,
-	Optional,
 	Set,
 	Tuple,
 )

--- a/source/contentRecog/recogUi.py
+++ b/source/contentRecog/recogUi.py
@@ -10,7 +10,7 @@ and present the result to the user so they can read it with cursor keys, etc.
 NVDA scripts or GUI call the L{recognizeNavigatorObject} function with the recognizer they wish to use.
 """
 
-from typing import Optional, Union, TYPE_CHECKING
+from typing import Union, TYPE_CHECKING
 import api
 import ui
 import screenBitmap

--- a/source/contentRecog/recogUi.py
+++ b/source/contentRecog/recogUi.py
@@ -120,7 +120,7 @@ class RefreshableRecogResultNVDAObject(RecogResultNVDAObject, LiveText):
 		self,
 		recognizer: ContentRecognizer,
 		imageInfo: RecogImageInfo,
-		obj: Optional[NVDAObjects.NVDAObject] = None,
+		obj: NVDAObjects.NVDAObject | None = None,
 	):
 		self.recognizer = recognizer
 		self.imageInfo = imageInfo

--- a/source/controlTypes/processAndLabelStates.py
+++ b/source/controlTypes/processAndLabelStates.py
@@ -14,7 +14,7 @@ def _processPositiveStates(
 	role: Role,
 	states: Set[State],
 	reason: OutputReason,
-	positiveStates: Optional[Set[State]] = None,
+	positiveStates: Set[State] | None = None,
 ) -> Set[State]:
 	"""Processes the states for an object and returns the positive states to output for a specified reason.
 	For example, if C{State.CHECKED} is in the returned states, it means that the processed object is checked.
@@ -90,7 +90,7 @@ def _processNegativeStates(
 	role: Role,
 	states: Set[State],
 	reason: OutputReason,
-	negativeStates: Optional[Set[State]] = None,
+	negativeStates: Set[State] | None = None,
 ) -> Set[State]:
 	"""Processes the states for an object and returns the negative states to output for a specified reason.
 	For example, if C{State.CHECKED} is in the returned states, it means that the processed object is not
@@ -168,8 +168,8 @@ def processAndLabelStates(
 	role: Role,
 	states: Set[State],
 	reason: OutputReason,
-	positiveStates: Optional[Set[State]] = None,
-	negativeStates: Optional[Set[State]] = None,
+	positiveStates: Set[State] | None = None,
+	negativeStates: Set[State] | None = None,
 	positiveStateLabelDict: Dict[State, str] = {},
 	negativeStateLabelDict: Dict[State, str] = {},
 ) -> List[str]:

--- a/source/controlTypes/processAndLabelStates.py
+++ b/source/controlTypes/processAndLabelStates.py
@@ -3,7 +3,7 @@
 # See the file COPYING for more details.
 # Copyright (C) 2007-2021 NV Access Limited, Babbage B.V.
 
-from typing import Dict, List, Optional, Set
+from typing import Dict, List, Set
 
 from .role import Role, clickableRoles
 from .state import State, STATES_SORTED, STATES_LINK_TYPE

--- a/source/core.py
+++ b/source/core.py
@@ -211,8 +211,8 @@ def doStartupDialogs():
 @dataclass
 class NewNVDAInstance:
 	filePath: str
-	parameters: Optional[str] = None
-	directory: Optional[str] = None
+	parameters: str | None = None
+	directory: str | None = None
 
 
 def computeRestartCLIArgs(removeArgsList: list[str] | None = None) -> list[str]:
@@ -454,14 +454,14 @@ def _startNewInstance(newNVDA: NewNVDAInstance):
 	)
 
 
-def _doShutdown(newNVDA: Optional[NewNVDAInstance]):
+def _doShutdown(newNVDA: NewNVDAInstance | None):
 	_handleNVDAModuleCleanupBeforeGUIExit()
 	_closeAllWindows()
 	if newNVDA is not None:
 		_startNewInstance(newNVDA)
 
 
-def triggerNVDAExit(newNVDA: Optional[NewNVDAInstance] = None) -> bool:
+def triggerNVDAExit(newNVDA: NewNVDAInstance | None = None) -> bool:
 	"""
 	Used to safely exit NVDA. If a new instance is required to start after exit, queue one by specifying
 	instance information with `newNVDA`.

--- a/source/core.py
+++ b/source/core.py
@@ -413,7 +413,7 @@ def _setInitialFocus():
 		log.exception("Error retrieving initial focus")
 
 
-def getWxLangOrNone() -> Optional["wx.LanguageInfo"]:
+def getWxLangOrNone() -> "wx.LanguageInfo | None":
 	import wx
 
 	lang = languageHandler.getLanguage()

--- a/source/core.py
+++ b/source/core.py
@@ -11,7 +11,6 @@ from typing import (
 	TYPE_CHECKING,
 	Any,
 	List,
-	Optional,
 )
 import comtypes
 import sys

--- a/source/displayModel.py
+++ b/source/displayModel.py
@@ -550,7 +550,7 @@ class DisplayModelTextInfo(OffsetsTextInfo):
 	def _getTextRange(self, start, end):
 		return "".join(x for x in self._getFieldsInRange(start, end) if isinstance(x, str))
 
-	def getTextWithFields(self, formatConfig: Optional[Dict] = None) -> textInfos.TextInfo.TextWithFieldsT:
+	def getTextWithFields(self, formatConfig: Dict | None = None) -> textInfos.TextInfo.TextWithFieldsT:
 		start = self._startOffset
 		end = self._endOffset
 		if start == end:

--- a/source/displayModel.py
+++ b/source/displayModel.py
@@ -26,7 +26,6 @@ import textUtils
 from typing import (
 	List,
 	Tuple,
-	Optional,
 	Dict,
 )
 

--- a/source/documentBase.py
+++ b/source/documentBase.py
@@ -5,7 +5,7 @@
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Optional, Tuple, Union
+from typing import Any, Tuple, Union
 from baseObject import AutoPropertyObject, ScriptableObject
 import config
 import textInfos

--- a/source/documentBase.py
+++ b/source/documentBase.py
@@ -90,7 +90,7 @@ class DocumentWithTableNavigation(TextContainerObject, ScriptableObject):
 	The document could be an NVDAObject, or a BrowseModeDocument treeIntercepter for example.
 	"""
 
-	_lastTableSelection: Optional[_TableSelection] = None
+	_lastTableSelection: _TableSelection | None = None
 
 	def _maybeGetLayoutTableIds(self, info: textInfos.TextInfo):
 		"""
@@ -154,7 +154,7 @@ class DocumentWithTableNavigation(TextContainerObject, ScriptableObject):
 	def _getTableCellCoordsCached(
 		self,
 		info: textInfos.TextInfo,
-		axis: Optional[_Axis] = None,
+		axis: _Axis | None = None,
 	) -> _TableCell:
 		cell = self._getTableCellCoords(info)
 
@@ -346,11 +346,11 @@ class DocumentWithTableNavigation(TextContainerObject, ScriptableObject):
 
 	def _tableFindNewCell(
 		self,
-		movement: Optional[_Movement] = None,
-		axis: Optional[_Axis] = None,
-		selection: Optional[textInfos.TextInfo] = None,
+		movement: _Movement | None = None,
+		axis: _Axis | None = None,
+		selection: textInfos.TextInfo | None = None,
 		raiseOnEdge: bool = False,
-	) -> Tuple[_TableCell, textInfos.TextInfo, Optional[_TableSelection]]:
+	) -> Tuple[_TableCell, textInfos.TextInfo, _TableSelection | None]:
 		# documentBase is a core module and should not depend on these UI modules and so they are imported
 		import ui
 
@@ -414,7 +414,7 @@ class DocumentWithTableNavigation(TextContainerObject, ScriptableObject):
 	def _tableMovementScriptHelper(
 		self,
 		movement: _Movement = _Movement.NEXT,
-		axis: Optional[_Axis] = None,
+		axis: _Axis | None = None,
 	):
 		# documentBase is a core module and should not depend on these UI modules and so they are imported
 		# at run-time. (#12404)

--- a/source/documentNavigation/sentenceHelper.py
+++ b/source/documentNavigation/sentenceHelper.py
@@ -5,7 +5,6 @@
 # For more details see: https://www.gnu.org/licenses/gpl-2.0.html
 
 import re
-from typing import Optional
 
 WESTERN_TERMINATORS = "[.?!](?: |\r|\n|$)+"
 FULL_WIDTH_TERMINATORS = "[。！？](?:\r|\n)*"

--- a/source/documentNavigation/sentenceHelper.py
+++ b/source/documentNavigation/sentenceHelper.py
@@ -12,7 +12,7 @@ FULL_WIDTH_TERMINATORS = "[。！？](?:\r|\n)*"
 TERMINATORS_PATTERN: re.Pattern = re.compile(WESTERN_TERMINATORS + "|" + FULL_WIDTH_TERMINATORS)
 
 
-def _findNextEndOfSentence(sentence: str, offset: int) -> Optional[int]:
+def _findNextEndOfSentence(sentence: str, offset: int) -> int | None:
 	"""
 	Returns an index which points one character past the end of the current sentence,
 	or if the sentence is at the end of the string, returns the length of the string.

--- a/source/eventHandler.py
+++ b/source/eventHandler.py
@@ -41,7 +41,7 @@ lastQueuedFocusObject = None
 
 
 # Handle virtual desktop switch announcements in Windows 10 and later
-_virtualDesktopName: Optional[str] = None
+_virtualDesktopName: str | None = None
 _canAnnounceVirtualDesktopNames: bool = winVersion.getWinVer() >= winVersion.WIN10_1903
 
 
@@ -296,7 +296,7 @@ class FocusLossCancellableSpeechCommand(_CancellableSpeechCommand):
 def _getFocusLossCancellableSpeechCommand(
 	obj,
 	reason: controlTypes.OutputReason,
-) -> Optional[_CancellableSpeechCommand]:
+) -> _CancellableSpeechCommand | None:
 	if reason != controlTypes.OutputReason.FOCUS or not speech.manager._shouldCancelExpiredFocusEvents():
 		return None
 	from NVDAObjects import NVDAObject

--- a/source/eventHandler.py
+++ b/source/eventHandler.py
@@ -5,7 +5,6 @@
 
 import threading
 import typing
-from typing import Optional
 from comtypes import COMError
 
 import garbageHandler

--- a/source/extensionPoints/util.py
+++ b/source/extensionPoints/util.py
@@ -51,7 +51,7 @@ class BoundMethodWeakref(Generic[HandlerT]):
 	def __init__(
 		self,
 		target: HandlerT,
-		onDelete: Optional[Callable[[BoundMethodWeakref], None]] = None,
+		onDelete: Callable[[BoundMethodWeakref], None] | None = None,
 	):
 		if onDelete:
 
@@ -65,7 +65,7 @@ class BoundMethodWeakref(Generic[HandlerT]):
 		self.weakInst = weakref.ref(inst, onRefDelete)
 		self.weakFunc = weakref.ref(func, onRefDelete)
 
-	def __call__(self) -> Optional[HandlerT]:
+	def __call__(self) -> HandlerT | None:
 		inst = self.weakInst()
 		if not inst:
 			return

--- a/source/extensionPoints/util.py
+++ b/source/extensionPoints/util.py
@@ -15,7 +15,6 @@ from typing import (
 	Callable,
 	Generator,
 	Generic,
-	Optional,
 	OrderedDict,
 	Tuple,
 	TypeVar,

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -2605,7 +2605,7 @@ class GlobalCommands(ScriptableObject):
 	def _getTIAtCaret(
 		fallbackToPOSITION_FIRST: bool = False,
 		reportFailure: bool = True,
-	) -> Optional[textInfos.TextInfo]:
+	) -> textInfos.TextInfo | None:
 		# Returns text info at the caret position if there is a caret in the current control, None otherwise.
 		# Note that if there is no caret this fact is announced in speech and braille
 		# unless reportFailure is set to C{False}
@@ -2694,7 +2694,7 @@ class GlobalCommands(ScriptableObject):
 		elif repeats == 1:
 			self.script_showFormattingAtCaret(gesture)
 
-	def _getNvdaObjWithAnnotationUnderCaret(self) -> Optional[NVDAObject]:
+	def _getNvdaObjWithAnnotationUnderCaret(self) -> NVDAObject | None:
 		"""If it has an annotation, get the NVDA object for the single character under the caret or the object
 		with system focus.
 		@note: It is tempting to try to report any annotation details that exists in the range formed by prior
@@ -2842,7 +2842,7 @@ class GlobalCommands(ScriptableObject):
 			speech.speakSpelling(focusObject.name, useCharacterDescriptions=repeatCount > 1)
 
 	@staticmethod
-	def _getStatusBarText(setReviewCursor: bool = False) -> Optional[str]:
+	def _getStatusBarText(setReviewCursor: bool = False) -> str | None:
 		"""Returns text of the current status bar and optionally sets review cursor to it.
 		If no status bar has been found `None` is returned and this fact is announced in speech and braille.
 		"""
@@ -4756,8 +4756,8 @@ class GlobalCommands(ScriptableObject):
 		ui.message(msg)
 
 	_tempEnableScreenCurtain = True
-	_waitingOnScreenCurtainWarningDialog: Optional[wx.Dialog] = None
-	_toggleScreenCurtainMessage: Optional[str] = None
+	_waitingOnScreenCurtainWarningDialog: wx.Dialog | None = None
+	_toggleScreenCurtainMessage: str | None = None
 
 	@script(
 		description=_(

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -9,7 +9,6 @@
 
 import itertools
 from typing import (
-	Optional,
 	Tuple,
 	Union,
 )

--- a/source/globalVars.py
+++ b/source/globalVars.py
@@ -38,9 +38,9 @@ if TYPE_CHECKING:
 class DefaultAppArgs(argparse.Namespace):
 	quit: bool = False
 	check_running: bool = False
-	logFileName: Optional[os.PathLike] = ""
+	logFileName: os.PathLike | None = ""
 	logLevel: int = 0
-	configPath: Optional[os.PathLike] = None
+	configPath: os.PathLike | None = None
 	language: str | None = None
 	minimal: bool = False
 	secure: bool = False
@@ -65,9 +65,9 @@ class DefaultAppArgs(argparse.Namespace):
 	installSilent: bool = False
 	createPortable: bool = False
 	createPortableSilent: bool = False
-	portablePath: Optional[os.PathLike] = None
+	portablePath: os.PathLike | None = None
 	launcher: bool = False
-	enableStartOnLogon: Optional[bool] = None
+	enableStartOnLogon: bool | None = None
 	copyPortableConfig: bool = False
 	easeOfAccess: bool = False
 
@@ -86,7 +86,7 @@ focusObject: Optional["NVDAObjects.NVDAObject"] = None
 focusAncestors: List["NVDAObjects.NVDAObject"] = []
 """Deprecated, use `getFocusAncestors` from `api` instead"""
 
-focusDifferenceLevel: Optional[int] = None
+focusDifferenceLevel: int | None = None
 """Deprecated, use `getFocusDifferenceLevel` from `api` instead"""
 
 mouseObject: Optional["NVDAObjects.NVDAObject"] = None

--- a/source/globalVars.py
+++ b/source/globalVars.py
@@ -27,7 +27,6 @@ from typing import (
 	TYPE_CHECKING,
 	List,
 	Literal,
-	Optional,
 )
 
 if TYPE_CHECKING:

--- a/source/globalVars.py
+++ b/source/globalVars.py
@@ -74,13 +74,13 @@ class DefaultAppArgs(argparse.Namespace):
 
 # Encapsulated by api module,
 # refer to #14037 for removal strategy.
-desktopObject: Optional["NVDAObjects.NVDAObject"] = None
+desktopObject: "NVDAObjects.NVDAObject | None" = None
 """Deprecated, use `setDesktopObject|getDesktopObject` from `api` instead"""
 
-foregroundObject: Optional["NVDAObjects.NVDAObject"] = None
+foregroundObject: "NVDAObjects.NVDAObject | None" = None
 """Deprecated, use `setForegroundObject|getForegroundObject` from `api` instead"""
 
-focusObject: Optional["NVDAObjects.NVDAObject"] = None
+focusObject: "NVDAObjects.NVDAObject | None" = None
 """Deprecated, use `setFocusObject|getFocusObject` from `api` instead"""
 
 focusAncestors: List["NVDAObjects.NVDAObject"] = []
@@ -89,16 +89,16 @@ focusAncestors: List["NVDAObjects.NVDAObject"] = []
 focusDifferenceLevel: int | None = None
 """Deprecated, use `getFocusDifferenceLevel` from `api` instead"""
 
-mouseObject: Optional["NVDAObjects.NVDAObject"] = None
+mouseObject: "NVDAObjects.NVDAObject | None" = None
 """Deprecated, use ``setMouseObject|getMouseObject`` from `api` instead"""
 
-navigatorObject: Optional["NVDAObjects.NVDAObject"] = None
+navigatorObject: "NVDAObjects.NVDAObject | None" = None
 """Deprecated, use ``setNavigatorObject|getNavigatorObject`` from `api` instead"""
 
-reviewPosition: Optional["documentBase.TextContainerObject"] = None
+reviewPosition: "documentBase.TextContainerObject | None" = None
 """Deprecated, use ``getReviewPosition|setReviewPosition`` from `api` instead"""
 
-reviewPositionObj: Optional["NVDAObjects.NVDAObject"] = None
+reviewPositionObj: "NVDAObjects.NVDAObject | None" = None
 """Deprecated, use ``api.getReviewPosition().obj`` instead"""
 
 

--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -24,7 +24,6 @@ import queueHandler
 import core
 from typing import (
 	Any,
-	Optional,
 	Type,
 )
 import systemUtils

--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -101,7 +101,7 @@ ICON_PATH = os.path.join(NVDA_PATH, "images", "nvda.ico")
 DONATE_URL = f"{versionInfo.url}/donate/"
 
 ### Globals
-mainFrame: Optional["MainFrame"] = None
+mainFrame: "MainFrame | None" = None
 """Set by initialize. Should be used as the parent for "top level" dialogs.
 """
 

--- a/source/gui/addonStoreGui/controls/addonList.py
+++ b/source/gui/addonStoreGui/controls/addonList.py
@@ -5,7 +5,6 @@
 
 from typing import (
 	List,
-	Optional,
 )
 
 import wx

--- a/source/gui/addonStoreGui/controls/addonList.py
+++ b/source/gui/addonStoreGui/controls/addonList.py
@@ -73,7 +73,7 @@ class AddonVirtualList(
 			self.AppendColumn(col.displayString, width=self.scaleSize(col.width))
 		self.Layout()
 
-	def _getListSelectionPosition(self) -> Optional[wx.Position]:
+	def _getListSelectionPosition(self) -> wx.Position | None:
 		firstSelectedIndex: int = self.GetFirstSelected()
 		if firstSelectedIndex < 0:
 			return None

--- a/source/gui/addonStoreGui/viewModels/action.py
+++ b/source/gui/addonStoreGui/viewModels/action.py
@@ -8,7 +8,6 @@ from typing import (
 	Callable,
 	Generic,
 	Iterable,
-	Optional,
 	TypeVar,
 	TYPE_CHECKING,
 )

--- a/source/gui/addonStoreGui/viewModels/action.py
+++ b/source/gui/addonStoreGui/viewModels/action.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
 	from .addonList import AddonListItemVM
 
 
-ActionTargetT = TypeVar("ActionTargetT", Optional["AddonListItemVM"], Iterable["AddonListItemVM"])
+ActionTargetT = TypeVar("ActionTargetT", "AddonListItemVM | None", Iterable["AddonListItemVM"])
 
 
 class _AddonAction(Generic[ActionTargetT], ABC):
@@ -65,7 +65,7 @@ class _AddonAction(Generic[ActionTargetT], ABC):
 		callLater(delay=0, callable=self.updated.notify, addonActionVM=self)
 
 
-class AddonActionVM(_AddonAction[Optional["AddonListItemVM"]]):
+class AddonActionVM(_AddonAction["AddonListItemVM | None"]):
 	"""Actions/behaviour that can be embedded within other views/viewModels that can apply to a single
 	L{AddonListItemVM}.
 	Use the L{AddonActionVM.updated} extensionPoint.Action to be notified about changes.
@@ -80,7 +80,7 @@ class AddonActionVM(_AddonAction[Optional["AddonListItemVM"]]):
 		displayName: str,
 		actionHandler: Callable[["AddonListItemVM"], None],
 		validCheck: Callable[["AddonListItemVM"], bool],
-		actionTarget: Optional["AddonListItemVM"],
+		actionTarget: "AddonListItemVM | None",
 	):
 		"""
 		@param displayName: Translated string, to be displayed to the user. Should describe the action / behaviour.
@@ -89,11 +89,11 @@ class AddonActionVM(_AddonAction[Optional["AddonListItemVM"]]):
 		@param actionTarget: The listItemVM this action will be applied to. L{updated} notifies of modification.
 		"""
 
-		def _validCheck(listItemVM: Optional["AddonListItemVM"]) -> bool:
+		def _validCheck(listItemVM: "AddonListItemVM | None") -> bool:
 			# Handle the None case so that each validCheck doesn't have to.
 			return listItemVM is not None and validCheck(listItemVM)
 
-		def _actionHandler(listItemVM: Optional["AddonListItemVM"]):
+		def _actionHandler(listItemVM: "AddonListItemVM | None"):
 			# Handle the None case so that each actionHandler doesn't have to.
 			if listItemVM is not None:
 				actionHandler(listItemVM)
@@ -104,13 +104,13 @@ class AddonActionVM(_AddonAction[Optional["AddonListItemVM"]]):
 		if actionTarget:
 			actionTarget.updated.register(self._listItemChanged)
 
-	def _listItemChanged(self, addonListItemVM: Optional["AddonListItemVM"]):
+	def _listItemChanged(self, addonListItemVM: "AddonListItemVM | None"):
 		"""Something inside the AddonListItemVM has changed"""
 		assert self._actionTarget == addonListItemVM
 		self._notify()
 
 	@_AddonAction.actionTarget.setter
-	def actionTarget(self, newActionTarget: Optional["AddonListItemVM"]):
+	def actionTarget(self, newActionTarget: "AddonListItemVM | None"):
 		if self._actionTarget == newActionTarget:
 			return
 		if self._actionTarget:

--- a/source/gui/addonStoreGui/viewModels/addonList.py
+++ b/source/gui/addonStoreGui/viewModels/addonList.py
@@ -195,15 +195,15 @@ class AddonListItemVM(Generic[_AddonModelT]):
 class AddonDetailsVM:
 	def __init__(self, listVM: "AddonListVM"):
 		self._listVM = listVM
-		self._listItem: Optional[AddonListItemVM] = listVM.getSelection()
+		self._listItem: AddonListItemVM | None = listVM.getSelection()
 		self.updated = extensionPoints.Action()  # triggered by setting L{self._listItem}
 
 	@property
-	def listItem(self) -> Optional[AddonListItemVM]:
+	def listItem(self) -> AddonListItemVM | None:
 		return self._listItem
 
 	@listItem.setter
-	def listItem(self, newListItem: Optional[AddonListItemVM]):
+	def listItem(self, newListItem: AddonListItemVM | None):
 		self._listItem = newListItem
 		# ensure calling on the main thread.
 		core.callLater(delay=0, callable=self.updated.notify, addonDetailsVM=self)
@@ -221,10 +221,10 @@ class AddonListVM:
 		self.itemUpdated = extensionPoints.Action()
 		self.updated = extensionPoints.Action()
 		self.selectionChanged = extensionPoints.Action()
-		self.selectedAddonId: Optional[str] = None
+		self.selectedAddonId: str | None = None
 		self.lastSelectedAddonId = self.selectedAddonId
 		self._sortByModelField: AddonListField = AddonListField.displayName
-		self._filterString: Optional[str] = None
+		self._filterString: str | None = None
 		self._reverseSort: bool = False
 
 		self._setSelectionPending = False
@@ -270,7 +270,7 @@ class AddonListVM:
 		# ensure calling on the main thread.
 		core.callLater(delay=0, callable=self.updated.notify)
 
-	def getAddonFieldText(self, index: int, field: AddonListField) -> Optional[str]:
+	def getAddonFieldText(self, index: int, field: AddonListField) -> str | None:
 		"""Get the text for an item's attribute.
 		@param index: The index of the item in _addonsFilteredOrdered
 		@param field: The field attribute for the addon. See L{AddonList.presentedFields}
@@ -303,7 +303,7 @@ class AddonListVM:
 	def getCount(self) -> int:
 		return len(self._addonsFilteredOrdered)
 
-	def getSelectedIndex(self) -> Optional[int]:
+	def getSelectedIndex(self) -> int | None:
 		if self._addonsFilteredOrdered and self.selectedAddonId in self._addonsFilteredOrdered:
 			return self._addonsFilteredOrdered.index(self.selectedAddonId)
 		return None
@@ -313,7 +313,7 @@ class AddonListVM:
 		selectedAddonId = self._addonsFilteredOrdered[index]
 		return self._addons[selectedAddonId]
 
-	def setSelection(self, index: Optional[int]) -> Optional[AddonListItemVM]:
+	def setSelection(self, index: int | None) -> AddonListItemVM | None:
 		self._validate(selectionIndex=index)
 		self.selectedAddonId = None
 		if index is not None:
@@ -322,22 +322,22 @@ class AddonListVM:
 			except IndexError:
 				# Failed to get addonId, index may have been lost in refresh.
 				pass
-		selectedItemVM: Optional[AddonListItemVM] = self.getSelection()
+		selectedItemVM: AddonListItemVM | None = self.getSelection()
 		log.debug(f"selected Item: {selectedItemVM}")
 		# ensure calling on the main thread.
 		core.callLater(delay=0, callable=self.selectionChanged.notify)
 		return selectedItemVM
 
-	def getSelection(self) -> Optional[AddonListItemVM]:
+	def getSelection(self) -> AddonListItemVM | None:
 		if self.selectedAddonId is None:
 			return None
 		return self._addons.get(self.selectedAddonId)
 
 	def _validate(
 		self,
-		sortField: Optional[AddonListField] = None,
-		selectionIndex: Optional[int] = None,
-		selectionId: Optional[str] = None,
+		sortField: AddonListField | None = None,
+		selectionIndex: int | None = None,
+		selectionId: str | None = None,
 	):
 		if sortField is not None:
 			assert sortField in AddonListField
@@ -416,7 +416,7 @@ class AddonListVM:
 	def _tryPersistSelection(
 		self,
 		newOrder: List[str],
-	) -> Optional[str]:
+	) -> str | None:
 		"""Get the ID of the selection in new order, _addonsFilteredOrdered should not have changed yet."""
 		selectedIndex = self.getSelectedIndex()
 		selectedId = self.selectedAddonId

--- a/source/gui/addonStoreGui/viewModels/addonList.py
+++ b/source/gui/addonStoreGui/viewModels/addonList.py
@@ -11,7 +11,6 @@ from typing import (
 	FrozenSet,
 	Generic,
 	List,
-	Optional,
 	TYPE_CHECKING,
 	TypeVar,
 )

--- a/source/gui/addonStoreGui/viewModels/store.py
+++ b/source/gui/addonStoreGui/viewModels/store.py
@@ -11,7 +11,6 @@ import os
 from typing import (
 	Iterable,
 	List,
-	Optional,
 	cast,
 )
 import threading

--- a/source/gui/addonStoreGui/viewModels/store.py
+++ b/source/gui/addonStoreGui/viewModels/store.py
@@ -110,7 +110,7 @@ class AddonStoreVM:
 			action.actionTarget = selectedVM
 
 	def _makeActionsList(self):
-		selectedListItem: Optional[AddonListItemVM] = self.listVM.getSelection()
+		selectedListItem: AddonListItemVM | None = self.listVM.getSelection()
 		return [
 			AddonActionVM(
 				# Translators: Label for an action that installs the selected addon
@@ -542,7 +542,7 @@ class AddonStoreVM:
 	def _downloadComplete(
 		cls,
 		listItemVM: AddonListItemVM[_AddonStoreModel],
-		fileDownloaded: Optional[PathLike],
+		fileDownloaded: PathLike | None,
 	):
 		try:
 			addonDataManager._downloadsPendingCompletion.remove(listItemVM)

--- a/source/gui/dpiScalingHelper.py
+++ b/source/gui/dpiScalingHelper.py
@@ -49,7 +49,7 @@ class DpiScalingHelperMixinWithoutInit:
 	"""
 
 	GetHandle: Callable[[], Any]  # Should be provided by wx.Window
-	_scaleFactor: Optional[int] = None
+	_scaleFactor: int | None = None
 
 	def scaleSize(self, size: _Size) -> _ScaledSize:
 		if self._scaleFactor is None:

--- a/source/gui/dpiScalingHelper.py
+++ b/source/gui/dpiScalingHelper.py
@@ -3,7 +3,7 @@
 # Copyright (C) 2018-2023 NV Access Limited
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-from typing import Optional, Any, Callable, Tuple, Union
+from typing import Any, Callable, Tuple, Union
 
 
 _FloatInt = Union[int, float]

--- a/source/gui/guiHelper.py
+++ b/source/gui/guiHelper.py
@@ -52,7 +52,6 @@ import weakref
 from typing import (
 	Any,
 	Generic,
-	Optional,
 	ParamSpec,
 	Type,
 	TypeVar,

--- a/source/gui/guiHelper.py
+++ b/source/gui/guiHelper.py
@@ -344,8 +344,8 @@ class BoxSizerHelper:
 	def __init__(
 		self,
 		parent: wx.Dialog,
-		orientation: Optional[int] = None,
-		sizer: Optional[Union[wx.BoxSizer, wx.StaticBoxSizer]] = None,
+		orientation: int | None = None,
+		sizer: Union[wx.BoxSizer, wx.StaticBoxSizer] | None = None,
 	):
 		"""Init. Pass in either orientation OR sizer.
 		@param parent: An instance of the parent wx window. EG wx.Dialog

--- a/source/gui/inputGestures.py
+++ b/source/gui/inputGestures.py
@@ -17,7 +17,7 @@ import wx.lib.newevent
 import gui
 from logHandler import log
 
-from typing import List, Optional
+from typing import List
 import keyboardHandler
 from . import guiHelper
 import inputCore

--- a/source/gui/inputGestures.py
+++ b/source/gui/inputGestures.py
@@ -97,7 +97,7 @@ class _ScriptVM:
 	def __init__(self, displayName: str, scriptInfo: inputCore.AllGesturesScriptInfo):
 		self.displayName = displayName
 		self.scriptInfo = scriptInfo
-		self.pending: Optional[_PendingGesture] = None
+		self.pending: _PendingGesture | None = None
 		self.addedGestures = []
 		self.removedGestures = {}
 		self.gestures = []
@@ -213,7 +213,7 @@ class _EmuCategoryVM:
 		self.addedKbEmulation = []
 		self.removedKbEmulation = {}
 		self.scripts = []
-		self.pending: Optional[_PendingEmulatedGestureVM] = None
+		self.pending: _PendingEmulatedGestureVM | None = None
 		for scriptName in sorted(emuGestures, key=strxfrm):
 			emuG = emuGestures[scriptName]
 			if isinstance(emuG, inputCore.KbEmuScriptInfo):
@@ -269,16 +269,16 @@ _GestureVMTypes = Union[_GestureVM, _PendingGesture]
 
 _VmSelection = Tuple[
 	_CategoryVMTypes,
-	Optional[_ScriptVMTypes],
-	Optional[_GestureVMTypes],
+	_ScriptVMTypes | None,
+	_GestureVMTypes | None,
 ]
 
 
 class _InputGesturesViewModel:
 	allGestures: List[_CategoryVMTypes]
 	filteredGestures: List[_CategoryVMTypes]
-	isExpectingNewEmuGesture: Optional[_EmuCategoryVM] = None
-	isExpectingNewGesture: Optional[_ScriptVM] = None
+	isExpectingNewEmuGesture: _EmuCategoryVM | None = None
+	isExpectingNewGesture: _ScriptVM | None = None
 
 	def __init__(self):
 		self.reset()
@@ -485,7 +485,7 @@ class _GesturesTree(VirtualTree, wx.TreeCtrl):
 		gesture = scriptVm.gestures[gestureIndex]
 		return gesture.displayName
 
-	def getSelectedItemData(self) -> Optional[_VmSelection]:
+	def getSelectedItemData(self) -> _VmSelection | None:
 		selection = self.GetSelection()
 		try:
 			selIdx: Tuple[int, ...] = self.GetIndexOfItem(selection)
@@ -498,13 +498,13 @@ class _GesturesTree(VirtualTree, wx.TreeCtrl):
 			return None
 		# ensure that the length of tuple is 3, missing elements replaced with None
 		nonesForMissingElements = (None,) * (3 - len(selIdx))
-		selIdx: Tuple[int, Optional[int], Optional[int]] = selIdx + nonesForMissingElements
+		selIdx: Tuple[int, int | None, int | None] = selIdx + nonesForMissingElements
 		return self.getData(selIdx)
 
 	def getData(
 		self,
-		index: Tuple[int, Optional[int], Optional[int]],
-	) -> Optional[_VmSelection]:
+		index: Tuple[int, int | None, int | None],
+	) -> _VmSelection | None:
 		assert 3 == len(index) and index[0] is not None
 		if len(self.gesturesVM.filteredGestures) == 0:
 			log.debug("No filtered gestures available.")
@@ -524,7 +524,7 @@ class _GesturesTree(VirtualTree, wx.TreeCtrl):
 		if scriptIndex is None:
 			return (catVM, None, None)
 		try:
-			scriptVM: Optional[_ScriptVMTypes] = catVM.scripts[scriptIndex]
+			scriptVM: _ScriptVMTypes | None = catVM.scripts[scriptIndex]
 		except IndexError:
 			log.error(
 				"Exceeded expected script bounds, use _PendingEmulatedGestureVM as a placeholder."
@@ -552,7 +552,7 @@ class _GesturesTree(VirtualTree, wx.TreeCtrl):
 			raise
 		return (catVM, scriptVM, gestureVM)
 
-	def doRefresh(self, postFilter=False, focus: Optional[_VmSelection] = None):
+	def doRefresh(self, postFilter=False, focus: _VmSelection | None = None):
 		with guiHelper.autoThaw(self):
 			self.RefreshItems()
 			if postFilter:

--- a/source/gui/message.py
+++ b/source/gui/message.py
@@ -105,7 +105,7 @@ def messageBox(
 	message: str,
 	caption: str = wx.MessageBoxCaptionStr,
 	style: int = wx.OK | wx.CENTER,
-	parent: Optional[wx.Window] = None,
+	parent: wx.Window | None = None,
 ) -> int:
 	"""Display a modal message dialog.
 
@@ -149,7 +149,7 @@ class DisplayableError(Exception):
 	@type displayableError: DisplayableError
 	"""
 
-	def __init__(self, displayMessage: str, titleMessage: Optional[str] = None):
+	def __init__(self, displayMessage: str, titleMessage: str | None = None):
 		"""
 		@param displayMessage: A translated message, to be displayed to the user.
 		@param titleMessage: A translated message, to be used as a title for the display message.

--- a/source/gui/message.py
+++ b/source/gui/message.py
@@ -14,7 +14,7 @@ from collections import deque
 from collections.abc import Callable, Collection
 from enum import Enum, IntEnum, auto
 from functools import partialmethod, singledispatchmethod, wraps
-from typing import Any, Literal, NamedTuple, Optional, Self, TypeAlias
+from typing import Any, Literal, NamedTuple, Self, TypeAlias
 
 import core
 import extensionPoints

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -68,7 +68,6 @@ from typing import (
 	Any,
 	Callable,
 	List,
-	Optional,
 	Set,
 )
 import core

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -434,7 +434,7 @@ class SettingsPanel(
 		self,
 		message: str,
 		option: str,
-		category: Optional[str] = None,
+		category: str | None = None,
 	):
 		if category is None:
 			category = self.title
@@ -5161,7 +5161,7 @@ class VisionProviderStateControl(vision.providerBase.VisionProviderStateControl)
 	def getProviderInfo(self) -> vision.providerInfo.ProviderInfo:
 		return self._providerInfo
 
-	def getProviderInstance(self) -> Optional[vision.providerBase.VisionEnhancementProvider]:
+	def getProviderInstance(self) -> vision.providerBase.VisionEnhancementProvider | None:
 		return vision.handler.getProviderInstance(self._providerInfo)
 
 	def startProvider(
@@ -5237,7 +5237,7 @@ class VisionSettingsPanel(SettingsPanel):
 	def _createProviderSettingsPanel(
 		self,
 		providerInfo: vision.providerInfo.ProviderInfo,
-	) -> Optional[SettingsPanel]:
+	) -> SettingsPanel | None:
 		settingsPanelCls = providerInfo.providerClass.getSettingsPanelClass()
 		if not settingsPanelCls:
 			if gui._isDebug():
@@ -5396,7 +5396,7 @@ class VisionProviderSubPanel_Wrapper(
 		providerControl: VisionProviderStateControl,
 	):
 		self._providerControl = providerControl
-		self._providerSettings: Optional[VisionProviderSubPanel_Settings] = None
+		self._providerSettings: VisionProviderSubPanel_Settings | None = None
 		self._providerSettingsSizer = wx.BoxSizer(orient=wx.VERTICAL)
 		super().__init__(parent=parent)
 

--- a/source/hwIo/base.py
+++ b/source/hwIo/base.py
@@ -64,10 +64,10 @@ class IoBase(object):
 		self,
 		fileHandle: Union[ctypes.wintypes.HANDLE],
 		onReceive: Callable[[bytes], None],
-		writeFileHandle: Optional[ctypes.wintypes.HANDLE] = None,
+		writeFileHandle: ctypes.wintypes.HANDLE | None = None,
 		onReceiveSize: int = 1,
-		onReadError: Optional[Callable[[int], bool]] = None,
-		ioThread: Optional[IoThread] = None,
+		onReadError: Callable[[int], bool] | None = None,
+		ioThread: IoThread | None = None,
 	):
 		"""Constructor.
 		@param fileHandle: A handle to an open I/O device opened for overlapped I/O.
@@ -174,7 +174,7 @@ class IoBase(object):
 			if _isDebug():
 				log.debugWarning("Couldn't delete object gracefully", exc_info=True)
 
-	def _asyncRead(self, param: Optional[int] = None):
+	def _asyncRead(self, param: int | None = None):
 		ioThread = self._ioThreadRef()
 		if not ioThread:
 			raise RuntimeError("I/O thread is no longer available")
@@ -229,8 +229,8 @@ class Serial(IoBase):
 		self,
 		*args,
 		onReceive: Callable[[bytes], None],
-		onReadError: Optional[Callable[[int], bool]] = None,
-		ioThread: Optional[IoThread] = None,
+		onReadError: Callable[[int], bool] | None = None,
+		ioThread: IoThread | None = None,
 		**kwargs,
 	):
 		"""Constructor.
@@ -288,7 +288,7 @@ class Serial(IoBase):
 		super(Serial, self)._notifyReceive(data)
 		self._setTimeout(None)
 
-	def _setTimeout(self, timeout: Optional[int]):
+	def _setTimeout(self, timeout: int | None):
 		# #6035: pyserial reconfigures all settings of the port when setting a timeout.
 		# This can cause error 'Cannot configure port, some setting was wrong.'
 		# Therefore, manually set the timeouts using the Win32 API.
@@ -321,8 +321,8 @@ class Bulk(IoBase):
 		epOut: int,
 		onReceive: Callable[[bytes], None],
 		onReceiveSize: int = 1,
-		onReadError: Optional[Callable[[int], bool]] = None,
-		ioThread: Optional[IoThread] = None,
+		onReadError: Callable[[int], bool] | None = None,
+		ioThread: IoThread | None = None,
 	):
 		"""Constructor.
 		@param path: The device path.

--- a/source/hwIo/base.py
+++ b/source/hwIo/base.py
@@ -16,7 +16,7 @@ import sys
 import ctypes
 from ctypes import byref
 from ctypes.wintypes import DWORD
-from typing import Optional, Any, Union, Tuple, Callable
+from typing import Any, Union, Tuple, Callable
 import weakref
 import serial
 from serial.win32 import (

--- a/source/hwIo/hid.py
+++ b/source/hwIo/hid.py
@@ -12,7 +12,7 @@ See L{braille.BrailleDisplayDriver.isThreadSafe}.
 import ctypes
 from ctypes import byref
 from ctypes.wintypes import USHORT
-from typing import Tuple, Callable, Optional
+from typing import Tuple, Callable
 from .ioThread import IoThread
 
 from serial.win32 import FILE_FLAG_OVERLAPPED, INVALID_HANDLE_VALUE, CreateFile

--- a/source/hwIo/hid.py
+++ b/source/hwIo/hid.py
@@ -129,8 +129,8 @@ class Hid(IoBase):
 		path: str,
 		onReceive: Callable[[bytes], None],
 		exclusive: bool = True,
-		onReadError: Optional[Callable[[int], bool]] = None,
-		ioThread: Optional[IoThread] = None,
+		onReadError: Callable[[int], bool] | None = None,
+		ioThread: IoThread | None = None,
 	):
 		"""Constructor.
 		@param path: The device path.

--- a/source/hwIo/ioThread.py
+++ b/source/hwIo/ioThread.py
@@ -241,7 +241,7 @@ class IoThread(threading.Thread):
 		self._completionRoutineStore[addr] = (reference, overlapped)
 		return self._internalCompletionRoutine
 
-	def stop(self, timeout: typing.Optional[float] = None):
+	def stop(self, timeout: float | None = None):
 		if not self.is_alive():
 			raise RuntimeError("Thread is not running")
 		self.exit = True

--- a/source/inputCore.py
+++ b/source/inputCore.py
@@ -49,7 +49,7 @@ from NVDAState import WritePaths
 InputGestureBindingClassT = TypeVar("InputGestureBindingClassT")
 ScriptNameT = str
 
-InputGestureScriptT = Tuple[InputGestureBindingClassT, Optional[ScriptNameT]]
+InputGestureScriptT = Tuple[InputGestureBindingClassT, ScriptNameT | None]
 """
 The Python class and script name for each script;
 the script name may be C{None} indicating that the gesture should be unbound for this class.
@@ -190,9 +190,9 @@ class InputGesture(baseObject.AutoPropertyObject):
 		raise NotImplementedError
 
 	#: typing information for autoproperty _get_scriptableObject
-	scriptableObject: Optional[baseObject.ScriptableObject]
+	scriptableObject: baseObject.ScriptableObject | None
 
-	def _get_scriptableObject(self) -> Optional[baseObject.ScriptableObject]:
+	def _get_scriptableObject(self) -> baseObject.ScriptableObject | None:
 		"""An object which contains scripts specific to this  gesture or type of gesture.
 		This object will be searched for scripts before any other object when handling this gesture.
 		@return: The gesture specific scriptable object or C{None} if there is none.
@@ -230,8 +230,8 @@ class InputGesture(baseObject.AutoPropertyObject):
 FlattenedGestureMapT = Dict[
 	str,  # moduleName.className
 	Dict[
-		Optional[ScriptNameT],  # Script name
-		Optional[Union[str, List[str]]],  # Normalized gestures
+		ScriptNameT | None,  # Script name
+		Union[str, List[str]] | None,  # Normalized gestures
 	],
 ]
 ScriptT = Callable[[InputGesture], None]
@@ -241,7 +241,7 @@ _InternalGestureMapT = Dict[
 		Tuple[
 			str,  # module
 			str,  # class name
-			Optional[ScriptNameT],  # script
+			ScriptNameT | None,  # script
 		],
 	],
 ]
@@ -255,7 +255,7 @@ class GlobalGestureMap:
 	See that method for details of the file format.
 	"""
 
-	def __init__(self, entries: Optional[FlattenedGestureMapT] = None):
+	def __init__(self, entries: FlattenedGestureMapT | None = None):
 		"""Constructor.
 		@param entries: Initial entries to add; see L{update} for the format.
 		"""
@@ -263,7 +263,7 @@ class GlobalGestureMap:
 		#: Indicates that the last load or update contained an error.
 		self.lastUpdateContainedError: bool = False
 		#: The file name for this gesture map, if any.
-		self.fileName: Optional[str] = None
+		self.fileName: str | None = None
 		if entries:
 			self.update(entries)
 
@@ -277,7 +277,7 @@ class GlobalGestureMap:
 		gesture: str,
 		module: str,
 		className: str,
-		script: Optional[ScriptNameT],
+		script: ScriptNameT | None,
 		replace: bool = False,
 	):
 		"""Add a gesture mapping.
@@ -984,7 +984,7 @@ def getDisplayTextForGestureIdentifier(identifier):
 
 
 #: The singleton input manager instance.
-manager: Optional[InputManager] = None
+manager: InputManager | None = None
 
 
 def initialize():

--- a/source/inputCore.py
+++ b/source/inputCore.py
@@ -20,7 +20,6 @@ from typing import (
 	Dict,
 	Generator,
 	List,
-	Optional,
 	Tuple,
 	TypeVar,
 	Union,

--- a/source/keyboardHandler.py
+++ b/source/keyboardHandler.py
@@ -13,7 +13,6 @@ import typing
 from typing import (
 	Tuple,
 	List,
-	Optional,
 	Any,
 	TypeAlias,
 )

--- a/source/keyboardHandler.py
+++ b/source/keyboardHandler.py
@@ -127,7 +127,7 @@ def __getattr__(attrName: str) -> Any:
 	raise AttributeError(f"module {repr(__name__)} has no attribute {repr(attrName)}")
 
 
-def getNVDAModifierKeys() -> List[Tuple[int, Optional[bool]]]:
+def getNVDAModifierKeys() -> List[Tuple[int, bool | None]]:
 	keys = []
 	if config.conf["keyboard"]["NVDAModifierKeys"] & NVDAKey.EXTENDED_INSERT:
 		keys.append(vkCodes.byName["insert"])

--- a/source/keyboardHandler.py
+++ b/source/keyboardHandler.py
@@ -42,7 +42,7 @@ if typing.TYPE_CHECKING:
 	from NVDAObjects import NVDAObject  # noqa: F401
 	from watchdog import WatchdogObserver
 
-_watchdogObserver: typing.Optional["WatchdogObserver"] = None
+_watchdogObserver: "WatchdogObserver | None" = None
 ignoreInjected = False
 _lastInjectedKeyUp: tuple[int, int] | None = None
 _injectionDoneEvent: int | None = None
@@ -138,7 +138,7 @@ def getNVDAModifierKeys() -> List[Tuple[int, bool | None]]:
 	return keys
 
 
-def shouldUseToUnicodeEx(focus: Optional["NVDAObject"] = None):
+def shouldUseToUnicodeEx(focus: "NVDAObject | None" = None):
 	"Returns whether to use ToUnicodeEx to determine typed characters."
 	if not focus:
 		focus = api.getFocusObject()

--- a/source/languageHandler.py
+++ b/source/languageHandler.py
@@ -46,7 +46,7 @@ _language: str | None = None
 """Language of NVDA's UI.
 """
 
-installedTranslation: Optional[weakref.ReferenceType] = None
+installedTranslation: weakref.ReferenceType | None = None
 """Saved copy of the installed translation for ease of wrapping.
 """
 
@@ -123,7 +123,7 @@ def localeNameToWindowsLCID(localeName: str) -> int:
 	return LCID
 
 
-def windowsLCIDToLocaleName(lcid: int) -> Optional[str]:
+def windowsLCIDToLocaleName(lcid: int) -> str | None:
 	"""
 	Gets a normalized locale from a Windows LCID.
 
@@ -143,7 +143,7 @@ def windowsLCIDToLocaleName(lcid: int) -> Optional[str]:
 		return normalizeLanguage(localeName)
 
 
-def getLanguageDescription(language: str) -> Optional[str]:
+def getLanguageDescription(language: str) -> str | None:
 	"""Finds out the description (localized full name) of a given local name"""
 	if language == "Windows":
 		# Translators: the label for the Windows default NVDA interface language.
@@ -172,7 +172,7 @@ def getLanguageDescription(language: str) -> Optional[str]:
 	return desc
 
 
-def englishLanguageNameFromNVDALocale(localeName: str) -> Optional[str]:
+def englishLanguageNameFromNVDALocale(localeName: str) -> str | None:
 	"""Returns either English name of the given language  using `GetLocaleInfoEx` or None
 	if the given locale is not known to Windows."""
 	localeName = normalizeLocaleForWin32(localeName)
@@ -205,7 +205,7 @@ def englishLanguageNameFromNVDALocale(localeName: str) -> Optional[str]:
 	return None
 
 
-def englishCountryNameFromNVDALocale(localeName: str) -> Optional[str]:
+def englishCountryNameFromNVDALocale(localeName: str) -> str | None:
 	"""Returns either English name of the given country using GetLocaleInfoEx or None
 	if the given locale is not known to Windows."""
 	localeName = normalizeLocaleForWin32(localeName)
@@ -224,7 +224,7 @@ def englishCountryNameFromNVDALocale(localeName: str) -> Optional[str]:
 	return None
 
 
-def ansiCodePageFromNVDALocale(localeName: str) -> Optional[str]:
+def ansiCodePageFromNVDALocale(localeName: str) -> str | None:
 	"""Returns either ANSI code page for a given locale using GetLocaleInfoEx or None
 	if the given locale is not known to Windows."""
 	localeName = normalizeLocaleForWin32(localeName)
@@ -442,7 +442,7 @@ def getLanguage() -> str:
 	return _language
 
 
-def normalizeLanguage(lang: str) -> Optional[str]:
+def normalizeLanguage(lang: str) -> str | None:
 	"""
 	Normalizes a  language-dialect string  in to a standard form we can deal with.
 	Converts  any dash to underline, and makes sure that language is lowercase and dialect is upercase.

--- a/source/languageHandler.py
+++ b/source/languageHandler.py
@@ -22,7 +22,6 @@ import winKernel
 from typing import (
 	FrozenSet,
 	List,
-	Optional,
 	Tuple,
 )
 

--- a/source/logHandler.py
+++ b/source/logHandler.py
@@ -417,7 +417,7 @@ class Formatter(logging.Formatter):
 			record.codepath = "{name}.{funcName}".format(**record.__dict__)
 		return super().format(record)
 
-	def formatTime(self, record: logging.LogRecord, datefmt: Optional[str] = None) -> str:
+	def formatTime(self, record: logging.LogRecord, datefmt: str | None = None) -> str:
 		"""Custom implementation of `formatTime` which avoids `time.localtime`
 		since it causes a crash under some versions of Universal CRT when Python locale
 		is set to a Unicode one (#12160, Python issue 36792)
@@ -471,7 +471,7 @@ logging.setLoggerClass(Logger)
 #: The singleton logger instance.
 log: Logger = logging.getLogger(NVDA_LOGGER_NAME)
 #: The singleton log handler instance.
-logHandler: Optional[logging.Handler] = None
+logHandler: logging.Handler | None = None
 
 
 def _getDefaultLogFilePath():

--- a/source/logHandler.py
+++ b/source/logHandler.py
@@ -22,7 +22,6 @@ import buildVersion
 from typing import (
 	Literal,
 	NamedTuple,
-	Optional,
 	Protocol,
 	TYPE_CHECKING,
 )

--- a/source/logHandler.py
+++ b/source/logHandler.py
@@ -153,7 +153,7 @@ def getCodePath(f):
 	return ".".join(x for x in (path, className, funcName) if x)
 
 
-_onErrorSoundRequested: Optional["extensionPoints.Action"] = None
+_onErrorSoundRequested: "extensionPoints.Action | None" = None
 """
 Triggered every time an error sound needs to be played.
 When nvwave is initialized, it registers the handler responsible for playing the error sound.

--- a/source/mathPres/__init__.py
+++ b/source/mathPres/__init__.py
@@ -53,9 +53,9 @@ class MathPresentationProvider(object):
 		raise NotImplementedError
 
 
-speechProvider: Optional[MathPresentationProvider] = None
-brailleProvider: Optional[MathPresentationProvider] = None
-interactionProvider: Optional[MathPresentationProvider] = None
+speechProvider: MathPresentationProvider | None = None
+brailleProvider: MathPresentationProvider | None = None
+interactionProvider: MathPresentationProvider | None = None
 
 
 def registerProvider(
@@ -147,7 +147,7 @@ def stripExtraneousXml(xml):
 	return RE_STRIP_XML_PREFIX.sub("", xml)
 
 
-def getMathMlFromTextInfo(pos: textInfos.TextInfo) -> Optional[str]:
+def getMathMlFromTextInfo(pos: textInfos.TextInfo) -> str | None:
 	"""Get MathML (if any) at the start of a TextInfo.
 	@param pos: The TextInfo in question.
 	@return: The MathML or C{None} if there is no math.

--- a/source/mathPres/__init__.py
+++ b/source/mathPres/__init__.py
@@ -12,7 +12,7 @@ using L{registerProvider}.
 
 import re
 import typing
-from typing import List, Optional, Union
+from typing import List, Union
 
 from NVDAObjects.window import Window
 import controlTypes

--- a/source/mouseHandler.py
+++ b/source/mouseHandler.py
@@ -4,7 +4,6 @@
 # See the file COPYING for more details.
 
 from dataclasses import dataclass
-from typing import Optional
 import time
 import wx
 import gui

--- a/source/mouseHandler.py
+++ b/source/mouseHandler.py
@@ -338,7 +338,7 @@ def getLogicalButtonFlags() -> LogicalButtonFlags:
 def _doClick(
 	downFlag: int,
 	upFlag: int,
-	releaseDelay: Optional[float] = None,
+	releaseDelay: float | None = None,
 ):
 	executeMouseEvent(downFlag, 0, 0)
 	if releaseDelay:
@@ -346,7 +346,7 @@ def _doClick(
 	executeMouseEvent(upFlag, 0, 0)
 
 
-def doPrimaryClick(releaseDelay: Optional[float] = None):
+def doPrimaryClick(releaseDelay: float | None = None):
 	"""
 	Performs a primary mouse click at the current mouse pointer location.
 	The primary button is the one that usually activates or selects an item.
@@ -359,7 +359,7 @@ def doPrimaryClick(releaseDelay: Optional[float] = None):
 	_doClick(buttonFlags.primaryDown, buttonFlags.primaryUp, releaseDelay)
 
 
-def doSecondaryClick(releaseDelay: Optional[float] = None):
+def doSecondaryClick(releaseDelay: float | None = None):
 	"""
 	Performs a secondary mouse click at the current mouse pointer location.
 	The secondary button is the one that usually displays a context menu for an item when clicked.

--- a/source/nvwave.py
+++ b/source/nvwave.py
@@ -195,7 +195,7 @@ class WavePlayer(garbageHandler.TrackedObject):
 	#: Use the default device, this is the configSpec default value.
 	DEFAULT_DEVICE_KEY = typing.cast(str, config.conf.getConfigValidation(("audio", "outputDevice")).default)
 	#: The silence output device, None if not initialized.
-	_silenceDevice: typing.Optional[str] = None
+	_silenceDevice: str | None = None
 
 	def __init__(
 		self,
@@ -243,7 +243,7 @@ class WavePlayer(garbageHandler.TrackedObject):
 		self._doneCallbacks = {}
 		self._instances[self._player] = self
 		self.open()
-		self._lastActiveTime: typing.Optional[float] = None
+		self._lastActiveTime: float | None = None
 		self._isPaused: bool = False
 		if config.conf["audio"]["audioAwakeTime"] > 0 and WavePlayer._silenceDevice != outputDevice:
 			# The output device has changed. (Re)initialize silence.
@@ -309,8 +309,8 @@ class WavePlayer(garbageHandler.TrackedObject):
 	def feed(
 		self,
 		data: typing.Union[bytes, c_void_p],
-		size: typing.Optional[int] = None,
-		onDone: typing.Optional[typing.Callable] = None,
+		size: int | None = None,
+		onDone: typing.Callable | None = None,
 	) -> None:
 		"""Feed a chunk of audio data to be played.
 		This will block until there is sufficient space in the buffer.
@@ -409,9 +409,9 @@ class WavePlayer(garbageHandler.TrackedObject):
 	def setVolume(
 		self,
 		*,
-		all: Optional[float] = None,
-		left: Optional[float] = None,
-		right: Optional[float] = None,
+		all: float | None = None,
+		left: float | None = None,
+		right: float | None = None,
 	):
 		"""Set the volume of one or more channels in this stream.
 		Levels must be specified as a number between 0 and 1.
@@ -528,7 +528,7 @@ class WavePlayer(garbageHandler.TrackedObject):
 				break
 
 
-fileWavePlayer: Optional[WavePlayer] = None
+fileWavePlayer: WavePlayer | None = None
 fileWavePlayerThread: threading.Thread | None = None
 
 

--- a/source/nvwave.py
+++ b/source/nvwave.py
@@ -8,9 +8,6 @@
 
 import threading
 import typing
-from typing import (
-	Optional,
-)
 from enum import Enum, auto
 from ctypes import (
 	Structure,

--- a/source/review.py
+++ b/source/review.py
@@ -120,7 +120,7 @@ def getCurrentMode():
 def setCurrentMode(
 	mode: Union[int, str],
 	updateReviewPosition: bool = True,
-) -> Optional[str]:
+) -> str | None:
 	"""
 	Sets the current review mode to the given mode ID or index and updates the review position.
 	@param mode: either a 0-based index into the modes list, or one of the mode IDs (first item of a tuple in the modes list).

--- a/source/review.py
+++ b/source/review.py
@@ -4,7 +4,6 @@
 # For more details see: https://www.gnu.org/licenses/gpl-2.0.html
 
 from typing import (
-	Optional,
 	Union,
 )
 

--- a/source/scriptHandler.py
+++ b/source/scriptHandler.py
@@ -8,7 +8,6 @@ from typing import (
 	Generator,
 	Iterator,
 	List,
-	Optional,
 	Tuple,
 )
 import time

--- a/source/scriptHandler.py
+++ b/source/scriptHandler.py
@@ -30,11 +30,11 @@ import baseObject
 _ScriptFunctionT = Callable[["inputCore.InputGesture"], None]
 _ScriptFilterT = Callable[
 	[
-		Optional[_ScriptFunctionT],
+		_ScriptFunctionT | None,
 		"NVDAObjects.NVDAObject",
 		"inputCore.InputGesture",
 	],
-	Optional[_ScriptFunctionT],
+	_ScriptFunctionT | None,
 ]
 
 _numScriptsQueued = 0  # Number of scripts that are queued to be executed
@@ -61,7 +61,7 @@ def _getObjScript(
 	obj: "NVDAObjects.NVDAObject",
 	gesture: "inputCore.InputGesture",
 	globalMapScripts: List["inputCore.InputGestureScriptT"],
-) -> Optional[_ScriptFunctionT]:
+) -> _ScriptFunctionT | None:
 	"""
 	@param globalMapScripts: An ordered list of scripts.
 	The list is ordered by resolution priority,
@@ -105,7 +105,7 @@ def getGlobalMapScripts(gesture: "inputCore.InputGesture") -> List["inputCore.In
 	return globalMapScripts
 
 
-def findScript(gesture: "inputCore.InputGesture") -> Optional[_ScriptFunctionT]:
+def findScript(gesture: "inputCore.InputGesture") -> _ScriptFunctionT | None:
 	from utils.security import getSafeScripts
 	from winAPI.sessionTracking import isLockScreenModeActive
 
@@ -115,7 +115,7 @@ def findScript(gesture: "inputCore.InputGesture") -> Optional[_ScriptFunctionT]:
 	return foundScript
 
 
-def _findScript(gesture: "inputCore.InputGesture") -> Optional[_ScriptFunctionT]:
+def _findScript(gesture: "inputCore.InputGesture") -> _ScriptFunctionT | None:
 	focus = api.getFocusObject()
 	if not focus:
 		return None
@@ -134,10 +134,10 @@ def _findScript(gesture: "inputCore.InputGesture") -> Optional[_ScriptFunctionT]
 
 
 def _getTreeModeInterceptorScript(
-	func: Optional[_ScriptFunctionT],
+	func: _ScriptFunctionT | None,
 	obj: "NVDAObjects.NVDAObject",
 	gesture: "inputCore.InputGesture",
-) -> Optional[_ScriptFunctionT]:
+) -> _ScriptFunctionT | None:
 	"""
 	A filtering function used with _yieldObjectsForFindScript, to ensure a tree interceptor
 	should propagate scripts and therefore handle the input gesture.
@@ -152,10 +152,10 @@ def _getTreeModeInterceptorScript(
 
 
 def _getFocusAncestorScript(
-	func: Optional[_ScriptFunctionT],
+	func: _ScriptFunctionT | None,
 	obj: "NVDAObjects.NVDAObject",
 	gesture: "inputCore.InputGesture",
-) -> Optional[_ScriptFunctionT]:
+) -> _ScriptFunctionT | None:
 	"""
 	A filtering function used with _yieldObjectsForFindScript, to ensure a focus ancestor
 	should propagate scripts and therefore handle the input gesture.
@@ -167,7 +167,7 @@ def _getFocusAncestorScript(
 
 def _yieldObjectsForFindScript(
 	gesture: "inputCore.InputGesture",
-) -> Generator[Tuple["NVDAObjects.NVDAObject", Optional[_ScriptFilterT]], None, None]:
+) -> Generator[Tuple["NVDAObjects.NVDAObject", _ScriptFilterT | None], None, None]:
 	"""
 	This generator is used to determine which NVDAObject to perform an input gesture on,
 	in order of priority.
@@ -330,7 +330,7 @@ def clearLastScript():
 	_lastScriptCount = 0
 
 
-def getCurrentScript() -> Optional[_ScriptFunctionT]:
+def getCurrentScript() -> _ScriptFunctionT | None:
 	if not _isScriptRunning:
 		return None
 	lastScriptRef = _lastScriptRef() if _lastScriptRef else None
@@ -343,13 +343,13 @@ def isScriptWaiting():
 
 def script(
 	description: str = "",
-	category: Optional[str] = None,
-	gesture: Optional[str] = None,
-	gestures: Optional[Iterator[str]] = None,
+	category: str | None = None,
+	gesture: str | None = None,
+	gestures: Iterator[str] | None = None,
 	canPropagate: bool = False,
 	bypassInputHelp: bool = False,
 	allowInSleepMode: bool = False,
-	resumeSayAllMode: Optional[int] = None,
+	resumeSayAllMode: int | None = None,
 	speakOnDemand: bool = False,
 ):
 	"""Define metadata for a script.

--- a/source/shellapi.py
+++ b/source/shellapi.py
@@ -40,11 +40,11 @@ SEE_MASK_NOCLOSEPROCESS = 0x00000040
 
 
 def ShellExecute(
-	hwnd: Optional[int],
-	operation: Optional[str],
+	hwnd: int | None,
+	operation: str | None,
 	file: str,
-	parameters: Optional[str],
-	directory: Optional[str],
+	parameters: str | None,
+	directory: str | None,
 	showCmd: int,
 ) -> None:
 	if not file:

--- a/source/shellapi.py
+++ b/source/shellapi.py
@@ -5,7 +5,6 @@
 
 from ctypes import *  # noqa: F403
 from ctypes.wintypes import *  # noqa: F403
-from typing import Optional
 
 
 shell32 = windll.shell32  # noqa: F405

--- a/source/shlobj.py
+++ b/source/shlobj.py
@@ -15,7 +15,7 @@ import comtypes
 import ctypes
 from enum import Enum
 import functools
-from typing import Optional, Union
+from typing import Union
 
 
 class FolderId(str, Enum):

--- a/source/shlobj.py
+++ b/source/shlobj.py
@@ -42,7 +42,7 @@ class FolderId(str, Enum):
 def SHGetKnownFolderPath(
 	folderGuid: Union[FolderId, str],
 	dwFlags: int = 0,
-	hToken: Optional[int] = None,
+	hToken: int | None = None,
 ) -> str:
 	"""Wrapper for `SHGetKnownFolderPath` which caches the results
 	to avoid calling the win32 function unnecessarily."""

--- a/source/speech/commands.py
+++ b/source/speech/commands.py
@@ -9,9 +9,6 @@ Commands that can be embedded in a speech sequence for changing synth parameters
 """
 
 from abc import ABCMeta, abstractmethod
-from typing import (
-	Optional,
-)
 
 import config
 from synthDriverHandler import getSynth

--- a/source/speech/commands.py
+++ b/source/speech/commands.py
@@ -426,7 +426,7 @@ class CallbackCommand(BaseCallbackCommand):
 		otherwise it will block production of further speech and or other functionality in NVDA.
 	"""
 
-	def __init__(self, callback, name: Optional[str] = None):
+	def __init__(self, callback, name: str | None = None):
 		self._callback = callback
 		self._name = name if name else repr(callback)
 

--- a/source/speech/manager.py
+++ b/source/speech/manager.py
@@ -191,7 +191,7 @@ class SpeechManager(object):
 
 	_cancelCommandsForUtteranceBeingSpokenBySynth: Dict[_CancellableSpeechCommand, _IndexT]
 	_priQueues: Dict[Any, _ManagerPriorityQueue]
-	_curPriQueue: Optional[_ManagerPriorityQueue]  # None indicates no more speech.
+	_curPriQueue: _ManagerPriorityQueue | None  # None indicates no more speech.
 
 	def __init__(self):
 		#: A counter for indexes sent to the synthesizer for callbacks, etc.
@@ -540,9 +540,9 @@ class SpeechManager(object):
 	def _isIndexAAfterIndexB(cls, indexA: _IndexT, indexB: _IndexT) -> bool:
 		return indexA != indexB and not cls._isIndexABeforeIndexB(indexA, indexB)
 
-	def _getMostRecentlyCancelledUtterance(self) -> Optional[_IndexT]:
+	def _getMostRecentlyCancelledUtterance(self) -> _IndexT | None:
 		# Index of the most recently cancelled utterance.
-		latestCancelledUtteranceIndex: Optional[_IndexT] = None
+		latestCancelledUtteranceIndex: _IndexT | None = None
 		log._speechManagerDebug(
 			f"Length of _cancelCommandsForUtteranceBeingSpokenBySynth: "
 			f"{len(self._cancelCommandsForUtteranceBeingSpokenBySynth)} "
@@ -718,7 +718,7 @@ class SpeechManager(object):
 			# Even if we have many indexes, we should only push next speech once.
 			self._pushNextSpeech(False)
 
-	def _onSynthDoneSpeaking(self, synth: Optional[synthDriverHandler.SynthDriver] = None):
+	def _onSynthDoneSpeaking(self, synth: synthDriverHandler.SynthDriver | None = None):
 		log._speechManagerUnitTest(f"synthDoneSpeaking synth:{synth}")
 		if synth != getSynth():
 			return

--- a/source/speech/manager.py
+++ b/source/speech/manager.py
@@ -30,7 +30,6 @@ from typing import (
 	Any,
 	List,
 	Tuple,
-	Optional,
 	cast,
 )
 

--- a/source/speech/sayAll.py
+++ b/source/speech/sayAll.py
@@ -108,8 +108,8 @@ class _SayAllHandler:
 	def readText(
 		self,
 		cursor: CURSOR,
-		startPos: Optional[textInfos.TextInfo] = None,
-		nextLineFunc: Optional[Callable[[textInfos.TextInfo], textInfos.TextInfo]] = None,
+		startPos: textInfos.TextInfo | None = None,
+		nextLineFunc: Callable[[textInfos.TextInfo], textInfos.TextInfo] | None = None,
 		shouldUpdateCaret: bool = True,
 		startedFromScript: bool | None = False,
 	) -> None:
@@ -431,8 +431,8 @@ class _TableTextReader(_CaretTextReader):
 	def __init__(
 		self,
 		handler: _SayAllHandler,
-		startPos: Optional[textInfos.TextInfo] = None,
-		nextLineFunc: Optional[Callable[[textInfos.TextInfo], textInfos.TextInfo]] = None,
+		startPos: textInfos.TextInfo | None = None,
+		nextLineFunc: Callable[[textInfos.TextInfo], textInfos.TextInfo] | None = None,
 		shouldUpdateCaret: bool = True,
 	):
 		self.startPos = startPos

--- a/source/speech/sayAll.py
+++ b/source/speech/sayAll.py
@@ -6,7 +6,7 @@
 
 from abc import ABCMeta, abstractmethod
 from enum import IntEnum
-from typing import Callable, TYPE_CHECKING, Optional
+from typing import Callable, TYPE_CHECKING
 import weakref
 import garbageHandler
 from logHandler import log

--- a/source/speech/shortcutKeys.py
+++ b/source/speech/shortcutKeys.py
@@ -21,13 +21,13 @@ from typing import (
 )
 
 
-def speakKeyboardShortcuts(keyboardShortcutsStr: Optional[str]) -> None:
+def speakKeyboardShortcuts(keyboardShortcutsStr: str | None) -> None:
 	from .speech import speak
 
 	speak(getKeyboardShortcutsSpeech(keyboardShortcutsStr))
 
 
-def getKeyboardShortcutsSpeech(keyboardShortcutsStr: Optional[str]) -> SpeechSequence:
+def getKeyboardShortcutsSpeech(keyboardShortcutsStr: str | None) -> SpeechSequence:
 	"""Gets the speech sequence for a shortcuts string containing one or more shortcuts.
 	@param keyboardShortcutsStr: the shortcuts string.
 	"""

--- a/source/speech/shortcutKeys.py
+++ b/source/speech/shortcutKeys.py
@@ -15,7 +15,6 @@ import config
 from .commands import CharacterModeCommand
 from .types import SpeechSequence
 from typing import (
-	Optional,
 	List,
 	Tuple,
 )

--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -81,7 +81,7 @@ if typing.TYPE_CHECKING:
 	import NVDAObjects
 	from speechXml import MarkCallbackT
 
-_speechState: Optional["SpeechState"] = None
+_speechState: "SpeechState | None" = None
 _curWordChars: List[str] = []
 
 

--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -52,7 +52,6 @@ from .types import (
 )
 from typing import (
 	Iterable,
-	Optional,
 	Dict,
 	List,
 	Any,

--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -117,7 +117,7 @@ class SpeechState:
 	#: The number of typed characters for which to suppress speech.
 	_suppressSpeakTypedCharactersNumber = 0
 	#: The time at which suppressed typed characters were sent.
-	_suppressSpeakTypedCharactersTime: Optional[float] = None
+	_suppressSpeakTypedCharactersTime: float | None = None
 	# Property values that are kept from getPropertiesSpeech
 	oldTreeLevel = None
 	oldTableID = None
@@ -237,7 +237,7 @@ def _getSpeakMessageSpeech(
 
 def speakMessage(
 	text: str,
-	priority: Optional[Spri] = None,
+	priority: Spri | None = None,
 ) -> None:
 	"""Speaks a given message.
 	@param text: the message to speak
@@ -307,7 +307,7 @@ def getCurrentLanguage() -> str:
 def spellTextInfo(
 	info: textInfos.TextInfo,
 	useCharacterDescriptions: bool = False,
-	priority: Optional[Spri] = None,
+	priority: Spri | None = None,
 ) -> None:
 	"""Spells the text from the given TextInfo, honouring any LangChangeCommand objects it finds if autoLanguageSwitching is enabled."""
 	if not languageHandling.shouldMakeLangChangeCommand():
@@ -328,9 +328,9 @@ def spellTextInfo(
 
 def speakSpelling(
 	text: str,
-	locale: Optional[str] = None,
+	locale: str | None = None,
 	useCharacterDescriptions: bool = False,
-	priority: Optional[Spri] = None,
+	priority: Spri | None = None,
 ) -> None:
 	# This could be a very large list. In future we could convert this into chunks.
 	seq = list(
@@ -522,7 +522,7 @@ def getSingleCharDescriptionDelayMS() -> int:
 
 def getSingleCharDescription(
 	text: str,
-	locale: Optional[str] = None,
+	locale: str | None = None,
 ) -> Generator[SequenceItemT, None, None]:
 	"""
 	Returns a speech sequence:
@@ -561,7 +561,7 @@ def getSingleCharDescription(
 
 def getSpellingSpeech(
 	text: str,
-	locale: Optional[str] = None,
+	locale: str | None = None,
 	useCharacterDescriptions: bool = False,
 ) -> Generator[SequenceItemT, None, None]:
 	synth = getSynth()
@@ -623,8 +623,8 @@ def getCharDescListFromText(text, locale):
 def speakObjectProperties(
 	obj: "NVDAObjects.NVDAObject",
 	reason: OutputReason = OutputReason.QUERY,
-	_prefixSpeechCommand: Optional[SpeechCommand] = None,
-	priority: Optional[Spri] = None,
+	_prefixSpeechCommand: SpeechCommand | None = None,
+	priority: Spri | None = None,
 	**allowedProperties,
 ):
 	speechSequence = getObjectPropertiesSpeech(
@@ -643,7 +643,7 @@ def speakObjectProperties(
 def getObjectPropertiesSpeech(  # noqa: C901
 	obj: "NVDAObjects.NVDAObject",
 	reason: OutputReason = OutputReason.QUERY,
-	_prefixSpeechCommand: Optional[SpeechCommand] = None,
+	_prefixSpeechCommand: SpeechCommand | None = None,
 	**allowedProperties,
 ) -> SpeechSequence:
 	if objectBelowLockScreenAndWindowsIsLocked(obj):
@@ -797,8 +797,8 @@ def _getPlaceholderSpeechIfTextEmpty(
 def speakObject(
 	obj,
 	reason: OutputReason = OutputReason.QUERY,
-	_prefixSpeechCommand: Optional[SpeechCommand] = None,
-	priority: Optional[Spri] = None,
+	_prefixSpeechCommand: SpeechCommand | None = None,
+	priority: Spri | None = None,
 ):
 	sequence = getObjectSpeech(
 		obj,
@@ -812,7 +812,7 @@ def speakObject(
 def getObjectSpeech(
 	obj: "NVDAObjects.NVDAObject",
 	reason: OutputReason = OutputReason.QUERY,
-	_prefixSpeechCommand: Optional[SpeechCommand] = None,
+	_prefixSpeechCommand: SpeechCommand | None = None,
 ) -> SpeechSequence:
 	if objectBelowLockScreenAndWindowsIsLocked(obj):
 		return []
@@ -1173,7 +1173,7 @@ def speak(  # noqa: C901
 
 def speakPreselectedText(
 	text: str,
-	priority: Optional[Spri] = None,
+	priority: Spri | None = None,
 ):
 	"""Helper method to announce that a newly focused control already has
 	text selected. This method is in contrast with L{speakTextSelected}.
@@ -1213,7 +1213,7 @@ def getPreselectedTextSpeech(
 
 def speakTextSelected(
 	text: str,
-	priority: Optional[Spri] = None,
+	priority: Spri | None = None,
 ):
 	"""Helper method to announce that the user has caused text to be selected.
 	This method is in contrast with L{speakPreselectedText}.
@@ -1231,7 +1231,7 @@ def speakTextSelected(
 def speakSelectionMessage(
 	message: str,
 	text: str,
-	priority: Optional[Spri] = None,
+	priority: Spri | None = None,
 ):
 	seq = _getSelectionMessageSpeech(message, text)
 	if seq:
@@ -1263,7 +1263,7 @@ def speakSelectionChange(  # noqa: C901
 	speakSelected: bool = True,
 	speakUnselected: bool = True,
 	generalize: bool = False,
-	priority: Optional[Spri] = None,
+	priority: Spri | None = None,
 ):
 	"""Speaks a change in selection, either selected or unselected text.
 	@param oldInfo: a TextInfo instance representing what the selection was before
@@ -1460,12 +1460,12 @@ def speakTextInfo(
 	info: textInfos.TextInfo,
 	useCache: Union[bool, SpeakTextInfoState] = True,
 	formatConfig: Dict[str, bool] = None,
-	unit: Optional[str] = None,
+	unit: str | None = None,
 	reason: OutputReason = OutputReason.QUERY,
-	_prefixSpeechCommand: Optional[SpeechCommand] = None,
+	_prefixSpeechCommand: SpeechCommand | None = None,
 	onlyInitialFields: bool = False,
 	suppressBlanks: bool = False,
-	priority: Optional[Spri] = None,
+	priority: Spri | None = None,
 ) -> bool:
 	speechGen = getTextInfoSpeech(
 		info,
@@ -1491,9 +1491,9 @@ def getTextInfoSpeech(  # noqa: C901
 	info: textInfos.TextInfo,
 	useCache: Union[bool, SpeakTextInfoState] = True,
 	formatConfig: Dict[str, bool] = None,
-	unit: Optional[str] = None,
+	unit: str | None = None,
 	reason: OutputReason = OutputReason.QUERY,
-	_prefixSpeechCommand: Optional[SpeechCommand] = None,
+	_prefixSpeechCommand: SpeechCommand | None = None,
 	onlyInitialFields: bool = False,
 	suppressBlanks: bool = False,
 ) -> Generator[SpeechSequence, None, bool]:
@@ -1884,7 +1884,7 @@ def _isControlEndFieldCommand(command: Union[str, textInfos.FieldCommand]):
 
 
 def _getTextInfoSpeech_considerSpelling(
-	unit: Optional[textInfos.TextInfo],
+	unit: textInfos.TextInfo | None,
 	onlyInitialFields: bool,
 	textWithFields: textInfos.TextInfo.TextWithFieldsT,
 	reason: OutputReason,
@@ -1936,7 +1936,7 @@ def getPropertiesSpeech(  # noqa: C901
 	**propertyValues,
 ) -> SpeechSequence:
 	textList: SpeechSequence = []
-	name: Optional[str] = propertyValues.get("name")
+	name: str | None = propertyValues.get("name")
 	if name:
 		textList.append(name)
 	if "role" in propertyValues:
@@ -1949,17 +1949,17 @@ def getPropertiesSpeech(  # noqa: C901
 		speakRole = False
 		role = controlTypes.Role.UNKNOWN
 	role = controlTypes.Role(role)
-	value: Optional[str] = (
+	value: str | None = (
 		propertyValues.get("value") if role not in controlTypes.silentValuesForRoles else None
 	)
-	cellCoordsText: Optional[str] = propertyValues.get("cellCoordsText")
+	cellCoordsText: str | None = propertyValues.get("cellCoordsText")
 	rowNumber = propertyValues.get("rowNumber")
 	columnNumber = propertyValues.get("columnNumber")
 	includeTableCellCoords = propertyValues.get("includeTableCellCoords", True)
 
 	if role == controlTypes.Role.CHARTELEMENT:
 		speakRole = False
-	roleText: Optional[str] = propertyValues.get("roleText")
+	roleText: str | None = propertyValues.get("roleText")
 	if (
 		speakRole
 		and (
@@ -1999,11 +1999,11 @@ def getPropertiesSpeech(  # noqa: C901
 		labelStates = controlTypes.processAndLabelStates(role, realStates, reason, states, negativeStates)
 		textList.extend(labelStates)
 	# sometimes description key is present but value is None
-	description: Optional[str] = propertyValues.get("description")
+	description: str | None = propertyValues.get("description")
 	if description:
 		textList.append(description)
 	# sometimes keyboardShortcut key is present but value is None
-	keyboardShortcut: Optional[str] = propertyValues.get("keyboardShortcut")
+	keyboardShortcut: str | None = propertyValues.get("keyboardShortcut")
 	textList.extend(getKeyboardShortcutsSpeech(keyboardShortcut))
 	if includeTableCellCoords and cellCoordsText:
 		textList.append(cellCoordsText)
@@ -2022,7 +2022,7 @@ def getPropertiesSpeech(  # noqa: C901
 		if rowNumber and (
 			not sameTable or rowNumber != _speechState.oldRowNumber or rowSpan != _speechState.oldRowSpan
 		):
-			rowHeaderText: Optional[str] = propertyValues.get("rowHeaderText")
+			rowHeaderText: str | None = propertyValues.get("rowHeaderText")
 			if rowHeaderText:
 				textList.append(rowHeaderText)
 			if includeTableCellCoords and not cellCoordsText:
@@ -2042,7 +2042,7 @@ def getPropertiesSpeech(  # noqa: C901
 			or columnNumber != _speechState.oldColumnNumber
 			or columnSpan != _speechState.oldColumnSpan
 		):
-			columnHeaderText: Optional[str] = propertyValues.get("columnHeaderText")
+			columnHeaderText: str | None = propertyValues.get("columnHeaderText")
 			if columnHeaderText:
 				textList.append(columnHeaderText)
 			if includeTableCellCoords and not cellCoordsText:
@@ -2097,7 +2097,7 @@ def getPropertiesSpeech(  # noqa: C901
 				_("has details"),
 			)
 
-	placeholder: Optional[str] = propertyValues.get("placeholder", None)
+	placeholder: str | None = propertyValues.get("placeholder", None)
 	if placeholder:
 		textList.append(placeholder)
 	indexInGroup = propertyValues.get("positionInfo_indexInGroup", 0)
@@ -2133,7 +2133,7 @@ def getPropertiesSpeech(  # noqa: C901
 	return textList
 
 
-def _rowAndColumnCountText(rowCount: int, columnCount: int) -> Optional[str]:
+def _rowAndColumnCountText(rowCount: int, columnCount: int) -> str | None:
 	if rowCount and columnCount:
 		rowCountTranslation: str = _rowCountText(rowCount)
 		colCountTranslation: str = _columnCountText(columnCount)
@@ -2212,9 +2212,9 @@ def getControlFieldSpeech(  # noqa: C901
 	attrs: textInfos.ControlField,
 	ancestorAttrs: List[textInfos.Field],
 	fieldType: str,
-	formatConfig: Optional[Dict[str, bool]] = None,
+	formatConfig: Dict[str, bool] | None = None,
 	extraDetail: bool = False,
-	reason: Optional[OutputReason] = None,
+	reason: OutputReason | None = None,
 ) -> SpeechSequence:
 	if attrs.get("isHidden"):
 		return []
@@ -2244,7 +2244,7 @@ def getControlFieldSpeech(  # noqa: C901
 		errorMessage = attrs.get("errorMessage", None)
 	value = attrs.get("value", "")
 
-	description: Optional[str] = None
+	description: str | None = None
 	_descriptionFrom = attrs.get("_description-from", controlTypes.DescriptionFrom.UNKNOWN)
 	_descriptionIsContent: bool = attrs.get("descriptionIsContent", False)
 	_reportDescriptionAsAnnotation: bool = (
@@ -2542,10 +2542,10 @@ def getControlFieldSpeech(  # noqa: C901
 # and move logic out into smaller helper functions.
 def getFormatFieldSpeech(  # noqa: C901
 	attrs: textInfos.Field,
-	attrsCache: Optional[textInfos.Field] = None,
-	formatConfig: Optional[Dict[str, bool]] = None,
-	reason: Optional[OutputReason] = None,
-	unit: Optional[str] = None,
+	attrsCache: textInfos.Field | None = None,
+	formatConfig: Dict[str, bool] | None = None,
+	reason: OutputReason | None = None,
+	unit: str | None = None,
 	extraDetail: bool = False,
 	initialFormat: bool = False,
 ) -> SpeechSequence:
@@ -3040,8 +3040,8 @@ def getFormatFieldSpeech(  # noqa: C901
 
 
 def getTableInfoSpeech(
-	tableInfo: Optional[Dict[str, Any]],
-	oldTableInfo: Optional[Dict[str, Any]],
+	tableInfo: Dict[str, Any] | None,
+	oldTableInfo: Dict[str, Any] | None,
 	extraDetail: bool = False,
 ) -> SpeechSequence:
 	if tableInfo is None and oldTableInfo is None:

--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -1948,9 +1948,7 @@ def getPropertiesSpeech(  # noqa: C901
 		speakRole = False
 		role = controlTypes.Role.UNKNOWN
 	role = controlTypes.Role(role)
-	value: str | None = (
-		propertyValues.get("value") if role not in controlTypes.silentValuesForRoles else None
-	)
+	value: str | None = propertyValues.get("value") if role not in controlTypes.silentValuesForRoles else None
 	cellCoordsText: str | None = propertyValues.get("cellCoordsText")
 	rowNumber = propertyValues.get("rowNumber")
 	columnNumber = propertyValues.get("columnNumber")

--- a/source/speech/speechWithoutPauses.py
+++ b/source/speech/speechWithoutPauses.py
@@ -19,7 +19,6 @@ from .types import (
 )
 
 from typing import (
-	Optional,
 	Generator,
 	Callable,
 )

--- a/source/speech/speechWithoutPauses.py
+++ b/source/speech/speechWithoutPauses.py
@@ -53,7 +53,7 @@ class SpeechWithoutPauses:
 
 	def speakWithoutPauses(
 		self,
-		speechSequence: Optional[SpeechSequence],
+		speechSequence: SpeechSequence | None,
 		detectBreaks: bool = True,
 	) -> bool:
 		"""
@@ -75,7 +75,7 @@ class SpeechWithoutPauses:
 
 	def getSpeechWithoutPauses(  # noqa: C901
 		self,
-		speechSequence: Optional[SpeechSequence],
+		speechSequence: SpeechSequence | None,
 		detectBreaks: bool = True,
 	) -> Generator[SpeechSequence, None, bool]:
 		"""

--- a/source/speech/types.py
+++ b/source/speech/types.py
@@ -13,7 +13,6 @@ from typing import (
 	Union,
 	Iterable,
 	Any,
-	Optional,
 	Generator,
 )
 

--- a/source/speech/types.py
+++ b/source/speech/types.py
@@ -50,7 +50,7 @@ class GeneratorWithReturn(Iterable):
 
 def _flattenNestedSequences(
 	nestedSequences: Union[Iterable[SpeechSequence], GeneratorWithReturn],
-) -> Generator[SequenceItemT, Any, Optional[bool]]:
+) -> Generator[SequenceItemT, Any, bool | None]:
 	"""Turns [[a,b,c],[d,e]] into [a,b,c,d,e]"""
 	yield from (i for seq in nestedSequences for i in seq)
 	if isinstance(nestedSequences, GeneratorWithReturn):

--- a/source/speechViewer.py
+++ b/source/speechViewer.py
@@ -5,7 +5,6 @@
 
 from typing import (
 	Callable,
-	Optional,
 )
 import wx
 import gui

--- a/source/speechViewer.py
+++ b/source/speechViewer.py
@@ -156,7 +156,7 @@ class SpeechViewerFrame(
 		config.conf["speechViewer"]["autoPositionWindow"] = False
 
 
-_guiFrame: Optional[SpeechViewerFrame] = None
+_guiFrame: SpeechViewerFrame | None = None
 isActive: bool = False
 
 
@@ -170,7 +170,7 @@ def activate():
 
 def _setActive(
 	isNowActive: bool,
-	speechViewerFrame: Optional[SpeechViewerFrame] = None,
+	speechViewerFrame: SpeechViewerFrame | None = None,
 ) -> None:
 	global _guiFrame, isActive
 	isActive = isNowActive

--- a/source/synthDriverHandler.py
+++ b/source/synthDriverHandler.py
@@ -48,7 +48,7 @@ class LanguageInfo(StringParameterInfo):
 class VoiceInfo(StringParameterInfo):
 	"""Provides information about a single synthesizer voice."""
 
-	def __init__(self, id, displayName, language: Optional[str] = None):
+	def __init__(self, id, displayName, language: str | None = None):
 		"""
 		@param language: The ID of the language this voice speaks,
 			C{None} if not known or the synth implements language separate from voices.
@@ -114,10 +114,10 @@ class SynthDriver(driverHandler.Driver):
 	availableVoices: OrderedDict[str, VoiceInfo]
 	# type information for auto property _get_language
 	# the current voice's language
-	language: Optional[str]
+	language: str | None
 	# type information for auto property _get_availableLanguages
 	# the set of languages available in the availableVoices
-	availableLanguages: Set[Optional[str]]
+	availableLanguages: Set[str | None]
 
 	@classmethod
 	def LanguageSetting(cls):
@@ -233,13 +233,13 @@ class SynthDriver(driverHandler.Driver):
 	def cancel(self):
 		"""Silence speech immediately."""
 
-	def _get_language(self) -> Optional[str]:
+	def _get_language(self) -> str | None:
 		return self.availableVoices[self.voice].language
 
 	def _set_language(self, language):
 		raise NotImplementedError
 
-	def _get_availableLanguages(self) -> Set[Optional[str]]:
+	def _get_availableLanguages(self) -> Set[str | None]:
 		return {self.availableVoices[v].language for v in self.availableVoices}
 
 	def _get_voice(self):
@@ -402,7 +402,7 @@ class SynthDriver(driverHandler.Driver):
 		return None
 
 
-_curSynth: Optional[SynthDriver] = None
+_curSynth: SynthDriver | None = None
 _audioOutputDevice = None
 
 
@@ -457,7 +457,7 @@ def getSynthList() -> List[Tuple[str, str]]:
 	return synthList
 
 
-def getSynth() -> Optional[SynthDriver]:
+def getSynth() -> SynthDriver | None:
 	return _curSynth
 
 
@@ -478,7 +478,7 @@ if winVersion.getWinVer() >= winVersion.WIN10:
 	defaultSynthPriorityList.insert(0, "oneCore")
 
 
-def setSynth(name: Optional[str], isFallback: bool = False):
+def setSynth(name: str | None, isFallback: bool = False):
 	from synthDrivers.silence import SynthDriver as SilenceSynthDriver
 
 	asDefault = False

--- a/source/synthDriverHandler.py
+++ b/source/synthDriverHandler.py
@@ -8,7 +8,6 @@ import pkgutil
 import importlib
 from typing import (
 	List,
-	Optional,
 	OrderedDict,
 	Set,
 	Tuple,

--- a/source/synthDrivers/espeak.py
+++ b/source/synthDrivers/espeak.py
@@ -9,7 +9,6 @@ from collections import OrderedDict
 from typing import (
 	Dict,
 	List,
-	Optional,
 	Set,
 )
 

--- a/source/synthDrivers/espeak.py
+++ b/source/synthDrivers/espeak.py
@@ -73,7 +73,7 @@ class SynthDriver(SynthDriver):
 		"fr": "fr-fr",
 	}
 
-	availableLanguages: Set[Optional[str]]
+	availableLanguages: Set[str | None]
 	"""
 	For eSpeak commit 7e5457f91e10, this is equivalent to:
 	{
@@ -261,7 +261,7 @@ class SynthDriver(SynthDriver):
 		langWithLocale = command.lang if command.lang else self._language
 		langWithLocale = langWithLocale.lower().replace("_", "-")
 
-		langWithoutLocale: Optional[str] = stripLocaleFromLangCode(langWithLocale)
+		langWithoutLocale: str | None = stripLocaleFromLangCode(langWithLocale)
 
 		# Check for any language where the language code matches, regardless of dialect: e.g. ru-ru to ru
 		matchingLangs = filter(

--- a/source/synthDrivers/oneCore.py
+++ b/source/synthDrivers/oneCore.py
@@ -11,7 +11,6 @@ from typing import (
 	Callable,
 	Generator,
 	List,
-	Optional,
 	Set,
 	Tuple,
 	Union,

--- a/source/synthDrivers/oneCore.py
+++ b/source/synthDrivers/oneCore.py
@@ -102,7 +102,7 @@ class _OcSsmlConverter(speechXml.SsmlConverter):
 		# Therefore, we don't use it.
 		return None
 
-	def convertLangChangeCommand(self, command: LangChangeCommand) -> Optional[speechXml.SetAttrCommand]:
+	def convertLangChangeCommand(self, command: LangChangeCommand) -> speechXml.SetAttrCommand | None:
 		lcid = languageHandler.localeNameToWindowsLCID(command.lang)
 		if lcid is languageHandler.LCID_NONE:
 			log.debugWarning(f"Invalid language: {command.lang}")
@@ -235,7 +235,7 @@ class OneCoreSynthDriver(SynthDriver):
 
 		self._earlyExitCB = False
 		self._callbackInst = ocSpeech_Callback(self._callback)
-		self._ocSpeechToken: Optional[ctypes.POINTER] = self._dll.ocSpeech_initialize(self._callbackInst)
+		self._ocSpeechToken: ctypes.POINTER | None = self._dll.ocSpeech_initialize(self._callbackInst)
 		self._dll.ocSpeech_getVoices.restype = NVDAHelper.bstrReturn
 		self._dll.ocSpeech_getCurrentVoiceId.restype = ctypes.c_wchar_p
 		self._player = None

--- a/source/synthDrivers/sapi4.py
+++ b/source/synthDrivers/sapi4.py
@@ -876,7 +876,7 @@ class SynthDriver(SynthDriver):
 
 	def __init__(self):
 		self._comThread = _ComThread()
-		self._finalIndex: Optional[int] = None
+		self._finalIndex: int | None = None
 		self._ttsCentral = None
 		self._sinkRegKey = DWORD()
 		self._bookmarks = None

--- a/source/synthDrivers/sapi4.py
+++ b/source/synthDrivers/sapi4.py
@@ -29,7 +29,7 @@ from ctypes import (
 	windll,
 )
 from ctypes.wintypes import BOOL, DWORD, FILETIME, HANDLE, MSG, WORD
-from typing import TYPE_CHECKING, Callable, NamedTuple, Optional
+from typing import TYPE_CHECKING, Callable, NamedTuple
 import nvwave
 from synthDriverHandler import (
 	SynthDriver,

--- a/source/systemUtils.py
+++ b/source/systemUtils.py
@@ -221,7 +221,7 @@ class ExecAndPump(threading.Thread, Generic[_execAndPumpResT]):
 		# Intentionally uses older syntax with `Optional`, instead of `_execAndPumpResT | None`,
 		# as latter is not yet supported for unions potentially containing two instances of `None`
 		# (see CPython issue 107271).
-		self.funcRes: Optional[_execAndPumpResT] = None
+		self.funcRes: Optional[_execAndPumpResT] = None  # noqa: UP045
 		fname = repr(func)
 		super().__init__(
 			name=f"{self.__class__.__module__}.{self.__class__.__qualname__}({fname})",

--- a/source/textInfos/__init__.py
+++ b/source/textInfos/__init__.py
@@ -246,7 +246,7 @@ class FieldCommand(object):
 	A command indicates the start or end of a control or that the formatting of the text has changed.
 	"""
 
-	def __init__(self, command: str, field: Optional[Union[ControlField, FormatField]]):
+	def __init__(self, command: str, field: Union[ControlField, FormatField] | None):
 		"""Constructor.
 		@param command: The command; one of:
 			"controlStart", indicating the start of a L{ControlField};
@@ -418,7 +418,7 @@ class TextInfo(baseObject.AutoPropertyObject):
 	TextOrFieldsT = Union[str, FieldCommand]
 	TextWithFieldsT = List[TextOrFieldsT]
 
-	def getTextWithFields(self, formatConfig: Optional[Dict] = None) -> "TextInfo.TextWithFieldsT":
+	def getTextWithFields(self, formatConfig: Dict | None = None) -> "TextInfo.TextWithFieldsT":
 		"""Retrieves the text in this range, as well as any control/format fields associated therewith.
 		Subclasses may override this. The base implementation just returns the text.
 		@param formatConfig: Document formatting configuration, useful if you wish to force a particular
@@ -637,9 +637,9 @@ class TextInfo(baseObject.AutoPropertyObject):
 		attrs: ControlField,
 		ancestorAttrs: List[Field],
 		fieldType: str,
-		formatConfig: Optional[Dict[str, bool]] = None,
+		formatConfig: Dict[str, bool] | None = None,
 		extraDetail: bool = False,
-		reason: Optional[OutputReason] = None,
+		reason: OutputReason | None = None,
 	) -> SpeechSequence:
 		# Import late to avoid circular import.
 		import speech
@@ -664,10 +664,10 @@ class TextInfo(baseObject.AutoPropertyObject):
 	def getFormatFieldSpeech(
 		self,
 		attrs: Field,
-		attrsCache: Optional[Field] = None,
-		formatConfig: Optional[Dict[str, bool]] = None,
-		reason: Optional[OutputReason] = None,
-		unit: Optional[str] = None,
+		attrsCache: Field | None = None,
+		formatConfig: Dict[str, bool] | None = None,
+		reason: OutputReason | None = None,
+		unit: str | None = None,
 		extraDetail: bool = False,
 		initialFormat: bool = False,
 	) -> SpeechSequence:

--- a/source/textInfos/__init__.py
+++ b/source/textInfos/__init__.py
@@ -18,7 +18,6 @@ from typing import (
 	Any,
 	Union,
 	List,
-	Optional,
 	Dict,
 	Tuple,
 	Self,

--- a/source/textInfos/offsets.py
+++ b/source/textInfos/offsets.py
@@ -16,7 +16,6 @@ from treeInterceptorHandler import TreeInterceptor
 import textUtils
 from dataclasses import dataclass
 from typing import (
-	Optional,
 	Tuple,
 	Dict,
 	List,

--- a/source/textInfos/offsets.py
+++ b/source/textInfos/offsets.py
@@ -159,7 +159,7 @@ class OffsetsTextInfo(textInfos.TextInfo):
 	#: Use uniscribe to calculate word offsets etc.
 	useUniscribe: bool = True
 	#: The encoding internal to the underlying text info implementation.
-	encoding: Optional[str] = textUtils.WCHAR_ENCODING
+	encoding: str | None = textUtils.WCHAR_ENCODING
 
 	def __eq__(self, other):
 		if self is other or (
@@ -327,7 +327,7 @@ class OffsetsTextInfo(textInfos.TextInfo):
 		lineText: str,
 		unit: str,
 		relOffset: int,
-	) -> Optional[Tuple[int, int]]:
+	) -> Tuple[int, int] | None:
 		"""
 		Calculates the bounds of a unit at an offset within a given string of text
 		using the Windows uniscribe  library, also used in Notepad, for example.
@@ -607,7 +607,7 @@ class OffsetsTextInfo(textInfos.TextInfo):
 			else:
 				self._startOffset = self._endOffset
 
-	def getTextWithFields(self, formatConfig: Optional[Dict] = None) -> textInfos.TextInfo.TextWithFieldsT:
+	def getTextWithFields(self, formatConfig: Dict | None = None) -> textInfos.TextInfo.TextWithFieldsT:
 		if not formatConfig:
 			formatConfig = config.conf["documentFormatting"]
 		if self.detectFormattingAfterCursorMaybeSlow and not formatConfig["detectFormatAfterCursor"]:

--- a/source/textUtils/__init__.py
+++ b/source/textUtils/__init__.py
@@ -13,7 +13,7 @@ import locale
 import unicodedata
 from abc import ABCMeta, abstractmethod, abstractproperty
 from functools import cached_property
-from typing import Generator, Optional, Tuple, Type
+from typing import Generator, Tuple, Type
 
 from logHandler import log
 

--- a/source/textUtils/__init__.py
+++ b/source/textUtils/__init__.py
@@ -245,7 +245,7 @@ class WideStringOffsetConverter(OffsetConverter):
 def getTextFromRawBytes(
 	buf: bytes,
 	numChars: int,
-	encoding: Optional[str] = None,
+	encoding: str | None = None,
 	errorsFallback: str = "replace",
 ):
 	"""

--- a/source/treeInterceptorHandler.py
+++ b/source/treeInterceptorHandler.py
@@ -6,7 +6,6 @@
 from typing import (
 	TYPE_CHECKING,
 	Dict,
-	Optional,
 )
 
 from logHandler import log

--- a/source/treeInterceptorHandler.py
+++ b/source/treeInterceptorHandler.py
@@ -262,7 +262,7 @@ class RootProxyTextInfo(textInfos.TextInfo):
 	def _get_boundingRects(self):
 		return self.innerTextInfo.boundingRects
 
-	def getTextWithFields(self, formatConfig: Optional[Dict] = None) -> textInfos.TextInfo.TextWithFieldsT:
+	def getTextWithFields(self, formatConfig: Dict | None = None) -> textInfos.TextInfo.TextWithFieldsT:
 		return self.innerTextInfo.getTextWithFields(formatConfig=formatConfig)
 
 	def expand(self, unit):
@@ -280,10 +280,10 @@ class RootProxyTextInfo(textInfos.TextInfo):
 	def getFormatFieldSpeech(
 		self,
 		attrs: textInfos.Field,
-		attrsCache: Optional[textInfos.Field] = None,
-		formatConfig: Optional[Dict[str, bool]] = None,
-		reason: Optional[OutputReason] = None,
-		unit: Optional[str] = None,
+		attrsCache: textInfos.Field | None = None,
+		formatConfig: Dict[str, bool] | None = None,
+		reason: OutputReason | None = None,
+		unit: str | None = None,
 		extraDetail: bool = False,
 		initialFormat: bool = False,
 	) -> SpeechSequence:

--- a/source/ui.py
+++ b/source/ui.py
@@ -237,8 +237,8 @@ def browseableMessage(
 
 def message(
 	text: str,
-	speechPriority: Optional[speech.Spri] = None,
-	brailleText: Optional[str] = None,
+	speechPriority: speech.Spri | None = None,
+	brailleText: str | None = None,
 ):
 	"""Present a message to the user.
 	The message will be presented in both speech and braille.
@@ -277,7 +277,7 @@ def delayedMessage(
 	)
 
 
-def reviewMessage(text: str, speechPriority: Optional[speech.Spri] = None):
+def reviewMessage(text: str, speechPriority: speech.Spri | None = None):
 	"""Present a message from review or object navigation to the user.
 	The message will always be presented in speech, and also in braille if it is tethered to review or when auto tethering is on.
 	@param text: The text of the message.
@@ -288,7 +288,7 @@ def reviewMessage(text: str, speechPriority: Optional[speech.Spri] = None):
 		braille.handler.message(text)
 
 
-def reportTextCopiedToClipboard(text: Optional[str] = None):
+def reportTextCopiedToClipboard(text: str | None = None):
 	"""Notify about the result of a "Copy to clipboard" operation.
 	@param text: The text that has been copied. Set to `None` to notify of a failed operation.
 	See: `api.copyToClip`

--- a/source/ui.py
+++ b/source/ui.py
@@ -29,7 +29,7 @@ import speech
 import braille
 from config.configFlags import TetherTo
 import globalVars
-from typing import Final, Optional
+from typing import Final
 from collections.abc import Callable
 
 from utils.security import isRunningOnSecureDesktop

--- a/source/updateCheck.py
+++ b/source/updateCheck.py
@@ -119,7 +119,7 @@ except OSError:
 		log.debugWarning("Default download path for updates %s could not be created." % storeUpdatesDir)
 
 #: Persistent state information.
-state: Optional[Dict[str, Any]] = None
+state: Dict[str, Any] | None = None
 
 #: The single instance of L{AutoUpdateChecker} if automatic update checking is enabled,
 #: C{None} if it is disabled.
@@ -287,7 +287,7 @@ def _setStateToNone(_state):
 	_state["pendingUpdateBackCompatToAPIVersion"] = (0, 0, 0)
 
 
-def getPendingUpdate() -> Optional[Tuple]:
+def getPendingUpdate() -> Tuple | None:
 	"""Returns a tuple of the path to and version of the pending update, if any. Returns C{None} otherwise."""
 	try:
 		pendingUpdateFile = state["pendingUpdateFile"]
@@ -446,7 +446,7 @@ class UpdateChecker(garbageHandler.TrackedObject):
 			wx.OK | wx.ICON_ERROR,
 		)
 
-	def _result(self, info: Optional[UpdateInfo]) -> None:
+	def _result(self, info: UpdateInfo | None) -> None:
 		wx.CallAfter(self._progressDialog.done)
 		self._progressDialog = None
 		wx.CallAfter(UpdateResultDialog, gui.mainFrame, info, False)

--- a/source/updateCheck.py
+++ b/source/updateCheck.py
@@ -13,7 +13,6 @@ from datetime import datetime
 from typing import (
 	Any,
 	Dict,
-	Optional,
 	Self,
 	Tuple,
 )

--- a/source/updateCheck.py
+++ b/source/updateCheck.py
@@ -123,7 +123,7 @@ state: Dict[str, Any] | None = None
 
 #: The single instance of L{AutoUpdateChecker} if automatic update checking is enabled,
 #: C{None} if it is disabled.
-autoChecker: Optional["AutoUpdateChecker"] = None
+autoChecker: "AutoUpdateChecker | None" = None
 
 
 @dataclass

--- a/source/utils/blockUntilConditionMet.py
+++ b/source/utils/blockUntilConditionMet.py
@@ -11,7 +11,6 @@ from time import (
 from typing import (
 	Any,
 	Callable,
-	Optional,
 	Tuple,
 )
 

--- a/source/utils/blockUntilConditionMet.py
+++ b/source/utils/blockUntilConditionMet.py
@@ -36,7 +36,7 @@ def blockUntilConditionMet(
 	intervalBetweenSeconds: float = DEFAULT_INTERVAL_BETWEEN_EVAL_SECONDS,
 ) -> Tuple[
 	EvaluatorWasMetT,  # Was evaluator met?
-	Optional[GetValueResultT],  # None or the value when the evaluator was met
+	GetValueResultT | None,  # None or the value when the evaluator was met
 ]:
 	"""Repeatedly tries to get a value up until a time limit expires.
 	Tries are separated by a time interval.

--- a/source/utils/security.py
+++ b/source/utils/security.py
@@ -9,7 +9,6 @@ from typing import (
 	BinaryIO,
 	Callable,
 	List,
-	Optional,
 	Set,
 	TYPE_CHECKING,
 )

--- a/source/utils/security.py
+++ b/source/utils/security.py
@@ -309,7 +309,7 @@ def _isWindowBelowWindowMatchesCond(
 	currentWindow = bottomWindow
 	currentIndex = 0  # 0 is the last/lowest window
 	window1Indexes: List[int] = []
-	window2Index: Optional[int] = None
+	window2Index: int | None = None
 	while currentWindow != winUser.GW_RESULT_NOT_FOUND:
 		if currentWindow == window:
 			window1Indexes.append(currentIndex)

--- a/source/virtualBuffers/MSHTML.py
+++ b/source/virtualBuffers/MSHTML.py
@@ -20,7 +20,6 @@ import config
 import exceptions
 from typing import (
 	Dict,
-	Optional,
 )
 
 FORMATSTATE_INSERTED = 1

--- a/source/virtualBuffers/MSHTML.py
+++ b/source/virtualBuffers/MSHTML.py
@@ -39,7 +39,7 @@ class MSHTMLTextInfo(VirtualBufferTextInfo):
 			log.debug(f"textPositionValue={textPositionValue}")
 			return TextPosition.BASELINE
 
-	def _getTextAlignAttribute(self, attrs: Dict[str, str]) -> Optional[TextAlign]:
+	def _getTextAlignAttribute(self, attrs: Dict[str, str]) -> TextAlign | None:
 		textAlignValue = attrs.get("text-align")
 		try:
 			return TextAlign(textAlignValue)

--- a/source/virtualBuffers/__init__.py
+++ b/source/virtualBuffers/__init__.py
@@ -10,7 +10,6 @@ import ctypes
 import collections  # noqa: F401
 import itertools  # noqa: F401
 from typing import (
-	Optional,
 	Dict,
 )
 import weakref

--- a/source/virtualBuffers/__init__.py
+++ b/source/virtualBuffers/__init__.py
@@ -348,7 +348,7 @@ class VirtualBufferTextInfo(browseMode.BrowseModeDocumentTextInfo, textInfos.off
 		]
 		return commandList
 
-	def getTextWithFields(self, formatConfig: Optional[Dict] = None) -> textInfos.TextInfo.TextWithFieldsT:
+	def getTextWithFields(self, formatConfig: Dict | None = None) -> textInfos.TextInfo.TextWithFieldsT:
 		start = self._startOffset
 		end = self._endOffset
 		if start == end:

--- a/source/virtualBuffers/gecko_ia2.py
+++ b/source/virtualBuffers/gecko_ia2.py
@@ -218,7 +218,7 @@ class Gecko_ia2_TextInfo(VirtualBufferTextInfo):
 				log.debug(f"detailsRoles: {attrs['detailsRoles']}")
 		return super()._normalizeControlField(attrs)
 
-	def _normalizeDetailsRole(self, detailsRoles: str) -> Iterable[Optional[controlTypes.Role]]:
+	def _normalizeDetailsRole(self, detailsRoles: str) -> Iterable[controlTypes.Role | None]:
 		"""
 		The attribute has been added directly to the buffer as a string, containing a comma separated list
 		of values, each value is either:

--- a/source/virtualBuffers/gecko_ia2.py
+++ b/source/virtualBuffers/gecko_ia2.py
@@ -7,7 +7,6 @@
 from dataclasses import dataclass
 from typing import (
 	Iterable,
-	Optional,
 )
 import typing
 from ctypes import byref

--- a/source/vision/__init__.py
+++ b/source/vision/__init__.py
@@ -14,7 +14,6 @@ using modules in the visionEnhancementProviders package containing a L{VisionEnh
 from .visionHandler import VisionHandler
 import visionEnhancementProviders  # noqa: F401
 import config
-from typing import Optional
 
 handler: VisionHandler | None = None
 

--- a/source/vision/__init__.py
+++ b/source/vision/__init__.py
@@ -16,7 +16,7 @@ import visionEnhancementProviders  # noqa: F401
 import config
 from typing import Optional
 
-handler: Optional[VisionHandler] = None
+handler: VisionHandler | None = None
 
 
 def initialize() -> None:

--- a/source/vision/providerBase.py
+++ b/source/vision/providerBase.py
@@ -11,7 +11,7 @@ import config
 from autoSettingsUtils.autoSettings import AutoSettings
 from baseObject import AutoPropertyObject
 from .visionHandlerExtensionPoints import EventExtensionPoints
-from typing import Optional, Any
+from typing import Any
 
 
 class VisionEnhancementProviderSettings(AutoSettings):

--- a/source/vision/providerBase.py
+++ b/source/vision/providerBase.py
@@ -106,7 +106,7 @@ class VisionEnhancementProvider(AutoPropertyObject):
 		...
 
 	@classmethod
-	def getSettingsPanelClass(cls) -> Optional[Any]:
+	def getSettingsPanelClass(cls) -> Any | None:
 		"""Returns the class to be used in order to construct a settingsPanel instance for the provider.
 		The returned class must have a constructor which accepts:
 			- parent: wx.Window

--- a/source/vision/util.py
+++ b/source/vision/util.py
@@ -11,7 +11,6 @@ import api
 import locationHelper
 from documentBase import TextContainerObject
 from NVDAObjects import NVDAObject
-from typing import Optional
 import textInfos
 import mouseHandler
 

--- a/source/vision/util.py
+++ b/source/vision/util.py
@@ -20,7 +20,7 @@ def getReviewRect() -> locationHelper.RectLTRB:
 	return getRectFromTextInfo(api.getReviewPosition())
 
 
-def getCaretRect(obj: Optional[TextContainerObject] = None) -> locationHelper.RectLTRB:
+def getCaretRect(obj: TextContainerObject | None = None) -> locationHelper.RectLTRB:
 	if obj is None:
 		obj = api.getCaretObject()
 	if api.isObjectInActiveTreeInterceptor(obj):
@@ -64,8 +64,8 @@ def getObjectRect(obj: NVDAObject) -> locationHelper.RectLTRB:
 
 def getContextRect(
 	context: Context,
-	obj: Optional[TextContainerObject] = None,
-) -> Optional[locationHelper.RectLTRB]:
+	obj: TextContainerObject | None = None,
+) -> locationHelper.RectLTRB | None:
 	"""Gets a rectangle for the specified context."""
 	if context == Context.FOCUS:
 		return getObjectRect(obj or api.getFocusObject())

--- a/source/vision/visionHandler.py
+++ b/source/vision/visionHandler.py
@@ -154,7 +154,7 @@ class VisionHandler(AutoPropertyObject):
 					)
 		return providerList
 
-	def getProviderInfo(self, providerId: providerInfo.ProviderIdT) -> Optional[providerInfo.ProviderInfo]:
+	def getProviderInfo(self, providerId: providerInfo.ProviderIdT) -> providerInfo.ProviderInfo | None:
 		for p in self._allProviders:
 			if p.providerId == providerId:
 				return p
@@ -176,7 +176,7 @@ class VisionHandler(AutoPropertyObject):
 	def getProviderInstance(
 		self,
 		provider: providerInfo.ProviderInfo,
-	) -> Optional[VisionEnhancementProvider]:
+	) -> VisionEnhancementProvider | None:
 		return self._providers.get(provider.providerId)
 
 	def terminateProvider(

--- a/source/vision/visionHandler.py
+++ b/source/vision/visionHandler.py
@@ -22,7 +22,7 @@ import config
 from logHandler import log
 import visionEnhancementProviders
 import queueHandler
-from typing import Type, Dict, List, Optional, Set
+from typing import Type, Dict, List, Set
 from . import exceptions
 
 

--- a/source/visionEnhancementProviders/NVDAHighlighter.py
+++ b/source/visionEnhancementProviders/NVDAHighlighter.py
@@ -378,7 +378,7 @@ class NVDAHighlighterGuiPanel(
 		else:
 			self._updateEnabledState()
 
-		providerInst: Optional[NVDAHighlighter] = self._providerControl.getProviderInstance()
+		providerInst: NVDAHighlighter | None = self._providerControl.getProviderInstance()
 		if providerInst:
 			providerInst.refresh()
 
@@ -393,7 +393,7 @@ class NVDAHighlighter(providerBase.VisionEnhancementProvider):
 	_refreshInterval = 100
 	customWindowClass = HighlightWindow
 	_settings = NVDAHighlighterSettings()
-	_window: Optional[customWindowClass] = None
+	_window: customWindowClass | None = None
 	enabledContexts: Tuple[Context]  # type info for autoprop: L{_get_enableContexts}
 
 	@classmethod  # override

--- a/source/visionEnhancementProviders/NVDAHighlighter.py
+++ b/source/visionEnhancementProviders/NVDAHighlighter.py
@@ -5,7 +5,7 @@
 
 """Default highlighter based on GDI Plus."""
 
-from typing import Optional, Tuple
+from typing import Tuple
 
 from autoSettingsUtils.autoSettings import SupportedSettingType
 from autoSettingsUtils.driverSetting import BooleanDriverSetting

--- a/source/visionEnhancementProviders/_exampleProvider_autoGui.py
+++ b/source/visionEnhancementProviders/_exampleProvider_autoGui.py
@@ -133,7 +133,7 @@ class AutoGuiTestProvider(providerBase.VisionEnhancementProvider):
 		return True  # Check any dependencies (Windows version, Hardware access, Installed applications)
 
 	@classmethod
-	def getSettingsPanelClass(cls) -> Optional[Type]:
+	def getSettingsPanelClass(cls) -> Type | None:
 		"""Returns the instance to be used in order to construct a settings panel for the provider.
 		@return: Optional[SettingsPanel]
 		@remarks: When None is returned, L{gui.settingsDialogs.VisionProviderSubPanel_Wrapper} is used.

--- a/source/visionEnhancementProviders/_exampleProvider_autoGui.py
+++ b/source/visionEnhancementProviders/_exampleProvider_autoGui.py
@@ -8,7 +8,7 @@ from autoSettingsUtils.driverSetting import BooleanDriverSetting, DriverSetting,
 import gui
 from autoSettingsUtils.utils import StringParameterInfo
 from autoSettingsUtils.autoSettings import SupportedSettingType
-from typing import Optional, Type, Any, List
+from typing import Type, Any, List
 
 """Example provider, which demonstrates using the automatically constructed GUI. Rename this file, removing
  the first underscore to test it with NVDA.

--- a/source/visionEnhancementProviders/screenCurtain.py
+++ b/source/visionEnhancementProviders/screenCurtain.py
@@ -327,7 +327,7 @@ class ScreenCurtainProvider(providerBase.VisionEnhancementProvider):
 		return True
 
 	@classmethod
-	def getSettingsPanelClass(cls) -> Optional[Type]:
+	def getSettingsPanelClass(cls) -> Type | None:
 		"""Returns the instance to be used in order to construct a settings panel for the provider.
 		@return: Optional[SettingsPanel]
 		@remarks: When None is returned, L{gui.settingsDialogs.VisionProviderSubPanel_Wrapper} is used.

--- a/source/visionEnhancementProviders/screenCurtain.py
+++ b/source/visionEnhancementProviders/screenCurtain.py
@@ -21,7 +21,7 @@ from gui.settingsDialogs import (
 	VisionProviderStateControl,
 )
 from logHandler import log
-from typing import Optional, Type
+from typing import Type
 import nvwave
 import globalVars
 import NVDAHelper

--- a/source/winAPI/_displayTracking.py
+++ b/source/winAPI/_displayTracking.py
@@ -13,9 +13,6 @@ and we notify the user of changes to the orientation.
 from ctypes import windll
 from dataclasses import dataclass
 import enum
-from typing import (
-	Optional,
-)
 
 from logHandler import log
 import ui

--- a/source/winAPI/_displayTracking.py
+++ b/source/winAPI/_displayTracking.py
@@ -36,7 +36,7 @@ class OrientationState:
 	style: Orientation
 
 
-_orientationState: Optional[OrientationState] = None
+_orientationState: OrientationState | None = None
 
 
 def initialize():
@@ -76,7 +76,7 @@ def _getNewOrientationStyle(
 	previousState: OrientationState,
 	height: int,
 	width: int,
-) -> Optional[Orientation]:
+) -> Orientation | None:
 	"""
 	@returns: Orientation if there has been an orientation state change, otherwise None
 	"""

--- a/source/winAPI/_powerTracking.py
+++ b/source/winAPI/_powerTracking.py
@@ -21,7 +21,6 @@ from enum import (
 )
 from typing import (
 	List,
-	Optional,
 )
 
 from logHandler import log

--- a/source/winAPI/_powerTracking.py
+++ b/source/winAPI/_powerTracking.py
@@ -163,7 +163,7 @@ def _reportPowerStatus(context: _ReportContext) -> None:
 		_powerState = systemPowerStatus.ACLineStatus
 
 
-def _getPowerStatus() -> Optional[SystemPowerStatus]:
+def _getPowerStatus() -> SystemPowerStatus | None:
 	sps = SystemPowerStatus()
 	systemPowerStatusUpdateResult = winKernel.GetSystemPowerStatus(sps)
 	if not systemPowerStatusUpdateResult:
@@ -173,7 +173,7 @@ def _getPowerStatus() -> Optional[SystemPowerStatus]:
 
 
 def _getSpeechForBatteryStatus(
-	systemPowerStatus: Optional[SystemPowerStatus],
+	systemPowerStatus: SystemPowerStatus | None,
 	context: _ReportContext,
 	oldPowerState: PowerState,
 ) -> List[str]:

--- a/source/winAPI/messageWindow.py
+++ b/source/winAPI/messageWindow.py
@@ -10,9 +10,6 @@ Message windows can be used to handle communications from other processes, new N
 """
 
 from enum import IntEnum
-from typing import (
-	Optional,
-)
 
 
 from . import (

--- a/source/winAPI/messageWindow.py
+++ b/source/winAPI/messageWindow.py
@@ -82,7 +82,7 @@ class _MessageWindow(windowUtils.CustomWindow):
 	We don't need to do anything else because wx handles WM_QUIT for all windows.
 	"""
 
-	def __init__(self, windowName: Optional[str] = None):
+	def __init__(self, windowName: str | None = None):
 		super().__init__(windowName)
 		_displayTracking.initialize()
 		_powerTracking.initialize()

--- a/source/winAPI/sessionTracking.py
+++ b/source/winAPI/sessionTracking.py
@@ -65,7 +65,7 @@ https://docs.microsoft.com/en-us/windows/win32/sync/synchronization-object-secur
 Unused in NVDA core, duplicate of winKernel.SYNCHRONIZE.
 """
 
-_lockStateTracker: "_WindowsLockedState" | None = None
+_lockStateTracker: "_WindowsLockedState | None" = None
 """
 Caches the Windows lock state as an auto property object.
 """

--- a/source/winAPI/sessionTracking.py
+++ b/source/winAPI/sessionTracking.py
@@ -65,7 +65,7 @@ https://docs.microsoft.com/en-us/windows/win32/sync/synchronization-object-secur
 Unused in NVDA core, duplicate of winKernel.SYNCHRONIZE.
 """
 
-_lockStateTracker: Optional["_WindowsLockedState"] = None
+_lockStateTracker: "_WindowsLockedState" | None = None
 """
 Caches the Windows lock state as an auto property object.
 """
@@ -213,7 +213,7 @@ def WTSCurrentSessionInfoEx() -> Generator[_WTS_INFO_POINTER_T, None, None]:
 		)
 
 
-def _getCurrentSessionInfoEx() -> Optional[_WTS_INFO_POINTER_T]:
+def _getCurrentSessionInfoEx() -> _WTS_INFO_POINTER_T | None:
 	"""
 	Gets the WTSINFOEXW for the current server/session or raises a RuntimeError
 	on failure.

--- a/source/winAPI/sessionTracking.py
+++ b/source/winAPI/sessionTracking.py
@@ -24,7 +24,6 @@ from ctypes.wintypes import (
 import enum
 from typing import (
 	Generator,
-	Optional,
 )
 
 from baseObject import AutoPropertyObject

--- a/source/winConsoleHandler.py
+++ b/source/winConsoleHandler.py
@@ -15,7 +15,6 @@ import textInfos
 import config
 import locationHelper
 from typing import (
-	Optional,
 	Dict,
 )
 

--- a/source/winConsoleHandler.py
+++ b/source/winConsoleHandler.py
@@ -254,7 +254,7 @@ class WinConsoleTextInfo(textInfos.offsets.OffsetsTextInfo):
 			start = end = self._getCaretOffset()
 		return start, end
 
-	def getTextWithFields(self, formatConfig: Optional[Dict] = None) -> textInfos.TextInfo.TextWithFieldsT:
+	def getTextWithFields(self, formatConfig: Dict | None = None) -> textInfos.TextInfo.TextWithFieldsT:
 		commands = []
 		if self.isCollapsed:
 			return commands

--- a/source/winKernel.py
+++ b/source/winKernel.py
@@ -18,7 +18,6 @@ from ctypes.wintypes import BOOL, DWORD, HANDLE, LARGE_INTEGER, LCID, LPWSTR, LP
 from typing import (
 	TYPE_CHECKING,
 	Any,
-	Optional,
 	Union,
 )
 

--- a/source/winKernel.py
+++ b/source/winKernel.py
@@ -615,7 +615,7 @@ def SetThreadExecutionState(esFlags):
 	return res
 
 
-def LCIDToLocaleName(windowsLCID: LCID) -> Optional[str]:
+def LCIDToLocaleName(windowsLCID: LCID) -> str | None:
 	# NVDA cannot run with this imported at module level
 	from logHandler import log
 

--- a/source/windowUtils.py
+++ b/source/windowUtils.py
@@ -16,7 +16,6 @@ from winUser import WNDCLASSEXW, WNDPROC
 from logHandler import log
 from abc import abstractmethod
 from baseObject import AutoPropertyObject
-from typing import Optional
 
 WNDENUMPROC = ctypes.WINFUNCTYPE(ctypes.wintypes.BOOL, ctypes.wintypes.HWND, ctypes.wintypes.LPARAM)
 

--- a/source/windowUtils.py
+++ b/source/windowUtils.py
@@ -155,7 +155,7 @@ class CustomWindow(AutoPropertyObject):
 	but it can be explicitly destroyed using L{destroy}.
 	"""
 
-	handle: Optional[int] = None
+	handle: int | None = None
 
 	@classmethod
 	def __new__(cls, *args, **kwargs):
@@ -188,10 +188,10 @@ class CustomWindow(AutoPropertyObject):
 
 	def __init__(
 		self,
-		windowName: Optional[str] = None,
+		windowName: str | None = None,
 		windowStyle: int = 0,
 		extendedWindowStyle: int = 0,
-		parent: Optional[int] = None,
+		parent: int | None = None,
 	):
 		"""Constructor.
 		@param windowName: The name of the window.

--- a/tests/system/libraries/ChromeLib.py
+++ b/tests/system/libraries/ChromeLib.py
@@ -45,9 +45,9 @@ class ChromeLib:
 
 	# Use class variables for state that should be tied to the RF library instance.
 	# These variables will be available in the teardown
-	_chromeWindow: _Optional[Window] = None
+	_chromeWindow: Window | None = None
 	"""Chrome Hwnd used to control Chrome via Windows functions."""
-	_processRFHandleForStart: _Optional[int] = None
+	_processRFHandleForStart: int | None = None
 	"""RF process handle, will wait for the chrome process to exit."""
 
 	@staticmethod

--- a/tests/system/libraries/ChromeLib.py
+++ b/tests/system/libraries/ChromeLib.py
@@ -11,7 +11,6 @@ Google Chrome with a HTML sample and assert NVDA interacts with it in the expect
 import datetime as _datetime
 from os.path import join as _pJoin
 import tempfile as _tempfile
-from typing import Optional as _Optional
 from SystemTestSpy import (
 	_blockUntilConditionMet,
 	_getLib,

--- a/tests/system/libraries/NotepadLib.py
+++ b/tests/system/libraries/NotepadLib.py
@@ -47,8 +47,8 @@ class NotepadLib:
 
 	# Use class variables for state that should be tied to the RF library instance.
 	# These variables will be available in the teardown
-	notepadWindow: _Optional[_Window] = None
-	processRFHandleForStart: _Optional[int] = None
+	notepadWindow: _Window | None = None
+	processRFHandleForStart: int | None = None
 
 	@staticmethod
 	def _getTestCasePath(filename):

--- a/tests/system/libraries/NotepadLib.py
+++ b/tests/system/libraries/NotepadLib.py
@@ -11,7 +11,6 @@ Windows Notepad with a text sample and assert NVDA interacts with it in the expe
 from os.path import join as _pJoin
 import datetime as _datetime
 import tempfile as _tempfile
-from typing import Optional as _Optional
 from SystemTestSpy import (
 	_blockUntilConditionMet,
 	_getLib,

--- a/tests/system/libraries/NvdaLib.py
+++ b/tests/system/libraries/NvdaLib.py
@@ -131,7 +131,7 @@ class NvdaLib:
 	"""
 
 	def __init__(self):
-		self.nvdaSpy: "NVDASpyLib" | None = None
+		self.nvdaSpy: "NVDASpyLib | None" = None
 		self.nvdaHandle: int | None = None
 		self.lastNVDAStart: _datetime | None = None
 

--- a/tests/system/libraries/NvdaLib.py
+++ b/tests/system/libraries/NvdaLib.py
@@ -88,7 +88,7 @@ class _NvdaLocationData:
 			"nvdaTestRunLogs",
 		)
 
-	def getPy2exeBootLogPath(self) -> _Optional[str]:
+	def getPy2exeBootLogPath(self) -> str | None:
 		if self.whichNVDA == "installed":
 			executablePath = _locations.findInstalledNVDAPath()
 			# py2exe names this log file after the executable, see py2exe/boot_common.py
@@ -96,7 +96,7 @@ class _NvdaLocationData:
 		elif self.whichNVDA == "source":
 			return None  # Py2exe not used for source.
 
-	def findInstalledNVDAPath(self) -> _Optional[str]:
+	def findInstalledNVDAPath(self) -> str | None:
 		NVDAFilePath = _pJoin(_expandvars("%PROGRAMFILES%"), "nvda", "nvda.exe")
 		legacyNVDAFilePath = _pJoin(_expandvars("%PROGRAMFILES%"), "NVDA", "nvda.exe")
 		exeErrorMsg = f"Unable to find installed NVDA exe. Paths tried: {NVDAFilePath}, {legacyNVDAFilePath}"
@@ -131,9 +131,9 @@ class NvdaLib:
 	"""
 
 	def __init__(self):
-		self.nvdaSpy: _Optional["NVDASpyLib"] = None
-		self.nvdaHandle: _Optional[int] = None
-		self.lastNVDAStart: _Optional[_datetime] = None
+		self.nvdaSpy: "NVDASpyLib" | None = None
+		self.nvdaHandle: int | None = None
+		self.lastNVDAStart: _datetime | None = None
 
 	@staticmethod
 	def _createTestIdFileName(name):
@@ -144,7 +144,7 @@ class NvdaLib:
 		return outputFileName
 
 	@staticmethod
-	def setup_nvda_profile(configFileName, gesturesFileName: _Optional[str] = None):
+	def setup_nvda_profile(configFileName, gesturesFileName: str | None = None):
 		configManager.setupProfile(
 			_locations.repoRoot,
 			configFileName,
@@ -294,7 +294,7 @@ class NvdaLib:
 				],
 			)
 
-	def start_NVDA(self, settingsFileName: str, gesturesFileName: _Optional[str] = None):
+	def start_NVDA(self, settingsFileName: str, gesturesFileName: str | None = None):
 		self.lastNVDAStart = _datetime.utcnow()
 		builtIn.log(f"Starting NVDA with config: {settingsFileName}")
 		self.setup_nvda_profile(settingsFileName, gesturesFileName)
@@ -380,9 +380,9 @@ class NvdaLib:
 
 	@staticmethod
 	def check_for_crash_dump(
-		since: _Optional[_datetime],
-		overridePath: _Optional[str] = None,
-	) -> _Optional[str]:
+		since: _datetime | None,
+		overridePath: str | None = None,
+	) -> str | None:
 		"""
 		Checks if a crash.dmp exits and returns the crash dmp path if so
 		"""
@@ -396,7 +396,7 @@ class NvdaLib:
 			if crashTime >= since:
 				return crashPath
 
-	def save_crash_dump_if_exists(self, deleteCachedAfter: bool = True) -> _Optional[str]:
+	def save_crash_dump_if_exists(self, deleteCachedAfter: bool = True) -> str | None:
 		crashPath = self.check_for_crash_dump(self.lastNVDAStart)
 		if crashPath is None:
 			return None

--- a/tests/system/libraries/NvdaLib.py
+++ b/tests/system/libraries/NvdaLib.py
@@ -25,7 +25,6 @@ from os.path import (
 )
 import tempfile as _tempFile
 from typing import (
-	Optional as _Optional,
 	Tuple as _Tuple,
 )
 from urllib.parse import quote as _quoteStr

--- a/tests/system/libraries/SystemTestSpy/blockUntilConditionMet.py
+++ b/tests/system/libraries/SystemTestSpy/blockUntilConditionMet.py
@@ -37,10 +37,10 @@ def _blockUntilConditionMet(
 	giveUpAfterSeconds: float,
 	shouldStopEvaluator: Callable[[GetValueResultT], bool] = lambda value: bool(value),
 	intervalBetweenSeconds: float = DEFAULT_INTERVAL_BETWEEN_EVAL_SECONDS,
-	errorMessage: Optional[str] = None,
+	errorMessage: str | None = None,
 ) -> Tuple[
 	EvaluatorWasMetT,  # Was evaluator met?
-	Optional[GetValueResultT],  # Value when the evaluator was met, if it was met.
+	GetValueResultT | None,  # Value when the evaluator was met, if it was met.
 ]:
 	"""Repeatedly tries to get a value up until a time limit expires.
 	Tries are separated by a time interval.

--- a/tests/system/libraries/SystemTestSpy/blockUntilConditionMet.py
+++ b/tests/system/libraries/SystemTestSpy/blockUntilConditionMet.py
@@ -15,7 +15,6 @@ from time import (
 from typing import (
 	Any,
 	Callable,
-	Optional,
 	Tuple,
 )
 

--- a/tests/system/libraries/SystemTestSpy/configManager.py
+++ b/tests/system/libraries/SystemTestSpy/configManager.py
@@ -97,7 +97,7 @@ def setupProfile(
 	repoRoot: str,
 	settingsFileName: str,
 	stagingDir: str,
-	gesturesFileName: Optional[str] = None,
+	gesturesFileName: str | None = None,
 ):
 	builtIn.log("Copying files into NVDA profile", level="DEBUG")
 	opSys.copy_file(

--- a/tests/system/libraries/SystemTestSpy/configManager.py
+++ b/tests/system/libraries/SystemTestSpy/configManager.py
@@ -11,7 +11,6 @@ NVDA config before NVDA is started by the system tests.
 from os.path import join as _pJoin
 from .getLib import _getLib
 import sys
-from typing import Optional
 
 # Imported for type information
 from robot.libraries.BuiltIn import BuiltIn

--- a/tests/system/libraries/SystemTestSpy/speechSpyGlobalPlugin.py
+++ b/tests/system/libraries/SystemTestSpy/speechSpyGlobalPlugin.py
@@ -122,7 +122,7 @@ class NVDASpyLib:
 		gesture: str,
 		module: str,
 		className: str,
-		script: Optional[str],
+		script: str | None,
 		replace: bool = False,
 	):
 		import inputCore
@@ -135,7 +135,7 @@ class NVDASpyLib:
 			replace,
 		)
 
-	fakeTranslations: typing.Optional[gettext.NullTranslations] = None
+	fakeTranslations: gettext.NullTranslations | None = None
 
 	def override_translationString(self, invariantString: str, replacementString: str):
 		import languageHandler
@@ -246,7 +246,7 @@ class NVDASpyLib:
 		with self._speechLock:
 			return len(self._nvdaSpeech_requiresLock) - 1
 
-	def _getIndexOfSpeech(self, speech, searchAfterIndex: Optional[int] = None):
+	def _getIndexOfSpeech(self, speech, searchAfterIndex: int | None = None):
 		if searchAfterIndex is None:
 			firstIndexToCheck = 0
 		else:
@@ -259,7 +259,7 @@ class NVDASpyLib:
 					return index
 			return -1
 
-	def _hasSpeechFinished(self, speechStartedIndex: Optional[int] = None):
+	def _hasSpeechFinished(self, speechStartedIndex: int | None = None):
 		with self._speechLock:
 			nextIndex = self.get_next_speech_index()
 			started = speechStartedIndex is None or speechStartedIndex < nextIndex
@@ -379,10 +379,10 @@ class NVDASpyLib:
 	def _has_speech_occurred_before_timeout(
 		self,
 		speech: str,
-		afterIndex: Optional[int],
+		afterIndex: int | None,
 		maxWaitSeconds: float,
 		intervalBetweenSeconds: float,
-	) -> Tuple[bool, Optional[int]]:
+	) -> Tuple[bool, int | None]:
 		"""
 		@param speech: The speech to expect.
 		@param afterIndex: The speech should come after this index. The index is exclusive.
@@ -401,10 +401,10 @@ class NVDASpyLib:
 	def wait_for_specific_speech_no_raise(
 		self,
 		speech: str,
-		afterIndex: Optional[int] = None,
+		afterIndex: int | None = None,
 		maxWaitSeconds: float = 5.0,
 		intervalBetweenSeconds: float = DEFAULT_INTERVAL_BETWEEN_EVAL_SECONDS,
-	) -> Optional[int]:
+	) -> int | None:
 		"""
 		@param speech: The speech to expect.
 		@param afterIndex: The speech should come after this index. The index is exclusive.
@@ -425,7 +425,7 @@ class NVDASpyLib:
 	def wait_for_specific_speech(
 		self,
 		speech: str,
-		afterIndex: Optional[int] = None,
+		afterIndex: int | None = None,
 		maxWaitSeconds: float = 5.0,
 		intervalBetweenSeconds: float = DEFAULT_INTERVAL_BETWEEN_EVAL_SECONDS,
 	) -> int:
@@ -453,7 +453,7 @@ class NVDASpyLib:
 	def ensure_speech_did_not_occur(
 		self,
 		speech: str,
-		afterIndex: Optional[int] = None,
+		afterIndex: int | None = None,
 		maxWaitSeconds: float = SPEECH_HAS_FINISHED_SECONDS,
 		intervalBetweenSeconds: float = DEFAULT_INTERVAL_BETWEEN_EVAL_SECONDS,
 	) -> None:
@@ -481,8 +481,8 @@ class NVDASpyLib:
 	def wait_for_speech_to_finish(
 		self,
 		maxWaitSeconds=5.0,
-		speechStartedIndex: Optional[int] = None,
-		errorMessage: Optional[str] = "Speech did not finish before timeout",
+		speechStartedIndex: int | None = None,
+		errorMessage: str | None = "Speech did not finish before timeout",
 	) -> bool:
 		"""speechStartedIndex should generally be fetched with get_next_speech_index
 		@param errorMessage: Supply None to bypass assert.
@@ -586,7 +586,7 @@ class SystemTestSpyServer(globalPluginHandler.GlobalPlugin):
 		self._server.stop()
 
 
-def _crashNVDA(param: Optional[int] = None):
+def _crashNVDA(param: int | None = None):
 	# Causes a breakpoint exception to occur in the current process.
 	# This allows the calling thread to signal the debugger to handle the exception.
 	#

--- a/tests/system/libraries/SystemTestSpy/windows.py
+++ b/tests/system/libraries/SystemTestSpy/windows.py
@@ -19,7 +19,6 @@ from typing import (
 	Callable,
 	List,
 	NamedTuple,
-	Optional,
 )
 import re
 from SystemTestSpy.blockUntilConditionMet import _blockUntilConditionMet

--- a/tests/system/libraries/SystemTestSpy/windows.py
+++ b/tests/system/libraries/SystemTestSpy/windows.py
@@ -110,7 +110,7 @@ def SetForegroundWindow(window: Window, logger: Logger) -> bool:
 	return windll.user32.SetForegroundWindow(window.hwndVal)
 
 
-def GetWindowWithTitle(targetTitle: re.Pattern, logger: Logger) -> Optional[Window]:
+def GetWindowWithTitle(targetTitle: re.Pattern, logger: Logger) -> Window | None:
 	windows = _GetWindows(
 		filterUsingWindow=lambda _window: bool(re.match(targetTitle, _window.title)),
 	)

--- a/tests/system/libraries/WindowsLib.py
+++ b/tests/system/libraries/WindowsLib.py
@@ -164,7 +164,7 @@ def _tryOpenTaskSwitcher() -> _Optional["_SpeechIndexT"]:
 	spy.emulateKeyPress("control+alt+tab")  # opens the task switcher until enter or escape is pressed.
 	# each item has "row 1 column 1" appended, ensure that the task switcher has opened.
 	firstRow = "row 1"
-	indexOfSpeech: _Optional[int] = spy.wait_for_specific_speech_no_raise(
+	indexOfSpeech: int | None = spy.wait_for_specific_speech_no_raise(
 		firstRow,
 		afterIndex=expectedStartOfKeypressSpeechIndex - 1,
 		maxWaitSeconds=5,

--- a/tests/system/libraries/WindowsLib.py
+++ b/tests/system/libraries/WindowsLib.py
@@ -154,7 +154,7 @@ def taskSwitchToItemMatching(targetWindowNamePattern: _re.Pattern, maxWindowsToT
 			)
 
 
-def _tryOpenTaskSwitcher() -> _Optional["_SpeechIndexT"]:
+def _tryOpenTaskSwitcher() -> "_SpeechIndexT | None":
 	"""
 	@return: If the task switcher 'row 1' was spoken, the speech index for the start of the task switcher
 	speech.

--- a/tests/system/libraries/WindowsLib.py
+++ b/tests/system/libraries/WindowsLib.py
@@ -9,9 +9,6 @@ features.
 
 # imported methods start with underscore (_) so they don't get imported into robot files as keywords
 import typing as _typing
-from typing import (
-	Optional as _Optional,
-)
 from SystemTestSpy import (
 	_getLib,
 )

--- a/tests/system/robot/NVDASettings.py
+++ b/tests/system/robot/NVDASettings.py
@@ -19,7 +19,6 @@ from robot.libraries.Process import Process as _ProcessLib
 from AssertsLib import AssertsLib as _AssertsLib
 
 import os
-from typing import Optional
 import NvdaLib as _nvdaLib
 from NvdaLib import NvdaLib as _nvdaRobotLib
 

--- a/tests/system/robot/NVDASettings.py
+++ b/tests/system/robot/NVDASettings.py
@@ -47,7 +47,7 @@ def navigate_to_settings(settingsName):
 	spy.reset_all_speech_index()
 
 
-def read_settings(settingsName, cacheFolder, currentVersion, compareVersion: Optional[str] = None):
+def read_settings(settingsName, cacheFolder, currentVersion, compareVersion: str | None = None):
 	spy = _nvdaLib.getSpyLib()
 	start_speech_index = spy.get_next_speech_index()
 	advancedWarning = "I understand that changing these settings may cause NVDA to function incorrectly."

--- a/tests/unit/test_speechManager/__init__.py
+++ b/tests/unit/test_speechManager/__init__.py
@@ -6,7 +6,7 @@
 """Unit tests for speech/manager module"""
 
 import unittest
-from typing import Optional, Callable
+from typing import Callable
 
 import config
 import speech

--- a/tests/unit/test_speechManager/__init__.py
+++ b/tests/unit/test_speechManager/__init__.py
@@ -169,8 +169,8 @@ class _CancellableSpeechCommand_withLamda(_CancellableSpeechCommand):
 
 	def __init__(
 		self,
-		checkIfValid: Optional[Callable[[], bool]] = None,
-		getDevInfo: Optional[Callable[[], str]] = None,
+		checkIfValid: Callable[[], bool] | None = None,
+		getDevInfo: Callable[[], str] | None = None,
 	):
 		if checkIfValid is not None:
 			self._checkIfValid = checkIfValid

--- a/tests/unit/test_speechManager/speechManagerTestHarness.py
+++ b/tests/unit/test_speechManager/speechManagerTestHarness.py
@@ -12,7 +12,6 @@ from typing import (
 	Callable,
 	Tuple,
 	Union,
-	Optional,
 	List,
 )
 from unittest import mock

--- a/tests/unit/test_speechManager/speechManagerTestHarness.py
+++ b/tests/unit/test_speechManager/speechManagerTestHarness.py
@@ -121,7 +121,7 @@ class SpeechManagerInteractions:
 		#: Number of cancel calls we are waiting for
 		self._awaitingCancelCalls: int = 0
 		#: Index and Callbacks for callback commands
-		self._awaitingCallbackForIndex: List[Tuple[_IndexT, Optional[Callable[[], None]]]] = []
+		self._awaitingCallbackForIndex: List[Tuple[_IndexT, Callable[[], None] | None]] = []
 		#: Map of mocks to the number of times that we expect for them get called in this expect block.
 		self._awaitingMockCalls: typing.Dict[MagicMock, int] = {}
 
@@ -375,7 +375,7 @@ class SpeechManagerInteractions:
 	def expect_indexReachedCallback(
 		self,
 		forIndex: _IndexT,
-		sideEffect: Optional[Callable[[], None]] = None,
+		sideEffect: Callable[[], None] | None = None,
 	):
 		"""Expect that upon exiting the expectation block, forIndex will have been reached.
 		If a side effect is required (such as speaking more text) this must be called before
@@ -429,8 +429,8 @@ class SpeechManagerInteractions:
 
 	def expect_synthSpeak(
 		self,
-		sequenceNumbers: Optional[Union[int, typing.Iterable[int]]] = None,
-		sequence: Optional[List[Union[speech.types.SequenceItemT, ExpectedProsody, ExpectedIndex]]] = None,
+		sequenceNumbers: Union[int, typing.Iterable[int]] | None = None,
+		sequence: List[Union[speech.types.SequenceItemT, ExpectedProsody, ExpectedIndex]] | None = None,
 	):
 		isSpeechSpecified = sequence is not None
 		areNumbersSpecified = sequenceNumbers is not None

--- a/tests/unit/test_util/test_security.py
+++ b/tests/unit/test_util/test_security.py
@@ -123,7 +123,7 @@ class Test_isWindowAboveWindowMatchesCond_dynamic(_Test_isWindowAboveWindowMatch
 	windows will change.
 	"""
 
-	_queuedMove: Optional[_MoveWindow] = None
+	_queuedMove: _MoveWindow | None = None
 
 	def _getWindow_patched(self, hwnd: winUser.HWNDVal, relation: int) -> int:
 		self._triggerQueuedMove(hwnd)
@@ -149,8 +149,8 @@ class Test_isWindowAboveWindowMatchesCond_dynamic(_Test_isWindowAboveWindowMatch
 		move: _MoveWindow,
 		aboveWindow: winUser.HWNDVal,
 		belowWindow: winUser.HWNDVal,
-		aboveRaises: Optional[Type[Exception]] = None,
-		belowRaises: Optional[Type[Exception]] = None,
+		aboveRaises: Type[Exception] | None = None,
+		belowRaises: Type[Exception] | None = None,
 		aboveExpectFailure: bool = False,
 		belowExpectFailure: bool = False,
 	):

--- a/tests/unit/test_util/test_security.py
+++ b/tests/unit/test_util/test_security.py
@@ -8,7 +8,6 @@
 from dataclasses import dataclass
 from typing import (
 	List,
-	Optional,
 	Type,
 )
 import unittest


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
<!-- Use Closes/Fixes/Resolves #xxx to link this PR to the issue it is responding to. -->
#18381

### Summary of the issue:
`typing.Optional` was deprecated in Python 3.10. `type | None` is more modern/Pythonic.

### Description of user facing changes:
None.

### Description of developer facing changes:
None.

### Description of development approach:

Obsolete `Optional` usages are replaced with Ruff: `ruff check --select UP045 --fix .`

Some instances are manually replaced with Find and Replace.

### Testing strategy:

Linting check passed, and NVDA is still able to launch normally.

### Known issues with pull request:

Some instances of `typing.Optional` should not be replaced, for example in systemUtils.py:

```python
def __init__(self, func: Callable[..., _execAndPumpResT], *args, **kwargs) -> None:
	self.func = func
	self.args = args
	self.kwargs = kwargs
	# Intentionally uses older syntax with `Optional`, instead of `_execAndPumpResT | None`,
	# as latter is not yet supported for unions potentially containing two instances of `None`
	# (see CPython issue 107271).
	self.funcRes: Optional[_execAndPumpResT] = None
```

The comment said that the older syntax is intentionally used. I found this comment, so I restored the replacement here manually. But it's possible that there are other instances that weren't noticed and got replaced anyway.

Some type hints that only use the bare `Optional` were left unchanged. For example:

```python
def __init__(  # noqa: C901
	self,
	windowHandle: int | None = None,  # replaced
	IAccessibleObject: Union[IUnknown, IA.IAccessible, IA2.IAccessible2] | None = None,  # replaced
	IAccessibleChildID: int | None = None,  # replaced
	event_windowHandle: Optional = None,
	event_objectID: Optional = None,
	event_childID: Optional = None,
):
```

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [ ] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [ ] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
