### PR TITLE
Explisitly link nvdahelperLocal against runtimeobject.lib to allow building on VS build tools 17.14.8

### DIFF
--- a/nvdaHelper/local/sconscript
+++ b/nvdaHelper/local/sconscript
@@ -113,6 +113,7 @@ localLib = env.SharedLibrary(
 		"Gdiplus",
 		"Iphlpapi",
 		"Ws2_32",
+		"runtimeobject",
 	],
 )
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
<!-- Use Closes/Fixes/Resolves #xxx to link this PR to the issue it is responding to. -->
Reported in discussion #18446.

### Summary of the issue:
uiaUtils in nvdaHelperLocal uses c++/winrt objects, which require linking against runtimeobject.lib. Previous to the 10.0.2610 Windows SDK version in VS 2022 V17.14.8, this was linked implisitly. It seems now we need to do this explisitly.
This was noticed on some local builds, and on GitHub actions most likely with an image from July 10.
 Error:
```
UIAUtils.obj : error LNK2019: unresolved external symbol _WINRT_IMPL_RoGetActivationFactory@12 referenced in function "struct winrt::hresult __cdecl winrt::impl::get_runtime_activation_factory_impl<0>(struct winrt::param::hstring const &,struct winrt::guid const &,void * *)" (??$get_runtime_activation_factory_impl@$0A@@impl@winrt@@YA?AUhresult@1@ABUhstring@param@1@ABUguid@1@PAPAX@Z)                                 
UIAUtils.obj : error LNK2019: unresolved external symbol _WINRT_IMPL_RoOriginateLanguageException@12 referenced in function "private: void __thiscall winrt::hresult_error::originate(struct winrt::hresult,void *,struct winrt::impl::slim_source_location const &)" (?originate@hresult_error@winrt@@AAEXUhresult@2@PAXABUslim_source_location@impl@2@@Z)                                                                       
build\x86\local\nvdaHelperLocal.dll : fatal error LNK1120: 2 unresolved externals 
```

### Description of user facing changes:
None.

### Description of developer facing changes:
NVDA will build again with VS 2022 V17.14.8.

### Description of development approach:
Explisitly link nvdaHelperLocal against runtimeobject.lib in `nvdaHelper/local/sconscript`.

### Testing strategy:
* [x] NVDA builds locally.
* [ ] NVDA builds via Appveyor.
* [ ] NvDA builds via GitHub actions

### Known issues with pull request:
None known.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
