### PR TITLE
Make comtypes generated files IDE-friendly

### DIFF
--- a/source/comInterfaces_sconscript
+++ b/source/comInterfaces_sconscript
@@ -11,7 +11,7 @@
 # This license can be found at:
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 ###
-from typing import List
+from typing import Callable, List
 import re
 from SCons.Node.FS import File
 
@@ -35,31 +35,76 @@ def new_my_import(fullname):
 comtypes.client._generate._my_import = new_my_import
 
 
+def codeReplacer(
+	template: str, indentedGroups: tuple[int | str] | None = None
+) -> Callable[[re.Match[str]], str]:
+	"""
+	Return a function for the `repl` parameter of `re.sub()`,
+	in order to do some preprocessing before actual replacement.
+
+	:param template: Template strings for replacement.
+		Placeholders are in `str.format`'s style, such as `{1}` or `{name}`.
+	:param indentedGroups: All groups that needs to have one more level of indentation.
+		Specify indices for unnamed groups, or names for named groups.
+	"""
+
+	def repl(match: re.Match[str]) -> str:
+		groups = list(match.groups(""))
+		groupdict = match.groupdict("")
+		if indentedGroups:
+			for grp in indentedGroups:
+				if isinstance(grp, int) and 0 <= grp < len(groups):
+					collection = groups
+				else:
+					collection = groupdict
+				# Add one level of indentation before each line
+				lines = collection[grp].splitlines()
+				for i in range(len(lines)):
+					if lines[i]:  # Add indentation for non-empty lines
+						lines[i] = "    " + lines[i]
+				collection[grp] = "\n".join(lines)
+		return template.format(*groups, **groupdict)
+
+	return repl
+
+
 def makeIDEFriendly(path: str) -> None:
 	"""
-	Add a local import of * so that tools and IDE's can find definitions.
+	Add local imports so that tools and IDE's can find definitions.
 	Prefer to import from comtypes.gen, at runtime behavior will not have changed.
-	@param path: Path to the friendly name comInterfaces module.
-	"""
-	importTemplate = """try:
-	from comtypes.gen import {libIdentifier}
-except ModuleNotFoundError:
-	import {libIdentifier}
-	from {libIdentifier} import *
-"""
 
-	importPattern = re.compile(r"from comtypes\.gen import ([\w]+)\n")
-	IDEFriendlyContent = list()
+	:param path: Path to the friendly name comInterfaces module.
+	"""
+	importTemplate = """from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+	from .{libId} import (
+{importList}
+	)
+else:
+	from comtypes.gen.{libId} import (
+{importList}
+	)
+"""
+	# Matches:
+	# from comtypes.gen._SomeLibId_ import (
+	#     aaa, bbb, ccc,
+	#     xxx, yyy, zzz,   # these lines should be indented
+	# )
+	importPattern = re.compile(
+		r"^from comtypes\.gen\.(?P<libId>\w+) import \(\n"
+		r"(?P<importList>(?:    [\w, ]+\n)+)"
+		r"\)\n",
+		re.MULTILINE,
+	)
+
 	with open(path, "r") as interfaceFile:
-		for line in interfaceFile:
-			match = importPattern.match(line)
-			if match:
-				libId = match.group(1)
-				IDEFriendlyContent.append(importTemplate.format(libIdentifier=libId))
-			else:
-				IDEFriendlyContent.append(line)
+		fileContent = interfaceFile.read()
+		fileContent = importPattern.sub(
+			codeReplacer(importTemplate, indentedGroups=("importList",)), fileContent
+		)
+
 	with open(path, "w") as interfaceFile:
-		interfaceFile.writelines(IDEFriendlyContent)
+		interfaceFile.write(fileContent)
 
 
 def interfaceAction(target: List[File], source, env):

--- a/source/comInterfaces_sconscript
+++ b/source/comInterfaces_sconscript
@@ -36,7 +36,8 @@ comtypes.client._generate._my_import = new_my_import
 
 
 def codeReplacer(
-	template: str, indentedGroups: tuple[int | str] | None = None
+	template: str,
+	indentedGroups: tuple[int | str] | None = None,
 ) -> Callable[[re.Match[str]], str]:
 	"""
 	Return a function for the `repl` parameter of `re.sub()`,

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -32,6 +32,7 @@ Please refer to [the developer guide](https://download.nvaccess.org/documentatio
 * Updated `include` dependencies:
   * detours to `9764cebcb1a75940e68fa83d6730ffaf0f669401`. (#18447, @LeonarddeR)
 * The `nvda_dmp` utility has been removed. (#18480, @codeofdusk)
+* `comInterfaces_sconscript` has been updated to make the generated files in `comInterfaces` work better with IDEs. (#17608, @gexgd0419)
 
 #### Deprecations
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
<!-- Use Closes/Fixes/Resolves #xxx to link this PR to the issue it is responding to. -->
Fixes #17608

### Summary of the issue:

Since newer versions of `comtypes` changed the generated `comtypes.gen` module code, the function `makeIDEFriendly` in `comInterfaces_sconscript` no longer patches the generated files.

Some background: NVDA uses its own custom folder, `comInterfaces`, for the modules generated by `comtypes`, which would by default be put under `comtypes.gen`. Although special care is taken to make sure `comtypes.gen.SomeLibrary` can still reference the module in `comInterfaces`, IDEs such as VS Code is not smart enough to figure that out, and continue to find those modules in `comtypes.gen`, where those modules don't exist because they have been moved to `comInterfaces`.

`makeIDEFriendly` was created to address this issue by replacing the following lines in the generated code:

``` python
from comtypes.gen import SomeLib
```

with something like this:

``` python
try:
    from comtypes.gen import SomeLib  # works fine at runtime
except ModuleNotFoundError:
    import SomeLib  # fallback for static analyzers, import directly from `comInterfaces`
    from SomeLib import *
```

but it stops working now, because comtypes now generates the following code:

``` python
import comtypes.gen._SomeLibId_ as __wrapper_module__
from comtypes.gen._SomeLibId_ import (
    # a long list of all individual imported items
)
```

### Description of user facing changes:
None

### Description of developer facing changes:
IDEs such as VS Code will be able to locate COM module imports again.

### Description of development approach:

Change `makeIDEFriendly`, so now it replaces the following:

``` python
from comtypes.gen._SomeLibId_ import (
    # a long list of all individual imported items
)
```

with the following:

``` python
from typing import TYPE_CHECKING
if TYPE_CHECKING:
    from ._SomeLibId_ import (
        # a long list of all individual imported items
    )
else:
    from comtypes.gen._SomeLibId_ import (
        # a long list of all individual imported items
    )
```

### Testing strategy:

Regenerated the COM modules using `./scons source`.

### Known issues with pull request:

The fix might break again with a future comtypes version.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [ ] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
