### PR TITLE
Fix HID enumeration on X64

### DIFF
--- a/source/hwPortUtils.py
+++ b/source/hwPortUtils.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2001-2023 Chris Liechti, NV Access Limited, Babbage B.V., Leonard de Ruijter
+# Copyright (C) 2001-2025 Chris Liechti, NV Access Limited, Babbage B.V., Leonard de Ruijter
 # Based on serial scanner code by Chris Liechti from https://raw.githubusercontent.com/pyserial/pyserial/81167536e796cc2e13aa16abd17a14634dc3aed1/pyserial/examples/scanwin32.py
 
 """Utilities for working with hardware connection ports."""

--- a/source/hwPortUtils.py
+++ b/source/hwPortUtils.py
@@ -6,6 +6,8 @@
 
 import ctypes
 import itertools
+import math
+import sys
 import typing
 import winreg
 from ctypes.wintypes import BOOL, DWORD, HWND, PDWORD, ULONG, USHORT, WCHAR

--- a/source/hwPortUtils.py
+++ b/source/hwPortUtils.py
@@ -72,7 +72,7 @@ class DEVPROPKEY(ctypes.Structure):
 class dummy(ctypes.Structure):
 	_fields_ = (("d1", DWORD), ("d2", WCHAR))
 	# SetupAPI.h in the Windows headers includes pshpack8.h when 64 bit, pshpack1.h otherwise
-	_pack_ = 8 if platform.architecture()[0].startswith("64") else 1
+	_pack_ = 8 if sys.maxsize > 2**32 else 1
 
 
 SIZEOF_SP_DEVICE_INTERFACE_DETAIL_DATA_W = ctypes.sizeof(dummy)

--- a/source/hwPortUtils.py
+++ b/source/hwPortUtils.py
@@ -407,7 +407,7 @@ def _listDevices(
 			class SP_DEVICE_INTERFACE_DETAIL_DATA_W(ctypes.Structure):
 				_fields_ = (
 					("cbSize", DWORD),
-					("DevicePath", WCHAR * ((dwNeeded.value - ctypes.sizeof(DWORD)) // ctypes.sizeof(WCHAR))),
+					("DevicePath", WCHAR * math.ceil(((dwNeeded.value - ctypes.sizeof(DWORD)) / ctypes.sizeof(WCHAR)))),
 				)
 				_pack_ = dummy._pack_
 

--- a/source/hwPortUtils.py
+++ b/source/hwPortUtils.py
@@ -410,7 +410,7 @@ def _listDevices(
 					("cbSize", DWORD),
 					(
 						"DevicePath",
-						WCHAR * math.ceil(((dwNeeded.value - ctypes.sizeof(DWORD)) / ctypes.sizeof(WCHAR))),
+						WCHAR * math.ceil((dwNeeded.value - ctypes.sizeof(DWORD)) / ctypes.sizeof(WCHAR)),
 					),
 				)
 				_pack_ = dummy._pack_

--- a/source/hwPortUtils.py
+++ b/source/hwPortUtils.py
@@ -7,7 +7,6 @@
 import ctypes
 import itertools
 import math
-import sys
 import typing
 import winreg
 from ctypes.wintypes import BOOL, DWORD, HWND, PDWORD, ULONG, USHORT, WCHAR

--- a/source/hwPortUtils.py
+++ b/source/hwPortUtils.py
@@ -6,7 +6,6 @@
 
 import ctypes
 import itertools
-import platform
 import typing
 import winreg
 from ctypes.wintypes import BOOL, DWORD, HWND, PDWORD, ULONG, USHORT, WCHAR
@@ -407,7 +406,10 @@ def _listDevices(
 			class SP_DEVICE_INTERFACE_DETAIL_DATA_W(ctypes.Structure):
 				_fields_ = (
 					("cbSize", DWORD),
-					("DevicePath", WCHAR * math.ceil(((dwNeeded.value - ctypes.sizeof(DWORD)) / ctypes.sizeof(WCHAR)))),
+					(
+						"DevicePath",
+						WCHAR * math.ceil(((dwNeeded.value - ctypes.sizeof(DWORD)) / ctypes.sizeof(WCHAR))),
+					),
 				)
 				_pack_ = dummy._pack_
 

--- a/source/hwPortUtils.py
+++ b/source/hwPortUtils.py
@@ -73,7 +73,7 @@ class DEVPROPKEY(ctypes.Structure):
 class dummy(ctypes.Structure):
 	_fields_ = (("d1", DWORD), ("d2", WCHAR))
 	# SetupAPI.h in the Windows headers includes pshpack8.h when 64 bit, pshpack1.h otherwise
-	_pack_ = 8 if sys.maxsize > 2**32 else 1
+	_pack_ = 8 if ctypes.sizeof(ctypes.c_void_p) == 8 else 1
 
 
 SIZEOF_SP_DEVICE_INTERFACE_DETAIL_DATA_W = ctypes.sizeof(dummy)

--- a/source/hwPortUtils.py
+++ b/source/hwPortUtils.py
@@ -410,6 +410,7 @@ def _listDevices(
 					("cbSize", DWORD),
 					(
 						"DevicePath",
+						# Round up to the next WCHAR count to ensure proper memory alignment
 						WCHAR * math.ceil((dwNeeded.value - ctypes.sizeof(DWORD)) / ctypes.sizeof(WCHAR)),
 					),
 				)


### PR DESCRIPTION
### Link to issue number:
Fixup for #18207 

### Summary of the issue:
HID enumeration does not work on the experimental X64 branch. I actually found two issues with the current code.

### Description of user facing changes:
None

### Description of developer facing changes:
None

### Description of development approach:
1. it turned out that wrong packing was used. The correct packing is 1 on X86 and 8 on X64. This can be easily found in `SetupAPI.h`, the header that defines `SP_DEVICE_INTERFACE_DETAIL_DATA_W`. I validated with a small c program that `sizeof(SP_DEVICE_INTERFACE_DETAIL_DATA_W))` returns 8 on X64 builds and 6 on x86 builds. I also validated this with ctypes on X86 and X64 runs of NVDA.
2. The current code allocates a buffer that is twice too big for the data. This is also easy to explain. The struct contains a DWORD cbSize field as well as an array of wchars. The array of wchars should be the required size as fetched by the first call of `SetupDiGetDeviceInterfaceDetail`, mines the cbSize field. In the old situation however, there wasn't accounted for the fact that WCHAR is already two bytes. Therefore we now divide through the size of WCHAR.

Old situation:
```python
dwNeeded = DWORD(200)
class SP_DEVICE_INTERFACE_DETAIL_DATA_W(ctypes.Structure):
 _fields_ = (
  ("cbSize", DWORD),
  ("DevicePath", WCHAR * (dwNeeded.value - ctypes.sizeof(DWORD))),
)

>>> sizeof(SP_DEVICE_INTERFACE_DETAIL_DATA_W)
396
```

New situation
```python
dwNeeded = DWORD(200)
class SP_DEVICE_INTERFACE_DETAIL_DATA_W(ctypes.Structure):
	_fields_ = (
		("cbSize", DWORD),
		("DevicePath", WCHAR * ((dwNeeded.value - ctypes.sizeof(DWORD)) // ctypes.sizeof(WCHAR))),
)

>>> sizeof(SP_DEVICE_INTERFACE_DETAIL_DATA_W)
200
```

### Testing strategy:
Ensured that hid devices could be enumerated on both x86 master based builds as well as experimental 64 bit runs of NVDA.

### Known issues with pull request:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
