### PR TITLE
Move builds to windows-2025

### DIFF
--- a/.github/workflows/add-new-language.yml
+++ b/.github/workflows/add-new-language.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   add-new-languages:
-    runs-on: windows-latest
+    runs-on: windows-2025
     permissions:
       contents: write
       pull-requests: write
@@ -29,6 +29,12 @@ jobs:
         fetch-depth: 1
         submodules: true
 
+    - name: Set up python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11.9'
+        architecture: 'x86'
+
     - name: setup uv
       uses: astral-sh/setup-uv@v6
 
@@ -37,11 +43,6 @@ jobs:
       env:
         crowdinProjectID: ${{ vars.CROWDIN_PROJECT_ID }}
         crowdinAuthToken: ${{ secrets.CROWDIN_AUTH_TOKEN }}
-
-    - name: Set up python
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.11'
 
     - name: Install pre-commit
       run: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
-    runs-on: windows-latest
+    runs-on: windows-2025
     permissions:
       # required for all workflows
       security-events: write

--- a/.github/workflows/fetch-crowdin-translations.yml
+++ b/.github/workflows/fetch-crowdin-translations.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   download-from-crowdin:
-    runs-on: windows-latest
+    runs-on: windows-2025
     permissions:
       contents: write
       pull-requests: write
@@ -29,6 +29,12 @@ jobs:
         fetch-depth: 1
         submodules: true
 
+    - name: Set up python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11.9'
+        architecture: 'x86'
+
     - name: setup uv
       uses: astral-sh/setup-uv@v6
 
@@ -37,11 +43,6 @@ jobs:
       env:
         crowdinProjectID: ${{ vars.CROWDIN_PROJECT_ID }}
         crowdinAuthToken: ${{ secrets.CROWDIN_AUTH_TOKEN }}
-
-    - name: Set up python
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.11'
 
     - name: Install pre-commit
       run: |

--- a/.github/workflows/regenerate_english_userDocs_translation_source.yml
+++ b/.github/workflows/regenerate_english_userDocs_translation_source.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   rebuild-translation-source:
-    runs-on: windows-latest
+    runs-on: windows-2025
 
     steps:
     - name: Checkout repository
@@ -17,10 +17,11 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Set up Python
-      uses: actions/setup-python@v4
+    - name: Set up python
+      uses: actions/setup-python@v5
       with:
-        python-version: '3.11'
+        python-version: '3.11.9'
+        architecture: 'x86'
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -127,7 +127,7 @@ jobs:
     - name: Set up python
       uses: actions/setup-python@v5
       with:
-        python-version: 3.11.9
+        python-version: ${{ env.pythonVersion }}
         architecture: ${{ env.arch }}
     - name: Install pre-commit
       run: |

--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -41,7 +41,7 @@ env:
 jobs:
   buildNVDA:
     name: Build NVDA
-    runs-on: windows-latest
+    runs-on: windows-2025
     outputs:
       version: ${{ steps.releaseInfo.outputs.VERSION }}
       versionType: ${{ steps.releaseInfo.outputs.VERSION_TYPE }}
@@ -55,7 +55,7 @@ jobs:
     - name: Install Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.11'
+        python-version: '3.11.9'
         architecture: x86
     - name: Install the latest version of uv
       uses: astral-sh/setup-uv@v6
@@ -94,7 +94,7 @@ jobs:
 
   typeCheck:
     name: Check types with Pyright
-    runs-on: windows-latest
+    runs-on: windows-2025
     needs: buildNVDA
     steps:
     - name: Checkout cached build
@@ -103,6 +103,11 @@ jobs:
         path: ${{ github.workspace }}
         key: ${{ github.ref }}-${{ github.run_id }}
         fail-on-cache-miss: true
+    - name: Install Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11.9'
+        architecture: x86
     - name: Install the latest version of uv
       uses: astral-sh/setup-uv@v6
     - name: Static type analysis
@@ -110,7 +115,7 @@ jobs:
 
   checkPo:
     name: Check po files for errors
-    runs-on: windows-latest
+    runs-on: windows-2025
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
@@ -120,7 +125,8 @@ jobs:
     - name: Set up python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.11'
