### PR TITLE
build dev guide when building dist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ dlldata.c
 *.pdb
 .sconsign.dblite
 *.md.sub
+user_docs/developerGuide.html
 user_docs/*/*.html
 user_docs/*/*.css
 user_docs/*/*.ico

--- a/projectDocs/dev/developerGuide/sconscript
+++ b/projectDocs/dev/developerGuide/sconscript
@@ -5,7 +5,7 @@
 
 import sys
 
-Import("env", "outputDir", "sourceDir")
+Import("env", "outputDir", "sourceDir", "userDocsDir")
 
 env = env.Clone()
 
@@ -27,9 +27,11 @@ htmlFile = env.Command(
 	action=[f'@"{sys.executable}" source/md2html.py -t developerGuide "$SOURCE" "$TARGET"'],
 )
 devGuide = env.Command(
-	target=devDocsOutputDir.File("developerGuide.html"), source=htmlFile, action=Move("$TARGET", "$SOURCE")
+	target=userDocsDir.File("developerGuide.html"), source=htmlFile, action=Move("$TARGET", "$SOURCE")
 )
 env.Alias("developerGuide", devGuide)
+# Return the developer docs targets so they can be used as dependencies
+Return(["devGuide"])
 
 devDocs_nvdaHelper_temp = env.Doxygen(source="../../../nvdaHelper/doxyfile")
 devDocs_nvdaHelper = env.Command(

--- a/sconstruct
+++ b/sconstruct
@@ -510,8 +510,10 @@ uninstaller = env.Command(uninstFile, uninstGen, [uninstGen])
 if certFile or apiSigningToken:
 	env.AddPostAction(uninstaller, [env["signExec"]])
 
+devDocTargets = env.SConscript("projectDocs/dev/developerGuide/sconscript", exports=["env", "outputDir", "sourceDir", "userDocsDir"])
 dist = env.NVDADist("dist", [sourceDir, userDocsDir], uiAccess=bool(certFile) or bool(apiSigningToken))
 env.Depends(dist, uninstaller)
+env.Depends(dist, devDocTargets)
 # dist will always be considered obsolete
 AlwaysBuild(dist)
 # Dir node targets don't get cleaned, so cleaning of the dist nodes has to be explicitly specified.
@@ -639,11 +641,6 @@ def makePot(target, source, env):
 			out.write(line)
 	os.remove(potFn)
 	os.rename(tmpFn, potFn)
-
-
-env.SConscript("projectDocs/dev/developerGuide/sconscript", exports=["env", "outputDir", "sourceDir"])
-
-
 def getSubDirs(path):
 	for root, dirNames, fileNames in os.walk(path):
 		yield root

--- a/source/md2html.py
+++ b/source/md2html.py
@@ -133,7 +133,7 @@ def _generateSanitizedHTML(md: str, isKeyCommands: bool = False) -> str:
 
 
 def main(source: str, dest: str, lang: str = "en", docType: str | None = None):
-	print(f"Converting {docType or 'document'} at {source} to {dest}, {lang=}")
+	print(f"Converting {docType or 'document'} ({lang=}) at {source} to {dest}")
 	isUserGuide = docType == "userGuide"
 	isDevGuide = docType == "developerGuide"
 	isChanges = docType == "changes"

--- a/source/setup.py
+++ b/source/setup.py
@@ -271,11 +271,6 @@ freeze(
 	data_files=[
 		(".", glob("*.dll") + glob("*.manifest") + ["builtin.dic"]),
 		("documentation", ["../copying.txt"]),
-		# Include the developer guide HTML file if it has been built.
-		(
-			"documentation",
-			[file for file in ["../output/devDocs/developerGuide.html"] if os.path.isfile(file)],
-		),
 		("lib/%s" % version, glob("lib/*.dll") + glob("lib/*.manifest")),
 		("lib64/%s" % version, glob("lib64/*.dll") + glob("lib64/*.exe")),
 		("libArm64/%s" % version, glob("libArm64/*.dll") + glob("libArm64/*.exe")),


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Fixup of #18467
Fixes #18459


### Summary of the issue:
The developer guide was only being included in the distribution if it had been built separately previously.
Instead, the NVDA distribution should require the dev guide to be built.
