### PR TITLE
Encapsulate registry keys more consistently

### DIFF
--- a/sconstruct
+++ b/sconstruct
@@ -401,8 +401,7 @@ def NVDADistGenerator(target, source, env, for_signature):
 		with winreg.OpenKey(
 			winreg.HKEY_LOCAL_MACHINE,
 			r"SOFTWARE\Microsoft\Microsoft SDKs\Windows\v10.0",
-			0,
-			winreg.KEY_READ | winreg.KEY_WOW64_32KEY,
+			access=winreg.KEY_READ | winreg.KEY_WOW64_32KEY,
 		) as SDKKey:
 			sdk_installationFolder = winreg.QueryValueEx(SDKKey, "InstallationFolder")[0]
 			sdk_productVersion = winreg.QueryValueEx(SDKKey, "ProductVersion")[0]

--- a/site_scons/site_tools/doxygen.py
+++ b/site_scons/site_tools/doxygen.py
@@ -32,8 +32,7 @@ def fetchDoxygenPath():
 		with winreg.OpenKey(
 			winreg.HKEY_LOCAL_MACHINE,
 			r"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\doxygen_is1",
-			0,
-			winreg.KEY_READ | winreg.KEY_WOW64_64KEY,
+			access=winreg.KEY_READ | winreg.KEY_WOW64_64KEY,
 		) as doxygenKey:
 			doxygenPath = '"%s"' % os.path.join(
 				winreg.QueryValueEx(doxygenKey, "InstallLocation")[0],

--- a/source/NVDAState.py
+++ b/source/NVDAState.py
@@ -165,6 +165,7 @@ class _TrackNVDAInitialization:
 
 
 def _forceSecureModeEnabled() -> bool:
+	# Avoid circular import
 	from config.registry import RegistryKey
 
 	try:
@@ -176,6 +177,7 @@ def _forceSecureModeEnabled() -> bool:
 
 
 def _serviceDebugEnabled() -> bool:
+	# Avoid circular import
 	from config.registry import RegistryKey
 
 	try:
@@ -187,6 +189,7 @@ def _serviceDebugEnabled() -> bool:
 
 
 def _configInLocalAppDataEnabled() -> bool:
+	# Avoid circular imports
 	from config.registry import RegistryKey
 	from logHandler import log
 

--- a/source/NVDAState.py
+++ b/source/NVDAState.py
@@ -165,7 +165,7 @@ class _TrackNVDAInitialization:
 
 
 def _forceSecureModeEnabled() -> bool:
-	from config import RegistryKey
+	from config.registry import RegistryKey
 
 	try:
 		k = winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, RegistryKey.NVDA.value)
@@ -176,7 +176,7 @@ def _forceSecureModeEnabled() -> bool:
 
 
 def _serviceDebugEnabled() -> bool:
-	from config import RegistryKey
+	from config.registry import RegistryKey
 
 	try:
 		k = winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, RegistryKey.NVDA.value)
@@ -187,7 +187,7 @@ def _serviceDebugEnabled() -> bool:
 
 
 def _configInLocalAppDataEnabled() -> bool:
-	from config import RegistryKey
+	from config.registry import RegistryKey
 	from logHandler import log
 
 	try:

--- a/source/_remoteClient/localMachine.py
+++ b/source/_remoteClient/localMachine.py
@@ -26,7 +26,7 @@ import winreg
 
 import api
 import braille
-from config import RegistryKey
+from config.registry import RegistryKey
 import inputCore
 import nvwave
 import speech

--- a/source/_remoteClient/localMachine.py
+++ b/source/_remoteClient/localMachine.py
@@ -26,6 +26,7 @@ import winreg
 
 import api
 import braille
+from config import RegistryKey
 import inputCore
 import nvwave
 import speech
@@ -62,10 +63,10 @@ class SoftwareSASGeneration(IntEnum):
 	"""both services and Ease of Access applications can simulate the SAS."""
 
 	KEY: int = nonmember(winreg.HKEY_LOCAL_MACHINE)
-	SUBKEY: str = nonmember(r"Software\Microsoft\Windows\CurrentVersion\Policies\System")
+	SUBKEY: str = nonmember(rf"{RegistryKey.CURRENT_VERSION.value}\Policies\System")
 	VALUE_NAME: str = nonmember("SoftwareSASGeneration")
 	DISPLAY_PATH: str = nonmember(
-		r"HKLM\Software\Microsoft\Windows\CurrentVersion\Policies\System!SoftwareSASGeneration",
+		rf"HKLM\{RegistryKey.CURRENT_VERSION.value}\Policies\System!SoftwareSASGeneration",
 	)
 
 

--- a/source/_remoteClient/localMachine.py
+++ b/source/_remoteClient/localMachine.py
@@ -63,10 +63,10 @@ class SoftwareSASGeneration(IntEnum):
 	"""both services and Ease of Access applications can simulate the SAS."""
 
 	KEY: int = nonmember(winreg.HKEY_LOCAL_MACHINE)
-	SUBKEY: str = nonmember(rf"{RegistryKey.CURRENT_VERSION.value}\Policies\System")
+	SUBKEY: str = nonmember(RegistryKey.SYSTEM_POLICIES.value)
 	VALUE_NAME: str = nonmember("SoftwareSASGeneration")
 	DISPLAY_PATH: str = nonmember(
-		rf"HKLM\{RegistryKey.CURRENT_VERSION.value}\Policies\System!SoftwareSASGeneration",
+		rf"HKLM\{RegistryKey.SYSTEM_POLICIES.value}!SoftwareSASGeneration",
 	)
 
 

--- a/source/_remoteClient/urlHandler.py
+++ b/source/_remoteClient/urlHandler.py
@@ -68,7 +68,7 @@ def _deleteRegistryKeyRecursive(baseKey: int, subkeyPath: str):
 	except WindowsError:
 		# If that fails, need to do recursive deletion
 		try:
-			with winreg.OpenKey(baseKey, subkeyPath, 0, winreg.KEY_READ | winreg.KEY_WRITE) as key:
+			with winreg.OpenKey(baseKey, subkeyPath, access=winreg.KEY_READ | winreg.KEY_WRITE) as key:
 				# Enumerate and delete all subkeys
 				while True:
 					try:

--- a/source/config/__init__.py
+++ b/source/config/__init__.py
@@ -120,14 +120,25 @@ def saveOnExit():
 
 
 class RegistryKey(str, Enum):
-	INSTALLED_COPY = r"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\NVDA"
-	RUN = r"SOFTWARE\Microsoft\Windows\CurrentVersion\Run"
-	NVDA = r"SOFTWARE\NVDA"
+	SOFTWARE = "SOFTWARE"
 	r"""
 	The name of the registry key stored under HKEY_LOCAL_MACHINE where system wide NVDA settings are stored.
-	Note that NVDA is a 32-bit application, so on X64 systems,
-	this will evaluate to `r"SOFTWARE\WOW6432Node\nvda"`
+	Note that if NVDA is a 32-bit application, on x64 systems,
+	this will evaluate to `r"SOFTWARE\WOW6432Node"`
 	"""
+	CURRENT_VERSION = rf"{SOFTWARE}\Microsoft\Windows\CurrentVersion"
+	INSTALLED_COPY = rf"{CURRENT_VERSION}\Uninstall\NVDA"
+	RUN = rf"{CURRENT_VERSION}\Run"
+	NVDA = rf"{SOFTWARE}\NVDA"
+	APP_PATH = rf"{CURRENT_VERSION}\App Paths\nvda.exe"
+	NT_CURRENT_VERSION = rf"{SOFTWARE}\Microsoft\Windows NT\CurrentVersion"
+	EASE_OF_ACCESS = rf"{NT_CURRENT_VERSION}\Accessibility"
+	EASE_OF_ACCESS_TEMP = rf"{NT_CURRENT_VERSION}\AccessibilityTemp"
+	EASE_OF_ACCESS_APP_KEY_NAME = "nvda_nvda_v1"
+	EASE_OF_ACCESS_APP = rf"{EASE_OF_ACCESS}\ATs\{EASE_OF_ACCESS_APP_KEY_NAME}"
+
+	# Sub keys
+
 	CONFIG_IN_LOCAL_APPDATA_SUBKEY = "configInLocalAppData"
 	"""
 	#6864: The name of the subkey stored under RegistryKey.NVDA where the value is stored
@@ -140,6 +151,24 @@ class RegistryKey(str, Enum):
 	"""
 	FORCE_SECURE_MODE_SUBKEY = "forceSecureMode"
 	SERVICE_DEBUG_SUBKEY = "serviceDebug"
