### PR TITLE
Fix bug where only the first math expression on a line was being spoken/brailled

### DIFF
--- a/source/NVDAObjects/IAccessible/adobeAcrobat.py
+++ b/source/NVDAObjects/IAccessible/adobeAcrobat.py
@@ -154,6 +154,22 @@ class AcrobatNode(IAccessible):
 				answer += AcrobatNode.getMathMLAttributes(node, ["encoding"])
 			case "ms":
 				answer += AcrobatNode.getMathMLAttributes(node, ["open", "close"])
+			case "mspace":
+				answer += AcrobatNode.getMathMLAttributes(node, ["width"])
+			case "msgroup":
+				answer += AcrobatNode.getMathMLAttributes(node, ["position", "shift"])
+			case "msrow":
+				answer += AcrobatNode.getMathMLAttributes(node, ["position"])
+			case "msline":
+				answer += AcrobatNode.getMathMLAttributes(node, ["position", "length"])
+			case "mscarries":
+				answer += AcrobatNode.getMathMLAttributes(node, ["position", "crossout"])
+			case "mscarry":
+				answer += AcrobatNode.getMathMLAttributes(node, ["crossout"])
+			case "mstack":
+				answer += AcrobatNode.getMathMLAttributes(node, ["align", "stackalign"])
+			case "mlongdiv":
+				answer += AcrobatNode.getMathMLAttributes(node, ["longdivstyle"])
 			case _:
 				pass
 		answer += ">"

--- a/source/NVDAObjects/IAccessible/adobeAcrobat.py
+++ b/source/NVDAObjects/IAccessible/adobeAcrobat.py
@@ -154,22 +154,6 @@ class AcrobatNode(IAccessible):
 				answer += AcrobatNode.getMathMLAttributes(node, ["encoding"])
 			case "ms":
 				answer += AcrobatNode.getMathMLAttributes(node, ["open", "close"])
-			case "mspace":
-				answer += AcrobatNode.getMathMLAttributes(node, ["width"])
-			case "msgroup":
-				answer += AcrobatNode.getMathMLAttributes(node, ["position", "shift"])
-			case "msrow":
-				answer += AcrobatNode.getMathMLAttributes(node, ["position"])
-			case "msline":
-				answer += AcrobatNode.getMathMLAttributes(node, ["position", "length"])
-			case "mscarries":
-				answer += AcrobatNode.getMathMLAttributes(node, ["position", "crossout"])
-			case "mscarry":
-				answer += AcrobatNode.getMathMLAttributes(node, ["crossout"])
-			case "mstack":
-				answer += AcrobatNode.getMathMLAttributes(node, ["align", "stackalign"])
-			case "mlongdiv":
-				answer += AcrobatNode.getMathMLAttributes(node, ["longdivstyle"])
 			case _:
 				pass
 		answer += ">"

--- a/source/NVDAObjects/IAccessible/adobeAcrobat.py
+++ b/source/NVDAObjects/IAccessible/adobeAcrobat.py
@@ -175,7 +175,7 @@ class AcrobatNode(IAccessible):
 		answer += ">"
 		val = node.GetValue()
 		if val:
-			answer += html.escape(val)
+			answer += val
 		else:
 			for childNum in range(node.GetChildCount()):
 				try:
@@ -230,7 +230,7 @@ class AcrobatNode(IAccessible):
 
 		# not MathML -- fall back to return the contents, which is hopefully alt text, inside an <mtext>
 		# note: we need to convert '<' and '%' to entity names
-		answer = f"<math><mtext>{html.escape(s=mathMl)}</mtext></math>"
+		answer = f"<math><mtext>{html.escape(mathMl)}</mtext></math>"
 		log.debug(f"_get_mathMl: didn't find MathML -- returning value as mtext: {answer}")
 		return answer
 

--- a/source/NVDAObjects/IAccessible/adobeAcrobat.py
+++ b/source/NVDAObjects/IAccessible/adobeAcrobat.py
@@ -175,7 +175,7 @@ class AcrobatNode(IAccessible):
 		answer += ">"
 		val = node.GetValue()
 		if val:
-			answer += val
+			answer += html.escape(val)
 		else:
 			for childNum in range(node.GetChildCount()):
 				try:
@@ -230,7 +230,7 @@ class AcrobatNode(IAccessible):
 
 		# not MathML -- fall back to return the contents, which is hopefully alt text, inside an <mtext>
 		# note: we need to convert '<' and '%' to entity names
-		answer = f"<math><mtext>{html.escape(mathMl)}</mtext></math>"
+		answer = f"<math><mtext>{html.escape(s=mathMl)}</mtext></math>"
 		log.debug(f"_get_mathMl: didn't find MathML -- returning value as mtext: {answer}")
 		return answer
 

--- a/source/NVDAObjects/UIA/wordDocument.py
+++ b/source/NVDAObjects/UIA/wordDocument.py
@@ -373,7 +373,7 @@ class WordDocumentTextInfo(UIATextInfo):
 							mathStartIndex = index
 					elif isinstance(field, textInfos.FieldCommand) and field.command == "controlEnd":
 						if curLevel == mathLevel and field.field.get("mathml"):
