### PR TITLE
Fix SAPI5

### DIFF
--- a/source/synthDrivers/sapi5.py
+++ b/source/synthDrivers/sapi5.py
@@ -504,6 +504,7 @@ class SapiSink(COMObject):
 	def EndStream(self, streamNum: int, pos: int):
 		synth = self.synthRef()
 		if synth._isCancelling:
+			self._bookmarkLists.clear()
 			return
 		if synth.player:
 			# WASAPI is on

--- a/source/synthDrivers/sapi5.py
+++ b/source/synthDrivers/sapi5.py
@@ -504,7 +504,7 @@ class SapiSink(COMObject):
 	def EndStream(self, streamNum: int, pos: int):
 		synth = self.synthRef()
 		if synth._isCancelling:
-			self._bookmarkLists.clear()
+			synth._bookmarkLists.clear()
 			return
 		if synth.player:
 			# WASAPI is on

--- a/source/synthDrivers/sapi5.py
+++ b/source/synthDrivers/sapi5.py
@@ -1096,4 +1096,4 @@ class SynthDriver(SynthDriver):
 			# and all its references can also be removed,
 			# as it is not doing anything useful.
 			return self._isSpeaking
-		return super().__getattr__(attrName)
+		raise AttributeError(f"'{type(self).__name__}' object has no attribute '{attrName}'")

--- a/source/synthDrivers/sapi5.py
+++ b/source/synthDrivers/sapi5.py
@@ -281,7 +281,7 @@ class SynthDriverAudioStream(COMObject):
 		if (
 			synth._isFirstAudioChunk
 			and synth.sonicStream.samplesAvailable
-			< synth.sonicStream.sampleRate * 1000 // _FIRST_AUDIO_CHUNK_MIN_DURATION_MS
+			< synth.sonicStream.sampleRate * _FIRST_AUDIO_CHUNK_MIN_DURATION_MS // 1000
 		):
 			return
 		synth._isFirstAudioChunk = False

--- a/source/synthDrivers/sapi5.py
+++ b/source/synthDrivers/sapi5.py
@@ -591,12 +591,12 @@ class SynthDriver(SynthDriver):
 		self._isStoppingThread = False
 		self._isFirstAudioChunk = False
 		self._rateBoost = False
-		self._initTts(_defaultVoiceToken)
 		self._bookmarkLists: deque[deque[int]] = deque()
 		self._thread: threading.Thread | None = None
 		self._threadCond = threading.Condition()
 		self._speakRequests: deque[_SpeakRequest] = deque()
 		self._isCompleted = False  # True when the last speak request reaches EndStream
+		self._initTts(_defaultVoiceToken)
 
 	def _stopThread(self) -> None:
 		"""Stops the WASAPI speak thread (if it's running) and waits for the thread to quit."""

--- a/source/synthDrivers/sapi5.py
+++ b/source/synthDrivers/sapi5.py
@@ -1046,7 +1046,6 @@ class SynthDriver(SynthDriver):
 		self._isCancelling = True
 		if self.player:
 			self.player.stop()  # stop the audio and stop waiting for idle()
-			self._speakRequests = deque()  # clear the queue
 			with self._threadCond:  # clear the queue and wake up the thread
 				self._speakRequests.clear()
 				self._threadCond.notify()

--- a/source/synthDrivers/sapi5.py
+++ b/source/synthDrivers/sapi5.py
@@ -1047,7 +1047,8 @@ class SynthDriver(SynthDriver):
 		if self.player:
 			self.player.stop()  # stop the audio and stop waiting for idle()
 			self._speakRequests = deque()  # clear the queue
