### PR TITLE
Create discussion and upload exe to beta/RCs

### DIFF
--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -540,7 +540,7 @@ jobs:
     permissions:
       actions: write
     needs: [matrix, allTestsPass, crowdinUpload, uploadSymbols]
-    if: ${{ always() && (github.event_name == 'push' || github.event.pull_request.head.repo.owner == github.repository_owner) }}
+    if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.owner == github.repository_owner }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -685,7 +685,8 @@ jobs:
           --prerelease \
           --title "${{ steps.getReleaseNotes.outputs.RELEASE_NAME }}" \
           --notes-file /tmp/releaseNotes.md \
-          --verify-tag
+          --verify-tag \
+          --discussion-category Releases
     - name: Publish stable release
       if: ${{ !contains(github.ref_name, 'rc') && !contains(github.ref_name, 'beta') }}
       shell: bash
@@ -698,6 +699,11 @@ jobs:
           --notes-file /tmp/releaseNotes.md \
           --verify-tag \
           --discussion-category Releases
+    - name: Upload exe to release assets
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
         gh release upload ${{github.ref_name }} \
             --repo ${{ github.repository }} \
             --clobber \

--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -704,7 +704,7 @@ jobs:
       env:
         GH_TOKEN: ${{ github.token }}
       run: |
-        gh release upload ${{github.ref_name }} \
+        gh release upload ${{ github.ref_name }} \
             --repo ${{ github.repository }} \
             --clobber \
             output/nvda*.exe#Installer


### PR DESCRIPTION

### Link to issue number:
Part of #18556 

### Summary of the issue:

Beta/RC tags do not upload the exe to the release assets, unlike stable releases.

Additionally, to make it easier to discuss issues with betas, creating a beta discussion is useful.
It also allows us to easily share each new release in slack and other places via [Discussions](https://github.com/nvaccess/nvda/discussions/categories/releases.atom) RSS feed. The [releases RSS feed](http://github.com/nvaccess/nvda/releases.atom) includes tags, which duplicates posts to slack.

If a build fails due to system tests, you cannot rebuild it as the cache gets deleted.


### Description of user facing changes:

None

### Description of developer facing changes:
GitHub discussions are created for betas and RCs.
All releases are auto-posted to slack.
The installer artifact is uploaded to the release assets.

### Description of development approach:
fix up action

only delete cache on successful build
### Testing strategy:

### Known issues with pull request:

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
