### PR TITLE
Open links in `ui.browseableMessage` in the default browser

### DIFF
--- a/source/message.html
+++ b/source/message.html
@@ -58,7 +58,11 @@ function windowOnClick(e) {
 	if (target.tagName == 'A') {
 		// If clicked on a link, open with the system default browser,
 		// instead of in a new IE window.
-		new ActiveXObject('WScript.Shell').Run(target.href);
+		try {
+			new ActiveXObject('WScript.Shell').Run(target.href);
+		} catch (err) {
+			return;  // fallback to standard behavior
+		}
 		return false;  // cancels default processing
 	}
 }

--- a/source/message.html
+++ b/source/message.html
@@ -49,6 +49,20 @@ function onCloseButtonPress() {
 	window.close();
 }
 
+function windowOnClick(e) {
+	// This is only supported in IE browsers.
+	if (!window.ActiveXObject) {
+		return;
+	}
+	var target = window.event.srcElement;
+	if (target.tagName == 'A') {
+		// If clicked on a link, open with the system default browser,
+		// instead of in a new IE window.
+		new ActiveXObject('WScript.Shell').Run(target.href);
+		return false;  // cancels default processing
+	}
+}
+
 function windowOnLoad() {
 	if (args) {
 		document.title = args.item('title');
@@ -79,7 +93,7 @@ function windowOnLoad() {
 //-->
 </SCRIPT>
 </HEAD>
-<body tabindex='0' id='main_body' style="margin:1em" onload="return windowOnLoad()" onkeydown="return handleKeyPress()" >
+<body tabindex='0' id='main_body' style="margin:1em" onload="return windowOnLoad()" onkeydown="return handleKeyPress()" onclick="return windowOnClick()">
 <div id="messageDiv"></div>
 
 <!-- "tabindex" is needed to circumvent an old IE/MSHTML bug in the handling of aria-labelledby.


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
<!-- Use Closes/Fixes/Resolves #xxx to link this PR to the issue it is responding to. -->
None

### Summary of the issue:

In an HTML dialog opened by `ui.browseableMessage`, when a user clicks on a hyperlink, instead of using the system's default browser, a new Internet Explorer window will open and navigate to this link.

This is because `ui.browseableMessage` uses `ShowHTMLDialogEx` in `mshtml.dll` to open an HTML dialog, which is based on Internet Explorer's component. As a result, when a link is being opened, Internet Explorer will be launched.

As we know, Internet Explorer has been retired, and although it may still be fine for simple HTML pages, it is no longer suitable for modern websites.

### Description of user facing changes:
Links in the HTML dialog will now open in the system's default browser.

### Description of developer facing changes:
None.

### Description of development approach:

A Javascript snippet is added into `messages.html`. The click event of links will be intercepted, and it will use `WScript.Shell` to launch the system's default browser instead.

### Testing strategy:
Tested manually.

### Known issues with pull request:

As the click event is intercepted, clicked links will not turn into visited state.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [ ] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [ ] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
