### PR TITLE
Disable beta appveyor builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,10 +7,6 @@ version: "{branch}-{build}"
 
 branches:
  only:
-  - master
-  - beta
-  - rc
-  - /try-.*/
   - /release-.*/
 
 environment:


### PR DESCRIPTION
Takes #18555 to beta to prevent beta/rc PRs and snapshots from building on appveyor
