### PR TITLE
Disable auto merge for snapshot deployments

### DIFF
--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -439,7 +439,7 @@ jobs:
           -f "task=release" \
           -f "description=Release of $NVDA_EXE_NAME" \
           -f "ref=${{ github.ref_name }}" \
-          -F "auto_merge=true" \
+          -F "auto_merge=false" \
           -f "environment=snapshot" \
           -f "required_contexts[]" \
           -f "payload[NVDA_HASH]=$NVDA_HASH" \


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Fixup of #18244 

### Summary of the issue:
Beta/rc snapshots will fail to deploy if there are merge conflicts between master and the snapshot commit.
This will cause releases to be blocked, as we expect a passing beta/rc snapshot to perform the tagged release.
Beta/rc don't need to have merge conflicts resolved to be a valid build, though regular merging to minimize these is ideal.

### Description of user facing changes:
None
