### PR TITLE
re-enable chrome image tests

### DIFF
--- a/tests/system/robot/chromeTests.py
+++ b/tests/system/robot/chromeTests.py
@@ -1191,12 +1191,12 @@ def test_ariaRoleDescription_inline_browseMode():
 	actualSpeech = _chrome.getSpeechAfterKey("control+rightArrow")
 	_asserts.strings_match(
 		actualSpeech,
-		"drawing  Our",
+		"Unlabeled graphic  Our",
 	)
 	actualSpeech = _chrome.getSpeechAfterKey("control+rightArrow")
 	_asserts.strings_match(
 		actualSpeech,
-		"logo  out of drawing",
+		"logo  out of graphic",
 	)
 	actualSpeech = _chrome.getSpeechAfterKey("control+rightArrow")
 	_asserts.strings_match(
@@ -1275,7 +1275,7 @@ def test_ariaRoleDescription_inline_contentEditable():
 	actualSpeech = _chrome.getSpeechAfterKey("control+rightArrow")
 	_asserts.strings_match(
 		actualSpeech,
-		"drawing  Our logo    out of drawing",
+		"Unlabeled graphic  Our logo    out of graphic",
 	)
 	actualSpeech = _chrome.getSpeechAfterKey("control+rightArrow")
 	_asserts.strings_match(

--- a/tests/system/robot/chromeTests.py
+++ b/tests/system/robot/chromeTests.py
@@ -1164,6 +1164,8 @@ def test_ariaRoleDescription_focus():
 		"Meat  pizza",
 	)
 
+IMG_DESC_MSG = "To get missing image descriptions, open the context menu."
+
 
 def test_ariaRoleDescription_inline_browseMode():
 	"""
@@ -1182,7 +1184,7 @@ def test_ariaRoleDescription_inline_browseMode():
 	actualSpeech = _chrome.getSpeechAfterKey("downArrow")
 	_asserts.strings_match(
 		actualSpeech,
-		"Start  Unlabeled graphic  Our logo. To get missing image descriptions, open the context menu.  End",
+		f"Start  Unlabeled graphic  Our logo. {IMG_DESC_MSG}    End",
 	)
 	# When reading the line by word,
 	# Both entering and exiting the custom role should be reported.
@@ -1266,7 +1268,7 @@ def test_ariaRoleDescription_inline_contentEditable():
 	actualSpeech = _chrome.getSpeechAfterKey("downArrow")
 	_asserts.strings_match(
 		actualSpeech,
-		"Start  Unlabeled graphic  Our logo. To get missing image descriptions, open the context menu.  End",
+		f"Start  Unlabeled graphic  Our logo. {IMG_DESC_MSG}    End",
 	)
 	# When reading the line by word,
 	# Both entering and exiting the custom role should be reported.

--- a/tests/system/robot/chromeTests.py
+++ b/tests/system/robot/chromeTests.py
@@ -1164,6 +1164,7 @@ def test_ariaRoleDescription_focus():
 		"Meat  pizza",
 	)
 
+
 IMG_DESC_MSG = "To get missing image descriptions, open the context menu."
 
 

--- a/tests/system/robot/chromeTests.py
+++ b/tests/system/robot/chromeTests.py
@@ -1182,7 +1182,7 @@ def test_ariaRoleDescription_inline_browseMode():
 	actualSpeech = _chrome.getSpeechAfterKey("downArrow")
 	_asserts.strings_match(
 		actualSpeech,
-		"Start  drawing  Our logo  End",
+		"Start  Unlabeled graphic  Our logo. To get missing image descriptions, open the context menu.  End",
 	)
 	# When reading the line by word,
 	# Both entering and exiting the custom role should be reported.
@@ -1266,7 +1266,7 @@ def test_ariaRoleDescription_inline_contentEditable():
 	actualSpeech = _chrome.getSpeechAfterKey("downArrow")
 	_asserts.strings_match(
 		actualSpeech,
-		"Start  drawing  Our logo    End",
+		"Start  Unlabeled graphic  Our logo. To get missing image descriptions, open the context menu.  End",
 	)
 	# When reading the line by word,
 	# Both entering and exiting the custom role should be reported.

--- a/tests/system/robot/chromeTests.py
+++ b/tests/system/robot/chromeTests.py
@@ -1197,7 +1197,7 @@ def test_ariaRoleDescription_inline_browseMode():
 	actualSpeech = _chrome.getSpeechAfterKey("control+rightArrow")
 	_asserts.strings_match(
 		actualSpeech,
-		"logo  out of Unlabeled graphic",
+		"logo.",
 	)
 	actualSpeech = _chrome.getSpeechAfterKey("control+rightArrow")
 	_asserts.strings_match(

--- a/tests/system/robot/chromeTests.py
+++ b/tests/system/robot/chromeTests.py
@@ -1199,11 +1199,6 @@ def test_ariaRoleDescription_inline_browseMode():
 		actualSpeech,
 		"logo.",
 	)
-	actualSpeech = _chrome.getSpeechAfterKey("control+rightArrow")
-	_asserts.strings_match(
-		actualSpeech,
-		"End",
-	)
 
 
 def test_ariaRoleDescription_block_browseMode():

--- a/tests/system/robot/chromeTests.py
+++ b/tests/system/robot/chromeTests.py
@@ -1185,7 +1185,7 @@ def test_ariaRoleDescription_inline_browseMode():
 	actualSpeech = _chrome.getSpeechAfterKey("downArrow")
 	_asserts.strings_match(
 		actualSpeech,
-		f"Start  Unlabeled graphic  Our logo. {IMG_DESC_MSG}    End",
+		f"Start  Unlabeled graphic  Our logo. {IMG_DESC_MSG}  End",
 	)
 	# When reading the line by word,
 	# Both entering and exiting the custom role should be reported.
@@ -1197,7 +1197,7 @@ def test_ariaRoleDescription_inline_browseMode():
 	actualSpeech = _chrome.getSpeechAfterKey("control+rightArrow")
 	_asserts.strings_match(
 		actualSpeech,
-		"logo  out of graphic",
+		"logo  out of Unlabeled graphic",
 	)
 	actualSpeech = _chrome.getSpeechAfterKey("control+rightArrow")
 	_asserts.strings_match(
@@ -1276,7 +1276,7 @@ def test_ariaRoleDescription_inline_contentEditable():
 	actualSpeech = _chrome.getSpeechAfterKey("control+rightArrow")
 	_asserts.strings_match(
 		actualSpeech,
-		"Unlabeled graphic  Our logo    out of graphic",
+		f"Unlabeled graphic  Our logo. {IMG_DESC_MSG}    out of Unlabeled graphic",
 	)
 	actualSpeech = _chrome.getSpeechAfterKey("control+rightArrow")
 	_asserts.strings_match(

--- a/tests/system/robot/chromeTests.robot
+++ b/tests/system/robot/chromeTests.robot
@@ -91,16 +91,12 @@ ARIA roleDescription focus
 ARIA roleDescription inline browse mode
 	[Documentation]	Read an inline element with a custom role in browse mode
 	test_ariaRoleDescription_inline_browseMode
-	# Disabled due to chrome message "To get missing image descriptions, open the context menu."
-	[Tags]	excluded_from_build
 ARIA roleDescription block browse mode
 	[Documentation]	Read a block element with a custom role in browse mode
 	test_ariaRoleDescription_block_browseMode
-	# Disabled due to chrome message "To get missing image descriptions, open the context menu."
 ARIA roleDescription inline content editable
 	[Documentation]	Read an inline element with a custom role in content editables 
 	test_ariaRoleDescription_inline_contentEditable
-	[Tags]	excluded_from_build
 ARIA roleDescription block content editable
 	[Documentation]	Read an block element with a custom role in content editables 
 	test_ariaRoleDescription_block_contentEditable
@@ -152,7 +148,6 @@ multiple ARIA details targets
 	test_annotations_multi_target
 i10890
 	[Documentation]	Test sort state is announced on column header when changed with inner button
-	[Tags]	excluded_from_build
 	test_i10890
 ARIA switch role
 	[Documentation]	Test aria switch control has appropriate role and states in browse mode and when focused


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
None

### Summary of the issue:
Certain chrome tests were disabled due to chrome introducing a new message "To get missing image descriptions, open the context menu.".
It seems like this behaviour is here to stay, so tests should be adopted to expect this string

### Description of user facing changes:
None
### Description of developer facing changes:
None
### Description of development approach:
updated tests
### Testing strategy:

### Known issues with pull request:

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