+
+
+class _RegistryKeyX86(str, Enum):
+	"""
+	Used to access the 32-bit registry view on x64 systems.
+	For cleaning up legacy 32-bit NVDA copies.
+	"""
+	SOFTWARE = r"SOFTWARE\WOW6432Node"
+	CURRENT_VERSION = rf"{SOFTWARE}\Microsoft\Windows\CurrentVersion"
+	INSTALLED_COPY = rf"{CURRENT_VERSION}\Uninstall\NVDA"
+	RUN = rf"{CURRENT_VERSION}\Run"
+	NVDA = rf"{SOFTWARE}\NVDA"
+	APP_PATH = rf"{CURRENT_VERSION}\App Paths\nvda.exe"
+	NT_CURRENT_VERSION = rf"{SOFTWARE}\Microsoft\Windows NT\CurrentVersion"
+	EASE_OF_ACCESS = rf"{NT_CURRENT_VERSION}\Accessibility"
+	EASE_OF_ACCESS_TEMP = rf"{NT_CURRENT_VERSION}\AccessibilityTemp"
+	EASE_OF_ACCESS_APP_KEY_NAME = "nvda_nvda_v1"
+	EASE_OF_ACCESS_APP = rf"{EASE_OF_ACCESS}\ATs\{EASE_OF_ACCESS_APP_KEY_NAME}"
 
 
 def isInstalledCopy() -> bool:

--- a/source/config/__init__.py
+++ b/source/config/__init__.py
@@ -158,6 +158,7 @@ class _RegistryKeyX86(str, Enum):
 	Used to access the 32-bit registry view on x64 systems.
 	For cleaning up legacy 32-bit NVDA copies.
 	"""
+
 	SOFTWARE = r"SOFTWARE\WOW6432Node"
 	CURRENT_VERSION = rf"{SOFTWARE}\Microsoft\Windows\CurrentVersion"
 	INSTALLED_COPY = rf"{CURRENT_VERSION}\Uninstall\NVDA"

--- a/source/config/__init__.py
+++ b/source/config/__init__.py
@@ -153,7 +153,7 @@ class RegistryKey(str, Enum):
 	SERVICE_DEBUG_SUBKEY = "serviceDebug"
 
 
-class _RegistryKeyX86(str, Enum):
+class _RegistryKeyX86(str, Enum):  # type: ignore[reportUnusedClass]
 	"""
 	Used to access the 32-bit registry view on x64 systems.
 	For cleaning up legacy 32-bit NVDA copies.

--- a/source/config/__init__.py
+++ b/source/config/__init__.py
@@ -14,7 +14,6 @@ from enum import Enum
 import globalVars
 import winreg
 import ctypes
-import ctypes.wintypes
 import os
 import sys
 import errno
@@ -40,6 +39,7 @@ from .featureFlag import (
 	_transformSpec_AddFeatureFlagDefault,
 	_validateConfig_featureFlag,
 )
+from .registry import RegistryKey as _RegistryKey
 from typing import (
 	Any,
 	Dict,
@@ -77,12 +77,15 @@ post_configReset = extensionPoints.Action()
 
 def __getattr__(attrName: str) -> Any:
 	"""Module level `__getattr__` used to preserve backward compatibility."""
+	if attrName == "RegistryKey" and NVDAState._allowDeprecatedAPI():
+		log.warning("Importing RegistryKey from here is deprecated, use config.registry.RegistryKey instead.")
+		return _RegistryKey
 	if attrName == "NVDA_REGKEY" and NVDAState._allowDeprecatedAPI():
 		log.warning("NVDA_REGKEY is deprecated, use RegistryKey.NVDA instead.")
-		return RegistryKey.NVDA.value
+		return _RegistryKey.NVDA.value
 	if attrName == "RUN_REGKEY" and NVDAState._allowDeprecatedAPI():
 		log.warning("RUN_REGKEY is deprecated, use RegistryKey.RUN instead.")
-		return RegistryKey.RUN.value
+		return _RegistryKey.RUN.value
 	if attrName == "addConfigDirsToPythonPackagePath" and NVDAState._allowDeprecatedAPI():
 		log.warning(
 			"addConfigDirsToPythonPackagePath is deprecated, "
@@ -98,7 +101,7 @@ def __getattr__(attrName: str) -> Any:
 			"Instead use RegistryKey.CONFIG_IN_LOCAL_APPDATA_SUBKEY. ",
 			stack_info=True,
 		)
-		return RegistryKey.CONFIG_IN_LOCAL_APPDATA_SUBKEY.value
+		return _RegistryKey.CONFIG_IN_LOCAL_APPDATA_SUBKEY.value
 	raise AttributeError(f"module {repr(__name__)} has no attribute {repr(attrName)}")
 
 
@@ -119,75 +122,22 @@ def saveOnExit():
 			pass
 
 
-class RegistryKey(str, Enum):
-	SOFTWARE = "SOFTWARE"
-	r"""
-	The name of the registry key stored under HKEY_LOCAL_MACHINE where system wide NVDA settings are stored.
-	Note that if NVDA is a 32-bit application, on x64 systems,
-	this will evaluate to `r"SOFTWARE\WOW6432Node"`
-	"""
-	CURRENT_VERSION = rf"{SOFTWARE}\Microsoft\Windows\CurrentVersion"
-	INSTALLED_COPY = rf"{CURRENT_VERSION}\Uninstall\NVDA"
-	RUN = rf"{CURRENT_VERSION}\Run"
-	NVDA = rf"{SOFTWARE}\NVDA"
-	APP_PATH = rf"{CURRENT_VERSION}\App Paths\nvda.exe"
-	NT_CURRENT_VERSION = rf"{SOFTWARE}\Microsoft\Windows NT\CurrentVersion"
-	EASE_OF_ACCESS = rf"{NT_CURRENT_VERSION}\Accessibility"
-	EASE_OF_ACCESS_TEMP = rf"{NT_CURRENT_VERSION}\AccessibilityTemp"
-	EASE_OF_ACCESS_APP_KEY_NAME = "nvda_nvda_v1"
-	EASE_OF_ACCESS_APP = rf"{EASE_OF_ACCESS}\ATs\{EASE_OF_ACCESS_APP_KEY_NAME}"
-
-	# Sub keys
-
-	CONFIG_IN_LOCAL_APPDATA_SUBKEY = "configInLocalAppData"
-	"""
-	#6864: The name of the subkey stored under RegistryKey.NVDA where the value is stored
-	which will make an installed NVDA load the user configuration either from the local or from
-	the roaming application data profile.
-	The registry value is unset by default.
-	When setting it manually, a DWORD value is preferred.
-	A value of 0 will evaluate to loading the configuration from the roaming application data (default).
-	A value of 1 means loading the configuration from the local application data folder.
-	"""
-	FORCE_SECURE_MODE_SUBKEY = "forceSecureMode"
-	SERVICE_DEBUG_SUBKEY = "serviceDebug"
-
-
-class _RegistryKeyX86(str, Enum):  # type: ignore[reportUnusedClass]
-	"""
-	Used to access the 32-bit registry view on x64 systems.
-	For cleaning up legacy 32-bit NVDA copies.
-	"""
-
-	SOFTWARE = r"SOFTWARE\WOW6432Node"
-	CURRENT_VERSION = rf"{SOFTWARE}\Microsoft\Windows\CurrentVersion"
-	INSTALLED_COPY = rf"{CURRENT_VERSION}\Uninstall\NVDA"
-	RUN = rf"{CURRENT_VERSION}\Run"
-	NVDA = rf"{SOFTWARE}\NVDA"
-	APP_PATH = rf"{CURRENT_VERSION}\App Paths\nvda.exe"
-	NT_CURRENT_VERSION = rf"{SOFTWARE}\Microsoft\Windows NT\CurrentVersion"
-	EASE_OF_ACCESS = rf"{NT_CURRENT_VERSION}\Accessibility"
-	EASE_OF_ACCESS_TEMP = rf"{NT_CURRENT_VERSION}\AccessibilityTemp"
-	EASE_OF_ACCESS_APP_KEY_NAME = "nvda_nvda_v1"
-	EASE_OF_ACCESS_APP = rf"{EASE_OF_ACCESS}\ATs\{EASE_OF_ACCESS_APP_KEY_NAME}"
-
-
 def isInstalledCopy() -> bool:
 	"""Checks to see if this running copy of NVDA is installed on the system"""
 	try:
 		k = winreg.OpenKey(
 			winreg.HKEY_LOCAL_MACHINE,
-			RegistryKey.INSTALLED_COPY.value,
+			_RegistryKey.INSTALLED_COPY.value,
 		)
 	except FileNotFoundError:
 		log.debug(
-			f"Unable to find isInstalledCopy registry key {RegistryKey.INSTALLED_COPY}"
+			f"Unable to find isInstalledCopy registry key {_RegistryKey.INSTALLED_COPY}"
 			"- this is not an installed copy.",
 		)
 		return False
 	except WindowsError:
 		log.error(
-			f"Unable to open isInstalledCopy registry key {RegistryKey.INSTALLED_COPY}",
+			f"Unable to open isInstalledCopy registry key {_RegistryKey.INSTALLED_COPY}",
 			exc_info=True,
 		)
 		return False
@@ -196,7 +146,7 @@ def isInstalledCopy() -> bool:
 		instDir = winreg.QueryValueEx(k, "UninstallDirectory")[0]
 	except FileNotFoundError:
 		log.debug(
-			f"Unable to find UninstallDirectory value for {RegistryKey.INSTALLED_COPY}"
+			f"Unable to find UninstallDirectory value for {_RegistryKey.INSTALLED_COPY}"
 			"- this may not be an installed copy.",
 		)
 		return False
@@ -218,7 +168,7 @@ def isInstalledCopy() -> bool:
 
 def getInstalledUserConfigPath() -> Optional[str]:
 	try:
-		winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, RegistryKey.NVDA.value)
+		winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, _RegistryKey.NVDA.value)
 	except FileNotFoundError:
 		log.debug("Could not find nvda registry key, NVDA is not currently installed")
 		return None
