### PR TITLE
Persist selected index in Remote Access connection dialog"

### DIFF
--- a/source/_remoteClient/dialogs.py
+++ b/source/_remoteClient/dialogs.py
@@ -21,6 +21,7 @@ from logHandler import log
 from gui.guiHelper import alwaysCallAfter, BoxSizerHelper
 from gui import guiHelper
 from gui.nvdaControls import SelectOnFocusSpinCtrl
+from gui.persistenceHandler import EnumeratedChoiceHandler
 from config.configFlags import RemoteConnectionMode, RemoteServerType
 
 from . import configuration, serializer, server, protocol, transport
@@ -369,7 +370,13 @@ class DirectConnectDialog(ContextHelpMixin, wx.Dialog):
 	def _registerAndRestorePersistentControls(self):
 		persistenceManager = persist.PersistenceManager.Get()
 		for control in self._persistentControls:
-			persistenceManager.RegisterAndRestore(control)
+			persistenceManager.Register(
+				control,
+				# Use a custom persistence handler that persists selection index for wx.Choice controls,
+				# Otherwise, use the default persistence handler.
+				EnumeratedChoiceHandler if isinstance(control, wx.Choice) else None,
+			)
+			persistenceManager.Restore(control)
 
 	def _savePersistentControls(self):
 		persistenceManager = persist.PersistenceManager.Get()

--- a/source/gui/persistenceHandler.py
+++ b/source/gui/persistenceHandler.py
@@ -1,0 +1,76 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2025 NV Access Limited
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+
+"""Custom persistence handlers for use with :mod:`wx.lib.agw.persist`."""
+
+import wx
+import wx.lib
+from wx.lib.agw.persist.persist_handlers import AbstractHandler
+from wx.lib.agw.persist.persistencemanager import PersistentObject
+
+
+class EnumeratedChoiceHandler(AbstractHandler):
+	"""
+	Persistence handler which stores and retrieves the persisted window's selected index.
+
+	Supported windows:
+	- :class:`wx.Choice`
+
+	In theory, any `wx.Window` subclass that implements integer `GetSelection` and `SetSelection` should work.
+	"""
+
+	_KIND = "EnumeratedChoice"
+	"""String that uniquely identifies this persistence handler."""
+
+	_NAME = "Selection"
+	"""Key for the :attr:`wx.Choice.Selection` when persisted."""
+
+	# Type hints for AbstractHandler
+	_pObject: PersistentObject
+	"""PersistentObject we're handling read/write for."""
+
+	_window: wx.Choice
+	"""Window being persisted."""
+
+	def __init__(self, pObject: PersistentObject):
+		"""Initialiser.
+
+		:param pObject: Persistent object for which we're handling saving and restoring.
+		:raises TypeError: If ``pObject``'s ``Window`` isn't a :class:`wx.Choice`.
+		"""
+		if not isinstance(pObject.GetWindow(), wx.Choice):
+			raise TypeError("Only wx.Choice controls are supported.")
+		super().__init__(pObject)
+
+	def Save(self) -> bool:
+		"""Save the control's value to storage.
+
+		:return: ``True`` if successful; ``false`` otherwise.
+		"""
+		self._pObject.SaveCtrlValue(self._NAME, self._window.GetSelection())
+		return True
+
+	def Restore(self) -> bool:
+		"""Restore the control's value from storage.
+
+		:return: ``True`` if the control's selection was restored from storage; ``False`` otherwise.
+		"""
+		value = self._pObject.RestoreCtrlValue(self._NAME)
+		if value is not None:
+			try:
+				value = int(value)
+			except ValueError:
+				return False
+			if value in range(self._window.GetCount()) or value == wx.NOT_FOUND:
+				self._window.SetSelection(value)
+				return True
+		return False
+
+	def GetKind(self) -> str:
+		"""Get a string that uniquely identifies the type of persistence handler being used.
+
+		:return: A unique string that identifies this class of persistence handler.
+		"""
+		return self._KIND

--- a/source/gui/persistenceHandler.py
+++ b/source/gui/persistenceHandler.py
@@ -37,7 +37,7 @@ class EnumeratedChoiceHandler(AbstractHandler):
 	def __init__(self, pObject: PersistentObject):
 		"""Initialiser.
 
-		:param pObject: Persistent object for which we're handling saving and restoring.
+		:param pObject: :class:`PersistentObject` for which we're handling saving and restoring.
 		:raises TypeError: If ``pObject``'s ``Window`` isn't a :class:`wx.Choice`.
 		"""
 		if not isinstance(pObject.GetWindow(), wx.Choice):
@@ -47,7 +47,7 @@ class EnumeratedChoiceHandler(AbstractHandler):
 	def Save(self) -> bool:
 		"""Save the control's value to storage.
 
-		:return: ``True`` if successful; ``false`` otherwise.
+		:return: ``True`` if successful; ``False`` otherwise.
 		"""
 		self._pObject.SaveCtrlValue(self._NAME, self._window.GetSelection())
 		return True
@@ -63,7 +63,7 @@ class EnumeratedChoiceHandler(AbstractHandler):
 				value = int(value)
 			except ValueError:
 				return False
-			if value in range(self._window.GetCount()) or value == wx.NOT_FOUND:
+			if (0 <= value < self._window.GetCount()) or value == wx.NOT_FOUND:
 				self._window.SetSelection(value)
 				return True
 		return False

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -38,7 +38,7 @@ Localisation data for emojis has been added for Belarusian and Bosnian.
   Note that this is disabled by default due to the device using generic USB identifiers, but can be enabled in braille settings. (#18444, @bramd)
 * When the selection covers more than one cell in Microsoft Excel, pressing `tab` or `enter` to move the active cell now reports the new active cell rather than the whole selection. (#6959, @CyrilleB79)
 * In terminal programs on Windows 10 version 1607 and later, the calculation of changed text now runs within NVDA instead of via an external process, which may improve performance and reliability. (#18480, @codeofdusk)
-* The NVDA Remote Access connection dialog now remembers the most recent connection mode, server type and locally hosted port of manual connections. (#18512)
+* The NVDA Remote Access connection dialog now remembers the most recent connection mode, server type and locally hosted port of manual connections. (#18512, #18701)
 
 ### Bug Fixes
 


### PR DESCRIPTION
### Link to issue number:
Fixes #18691

### Summary of the issue:
Remote Access settings are only persisted for the currently active NVDA language. Changing NVDA's interface language will cause the selections to be forgotten.

### Description of user facing changes:
Selections in the Remote Access connection dialog are now persisted across languages.

### Description of developer facing changes:
None

### Description of development approach:
Added a new `wx.lib.agw.persist.persistence_handler.AbstractHandler` subclass that persists `wx.Choice.Selection` (the default is to persist `StringSelection`).
Used this persistence handler in place of the default when registering `wx.Choice` controls with the global persistence manager in `_remoteClient.dialogs.DirectConnectDialog._registerAndRestorePersistentControls`.

### Testing strategy:
Started Remote Access connections with a variety of configurations, and ensured that the selections were kept the next time the dialog was opened.

### Known issues with pull request:
None.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
