### PR TITLE
fix up unnamed percent rule to exclude %%

### DIFF
--- a/source/l10nUtil.py
+++ b/source/l10nUtil.py
@@ -572,8 +572,11 @@ class _PoChecker:
 			return False
 		return True
 
-	RE_UNNAMED_PERCENT = re.compile(r"(?<!%)%[.\d]*[a-zA-Z]")
+	# e.g. %s %d %%
+	RE_UNNAMED_PERCENT = re.compile(r"(?<!%)%[.\d]*[a-zA-Z%]")
+	# e.g. %(name)s %(name)d
 	RE_NAMED_PERCENT = re.compile(r"(?<!%)%\([^(]+\)[.\d]*[a-zA-Z]")
+	# e.g. {name} {name:format}
 	RE_FORMAT = re.compile(r"(?<!{){([^{}:]+):?[^{}]*}")
 
 	def _getInterpolations(self, text: str) -> tuple[list[str], set[str], set[str]]:

--- a/source/l10nUtil.py
+++ b/source/l10nUtil.py
@@ -572,8 +572,8 @@ class _PoChecker:
 			return False
 		return True
 
-	# e.g. %s %d %%
-	RE_UNNAMED_PERCENT = re.compile(r"(?<!%)%[.\d]*[a-zA-Z%]")
+	# e.g. %s %d (but not %%)
+	RE_UNNAMED_PERCENT = re.compile(r"(?<!%)%(?!%)[.\d]*[a-zA-Z]")
 	# e.g. %(name)s %(name)d
 	RE_NAMED_PERCENT = re.compile(r"(?<!%)%\([^(]+\)[.\d]*[a-zA-Z]")
 	# e.g. {name} {name:format}


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
None

### Summary of the issue:

The regex to check for unnamed string interpolations doesn't support the `%%` symbol, which escapes `%`.
This leads to certain usages of it raising incorrect interpolation errors.

```
File source/locale/tr/LC_MESSAGES/nvda.po: 1 error
Message starting on line 10286
Original: "%s%%"
Translated: "%%%s"
Error: unnamed percent interpolations differ
Expected: unnamed percent interpolations in this order: ['%s']
Got: no interpolations
```

### Description of user facing changes:
error fixed for translators
### Description of developer facing changes:
none
### Description of development approach:
Fixed up regex

### Testing strategy:

Check all po files with this

Ensure the example case is fixed

### Known issues with pull request:

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.