@@ -327,16 +277,16 @@ def getStartAfterLogon() -> bool:
 	if easeOfAccess.willAutoStart(easeOfAccess.AutoStartContext.AFTER_LOGON):
 		return True
 	try:
-		k = winreg.OpenKey(winreg.HKEY_CURRENT_USER, RegistryKey.RUN.value)
+		k = winreg.OpenKey(winreg.HKEY_CURRENT_USER, _RegistryKey.RUN.value)
 	except FileNotFoundError:
 		log.debugWarning(
-			f"Unable to find run registry key {RegistryKey.RUN}",
+			f"Unable to find run registry key {_RegistryKey.RUN}",
 			exc_info=True,
 		)
 		return False
 	except WindowsError:
 		log.error(
-			f"Unable to open run registry key {RegistryKey.RUN}",
+			f"Unable to open run registry key {_RegistryKey.RUN}",
 			exc_info=True,
 		)
 		return False
@@ -390,7 +340,7 @@ def setStartAfterLogon(enable: bool) -> None:
 		return
 	# We're disabling, so ensure the run key is cleared,
 	# as it might have been set by an old version.
-	k = winreg.OpenKey(winreg.HKEY_CURRENT_USER, RegistryKey.RUN.value, 0, winreg.KEY_WRITE)
+	k = winreg.OpenKey(winreg.HKEY_CURRENT_USER, _RegistryKey.RUN.value, access=winreg.KEY_WRITE)
 	try:
 		winreg.QueryValue(k, "nvda")
 	except FileNotFoundError:
@@ -423,19 +373,19 @@ def getStartOnLogonScreen() -> bool:
 	if easeOfAccess.willAutoStart(easeOfAccess.AutoStartContext.ON_LOGON_SCREEN):
 		return True
 	try:
-		k = winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, RegistryKey.NVDA.value)
+		k = winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, _RegistryKey.NVDA.value)
 	except FileNotFoundError:
-		log.debugWarning(f"Could not find NVDA reg key {RegistryKey.NVDA}", exc_info=True)
+		log.debugWarning(f"Could not find NVDA reg key {_RegistryKey.NVDA}", exc_info=True)
 	except WindowsError:
-		log.error(f"Failed to open NVDA reg key {RegistryKey.NVDA}", exc_info=True)
+		log.error(f"Failed to open NVDA reg key {_RegistryKey.NVDA}", exc_info=True)
 	else:
 		try:
 			return bool(winreg.QueryValueEx(k, "startOnLogonScreen")[0])
 		except FileNotFoundError:
-			log.debug(f"Could not find startOnLogonScreen value for {RegistryKey.NVDA} - likely unset.")
+			log.debug(f"Could not find startOnLogonScreen value for {_RegistryKey.NVDA} - likely unset.")
 			return False
 		except WindowsError:
-			log.error(f"Failed to query startOnLogonScreen value for {RegistryKey.NVDA}", exc_info=True)
+			log.error(f"Failed to query startOnLogonScreen value for {_RegistryKey.NVDA}", exc_info=True)
 			return False
 	return False
 

--- a/source/config/registry.py
+++ b/source/config/registry.py
@@ -23,9 +23,9 @@ class RegistryKey(str, Enum):
 	APP_PATH = rf"{CURRENT_VERSION}\App Paths\nvda.exe"
 	EXPLORER_ADVANCED = rf"{CURRENT_VERSION}\Explorer\Advanced"
 	SYSTEM_POLICIES = rf"{CURRENT_VERSION}\Policies\System"
-	_NT_CURRENT_VERSION = nonmember(rf"{_SOFTWARE}\Microsoft\Windows NT\CurrentVersion")
-	EASE_OF_ACCESS = rf"{_NT_CURRENT_VERSION}\Accessibility"
-	EASE_OF_ACCESS_TEMP = rf"{_NT_CURRENT_VERSION}\AccessibilityTemp"
+	NT_CURRENT_VERSION = rf"{_SOFTWARE}\Microsoft\Windows NT\CurrentVersion"
+	EASE_OF_ACCESS = rf"{NT_CURRENT_VERSION}\Accessibility"
+	EASE_OF_ACCESS_TEMP = rf"{NT_CURRENT_VERSION}\AccessibilityTemp"
 	EASE_OF_ACCESS_APP = rf"{EASE_OF_ACCESS}\ATs\{EASE_OF_ACCESS_APP_KEY_NAME}"
 
 	# Sub keys
@@ -58,7 +58,7 @@ class _RegistryKeyX86(str, Enum):  # type: ignore[reportUnusedClass]
 	APP_PATH = rf"{CURRENT_VERSION}\App Paths\nvda.exe"
 	EXPLORER_ADVANCED = rf"{CURRENT_VERSION}\Explorer\Advanced"
 	SYSTEM_POLICIES = rf"{CURRENT_VERSION}\Policies\System"
