### PR TITLE
Fix SAPI5 WASAPI audio

### DIFF
--- a/source/synthDrivers/sapi5.py
+++ b/source/synthDrivers/sapi5.py
@@ -268,7 +268,10 @@ class SynthDriverAudioStream(COMObject):
 		synth.sonicStream.writeShort(pv, cb // 2 // synth.sonicStream.channels)
 		# For the first audio chunk, wait for at least 50ms of audio
 		# in order to avoid audio gaps if further processing takes longer time
-		if synth._isFirstAudioChunk and synth.sonicStream.samplesAvailable < synth.sonicStream.sampleRate // 20:
+		if (
+			synth._isFirstAudioChunk
+			and synth.sonicStream.samplesAvailable < synth.sonicStream.sampleRate // 20
+		):
 			return
 		synth._isFirstAudioChunk = False
 		audioData = synth.sonicStream.readShort()

--- a/source/synthDrivers/sapi5.py
+++ b/source/synthDrivers/sapi5.py
@@ -264,7 +264,7 @@ class SynthDriverAudioStream(COMObject):
 			log.debugWarning("Called Write method on AudioStream while driver is dead")
 			return hresult.E_UNEXPECTED
 		if synth._isCancelling:
-			return hresult.E_FAIL
+			return hresult.S_OK
 		synth.sonicStream.writeShort(pv, cb // 2 // synth.sonicStream.channels)
 		# For the first audio chunk, wait for at least 50ms of audio
 		# in order to avoid audio gaps if further processing takes longer time

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -36,6 +36,7 @@ Note that this is disabled by default due to the device using generic USB identi
 * Fixed a bug which stopped speech from working via NVDA Remote Access when the controlled computer had no audio output devices enabled. (#18544)
 * Fixed a bug which caused NVDA Remote Access to stop working if a session was interrupted while connecting to the server. (#18476)
 * A portable copy launched immediately after creation now correctly use its own configuration instead of another one. (#18442, @CyrilleB79)
+* Fixed audio gaps in speech when using some SAPI 5 voices with WASAPI and rate boost enabled. (#17967, @gexgd0419)
 
 ### Changes for Developers
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
<!-- Use Closes/Fixes/Resolves #xxx to link this PR to the issue it is responding to. -->
Fixes #17967.

### Summary of the issue:
When rate boost is enabled and the rate is fast enough, if some audio takes longer time to process, an audio gap might appear in the speech audio.

### Description of user facing changes:
The audio gap issue should be fixed.

### Description of developer facing changes:
None.

### Description of development approach:
Wait for at least 50ms of audio data before sending the first chunk to the output device.

This mitigates the problem when the first small chunk is immediately played, but during processing of the next chunk, there isn't enough audio to cover this duration, leaving audible gaps.

Also the return value of `IStream::Write` is changed to `S_OK` instead of an error code during cancellation.

### Testing strategy:
Tested with VW Julie with the text "i unselected" to confirm there's no gap in the audio.

### Known issues with pull request:

This might slightly increase the speech delay since audio won't be immediately played.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
