### PR TITLE
Fix tests: "NVDA restarts on quit" and first time opening notepad failing

### DIFF
--- a/tests/system/robot/startupShutdownNVDA.py
+++ b/tests/system/robot/startupShutdownNVDA.py
@@ -223,7 +223,7 @@ def _ensureRestartWithCrashDump(crashFunction: _Callable[[], None]):
 	crashFunction()
 	_blockUntilConditionMet(
 		getValue=lambda: windowWithHandleExists(oldMsgWindowHandle) is False,
-		giveUpAfterSeconds=3,
+		giveUpAfterSeconds=10,
 		errorMessage="Old NVDA is still running",
 	)
 	_builtIn.should_not_be_true(


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Fixes some issues from #18597 

### Summary of the issue:

- Our timeout for waiting for NVDA exit when a crash is triggered is only 3 seconds. Our timeout is 10 seconds for when testing for testing NVDA to restart normally. This is causing the test to fail regularly
- Starting notepad is fragile. If notepad doesn't load before we open task switcher, then it may fail to get focus. This results in the first notepad test regularly failing.


### Description of user facing changes:
none
### Description of developer facing changes:
none
### Description of development approach:

- The timeout for waiting for NVDA to exit after a crash is triggered is increased.
- When starting notepad, we first wait to see if it gets focus normally. If not, we try to task switch to it. This gives ample time for notepad to load, and avoids task switching if its not necessary

### Testing strategy:

Ran [each test 50 times](https://github.com/nvaccess/nvda/actions/runs/16769835223)

results:
17 failures out of 50 runs of 4 test suites.
This is around the same rate as #18597, however there is an increase to timeout issues (likely due to reduced resources for 50x4 matrix jobs).
It is likely that these timeout issues will occur with a lower frequency on normal builds.

Test failures:

- "Speech did not finish before timeout" - 7
- "Timed out waiting for key to be processed" - 4
- "Timed out waiting for core to sleep again" - 2
- "Unable to get chrome window" - 1
- "Unable to get notepad window" - 1
- "Unable to connect to nvdaSpyLib" - 1
- "Focus mode: report content editable with details braille Actual != Expected: Focus mode != The word hlght has cmnt cat hlght end has a comment tied to it." - 1

Note that the failures noted in #18597 and targeted by this fix do not occur:
Startup/shutdown:

- 5x: Ensure NVDA restarts on crash: Old NVDA is still running.
- 3x: symbolInSpeechUI :: Ensure symbols aren't substituted within NVDA. Unable to focus Notepad.



### Known issues with pull request:

see test failures

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
