### PR TITLE
Added ability to sort add-ons by last tested version

### DIFF
--- a/source/gui/addonStoreGui/controls/details.py
+++ b/source/gui/addonStoreGui/controls/details.py
@@ -272,17 +272,17 @@ class AddonDetails(
 						details._addonHandlerModel.version,
 					)
 
-					self._appendDetailsLabelValue(
-						# Translators: Label for an extra detail field for the selected add-on. In the add-on store dialog.
-						pgettext("addonStore", "Minimum NVDA version:"),
-						formatVersionForGUI(*details.minimumNVDAVersion),
-					)
+				self._appendDetailsLabelValue(
+					# Translators: Label for an extra detail field for the selected add-on. In the add-on store dialog.
+					pgettext("addonStore", "Minimum NVDA version:"),
+					formatVersionForGUI(*details.minimumNVDAVersion),
+				)
 
-					self._appendDetailsLabelValue(
-						# Translators: Label for an extra detail field for the selected add-on. In the add-on store dialog.
-						pgettext("addonStore", "Last tested NVDA version:"),
-						formatVersionForGUI(*details.lastTestedNVDAVersion),
-					)
+				self._appendDetailsLabelValue(
+					# Translators: Label for an extra detail field for the selected add-on. In the add-on store dialog.
+					pgettext("addonStore", "Last tested NVDA version:"),
+					formatVersionForGUI(*details.lastTestedNVDAVersion),
+				)
 
 				if currentStatusKey not in AddonListField.availableAddonVersionName.hideStatuses:
 					self._appendDetailsLabelValue(

--- a/source/gui/addonStoreGui/viewModels/addonList.py
+++ b/source/gui/addonStoreGui/viewModels/addonList.py
@@ -107,6 +107,7 @@ class AddonListField(_AddonListFieldData, Enum):
 		50,
 	)
 
+
 _AddonModelT = TypeVar("_AddonModelT", bound=_AddonGUIModel)
 
 

--- a/source/gui/addonStoreGui/viewModels/addonList.py
+++ b/source/gui/addonStoreGui/viewModels/addonList.py
@@ -98,7 +98,7 @@ class AddonListField(_AddonListFieldData, Enum):
 	)
 	publicationDate = (
 		# Translators: The name of the column that contains the publication date of the add-on.
-		pgettext("addonStore", "Date"),
+		pgettext("addonStore", "Publication Date"),
 		50,
 	)
 

--- a/source/gui/addonStoreGui/viewModels/addonList.py
+++ b/source/gui/addonStoreGui/viewModels/addonList.py
@@ -30,6 +30,7 @@ from addonStore.models.status import (
 )
 import core
 import extensionPoints
+from buildVersion import formatVersionForGUI
 from logHandler import log
 
 
@@ -89,6 +90,11 @@ class AddonListField(_AddonListFieldData, Enum):
 		pgettext("addonStore", "Author"),
 		100,
 		frozenset({_StatusFilterKey.AVAILABLE, _StatusFilterKey.UPDATE}),
+	)
+	lastTestedVersion = (
+		# Translators: The name of the column that contains the last version of NVDA tested with this add-on.
+		pgettext("addonStore", "Last tested NVDA version"),
+		50,
 	)
 	publicationDate = (
 		# Translators: The name of the column that contains the publication date of the add-on.
@@ -298,6 +304,8 @@ class AddonListVM:
 			return listItemVM.status.displayString
 		if field is AddonListField.channel:
 			return listItemVM.model.channel.displayString
+		if field is AddonListField.lastTestedVersion:
+			return formatVersionForGUI(*listItemVM.model.lastTestedVersion)
 		return getattr(listItemVM.model, field.name, "")
 
 	def getCount(self) -> int:

--- a/source/gui/addonStoreGui/viewModels/addonList.py
+++ b/source/gui/addonStoreGui/viewModels/addonList.py
@@ -91,17 +91,21 @@ class AddonListField(_AddonListFieldData, Enum):
 		100,
 		frozenset({_StatusFilterKey.AVAILABLE, _StatusFilterKey.UPDATE}),
 	)
