### PR TITLE
Fixup START_BUILD_NUMBER

### DIFF
--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -30,7 +30,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  START_BUILD_NUMBER: ${{ vars.BUILD_NUMBER_OFFSET || 0 }}
+  START_BUILD_NUMBER: ${{ vars.BUILD_NUMBER_OFFSET || 50000 }}
   pullRequestNumber: ${{ github.event_name == 'pull_request' && github.event.number || 0 }}
   scons_publisher: ${{ vars.PUBLISHER_NAME || github.repository_owner }}
   # Don't send telemetry to Microsoft when using MSVC tooling, avoiding an unnecessary PowerShell script invocation.

--- a/ci/README.md
+++ b/ci/README.md
@@ -56,12 +56,12 @@ It currently defaults to the repository owner (e.g. `nvaccess`).
 ### Build number offset
 
 To offset from our previous build system, we start the sequential build count at a higher number than 0.
-This means our first build will be numbered something like 100,001 not 1.
+This means our first build will be numbered something like 50,001 not 1.
 
 To offset build numbers, set;
 
 * `BUILD_NUMBER_OFFSET` as a variable.
-It currently defaults to 0.
+It currently defaults to 50,000.
 
 ### Crowdin
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
<!-- Use Closes/Fixes/Resolves #xxx to link this PR to the issue it is responding to. -->
none

### Summary of the issue:
Currently, the default value of the START_BUILD_NUMBER variable is set to 0, which causes the base version number (1234) when pushing PR from the fork repository to the NV Access repository inconsistent with the version number (51234) built by NV Access

### Description of user facing changes:
The base version number from the Fork repository PR is the same as the version number of the NV Access repository

### Description of developer facing changes:
The base version number from the Fork repository PR is the same as the version number of the NV Access repository

### Description of development approach:
Change the default value of the START_BUILD_NUMBER variable from 0 to 50,000

### Testing strategy:
View workflow build results

### Known issues with pull request:
none

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [x]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
