### PR TITLE
Added temporary notice on license change to readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -15,7 +15,7 @@ Please refer to [our license](./copying.txt) for more information.
 
 ## Important temporary notice for contributors: Proposed license update
 
-We are proposing an update to the NVDA license and are seeking feedback from all historical contributors. 
+We are proposing an update to the NVDA license and are seeking feedback from all historical contributors.
 To ensure you have an opportunity to contribute to the discussion, please review the proposal:
 [Proposed update to the NVDA license](https://github.com/nvaccess/nvda/discussions/18574).
 The consultation period ends on 28 September 2025.

--- a/readme.md
+++ b/readme.md
@@ -13,6 +13,13 @@ NV Access also maintains a [development roadmap](https://www.nvaccess.org/post/n
 NVDA is available under a modified GNU General Public License version 2.
 Please refer to [our license](./copying.txt) for more information.
 
+## Important temporary notice for contributors: Proposed license update
+
+We are proposing an update to the NVDA license and are seeking feedback from all historical contributors. 
+To ensure you have an opportunity to contribute to the discussion, please review the proposal:
+[Proposed update to the NVDA license](https://github.com/nvaccess/nvda/discussions/18574).
+The consultation period ends on 28 September 2025.
+
 ## Acknowledgements
 
 We would like to extend our sincere gratitude to [SignPath](https://www.signpath.io/) for their generous support in providing code signing services to many open source projects, including NVDA.


### PR DESCRIPTION
Publicising the discussion on github for the GPL-2 license harmonisation. 

### Link to issue number:
https://github.com/nvaccess/nvda/discussions/18574

### Summary of the issue:
Community consultation on GPL-2 or later change.

### Description of user facing changes:
None 

### Description of developer facing changes:
2-month inclusion of notice in README.md

### Description of development approach:
On 28 Sept, the notice will be removed.

