### PR TITLE
Exclude generic USB serial converters from Braille display auto detection by default and make this behavior configurable

### DIFF
--- a/source/bdDetect.py
+++ b/source/bdDetect.py
@@ -292,7 +292,7 @@ def getDriversForConnectedUsbDevices(
 
 	for driver, match in fallbackDriversAndMatches:
 		# Skip generic devices in fallback matches if configured to exclude them
-		if match.isGeneric and config.conf["braille"]["auto"]["excludeGenericDisplays"]:
+		if _isGenericDeviceMatch(match) and config.conf["braille"]["auto"]["excludeGenericDisplays"]:
 			continue
 		yield (driver, match)
 
@@ -679,7 +679,7 @@ def getConnectedUsbDevicesForDriver(driver: str) -> Iterator[DeviceMatch]:
 
 	for match in fallbackMatches:
 		# Skip generic devices in fallback matches if configured to exclude them
-		if match.isGeneric and config.conf["braille"]["auto"]["excludeGenericDisplays"]:
+		if _isGenericDeviceMatch(match) and config.conf["braille"]["auto"]["excludeGenericDisplays"]:
 			continue
 		yield match
 

--- a/source/bdDetect.py
+++ b/source/bdDetect.py
@@ -268,6 +268,9 @@ def getDriversForConnectedUsbDevices(
 
 	fallbackDriversAndMatches: list[tuple[str, DeviceMatch]] = []
 	for match in itertools.chain(usbCustomDeviceMatches, usbHidDeviceMatchesForCustom, usbComDeviceMatches):
+		# Skip generic devices if configured to exclude them
+		if match.isGeneric and config.conf["braille"]["auto"]["excludeGenericDisplays"]:
+			continue
 		for driver, devs in _driverDevices.items():
 			if limitToDevices and driver not in limitToDevices:
 				continue
@@ -290,6 +293,9 @@ def getDriversForConnectedUsbDevices(
 			yield (hidName, match)
 
 	for driver, match in fallbackDriversAndMatches:
+		# Skip generic devices in fallback matches if configured to exclude them
+		if match.isGeneric and config.conf["braille"]["auto"]["excludeGenericDisplays"]:
+			continue
 		yield (driver, match)
 
 
@@ -647,6 +653,9 @@ def getConnectedUsbDevicesForDriver(driver: str) -> Iterator[DeviceMatch]:
 	fallbackMatches: list[DeviceMatch] = []
 
 	for match in usbDevs:
+		# Skip generic devices if configured to exclude them
+		if match.isGeneric and config.conf["braille"]["auto"]["excludeGenericDisplays"]:
+			continue
 		if driver == _getStandardHidDriverName():
 			if _isHIDBrailleMatch(match):
 				yield match
@@ -660,6 +669,9 @@ def getConnectedUsbDevicesForDriver(driver: str) -> Iterator[DeviceMatch]:
 						yield match
 
 	for match in fallbackMatches:
+		# Skip generic devices in fallback matches if configured to exclude them
+		if match.isGeneric and config.conf["braille"]["auto"]["excludeGenericDisplays"]:
+			continue
 		yield match
 
 

--- a/source/bdDetect.py
+++ b/source/bdDetect.py
@@ -63,6 +63,7 @@ GENERIC_USB_TO_SERIAL_IDS = {
 	"VID_10C4&PID_EA80",  # Silicon Labs CP210x UART Bridge
 	"VID_1A86&PID_7523",  # QinHeng Electronics CH340 serial converter
 	"VID_1A86&PID_5523",  # QinHeng Electronics CH341 serial converter
+	"VID_1A86&PID_55D3",  # QinHeng Electronics CH34x serial converter
 	"VID_067B&PID_2303",  # Prolific PL2303 Serial Port
 	"VID_04D8&PID_000A",  # Microchip CDC RS-232 Emulation Demo
 }

--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -13,7 +13,7 @@ from . import configDefaults
 #: provide an upgrade step (@see profileUpgradeSteps.py). An upgrade step does not need to be added when
 #: just adding a new element to (or removing from) the schema, only when old versions of the config
 #: (conforming to old schema versions) will not work correctly with the new schema.
-latestSchemaVersion = 18
+latestSchemaVersion = 19
 
 #: The configuration specification string
 #: @type: String
@@ -98,7 +98,7 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 	reportLiveRegions = featureFlag(optionsEnum="BoolFlag", behaviorOfDefault="enabled")
 	fontFormattingDisplay = featureFlag(optionsEnum="FontFormattingBrailleModeFlag", behaviorOfDefault="LIBLOUIS")
 	[[auto]]
-    	excludedDisplays = string_list(default=list("dotPad"))
+    	excludedDisplays = string_list(default=list())
     	excludeGenericDisplays = boolean(default=true)
 
 	# Braille display driver settings

--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -99,6 +99,7 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 	fontFormattingDisplay = featureFlag(optionsEnum="FontFormattingBrailleModeFlag", behaviorOfDefault="LIBLOUIS")
 	[[auto]]
     	excludedDisplays = string_list(default=list("dotPad"))
+    	excludeGenericDisplays = boolean(default=true)
 
 	# Braille display driver settings
 	[[__many__]]

--- a/source/config/profileUpgradeSteps.py
+++ b/source/config/profileUpgradeSteps.py
@@ -597,3 +597,21 @@ def upgradeConfigFrom_17_to_18(profile: ConfigObj) -> None:
 			"dotPad added to braille display auto detection excluded displays due to generic USB PID/VID. "
 			f"List is now: {excludedDisplays}",
 		)
+
+
+def upgradeConfigFrom_18_to_19(profile: ConfigObj) -> None:
+	"""Remove dotPad from excluded braille displays as it now has proper generic device detection."""
+	if "braille" not in profile:
+		return
+	if "auto" not in profile["braille"]:
+		return
+	if "excludedDisplays" not in profile["braille"]["auto"]:
+		return
+
+	excludedDisplays = profile["braille"]["auto"]["excludedDisplays"]
+	if "dotPad" in excludedDisplays:
+		excludedDisplays.remove("dotPad")
+		log.debug(
+			"dotPad removed from braille display auto detection excluded displays due to improved generic device detection. "
+			f"List is now: {excludedDisplays}",
+		)

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -4633,7 +4633,10 @@ class BrailleDisplaySelectionDialog(SettingsDialog):
 				n for i, n in enumerate(self.autoDetectValues) if i not in self.autoDetectList.CheckedItems
 			] + unknownDriversExcluded
 
-		config.conf["braille"]["auto"]["excludeGenericDisplays"] = self.excludeGenericDisplaysCheckBox.Value
+		if self.excludeGenericDisplaysCheckBox.IsEnabled():
+			config.conf["braille"]["auto"]["excludeGenericDisplays"] = (
+				self.excludeGenericDisplaysCheckBox.Value
+			)
 
 		if not braille.handler.setDisplayByName(display):
 			gui.messageBox(

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -4526,6 +4526,7 @@ class BrailleDisplaySelectionDialog(SettingsDialog):
 			wx.CheckBox(self, label=excludeGenericDisplaysText),
 		)
 		self.excludeGenericDisplaysCheckBox.Value = config.conf["braille"]["auto"]["excludeGenericDisplays"]
+		self.bindHelpEvent("SelectBrailleDisplayExcludeGenericDisplays", self.excludeGenericDisplaysCheckBox)
 
 		# Translators: The label for a setting in braille settings to choose the connection port (if the selected braille display supports port selection).
 		portsLabelText = _("&Port:")

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -4520,6 +4520,13 @@ class BrailleDisplaySelectionDialog(SettingsDialog):
 		)
 		self.bindHelpEvent("SelectBrailleDisplayAutoDetect", self.autoDetectList)
 
