### PR TITLE
Add an "Install date" column in the Add-on Store

### DIFF
--- a/source/addonStore/models/addon.py
+++ b/source/addonStore/models/addon.py
@@ -191,12 +191,6 @@ class _AddonStoreModel(_AddonGUIModel):
 		# Convert `self.submissionTime` to seconds.
 		return datetime.strftime(datetime.fromtimestamp(self.submissionTime // 1000), "%x")
 
-	@property
-	def displayableInstallDate(self) -> str | None:
-		if self.installDate is None:
-			return None
-		return self.installDate.strftime("%x")
-
 
 class _AddonManifestModel(_AddonGUIModel):
 	"""Get data from an add-on's manifest.

--- a/source/addonStore/models/addon.py
+++ b/source/addonStore/models/addon.py
@@ -191,6 +191,12 @@ class _AddonStoreModel(_AddonGUIModel):
 		# Convert `self.submissionTime` to seconds.
 		return datetime.strftime(datetime.fromtimestamp(self.submissionTime // 1000), "%x")
 
+	@property
+	def displayableInstallDate(self) -> str | None:
+		if self.installDate is None:
+			return None
+		return self.installDate.strftime("%x")
+
 
 class _AddonManifestModel(_AddonGUIModel):
 	"""Get data from an add-on's manifest.

--- a/source/gui/addonStoreGui/controls/details.py
+++ b/source/gui/addonStoreGui/controls/details.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2022-2024 NV Access Limited, Cyrille Bougot
+# Copyright (C) 2022-2025 NV Access Limited, Cyrille Bougot
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -344,14 +344,15 @@ class AddonDetails(
 							details.reviewURL,
 						)
 
-					if isinstance(details, _AddonManifestModel):
-						# Installed add-ons with a manifest only
-						self._appendDetailsLabelValue(
-							# Translators: Label for an extra detail field for the selected add-on in the add-on store dialog.
-							pgettext("addonStore", "Install date:"),
-							details.installDate.strftime("%x"),
-						)
+				if isinstance(details, _AddonManifestModel):
+					# Installed add-ons with a manifest only
+					self._appendDetailsLabelValue(
+						# Translators: Label for an extra detail field for the selected add-on in the add-on store dialog.
+						pgettext("addonStore", "Install date:"),
+						details.installDate.strftime("%x"),
+					)
 
+				if isinstance(details, _AddonStoreModel):
 					if details.publicationDate is not None:
 						self._appendDetailsLabelValue(
 							# Translators: Label for an extra detail field for the selected add-on. In the add-on store dialog.

--- a/source/gui/addonStoreGui/viewModels/addonList.py
+++ b/source/gui/addonStoreGui/viewModels/addonList.py
@@ -96,7 +96,7 @@ class AddonListField(_AddonListFieldData, Enum):
 		pgettext("addonStore", "Publication date"),
 		50,
 	)
-	displayableInstallDate = (
+	installDate = (
 		# Translators: The name of the column that contains the installation date of the add-on.
 		pgettext("addonStore", "Install date"),
 		50,
@@ -315,7 +315,7 @@ class AddonListVM:
 			return listItemVM.status.displayString
 		if field is AddonListField.channel:
 			return listItemVM.model.channel.displayString
-		if field is AddonListField.displayableInstallDate:
+		if field is AddonListField.installDate:
 			return listItemVM.model.installDate.strftime("%x")
 		if field is AddonListField.minimumNVDAVersion:
 			return formatVersionForGUI(*listItemVM.model.minimumNVDAVersion)
@@ -411,7 +411,7 @@ class AddonListVM:
 				if getattr(listItemVM.model, "submissionTime", None):
 					return listItemVM.model.submissionTime
 				return 0
-			if self._sortByModelField == AddonListField.displayableInstallDate:
+			if self._sortByModelField == AddonListField.installDate:
 				return listItemVM.model.installDate
 			return strxfrm(self._getAddonFieldText(listItemVM, self._sortByModelField))
 

--- a/source/gui/addonStoreGui/viewModels/addonList.py
+++ b/source/gui/addonStoreGui/viewModels/addonList.py
@@ -6,7 +6,6 @@
 from dataclasses import dataclass
 from enum import Enum
 
-from datetime import datetime, MINYEAR
 from locale import strxfrm
 from typing import (
 	FrozenSet,
@@ -316,6 +315,8 @@ class AddonListVM:
 			return listItemVM.status.displayString
 		if field is AddonListField.channel:
 			return listItemVM.model.channel.displayString
+		if field is AddonListField.displayableInstallDate:
+			return listItemVM.model.installDate.strftime("%x")
 		if field is AddonListField.minimumNVDAVersion:
 			return formatVersionForGUI(*listItemVM.model.minimumNVDAVersion)
 		if field is AddonListField.lastTestedVersion:
@@ -411,13 +412,7 @@ class AddonListVM:
 					return listItemVM.model.submissionTime
 				return 0
 			if self._sortByModelField == AddonListField.displayableInstallDate:
-				log.info(f'{getattr(listItemVM.model, "installDate", None)} - {listItemVM.model.name}')
-				if getattr(listItemVM.model, "installDate", None):
-					return listItemVM.model.installDate
-				else:
-					import globalVars as gv
-					gv.dbg = listItemVM.model
-				return datetime(MINYEAR, 1, 1)
+				return listItemVM.model.installDate
 			return strxfrm(self._getAddonFieldText(listItemVM, self._sortByModelField))
 
 		def _containsTerm(detailsVM: AddonListItemVM, term: str) -> bool:

--- a/source/gui/addonStoreGui/viewModels/addonList.py
+++ b/source/gui/addonStoreGui/viewModels/addonList.py
@@ -1,11 +1,12 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2022-2023 NV Access Limited, Cyrille Bougot
+# Copyright (C) 2022-2025 NV Access Limited, Cyrille Bougot
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
 from dataclasses import dataclass
 from enum import Enum
 
+from datetime import datetime, MINYEAR
 from locale import strxfrm
 from typing import (
 	FrozenSet,
@@ -93,8 +94,14 @@ class AddonListField(_AddonListFieldData, Enum):
 	)
 	publicationDate = (
 		# Translators: The name of the column that contains the publication date of the add-on.
-		pgettext("addonStore", "Publication Date"),
+		pgettext("addonStore", "Publication date"),
 		50,
+	)
+	displayableInstallDate = (
+		# Translators: The name of the column that contains the installation date of the add-on.
+		pgettext("addonStore", "Install date"),
+		50,
+		frozenset({_StatusFilterKey.AVAILABLE}),
 	)
 	minimumNVDAVersion = (
 		# Translators: The name of the column that contains the minimum version of NVDA required for this add-on.
@@ -403,6 +410,14 @@ class AddonListVM:
 				if getattr(listItemVM.model, "submissionTime", None):
 					return listItemVM.model.submissionTime
 				return 0
+			if self._sortByModelField == AddonListField.displayableInstallDate:
+				log.info(f'{getattr(listItemVM.model, "installDate", None)} - {listItemVM.model.name}')
+				if getattr(listItemVM.model, "installDate", None):
+					return listItemVM.model.installDate
+				else:
+					import globalVars as gv
+					gv.dbg = listItemVM.model
+				return datetime(MINYEAR, 1, 1)
 			return strxfrm(self._getAddonFieldText(listItemVM, self._sortByModelField))
 
 		def _containsTerm(detailsVM: AddonListItemVM, term: str) -> bool:

--- a/source/gui/addonStoreGui/viewModels/addonList.py
+++ b/source/gui/addonStoreGui/viewModels/addonList.py
@@ -100,7 +100,7 @@ class AddonListField(_AddonListFieldData, Enum):
 		# Translators: The name of the column that contains the installation date of the add-on.
 		pgettext("addonStore", "Install date"),
 		50,
-		frozenset({_StatusFilterKey.AVAILABLE}),
+		frozenset({_StatusFilterKey.AVAILABLE, _StatusFilterKey.UPDATE}),
 	)
 	minimumNVDAVersion = (
 		# Translators: The name of the column that contains the minimum version of NVDA required for this add-on.

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -7,7 +7,7 @@
 ### New Features
 
 * Add-on Store:
-  * Add-ons can be sorted by minimum and last tested NVDA version as welle as by installation date. (#18440, #18560, @nvdaes, @CyrilleB79)
+  * Add-ons can be sorted by minimum and last tested NVDA version as well as by installation date. (#18440, #18560, @nvdaes, @CyrilleB79)
   * Minimum and last tested version will now be also shown in the details area for an add-on in the Available Add-ons tab. (#18440, @nvdaes)
   * Installation date will now be also shown in the details area for external add-ons. (#18560, @CyrilleB79)
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -6,8 +6,10 @@
 
 ### New Features
 
-* In the Add-on Store, add-ons can be sorted by minimum and last tested NVDA version.
-Additionally, minimum and last tested version will now be also shown in the details area for an add-on in the Available Add-ons tab. (#18440, @nvdaes)
+* Add-on Store:
+  * Add-ons can be sorted by minimum and last tested NVDA version as welle as by installation date. (#18440, #18560, @nvdaes, @CyrilleB79)
+  * Minimum and last tested version will now be also shown in the details area for an add-on in the Available Add-ons tab. (#18440, @nvdaes)
+  * Installation date will now be also shown in the details area for external add-ons. (#18560, @CyrilleB79)
 
 ### Changes
 


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
In the Add-on Store, the install date of an add-on is available in the Details pane, and only for add-ons installed from the Store.
Having the install date displayed in a column of the list would allow to view them all at once and to sort the add-on by install date. This can be very useful to track a bug recently appeared.

### Description of user facing changes:
* The Add-on Store has now a column "Install date", except in Available add-ons tab where it does not make sense.

### Description of developer facing changes:
N/A
### Description of development approach:
See code
### Testing strategy:
Manual testing with:
* both external and Add-on Store add-ons.
* column sorting

### Known issues with pull request:
None
### Code Review Checklist:


- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
