### PR TITLE
Add send SAS script to the user guide

### DIFF
--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -3849,6 +3849,7 @@ Once a Remote Access session is active, you can switch between controlling the r
 | Disconnect | None | Ends an existing Remote Access session. |
 | Mute remote | None | Mutes or unmutes the speech coming from the remote computer. |
 | Send clipboard | None | Sends the contents of the clipboard to the remote computer. |
+| Send control+alt+delete | None | Sends `control+alt+delete` to the controlled computer. |
 <!-- KC:endInclude -->
 
 ## Add-ons and the Add-on Store {#AddonsManager}

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -3849,7 +3849,7 @@ Once a Remote Access session is active, you can switch between controlling the r
 | Disconnect | None | Ends an existing Remote Access session. |
 | Mute remote | None | Mutes or unmutes the speech coming from the remote computer. |
 | Send clipboard | None | Sends the contents of the clipboard to the remote computer. |
-| Send control+alt+delete | None | Sends `control+alt+delete` to the controlled computer. |
+| Send `control+alt+delete` | None | Sends `control+alt+delete` to the controlled computer. |
 <!-- KC:endInclude -->
 
 ## Add-ons and the Add-on Store {#AddonsManager}


### PR DESCRIPTION
### Link to issue number:
Follow-up to #18629

### Summary of the issue:
#18629 added an (unassigned) script to send `alt+ctrl+del` via Remote Access, but this wasn't included in the list of Remote Access keyboard shortcuts.

### Description of user facing changes:
This command is now listed in the list of Remote Access commands.

### Description of developer facing changes:
None

### Description of development approach:
Added row to table

### Testing strategy:
Built UG and checked output.

### Known issues with pull request:
None

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