+		# Translators: The label for a setting in braille settings to exclude generic USB-to-serial devices from automatic detection.
+		excludeGenericDisplaysText = _("&Exclude generic USB-to-serial devices from automatic detection")
+		self.excludeGenericDisplaysCheckBox = sHelper.addItem(
+			wx.CheckBox(self, label=excludeGenericDisplaysText),
+		)
+		self.excludeGenericDisplaysCheckBox.Value = config.conf["braille"]["auto"]["excludeGenericDisplays"]
+
 		# Translators: The label for a setting in braille settings to choose the connection port (if the selected braille display supports port selection).
 		portsLabelText = _("&Port:")
 		self.portsList = sHelper.addLabeledControl(portsLabelText, wx.Choice, choices=[])
@@ -4599,6 +4606,7 @@ class BrailleDisplaySelectionDialog(SettingsDialog):
 		self.portsList.Enable(enable)
 
 		self.autoDetectList.Enable(isAutoDisplaySelected)
+		self.excludeGenericDisplaysCheckBox.Enable(isAutoDisplaySelected)
 
 	def onDisplayNameChanged(self, evt):
 		self.updateStateDependentControls()
@@ -4623,6 +4631,8 @@ class BrailleDisplaySelectionDialog(SettingsDialog):
 			config.conf["braille"]["auto"]["excludedDisplays"] = [
 				n for i, n in enumerate(self.autoDetectValues) if i not in self.autoDetectList.CheckedItems
 			] + unknownDriversExcluded
