### PR TITLE
Handle playing waves with no enabled audio render endpoints connected"

### DIFF
--- a/source/nvwave.py
+++ b/source/nvwave.py
@@ -92,10 +92,11 @@ def playWaveFile(
 	isSpeechWaveFileCommand: bool = False,
 ):
 	"""plays a specified wave file.
-	@param fileName: the path to the wave file, usually absolute.
-	@param asynchronous: whether the wave file should be played asynchronously
-		If C{False}, the calling thread is blocked until the wave has finished playing.
-	@param isSpeechWaveFileCommand: whether this wave is played as part of a speech sequence.
+
+	:param fileName: the path to the wave file, usually absolute.
+	:param asynchronous: whether the wave file should be played asynchronously
+		If ``False``, the calling thread is blocked until the wave has finished playing.
+	:param isSpeechWaveFileCommand: whether this wave is played as part of a speech sequence.
 	"""
 	global fileWavePlayer, fileWavePlayerThread
 	f = wave.open(fileName, "r")

--- a/source/nvwave.py
+++ b/source/nvwave.py
@@ -156,7 +156,7 @@ def playWaveFile(
 			log.debugWarning("Unable to play wave file as the render endpoint was not found.", exc_info=True)
 			return
 		# In other cases, we should still raise.
-		raise exception
+		raise
 	if asynchronous:
 		fileWavePlayerThread = threading.Thread(
 			name=f"{__name__}.playWaveFile({os.path.basename(fileName)})",


### PR DESCRIPTION
### Link to issue number:
Related to #18544

### Summary of the issue:
If `nvwave.playWaveFile` is called on a system with no enabled audio render endpoints, an `OSError` is raised.

### Description of user facing changes:
None

### Description of developer facing changes:
The error is now logged at level debugwarning, and `playWaveFile` returns immediately.
All other exceptions (including other cases of `OSError`), are still raised.

### Description of development approach:
Wrap instantiation of `WavePlayer` in a try/except block. Except `OSError`, and check that the exception's `winerror` is `ERROR_NOT_FOUND`. In this case, log and return. In other cases of `OSError`, re-raise the exception.

### Testing strategy:
Disabled all render endpoints. Ran NVDA from source, and connected in via NVDA Remote Access. Used `nvwave.playWaveFile`, and checked the log to ensure the error was logged.

### Known issues with pull request:
None

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
