### PR TITLE
Re-enable start from desktop shortcut test

### DIFF
--- a/tests/system/libraries/SystemTestSpy/windows.py
+++ b/tests/system/libraries/SystemTestSpy/windows.py
@@ -1,10 +1,11 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2021-2022 NV Access Limited, Łukasz Golonka
+# Copyright (C) 2021-2025 NV Access Limited, Łukasz Golonka
 # This file may be used under the terms of the GNU General Public License, version 2 or later.
 # For more details see: https://www.gnu.org/licenses/gpl-2.0.html
 
 """This module provides functions to interact with the Windows system."""
 
+from collections.abc import Callable
 from ctypes.wintypes import LPARAM
 from ctypes import (
 	c_bool,
@@ -16,10 +17,7 @@ from ctypes import (
 	WinError,
 )
 from typing import (
-	Callable,
-	List,
 	NamedTuple,
-	Optional,
 )
 import re
 from SystemTestSpy.blockUntilConditionMet import _blockUntilConditionMet
@@ -49,8 +47,8 @@ def _GetWindowTitle(hwnd: HWNDVal) -> str:
 
 def _GetWindows(
 	filterUsingWindow: Callable[[Window], bool] = lambda _: True,
-) -> List[Window]:
-	windows: List[Window] = []
+) -> list[Window]:
+	windows: list[Window] = []
 
 	# BOOL CALLBACK EnumWindowsProc _In_ HWND,_In_ LPARAM
 	# HWND as a pointer creates confusion, treat as an int