-	_NT_CURRENT_VERSION = nonmember(rf"{_SOFTWARE}\Microsoft\Windows NT\CurrentVersion")
-	EASE_OF_ACCESS = rf"{_NT_CURRENT_VERSION}\Accessibility"
-	EASE_OF_ACCESS_TEMP = rf"{_NT_CURRENT_VERSION}\AccessibilityTemp"
+	NT_CURRENT_VERSION = rf"{_SOFTWARE}\Microsoft\Windows NT\CurrentVersion"
+	EASE_OF_ACCESS = rf"{NT_CURRENT_VERSION}\Accessibility"
+	EASE_OF_ACCESS_TEMP = rf"{NT_CURRENT_VERSION}\AccessibilityTemp"
 	EASE_OF_ACCESS_APP = rf"{EASE_OF_ACCESS}\ATs\{EASE_OF_ACCESS_APP_KEY_NAME}"

--- a/source/config/registry.py
+++ b/source/config/registry.py
@@ -1,0 +1,59 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2006-2025 NV Access Limited
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+
+from enum import Enum
+
+
+class RegistryKey(str, Enum):
+	SOFTWARE = "SOFTWARE"
+	r"""
+	The name of the registry key stored under HKEY_LOCAL_MACHINE where system wide NVDA settings are stored.
+	Note that if NVDA is a 32-bit application, on x64 systems,
+	this will evaluate to `r"SOFTWARE\WOW6432Node"`
+	"""
+	CURRENT_VERSION = rf"{SOFTWARE}\Microsoft\Windows\CurrentVersion"
+	INSTALLED_COPY = rf"{CURRENT_VERSION}\Uninstall\NVDA"
+	RUN = rf"{CURRENT_VERSION}\Run"
+	NVDA = rf"{SOFTWARE}\NVDA"
+	APP_PATH = rf"{CURRENT_VERSION}\App Paths\nvda.exe"
+	NT_CURRENT_VERSION = rf"{SOFTWARE}\Microsoft\Windows NT\CurrentVersion"
+	EASE_OF_ACCESS = rf"{NT_CURRENT_VERSION}\Accessibility"
+	EASE_OF_ACCESS_TEMP = rf"{NT_CURRENT_VERSION}\AccessibilityTemp"
+	EASE_OF_ACCESS_APP_KEY_NAME = "nvda_nvda_v1"
+	EASE_OF_ACCESS_APP = rf"{EASE_OF_ACCESS}\ATs\{EASE_OF_ACCESS_APP_KEY_NAME}"
+
+	# Sub keys
+
+	CONFIG_IN_LOCAL_APPDATA_SUBKEY = "configInLocalAppData"
+	"""
+	#6864: The name of the subkey stored under RegistryKey.NVDA where the value is stored
+	which will make an installed NVDA load the user configuration either from the local or from
+	the roaming application data profile.
+	The registry value is unset by default.
+	When setting it manually, a DWORD value is preferred.
+	A value of 0 will evaluate to loading the configuration from the roaming application data (default).
+	A value of 1 means loading the configuration from the local application data folder.
+	"""
+	FORCE_SECURE_MODE_SUBKEY = "forceSecureMode"
+	SERVICE_DEBUG_SUBKEY = "serviceDebug"
+
+
+class _RegistryKeyX86(str, Enum):  # type: ignore[reportUnusedClass]
+	"""
+	Used to access the 32-bit registry view on x64 systems.
+	For cleaning up legacy 32-bit NVDA copies.
+	"""
+
+	SOFTWARE = r"SOFTWARE\WOW6432Node"
+	CURRENT_VERSION = rf"{SOFTWARE}\Microsoft\Windows\CurrentVersion"
+	INSTALLED_COPY = rf"{CURRENT_VERSION}\Uninstall\NVDA"
+	RUN = rf"{CURRENT_VERSION}\Run"
+	NVDA = rf"{SOFTWARE}\NVDA"
+	APP_PATH = rf"{CURRENT_VERSION}\App Paths\nvda.exe"
+	NT_CURRENT_VERSION = rf"{SOFTWARE}\Microsoft\Windows NT\CurrentVersion"
+	EASE_OF_ACCESS = rf"{NT_CURRENT_VERSION}\Accessibility"
+	EASE_OF_ACCESS_TEMP = rf"{NT_CURRENT_VERSION}\AccessibilityTemp"
+	EASE_OF_ACCESS_APP_KEY_NAME = "nvda_nvda_v1"
+	EASE_OF_ACCESS_APP = rf"{EASE_OF_ACCESS}\ATs\{EASE_OF_ACCESS_APP_KEY_NAME}"

--- a/source/config/registry.py
+++ b/source/config/registry.py
@@ -3,25 +3,29 @@
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
-from enum import Enum
+from enum import Enum, nonmember
+
+
+EASE_OF_ACCESS_APP_KEY_NAME = "nvda_nvda_v1"
 
 
 class RegistryKey(str, Enum):
-	SOFTWARE = "SOFTWARE"
+	_SOFTWARE = nonmember("SOFTWARE")
 	r"""
 	The name of the registry key stored under HKEY_LOCAL_MACHINE where system wide NVDA settings are stored.
 	Note that if NVDA is a 32-bit application, on x64 systems,
 	this will evaluate to `r"SOFTWARE\WOW6432Node"`
 	"""
-	CURRENT_VERSION = rf"{SOFTWARE}\Microsoft\Windows\CurrentVersion"
+	CURRENT_VERSION = rf"{_SOFTWARE}\Microsoft\Windows\CurrentVersion"
 	INSTALLED_COPY = rf"{CURRENT_VERSION}\Uninstall\NVDA"
 	RUN = rf"{CURRENT_VERSION}\Run"
-	NVDA = rf"{SOFTWARE}\NVDA"
+	NVDA = rf"{_SOFTWARE}\NVDA"
 	APP_PATH = rf"{CURRENT_VERSION}\App Paths\nvda.exe"
-	NT_CURRENT_VERSION = rf"{SOFTWARE}\Microsoft\Windows NT\CurrentVersion"
-	EASE_OF_ACCESS = rf"{NT_CURRENT_VERSION}\Accessibility"
-	EASE_OF_ACCESS_TEMP = rf"{NT_CURRENT_VERSION}\AccessibilityTemp"
-	EASE_OF_ACCESS_APP_KEY_NAME = "nvda_nvda_v1"
+	EXPLORER_ADVANCED = rf"{CURRENT_VERSION}\Explorer\Advanced"
+	SYSTEM_POLICIES = rf"{CURRENT_VERSION}\Policies\System"
+	_NT_CURRENT_VERSION = nonmember(rf"{_SOFTWARE}\Microsoft\Windows NT\CurrentVersion")
+	EASE_OF_ACCESS = rf"{_NT_CURRENT_VERSION}\Accessibility"
+	EASE_OF_ACCESS_TEMP = rf"{_NT_CURRENT_VERSION}\AccessibilityTemp"
 	EASE_OF_ACCESS_APP = rf"{EASE_OF_ACCESS}\ATs\{EASE_OF_ACCESS_APP_KEY_NAME}"
 
 	# Sub keys
