### PR TITLE
Start dev cycle for 2026.1

### DIFF
--- a/source/addonAPIVersion.py
+++ b/source/addonAPIVersion.py
@@ -1,14 +1,11 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2018-2023 NV Access Limited
+# Copyright (C) 2018-2025 NV Access Limited
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
 
 import buildVersion
 import re
-from typing import (
-	Tuple,
-)
 from logHandler import log
 
 """
@@ -16,7 +13,7 @@ This module contains add-on API version information for this build of NVDA. This
 how the API has changed as well as the range of API versions supported by this build of NVDA
 """
 
-AddonApiVersionT = Tuple[int, int, int]
+AddonApiVersionT = tuple[int, int, int]
 
 CURRENT: AddonApiVersionT = (
 	buildVersion.version_year,
@@ -24,12 +21,13 @@ CURRENT: AddonApiVersionT = (
 	buildVersion.version_minor,
 )
 
-BACK_COMPAT_TO: AddonApiVersionT = (2025, 1, 0)
+BACK_COMPAT_TO: AddonApiVersionT = (2026, 1, 0)
 """
 As BACK_COMPAT_TO is incremented, the changed / removed parts / or reasoning should be added below.
 These only serve to act as a reminder, the changelog should be consulted for a comprehensive listing.
 EG: (x, y, z): Large changes to speech.py
 ---
+(2026, 1, 0): Upgrade to python 3.13 and migration to 64bit from 32bit
 (2025, 1, 0): HTML passed to browsableMessage is now sanitised, and various changes to the settings schema
 (2024, 1, 0): upgrade to python 3.11
 (2023, 1, 0): speech as str was dropped in favor of only SpeechCommand, and security changes.

--- a/source/buildVersion.py
+++ b/source/buildVersion.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2006-2024 NV Access Limited
+# Copyright (C) 2006-2025 NV Access Limited
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -63,8 +63,8 @@ def formatVersionForGUI(year, major, minor):
 
 # Version information for NVDA
 name = "NVDA"
-version_year = 2025
-version_major = 3
+version_year = 2026
+version_major = 1
 version_minor = 0
 version_build = 0  # Should not be set manually. Set in 'sconscript'.
 version = _formatDevVersionString()

--- a/source/versionInfo.py
+++ b/source/versionInfo.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2006-2024 NV Access Limited
+# Copyright (C) 2006-2025 NV Access Limited
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -14,7 +14,7 @@ from buildVersion import *  # noqa: F403
 longName = _("NonVisual Desktop Access")
 description = _("A free and open source screen reader for Microsoft Windows")
 url = "https://www.nvaccess.org"
-copyrightYears = "2006-2025"
+copyrightYears = "2006-2026"
 copyright = _("Copyright (C) {years} NVDA Contributors").format(
 	years=copyrightYears,
 )

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -1,5 +1,34 @@
 # What's New in NVDA
 
+## 2026.1
+
+### Important notes
+
+* This release breaks compatibility with existing add-ons.
+* Windows 8.1 is no longer supported.
+Windows 10 is the minimum Windows version supported.
+* 32-bit Windows is no longer supported.
+
+### New Features
+
+### Changes
+
+### Bug Fixes
+
+### Changes for Developers
+
+Please refer to [the developer guide](https://download.nvaccess.org/documentation/developerGuide.html#API) for information on NVDA's API deprecation and removal process.
+
+* Note: this is an Add-on API compatibility breaking release.
+Add-ons will need to be re-tested and have their manifest updated.
+
+#### API Breaking Changes
+
+These are breaking API changes.
+Please open a GitHub issue if your add-on has an issue with updating to the new API.
+
+#### Deprecations
+
 ## 2025.3
 
 ### Important notes


### PR DESCRIPTION
Start the dev cycle for the 2026.1 release.
This will be a compatibility breaking release.

Complete:
- [x] New section in the change log.
- [x] Update NVDA version in `master`
- [x] Bump the add-on API compatibility in `master`
- [x] Update [`nvdaAPIVersions.json` to include the next version](https://github.com/nvaccess/addon-datastore-transform)
  - Re-run the last "Transform NVDA addons to views" on [addon-datastore](https://github.com/nvaccess/addon-datastore/actions/workflows/transformDataToViews.yml) to regenerate projections (views) for the add-on datastore API.

On merge:
- [x] [Update auto milestone ID](https://github.com/nvaccess/nvda/settings/variables/actions)