-	lastTestedVersion = (
-		# Translators: The name of the column that contains the last version of NVDA tested with this add-on.
-		pgettext("addonStore", "Last tested NVDA version"),
-		50,
-	)
 	publicationDate = (
 		# Translators: The name of the column that contains the publication date of the add-on.
 		pgettext("addonStore", "Publication Date"),
 		50,
 	)
-
+	minimumNVDAVersion = (
+		# Translators: The name of the column that contains the minimum version of NVDA required for this add-on.
+		pgettext("addonStore", "Minimum NVDA version"),
+		50,
+	)
+	lastTestedVersion = (
+		# Translators: The name of the column that contains the last version of NVDA tested with this add-on.
+		pgettext("addonStore", "Last tested NVDA version"),
+		50,
+	)
 
 _AddonModelT = TypeVar("_AddonModelT", bound=_AddonGUIModel)
 
@@ -304,6 +308,8 @@ class AddonListVM:
 			return listItemVM.status.displayString
 		if field is AddonListField.channel:
 			return listItemVM.model.channel.displayString
+		if field is AddonListField.minimumNVDAVersion:
+			return formatVersionForGUI(*listItemVM.model.minimumNVDAVersion)
 		if field is AddonListField.lastTestedVersion:
 			return formatVersionForGUI(*listItemVM.model.lastTestedVersion)
 		return getattr(listItemVM.model, field.name, "")

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -6,7 +6,8 @@
 
 ### New Features
 
-* In add-on lists of the add-on store, add-ons can be sorted by last tested NVDA version (#18440, @nvdaes)
+* In add-on lists of the add-on store, add-ons can be sorted by minimum and last tested NVDA version. Additionally, minimum and last tested version will be shown in the Details area for all tabs of the store (#18440, @nvdaes)
+
 ### Changes
 
 * When braille word wrap is enabled, all braille cells will be used if the next character is a space. (#18016, @nvdaes)

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -6,6 +6,7 @@
 
 ### New Features
 
+* In add-on lists of the add-on store, add-ons can be sorted by last tested NVDA version (#18440, @nvdaes)
 ### Changes
 
 * When braille word wrap is enabled, all braille cells will be used if the next character is a space. (#18016, @nvdaes)

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -6,7 +6,8 @@
 
 ### New Features
 
-* In add-on lists of the add-on store, add-ons can be sorted by minimum and last tested NVDA version. Additionally, minimum and last tested version will be shown in the Details area for all tabs of the store (#18440, @nvdaes)
+* In the Add-on Store, add-ons can be sorted by minimum and last tested NVDA version.
+Additionally, minimum and last tested version will now be also shown in the details area for an add-on in the Available Add-ons tab. (#18440, @nvdaes)
 
 ### Changes
 


### PR DESCRIPTION
- **Add ability to sort add-ons by last tested NVDA version**
- **Update changelog**

<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
<!-- Use Closes/Fixes/Resolves #xxx to link this PR to the issue it is responding to. -->
Fixes #18440
### Summary of the issue:
Sorting add-ons by last tested version can be helpful to know if an add-on is compatible with an updated version of NVDA, available but not installed yet. In this way, users can decide if they prefer to update NVDA, or wait until a compatible version of the add-on is available.
### Description of user facing changes:
In add-on lists of the add-on store, a new column with last tested NVDA version is available, and add-ons can also be sorted by this column.

### Description of developer facing changes:

None.

### Description of development approach:
In addonStoreGui, viewModels, addonList module, a new field with its corresponding text has been added to create a new column, showing the last tested NVDA version

### Testing strategy:
Open the store, switch to various tabs, check that a new column with last tested version is available, and that add-ons can be sorted by this column.

### Known issues with pull request:
None.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
