### PR TITLE
Improve Remote Access's consistency regarding connections

### DIFF
--- a/source/_remoteClient/client.py
+++ b/source/_remoteClient/client.py
@@ -248,6 +248,7 @@ class RemoteClient:
 			log.debug("Disconnect called but no active sessions")
 			return
 		log.info("Disconnecting from remote session")
+		self.connecting = False
 		if self.localControlServer is not None:
 			self.localControlServer.close()
 			self.localControlServer = None
@@ -263,6 +264,7 @@ class RemoteClient:
 		self.leaderSession.close()
 		self.leaderSession = None
 		self.leaderTransport = None
+		self.connecting = False
 
 	def disconnectAsFollower(self):
 		"""Close follower session and clean up related resources."""
@@ -270,6 +272,7 @@ class RemoteClient:
 		self.followerSession = None
 		self.followerTransport = None
 		self.sdHandler.followerSession = None
+		self.connecting = False
 
 	@alwaysCallAfter
 	def onConnectAsLeaderFailed(self):

--- a/source/_remoteClient/client.py
+++ b/source/_remoteClient/client.py
@@ -264,6 +264,8 @@ class RemoteClient:
 		self.leaderSession.close()
 		self.leaderSession = None
 		self.leaderTransport = None
+		if self.menu:
+			self.menu.handleConnected(ConnectionMode.LEADER, False)
 		self._connecting = False
 
 	def disconnectAsFollower(self):
@@ -272,6 +274,8 @@ class RemoteClient:
 		self.followerSession = None
 		self.followerTransport = None
 		self.sdHandler.followerSession = None
+		if self.menu:
+			self.menu.handleConnected(ConnectionMode.FOLLOWER, False)
 		self._connecting = False
 
 	@alwaysCallAfter

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -5020,7 +5020,7 @@ class GlobalCommands(ScriptableObject):
 		gui.blockAction.Context.MODAL_DIALOG_OPEN,
 	)
 	def script_connectToRemote(self, gesture: "inputCore.InputGesture"):
-		if _remoteClient._remoteClient.isConnected() or _remoteClient._remoteClient.connecting:
+		if _remoteClient._remoteClient.isConnected() or _remoteClient._remoteClient.isConnecting:
 			# Translators: A message indicating that the remote client is already connected.
 			ui.message(_("Already connected"))
 			return

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -5034,7 +5034,7 @@ class GlobalCommands(ScriptableObject):
 	)
 	@gui.blockAction.when(gui.blockAction.Context.REMOTE_ACCESS_DISABLED)
 	def script_toggleRemoteConnection(self, gesture: "inputCore.InputGesture") -> None:
-		if _remoteClient._remoteClient.isConnected():
+		if _remoteClient._remoteClient.isConnected() or _remoteClient._remoteClient.isConnecting:
 			self.script_disconnectFromRemote(gesture)
 		else:
 			self.script_connectToRemote(gesture)

--- a/tests/unit/test_remote/test_remoteClient.py
+++ b/tests/unit/test_remote/test_remoteClient.py
@@ -31,6 +31,8 @@ class FakeMenu:
 		def Check(self, value):
 			self.checked = value
 
+	def handleConnected(self, *args, **kwargs): ...
+
 
 class FakeTransport:
 	def __init__(self):

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -31,6 +31,7 @@
 * Fixed a problem where NVDA fails to start with an SAPI5 Eloquence voice and falls back to OneCore voices. (#18301, @gexgd0419)
 * Fixed Highlighter not working with Outlook contact auto-complete lists. (#18483, @Nerlant)
 * Fixed a bug which stopped speech from working via NVDA Remote Access when the controlled computer had no audio output devices enabled. (#18544)
+* Fixed a bug which caused NVDA Remote Access to stop working if a session was interrupted while connecting to the server. (#18476)
 
 ### Changes for Developers
 


### PR DESCRIPTION
### Link to issue number:
Fixes #18476
Fixes #18383
Fixes #18106

### Summary of the issue:
NVDA Remote Access currently:
* Does not allow the user to abort a session while connecting to the server via the GUI or the toggle gesture.
* Allows a user to create a new session while already connecting to a server.
* Can get into an inconsistent state if a connection is aborted while connecting to the server.

### Description of user facing changes:
Fixed the above issues.

### Description of developer facing changes:
The `connecting` attribute of `RemoteClient` is now marked internal. It has been replaced by the `isConnecting` property, which synthesizes its return from more sources.

### Description of development approach:
* Set `_connecting` in more places.
* Update the GUI in more places.
* Replace `RemoteClient._connecting` with `RemoteClient.isConnecting`, as this reports whether RA is connecting or reconnecting.

### Testing strategy:
Set up Remote Access to automatically connect on NVDA start-up. Tried starting NVDA with my remote access server running and not running. In both states, tried disconnecting and creating new connections etc.

### Known issues with pull request:
The dialog presented to users when cancelling a session is the same regardless of whether they are in the connecting or connected state. I am not sure if this is a major issue.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
