### PR TITLE
Throw error on no MINI-SEIKA display

### DIFF
--- a/source/brailleDisplayDrivers/seikantk.py
+++ b/source/brailleDisplayDrivers/seikantk.py
@@ -170,7 +170,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 				dev = None
 
 		if not dev:
-			RuntimeError("No MINI-SEIKA display found")
+			raise RuntimeError("No MINI-SEIKA display found")
 		elif self.numCells == 0:
 			dev.close()
 			dev = None


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.
Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->
### Link to issue number:


### Summary of the issue:
The MINI-SEIKA braille display driver was not properly raising a `RuntimeError` when no display is found, causing the error condition to be silently ignored instead of properly handled.

### Description of user facing changes:
When no MINI-SEIKA display is found, users will now receive proper error feedback instead of the driver silently failing. This improves error reporting and makes it clearer when the display cannot be initialized.

### Description of developer facing changes:
Fixed a bug in `source/brailleDisplayDrivers/seikantk.py` where `RuntimeError("No MINI-SEIKA display found")` was not being raised properly - added missing `raise` keyword.

### Description of development approach:
Simple one-line fix to add the missing `raise` keyword before the RuntimeError instantiation. This ensures the exception is actually thrown rather than just creating an unused RuntimeError object.

### Testing strategy:

### Known issues with pull request:
None identified.

### Code Review Checklist:
<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->
- [ ] Documentation:
 - Change log entry
 - User Documentation (not applicable for this bug fix)
 - Developer / Technical Documentation (not applicable for this bug fix)
 - Context sensitive help for GUI changes (not applicable)
- [ ] Testing:
 - Unit tests (not applicable for this simple fix)
 - System (end to end) tests (manual testing performed)
 - Manual testing
- [ ] UX of all users considered:
 - Speech (error messages will be properly announced)
 - Braille (affects braille display error handling)
 - Low Vision (not applicable)
 - Different web browsers (not applicable)
 - Localization in other languages / culture than English (error handling improvement)
- [ ] API is compatible with existing add-ons.
- [] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary

## PR Summary
Small PR - fixes missing `raise` keyword when throwing an error on no MINI-SEIKA display found.

**Changes:**
- `source/brailleDisplayDrivers/seikantk.py`: Added missing `raise` keyword before `RuntimeError("No MINI-SEIKA display found")`