@@ -69,7 +67,7 @@ def _GetWindows(
 	return windows
 
 
-def _GetVisibleWindows() -> List[Window]:
+def _GetVisibleWindows() -> list[Window]:
 	return _GetWindows(
 		filterUsingWindow=lambda window: windll.user32.IsWindowVisible(window.hwndVal) and bool(window.title),
 	)
@@ -110,7 +108,7 @@ def SetForegroundWindow(window: Window, logger: Logger) -> bool:
 	return windll.user32.SetForegroundWindow(window.hwndVal)
 
 
-def GetWindowWithTitle(targetTitle: re.Pattern, logger: Logger) -> Optional[Window]:
+def GetWindowWithTitle(targetTitle: re.Pattern, logger: Logger) -> Window | None:
 	windows = _GetWindows(
 		filterUsingWindow=lambda _window: bool(re.match(targetTitle, _window.title)),
 	)
@@ -125,7 +123,7 @@ def GetWindowWithTitle(targetTitle: re.Pattern, logger: Logger) -> Optional[Wind
 		return None
 
 
-def GetVisibleWindowTitles() -> List[str]:
+def GetVisibleWindowTitles() -> list[str]:
 	windows = _GetVisibleWindows()
 	return [w.title for w in windows]
 
@@ -153,3 +151,15 @@ def getWindowHandle(windowClassName: str, windowName: str) -> HWNDVal:
 
 def windowWithHandleExists(handle: HWNDVal) -> bool:
 	return bool(windll.user32.IsWindow(handle))
+
+
+def sendKeyboardEvent(
+		vk: int,
+		scanCode: int,
+		flags: int,
+		extraInfo: int,
+	):
+	"""Wrapper for ctypes.windll.user32.keybd_event to simulate keyboard events."""
+	return windll.user32.keybd_event(
+		vk, scanCode, flags, extraInfo
+	)

--- a/tests/system/libraries/SystemTestSpy/windows.py
+++ b/tests/system/libraries/SystemTestSpy/windows.py
@@ -154,12 +154,15 @@ def windowWithHandleExists(handle: HWNDVal) -> bool:
 
 
 def sendKeyboardEvent(
-		vk: int,
-		scanCode: int,
-		flags: int,
-		extraInfo: int,
-	):
+	vk: int,
+	scanCode: int,
+	flags: int,
+	extraInfo: int,
+):
 	"""Wrapper for ctypes.windll.user32.keybd_event to simulate keyboard events."""
 	return windll.user32.keybd_event(
-		vk, scanCode, flags, extraInfo
+		vk,
+		scanCode,
+		flags,
+		extraInfo,
 	)

--- a/tests/system/robot/startupShutdownNVDA.py
+++ b/tests/system/robot/startupShutdownNVDA.py
@@ -129,8 +129,8 @@ def quits_from_keyboard():
 
 
 def test_desktop_shortcut():
-	VK_CONTROL = 17
 	# Press Control+Alt+N using keybd_event
+	VK_CONTROL = 17
 	VK_MENU = 18  # Alt key
 	VK_N = 78  # 'N' key
 	KEYEVENTF_KEYDOWN = 0

--- a/tests/system/robot/startupShutdownNVDA.py
+++ b/tests/system/robot/startupShutdownNVDA.py
@@ -15,7 +15,12 @@ from SystemTestSpy import (
 	_getLib,
 	_blockUntilConditionMet,
 )
-from SystemTestSpy.windows import getWindowHandle, sendKeyboardEvent, waitUntilWindowFocused, windowWithHandleExists
+from SystemTestSpy.windows import (
+	getWindowHandle,
+	sendKeyboardEvent,
+	waitUntilWindowFocused,
+	windowWithHandleExists,
+)
 
 # Imported for type information
 from robot.libraries.OperatingSystem import OperatingSystem as _OpSysLib
@@ -127,7 +132,7 @@ def test_desktop_shortcut():
 	VK_CONTROL = 17
 	# Press Control+Alt+N using keybd_event
 	VK_MENU = 18  # Alt key
-	VK_N = 78     # 'N' key
+	VK_N = 78  # 'N' key
 	KEYEVENTF_KEYDOWN = 0
 	KEYEVENTF_KEYUP = 2
 

--- a/tests/system/robot/startupShutdownNVDA.py
+++ b/tests/system/robot/startupShutdownNVDA.py
@@ -1,12 +1,12 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2020-2022 NV Access Limited, Łukasz Golonka
+# Copyright (C) 2020-2025 NV Access Limited, Łukasz Golonka
 # This file may be used under the terms of the GNU General Public License, version 2 or later.
 # For more details see: https://www.gnu.org/licenses/gpl-2.0.html
 
 """Logic for startupShutdownNVDA tests."""
 
 from datetime import datetime as _datetime
-from typing import Callable as _Callable
+from collections.abc import Callable as _Callable
 from robot.libraries.BuiltIn import BuiltIn
 
 # relative import not used for 'systemTestUtils' because the folder is added to the path for 'libraries'
@@ -15,7 +15,7 @@ from SystemTestSpy import (
 	_getLib,
 	_blockUntilConditionMet,
 )
-from SystemTestSpy.windows import getWindowHandle, waitUntilWindowFocused, windowWithHandleExists
+from SystemTestSpy.windows import getWindowHandle, sendKeyboardEvent, waitUntilWindowFocused, windowWithHandleExists
 
 # Imported for type information
 from robot.libraries.OperatingSystem import OperatingSystem as _OpSysLib
@@ -124,8 +124,26 @@ def quits_from_keyboard():
 
 
 def test_desktop_shortcut():
-	spy = _nvdaLib.getSpyLib()
-	spy.emulateKeyPress("control+alt+n")
+	VK_CONTROL = 17
+	# Press Control+Alt+N using keybd_event
+	VK_MENU = 18  # Alt key
+	VK_N = 78     # 'N' key
+	KEYEVENTF_KEYDOWN = 0
+	KEYEVENTF_KEYUP = 2
+
+	# Press Control down
+	sendKeyboardEvent(VK_CONTROL, 0, KEYEVENTF_KEYDOWN, 0)
+	# Press Alt down
+	sendKeyboardEvent(VK_MENU, 0, KEYEVENTF_KEYDOWN, 0)
+	# Press N down
+	sendKeyboardEvent(VK_N, 0, KEYEVENTF_KEYDOWN, 0)
+	# Release N
+	sendKeyboardEvent(VK_N, 0, KEYEVENTF_KEYUP, 0)
+	# Release Alt
+	sendKeyboardEvent(VK_MENU, 0, KEYEVENTF_KEYUP, 0)
+	# Release Control
+	sendKeyboardEvent(VK_CONTROL, 0, KEYEVENTF_KEYUP, 0)
+
 	# Takes some time to exit a running process and start a new one
 	waitUntilWindowFocused("Welcome to NVDA", timeoutSecs=7)
 

--- a/tests/system/robot/startupShutdownNVDA.robot
+++ b/tests/system/robot/startupShutdownNVDA.robot
@@ -27,8 +27,6 @@ Starts
 	NVDA_Starts	# run test
 
 Starts from desktop shortcut
-	# Excluded until test can be fixed. Tracked in issue: (#14293)
-	[Tags]	excluded_from_build
 	[Documentation]	Ensure that NVDA can start from desktop shortcut
 	[Setup]	start NVDA	standard-dontShowWelcomeDialog.ini
 	Pass Execution If	"${whichNVDA}"!="installed"	Desktop shortcut only exists on installed copies


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Closes #14293

### Summary of the issue:
The system test 'Starts from desktop shortcut' as part of the 'Basic start and exit tests' defined in startupShutdownNVDA.robot relied on NVDA to be running to send the keyboard shortcut which is intended to start NVDA.
As such it was flakey and disabled.

### Description of user facing changes:
none
### Description of developer facing changes:
none
### Description of development approach:
call keyevents directly rather than through NVDA
### Testing strategy:

### Known issues with pull request:

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
