### PR TITLE
Ensure the language code from a speech sequence is normalized before checking if the synth supports it.

### DIFF
--- a/source/speech/languageHandling.py
+++ b/source/speech/languageHandling.py
@@ -76,6 +76,9 @@ def getLangToReport(lang: str) -> str:
 	:param lang: A language code corresponding to the text been read.
 	:return: A language code corresponding to the language to be reported.
 	"""
+	# Ensure the language is in a standard form of xx[_YY], E.g. en_AU.
+	# Rather than say en-au.
+	lang = languageHandler.normalizeLanguage(lang)
 	if config.conf["speech"]["autoLanguageSwitching"] and not config.conf["speech"]["autoDialectSwitching"]:
 		return lang.split("_")[0]
 	return lang

--- a/source/speech/languageHandling.py
+++ b/source/speech/languageHandling.py
@@ -76,8 +76,8 @@ def getLangToReport(lang: str) -> str:
 	:param lang: A language code corresponding to the text been read.
 	:return: A language code corresponding to the language to be reported.
 	"""
-	# Ensure the language is in a standard form of xx[_YY], E.g. en_AU.
-	# Rather than say en-au.
+	# Ensure the language is in a standard form of xx[_YY],
+	# E.g. en_AU rather than en-au.
 	lang = languageHandler.normalizeLanguage(lang)
 	if config.conf["speech"]["autoLanguageSwitching"] and not config.conf["speech"]["autoDialectSwitching"]:
 		return lang.split("_")[0]


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
<!-- Use Closes/Fixes/Resolves #xxx to link this PR to the issue it is responding to. -->
None

### Summary of the issue:
Recently, NVDA gained the ability to report the name of a language, when speaking text in that language and the synthesizer did not support it. However, in particular situations such as reading mathML,  NvDA would report a language was not supported when it was. E.g. reading MathML in English with eSpeak, NvDA would report "English (not supported)".
The reason for this seems to be that a non-normalized language code E.g. en-gb was being compared against normalized language codes, such as en_GB, and never matching.

 
### Description of user facing changes:
NVDA will no longer incorrectly report a particular language is not supported.

### Description of developer facing changes:
 
### Description of development approach:
In speech.languageHandling.getLangToReport: normalize the language.

### Testing strategy:
With espeak and Windows Onecore, Read various math examples in MS Word, plus a html file in Firefox with various language changes that were both supported and not supported by the synthesizer.

### Known issues with pull request:
None known.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
