### PR TITLE
Remove handling for multiple aria-invalid attributes

### DIFF
--- a/source/NVDAObjects/IAccessible/__init__.py
+++ b/source/NVDAObjects/IAccessible/__init__.py
@@ -176,16 +176,18 @@ def normalizeIA2TextFormatField(formatField):
 	else:
 		formatField["italic"] = False
 	try:
-		invalid = formatField.pop("invalid")
+		invalid: str | None = formatField.pop("invalid")
 	except KeyError:
 		invalid = None
-	if invalid:
-		# aria-invalid can contain multiple values separated by a comma.
-		invalidList = [x.lower().strip() for x in invalid.split(",")]
-		if "spelling" in invalidList:
+	else:
+		invalid = invalid.lower().strip()
+	match invalid:
+		case "spelling":
 			formatField["invalid-spelling"] = True
-		if "grammar" in invalidList:
+		case "grammar":
 			formatField["invalid-grammar"] = True
+		case _:
+			pass
 	color = formatField.get("color")
 	if color:
 		try:

--- a/tests/system/robot/chromeTests.py
+++ b/tests/system/robot/chromeTests.py
@@ -1008,7 +1008,7 @@ def test_ariaTreeGrid_browseMode():
 
 def ARIAInvalid_spellingAndGrammar():
 	"""
-	Tests ARIA invalid values of "spelling", "grammar" and "spelling, grammar".
+	Tests ARIA invalid values of "spelling" and "grammar".
 	"""
 	_chrome.prepareChrome(
 		r"""

--- a/tests/system/robot/chromeTests.py
+++ b/tests/system/robot/chromeTests.py
@@ -1009,17 +1009,11 @@ def test_ariaTreeGrid_browseMode():
 def ARIAInvalid_spellingAndGrammar():
 	"""
 		Tests ARIA invalid values of "spelling", "grammar" and "spelling, grammar".
-		Please note that although IAccessible2 allows multiple values for invalid,
-		multiple values to aria-invalid is not yet standard.
-		And even if it were, they would be separated by space, not comma
-	thus the html for this test would need to change,
-		but the expected output shouldn't need to.
 	"""
 	_chrome.prepareChrome(
 		r"""
 			<p>Big <span aria-invalid="spelling">caat</span> meos</p>
 			<p>Small <span aria-invalid="grammar">a dog</span> woofs</p>
-			<p>Fat <span aria-invalid="grammar, spelling">a ffrog</span> crokes</p>
 		""",
 	)
 	actualSpeech = _chrome.getSpeechAfterKey("downArrow")
@@ -1031,11 +1025,6 @@ def ARIAInvalid_spellingAndGrammar():
 	_asserts.strings_match(
 		actualSpeech,
 		"Small  grammar error  a dog  woofs",
-	)
-	actualSpeech = _chrome.getSpeechAfterKey("downArrow")
-	_asserts.strings_match(
-		actualSpeech,
-		"Fat  spelling error  grammar error  a ffrog  crokes",
 	)
 
 

--- a/tests/system/robot/chromeTests.py
+++ b/tests/system/robot/chromeTests.py
@@ -1008,7 +1008,7 @@ def test_ariaTreeGrid_browseMode():
 
 def ARIAInvalid_spellingAndGrammar():
 	"""
-		Tests ARIA invalid values of "spelling", "grammar" and "spelling, grammar".
+	Tests ARIA invalid values of "spelling", "grammar" and "spelling, grammar".
 	"""
 	_chrome.prepareChrome(
 		r"""

--- a/tests/system/robot/chromeTests.robot
+++ b/tests/system/robot/chromeTests.robot
@@ -51,7 +51,6 @@ ARIA treegrid
 	test_ariaTreeGrid_browseMode
 ARIA invalid spelling and grammar
 	[Documentation]	Tests ARIA invalid values of "spelling", "grammar" and "spelling, grammar".
-	[Tags]	excluded_from_build
 	ARIAInvalid_spellingAndGrammar
 ARIA checkbox
 	[Documentation]	Navigate to an unchecked checkbox in reading mode.

--- a/tests/system/robot/chromeTests.robot
+++ b/tests/system/robot/chromeTests.robot
@@ -50,7 +50,7 @@ ARIA treegrid
 	[Documentation]	Ensure that ARIA treegrids are accessible as a standard table in browse mode.
 	test_ariaTreeGrid_browseMode
 ARIA invalid spelling and grammar
-	[Documentation]	Tests ARIA invalid values of "spelling", "grammar" and "spelling, grammar".
+	[Documentation]	Tests ARIA invalid values of "spelling" and "grammar".
 	ARIAInvalid_spellingAndGrammar
 ARIA checkbox
 	[Documentation]	Navigate to an unchecked checkbox in reading mode.


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Fixes #13321

### Summary of the issue:
The `aria-invalid` spec never supported multiple attributes, however browsers temporarily supported them.
This support no longer exists in Chrome or Firefox.

As such tests and handling for multiple aria-invalid attributes should be removed

### Description of user facing changes:
None (as browser support was dropped a long time ago)
### Description of developer facing changes:
None

### Description of development approach:

Remove test case, simplify handling

### Testing strategy:
Tested fetching `aria-invalid` via the virtual buffers for `aria-invalid="grammar spelling"` and `aria-invalid="grammar,spelling"` to confirm no support in firefox or chrome.

```
<p>Fat <span aria-invalid="grammar spelling">a ffrog</span> crokes</p>
<p>Fat <span aria-invalid="grammar, spelling">a ffrog</span> crokes</p>
```

### Known issues with pull request:

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