-			with self._threadCond:  # wake up the thread
+			with self._threadCond:  # clear the queue and wake up the thread
+				self._speakRequests.clear()
 				self._threadCond.notify()
 		if self.ttsAudioStream:
 			# For legacy audio

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -48,7 +48,6 @@ Localisation data for emojis has been added for Belarusian and Bosnian.
   * Fixed a problem where NVDA sometimes freezes completely when using SAPI5 voices. (#18298, @gexgd0419)
   * Fixed a problem where NVDA fails to start with a SAPI5 Eloquence voice and falls back to OneCore voices. (#18301, @gexgd0419)
   * Fixed audio gaps in speech when using some SAPI5 voices with WASAPI and rate boost enabled. (#17967, @gexgd0419)
-  * Fixed a problem where NVDA is slow to respond / freezes temporarily when stopping speech and beginning to speak new content when using SAPI 5 voices. (#18674, #18676, #18760, @gexgd0419)
 * Remote Access:
   * Fixed a bug which stopped speech from working via NVDA Remote Access when the controlled computer had no audio output devices enabled. (#18544)
   * Fixed a bug which caused NVDA Remote Access to stop working if a session was interrupted while connecting to the server. (#18476)

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -48,6 +48,7 @@ Localisation data for emojis has been added for Belarusian and Bosnian.
   * Fixed a problem where NVDA sometimes freezes completely when using SAPI5 voices. (#18298, @gexgd0419)
   * Fixed a problem where NVDA fails to start with a SAPI5 Eloquence voice and falls back to OneCore voices. (#18301, @gexgd0419)
   * Fixed audio gaps in speech when using some SAPI5 voices with WASAPI and rate boost enabled. (#17967, @gexgd0419)
+  * Fixed a problem where NVDA is slow to respond / freezes temporarily when stopping speech and beginning to speak new content when using SAPI 5 voices. (#18674, #18676, #18760, @gexgd0419)
 * Remote Access:
   * Fixed a bug which stopped speech from working via NVDA Remote Access when the controlled computer had no audio output devices enabled. (#18544)
   * Fixed a bug which caused NVDA Remote Access to stop working if a session was interrupted while connecting to the server. (#18476)
@@ -55,9 +56,6 @@ Localisation data for emojis has been added for Belarusian and Bosnian.
 * Fixed support for paragraph mouse text unit in Java applications. (#18231, @hwf1324)
 * Fixed Highlighter not working with Outlook contact auto-complete lists. (#18483, @Nerlant)
 * A portable copy launched immediately after creation now correctly use its own configuration instead of another one. (#18442, @CyrilleB79)
-* Fixed excessive leading silence trimming that trims part of the speech when using some voices. (#18003, @gexgd0419)
-* Fixed audio gaps in speech when using some SAPI 5 voices with WASAPI and rate boost enabled. (#17967, @gexgd0419)
-* Fixed a problem where NVDA is slow to respond / freezes temporarily when stopping speech and beginning to speak new content when using SAPI 5 voices. (#18674, #18676, #18760, @gexgd0419)
 
 ### Changes for Developers
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -55,6 +55,9 @@ Localisation data for emojis has been added for Belarusian and Bosnian.
 * Fixed support for paragraph mouse text unit in Java applications. (#18231, @hwf1324)
 * Fixed Highlighter not working with Outlook contact auto-complete lists. (#18483, @Nerlant)
 * A portable copy launched immediately after creation now correctly use its own configuration instead of another one. (#18442, @CyrilleB79)
+* Fixed excessive leading silence trimming that trims part of the speech when using some voices. (#18003, @gexgd0419)
+* Fixed audio gaps in speech when using some SAPI 5 voices with WASAPI and rate boost enabled. (#17967, @gexgd0419)
+* Fixed a problem where NVDA is slow to respond / freezes temporarily when stopping speech and beginning to speak new content when using SAPI 5 voices. (#18674, #18676, #18760, @gexgd0419)
 
 ### Changes for Developers
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
<!-- Use Closes/Fixes/Resolves #xxx to link this PR to the issue it is responding to. -->
Fixes #18674. Fixes #18676. Fixes #18760.

### Summary of the issue:
NVDA becomes unresponsive for a small period of time when speaking some text in SAPI5 voices.

#18658 leaves more audio data for the EndStream handler to be played, which causes NVDA to be frozen when the EndStream handler is feeding the remaining audio chunks.

### Description of user facing changes:
The above issue should be fixed.

### Description of developer facing changes:
None

### Description of development approach:

Moves the feeding logic in EndStream to the dedicated speak thread, avoiding blocking the SAPI5 thread that EndStream runs on.

The main thread no longer waits for cancellation to complete in order to prevent freezing.

The dedicated speak thread for WASAPI will be stopped and restarted when WASAPI is turned on or off, in order to prevent errors accessing the player when WASAPI is turned off and the player no longer exists.

### Testing strategy:

### Known issues with pull request:

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
