### PR TITLE
Fix issues in uniscribe code

### DIFF
--- a/nvdaHelper/local/textUtils.cpp
+++ b/nvdaHelper/local/textUtils.cpp
@@ -38,6 +38,7 @@ vector<SCRIPT_LOGATTR> _getLogAttrArray(const wchar_t* text, int textLength) {
 		LOG_ERROR(L"ScriptItemize failed for text '" << text << L"'; hr=" << hr);
 		return {};
 	}
+
 	vector<SCRIPT_LOGATTR> logAttrArray(textLength);
 	// The function always adds a terminal item to the item analysis array.
 	// numItems contains the number of actually processed items excluding the terminating item.
@@ -49,7 +50,7 @@ vector<SCRIPT_LOGATTR> _getLogAttrArray(const wchar_t* text, int textLength) {
 			LOG_ERROR(L"ScriptBreak failed for text '" << text << L"' at run " << itemIndex << L"; hr=" << hr);
 			return {};
 		}
-		// Note, ideally we'd set nextICharPos  to iCharPos, so that the
+		// Note, ideally we'd set nextICharPos to iCharPos, so that the
 		// next iteration of the loop will only call ScriptBreak for the text that belongs to the current item.
 		// Now that we don't do this, every call of ScriptBreak refills logAttrArray
 		// for the characters after this item based on the SCRIPT_ANALYSIS for the current item,

--- a/source/textInfos/offsets.py
+++ b/source/textInfos/offsets.py
@@ -344,26 +344,21 @@ class OffsetsTextInfo(textInfos.TextInfo):
 			raise NotImplementedError(f"Unit: {unit}")
 		relStart = ctypes.c_int()
 		relEnd = ctypes.c_int()
-		# uniscribe does some strange things
-		# when you give it a string  with not more than two alphanumeric chars in a row.
-		# Inject two alphanumeric characters at the end to fix this
-		uniscribeLineText = lineText + "xx"
 		# We can't rely on len(lineText) to calculate the length of the line.
 		offsetConverter = textUtils.WideStringOffsetConverter(lineText)
 		lineLength = offsetConverter.encodedStringLength
 		if self.encoding != textUtils.WCHAR_ENCODING:
 			# We need to convert the str based line offsets to wide string offsets.
 			relOffset = offsetConverter.strToEncodedOffsets(relOffset, relOffset)[0]
-		uniscribeLineLength = lineLength + 2
 		if helperFunc(
-			uniscribeLineText,
-			uniscribeLineLength,
+			lineText,
+			lineLength,
 			relOffset,
 			ctypes.byref(relStart),
 			ctypes.byref(relEnd),
 		):
 			relStart = relStart.value
-			relEnd = min(lineLength, relEnd.value)
+			relEnd = relEnd.value
 			if self.encoding != textUtils.WCHAR_ENCODING:
 				# We need to convert the uniscribe based offsets to str offsets.
 				relStart, relEnd = offsetConverter.encodedToStrOffsets(relStart, relEnd)

--- a/source/textInfos/offsets.py
+++ b/source/textInfos/offsets.py
@@ -358,7 +358,7 @@ class OffsetsTextInfo(textInfos.TextInfo):
 			ctypes.byref(relEnd),
 		):
 			relStart = relStart.value
-			relEnd = relEnd.value
+			relEnd = min(lineLength, relEnd.value)
 			if self.encoding != textUtils.WCHAR_ENCODING:
 				# We need to convert the uniscribe based offsets to str offsets.
 				relStart, relEnd = offsetConverter.encodedToStrOffsets(relStart, relEnd)

--- a/source/textUtils/uniscribe.py
+++ b/source/textUtils/uniscribe.py
@@ -20,14 +20,10 @@ def splitAtCharacterBoundaries(text: str) -> Generator[str, None, None]:
 		raise RuntimeError("NVDAHelper not initialized")
 	if not text:
 		return
-	# uniscribe does some strange things
-	# when you give it a string with not more than two alphanumeric chars in a row.
-	# Inject two alphanumeric characters at the end to fix this
-	uniscribeText = text + "xx"
-	buffer = ctypes.create_unicode_buffer(uniscribeText)
+	buffer = ctypes.create_unicode_buffer(text)
 	textLength = len(buffer) - 1  # Length without terminating NULL character
 	offsetsCount = ctypes.c_int()
-	offsets = (ctypes.c_int * textLength)()
+	offsets = (ctypes.c_int * (textLength + 1))()
 	if not NVDAHelper.localLib.calculateCharacterBoundaries(
 		buffer,
 		textLength,
@@ -36,7 +32,7 @@ def splitAtCharacterBoundaries(text: str) -> Generator[str, None, None]:
 	):
 		raise RuntimeError("NVDAHelper calculateCharacterBoundaries failed")
 	# Get the end offsets of the characters we need.