+        python-version: '3.11.9'
+        architecture: 'x86'
     - name: Install pre-commit
       run: |
         python -m pip install --upgrade pip
@@ -139,7 +145,7 @@ jobs:
 
   checkPot:
     name: Check translator comments
-    runs-on: windows-latest
+    runs-on: windows-2025
     needs: buildNVDA
     steps:
     - name: Checkout cached build
@@ -148,6 +154,11 @@ jobs:
         path: ${{ github.workspace }}
         key: ${{ github.ref }}-${{ github.run_id }}
         fail-on-cache-miss: true
+    - name: Install Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11.9'
+        architecture: x86
     - name: Install the latest version of uv
       uses: astral-sh/setup-uv@v6
     - name: Check comments for translators
@@ -163,7 +174,7 @@ jobs:
 
   licenseCheck:
     name: Check license compatibility of dependencies
-    runs-on: windows-latest
+    runs-on: windows-2025
     needs: buildNVDA
     steps:
     - name: Checkout cached build
@@ -172,6 +183,11 @@ jobs:
         path: ${{ github.workspace }}
         key: ${{ github.ref }}-${{ github.run_id }}
         fail-on-cache-miss: true
+    - name: Install Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11.9'
+        architecture: x86
     - name: Install the latest version of uv
       uses: astral-sh/setup-uv@v6
     - name: License check
@@ -179,7 +195,7 @@ jobs:
 
   unitTests:
     name: Run unit tests
-    runs-on: windows-latest
+    runs-on: windows-2025
     needs: buildNVDA
     steps:
     - name: Checkout cached build
@@ -188,6 +204,11 @@ jobs:
         path: ${{ github.workspace }}
         key: ${{ github.ref }}-${{ github.run_id }}
         fail-on-cache-miss: true
+    - name: Install Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11.9'
+        architecture: x86
     - name: Install the latest version of uv
       uses: astral-sh/setup-uv@v6
     - name: Run unit tests
@@ -214,7 +235,7 @@ jobs:
 
   crowdinUpload:
     name: Upload translations to Crowdin
-    runs-on: windows-latest
+    runs-on: windows-2025
     needs: [buildNVDA, checkPot]
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/beta' && vars.CROWDIN_PROJECT_ID }}
     steps:
@@ -229,6 +250,11 @@ jobs:
       with:
         name: makePot results
         path: output
+    - name: Install Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11.9'
+        architecture: x86
     - name: Install the latest version of uv
       uses: astral-sh/setup-uv@v6
     - name: Upload translations to Crowdin
@@ -239,7 +265,7 @@ jobs:
 
   createLauncher:
     name: Create launcher
-    runs-on: windows-latest
+    runs-on: windows-2025
     needs: buildNVDA
     outputs:
       launcherArtifactId: ${{ steps.uploadLauncher.outputs.artifact-id }}
@@ -251,6 +277,11 @@ jobs:
         path: ${{ github.workspace }}
         key: ${{ github.ref }}-${{ github.run_id }}
         fail-on-cache-miss: true
+    - name: Install Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11.9'
+        architecture: x86
     - name: Install the latest version of uv
       uses: astral-sh/setup-uv@v6
     - name: Set version variables
@@ -302,9 +333,9 @@ jobs:
       fail-fast: false
       matrix:
         # To skip tests, and just run install, replace with [excluded_from_build]
-        testSuite: [chrome, installer, startupShutdown]
+        testSuite: [chrome, installer, startupShutdown, symbols]
     name: Run system tests
-    runs-on: windows-latest
+    runs-on: windows-2025
     needs: createLauncher
     steps:
     - name: Checkout cached build
@@ -313,6 +344,11 @@ jobs:
         path: ${{ github.workspace }}
         key: ${{ github.ref }}-${{ github.run_id }}
         fail-on-cache-miss: true
+    - name: Install Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11.9'
+        architecture: x86
     - name: Install the latest version of uv
       uses: astral-sh/setup-uv@v6
     - name: Get NVDA launcher
@@ -350,7 +386,7 @@ jobs:
 
   createSymbols:
     name: Create symbols
