### PR TITLE
Fix SAPI5

### DIFF
--- a/source/synthDrivers/sapi5.py
+++ b/source/synthDrivers/sapi5.py
@@ -202,11 +202,15 @@ class SapiSink(COMObject):
 
 	def Bookmark(self, streamNum: int, pos: int, bookmark: str, bookmarkId: int):
 		synth = self.synthRef()
-		if not synth.isSpeaking or not synth.player:
+		if not synth.isSpeaking:
 			return
-		# Bookmark event is raised before the audio after that point.
-		# Queue an IndexReached event at this point.
-		synth.player.feed(None, 0, lambda: self.onIndexReached(streamNum, bookmarkId))
+		if synth.player:
+			# Bookmark event is raised before the audio after that point.
+			# Queue an IndexReached event at this point.
+			synth.player.feed(None, 0, lambda: self.onIndexReached(streamNum, bookmarkId))
+		else:
+			# Bookmark notifications should be sent immediately when WASAPI is off.
+			self.onIndexReached(streamNum, bookmarkId)
 
 	def EndStream(self, streamNum: int, pos: int):
 		synth = self.synthRef()

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -39,6 +39,7 @@ There have also been a number of other fixes and improvements, including to mous
 * Unassigned commands have been added to open the NVDA settings dialog in the following categories: Vision, Windows OCR, Add-on Store and Advanced. (#18313, @CyrilleB79)
 * Introduced support for Windows 11 Voice Access, including reporting dictated text and microphone status from everywhere (requires NVDA to be installed). (#16862, #17384, @josephsl)
 * Support for the NLS eReader Zoomax braille display has been added. (#15863, @florin-trutiu)
+* A checkbox has been added in the speech settings to allow users to disable WASAPI for SAPI5 voices. (#18309, @gexgd0419)
 
 ### Changes
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
<!-- Use Closes/Fixes/Resolves #xxx to link this PR to the issue it is responding to. -->
Fixup of #18352.

### Summary of the issue:

When WASAPI is turned off, bookmark events are not handled properly.

### Description of user facing changes:
Users might not notice that, because although the bookmarks are not handled in time, they are still processed at the end of the utterance.

### Description of developer facing changes:
None

### Description of development approach:

Code that handles the bookmark events when WASAPI is off is added.

### Testing strategy:

Tested manually.

### Known issues with pull request:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
