### PR TITLE
Add user docs markdown files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ dlldata.c
 *.md.sub
 user_docs/*/*.html
 user_docs/*/*.md
+!user_docs/en/*.md
 user_docs/*/*.css
 user_docs/*/*.ico
 extras/controllerClient/x86/nvdaController.h

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ dlldata.c
 .sconsign.dblite
 *.md.sub
 user_docs/*/*.html
+user_docs/*/*.md
 user_docs/*/*.css
 user_docs/*/*.ico
 extras/controllerClient/x86/nvdaController.h


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
None

### Summary of the issue:
Some languages have their user guide and changes file committed as markdown.
These are being moved to xliff.

Markdown files as user docs are no longer being updated, only removed.

Markdown files are also generated from the xliff as part of the build process.
This causes a large amount of dirtied markdown files when building.