@@ -46,14 +50,15 @@ class _RegistryKeyX86(str, Enum):  # type: ignore[reportUnusedClass]
 	For cleaning up legacy 32-bit NVDA copies.
 	"""
 
-	SOFTWARE = r"SOFTWARE\WOW6432Node"
-	CURRENT_VERSION = rf"{SOFTWARE}\Microsoft\Windows\CurrentVersion"
+	_SOFTWARE = nonmember(r"SOFTWARE\WOW6432Node")
+	CURRENT_VERSION = rf"{_SOFTWARE}\Microsoft\Windows\CurrentVersion"
 	INSTALLED_COPY = rf"{CURRENT_VERSION}\Uninstall\NVDA"
 	RUN = rf"{CURRENT_VERSION}\Run"
-	NVDA = rf"{SOFTWARE}\NVDA"
+	NVDA = rf"{_SOFTWARE}\NVDA"
 	APP_PATH = rf"{CURRENT_VERSION}\App Paths\nvda.exe"
-	NT_CURRENT_VERSION = rf"{SOFTWARE}\Microsoft\Windows NT\CurrentVersion"
-	EASE_OF_ACCESS = rf"{NT_CURRENT_VERSION}\Accessibility"
-	EASE_OF_ACCESS_TEMP = rf"{NT_CURRENT_VERSION}\AccessibilityTemp"
-	EASE_OF_ACCESS_APP_KEY_NAME = "nvda_nvda_v1"
+	EXPLORER_ADVANCED = rf"{CURRENT_VERSION}\Explorer\Advanced"
+	SYSTEM_POLICIES = rf"{CURRENT_VERSION}\Policies\System"
+	_NT_CURRENT_VERSION = nonmember(rf"{_SOFTWARE}\Microsoft\Windows NT\CurrentVersion")
+	EASE_OF_ACCESS = rf"{_NT_CURRENT_VERSION}\Accessibility"
+	EASE_OF_ACCESS_TEMP = rf"{_NT_CURRENT_VERSION}\AccessibilityTemp"
 	EASE_OF_ACCESS_APP = rf"{EASE_OF_ACCESS}\ATs\{EASE_OF_ACCESS_APP_KEY_NAME}"

--- a/source/easeOfAccess.py
+++ b/source/easeOfAccess.py
@@ -24,6 +24,7 @@ def __getattr__(attrName: str) -> Any:
 			ROOT = _RegistryKey.EASE_OF_ACCESS
 			TEMP = _RegistryKey.EASE_OF_ACCESS_TEMP
 			APP = _RegistryKey.EASE_OF_ACCESS_APP
+
 		return RegistryKey
 
 	if attrName == "ROOT_KEY" and NVDAState._allowDeprecatedAPI():
@@ -122,7 +123,9 @@ def _getAutoStartConfiguration(autoStartContext: AutoStartContext) -> list[str]:
 		log.debug(f"Unable to find existing {autoStartContext} {_RegistryKey.EASE_OF_ACCESS}")
 		return []
 	except WindowsError:
-		log.error(f"Unable to open {autoStartContext} {_RegistryKey.EASE_OF_ACCESS} for reading", exc_info=True)
+		log.error(
+			f"Unable to open {autoStartContext} {_RegistryKey.EASE_OF_ACCESS} for reading", exc_info=True
+		)
 		return []
 
 	try:
@@ -130,7 +133,9 @@ def _getAutoStartConfiguration(autoStartContext: AutoStartContext) -> list[str]:
 	except FileNotFoundError:
 		log.debug(f"Unable to find {autoStartContext} {_RegistryKey.EASE_OF_ACCESS} configuration")
 	except WindowsError:
-		log.error(f"Unable to query {autoStartContext} {_RegistryKey.EASE_OF_ACCESS} configuration", exc_info=True)
+		log.error(
+			f"Unable to query {autoStartContext} {_RegistryKey.EASE_OF_ACCESS} configuration", exc_info=True
+		)
 	else:
 		if not conf[0]:
 			# "".split(",") returns [""], so remove the empty string.

--- a/source/easeOfAccess.py
+++ b/source/easeOfAccess.py
@@ -21,9 +21,9 @@ def __getattr__(attrName: str) -> Any:
 		log.warning("easeOfAccess.RegistryKey is deprecated, use config.RegistryKey instead.")
 
 		class RegistryKey(str, Enum):
-			ROOT = _RegistryKey.EASE_OF_ACCESS
-			TEMP = _RegistryKey.EASE_OF_ACCESS_TEMP
-			APP = _RegistryKey.EASE_OF_ACCESS_APP
+			ROOT = _RegistryKey.EASE_OF_ACCESS.value
+			TEMP = _RegistryKey.EASE_OF_ACCESS_TEMP.value
+			APP = _RegistryKey.EASE_OF_ACCESS_APP.value
 
 		return RegistryKey
 

--- a/source/easeOfAccess.py
+++ b/source/easeOfAccess.py
@@ -124,7 +124,8 @@ def _getAutoStartConfiguration(autoStartContext: AutoStartContext) -> list[str]:
 		return []
 	except WindowsError:
 		log.error(
-			f"Unable to open {autoStartContext} {_RegistryKey.EASE_OF_ACCESS} for reading", exc_info=True
+			f"Unable to open {autoStartContext} {_RegistryKey.EASE_OF_ACCESS} for reading",
+			exc_info=True,
 		)
 		return []
 
@@ -134,7 +135,8 @@ def _getAutoStartConfiguration(autoStartContext: AutoStartContext) -> list[str]:
 		log.debug(f"Unable to find {autoStartContext} {_RegistryKey.EASE_OF_ACCESS} configuration")
 	except WindowsError:
 		log.error(
-			f"Unable to query {autoStartContext} {_RegistryKey.EASE_OF_ACCESS} configuration", exc_info=True
+			f"Unable to query {autoStartContext} {_RegistryKey.EASE_OF_ACCESS} configuration",
+			exc_info=True,
 		)
 	else:
 		if not conf[0]:

--- a/source/easeOfAccess.py
+++ b/source/easeOfAccess.py
@@ -8,7 +8,7 @@
 from enum import Enum, IntEnum
 from typing import Any
 
-from config.registry import RegistryKey as _RegistryKey
+from config.registry import RegistryKey as _RegistryKey, EASE_OF_ACCESS_APP_KEY_NAME
 from logHandler import log
 import NVDAState
 import winreg
@@ -18,7 +18,7 @@ import winUser
 def __getattr__(attrName: str) -> Any:
 	"""Module level `__getattr__` used to preserve backward compatibility."""
 	if attrName == "RegistryKey" and NVDAState._allowDeprecatedAPI():
-		log.warning("easeOfAccess.RegistryKey is deprecated, use config.RegistryKey instead.")
+		log.warning("easeOfAccess.RegistryKey is deprecated, use config.registry.RegistryKey instead.")
 
 		class RegistryKey(str, Enum):
 			ROOT = _RegistryKey.EASE_OF_ACCESS.value
@@ -28,14 +28,14 @@ def __getattr__(attrName: str) -> Any:
 		return RegistryKey
 
 	if attrName == "ROOT_KEY" and NVDAState._allowDeprecatedAPI():
-		log.warning("ROOT_KEY is deprecated, use config.RegistryKey.EASE_OF_ACCESS instead.")
+		log.warning("ROOT_KEY is deprecated, use config.registry.RegistryKey.EASE_OF_ACCESS instead.")
 		return _RegistryKey.EASE_OF_ACCESS.value
 	if attrName == "APP_KEY_PATH" and NVDAState._allowDeprecatedAPI():
-		log.warning("APP_KEY_PATH is deprecated, use config.RegistryKey.EASE_OF_ACCESS_APP instead.")
+		log.warning("APP_KEY_PATH is deprecated, use config.registry.RegistryKey.EASE_OF_ACCESS_APP instead.")
 		return _RegistryKey.EASE_OF_ACCESS_APP.value
 	if attrName == "APP_KEY_NAME" and NVDAState._allowDeprecatedAPI():
-		log.warning("APP_KEY_NAME is deprecated, use config.RegistryKey.EASE_OF_ACCESS_APP_KEY_NAME instead.")
-		return _RegistryKey.EASE_OF_ACCESS_APP_KEY_NAME.value
+		log.warning("APP_KEY_NAME is deprecated, use config.registry.EASE_OF_ACCESS_APP_KEY_NAME instead.")
+		return EASE_OF_ACCESS_APP_KEY_NAME
 	if attrName == "canConfigTerminateOnDesktopSwitch" and NVDAState._allowDeprecatedAPI():
 		log.warning("canConfigTerminateOnDesktopSwitch is deprecated.")
 		return True
@@ -68,7 +68,7 @@ def notify(signal):
 	if not isRegistered():
 		return
 	with winreg.CreateKey(winreg.HKEY_CURRENT_USER, _RegistryKey.EASE_OF_ACCESS_TEMP.value) as rkey:
-		winreg.SetValueEx(rkey, _RegistryKey.EASE_OF_ACCESS_APP_KEY_NAME, None, winreg.REG_DWORD, signal)
+		winreg.SetValueEx(rkey, EASE_OF_ACCESS_APP_KEY_NAME, None, winreg.REG_DWORD, signal)
 	keys = []
 	# The user might be holding unwanted modifiers.
 	for vk in winUser.VK_SHIFT, winUser.VK_CONTROL, winUser.VK_MENU:
@@ -101,7 +101,7 @@ def willAutoStart(autoStartContext: AutoStartContext) -> bool:
 
 	Returns False on failure
 	"""
