### PR TITLE
Fix auto milestone action

### DIFF
--- a/.github/workflows/assign-milestone-on-close.yml
+++ b/.github/workflows/assign-milestone-on-close.yml
@@ -8,6 +8,7 @@ on:
     types: [closed]
 
 permissions:
+  issues: write
   pull-requests: write
 
 jobs:


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
The auto milestone action has been broken since #18396.

### Description of user facing changes:
None

### Description of developer facing changes:
Pull requests should have a milestone automatically applied on merge.

### Description of development approach:
Gave the action write permission for issues.
This is needed because PRs are considered to be a type of issue by GitHub. The action still needs write permission for pull requests as only users with merge permissions can add a milestone to pull requests.

### Testing strategy:
Ran the action on a fork of NVDA.

* With only `issues: write`: <https://github.com/SaschaCowley/nvda/actions/runs/17027879005>
* With both `issues` and `pull-requests: write`: <https://github.com/SaschaCowley/nvda/actions/runs/17027997599>

### Known issues with pull request:
Still doesn't address the fact that PRs merged to beta/rc will get the wrong milestone, and PRs not merged to master/beta/rc shouldn't be milestoned at all.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