+
+		config.conf["braille"]["auto"]["excludeGenericDisplays"] = self.excludeGenericDisplaysCheckBox.Value
 
 		if not braille.handler.setDisplayByName(display):
 			gui.messageBox(

--- a/tests/unit/test_bdDetect.py
+++ b/tests/unit/test_bdDetect.py
@@ -167,33 +167,31 @@ class TestGenericDeviceDetection(unittest.TestCase):
 				result = bdDetect._isGenericUsbDevice(usbId, deviceInfo)
 				self.assertTrue(result)
 
-	def test_deviceMatch_isGenericProperty(self):
-		"""Test that DeviceMatch properly includes the isGeneric property."""
-		# Generic device
+	def test_isGenericDeviceMatch_function(self):
+		"""Test that _isGenericDeviceMatch function works properly."""
+		# Generic serial device
 		genericMatch = bdDetect.DeviceMatch(
 			bdDetect.ProtocolType.SERIAL,
 			"VID_0403&PID_6001",
 			"COM1",
 			{"busDescription": "USB Serial Port"},
-			True,
 		)
-		self.assertTrue(genericMatch.isGeneric)
+		self.assertTrue(bdDetect._isGenericDeviceMatch(genericMatch))
 
-		# Non-generic device
+		# Non-generic serial device
 		specificMatch = bdDetect.DeviceMatch(
 			bdDetect.ProtocolType.SERIAL,
 			"VID_0403&PID_6001",
 			"COM2",
 			{"busDescription": "DotPad Braille Display"},
-			False,
 		)
-		self.assertFalse(specificMatch.isGeneric)
+		self.assertFalse(bdDetect._isGenericDeviceMatch(specificMatch))
 
-		# Default value should be False
-		defaultMatch = bdDetect.DeviceMatch(
+		# Non-serial device (should always be False)
+		hidMatch = bdDetect.DeviceMatch(
 			bdDetect.ProtocolType.HID,
 			"VID_1234&PID_5678",
 			r"\\?\hid#vid_1234&pid_5678#1&2345678&0&0000#{4d1e55b2-f16f-11cf-88cb-001111000030}",
 			{},
 		)
-		self.assertFalse(defaultMatch.isGeneric)
+		self.assertFalse(bdDetect._isGenericDeviceMatch(hidMatch))

--- a/tests/unit/test_bdDetect.py
+++ b/tests/unit/test_bdDetect.py
@@ -99,3 +99,101 @@ class TestDriverRegistration(unittest.TestCase):
 
 		registrar.addBluetoothDevices(matchFunc)
 		self.assertEqual(registrar._getDriverDict().get(bdDetect.CommunicationType.BLUETOOTH), matchFunc)
+
+
+class TestGenericDeviceDetection(unittest.TestCase):
+	"""Tests for generic USB-to-serial device detection."""
+
+	def test_isGenericUsbDevice_withGenericVidPidAndGenericDescription(self):
+		"""Test that devices with generic VID/PID and generic descriptions are detected as generic."""
+		test_cases = [
+			("VID_0403&PID_6001", {"busDescription": "USB Serial Port"}),
+			("VID_0403&PID_6001", {"busDescription": "FTDI USB Serial Device"}),
+			("VID_1A86&PID_7523", {"busDescription": "CH340 USB to Serial"}),
+			("VID_067B&PID_2303", {"busDescription": "Prolific USB-to-Serial Comm Port"}),
+			("VID_10C4&PID_EA60", {"busDescription": "Silicon Labs CP210x USB to UART Bridge"}),
+		]
+		for usbId, deviceInfo in test_cases:
+			with self.subTest(usbId=usbId, deviceInfo=deviceInfo):
+				result = bdDetect._isGenericUsbDevice(usbId, deviceInfo)
+				self.assertTrue(result)
+
+	def test_isGenericUsbDevice_withGenericVidPidAndNoBusDescription(self):
+		"""Test that devices with generic VID/PID but no busDescription are detected as generic."""
+		test_cases = [
+			("VID_0403&PID_6001", {}),
+			("VID_0403&PID_6001", {"busDescription": ""}),
+			("VID_1A86&PID_7523", {"someOtherField": "value"}),
+		]
+		for usbId, deviceInfo in test_cases:
+			with self.subTest(usbId=usbId, deviceInfo=deviceInfo):
+				result = bdDetect._isGenericUsbDevice(usbId, deviceInfo)
+				self.assertTrue(result)
+
+	def test_isGenericUsbDevice_withGenericVidPidButSpecificDescription(self):
+		"""Test that devices with generic VID/PID but specific descriptions are NOT detected as generic."""
+		test_cases = [
+			("VID_0403&PID_6001", {"busDescription": "DotPad Braille Display"}),
+			("VID_0403&PID_6001", {"busDescription": "HumanWare Brailliant"}),
+			("VID_1A86&PID_7523", {"busDescription": "NLS eReader Zoomax Braille Device"}),
+			("VID_067B&PID_2303", {"busDescription": "Papenmeier Braille Terminal"}),
+		]
+		for usbId, deviceInfo in test_cases:
+			with self.subTest(usbId=usbId, deviceInfo=deviceInfo):
+				result = bdDetect._isGenericUsbDevice(usbId, deviceInfo)
+				self.assertFalse(result)
+
+	def test_isGenericUsbDevice_withNonGenericVidPid(self):
+		"""Test that devices with non-generic VID/PID are never detected as generic."""
+		test_cases = [
+			("VID_1234&PID_5678", {"busDescription": "USB Serial Port"}),
+			("VID_ABCD&PID_EFGH", {}),
+			("VID_0F4E&PID_0100", {"busDescription": "FTDI Serial Converter"}),
+		]
+		for usbId, deviceInfo in test_cases:
+			with self.subTest(usbId=usbId, deviceInfo=deviceInfo):
+				result = bdDetect._isGenericUsbDevice(usbId, deviceInfo)
+				self.assertFalse(result)
+
+	def test_isGenericUsbDevice_caseInsensitive(self):
+		"""Test that bus description matching is case-insensitive."""
+		test_cases = [
+			("VID_0403&PID_6001", {"busDescription": "USB SERIAL PORT"}),
+			("VID_0403&PID_6001", {"busDescription": "Ftdi USB Serial Device"}),
+			("VID_1A86&PID_7523", {"busDescription": "CH340 usb-serial controller"}),
+		]
+		for usbId, deviceInfo in test_cases:
+			with self.subTest(usbId=usbId, deviceInfo=deviceInfo):
+				result = bdDetect._isGenericUsbDevice(usbId, deviceInfo)
+				self.assertTrue(result)
+
+	def test_deviceMatch_isGenericProperty(self):
+		"""Test that DeviceMatch properly includes the isGeneric property."""
+		# Generic device
+		genericMatch = bdDetect.DeviceMatch(
+			bdDetect.ProtocolType.SERIAL,
+			"VID_0403&PID_6001",
+			"COM1",
+			{"busDescription": "USB Serial Port"},
+			True,
+		)
+		self.assertTrue(genericMatch.isGeneric)
+
+		# Non-generic device
+		specificMatch = bdDetect.DeviceMatch(
+			bdDetect.ProtocolType.SERIAL,
+			"VID_0403&PID_6001",
+			"COM2",
+			{"busDescription": "DotPad Braille Display"},
+			False,
+		)
+		self.assertFalse(specificMatch.isGeneric)
+
+		# Default value should be False
+		defaultMatch = bdDetect.DeviceMatch(
+			bdDetect.ProtocolType.HID,
+			"VID_1234&PID_5678",
+			r"\\?\hid#vid_1234&pid_5678#1&2345678&0&0000#{4d1e55b2-f16f-11cf-88cb-001111000030}",
+			{},
+		)
+		self.assertFalse(defaultMatch.isGeneric)

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -10,6 +10,7 @@
   * Add-ons can be sorted by minimum and last tested NVDA version as well as by installation date. (#18440, #18560, @nvdaes, @CyrilleB79)
   * Minimum and last tested version will now be also shown in the details area for an add-on in the Available Add-ons tab. (#18440, @nvdaes)
   * Installation date will now be also shown in the details area for external add-ons. (#18560, @CyrilleB79)
+* Braille: Added option to exclude generic USB-to-serial devices from automatic detection to prevent potential damage to other serial devices. This option is enabled by default and can be disabled in braille settings if needed. (@bramd)
 
 ### Changes
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -10,7 +10,7 @@
   * Add-ons can be sorted by minimum and last tested NVDA version as well as by installation date. (#18440, #18560, @nvdaes, @CyrilleB79)
   * Minimum and last tested version will now be also shown in the details area for an add-on in the Available Add-ons tab. (#18440, @nvdaes)
   * Installation date will now be also shown in the details area for external add-ons. (#18560, @CyrilleB79)
-* Braille: Added option to exclude generic USB-to-serial devices from automatic detection to prevent potential damage to other serial devices. This option is enabled by default and can be disabled in braille settings if needed. (@bramd)
+* Braille: Added option to exclude generic USB-to-serial devices from automatic detection to prevent potential damage to other serial devices. This option is enabled by default and can be disabled in braille settings if needed. (#18655, @bramd)
 
 ### Changes
 

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -2421,6 +2421,18 @@ Any driver added, for example in a future version of NVDA or in an add-on, will 
 
 You may consult the documentation for your braille display in the section [Supported Braille Displays](#SupportedBrailleDisplays) to check whether the driver supports automatic detection of displays.
 
+##### Exclude generic USB-to-serial devices from automatic detection {#SelectBrailleDisplayExcludeGenericDisplays}
+
+When braille display is set to "Automatic", this checkbox allows you to exclude generic USB-to-serial devices from the automatic detection process.
+Generic USB-to-serial converters use common vendor and product IDs that are shared by many non-braille devices.
+When this option is enabled (which it is by default), NVDA will not attempt to connect to braille displays through these generic converters during automatic detection.
+This helps prevent potential damage to other serial devices that are not braille displays and improves the reliability of automatic detection.
+
+If you have a braille display that requires a generic USB-to-serial converter and cannot be detected through other means (such as Bluetooth or device-specific USB connections), you can uncheck this option to allow detection through generic converters.
+Consult the documentation for your specific braille display in the [Supported Braille Displays](#SupportedBrailleDisplays) section to check if generic USB-to-serial converters might be used by your display.
+
+Note that most braille displays can still be detected through Bluetooth, HID, or device-specific USB connections even when this option is enabled.
+
 ##### Port {#SelectBrailleDisplayPort}
 
 This option, if available, allows you to choose what port or type of connection will be used to communicate with the braille display you have selected.
@@ -4364,6 +4376,9 @@ Please see the display's documentation for descriptions of where these keys can 
 NVDA supports most displays from [Handy Tech](https://www.handytech.de/) when connected via USB, serial port or bluetooth.
 For older USB displays, you will need to install the USB drivers from Handy Tech on your system.
 
+Some Handy Tech displays may use generic USB-to-serial converters.
+If you have trouble with automatic detection, you may need to disable the "Exclude generic USB-to-serial devices from automatic detection" option in the braille display selection dialog.
+
 The following displays are not supported out of the box, but can be used via [Handy Tech's universal driver](https://handytech.de/en/service/downloads-and-manuals/handy-tech-software/braille-display-drivers) and NVDA add-on:
 
 * Braillino
@@ -4597,6 +4612,9 @@ Please see the display's documentation for descriptions of where these keys can 
 
 NVDA supports Braille Sense, Braille EDGE, Smart Beetle and Sync Braille displays from [Hims](https://www.hims-inc.com/) when connected via USB or bluetooth.
 If connecting via USB, you will need to install the [USB drivers from HIMS](http://www.himsintl.com/upload/HIMS_USB_Driver_v25.zip) on your system.
+
+Some HIMS displays may use generic USB-to-serial converters.
+If you have trouble with automatic detection, you may need to disable the "Exclude generic USB-to-serial devices from automatic detection" option in the braille display selection dialog.
 
 Following are the key assignments for these displays with NVDA.
 Please see the display's documentation for descriptions of where these keys can be found.
@@ -5405,6 +5423,9 @@ For computers where the Internet connection is disabled or not available, you ca
 By default, NVDA can automatically detect and connect to this display via USB or bluetooth.
 However, when configuring the display, you can also explicitly select "USB" or "Bluetooth" ports to restrict the connection type to be used.
 
+The NLS eReader Zoomax uses a generic USB-to-serial converter for USB connections.
+If you have trouble with automatic detection, you may need to disable the "Exclude generic USB-to-serial devices from automatic detection" option in the braille display selection dialog.
+
 Following are the key assignments for this display with NVDA.
 Please see the display's documentation for descriptions of where these keys can be found.
 <!-- KC:beginInclude -->
@@ -5468,9 +5489,8 @@ You can configure whether NVDA displays braille on the dedicated braille display
 Panning keys are supported, but due to limited buttons on the device, other commands and routing capabilities are currently not available.
 
 The Dot Pad driver supports automatic detection of USB-connected devices.
-However, automatic detection is disabled by default due to the device using generic USB identifiers that could conflict with other devices.
-To enable automatic detection, go to NVDA's Braille settings and check "Dot Pad" in the automatic detection list.
-When automatic detection is enabled and a compatible device is detected, NVDA will automatically connect to it.
+The Dot Pad uses generic USB-to-serial converters for USB connections.
+If you have trouble with automatic detection, you may need to disable the "Exclude generic USB-to-serial devices from automatic detection" option in the braille display selection dialog.
 You can also manually select a specific USB or Bluetooth virtual serial port if needed.
 
 Please note that due to hardware limitations, the Dot Pad will not refresh all dots correctly while your hand is on the device.


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
<!-- Use Closes/Fixes/Resolves #xxx to link this PR to the issue it is responding to. -->
Fixes issue #18563

### Summary of the issue:

Since generic USB-serial converters are used for all kinds of devices there is a rist when including them in automatic detection of Braille displays. Therefore, this PR disables auto detection for them by default.

### Description of user facing changes:

Braille Displays with a generic vendor and product ID of a USB-serial converter are no longer automatically detected over USB. They will still be detected over Bluetooth. There is a new setting in the Braille Display Selection dialog to change this behavior and include these devices in automatic detection again.

### Description of developer facing changes:

### Description of development approach:

Collected a list of common IDs for USB-serial converters and their device names/bus descriptions. Added checks to bdDetect to exclude these from automatic detection if the corresponding configuration option is enabled (which is the default).
Removed dotPad from the default exclusions list for automatic detection, since this PR solves the reason why it is excluded by default in a more generic way.
Tried to find all drivers affected and documented this in the User Guide.

### Testing strategy:

### Known issues with pull request:

* People who rely on automatic braille display detection and use an affected display will lose braille output if they don't change their settings
* Users who explicitly excluded dotPad from automatic detection themselves will have it re-enabled, since we have no way to determine if the exclusion was added by the user or our default configuration

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [ ] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [ ] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [ ] API is compatible with existing add-ons.
- [ ] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
