### PR TITLE
Split Turkish braille tables

### DIFF
--- a/source/brailleTables/__tables.py
+++ b/source/brailleTables/__tables.py
@@ -561,10 +561,13 @@ addTable("th-g1.utb", _("Thai grade 1"), input=False, contracted=True, outputFor
 addTable("th-g2.ctb", _("Thai grade 2"), input=False, contracted=True)
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
-addTable("tr.ctb", _("Turkish grade 1"), inputForLangs={"tr"}, outputForLangs={"tr"})
+addTable("tr.ctb", _("Turkish 8 dot computer braille"), inputForLangs={"tr"}, outputForLangs={"tr"})
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
-addTable("tr-g2.ctb", _("Turkish grade 2"), contracted=True)
+addTable("tr-g1.ctb", _("Turkish grade 1"), inputForLangs={"tr"}, outputForLangs={"tr"})
+# Translators: The name of a braille table displayed in the
+# braille settings dialog.
+addTable("tr-g2.ctb", _("Turkish grade 2"), contracted=True, inputForLangs={"tr"}, outputForLangs={"tr"})
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("tsn-za-g1.ctb", _("Setswana grade 1"))


### PR DESCRIPTION
### Link to issue number:
None
### Summary of the issue:
The Turkish braille tables is incorrect in NVDA.
### Description of user facing changes:
The user will see the Turkish 8 dot computer braille, Turkish grade 1 and Turkish grade 2.
### Description of developer facing changes:
None
### Description of development approach:
Add original Turkish grade 1, and rename tr.ctb as Turkish 8 dot computer braille.
### Testing strategy:
Manual test using a braille display.
### Known issues with pull request:
None
### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

@coderabbitai summary