### PR TITLE
Fix silence detection default threshold

### DIFF
--- a/nvdaHelper/local/silenceDetect.h
+++ b/nvdaHelper/local/silenceDetect.h
@@ -65,12 +65,7 @@ struct WaveFormat {
 
 	static constexpr SampleType defaultThreshold() {
 		// Default threshold: 1 / 2^10 or 0.0009765625
-		if constexpr (std::is_floating_point_v<SampleType>)
-			return SampleType(1) / (1 << 10);
-		else if constexpr (bytesPerSample * 8 > 10)
-			return SampleType(1) << (bytesPerSample * 8 - 10);
-		else
-			return SampleType();
+		return (max)() / (1 << 10);
 	}
 
 	static constexpr auto toSigned(SampleType smp) {

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -36,6 +36,7 @@ Note that this is disabled by default due to the device using generic USB identi
 * Fixed a bug which stopped speech from working via NVDA Remote Access when the controlled computer had no audio output devices enabled. (#18544)
 * Fixed a bug which caused NVDA Remote Access to stop working if a session was interrupted while connecting to the server. (#18476)
 * A portable copy launched immediately after creation now correctly use its own configuration instead of another one. (#18442, @CyrilleB79)
+* Fixed excessive leading silence trimming that trims part of the speech when using some voices. (#18003, @gexgd0419)
 
 ### Changes for Developers
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
<!-- Use Closes/Fixes/Resolves #xxx to link this PR to the issue it is responding to. -->
Fixes #18003.

### Summary of the issue:
The default threshold values for signed integer types are incorrect, becoming twice as large, causing more parts to be trimmed than expected.

### Description of user facing changes:
The excessive trimming will be fixed.

### Description of developer facing changes:
None.

### Description of development approach:

`WaveFormat::defaultThreshold` should use 1 / 2^10 or 0.0009765625 as the threshold value for all types.

The current implementation handles floating points and unsigned integers correctly, but fails to differentiate the signedness, so signed integer types will have a threshold value that's twice as large.

The solution is to replace the case-by-case implementation to a more general and correct `max() / (1 << 10)`.

### Testing strategy:

I wrote a C++ program to run the silence detection algorithm on the [user-provided wave data](https://github.com/nvaccess/nvda/issues/18003#issuecomment-3160758490). Now the algorithm detects a consistent duration of silence for 16-bit, 24-bit, and 32-bit float formats.

### Known issues with pull request:

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
