### PR TITLE
Build workflow: fix step name to upload controller client

### DIFF
--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -261,7 +261,7 @@ jobs:
           output/devDocs
           output/*.html
           output/*.css
-    - name: Upload build artifacts
+    - name: Upload Controller client and packaging metadata
       uses: actions/upload-artifact@v4
       id: uploadBuildArtifacts
       with:


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
In the build workflow, the name of the step to upload the controller client is not clear. This makes artefacts download more difficult.

### Description of user facing changes:
None

### Description of developer facing changes:
In the job's log, the name of the step to upload the artefact is now more explicit. This helps downloading the correct artefact.

### Description of development approach:
Changed the step's name in the yaml workflow file.

### Testing strategy:
Check CI.

### Known issues with pull request:
None

### Code Review Checklist:


- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