-	return _RegistryKey.EASE_OF_ACCESS_APP_KEY_NAME in _getAutoStartConfiguration(autoStartContext)
+	return EASE_OF_ACCESS_APP_KEY_NAME in _getAutoStartConfiguration(autoStartContext)
 
 
 def _getAutoStartConfiguration(autoStartContext: AutoStartContext) -> list[str]:
@@ -155,14 +155,14 @@ def setAutoStart(autoStartContext: AutoStartContext, enable: bool) -> None:
 	Raises `Union[WindowsError, FileNotFoundError]`
 	"""
 	conf = _getAutoStartConfiguration(autoStartContext)
-	currentlyEnabled = _RegistryKey.EASE_OF_ACCESS_APP_KEY_NAME in conf
+	currentlyEnabled = EASE_OF_ACCESS_APP_KEY_NAME in conf
 	changed = False
 
 	if enable and not currentlyEnabled:
-		conf.append(_RegistryKey.EASE_OF_ACCESS_APP_KEY_NAME)
+		conf.append(EASE_OF_ACCESS_APP_KEY_NAME)
 		changed = True
 	elif not enable and currentlyEnabled:
-		conf.remove(_RegistryKey.EASE_OF_ACCESS_APP_KEY_NAME)
+		conf.remove(EASE_OF_ACCESS_APP_KEY_NAME)
 		changed = True
 
 	if changed:

--- a/source/easeOfAccess.py
+++ b/source/easeOfAccess.py
@@ -1,43 +1,44 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2014-2023 NV Access Limited
+# Copyright (C) 2014-2025 NV Access Limited
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
 """Utilities for working with the Windows Ease of Access Center."""
 
 from enum import Enum, IntEnum
-from typing import Any, List
+from typing import Any
 
+from config import RegistryKey as _RegistryKey
 from logHandler import log
 import NVDAState
 import winreg
 import winUser
 
 
-_APP_KEY_NAME = "nvda_nvda_v1"
-
-
 def __getattr__(attrName: str) -> Any:
 	"""Module level `__getattr__` used to preserve backward compatibility."""
+	if attrName == "RegistryKey" and NVDAState._allowDeprecatedAPI():
+		log.warning("easeOfAccess.RegistryKey is deprecated, use config.RegistryKey instead.")
+
+		class RegistryKey(str, Enum):
+			ROOT = _RegistryKey.EASE_OF_ACCESS
+			TEMP = _RegistryKey.EASE_OF_ACCESS_TEMP
+			APP = _RegistryKey.EASE_OF_ACCESS_APP
+		return RegistryKey
+
 	if attrName == "ROOT_KEY" and NVDAState._allowDeprecatedAPI():
-		log.warning("ROOT_KEY is deprecated, use RegistryKey.ROOT instead.")
-		return RegistryKey.ROOT.value
+		log.warning("ROOT_KEY is deprecated, use config.RegistryKey.EASE_OF_ACCESS instead.")
+		return _RegistryKey.EASE_OF_ACCESS.value
 	if attrName == "APP_KEY_PATH" and NVDAState._allowDeprecatedAPI():
-		log.warning("APP_KEY_PATH is deprecated, use RegistryKey.APP instead.")
-		return RegistryKey.APP.value
+		log.warning("APP_KEY_PATH is deprecated, use config.RegistryKey.EASE_OF_ACCESS_APP instead.")
+		return _RegistryKey.EASE_OF_ACCESS_APP.value
 	if attrName == "APP_KEY_NAME" and NVDAState._allowDeprecatedAPI():
-		log.warning("APP_KEY_NAME is deprecated.")
-		return _APP_KEY_NAME
+		log.warning("APP_KEY_NAME is deprecated, use config.RegistryKey.EASE_OF_ACCESS_APP_KEY_NAME instead.")
+		return _RegistryKey.EASE_OF_ACCESS_APP_KEY_NAME.value
 	if attrName == "canConfigTerminateOnDesktopSwitch" and NVDAState._allowDeprecatedAPI():
 		log.warning("canConfigTerminateOnDesktopSwitch is deprecated.")
 		return True
 	raise AttributeError(f"module {repr(__name__)} has no attribute {repr(attrName)}")
-
-
-class RegistryKey(str, Enum):
-	ROOT = r"Software\Microsoft\Windows NT\CurrentVersion\Accessibility"
-	TEMP = r"Software\Microsoft\Windows NT\CurrentVersion\AccessibilityTemp"
-	APP = r"%s\ATs\%s" % (ROOT, _APP_KEY_NAME)
 
 
 class AutoStartContext(IntEnum):
@@ -51,7 +52,7 @@ def isRegistered() -> bool:
 	try:
 		winreg.OpenKey(
 			winreg.HKEY_LOCAL_MACHINE,
-			RegistryKey.APP.value,
+			_RegistryKey.EASE_OF_ACCESS_APP.value,
 			0,
 			winreg.KEY_READ | winreg.KEY_WOW64_64KEY,
 		)
@@ -66,8 +67,8 @@ def isRegistered() -> bool:
 def notify(signal):
 	if not isRegistered():
 		return
-	with winreg.CreateKey(winreg.HKEY_CURRENT_USER, RegistryKey.TEMP.value) as rkey:
-		winreg.SetValueEx(rkey, _APP_KEY_NAME, None, winreg.REG_DWORD, signal)
+	with winreg.CreateKey(winreg.HKEY_CURRENT_USER, _RegistryKey.EASE_OF_ACCESS_TEMP.value) as rkey:
+		winreg.SetValueEx(rkey, _RegistryKey.EASE_OF_ACCESS_APP_KEY_NAME, None, winreg.REG_DWORD, signal)
 	keys = []
 	# The user might be holding unwanted modifiers.
 	for vk in winUser.VK_SHIFT, winUser.VK_CONTROL, winUser.VK_MENU:
@@ -100,10 +101,10 @@ def willAutoStart(autoStartContext: AutoStartContext) -> bool:
 
 	Returns False on failure
 	"""
