### PR TITLE
Warn before installing or updating if connected as follower

### DIFF
--- a/source/_remoteClient/client.py
+++ b/source/_remoteClient/client.py
@@ -669,6 +669,13 @@ class RemoteClient:
 			return connector.connected
 		return False
 
+	@property
+	def isConnectedAsFollower(self) -> bool:
+		"""Check if we are connected as the controlled computer."""
+		if self.followerTransport is not None:
+			return self.followerTransport.connected
+		return False
+
 	def registerLocalScript(self, script: scriptHandler._ScriptFunctionT):
 		"""Add a script to be handled locally instead of sent to remote.
 

--- a/source/gui/exit.py
+++ b/source/gui/exit.py
@@ -163,6 +163,14 @@ class ExitDialog(wx.Dialog):
 			queueHandler.queueFunction(queueHandler.eventQueue, core.restart, debugLogging=True)
 		elif action == _ExitAction.INSTALL_PENDING_UPDATE:
 			if updateCheck:
+				from _remoteClient import _remoteClient
+
+				if (
+					_remoteClient is not None
+					and _remoteClient.isConnectedAsFollower
+					and not updateCheck._warnAndConfirmIfUpdatingRemotely()
+				):
+					return
 				destPath, version, apiVersion, backCompatTo = updateCheck.getPendingUpdate()
 				from addonHandler import getIncompatibleAddons
 				from gui import mainFrame

--- a/source/gui/exit.py
+++ b/source/gui/exit.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2006-2024 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Mesar Hameed, Joseph Lee,
+# Copyright (C) 2006-2025 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Mesar Hameed, Joseph Lee,
 # Thomas Stivers, Babbage B.V., Accessolutions, Julien Cochuyt, Cyrille Bougot
 # This file may be used under the terms of the GNU General Public License, version 2 or later.
 # For more details see: https://www.gnu.org/licenses/gpl-2.0.html

--- a/source/gui/installerGui.py
+++ b/source/gui/installerGui.py
@@ -1,7 +1,7 @@
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-# Copyright (C) 2011-2023 NV Access Limited, Babbage B.v., Cyrille Bougot, Julien Cochuyt, Accessolutions,
+# Copyright (C) 2011-2025 NV Access Limited, Babbage B.v., Cyrille Bougot, Julien Cochuyt, Accessolutions,
 # Bill Dengler, Joseph Lee, Takuya Nishimoto
 
 import ctypes

--- a/source/gui/installerGui.py
+++ b/source/gui/installerGui.py
@@ -452,21 +452,21 @@ def _warnAndConfirmIfInstallingRemotely(isUpdate: bool) -> bool:
 				(
 					_(
 						# Translators: Message shown to users when attempting to update NVDA
-						# on a computer which is being remotely controled via NVDA Remote Access
-						"Updating NVDA when connected to NVDA Remote Access as the controled computer is not recommended. ",
+						# on a computer which is being remotely controlled via NVDA Remote Access
+						"Updating NVDA when connected to NVDA Remote Access as the controlled computer is not recommended. ",
 					)
 					if isUpdate
 					else _(
 						# Translators: Message shown to users when attempting to install NVDA
-						# on a computer which is being remotely controled via NVDA Remote Access
-						"Installing NVDA when connected to NVDA Remote Access as the controled computer is not recommended. ",
+						# on a computer which is being remotely controlled via NVDA Remote Access
+						"Installing NVDA when connected to NVDA Remote Access as the controlled computer is not recommended. ",
 					)
 				)
 				+ _(
 					# Translators: Message shown to users when attempting to install or update NVDA from the launcher
-					# on a computer which is being remotely controled via NVDA Remote Access
+					# on a computer which is being remotely controlled via NVDA Remote Access
 					"You will be unable to respond to User Account Control (UAC) prompts from the controlling computer. "
-					"You should only procede if you have physical access to the controlled computer.\n\n"
+					"You should only proceed if you have physical access to the controlled computer.\n\n"
 					"Are you sure you want to continue?",
 				),
 				# Translators: The title of a dialog.

--- a/source/gui/installerGui.py
+++ b/source/gui/installerGui.py
@@ -25,16 +25,16 @@ import ui
 from NVDAState import WritePaths
 from .message import DialogType, MessageDialog, ReturnCode, displayDialogAsModal
 
-IsUserAnAdmin = ctypes.windll.shell32.IsUserAnAdmin
-IsUserAnAdmin.argtypes = []
-IsUserAnAdmin.restype = ctypes.wintypes.BOOL
+_IsUserAnAdmin = ctypes.windll.shell32.IsUserAnAdmin
+_IsUserAnAdmin.argtypes = []
+_IsUserAnAdmin.restype = ctypes.wintypes.BOOL
 
 
 def _shouldWarnBeforeUpdate() -> bool:
 	"""Whether or not a warning about being unable to complete installation when connected as follower should be shown to the user."""
 	from _remoteClient import _remoteClient
 
-	return _remoteClient is not None and _remoteClient.isConnectedAsFollower and not IsUserAnAdmin()
+	return _remoteClient is not None and _remoteClient.isConnectedAsFollower and not _IsUserAnAdmin()
 
 
 def _canPortableConfigBeCopied() -> bool:

--- a/source/gui/installerGui.py
+++ b/source/gui/installerGui.py
@@ -25,16 +25,16 @@ import ui
 from NVDAState import WritePaths
 from .message import DialogType, MessageDialog, ReturnCode, displayDialogAsModal
 
+IsUserAnAdmin = ctypes.windll.shell32.IsUserAnAdmin
+IsUserAnAdmin.argtypes = []
+IsUserAnAdmin.restype = ctypes.wintypes.BOOL
+
 
 def _shouldWarnBeforeUpdate() -> bool:
+	"""Whether or not a warning about being unable to complete installation when connected as follower should be shown to the user."""
 	from _remoteClient import _remoteClient
 
-	isUserAnAdmin = ctypes.windll.shell32.IsUserAnAdmin
-	isUserAnAdmin.argtypes = []
-	isUserAnAdmin.restype = ctypes.wintypes.BOOL
-	if _remoteClient is not None:
-		return not (_remoteClient.isConnectedAsFollower and not isUserAnAdmin())
-	return True
+	return _remoteClient is not None and _remoteClient.isConnectedAsFollower and not IsUserAnAdmin()
 
 
 def _canPortableConfigBeCopied() -> bool:

--- a/source/updateCheck.py
+++ b/source/updateCheck.py
@@ -56,7 +56,7 @@ import synthDriverHandler  # noqa: E402
 import braille
 import gui
 from gui import guiHelper
-from gui.message import displayDialogAsModal  # noqa: E402
+from gui.message import DialogType, MessageDialog, ReturnCode, displayDialogAsModal  # noqa: E402
 from addonHandler import getCodeAddon, AddonError, getIncompatibleAddons
 from addonStore.models.version import (  # noqa: E402
 	getAddonCompatibilityMessage,
@@ -602,6 +602,8 @@ class UpdateResultDialog(
 		self.Show()
 
 	def onUpdateButton(self, destPath):
+		if not _warnAndConfirmIfUpdatingRemotely():
+			return
 		_executeUpdate(destPath)
 		self.Destroy()
 
@@ -774,6 +776,8 @@ class UpdateAskInstallDialog(
 		return callback
 
 	def onUpdateButton(self, evt):
+		if not _warnAndConfirmIfUpdatingRemotely():
+			return
 		self.EndModal(wx.ID_OK)
 
 	def onPostponeButton(self, evt):
@@ -1002,6 +1006,39 @@ def saveState():
 			pickle.dump(state, f, protocol=0)
 	except:  # noqa: E722
 		log.debugWarning("Error saving state", exc_info=True)
+
+
+def _warnAndConfirmIfUpdatingRemotely() -> bool:
+	# Import late to avoid circular import
+	from _remoteClient import _remoteClient
+
+	if _remoteClient is not None and _remoteClient.isConnectedAsFollower:
+		confirmationDialog = (
+			MessageDialog(
+				gui.mainFrame,
+				_(
+					# Translators: Message shown to users when attempting to update NVDA
+					# on a computer which is being remotely controled via NVDA Remote Access
+					"Updating NVDA when connected to NVDA Remote Access as the controled computer is not recommended. ",
+				)
+				+ _(
+					# Translators: Message shown to users when attempting to update NVDA from an installed copy
+					# on a computer which is being remotely controled via NVDA Remote Access.
+					"The currently active connection may not be continued during or after the update. "
+					"Even if the connection is continued, you will be unable to respond to User Account Control (UAC) prompts from the controlling computer. "
+					"You should only procede if you have physical access to the controlled computer.\n\n"
+					"Are you sure you want to continue?",
+				),
+				# Translators: The title of a dialog.
+				_("Warning"),
+				DialogType.WARNING,
+				buttons=None,
+			)
+			.addNoButton(defaultFocus=True, fallbackAction=True)
+			.addYesButton()
+		)
+		return confirmationDialog.ShowModal() == ReturnCode.YES
+	return True
 
 
 def initialize():

--- a/source/updateCheck.py
+++ b/source/updateCheck.py
@@ -1018,15 +1018,15 @@ def _warnAndConfirmIfUpdatingRemotely() -> bool:
 				gui.mainFrame,
 				_(
 					# Translators: Message shown to users when attempting to update NVDA
-					# on a computer which is being remotely controled via NVDA Remote Access
-					"Updating NVDA when connected to NVDA Remote Access as the controled computer is not recommended. ",
+					# on a computer which is being remotely controlled via NVDA Remote Access
+					"Updating NVDA when connected to NVDA Remote Access as the controlled computer is not recommended. ",
 				)
 				+ _(
 					# Translators: Message shown to users when attempting to update NVDA from an installed copy
-					# on a computer which is being remotely controled via NVDA Remote Access.
+					# on a computer which is being remotely controlled via NVDA Remote Access.
 					"The currently active connection may not be continued during or after the update. "
 					"Even if the connection is continued, you will be unable to respond to User Account Control (UAC) prompts from the controlling computer. "
-					"You should only procede if you have physical access to the controlled computer.\n\n"
+					"You should only proceed if you have physical access to the controlled computer.\n\n"
 					"Are you sure you want to continue?",
 				),
 				# Translators: The title of a dialog.

--- a/tests/unit/test_installer.py
+++ b/tests/unit/test_installer.py
@@ -131,7 +131,7 @@ class testFollowerWarning(unittest.TestCase):
 		isUserAnAdmin: bool,
 		expectedReturn: bool,
 	):
-		with patch("gui.installerGui.IsUserAnAdmin", return_value=isUserAnAdmin):
+		with patch("gui.installerGui._IsUserAnAdmin", return_value=isUserAnAdmin):
 			with patch(
 				"_remoteClient.client.RemoteClient",
 				isConnectedAsFollower=isConnectedAsFollower,

--- a/tests/unit/test_installer.py
+++ b/tests/unit/test_installer.py
@@ -1,14 +1,19 @@
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-# Copyright (C) 2024 NV Access Limited
+# Copyright (C) 2024-2025 NV Access Limited
 
 """Unit tests for the installer module."""
 
 import pathlib
 import tempfile
+from typing import NamedTuple
 import unittest
+from unittest.mock import patch
 
+from parameterized import parameterized
+
+from gui import installerGui
 import installer
 
 
@@ -64,3 +69,75 @@ class Test_BatchDeletion(unittest.TestCase):
 		installer._deleteFileGroupOrFail(self._originalTempDir, self._sampleFiles)
 		for file in self._sampleFiles:
 			self.assertFalse(pathlib.Path(self._originalTempDir, file).exists())
+
+
+class _ShouldWarnBeforeUpdateFactors(NamedTuple):
+	remoteEnabled: bool
+	isConnectedAsFollower: bool
+	isUserAnAdmin: bool
+	expectedReturn: bool = False
+
+
+class testFollowerWarning(unittest.TestCase):
+	@parameterized.expand(
+		(
+			_ShouldWarnBeforeUpdateFactors(
+				remoteEnabled=False,
+				isConnectedAsFollower=False,
+				isUserAnAdmin=False,
+			),
+			_ShouldWarnBeforeUpdateFactors(
+				remoteEnabled=False,
+				isConnectedAsFollower=False,
+				isUserAnAdmin=True,
+			),
+			_ShouldWarnBeforeUpdateFactors(
+				remoteEnabled=False,
+				isConnectedAsFollower=True,
+				isUserAnAdmin=False,
+			),
+			_ShouldWarnBeforeUpdateFactors(
+				remoteEnabled=False,
+				isConnectedAsFollower=True,
+				isUserAnAdmin=True,
+			),
+			_ShouldWarnBeforeUpdateFactors(
+				remoteEnabled=True,
+				isConnectedAsFollower=False,
+				isUserAnAdmin=False,
+			),
+			_ShouldWarnBeforeUpdateFactors(
+				remoteEnabled=True,
+				isConnectedAsFollower=False,
+				isUserAnAdmin=True,
+			),
+			_ShouldWarnBeforeUpdateFactors(
+				remoteEnabled=True,
+				isConnectedAsFollower=True,
+				isUserAnAdmin=False,
+				expectedReturn=True,
+			),
+			_ShouldWarnBeforeUpdateFactors(
+				remoteEnabled=True,
+				isConnectedAsFollower=True,
+				isUserAnAdmin=True,
+			),
+		),
+	)
+	def test_shouldWarnBeforeUpdate(
+		self,
+		remoteEnabled: bool,
+		isConnectedAsFollower: bool,
+		isUserAnAdmin: bool,
+		expectedReturn: bool,
+	):
+		with patch("gui.installerGui.IsUserAnAdmin", return_value=isUserAnAdmin):
+			with patch(
+				"_remoteClient.client.RemoteClient",
+				isConnectedAsFollower=isConnectedAsFollower,
+			) as patchedRemoteClient:
+				with patch.dict(
+					"_remoteClient.__dict__",
+					_remoteClient=patchedRemoteClient if remoteEnabled else None,
+				):
+					self.assertEqual(installerGui._shouldWarnBeforeUpdate(), expectedReturn)

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -53,6 +53,7 @@ There have also been a number of other fixes and improvements, including to mous
 * In browse mode, it is now possible to use number keys 1 to 9 (previously 1 to 6), to navigate to the corresponding heading. (#18014, @CyrilleB79)
 * When the Elements List or Find dialog is opened, NVDA won't change the configuration profile, similar to the behavior in other NVDA dialogs. (#18160, @nvdaes)
 * In Microsoft Edge, NVDA will no longer cancel say all when notifications such as "loading complete" are announced. (#17986, @josephsl)
+* NVDA will now warn before updating when connected as the controlled computer with NVDA Remote Access. (#18455)
 
 ### Bug Fixes
 


### PR DESCRIPTION
### Link to issue number:
Closes #18455

### Summary of the issue:
When installing or updating NVDA, if the computer is being operated via NVDA Remote Access, the user will lose access because the secure copy of NVDA will not connect to unknown executables.

### Description of user facing changes:
The launcher warns the user before installing or updating NVDA if Remote Access is connected as a follower, unless it is running as administrator, in which case we should not encounter UAC.
NVDA warns the user before installing an update from the update check UI or via the exit dialog.
In all cases, the user is discouraged from proceding, and the default response is to not continue with the installation.

### Description of developer facing changes:
None

### Description of development approach:
Check if connected as follower and not admin before installing from the launcher.
Check if connected as follower in update checker and exit dialog (when the exit action is to update).
All checks implemented as functions that return `True` if we should procede (there is no blocker, or the user has chosen to continue), or `False` if there is a blocker and the user has not chosen to continue.
Functions with checks return early if the check function returns `False`.

### Testing strategy:
Built launcher and tried to install while not connected, or connected as follower.
Ran from source and manually envoked the installer GUI and attempted to install when connected as follower or not connected.
Spoofed versions and attempted updating when connected as follower and not connected.

### Known issues with pull request:
This problem is not unique to NVDA updates. If the user encounters a UAC prompt while connected as follower and is running portably or has not enabled Remote Access on secure screens, they will be stuck in the same way as this PR warns against. However, there is nothing we can do in these cases, as we cannot control whether UAC appears or not.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
