### PR TITLE
Fix double speaking "disconnected" when leader

### DIFF
--- a/source/_remoteClient/client.py
+++ b/source/_remoteClient/client.py
@@ -392,8 +392,6 @@ class RemoteClient:
 	@alwaysCallAfter
 	def onDisconnectedAsLeader(self):
 		log.info("Leader session disconnected")
-		# Translators: Presented when connection to a remote computer was interupted.
-		ui.message(_("Disconnected"))
 
 	def connectAsFollower(self, connectionInfo: ConnectionInfo):
 		transport = RelayTransport.create(


### PR DESCRIPTION
### Link to issue number:

Closes #18692

### Summary of the issue:

When connected as the controlling computer, disconnecting causes NVDA to speak "Disconnected" twice.

### Description of user facing changes:

NVDA speaks "Disconnected" once.

### Description of developer facing changes:

None

### Description of development approach:

Removed superfluous `ui.message` from `_remoteClient.client.RemoteClient.onDisconnectedAsLeader`.

### Testing strategy:

Connected as leader, then disconnected and ensured "disconnected" was only spoken once. Did so from the menu and with `NVDA+alt+r`.

### Known issues with pull request:

None

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