-	calculatedOffsets = offsets[1 : (offsetsCount.value - 1)]
+	calculatedOffsets = offsets[1 : (offsetsCount.value + 1)]
 	start = 0
 	for end in calculatedOffsets:
 		yield buffer[start:end]

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -20,6 +20,8 @@ This can be enabled using the "Report when lists support multiple selection" set
 
 ### Bug Fixes
 
+* When unicode normalization is enabled for speech, navigating by character will again correctly announce combining diacritic characters like acute ( &#x0301; ). (#18722, @LeonarddeR)
+
 ### Changes for Developers
 
 Please refer to [the developer guide](https://download.nvaccess.org/documentation/developerGuide.html#API) for information on NVDA's API deprecation and removal process.
@@ -89,7 +91,6 @@ Localisation data for emojis has been added for Belarusian and Bosnian.
   * Fixed a problem where NVDA sometimes freezes completely when using SAPI5 voices. (#18298, @gexgd0419)
   * Fixed a problem where NVDA fails to start with a SAPI5 Eloquence voice and falls back to OneCore voices. (#18301, @gexgd0419)
   * Fixed audio gaps in speech when using some SAPI5 voices with WASAPI and rate boost enabled. (#17967, @gexgd0419)
-  * When unicode normalization is on, navigating by character will again correctly announce combining diacritic characters like acute (\u0301). (#18722, @LeonarddeR)
 * Remote Access:
   * Fixed a bug which stopped speech from working via NVDA Remote Access when the controlled computer had no audio output devices enabled. (#18544)
   * Fixed a bug which caused NVDA Remote Access to stop working if a session was interrupted while connecting to the server. (#18476)

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -89,6 +89,7 @@ Localisation data for emojis has been added for Belarusian and Bosnian.
   * Fixed a problem where NVDA sometimes freezes completely when using SAPI5 voices. (#18298, @gexgd0419)
   * Fixed a problem where NVDA fails to start with a SAPI5 Eloquence voice and falls back to OneCore voices. (#18301, @gexgd0419)
   * Fixed audio gaps in speech when using some SAPI5 voices with WASAPI and rate boost enabled. (#17967, @gexgd0419)
+  * When unicode normalization is on, navigating by character will again correctly announce combining diacritic characters like acute (\u0301). (#18722, @LeonarddeR)
 * Remote Access:
   * Fixed a bug which stopped speech from working via NVDA Remote Access when the controlled computer had no audio output devices enabled. (#18544)
   * Fixed a bug which caused NVDA Remote Access to stop working if a session was interrupted while connecting to the server. (#18476)


### PR DESCRIPTION
### Link to issue number:
Closes #18722 
Reverts 021bcd8f2ac

### Summary of the issue:
The code that split a string at character boundaries discarded characters like \u0301 when such a character was the only character in a string.

### Description of user facing changes:
When unicode normalization is on, navigating by character will again correctly announce characters like acute (\u0301)

### Description of developer facing changes:
- NVDAHelper local `calculateCharacterBoundaries` now needs an offsets array that is textLength + 1 in size, rather than only the text length. This is to store the end offset of the last character.
- This reverts 021bcd8f2ac, therefore we don't pass additional extraneous alphanumeric characters to uniscribe to make it happy.

### Description of development approach:
While debugging this issue, I found several issues in NVDAHelper local textUtils `_getLogAttrArray` function that is the base of the several calculation functions:

1. The buffer passed to `ScriptItemize` was too small when a string only contained one character. The buffer should have space for at least two SCRIPT_ITEM structures in size. This is my hypothesis about the necessity of 021bcd8f2ac, namely the addition of two alphanumeric characters passed to the uniscribe methods. While there are no exactly known str to reproduce the issue behind 021bcd8f2ac, I tried several combinations of shorter and longer strings without alpha numeric characters, and I couldn't reproduce any of the behavior described in it after my changes to the c++ code. Therefore I reverted 021bcd8f2ac, as there is enough time to test this in Alpha thoroughly.
2. Calculation of character offsets would never set the end offset when requesting the offsets of the last character in the string, since the end offset calculation starts at offset + 1 and offset + 1 is equal to textLength.
3. Failed calls of `ScriptItemize` and `ScriptBreak` were never logged. `ScriptItemize` definitely failed when passing a string with only one character in it because the expected buffer was to small.

### Testing strategy:
- Unit tests
- System tests
- STR from #18722

### Known issues with pull request:
The call of `ScriptBreak` seems wrong when a string contains two or more items generated by `ScriptItemize`. This seems so because the `iCharLength` variable is never limited to the length of the item, but rather extended to the length of the string every time. However, if we reset `iCharLength` and call `ScriptBreak` for only the text that belongs to the current item, we get word navigation behavior that diverges from the one in Notepad. Therefore I left this as is and documented it in code in case someone stumbles upon this again in the future.

### Code Review Checklist:
- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
