### PR TITLE
Use root certificates when using the add-on store and NVDA remote

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,8 @@ dependencies = [
 	# pinned to a commit in tool.uv.sources
 	"configobj",
 	"requests==2.32.3",
+	# Overrides certifi so that requests uses system certificates instead
+	"truststore==0.10.4",
 	"url-normalize==1.4.3",
 	"schedule==1.2.2",
 	# NVDA_DMP requires diff-match-patch

--- a/source/_remoteClient/transport.py
+++ b/source/_remoteClient/transport.py
@@ -432,11 +432,15 @@ class TCPTransport(Transport):
 			serverSock.settimeout(self.timeout)
 		serverSock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
 		serverSock.ioctl(socket.SIO_KEEPALIVE_VALS, (1, 60000, 2000))
-		ctx = ssl.SSLContext(ssl.PROTOCOL_TLSv1_2)
-		if insecure:
-			ctx.verify_mode = ssl.CERT_NONE
-			log.warn(f"Skipping certificate verification for {host}:{port}")
+		ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+		ctx.minimum_version = ssl.TLSVersion.TLSv1_2
+		ctx.maximum_version = ssl.TLSVersion.TLSv1_3
+		# Must be set before verify_mode.
 		ctx.check_hostname = not insecure
+		if insecure:
+			log.warn(f"Skipping certificate verification for {host}:{port}")
+			ctx.verify_mode = ssl.CERT_NONE
+
 		ctx.load_default_certs()
 
 		serverSock = ctx.wrap_socket(sock=serverSock, server_hostname=host)

--- a/source/addonStore/dataManager.py
+++ b/source/addonStore/dataManager.py
@@ -27,6 +27,7 @@ import languageHandler
 from logHandler import log
 import NVDAState
 from NVDAState import WritePaths
+from utils.networking import _fetchUrlAndUpdateRootCertificates
 
 from .models.addon import (
 	AddonStoreModel,
@@ -124,7 +125,7 @@ class _DataManager:
 		url = _getAddonStoreURL(self._preferredChannel, self._lang, apiVersion)
 		try:
 			log.debug(f"Fetching add-on data from {url}")
-			response = requests.get(url, timeout=FETCH_TIMEOUT_S)
+			response = _fetchUrlAndUpdateRootCertificates(url)
 		except requests.exceptions.RequestException as e:
 			log.debugWarning(f"Unable to fetch addon data: {e}")
 			return None
@@ -135,11 +136,11 @@ class _DataManager:
 			return None
 		return response.content
 
-	def _getCacheHash(self) -> Optional[str]:
+	def _getCacheHash(self) -> str | None:
 		url = _getCacheHashURL()
 		try:
 			log.debug(f"Fetching add-on data from {url}")
-			response = requests.get(url, timeout=FETCH_TIMEOUT_S)
+			response = _fetchUrlAndUpdateRootCertificates(url)
 		except requests.exceptions.RequestException as e:
 			log.debugWarning(f"Unable to get cache hash: {e}")
 			return None

--- a/source/core.py
+++ b/source/core.py
@@ -31,6 +31,7 @@ import extensionPoints
 import garbageHandler
 import NVDAState
 from NVDAState import WritePaths
+import truststore
 
 if TYPE_CHECKING:
 	import wx
@@ -676,6 +677,10 @@ def main():
 	Finally, it starts the wx main loop.
 	"""
 	log.debug("Core starting")
+
+	# Use Windows root certificates for requests rather than certifi.
+	truststore.inject_into_ssl()
+
 	if NVDAState.isRunningAsSource():
 		# When running as packaged version, DPI awareness is set via the app manifest.
 		from winAPI.dpiAwareness import setDPIAwareness
@@ -698,6 +703,7 @@ def main():
 		WritePaths.configDir = config.getUserDefaultConfigPath(
 			useInstalledPathIfExists=globalVars.appArgs.launcher,
 		)
+
 	# Initialize the config path (make sure it exists)
 	config.initConfigPath()
 	log.info(f"Config dir: {WritePaths.configDir}")

--- a/source/utils/networking.py
+++ b/source/utils/networking.py
@@ -1,0 +1,121 @@
+# A part of NonVisual Desktop Access (NVDA)
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+# Copyright (C) 2012-2025 NV Access Limited, Zahari Yurukov,
+# Babbage B.V., Joseph Lee, Christopher Proß
+
+import ctypes
+import ctypes.wintypes
+import ssl
+
+import requests
+
+from logHandler import log
+from winBindings import crypt32
+
+
+_FETCH_TIMEOUT_S = 30
+"""Timeout for fetching in seconds."""
+
+
+# These structs are only complete enough to achieve what we need.
+class _CERT_USAGE_MATCH(ctypes.Structure):
+	_fields_ = (
+		("dwType", ctypes.wintypes.DWORD),
+		# CERT_ENHKEY_USAGE struct
+		("cUsageIdentifier", ctypes.wintypes.DWORD),
+		("rgpszUsageIdentifier", ctypes.c_void_p),  # LPSTR *
+	)
+
+
+class _CERT_CHAIN_PARA(ctypes.Structure):
+	_fields_ = (
+		("cbSize", ctypes.wintypes.DWORD),
+		("RequestedUsage", _CERT_USAGE_MATCH),
+		("RequestedIssuancePolicy", _CERT_USAGE_MATCH),
+		("dwUrlRetrievalTimeout", ctypes.wintypes.DWORD),
+		("fCheckRevocationFreshnessTime", ctypes.wintypes.BOOL),
+		("dwRevocationFreshnessTime", ctypes.wintypes.DWORD),
+		("pftCacheResync", ctypes.c_void_p),  # LPFILETIME
+		("pStrongSignPara", ctypes.c_void_p),  # PCCERT_STRONG_SIGN_PARA
+		("dwStrongSignFlags", ctypes.wintypes.DWORD),
+	)
+
+
+def _getCertificate(url: str) -> bytes:
+	"""Gets the certificate from the server."""
+	log.debug(f"Getting certificate from: {url}")
+	with requests.get(
+		url,
+		timeout=_FETCH_TIMEOUT_S,
+		# Use an unverified connection to avoid a certificate error.
+		verify=False,
+		stream=True,
+	) as response:
+		# Get the server certificate.
+		return response.raw.connection.sock.getpeercert(True)
+
+
+def _updateWindowsRootCertificates(cert: bytes) -> None:
+	"""Adds the certificate to the Windows root certificates."""
+	log.debug("Updating Windows root certificates")
+	# Convert to a form usable by Windows.
+	certCont = crypt32.CertCreateCertificateContext(
+		0x00000001,  # X509_ASN_ENCODING
+		cert,
+		len(cert),
+	)
+	# Ask Windows to build a certificate chain, thus triggering a root certificate update.
+	chainCont = ctypes.c_void_p()
+	crypt32.CertGetCertificateChain(
+		None,
+		certCont,
+		None,
+		None,
+		ctypes.byref(
+			_CERT_CHAIN_PARA(
+				cbSize=ctypes.sizeof(_CERT_CHAIN_PARA),
+				RequestedUsage=_CERT_USAGE_MATCH(),
+			),
+		),
+		0,
+		None,
+		ctypes.byref(chainCont),
+	)
+	crypt32.CertFreeCertificateChain(chainCont)
+	crypt32.CertFreeCertificateContext(certCont)
+
+
+def _is_cert_verification_error(exception: requests.exceptions.SSLError) -> bool:
+	return (
+		exception.__context__
+		and exception.__context__.__cause__
+		and exception.__context__.__cause__.__context__
+		and isinstance(exception.__context__.__cause__.__context__, ssl.SSLCertVerificationError)
+		and hasattr(exception.__context__.__cause__.__context__, "reason")
+		and exception.__context__.__cause__.__context__.reason == "CERTIFICATE_VERIFY_FAILED"
+	)
+
+
+def _fetchUrlAndUpdateRootCertificates(url: str, certFetchUrl: str | None = None) -> requests.Response:
+	"""Fetches the content of a URL and updates the Windows root certificates.
+
+	:param url: The URL to fetch.
+	:param certFetchUrl: An optional URL to use for fetching the certificate if the original URL fails due to a certificate error.
+	:return: The content of the URL.
+	"""
+	try:
+		log.debug(f"Fetching data from: {url}")
+		result = requests.get(url, timeout=_FETCH_TIMEOUT_S)
+		log.debug(f"Got response with status code: {result.status_code}")
+	except requests.exceptions.SSLError as e:
+		if _is_cert_verification_error(e):
+			# #4803: Windows fetches trusted root certificates on demand.
+			# Python doesn't trigger this fetch (PythonIssue:20916), so try it ourselves.
+			cert = _getCertificate(certFetchUrl or url)
+			_updateWindowsRootCertificates(cert)
+			log.debug(f"Retrying fetching data from: {url}")
+			result = requests.get(url, timeout=_FETCH_TIMEOUT_S)
+		else:
+			raise
+	return result

--- a/source/utils/networking.py
+++ b/source/utils/networking.py
@@ -5,41 +5,17 @@
 # Babbage B.V., Joseph Lee, Christopher Proß
 
 import ctypes
-import ctypes.wintypes
 import ssl
 
 import requests
 
 from logHandler import log
 from winBindings import crypt32
+from winBindings.crypt32 import CERT_CHAIN_PARA, CERT_USAGE_MATCH
 
 
 _FETCH_TIMEOUT_S = 30
 """Timeout for fetching in seconds."""
-
-
-# These structs are only complete enough to achieve what we need.
-class _CERT_USAGE_MATCH(ctypes.Structure):
-	_fields_ = (
-		("dwType", ctypes.wintypes.DWORD),
-		# CERT_ENHKEY_USAGE struct
-		("cUsageIdentifier", ctypes.wintypes.DWORD),
-		("rgpszUsageIdentifier", ctypes.c_void_p),  # LPSTR *
-	)
-
-
-class _CERT_CHAIN_PARA(ctypes.Structure):
-	_fields_ = (
-		("cbSize", ctypes.wintypes.DWORD),
-		("RequestedUsage", _CERT_USAGE_MATCH),
-		("RequestedIssuancePolicy", _CERT_USAGE_MATCH),
-		("dwUrlRetrievalTimeout", ctypes.wintypes.DWORD),
-		("fCheckRevocationFreshnessTime", ctypes.wintypes.BOOL),
-		("dwRevocationFreshnessTime", ctypes.wintypes.DWORD),
-		("pftCacheResync", ctypes.c_void_p),  # LPFILETIME
-		("pStrongSignPara", ctypes.c_void_p),  # PCCERT_STRONG_SIGN_PARA
-		("dwStrongSignFlags", ctypes.wintypes.DWORD),
-	)
 
 
 def _getCertificate(url: str) -> bytes:
@@ -73,9 +49,9 @@ def _updateWindowsRootCertificates(cert: bytes) -> None:
 		None,
 		None,
 		ctypes.byref(
-			_CERT_CHAIN_PARA(
-				cbSize=ctypes.sizeof(_CERT_CHAIN_PARA),
-				RequestedUsage=_CERT_USAGE_MATCH(),
+			CERT_CHAIN_PARA(
+				cbSize=ctypes.sizeof(CERT_CHAIN_PARA),
+				RequestedUsage=CERT_USAGE_MATCH(),
 			),
 		),
 		0,

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -183,6 +183,7 @@ Use `INPUT_TYPE.MOUSE`, `INPUT_TYPE.KEYBOARD`, `KEYEVENTF.KEYUP` and `KEYEVENTF.
 Use `winBindings.magnification.MAGCOLOREFFECT` instead. (#18958)
 * `visionEnhancementProviders.screenCurtain.isScreenFullyBlack` is deprecated.
 Use `NVDAHelper.localLib.isScreenFullyBlack` instead. (#18958)
+* `updateCheck.UPDATE_FETCH_TIMEOUT_S` is deprecated for removal without replacement. (#18354)
 
 <!-- Beyond this point, Markdown should not be linted, as we don't modify old change log sections. -->
 <!-- markdownlint-disable -->
@@ -379,11 +380,6 @@ Please refer to [the developer guide](https://www.nvaccess.org/files/nvda/docume
 The several built-in table definitions are moved to the `__tables` module in that package. (#18194, @LeonarddeR)
 * Microsoft SQL Server Management Studio now uses the Visual Studio app module, as SSMS is based on Visual Studio. (#18176, @LeonarddeR)
 * NVDA will report Windows release revision number (for example: 10.0.26100.0) when `winVersion.getWinVer` is called and log this information at startup. (#18266, @josephsl)
-* `ssl.SSLContext` now uses Windows' trusted certificate stores, not `certifi` via `truststore` patching. (#15905)
-
-#### Deprecations
-
-* The following symbols in `updateCheck` are deprecated for removal without replacement: `CERT_USAGE_MATCH`, `CERT_CHAIN_PARA`, `UPDATE_FETCH_TIMEOUT_S`. (#18354)
 
 ## 2025.1.2
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -56,6 +56,7 @@ We recommend using Windows 11, or if that is not possible, the latest Windows 10
 * Fixed a problem where some SAPI 4 voices (e.g. IBM ViaVoice) start speaking in the maximum volume instead of the current volume when speaking capital letters. (#18866, @gexgd0419)
 * NVDA no longer fails to read the contents of wx Web View controls. (#17273, @LeonarddeR)
 * When NVDA is configured to update add-ons automatically in the background, add-ons can be properly updated. (#18965, @nvdaes)
+* Fixed bug when trying to access the Add-on Store from certain environments such as corporates. (#18354)
 
 ### Changes for Developers
 
@@ -376,6 +377,11 @@ Please refer to [the developer guide](https://www.nvaccess.org/files/nvda/docume
 The several built-in table definitions are moved to the `__tables` module in that package. (#18194, @LeonarddeR)
 * Microsoft SQL Server Management Studio now uses the Visual Studio app module, as SSMS is based on Visual Studio. (#18176, @LeonarddeR)
 * NVDA will report Windows release revision number (for example: 10.0.26100.0) when `winVersion.getWinVer` is called and log this information at startup. (#18266, @josephsl)
+* `ssl.SSLContext` now uses Windows' trusted certificate stores, not `certifi` via `truststore` patching. (#15905)
+
+#### Deprecations
+
+* The following symbols in `updateCheck` are deprecated for removal without replacement: `CERT_USAGE_MATCH`, `CERT_CHAIN_PARA`, `UPDATE_FETCH_TIMEOUT_S`. (#18354)
 
 ## 2025.1.2
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -56,7 +56,7 @@ We recommend using Windows 11, or if that is not possible, the latest Windows 10
 * Fixed a problem where some SAPI 4 voices (e.g. IBM ViaVoice) start speaking in the maximum volume instead of the current volume when speaking capital letters. (#18866, @gexgd0419)
 * NVDA no longer fails to read the contents of wx Web View controls. (#17273, @LeonarddeR)
 * When NVDA is configured to update add-ons automatically in the background, add-ons can be properly updated. (#18965, @nvdaes)
-* Fixed bug when trying to access the Add-on Store from certain environments such as corporates. (#18354)
+* Fixed bug when trying to access the Add-on Store from certain environments such as corporate networks. (#18354)
 
 ### Changes for Developers
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -81,6 +81,8 @@ These are breaking API changes.
 Please open a GitHub issue if your add-on has an issue with updating to the new API.
 
 * NVDA is now built with Python 3.13. (#18591)
+* NVDA now uses `truststore` to always use Windows root certificates, which injects to libraries like `requests`.
+Wrap code with `truststore.extract_from_ssl` and `truststore.inject_into_ssl` to disable this behavior where required. (#18528)
 * typing_extensions have been removed.
 These should be supported natively in Python 3.13. (#18689)
 * `copyrightYears` and `url` have been moved from `versionInfo` to `buildVersion`. (#18682)

--- a/uv.lock
+++ b/uv.lock
@@ -591,7 +591,7 @@ requires-dist = [
     { name = "pyserial", specifier = "==3.5" },
     { name = "requests", specifier = "==2.32.3" },
     { name = "schedule", specifier = "==1.2.2" },
-    { name = "truststore", specifier = "==0.10.1" },
+    { name = "truststore", specifier = "==0.10.4" },
     { name = "url-normalize", specifier = "==1.4.3" },
     { name = "wxpython", specifier = "==4.2.2" },
 ]
@@ -1192,11 +1192,11 @@ wheels = [
 
 [[package]]
 name = "truststore"
-version = "0.10.1"
+version = "0.10.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0f/a7/b7a43228762966a13598a404f3dfb4803ea29a906f449d8b0e73ed0bcd30/truststore-0.10.1.tar.gz", hash = "sha256:eda021616b59021812e800fa0a071e51b266721bef3ce092db8a699e21c63539", size = 26101, upload-time = "2025-02-07T18:57:38.201Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bc/df/8ad635bdcfa8214c399e5614f7c2121dced47defb755a85ea1fa702ffb1c/truststore-0.10.1-py3-none-any.whl", hash = "sha256:b64e6025a409a43ebdd2807b0c41c8bff49ea7ae6550b5087ac6df6619352d4c", size = 18496, upload-time = "2025-02-07T18:57:36.348Z" },
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -536,6 +536,7 @@ dependencies = [
     { name = "pyserial", marker = "sys_platform == 'win32'" },
     { name = "requests", marker = "sys_platform == 'win32'" },
     { name = "schedule", marker = "sys_platform == 'win32'" },
+    { name = "truststore", marker = "sys_platform == 'win32'" },
     { name = "url-normalize", marker = "sys_platform == 'win32'" },
     { name = "wxpython", marker = "sys_platform == 'win32'" },
 ]
@@ -590,6 +591,7 @@ requires-dist = [
     { name = "pyserial", specifier = "==3.5" },
     { name = "requests", specifier = "==2.32.3" },
     { name = "schedule", specifier = "==1.2.2" },
+    { name = "truststore", specifier = "==0.10.1" },
     { name = "url-normalize", specifier = "==1.4.3" },
     { name = "wxpython", specifier = "==4.2.2" },
 ]
@@ -1186,6 +1188,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5b/b9/1ed31d167be802da0fc95020d04cd27b7d7065cc6fbefdd2f9186f60d7bd/tomli-2.2.1-cp313-cp313-win32.whl", hash = "sha256:d3f5614314d758649ab2ab3a62d4f2004c825922f9e370b29416484086b264ec", size = 98724, upload-time = "2024-11-27T22:38:32.837Z" },
     { url = "https://files.pythonhosted.org/packages/c7/32/b0963458706accd9afcfeb867c0f9175a741bf7b19cd424230714d722198/tomli-2.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:a38aa0308e754b0e3c67e344754dff64999ff9b513e691d0e786265c93583c69", size = 109383, upload-time = "2024-11-27T22:38:34.455Z" },
     { url = "https://files.pythonhosted.org/packages/6e/c2/61d3e0f47e2b74ef40a68b9e6ad5984f6241a942f7cd3bbfbdbd03861ea9/tomli-2.2.1-py3-none-any.whl", hash = "sha256:cb55c73c5f4408779d0cf3eef9f762b9c9f147a77de7b258bef0a5628adc85cc", size = 14257, upload-time = "2024-11-27T22:38:35.385Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/a7/b7a43228762966a13598a404f3dfb4803ea29a906f449d8b0e73ed0bcd30/truststore-0.10.1.tar.gz", hash = "sha256:eda021616b59021812e800fa0a071e51b266721bef3ce092db8a699e21c63539", size = 26101, upload-time = "2025-02-07T18:57:38.201Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/df/8ad635bdcfa8214c399e5614f7c2121dced47defb755a85ea1fa702ffb1c/truststore-0.10.1-py3-none-any.whl", hash = "sha256:b64e6025a409a43ebdd2807b0c41c8bff49ea7ae6550b5087ac6df6619352d4c", size = 18496, upload-time = "2025-02-07T18:57:36.348Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Reimplements https://github.com/nvaccess/nvda/pull/18354
Reimplements https://github.com/nvaccess/nvda/pull/18490
Reimplements https://github.com/nvaccess/nvda/pull/18402
Fixes #15905

### Summary of the issue:
When trying to download an add-on from the add-on store in certain environments such as corporates, the download fails due to the machine not trusting the root certificate of the add-on source.

This can be caused by two issues:

* the requests library using certifi rather than the system root certificates
* the system root certificates not trusting the add-on download source

When performing an update check, we update windows root certificates if our certificate is invalid or out of date.

### Description of user facing changes:
NVDA should more reliably trust request endpoints using windows root certificates. e.g. accessing the add-on store in a corporate environment.

### Description of developer facing changes:
requests and similar libraries now has truststore injected into it

### Description of development approach:
This pull request improves how NVDA handles SSL/TLS certificate verification, particularly for HTTPS requests and add-on downloads. It ensures that the application uses the Windows root certificate store instead of the Python default (certifi), provides a fallback mechanism to update root certificates when encountering untrusted certificates, and enhances user interaction when certificate errors occur during add-on downloads. Additionally, shared networking logic has been refactored and centralized for maintainability.

**Certificate Verification and Networking Improvements:**

* Added the `truststore` dependency and injected it at startup so that all `requests` HTTP calls use the Windows root certificate store instead of certifi, improving compatibility in corporate and managed environments. (`pyproject.toml`, `source/core.py`) [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R32-R33) [[2]](diffhunk://#diff-dbe862167add4fbe8e502757f792615f714c7603621c03d0c60c08a6a613ad68R34) [[3]](diffhunk://#diff-dbe862167add4fbe8e502757f792615f714c7603621c03d0c60c08a6a613ad68R680-R683)
* Introduced a new `utils/networking.py` module that centralizes logic for fetching URLs, handling certificate verification errors, and updating Windows root certificates. This includes helper functions like `_fetchUrlAndUpdateRootCertificates`, `_getCertificate`, and `_updateWindowsRootCertificates`. (`source/utils/networking.py`)

**Add-on Store and Update Check Enhancements:**

* Updated add-on store and update check logic to use the new `_fetchUrlAndUpdateRootCertificates` function, ensuring robust handling of certificate verification failures and automatic root certificate updates when necessary. (`source/addonStore/dataManager.py`, `source/updateCheck.py`) [[1]](diffhunk://#diff-9fd9bbb610bac3157554c0876fba6ea3475383ea9de36c2101ba1127cf5189e5R30) [[2]](diffhunk://#diff-9fd9bbb610bac3157554c0876fba6ea3475383ea9de36c2101ba1127cf5189e5L127-R128) [[3]](diffhunk://#diff-9fd9bbb610bac3157554c0876fba6ea3475383ea9de36c2101ba1127cf5189e5L138-R143) [[4]](diffhunk://#diff-69aa1f3d46c308cf71c96483fd196eb49d6348727ab1953f834b1974ff031a43R68-R76) [[5]](diffhunk://#diff-69aa1f3d46c308cf71c96483fd196eb49d6348727ab1953f834b1974ff031a43L241-R245)
* Improved the add-on download process to prompt the user when encountering an untrusted certificate, displaying the SHA256 fingerprint and allowing the user to trust and install the root certificate if appropriate. (`source/addonStore/network.py`) [[1]](diffhunk://#diff-097e46da59cc87eb0100bd63db7cfe32c7095ec66cf4be02d5dc84f28682ac7eL239-R297) [[2]](diffhunk://#diff-097e46da59cc87eb0100bd63db7cfe32c7095ec66cf4be02d5dc84f28682ac7eR314-R315)

**Codebase Cleanup and Refactoring:**

* Removed duplicate and now-unnecessary certificate update logic from `updateCheck.py` and centralized all certificate handling in `utils/networking.py`. (`source/updateCheck.py`)
* Updated variable naming and improved code clarity in the add-on download logic. (`source/addonStore/network.py`) [[1]](diffhunk://#diff-097e46da59cc87eb0100bd63db7cfe32c7095ec66cf4be02d5dc84f28682ac7eL239-R297) [[2]](diffhunk://#diff-097e46da59cc87eb0100bd63db7cfe32c7095ec66cf4be02d5dc84f28682ac7eR314-R315) [[3]](diffhunk://#diff-097e46da59cc87eb0100bd63db7cfe32c7095ec66cf4be02d5dc84f28682ac7eL268-R324) [[4]](diffhunk://#diff-097e46da59cc87eb0100bd63db7cfe32c7095ec66cf4be02d5dc84f28682ac7eL278-R334) [[5]](diffhunk://#diff-097e46da59cc87eb0100bd63db7cfe32c7095ec66cf4be02d5dc84f28682ac7eL290-R346)

### Testing strategy:

- [x] Get user testing from #15905
- [x] Smoke test using add-on store
- [x] Smoke test update check

### Known issues with pull request:
None
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
