### PR TITLE
Fix l10n util, bundle gettext

### DIFF
--- a/source/l10nUtil.py
+++ b/source/l10nUtil.py
@@ -280,9 +280,6 @@ def uploadTranslationFile(crowdinFilePath: str, localFilePath: str, language: st
 	print("Done")
 
 
-_MSGFMT = r"miscDeps\tools\msgfmt.exe"
-
-
 class _PoChecker:
 	"""Checks a po file for errors not detected by msgfmt.
 	This first runs msgfmt to check for syntax errors.
@@ -364,6 +361,7 @@ class _PoChecker:
 		"""Check the syntax of the po file using msgfmt.
 		This will set the hasSyntaxError attribute to True if there is a syntax error.
 		"""
+		_MSGFMT = os.path.join(os.path.dirname(__file__), "..", "miscDeps", "tools", "msgfmt.exe")
 		result = subprocess.run(
 			(_MSGFMT, "-o", "-", self._poPath),
 			stdout=subprocess.DEVNULL,

--- a/source/l10nUtil.py
+++ b/source/l10nUtil.py
@@ -368,11 +368,11 @@ class _PoChecker:
 			# When running from a distribution, source/l10nUtil.py is built to l10nUtil.exe.
 			# miscDeps is the sibling of this script in the distribution.
 			_MSGFMT = os.path.join(sys.prefix, "miscDeps", "tools", "msgfmt.exe")
-	
+
 		if not os.path.exists(_MSGFMT):
 			raise FileNotFoundError(
 				"msgfmt executable not found. "
-				"Please ensure that miscDeps/tools/msgfmt.exe exists in the source tree or distribution."
+				"Please ensure that miscDeps/tools/msgfmt.exe exists in the source tree or distribution.",
 			)
 		return _MSGFMT
 
@@ -380,7 +380,7 @@ class _PoChecker:
 		"""Check the syntax of the po file using msgfmt.
 		This will set the hasSyntaxError attribute to True if there is a syntax error.
 		"""
-		
+
 		result = subprocess.run(
 			(self.MSGFMT_PATH, "-o", "-", self._poPath),
 			stdout=subprocess.DEVNULL,

--- a/source/l10nUtil.py
+++ b/source/l10nUtil.py
@@ -361,7 +361,7 @@ class _PoChecker:
 		"""Check the syntax of the po file using msgfmt.
 		This will set the hasSyntaxError attribute to True if there is a syntax error.
 		"""
-		_MSGFMT = os.path.join("..", "miscDeps", "tools", "msgfmt.exe")
+		_MSGFMT = os.path.join(os.getcwd(), "miscDeps", "tools", "msgfmt.exe")
 		result = subprocess.run(
 			(_MSGFMT, "-o", "-", self._poPath),
 			stdout=subprocess.DEVNULL,

--- a/source/l10nUtil.py
+++ b/source/l10nUtil.py
@@ -361,7 +361,7 @@ class _PoChecker:
 		"""Check the syntax of the po file using msgfmt.
 		This will set the hasSyntaxError attribute to True if there is a syntax error.
 		"""
-		_MSGFMT = os.path.join(os.path.dirname(__file__), "..", "miscDeps", "tools", "msgfmt.exe")
+		_MSGFMT = os.path.join("..", "miscDeps", "tools", "msgfmt.exe")
 		result = subprocess.run(
 			(_MSGFMT, "-o", "-", self._poPath),
 			stdout=subprocess.DEVNULL,

--- a/source/setup.py
+++ b/source/setup.py
@@ -284,6 +284,7 @@ freeze(
 		("fonts", glob("fonts/*.ttf")),
 		("louis/tables", glob("louis/tables/*")),
 		("COMRegistrationFixes", glob("COMRegistrationFixes/*.reg")),
+		("miscDeps/tools", ["../miscDeps/tools/msgfmt.exe"]),
 		(".", glob("../miscDeps/python/*.dll")),
 		(".", ["message.html"]),
 		(".", [os.path.join(sys.base_prefix, "python3.dll")]),


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Fixup of https://github.com/nvaccess/nvda/pull/18270

https://github.com/nvaccess/nvda/pull/18453#issuecomment-3071991867

### Summary of the issue:

We use gettext in l10nUtil now, but it wasn't bundled correctly into NVDA

### Description of user facing changes:
l10nutil is fixed for translators

### Description of development approach:
bundle gettext into nvda distributions
### Testing strategy:
test with nvda build
### Known issues with pull request:
none
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
