### PR TITLE
simplify encoding standards

### DIFF
--- a/projectDocs/dev/codingStandards.md
+++ b/projectDocs/dev/codingStandards.md
@@ -10,17 +10,7 @@ If there is a reason you are unable to follow these standards in a contribution 
 
 ### Encoding
 
-* Where Python files contain non-ASCII characters, they should be encoded in UTF-8.
-  * There should be no Unicode BOM at the start of the file, as this unfortunately breaks one of the translation tools we use (`xgettext`).
-  Instead, include this as the first line of the file, only if the file contains non-ASCII characters:
-
-  ```py
-  # -*- coding: UTF-8 -*-
-  ```
-
-  * This coding comment must also be included if strings in the code (even strings that aren't translatable) contain escape sequences that produce non-ASCII characters; e.g. `"\xff"`.
-    This is particularly relevant for braille display drivers.
-    This is due to a `gettext` bug; see [comment on #2592](https://github.com/nvaccess/nvda/issues/2592#issuecomment-155299911).
+* Python files should be encoded in UTF-8.
 * Text files should be committed with `LF` line endings.
 Files can be checked out locally using CRLF if needed for Windows development using [git](https://git-scm.com/book/en/v2/Customizing-Git-Git-Configuration#_core_autocrlf).
 


### PR DESCRIPTION
UTF-8 encoded files are no longer an issue with gettext/python.
It's unknown when this was fixed, likely around Python 3.11 update