### PR TITLE
preserve tabs in codefences

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,11 +42,12 @@ dependencies = [
 	# l10nUtil requires Crowdin
 	"crowdin-api-client==1.21.0",
 	# Building user documentation and the l10nUtil
-	"Markdown==3.7",
+	"Markdown==3.8.2",
 	"lxml==5.3.2",
 	"mdx_truly_sane_lists==1.3",
 	"markdown-link-attr-modifier==0.2.1",
 	"mdx-gh-links==0.4",
+	"pymdown-extensions==10.16.1",
 ]
 
 [project.urls]

--- a/source/md2html.py
+++ b/source/md2html.py
@@ -41,7 +41,7 @@ def __getattr__(attrName: str) -> Any:
 			# Include stack info so testers can report warning to add-on author.
 			stack_info=True,
 		)
-		# Ensure the API of deprecatedSymbolNameReplacement is the same as the deprecated symbol.
+		# Return a frozenset to match the API of the deprecated DEFAULT_EXTENSIONS symbol.
 		return frozenset(_DEFAULT_EXTENSIONS_ORDERED)
 	raise AttributeError(f"module {repr(__name__)} has no attribute {repr(attrName)}")
 

--- a/source/md2html.py
+++ b/source/md2html.py
@@ -35,9 +35,9 @@ def __getattr__(attrName: str) -> Any:
 	if attrName == "DEFAULT_EXTENSIONS":
 		# Note: this should only log in situations where it will not be excessively noisy.
 		from logHandler import log
+
 		log.warning(
-			"Importing DEFAULT_EXTENSIONS from here is deprecated. "
-			"Importing from md2html is discouraged. ",
+			"Importing DEFAULT_EXTENSIONS from here is deprecated. Importing from md2html is discouraged. ",
 			# Include stack info so testers can report warning to add-on author.
 			stack_info=True,
 		)

--- a/source/md2html.py
+++ b/source/md2html.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2023-2024 NV Access Limited
+# Copyright (C) 2023-2025 NV Access Limited
 # This file may be used under the terms of the GNU General Public License, version 2 or later.
 # For more details see: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -8,21 +8,43 @@ from copy import deepcopy
 import io
 import re
 import shutil
+from typing import Any
 
