### PR TITLE
Review 2025.3 changelog documentation changes

### DIFF
--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -45,7 +45,7 @@ Localisation data for emojis has been added for Belarusian and Bosnian.
 * Speech:
   * Fixed excessive leading silence trimming that trims part of the speech when using some voices. (#18003, @gexgd0419)
   * Fixed a problem where NVDA sometimes freezes completely when using SAPI5 voices. (#18298, @gexgd0419)
-  * Fixed a problem where NVDA fails to start with an SAPI5 Eloquence voice and falls back to OneCore voices. (#18301, @gexgd0419)
+  * Fixed a problem where NVDA fails to start with a SAPI5 Eloquence voice and falls back to OneCore voices. (#18301, @gexgd0419)
   * Fixed audio gaps in speech when using some SAPI5 voices with WASAPI and rate boost enabled. (#17967, @gexgd0419)
 * Remote Access:
   * Fixed a bug which stopped speech from working via NVDA Remote Access when the controlled computer had no audio output devices enabled. (#18544)

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -8,7 +8,7 @@ Add-ons in the Add-on Store can now be sorted by minimum/last tested NVDA versio
 
 Remote Access has had several minor fixes and improvements including adding a command to send `control+alt+delete` and remembering recent connection settings. There are also fixes for connection and audio issues.
 
-Braille improves with smarter word wrap, stable table selection across language changes, and optional USB auto‑detection for Dot Pad.
+Braille improves with smarter word wrap, stable table selection across language changes, and optional USB auto-detection for Dot Pad.
 
 There are several bug fixes for SAPI5 voices, including fixes for excessive leading silence trimming, freezing issues, and audio gaps.
 
@@ -64,9 +64,8 @@ Please refer to [the developer guide](https://download.nvaccess.org/documentatio
   * Updated comtypes to 1.4.11. (#18611)
   * Updated py2exe to 0.14.0.0. (#18611)
   * Updated markdown to 3.8.2. (#18638)
-* For `IAccessible` objects, the `flowsFrom` and `flowsTo` properties will now raise a `NotImplementedError` for MSAA (non-IA2) objects. (#18416, @LeonarddeR)
-* Updated `include` dependencies:
   * detours to `9764cebcb1a75940e68fa83d6730ffaf0f669401`. (#18447, @LeonarddeR)
+* For `IAccessible` objects, the `flowsFrom` and `flowsTo` properties will now raise a `NotImplementedError` for MSAA (non-IA2) objects. (#18416, @LeonarddeR)
 * The `nvda_dmp` utility has been removed. (#18480, @codeofdusk)
 * `comInterfaces_sconscript` has been updated to make the generated files in `comInterfaces` work better with IDEs. (#17608, @gexgd0419)
 * NVDA now configures `wx.lib.agw.persist.PersistenceManager` on GUI initialisation. (#18601)

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -6,7 +6,8 @@ This release includes improvements to Remote Access, SAPI5 voices, braille and t
 
 Add-ons in the Add-on Store can now be sorted by minimum/last tested NVDA version and install date.
 
-Remote Access has had several minor fixes and improvements including adding a command to send `control+alt+delete` and remembering recent connection settings. There are also fixes for connection and audio issues.
+Remote Access has had several minor fixes and improvements including adding a command to send `control+alt+delete` and remembering recent connection settings.
+There are also fixes for connection and audio issues.
 
 Braille improves with smarter word wrap, stable table selection across language changes, and optional USB auto-detection for Dot Pad.
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -2,7 +2,18 @@
 
 ## 2025.3
 
-### Important notes
+This release includes improvements to Remote Access, SAPI5 voices, braille and the Add-on Store.
+
+Add-ons in the Add-on Store can now be sorted by minimum/last tested NVDA version and install date.
+
+Remote Access has had several minor fixes and improvements including adding a command to send `control+alt+delete` and remembering recent connection settings. There are also fixes for connection and audio issues.
+
+Braille improves with smarter word wrap, stable table selection across language changes, and optional USB auto‑detection for Dot Pad.
+
+There are several bug fixes for SAPI5 voices, including fixes for excessive leading silence trimming, freezing issues, and audio gaps.
+
+eSpeak NG and Unicode CLDR have been updated.
+Localisation data for emojis has been added for Belarusian and Bosnian.
 
 ### New Features
 
@@ -19,26 +30,29 @@
   There have been improvements to Farsi/Persian. (#18342, #18633, @codeofdusk)
   * Updated Unicode CLDR to [47.0](https://cldr.unicode.org/downloads/cldr-47).
   Localisation data for emojis has been added for Belarusian and Bosnian. (#18581)
-* When braille word wrap is enabled, all braille cells will be used if the next character is a space. (#18016, @nvdaes)
+* Braille:
+  * When braille word wrap is enabled, all braille cells will be used if the next character is a space. (#18016, @nvdaes)
+  * NVDA no longer resets braille tables to automatic when changing its language. (#18538, @LeonarddeR)
+  * The Dot Pad braille display driver now supports automatic detection of USB-connected devices.
+  Note that this is disabled by default due to the device using generic USB identifiers, but can be enabled in braille settings. (#18444, @bramd)
 * When the selection covers more than one cell in Microsoft Excel, pressing `tab` or `enter` to move the active cell now reports the new active cell rather than the whole selection. (#6959, @CyrilleB79)
 * In terminal programs on Windows 10 version 1607 and later, the calculation of changed text now runs within NVDA instead of via an external process, which may improve performance and reliability. (#18480, @codeofdusk)
-* NVDA no longer resets braille tables to automatic when changing its language. (#18538, @LeonarddeR)
-* The Dot Pad braille display driver now supports automatic detection of USB-connected devices.
-Note that this is disabled by default due to the device using generic USB identifiers, but can be enabled in braille settings. (#18444, @bramd)
 * The NVDA Remote Access connection dialog now remembers the most recent connection mode, server type and locally hosted port of manual connections. (#18512)
 
 ### Bug Fixes
 
+* Speech:
+  * Fixed excessive leading silence trimming that trims part of the speech when using some voices. (#18003, @gexgd0419)
+  * Fixed a problem where NVDA sometimes freezes completely when using SAPI5 voices. (#18298, @gexgd0419)
+  * Fixed a problem where NVDA fails to start with an SAPI5 Eloquence voice and falls back to OneCore voices. (#18301, @gexgd0419)
+  * Fixed audio gaps in speech when using some SAPI5 voices with WASAPI and rate boost enabled. (#17967, @gexgd0419)
+* Remote Access:
+  * Fixed a bug which stopped speech from working via NVDA Remote Access when the controlled computer had no audio output devices enabled. (#18544)
+  * Fixed a bug which caused NVDA Remote Access to stop working if a session was interrupted while connecting to the server. (#18476)
 * Fixed bug with multiple math expressions on the same line in Microsoft Word documents: everything after the first expression was not spoken or brailled. (#18386, @NSoiffer)
 * Fixed support for paragraph mouse text unit in Java applications. (#18231, @hwf1324)
-* Fixed a problem where NVDA sometimes freezes completely when using SAPI5 voices. (#18298, @gexgd0419)
-* Fixed a problem where NVDA fails to start with an SAPI5 Eloquence voice and falls back to OneCore voices. (#18301, @gexgd0419)
 * Fixed Highlighter not working with Outlook contact auto-complete lists. (#18483, @Nerlant)
-* Fixed a bug which stopped speech from working via NVDA Remote Access when the controlled computer had no audio output devices enabled. (#18544)
-* Fixed a bug which caused NVDA Remote Access to stop working if a session was interrupted while connecting to the server. (#18476)
 * A portable copy launched immediately after creation now correctly use its own configuration instead of another one. (#18442, @CyrilleB79)
-* Fixed excessive leading silence trimming that trims part of the speech when using some voices. (#18003, @gexgd0419)
-* Fixed audio gaps in speech when using some SAPI 5 voices with WASAPI and rate boost enabled. (#17967, @gexgd0419)
 
 ### Changes for Developers
 


### PR DESCRIPTION
**Must be a squash merge**

Changes from this PR to the previous release:
- Files to check: `user_docs/en/userGuide.md`, `user_docs/en/changes.md` `developerGuide.md`
- [Compare this branch to the previous release](https://github.com/nvaccess/nvda/compare/release-2025.2...docsFor2025.3?expand=1)
- Comparison command:
`git diff release-2025.2...docsFor2025.3 -- "**/en/*.md" "**/developerGuide.md"`

Common mistakes to check for:
- Issue/PR reference in changes file is incorrect
- Incorrect spelling.
- Shortcuts added without code markdown (e.g. `NVDA+d`)
- List items not indented by a multiple of 2 spaces (regex `^ (  )*\*`)
- Double spaces (regex `[^ ]  `)
- Inconsistent use of single vs double quote. (regex `' `)