### PR TITLE
Create script to clear older caches

### DIFF
--- a/.github/workflows/clearCaches.yml
+++ b/.github/workflows/clearCaches.yml
@@ -1,0 +1,35 @@
+name: Clear caches
+
+on:
+  schedule:
+    # every 3 hours
+    - cron: '0 */3 * * *'
+  workflow_dispatch:
+    inputs:
+      cache_expiration:
+        description: 'Delete all caches older than X seconds (Default 6 hours, 21600)'
+        required: false
+
+env:
+  CACHE_EXPIRATION_SEC: ${{ inputs.cache_expiration || 21600 }}
+
+jobs:
+  cleanupCache:
+    name: Cleanup caches
+    permissions:
+      actions: write
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - name: Cleanup cache
+        shell: bash
+        run: |
+          gh -R nvaccess/nvda cache list --json key,createdAt | jq -r '${{ env.jqStr }}' | while read -r cache; do
+            gh -R nvaccess/nvda cache delete $cache
+          done
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          # Filter the past 
+          jqStr: 'map(select((.createdAt | sub("\\.\\d+Z$"; "Z") | fromdateiso8601) < (now - ${{ env.CACHE_EXPIRATION_SEC }} * 86400))) | .[].key'

--- a/.github/workflows/clearCaches.yml
+++ b/.github/workflows/clearCaches.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Cleanup cache
         shell: bash
         run: |
-          gh cache list --json key,lastAccessedAt | jq -r '${{ env.jqStr }}' | while read -r cache; do
+          gh cache list --order asc --json key,lastAccessedAt | jq --raw-output '${{ env.jqStr }}' | while read -r cache; do
             gh cache delete $cache
           done
         env:

--- a/.github/workflows/clearCaches.yml
+++ b/.github/workflows/clearCaches.yml
@@ -26,10 +26,10 @@ jobs:
         shell: bash
         run: |
           gh cache list --order asc --json key,lastAccessedAt | jq --raw-output '${{ env.jqStr }}' | while read -r cache; do
-            gh cache delete $cache
+            gh cache delete "$cache"
           done
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
           # Filter for caches last accessed older than the expiration time
-          jqStr: 'map(select((.lastAccessedAt | sub("\\.\\d+Z$"; "Z") | fromdateiso8601) < (now - ${{ env.CACHE_EXPIRATION_HOUR }} * 3600))) | .[].key'
+          jqStr: 'map(select((.lastAccessedAt | sub("\\.[0-9]+Z$"; "Z") | fromdateiso8601) < (now - ${{ env.CACHE_EXPIRATION_HOUR }} * 3600))) | .[].key'

--- a/.github/workflows/clearCaches.yml
+++ b/.github/workflows/clearCaches.yml
@@ -7,11 +7,11 @@ on:
   workflow_dispatch:
     inputs:
       cache_expiration:
-        description: 'Delete all caches older than X seconds (Default 6 hours, 21600)'
+        description: 'Delete all caches older than X hours (Default 6 hours)'
         required: false
 
 env:
-  CACHE_EXPIRATION_SEC: ${{ inputs.cache_expiration || 21600 }}
+  CACHE_EXPIRATION_HOUR: ${{ inputs.cache_expiration || 6 }}
 
 jobs:
   cleanupCache:
@@ -25,11 +25,11 @@ jobs:
       - name: Cleanup cache
         shell: bash
         run: |
-          gh -R nvaccess/nvda cache list --json key,createdAt | jq -r '${{ env.jqStr }}' | while read -r cache; do
-            gh -R nvaccess/nvda cache delete $cache
+          gh cache list --json key,lastAccessedAt | jq -r '${{ env.jqStr }}' | while read -r cache; do
+            gh cache delete $cache
           done
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
-          # Filter the past
-          jqStr: 'map(select((.createdAt | sub("\\.\\d+Z$"; "Z") | fromdateiso8601) < (now - ${{ env.CACHE_EXPIRATION_SEC }} * 86400))) | .[].key'
+          # Filter for caches last accessed older than the expiration time
+          jqStr: 'map(select((.lastAccessedAt | sub("\\.\\d+Z$"; "Z") | fromdateiso8601) < (now - ${{ env.CACHE_EXPIRATION_HOUR }} * 3600))) | .[].key'

--- a/.github/workflows/clearCaches.yml
+++ b/.github/workflows/clearCaches.yml
@@ -31,5 +31,5 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
-          # Filter the past 
+          # Filter the past
           jqStr: 'map(select((.createdAt | sub("\\.\\d+Z$"; "Z") | fromdateiso8601) < (now - ${{ env.CACHE_EXPIRATION_SEC }} * 86400))) | .[].key'


### PR DESCRIPTION
### Link to issue number:
Part of #17878 

### Summary of the issue:
PRs have been failing recently as we are well over  our cache limit.
GitHub actions doesn't allow us to easily delete the caches of PR builds from within PRs, due to it being a cache poisoning risk.
Instead, we should clear caches manually on a regular basis.

### Description of user facing changes:
None

### Description of developer facing changes:

PRs more reliable

### Description of development approach:

- Use gh cli to fetch cache items
- filter with jq for cache items last accessed older than 6 hours ago
- delete filtered cache items

### Testing strategy:

Tested locally from CLI

### Known issues with pull request:

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
