### PR TITLE
Add instructions for setting indentation mode to tabs when translating on github

### DIFF
--- a/projectDocs/translating/github.md
+++ b/projectDocs/translating/github.md
@@ -74,6 +74,12 @@ New gestures will be announced there, and localisations can be added to `gesture
     - Tab to the "edit file" button to open the editor for the file.
     - If it's your first time doing this, GitHub will ask you to fork this repository.
     Click "Fork this repository".
+    - Ensure indentation formatting is using tabs not spaces.
+        - You may need to change the indent mode to tabs.
+        - From the code editor, press `NVDA+space` to switch to browse mode, then press `shift+c` until you get to the "Indent mode" combo-box.
+        - Press `enter` to activate it, then press `downArrow` to select "Tabs".
+        - You can then press `NVDA+space` to switch to browse mode, then `e` to get back to the code editor, and `enter` to focus it in focus mode.
+        - The tab key should then insert the tab character, rather than spaces.
     - English example: <https://github.com/nvaccess/nvda/edit/beta/source/locale/en/symbols.dic>
     - Format (replace `{lang}` and `{fileName}`): `https://github.com/nvaccess/nvda/edit/beta/source/locale/{lang}/{fileName}`
     - Refer to [background](#background) for more information on the format of the files


### PR DESCRIPTION


<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Original discussion https://github.com/nvaccess/nvda/pull/18603#issuecomment-3148770899

### Summary of the issue:
Tabs for indentation are needed when editing `.dic` files.
GitHub's code editor by default uses spaces when hitting the tab key.
You can change this from the code editor when editing a file.

### Description of user facing changes:
Fix up docs