-    runs-on: windows-latest
+    runs-on: windows-2025
     needs: buildNVDA
     outputs:
       symbolsArtifactId: ${{ steps.uploadArtifact.outputs.artifact-id }}
@@ -361,6 +397,9 @@ jobs:
         path: ${{ github.workspace }}
         key: ${{ github.ref }}-${{ github.run_id }}
         fail-on-cache-miss: true
+    - name: Install Windows SDK
+      # Installs symstore.exe to expected location.
+      run: choco install -y windows-sdk-10.0
     - name: Create build symbols
       env:
         symStore: C:\Program Files (x86)\Windows Kits\10\Debuggers\x64\symstore.exe
@@ -385,7 +424,7 @@ jobs:
 
   uploadSymbols:
     name: Upload symbols
-    runs-on: windows-latest
+    runs-on: windows-2025
     needs: createSymbols
     if: ${{ github.event_name == 'push' && vars.feature_uploadSymbolsToMozilla }}
     steps:
@@ -395,6 +434,11 @@ jobs:
         path: ${{ github.workspace }}
         key: ${{ github.ref }}-${{ github.run_id }}
         fail-on-cache-miss: true
+    - name: Install Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11.9'
+        architecture: x86
     - name: Install the latest version of uv
       uses: astral-sh/setup-uv@v6
     - name: Get symbols

--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -37,6 +37,8 @@ env:
   VSCMD_SKIP_SENDTELEMETRY: 1
   # Cache details about available MSVC tooling for subsequent SCons invocations to the provided file.
   SCONS_CACHE_MSVC_CONFIG: ".scons_msvc_cache.json"
+  arch: x86
+  pythonVersion: '3.11.9'
 
 jobs:
   buildNVDA:
@@ -55,8 +57,8 @@ jobs:
     - name: Install Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.11.9'
-        architecture: x86
+        python-version: ${{ env.pythonVersion }}
+        architecture: ${{ env.arch }}
     - name: Install the latest version of uv
       uses: astral-sh/setup-uv@v6
     - name: Set version variables
@@ -106,8 +108,8 @@ jobs:
     - name: Install Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.11.9'
-        architecture: x86
+        python-version: ${{ env.pythonVersion }}
+        architecture: ${{ env.arch }}
     - name: Install the latest version of uv
       uses: astral-sh/setup-uv@v6
     - name: Static type analysis
@@ -125,8 +127,8 @@ jobs:
     - name: Set up python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.11.9'
-        architecture: 'x86'
+        python-version: 3.11.9
+        architecture: ${{ env.arch }}
     - name: Install pre-commit
       run: |
         python -m pip install --upgrade pip
@@ -157,8 +159,8 @@ jobs:
     - name: Install Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.11.9'
-        architecture: x86
+        python-version: ${{ env.pythonVersion }}
+        architecture: ${{ env.arch }}
     - name: Install the latest version of uv
       uses: astral-sh/setup-uv@v6
     - name: Check comments for translators
@@ -186,8 +188,8 @@ jobs:
     - name: Install Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.11.9'
-        architecture: x86
+        python-version: ${{ env.pythonVersion }}
+        architecture: ${{ env.arch }}
     - name: Install the latest version of uv
       uses: astral-sh/setup-uv@v6
     - name: License check
@@ -207,8 +209,8 @@ jobs:
     - name: Install Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.11.9'
-        architecture: x86
+        python-version: ${{ env.pythonVersion }}
+        architecture: ${{ env.arch }}
     - name: Install the latest version of uv
       uses: astral-sh/setup-uv@v6
     - name: Run unit tests
@@ -253,8 +255,8 @@ jobs:
     - name: Install Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.11.9'
-        architecture: x86
+        python-version: ${{ env.pythonVersion }}
+        architecture: ${{ env.arch }}
     - name: Install the latest version of uv
       uses: astral-sh/setup-uv@v6
     - name: Upload translations to Crowdin
@@ -280,8 +282,8 @@ jobs:
     - name: Install Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.11.9'
-        architecture: x86
+        python-version: ${{ env.pythonVersion }}
+        architecture: ${{ env.arch }}
     - name: Install the latest version of uv
       uses: astral-sh/setup-uv@v6
     - name: Set version variables