-							del fields[mathStartIndex + 1: index]
+							del fields[mathStartIndex + 1 : index]
 							index = mathStartIndex + 1
 						curLevel -= 1
 					index += 1

--- a/source/NVDAObjects/UIA/wordDocument.py
+++ b/source/NVDAObjects/UIA/wordDocument.py
@@ -362,20 +362,21 @@ class WordDocumentTextInfo(UIATextInfo):
 				curLevel = 0
 				mathLevel = None
 				mathStartIndex = None
-				mathEndIndex = None
-				for index in range(len(fields)):
+				index = 0
+				# we delete items from 'fields' in the loop, so we can't use a for loop
+				while index < len(fields):
 					field = fields[index]
 					if isinstance(field, textInfos.FieldCommand) and field.command == "controlStart":
 						curLevel += 1
-						if mathLevel is None and field.field.get("mathml"):
+						if field.field.get("mathml"):
 							mathLevel = curLevel
 							mathStartIndex = index
 					elif isinstance(field, textInfos.FieldCommand) and field.command == "controlEnd":
-						if curLevel == mathLevel:
-							mathEndIndex = index
+						if curLevel == mathLevel and field.field.get("mathml"):
+							del fields[mathStartIndex + 1: index]
+							index = mathStartIndex + 1
 						curLevel -= 1
-				if mathEndIndex is not None:
-					del fields[mathStartIndex + 1 : mathEndIndex]
+					index += 1
 
 		# Sometimes embedded objects and graphics In MS Word can cause a controlStart then a controlEnd with no actual formatChange / text in the middle.
 		# SpeakTextInfo always expects that the first lot of controlStarts will always contain some text.

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -13,6 +13,7 @@
 
 ### Bug Fixes
 
+* Fixed missing MathML attributes for `mspace` in PDF documents. Also passed along attributes for elementary math elements.
 * Fixed support for paragraph mouse text unit in Java applications. (#18231, @hwf1324)
 
 ### Changes for Developers

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -13,6 +13,7 @@
 
 ### Bug Fixes
 
+* Fixed '<' not being escaped in MathML in PDF documents. Most likely this will happen in `mo` elements.
 * Fixed missing MathML attributes for `mspace` in PDF documents. Also passed along attributes for elementary math elements.
 * Fixed support for paragraph mouse text unit in Java applications. (#18231, @hwf1324)
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -13,8 +13,7 @@
 
 ### Bug Fixes
 
-* Fixed '<' not being escaped in MathML in PDF documents. Most likely this will happen in `mo` elements.
-* Fixed missing MathML attributes for `mspace` in PDF documents. Also passed along attributes for elementary math elements.
+* Fixed problem with multiple expressions on a line in word documents: everything after the first expression was dropped (not spoken or brailled)
 * Fixed support for paragraph mouse text unit in Java applications. (#18231, @hwf1324)
 
 ### Changes for Developers

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -13,7 +13,7 @@
 
 ### Bug Fixes
 
-* Fixed problem with multiple expressions on a line in word documents: everything after the first expression was dropped (not spoken or brailled)
+* Fixed bug with multiple math expressions on the same line in Microsoft Word documents: everything after the first expression was not spoken or brailled. (#18386, @NSoiffer)
 * Fixed support for paragraph mouse text unit in Java applications. (#18231, @hwf1324)
 
 ### Changes for Developers


### PR DESCRIPTION
### Link to issue number:
This fixes #18386 

### Summary of the issue:
If there is more than one math expression on a line, only the first math expression is spoken/brailled. Any text or math after that is dropped.

### Description of user facing changes:
Now the full line is read/brailled.

### Description of developer facing changes:
None

### Description of development approach:
The bug was in wordDocument.py. There was/is special code to avoid saying both the MathML and word's speech for the math. However that code seemed to assume that there was only one piece of math per line and did a single (large) deletion after looping through what was on the line.

The code now correctly deletes only Word's math speech string. It does this in the loop. Because deletion is done on the array as we are looping, the code has to be careful to make sure the index into the array tracks where we are after the deletion.

### Testing strategy:
I created a sample [Word doc](https://github.com/user-attachments/files/21355912/NVDA-bug18386.docx). This doc has three expressions on the line to better test the problem. Before the change, everything after the first expression was dropped. Now the entire line is read, including all the math and the text around the math.

### Known issues with pull request:
I accidentally created the branch from another bug fix. I did a `git revert` and should have pulled out the other commits, but I still see the commits mentioned. On the other hand, only two changed files are listed, and those  have the appropriate changes.

Note: this is a pull request against master. However, this is a pretty bad bug that was reported elsewhere before finally being reported here. **I strongly suggest this goes into 2025.2.beta.** I have tried to build the beta, but it isn't working for me, so I can't test the fix there.

Update: I forgot to mention that I left in the original code that does a "level check":  every `controlStart` bumps the level and every `controlEnd` end decreases the level. The code records the level of the `controlStart`  of math and only does deletion of content if the `controlEnd` of the math matches that level. I don't believe this is needed, but I don't know why it was part of the original code and perhaps there are cases where it is needed. @michaelDCurran wrote the original code: do you remember why you did that (four years ago)?

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