-	return _APP_KEY_NAME in _getAutoStartConfiguration(autoStartContext)
+	return _RegistryKey.EASE_OF_ACCESS_APP_KEY_NAME in _getAutoStartConfiguration(autoStartContext)
 
 
-def _getAutoStartConfiguration(autoStartContext: AutoStartContext) -> List[str]:
+def _getAutoStartConfiguration(autoStartContext: AutoStartContext) -> list[str]:
 	"""Based on autoStartContext, returns a list of app names which start automatically:
 	 - AutoStartContext.ON_LOGON_SCREEN : on the logon screen
 	 - AutoStartContext.AFTER_LOGON : after logging on
@@ -113,23 +114,23 @@ def _getAutoStartConfiguration(autoStartContext: AutoStartContext) -> List[str]:
 	try:
 		k = winreg.OpenKey(
 			autoStartContext.value,
-			RegistryKey.ROOT.value,
+			_RegistryKey.EASE_OF_ACCESS.value,
 			0,
 			winreg.KEY_READ | winreg.KEY_WOW64_64KEY,
 		)
 	except FileNotFoundError:
-		log.debug(f"Unable to find existing {autoStartContext} {RegistryKey.ROOT}")
+		log.debug(f"Unable to find existing {autoStartContext} {_RegistryKey.EASE_OF_ACCESS}")
 		return []
 	except WindowsError:
-		log.error(f"Unable to open {autoStartContext} {RegistryKey.ROOT} for reading", exc_info=True)
+		log.error(f"Unable to open {autoStartContext} {_RegistryKey.EASE_OF_ACCESS} for reading", exc_info=True)
 		return []
 
 	try:
-		conf: List[str] = winreg.QueryValueEx(k, "Configuration")[0].split(",")
+		conf: list[str] = winreg.QueryValueEx(k, "Configuration")[0].split(",")
 	except FileNotFoundError:
-		log.debug(f"Unable to find {autoStartContext} {RegistryKey.ROOT} configuration")
+		log.debug(f"Unable to find {autoStartContext} {_RegistryKey.EASE_OF_ACCESS} configuration")
 	except WindowsError:
-		log.error(f"Unable to query {autoStartContext} {RegistryKey.ROOT} configuration", exc_info=True)
+		log.error(f"Unable to query {autoStartContext} {_RegistryKey.EASE_OF_ACCESS} configuration", exc_info=True)
 	else:
 		if not conf[0]:
 			# "".split(",") returns [""], so remove the empty string.
@@ -149,20 +150,20 @@ def setAutoStart(autoStartContext: AutoStartContext, enable: bool) -> None:
 	Raises `Union[WindowsError, FileNotFoundError]`
 	"""
 	conf = _getAutoStartConfiguration(autoStartContext)
-	currentlyEnabled = _APP_KEY_NAME in conf
+	currentlyEnabled = _RegistryKey.EASE_OF_ACCESS_APP_KEY_NAME in conf
 	changed = False
 
 	if enable and not currentlyEnabled:
-		conf.append(_APP_KEY_NAME)
+		conf.append(_RegistryKey.EASE_OF_ACCESS_APP_KEY_NAME)
 		changed = True
 	elif not enable and currentlyEnabled:
-		conf.remove(_APP_KEY_NAME)
+		conf.remove(_RegistryKey.EASE_OF_ACCESS_APP_KEY_NAME)
 		changed = True
 
 	if changed:
 		k = winreg.OpenKey(
 			autoStartContext.value,
-			RegistryKey.ROOT.value,
+			_RegistryKey.EASE_OF_ACCESS.value,
 			0,
 			winreg.KEY_READ | winreg.KEY_WRITE | winreg.KEY_WOW64_64KEY,
 		)

--- a/source/easeOfAccess.py
+++ b/source/easeOfAccess.py
@@ -52,6 +52,7 @@ class AutoStartContext(IntEnum):
 
 def isRegistered() -> bool:
 	from config import RegistryKey