@@ -347,8 +349,8 @@ jobs:
     - name: Install Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.11.9'
-        architecture: x86
+        python-version: ${{ env.pythonVersion }}
+        architecture: ${{ env.arch }}
     - name: Install the latest version of uv
       uses: astral-sh/setup-uv@v6
     - name: Get NVDA launcher
@@ -437,8 +439,8 @@ jobs:
     - name: Install Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.11.9'
-        architecture: x86
+        python-version: ${{ env.pythonVersion }}
+        architecture: ${{ env.arch }}
     - name: Install the latest version of uv
       uses: astral-sh/setup-uv@v6
     - name: Get symbols

--- a/tests/system/libraries/NotepadLib.py
+++ b/tests/system/libraries/NotepadLib.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2021 NV Access Limited
+# Copyright (C) 2021-2025 NV Access Limited
 # This file may be used under the terms of the GNU General Public License, version 2 or later.
 # For more details see: https://www.gnu.org/licenses/gpl-2.0.plaintext
 
@@ -11,7 +11,6 @@ Windows Notepad with a text sample and assert NVDA interacts with it in the expe
 from os.path import join as _pJoin
 import datetime as _datetime
 import tempfile as _tempfile
-from typing import Optional as _Optional
 from SystemTestSpy import (
 	_blockUntilConditionMet,
 	_getLib,
@@ -47,8 +46,8 @@ class NotepadLib:
 
 	# Use class variables for state that should be tied to the RF library instance.
 	# These variables will be available in the teardown
-	notepadWindow: _Optional[_Window] = None
-	processRFHandleForStart: _Optional[int] = None
+	notepadWindow: _Window | None = None
+	processRFHandleForStart: int | None = None
 
 	@staticmethod
 	def _getTestCasePath(filename):
@@ -186,4 +185,4 @@ class NotepadLib:
 		self._waitForNotepadFocus(uniqueTitleRegex)
 		windowsLib.logForegroundWindowTitle()
 		# Move to the start of file
-		_NvdaLib.getSpeechAfterKey("home")
+		_NvdaLib.getSpeechAfterKey("control+home")

--- a/tests/system/libraries/NotepadLib.py
+++ b/tests/system/libraries/NotepadLib.py
@@ -94,7 +94,7 @@ class NotepadLib:
 				expectedTitlePattern,
 				lambda message: builtIn.log(message, "DEBUG"),
 			),
-			giveUpAfterSeconds=3,
+			giveUpAfterSeconds=5,
 			shouldStopEvaluator=lambda _window: _window is not None,
 			intervalBetweenSeconds=0.5,
 			errorMessage="Unable to get notepad window",

--- a/tests/system/libraries/NotepadLib.py
+++ b/tests/system/libraries/NotepadLib.py
@@ -150,12 +150,6 @@ class NotepadLib:
 			f"Unable to focus Notepad.\n{windowInformation}",
 		)
 
