### PR TITLE
No longer print warnings for every specific empty / corrupt translation when generating markdown from xliff

### DIFF
--- a/source/markdownTranslate.py
+++ b/source/markdownTranslate.py
@@ -459,7 +459,6 @@ def generateMarkdown(xliffPath: str, outputPath: str, translated: bool = True) -
 						"&lt;target&gt;&lt;/target&gt;",
 					):
 						res.numBadTranslationStrings += 1
-						print(f"Warning: line {lineNum} contained a corrupt empty translation. Using source")
 						translation = ""
 					else:
 						res.numTranslatedStrings += 1


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
<!-- Use Closes/Fixes/Resolves #xxx to link this PR to the issue it is responding to. -->
None.

### Summary of the issue:
markdownTranslate generateMarkdown currently outputs a warning for every line of an xliff that contains an empty or corrupt translation. For some translations this can be thousands of lines. These empty / corrupt translations are known issues caused by Poedit / Crowdin. These are translparently handled and appropriately ignored (using the source text instead) when generating the markdown, and the number of empty / corrupt translations are once at the very end. Therefore, these individual warnings are just noise.
 
### Description of user facing changes:
None.

### Description of developer facing changes:
NVDA build output will no longer contain many warnings about empty / corrupt translations.

### Description of development approach:
Simply remove that print statement.

### Testing strategy:
Built NVDA including translations. Confirmed that for files with more than one empty / corrupt translation, individual warnings were no longer emitted.

### Known issues with pull request:
None known.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
