### PR TITLE
Fix syntax error handling on Python 3.13

### DIFF
--- a/source/pythonConsole.py
+++ b/source/pythonConsole.py
@@ -2,7 +2,7 @@
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-# Copyright (C) 2008-2024 NV Access Limited, Leonard de Ruijter, Julien Cochuyt, Cyrille Bougot
+# Copyright (C) 2008-2025 NV Access Limited, Leonard de Ruijter, Julien Cochuyt, Cyrille Bougot
 
 """Provides an interactive Python console which can be run from within NVDA.
 To use, call L{initialize} to create a singleton instance of the console GUI. This can then be accessed externally as L{consoleUI}.
@@ -204,10 +204,10 @@ class PythonConsole(code.InteractiveConsole, AutoPropertyObject):
 		self.prompt = "..." if more else ">>>"
 		return more
 
-	def showsyntaxerror(self, filename=None):
+	def showsyntaxerror(self, filename=None, **kwargs):
 		excepthook = sys.excepthook
 		sys.excepthook = sys.__excepthook__
-		super().showsyntaxerror(filename=filename)
+		super().showsyntaxerror(filename=filename, **kwargs)
 		sys.excepthook = excepthook
 
 	def showtraceback(self):

--- a/source/pythonConsole.py
+++ b/source/pythonConsole.py
@@ -204,7 +204,7 @@ class PythonConsole(code.InteractiveConsole, AutoPropertyObject):
 		self.prompt = "..." if more else ">>>"
 		return more
 
-	def showsyntaxerror(self, filename=None, **kwargs):
+	def showsyntaxerror(self, filename: str | None = None, **kwargs):
 		excepthook = sys.excepthook
 		sys.excepthook = sys.__excepthook__
 		super().showsyntaxerror(filename=filename, **kwargs)


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
When generating a syntax erro in a Python 3.13 Python console, the following is logged:
```log
ERROR - unhandled exception (09:14:31.494) - MainThread (11952):
Traceback (most recent call last):
  File "code.pyc", line 65, in runsource
  File "pythonConsole.pyc", line 143, in __call__
  File "codeop.pyc", line 155, in __call__
  File "codeop.pyc", line 75, in _maybe_compile
  File "codeop.pyc", line 118, in __call__
  File "<console>", line 1
    fl@
SyntaxError: invalid syntax

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "pythonConsole.pyc", line 509, in onInputChar
  File "pythonConsole.pyc", line 385, in execute
  File "pythonConsole.pyc", line 196, in push
  File "code.pyc", line 314, in push
  File "code.pyc", line 68, in runsource
TypeError: PythonConsole.showsyntaxerror() got an unexpected keyword argument 'source'
```

### Description of user facing changes:
Python console no longer breaks on syntax errors on Python 3.13 builds.

### Description of developer facing changes:
None

### Description of development approach:
Python 3.13 added **kwargs to the `showsyntaxerror` method. Adding this shouldn't do any harm on Python 3.11. kwargs will always be empty there and it's not problematic to pass a **kwargs to a non-kwargs supporting function when kwargs is empty.

### Testing strategy:
- [ ] Test generating a syntax error on Python 3.11 builds
- [x] Test generating a syntax error on Python 3.13 builds

### Known issues with pull request:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