-	def canNotepadTitleBeReported(self, notepadTitleSpeechPattern: re.Pattern) -> bool:
-		titleSpeech = _NvdaLib.getSpeechAfterKey("NVDA+t")
-		return bool(
-			notepadTitleSpeechPattern.search(titleSpeech),
-		)
-
 	def prepareNotepad(self, testCase: str) -> None:
 		"""
 		Starts Notepad opening a file containing the plaintext sample.
@@ -177,10 +171,9 @@ class NotepadLib:
 			# Unlike getUniqueTestCaseTitleRegex, this speech does not have to be at the start of the string.
 			f"{NotepadLib._testCaseTitle} \\({abs(_testCaseHash)}\\)",
 		)
-		if not self.canNotepadTitleBeReported(notepadTitleSpeechPattern=testCaseNotepadTitleSpeech):
-			builtIn.log("Trying to switch to notepad Window")
-			windowsLib.taskSwitchToItemMatching(targetWindowNamePattern=testCaseNotepadTitleSpeech)
-			windowsLib.logForegroundWindowTitle()
+		builtIn.log("Trying to switch to notepad Window")
+		windowsLib.taskSwitchToItemMatching(targetWindowNamePattern=testCaseNotepadTitleSpeech)
+		windowsLib.logForegroundWindowTitle()
 
 		self._waitForNotepadFocus(uniqueTitleRegex)
 		windowsLib.logForegroundWindowTitle()

--- a/tests/system/libraries/SystemTestSpy/speechSpyGlobalPlugin.py
+++ b/tests/system/libraries/SystemTestSpy/speechSpyGlobalPlugin.py
@@ -542,7 +542,7 @@ class NVDASpyLib:
 			queueHandler.queueFunction(queueHandler.eventQueue, _setQueueProcessed)
 			_blockUntilConditionMet(
 				getValue=lambda: queueProcessed,
-				giveUpAfterSeconds=self._minTimeout(5),
+				giveUpAfterSeconds=self._minTimeout(10),
 				errorMessage="Timed out waiting for key to be processed",
 			)
 
@@ -552,7 +552,7 @@ class NVDASpyLib:
 			log.debug("Waiting for core to sleep, to ensure all resulting events have been processed.")
 			_blockUntilConditionMet(
 				getValue=lambda: watchdog.isCoreAsleep(),
-				giveUpAfterSeconds=self._minTimeout(5),
+				giveUpAfterSeconds=self._minTimeout(10),
 				errorMessage="Timed out waiting for core to sleep again",
 			)
 			log.debug("Core sleeping")

--- a/tests/system/libraries/SystemTestSpy/speechSpySynthDriver.py
+++ b/tests/system/libraries/SystemTestSpy/speechSpySynthDriver.py
@@ -99,9 +99,11 @@ class SpeechSpySynthDriver(synthDriverHandler.SynthDriver):
 					if self._speechStarted:
 						self._doDoneSpeaking()
 						self._speechStarted = False
-					continue
-				self._speechStarted = True
-				self._processSpeechSequence(speechSequence)
+					else:
+						_yieldThread()
+				else:
+					self._speechStarted = True
+					self._processSpeechSequence(speechSequence)
 		log.debug("Stopping")
 
 	def _processSpeechSequence(self, speechSequence: SpeechSequence):

--- a/tests/system/robot/symbolPronunciationTests.robot
+++ b/tests/system/robot/symbolPronunciationTests.robot
@@ -1,10 +1,10 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2021-2022 NV Access Limited
+# Copyright (C) 2021-2025 NV Access Limited
 # This file may be used under the terms of the GNU General Public License, version 2 or later.
 # For more details see: https://www.gnu.org/licenses/gpl-2.0.html
 *** Settings ***
 Documentation	Symbol pronunciation tests
-Force Tags	NVDA	smoke test	symbols	excluded_from_build
+Force Tags	NVDA	smoke test	symbols
 
 # for start & quit in Test Setup and Test Test Teardown
 Library	NvdaLib.py
@@ -65,7 +65,7 @@ selectionByCharacter
 
 tableHeaderSymbols
 	[Documentation]	Ensure symbols announced as expected in table headers.
-	[Tags]	table	excluded_from_build
+	[Tags]	table
 	test_tableHeaders
 
 ignoreBlankLinesForReportLineIndentation


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Fixes #15104
Fixes #14372
Fixes #14353

### Summary of the issue:

- Most NVDA developers are on Windows 11, including all of NV Access, but NVDA is still being built on Windows Server 2022 (Windows 10 based). 
- Windows 11 is the expected environment for system testing and builds.
- GitHub actions will move `windows-latest` to `windows-2025` this year.
- A bug exists with windows 10 notepad that prevents NVDA from focusing it. This causes our symbol pronunciation tests to be disabled.

### Description of user facing changes:

None

### Description of developer facing changes:

symbols tests are re-enabled

### Description of development approach:

- Set windows-2025 rather than windows-latest for build steps
- Explicitly call `setup-python` more frequently as our required version of python doesn't come pre-installed in windows-2025. This can be fixed in #18591 
- explicitly install the windows-sdk when creating symbols, as it appears that `symstore.exe` is not installed at all or not installed in the expected place.
- Enable symbol pronunciation tests again. 

### Testing strategy:

CI/CD tests

### Known issues with pull request:

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
