### PR TITLE
winVersion.getWinVer: set update revision to 0 if UBR cannot be accessed via Widows Registry

### DIFF
--- a/source/winVersion.py
+++ b/source/winVersion.py
@@ -194,7 +194,12 @@ def getWinVer():
 		winreg.HKEY_LOCAL_MACHINE,
 		r"Software\Microsoft\Windows NT\CurrentVersion",
 	) as currentVersion:
-		buildRevision = winreg.QueryValueEx(currentVersion, "UBR")[0]
+		# #18617: in Windows 8.1, attempting to access the below registry path results inn an error.
+		# Therefore, set UBR (update build revision) to 0.
+		try:
+			buildRevision = winreg.QueryValueEx(currentVersion, "UBR")[0]
+		except FileNotFoundError:
+			buildRevision = 0
 	return WinVersion(
 		major=winVer.major,
 		minor=winVer.minor,


### PR DESCRIPTION

### Link to issue number:
Closes #18617 

### Summary of the issue:
In Windows 8.1, attempting to access Windows Registry to obtain update build revision (UBR) results in file not found error and the snapshot installer no longer starts.

### Description of user facing changes:
Alpha/beta builds can be installed on Windows 8.1 again.

### Description of developer facing changes:
If UBR cannot be obtained, build revision will be set to 0.

### Description of development approach:
in winVersion module, put build revision assignment inside a try block, and set build revision to 0 if an exception occurs while accessing the registry. In Windows 8.1, this will result in NVDA reporting "6.3.9600.0" which is acceptable as Windows 8.1 (client version) is no longer supported by Microsoft (Windows Server 2012 R2 is supported under extended security updates program).

### Testing strategy:
Manual testing: Windows 8.1/Server 2012 R2 users must report back on success of this PR.

### Known issues with pull request:
None so far

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