-DEFAULT_EXTENSIONS = frozenset(
-	{
-		# Supports tables, HTML mixed with markdown, code blocks, custom attributes and more
-		"markdown.extensions.extra",
-		# Allows TOC with [TOC]"
-		"markdown.extensions.toc",
-		# Makes list behaviour better, including 2 space indents by default
-		"mdx_truly_sane_lists",
-		# External links will open in a new tab, and title will be set to the link text
-		"markdown_link_attr_modifier",
-		# Adds links to GitHub authors, issues and PRs
-		"mdx_gh_links",
-	},
+_DEFAULT_EXTENSIONS_ORDERED = (
+	# Supports tables, HTML mixed with markdown, code blocks, custom attributes and more
+	"markdown.extensions.extra",
+	# Used to preserve tabs in code blocks
+	"pymdownx.superfences",
+	# Allows TOC with [TOC]"
+	"markdown.extensions.toc",
+	# Makes list behaviour better, including 2 space indents by default
+	"mdx_truly_sane_lists",
+	# External links will open in a new tab, and title will be set to the link text
+	"markdown_link_attr_modifier",
+	# Adds links to GitHub authors, issues and PRs
+	"mdx_gh_links",
 )
+"""
+Default extensions to use for markdown conversion.
+Order is important, as some extensions depend on or affect others.
+"""
+
+
+def __getattr__(attrName: str) -> Any:
+	"""Module level `__getattr__` used to preserve backward compatibility."""
+	if attrName == "DEFAULT_EXTENSIONS":
+		# Note: this should only log in situations where it will not be excessively noisy.
+		from logHandler import log
+		log.warning(
+			"Importing DEFAULT_EXTENSIONS from here is deprecated. "
+			"Do not import from md2html. ",
+			# Include stack info so testers can report warning to add-on author.
+			stack_info=True,
+		)
+		# Ensure the API of deprecatedSymbolNameReplacement is the same as the deprecated symbol.
+		return frozenset(_DEFAULT_EXTENSIONS_ORDERED)
+	raise AttributeError(f"module {repr(__name__)} has no attribute {repr(attrName)}")
+
 
 EXTENSIONS_CONFIG = {
 	"markdown_link_attr_modifier": {
@@ -32,6 +54,9 @@ EXTENSIONS_CONFIG = {
 	"mdx_gh_links": {
 		"user": "nvaccess",
 		"repo": "nvda",
+	},
+	"pymdownx.superfences": {
+		"preserve_tabs": True,
 	},
 }
 
@@ -107,11 +132,11 @@ def _generateSanitizedHTML(md: str, isKeyCommands: bool = False) -> str:
 	import markdown
 	import nh3
 
-	extensions = set(DEFAULT_EXTENSIONS)
+	extensions = list(_DEFAULT_EXTENSIONS_ORDERED)
 	if isKeyCommands:
 		from keyCommandsDoc import KeyCommandsExtension
 
-		extensions.add(KeyCommandsExtension())
+		extensions.append(KeyCommandsExtension())
 
 	htmlOutput = markdown.markdown(
 		text=md,

--- a/source/md2html.py
+++ b/source/md2html.py
@@ -37,7 +37,7 @@ def __getattr__(attrName: str) -> Any:
 		from logHandler import log
 		log.warning(
 			"Importing DEFAULT_EXTENSIONS from here is deprecated. "
-			"Do not import from md2html. ",
+			"Importing from md2html is discouraged. ",
 			# Include stack info so testers can report warning to add-on author.
 			stack_info=True,
 		)

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -42,7 +42,7 @@ Please refer to [the developer guide](https://download.nvaccess.org/documentatio
 * Component updates:
   * Updated Pyright to 1.1.403. (#18424)
   * Updated Ruff to 0.12.5. (#18424)
-  * Updated markdown to 3.8.2. (#TODO)
+  * Updated markdown to 3.8.2. (#18638)
 * For `IAccessible` objects, the `flowsFrom` and `flowsTo` properties will now raise a `NotImplementedError` for MSAA (non-IA2) objects. (#18416, @LeonarddeR)
 * Updated `include` dependencies:
   * detours to `9764cebcb1a75940e68fa83d6730ffaf0f669401`. (#18447, @LeonarddeR)
@@ -58,7 +58,7 @@ Please refer to [the developer guide](https://download.nvaccess.org/documentatio
   * `SynthDriver.isSpeaking`
 * `easeOfAccess.RegistryKey` and `config.RegistryKey` is deprecated, use `config.registry.RegistryKey` instead. (#18608)
 * Importing `DEFAULT_EXTENSIONS` from `md2html` is deprecated.
-Importing from `md2html` in general is discouraged. (#TODO)
+Importing from `md2html` is discouraged. (#18638)
 
 ## 2025.2
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -42,6 +42,7 @@ Please refer to [the developer guide](https://download.nvaccess.org/documentatio
 * Component updates:
   * Updated Pyright to 1.1.403. (#18424)
   * Updated Ruff to 0.12.5. (#18424)
+  * Updated markdown to 3.8.2. (#TODO)
 * For `IAccessible` objects, the `flowsFrom` and `flowsTo` properties will now raise a `NotImplementedError` for MSAA (non-IA2) objects. (#18416, @LeonarddeR)
 * Updated `include` dependencies:
   * detours to `9764cebcb1a75940e68fa83d6730ffaf0f669401`. (#18447, @LeonarddeR)
@@ -56,6 +57,8 @@ Please refer to [the developer guide](https://download.nvaccess.org/documentatio
   * `LP__ULARGE_INTEGER`
   * `SynthDriver.isSpeaking`
 * `easeOfAccess.RegistryKey` and `config.RegistryKey` is deprecated, use `config.registry.RegistryKey` instead. (#18608)
+* Importing `DEFAULT_EXTENSIONS` from `md2html` is deprecated.
+Importing from `md2html` in general is discouraged. (#TODO)
 
 ## 2025.2
 

--- a/uv.lock
+++ b/uv.lock
@@ -462,6 +462,7 @@ dependencies = [
     { name = "mdx-truly-sane-lists", marker = "sys_platform == 'win32'" },
     { name = "nh3", marker = "sys_platform == 'win32'" },
     { name = "pycaw", marker = "sys_platform == 'win32'" },
+    { name = "pymdown-extensions", marker = "sys_platform == 'win32'" },
     { name = "pyserial", marker = "sys_platform == 'win32'" },
     { name = "requests", marker = "sys_platform == 'win32'" },
     { name = "schedule", marker = "sys_platform == 'win32'" },
@@ -513,6 +514,7 @@ requires-dist = [
     { name = "mdx-truly-sane-lists", specifier = "==1.3" },
     { name = "nh3", specifier = "==0.2.19" },
     { name = "pycaw", specifier = "==20240210" },
+    { name = "pymdown-extensions", specifier = "==10.16.1" },
     { name = "pyserial", specifier = "==3.5" },
     { name = "requests", specifier = "==2.32.3" },
     { name = "schedule", specifier = "==1.2.2" },
@@ -704,6 +706,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7c/2d/c3338d48ea6cc0feb8446d8e6937e1408088a72a39937982cc6111d17f84/pygments-2.19.1.tar.gz", hash = "sha256:61c16d2a8576dc0649d9f39e089b5f02bcd27fba10d8fb4dcc28173f7a45151f", size = 4968581, upload-time = "2025-01-06T17:26:30.443Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8a/0b/9fcc47d19c48b59121088dd6da2488a49d5f72dacf8262e2790a1d2c7d15/pygments-2.19.1-py3-none-any.whl", hash = "sha256:9ea1544ad55cecf4b8242fab6dd35a93bbce657034b0611ee383099054ab6d8c", size = 1225293, upload-time = "2025-01-06T17:26:25.553Z" },
+]
+
+[[package]]
+name = "pymdown-extensions"
+version = "10.16.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown", marker = "sys_platform == 'win32'" },
+    { name = "pyyaml", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/b3/6d2b3f149bc5413b0a29761c2c5832d8ce904a1d7f621e86616d96f505cc/pymdown_extensions-10.16.1.tar.gz", hash = "sha256:aace82bcccba3efc03e25d584e6a22d27a8e17caa3f4dd9f207e49b787aa9a91", size = 853277, upload-time = "2025-07-28T16:19:34.167Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/06/43084e6cbd4b3bc0e80f6be743b2e79fbc6eed8de9ad8c629939fa55d972/pymdown_extensions-10.16.1-py3-none-any.whl", hash = "sha256:d6ba157a6c03146a7fb122b2b9a121300056384eafeec9c9f9e584adfdb2a32d", size = 266178, upload-time = "2025-07-28T16:19:31.401Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Fixes #18622 

### Summary of the issue:
Tabs are replaced with spaces in codefences when converting markdown to html.
This causes examples for characterDescriptions, gestures and symbol files to contain incorrect syntax.

### Description of user facing changes:
Fixed example in dev guide

### Description of developer facing changes:
- Updated markdown
- added [python markdown extensions suite](https://github.com/facelessuser/pymdown-extensions)
- deprecated DEFAULT_EXTENSIONS 

### Description of development approach:

- enabled [preserve tabs](https://facelessuser.github.io/pymdown-extensions/extensions/superfences/#preserve-tabs)
- made markdown extensions ordered

### Testing strategy:
Built dev guide, ensured tabs are preserved
### Known issues with pull request:

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
