### PR TITLE
Fix app module loading on X64

### DIFF
--- a/source/appModuleHandler.py
+++ b/source/appModuleHandler.py
@@ -65,11 +65,12 @@ since appModules in add-ons should take precedence over the one bundled in NVDA.
 
 
 class processEntry32W(ctypes.Structure):
+	"""See https://learn.microsoft.com/en-us/windows/win32/api/tlhelp32/ns-tlhelp32-processentry32w"""
 	_fields_ = [
 		("dwSize", ctypes.wintypes.DWORD),
 		("cntUsage", ctypes.wintypes.DWORD),
 		("th32ProcessID", ctypes.wintypes.DWORD),
-		("th32DefaultHeapID", ctypes.wintypes.DWORD),
+		("th32DefaultHeapID", ctypes.wintypes.PULONG),
 		("th32ModuleID", ctypes.wintypes.DWORD),
 		("cntThreads", ctypes.wintypes.DWORD),
 		("th32ParentProcessID", ctypes.wintypes.DWORD),

--- a/source/appModuleHandler.py
+++ b/source/appModuleHandler.py
@@ -66,6 +66,7 @@ since appModules in add-ons should take precedence over the one bundled in NVDA.
 
 class processEntry32W(ctypes.Structure):
 	"""See https://learn.microsoft.com/en-us/windows/win32/api/tlhelp32/ns-tlhelp32-processentry32w"""
+
 	_fields_ = [
 		("dwSize", ctypes.wintypes.DWORD),
 		("cntUsage", ctypes.wintypes.DWORD),


### PR DESCRIPTION
### Link to issue number:
Fixup for #18207 that can be applied separately.

### Summary of the issue:
In `appModuleHandler`, there's a mistake in the `processEntry32W` definition. The `th32DefaultHeapID` field is declared as DWORD, but it should be PULONG. See `https://learn.microsoft.com/en-us/windows/win32/api/tlhelp32/ns-tlhelp32-processentry32w`

### Description of user facing changes:
None

### Description of developer facing changes:
None

### Description of development approach:
When merged into #18207, app module loading will work.

### Testing strategy:
Tested on both the x64 and the x86 branches of NVDA.

### Known issues with pull request:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