+
 	try:
 		winreg.OpenKey(
 			winreg.HKEY_LOCAL_MACHINE,
@@ -69,6 +70,7 @@ def isRegistered() -> bool:
 
 def notify(signal):
 	from config import RegistryKey
+
 	if not isRegistered():
 		return
 	with winreg.CreateKey(winreg.HKEY_CURRENT_USER, RegistryKey.EASE_OF_ACCESS_TEMP.value) as rkey:
@@ -106,6 +108,7 @@ def willAutoStart(autoStartContext: AutoStartContext) -> bool:
 	Returns False on failure
 	"""
 	from config import RegistryKey
+
 	return RegistryKey.EASE_OF_ACCESS_APP_KEY_NAME in _getAutoStartConfiguration(autoStartContext)
 
 
@@ -117,6 +120,7 @@ def _getAutoStartConfiguration(autoStartContext: AutoStartContext) -> list[str]:
 	Returns an empty list on failure.
 	"""
 	from config import RegistryKey
+
 	try:
 		k = winreg.OpenKey(
 			autoStartContext.value,
@@ -162,6 +166,7 @@ def setAutoStart(autoStartContext: AutoStartContext, enable: bool) -> None:
 	Raises `Union[WindowsError, FileNotFoundError]`
 	"""
 	from config import RegistryKey
+
 	conf = _getAutoStartConfiguration(autoStartContext)
 	currentlyEnabled = RegistryKey.EASE_OF_ACCESS_APP_KEY_NAME in conf
 	changed = False

--- a/source/installer.py
+++ b/source/installer.py
@@ -861,7 +861,7 @@ def createPortableCopy(destPath, shouldCopyUserConfig=True):
 def registerEaseOfAccess(installDir):
 	with winreg.CreateKeyEx(
 		winreg.HKEY_LOCAL_MACHINE,
-		RegistryKey.EASE_OF_ACCESS_APP,
+		RegistryKey.EASE_OF_ACCESS_APP.value,
 		0,
 		winreg.KEY_ALL_ACCESS | winreg.KEY_WOW64_64KEY,
 	) as appKey:

--- a/source/installer.py
+++ b/source/installer.py
@@ -16,7 +16,7 @@ import shellapi
 import globalVars
 import languageHandler
 import config
-from config import RegistryKey
+from config.registry import RegistryKey
 import versionInfo
 from logHandler import log
 import addonHandler
@@ -627,7 +627,7 @@ def unregisterAddonFileAssociation():
 
 # Windows API call regDeleteTree is only available on vist and above so rule our own.
 def _deleteKeyAndSubkeys(key, subkey):
-	with winreg.OpenKey(key, subkey, 0, winreg.KEY_WRITE | winreg.KEY_READ) as k:
+	with winreg.OpenKey(key, subkey, access=winreg.KEY_WRITE | winreg.KEY_READ) as k:
 		# Recursively delete subkeys (Depth first search order)
 		# So Pythonic... </rant>
 		for i in itertools.count():

--- a/source/mathType.py
+++ b/source/mathType.py
@@ -17,8 +17,7 @@ def _getDllPath():
 	with winreg.OpenKey(
 		winreg.HKEY_LOCAL_MACHINE,
 		r"SOFTWARE\Design Science\DSMT6\Directories",
-		0,
-		winreg.KEY_WOW64_32KEY | winreg.KEY_QUERY_VALUE,
+		access=winreg.KEY_WOW64_32KEY | winreg.KEY_QUERY_VALUE,
 	) as key:
 		return winreg.QueryValueEx(key, "AppSystemDir32")[0] + "\\MT6.dll"
 

--- a/source/systemUtils.py
+++ b/source/systemUtils.py
@@ -195,6 +195,7 @@ def _isSystemClockSecondsVisible() -> bool:
 	@return: True if the 'ShowSecondsInSystemClock' value is 1, False otherwise.
 	"""
 	from config.registry import RegistryKey
+
 	registry_path = rf"{RegistryKey.CURRENT_VERSION.value}\Explorer\Advanced"
 	value_name = "ShowSecondsInSystemClock"
 	try:

--- a/source/systemUtils.py
+++ b/source/systemUtils.py
@@ -197,10 +197,9 @@ def _isSystemClockSecondsVisible() -> bool:
 	# Import here to prevent circular import
 	from config.registry import RegistryKey
 
-	registry_path = rf"{RegistryKey.CURRENT_VERSION.value}\Explorer\Advanced"
 	value_name = "ShowSecondsInSystemClock"
 	try:
-		with winreg.OpenKey(winreg.HKEY_CURRENT_USER, registry_path) as key:
+		with winreg.OpenKey(winreg.HKEY_CURRENT_USER, RegistryKey.EXPLORER_ADVANCED.value) as key:
 			value, value_type = winreg.QueryValueEx(key, value_name)
 			return value == 1 and value_type == winreg.REG_DWORD
 	except FileNotFoundError:

--- a/source/systemUtils.py
+++ b/source/systemUtils.py
@@ -28,6 +28,7 @@ from typing_extensions import (
 	TypeVar,
 )
 
+from config import RegistryKey
 import winKernel
 import winreg
 import shellapi
@@ -194,7 +195,7 @@ def _isSystemClockSecondsVisible() -> bool:
 
 	@return: True if the 'ShowSecondsInSystemClock' value is 1, False otherwise.
 	"""
-	registry_path = r"SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced"
+	registry_path = rf"{RegistryKey.CURRENT_VERSION.value}\Explorer\Advanced"
 	value_name = "ShowSecondsInSystemClock"
 	try:
 		with winreg.OpenKey(winreg.HKEY_CURRENT_USER, registry_path) as key:

--- a/source/systemUtils.py
+++ b/source/systemUtils.py
@@ -28,7 +28,6 @@ from typing_extensions import (
 	TypeVar,
 )
 
-from config import RegistryKey
 import winKernel
 import winreg
 import shellapi
@@ -195,6 +194,7 @@ def _isSystemClockSecondsVisible() -> bool:
 
 	@return: True if the 'ShowSecondsInSystemClock' value is 1, False otherwise.
 	"""
+	from config.registry import RegistryKey
 	registry_path = rf"{RegistryKey.CURRENT_VERSION.value}\Explorer\Advanced"
 	value_name = "ShowSecondsInSystemClock"
 	try:

--- a/source/systemUtils.py
+++ b/source/systemUtils.py
@@ -194,6 +194,7 @@ def _isSystemClockSecondsVisible() -> bool:
 
 	@return: True if the 'ShowSecondsInSystemClock' value is 1, False otherwise.
 	"""
+	# Import here to prevent circular import
 	from config.registry import RegistryKey
 
 	registry_path = rf"{RegistryKey.CURRENT_VERSION.value}\Explorer\Advanced"

--- a/source/winVersion.py
+++ b/source/winVersion.py
@@ -17,7 +17,7 @@ import functools
 import winreg
 import platform
 import NVDAState
-from config import RegistryKey
+from config.registry import RegistryKey
 from logHandler import log
 
 

--- a/source/winVersion.py
+++ b/source/winVersion.py
@@ -17,6 +17,7 @@ import functools
 import winreg
 import platform
 import NVDAState
+from config import RegistryKey
 from logHandler import log
 
 
@@ -54,7 +55,7 @@ def _getRunningVersionNameFromWinReg() -> str:
 	# Cache the version in use on the system.
 	with winreg.OpenKey(
 		winreg.HKEY_LOCAL_MACHINE,
-		r"Software\Microsoft\Windows NT\CurrentVersion",
+		RegistryKey.NT_CURRENT_VERSION.value,
 	) as currentVersion:
 		# Version 20H2 and later where a separate display version string is used.
 		try:
@@ -192,7 +193,7 @@ def getWinVer():
 	# UBR is updated whenever cumulative updates are applied.
 	with winreg.OpenKey(
 		winreg.HKEY_LOCAL_MACHINE,
-		r"Software\Microsoft\Windows NT\CurrentVersion",
+		RegistryKey.NT_CURRENT_VERSION.value,
 	) as currentVersion:
 		buildRevision = winreg.QueryValueEx(currentVersion, "UBR")[0]
 	return WinVersion(

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -53,6 +53,7 @@ Please refer to [the developer guide](https://download.nvaccess.org/documentatio
   * `LP_c_ulong`
   * `LP__ULARGE_INTEGER`
   * `SynthDriver.isSpeaking`
+* `easeOfAccess.RegistryKey` is deprecated, use `config.RegistryKey` instead. (#18608)
 
 ## 2025.2
 
@@ -2063,7 +2064,7 @@ This can dramatically decrease build times on multi core systems. (#13226, #1337
 * Moved the UWP/OneCore interaction layer of NVDAHelper [from C++/CX to C++/Winrt](https://docs.microsoft.com/en-us/windows/uwp/cpp-and-winrt-apis/move-to-winrt-from-cx). (#10662)
 * It is now mandatory to subclass `DictionaryDialog` to use it. (#13268)
 * `config.RUN_REGKEY`, `config.NVDA_REGKEY` are deprecated, please use `config.RegistryKey.RUN`, `config.RegistryKey.NVDA` instead. These will be removed in 2023. (#13242)
-* `easeOfAccess.ROOT_KEY`, `easeOfAccess.APP_KEY_PATH` are deprecated, please use`easeOfAccess.RegistryKey.ROOT`, `easeOfAccess.RegistryKey.APP` instead. These will be removed in 2023. (#13242)
+* `easeOfAccess.ROOT_KEY`, `easeOfAccess.APP_KEY_PATH` are deprecated, please use`easeOfAccess.RegistryKey.EASE_OF_ACCESS`, `easeOfAccess.RegistryKey.APP` instead. These will be removed in 2023. (#13242)
 * `easeOfAccess.APP_KEY_NAME` has been deprecated, to be removed in 2023. (#13242)
 * `DictionaryDialog` and `DictionaryEntryDialog` are moved from `gui.settingsDialogs` to `gui.speechDict`. (#13294)
 * IAccessible2 relations are now shown in developer info for IAccessible2 objects. (#13315)

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -53,7 +53,7 @@ Please refer to [the developer guide](https://download.nvaccess.org/documentatio
   * `LP_c_ulong`
   * `LP__ULARGE_INTEGER`
   * `SynthDriver.isSpeaking`
-* `easeOfAccess.RegistryKey` is deprecated, use `config.RegistryKey` instead. (#18608)
+* `easeOfAccess.RegistryKey` and `config.RegistryKey` is deprecated, use `config.registry.RegistryKey` instead. (#18608)
 
 ## 2025.2
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -2064,7 +2064,7 @@ This can dramatically decrease build times on multi core systems. (#13226, #1337
 * Moved the UWP/OneCore interaction layer of NVDAHelper [from C++/CX to C++/Winrt](https://docs.microsoft.com/en-us/windows/uwp/cpp-and-winrt-apis/move-to-winrt-from-cx). (#10662)
 * It is now mandatory to subclass `DictionaryDialog` to use it. (#13268)
 * `config.RUN_REGKEY`, `config.NVDA_REGKEY` are deprecated, please use `config.RegistryKey.RUN`, `config.RegistryKey.NVDA` instead. These will be removed in 2023. (#13242)
-* `easeOfAccess.ROOT_KEY`, `easeOfAccess.APP_KEY_PATH` are deprecated, please use`easeOfAccess.RegistryKey.EASE_OF_ACCESS`, `easeOfAccess.RegistryKey.APP` instead. These will be removed in 2023. (#13242)
+* `easeOfAccess.ROOT_KEY`, `easeOfAccess.APP_KEY_PATH` are deprecated, please use`easeOfAccess.RegistryKey.ROOT`, `easeOfAccess.RegistryKey.APP` instead. These will be removed in 2023. (#13242)
 * `easeOfAccess.APP_KEY_NAME` has been deprecated, to be removed in 2023. (#13242)
 * `DictionaryDialog` and `DictionaryEntryDialog` are moved from `gui.settingsDialogs` to `gui.speechDict`. (#13294)
 * IAccessible2 relations are now shown in developer info for IAccessible2 objects. (#13315)


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Prep work for #16304

### Summary of the issue:
Registry keys are not consistently encapsulated in the NVDA code base.
When migrating to 64bit, we need to be able to fetch legacy 32bit versions of registry keys from the 64bit version.
Having more clear encapsulation of registry keys will make this easier.

### Description of user facing changes:

### Description of developer facing changes:
Deprecates `easeOfAccess.RegistryKey` for a more unified approach

### Description of development approach:
- Moved all major NVDA registry keys into `config.RegistryKey`. Create an `x86` version of this for use in the 64bit migration.
- Removed usages of the [reserved 0 parameter](https://docs.python.org/3/library/winreg.html#winreg.OpenKey). The magic number should either be documented as a constant or not used. it's available as `winreg.REG_OPTION_RESERVED` but this is not documented or part of the official python API. Rather than making a named constant, the value can only be the default value so it seems cleaner to drop it.

### Testing strategy:
Ensure nothing breaks in smoke testing

### Known issues with pull request:
None
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
