### PR TITLE
Add-on store: Fix column sorting combo-box when clicking add-on list column header

### DIFF
--- a/source/gui/addonStoreGui/controls/addonList.py
+++ b/source/gui/addonStoreGui/controls/addonList.py
@@ -151,6 +151,7 @@ class AddonVirtualList(
 		colIndex = evt.GetColumn()
 		log.debug(f"col clicked: {colIndex}")
 		self._addonsListVM.setSortField(self._addonsListVM.presentedFields[colIndex])
+		self.Parent.columnFilterCtrl.SetSelection(colIndex * 2)
 
 	def _doRefresh(self):
 		with guiHelper.autoThaw(self):

--- a/source/gui/addonStoreGui/controls/addonList.py
+++ b/source/gui/addonStoreGui/controls/addonList.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2022-2023 NV Access Limited, Leonard de Ruijter
+# Copyright (C) 2022-2025 NV Access Limited, Leonard de Ruijter, Cyrille Bougot
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -148,10 +148,17 @@ class AddonVirtualList(
 		return str(dataItem)
 
 	def OnColClick(self, evt: wx.ListEvent):
-		colIndex = evt.GetColumn()
-		log.debug(f"col clicked: {colIndex}")
-		self._addonsListVM.setSortField(self._addonsListVM.presentedFields[colIndex])
-		self.Parent.columnFilterCtrl.SetSelection(colIndex * 2)
+		newColIndex = evt.GetColumn()
+		log.debug(f"col clicked: {newColIndex}")
+		sel = self.Parent.columnFilterCtrl.GetSelection()
+		curColIndex = sel // 2
+		curReverse = sel % 2
+		if newColIndex == curColIndex:
+			newReverse = 0 if curReverse else 1
+		else:
+			newReverse = 0
+		self._addonsListVM.setSortField(self._addonsListVM.presentedFields[newColIndex], newReverse)
+		self.Parent.columnFilterCtrl.SetSelection(newColIndex * 2 + newReverse)
 
 	def _doRefresh(self):
 		with guiHelper.autoThaw(self):


### PR DESCRIPTION

### Link to issue number:
Closes #18540

### Summary of the issue:
When clicking an add-on's list header in the add-on store, the list is sorted, but the combo-box sorting indication is not updated accordingly.
### Description of user facing changes:
Sorting order combo-box will be sorted accordingly.
### Description of developer facing changes:
None
### Description of development approach:
Set the value of the combo-box when a header is clicked.

### Testing strategy:
* Sort clicking on header
* Sort selecting in the combo-box

In both cases check sorting order and consistency with the combo-box value.
### Known issues with pull request:
None
### Code Review Checklist:



- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
