### PR TITLE
Fix Remote Access speech when follower has no connected audio render endpoints

### DIFF
--- a/source/_remoteClient/cues.py
+++ b/source/_remoteClient/cues.py
@@ -9,6 +9,7 @@ from typing import TypedDict
 import globalVars
 import nvwave
 import ui
+from logHandler import log
 
 
 class Cue(TypedDict, total=False):
@@ -54,7 +55,13 @@ def _playCue(cueName: str) -> None:
 	"""Helper function to play a cue by name"""
 	# Play wave file
 	if wave := CUES[cueName].get("wave"):
-		nvwave.playWaveFile(os.path.join(globalVars.appDir, "waves", wave + ".wav"))
+		filePath = os.path.join(globalVars.appDir, "waves", wave + ".wav")
+		try:
+			nvwave.playWaveFile(filePath)
+		except Exception:
+			# We mustn't log at error level, as this may play a sound
+			# and playing a sound is what caused this exception.
+			log.debugWarning(f"Failed to play cue {filePath!r}.", exc_info=True)
 
 	# Show message if specified
 	if message := CUES[cueName].get("message"):

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -20,6 +20,7 @@ Additionally, minimum and last tested version will now be also shown in the deta
 
 * Fixed bug with multiple math expressions on the same line in Microsoft Word documents: everything after the first expression was not spoken or brailled. (#18386, @NSoiffer)
 * Fixed support for paragraph mouse text unit in Java applications. (#18231, @hwf1324)
+* Fixed a bug which stopped speech from working via NVDA Remote Access when the controlled computer had no audio output devices enabled. (#18544)
 
 ### Changes for Developers
 


### PR DESCRIPTION
### Link to issue number:
Fixes #18544

### Summary of the issue:
When using NVDA Remote Access, if the controlled computer has no audio output devices enabled, speech is not sent to the controlling computer.

### Description of user facing changes:
Speech is now sent, even if the controlled computer has no audio output devices enabled.

### Description of developer facing changes:
None

### Description of development approach:
The issue was caused by `nvwave.playWaveFile` raising an exception if no render endpoints were available.
To mitigate this, `_remoteClient.cues._playCue` now handles exceptions raised by `playWaveFile`.

### Testing strategy:
Configured the source copy of NVDA to connect as follower automatically on startup. Disabled all audio output devices and launched NVDA from source. Connected on a second device as leader and checked that speech was received.

### Known issues with pull request:
The underlying problem has not been resolved. As this involves a change in API behaviour, I will implement it in a separate PR.

### Code Review Checklist:
- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
