### PR TITLE
Remove support for embedded OLE objects in editable text

### DIFF
--- a/source/NVDAObjects/window/edit.py
+++ b/source/NVDAObjects/window/edit.py
@@ -13,7 +13,6 @@ import comtypes.client
 import ctypes
 from comtypes import COMError
 import colors
-import NVDAHelper
 import eventHandler
 import comInterfaces.tom
 from logHandler import log
@@ -832,24 +831,6 @@ class ITextDocumentTextInfo(textInfos.TextInfo):
 		).text
 		if label and not label.isspace():
 			return label
-		# Windows Live Mail exposes the label via the embedded object's data (IDataObject)
-		try:
-			dataObj = o.QueryInterface(oleTypes.IDataObject)
-		except comtypes.COMError:
-			dataObj = None
-		if dataObj:
-			text = comtypes.BSTR()
-			NVDAHelper.localLib.getOleClipboardText(dataObj, ctypes.byref(text))
-			label = text.value
-		if label:
-			return label
-		# As a final fallback (e.g. could not get display  model text for Outlook Express), use the embedded object's user type (e.g. "recipient").
-		try:
-			oleObj = o.QueryInterface(oleTypes.IOleObject)
-			label = oleObj.GetUserType(1)
-		except comtypes.COMError:
-			pass
-		return label
 
 	def _getTextAtRange(self, rangeObj):
 		embedRangeObj = None

--- a/source/NVDAObjects/window/edit.py
+++ b/source/NVDAObjects/window/edit.py
@@ -12,7 +12,7 @@ from typing import (
 import comtypes.client
 import ctypes
 from comtypes import COMError
-import oleTypes
+#import oleTypes
 import colors
 import NVDAHelper
 import eventHandler

--- a/source/NVDAObjects/window/edit.py
+++ b/source/NVDAObjects/window/edit.py
@@ -12,7 +12,8 @@ from typing import (
 import comtypes.client
 import ctypes
 from comtypes import COMError
-#import oleTypes
+
+# import oleTypes
 import colors
 import NVDAHelper
 import eventHandler

--- a/source/NVDAObjects/window/edit.py
+++ b/source/NVDAObjects/window/edit.py
@@ -12,8 +12,6 @@ from typing import (
 import comtypes.client
 import ctypes
 from comtypes import COMError
-
-# import oleTypes
 import colors
 import NVDAHelper
 import eventHandler

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -4,6 +4,8 @@
 
 ### Important notes
 
+* This release breaks support for reading some embedded objects in editable text in applications such as Windows Live Mail and Outlook Express. (#18456)
+
 ### New Features
 
 ### Changes


### PR DESCRIPTION
### Link to issue number:
Cherry-picked from #18207

### Summary of the issue:
The code to fetch the text of some embedded OLE objects causes problems for experimental 64-bit builds of NVDA. Since the affected applications are long out of support, this code must now be removed.

### Description of user facing changes:
NVDA will no-longer read some information in editable content in applications including Windows Live Mail and Outlook Express.

### Description of developer facing changes:
None

### Description of development approach:
Removed problematic code

### Testing strategy:

### Known issues with pull request:
None

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
