### PR TITLE
Test NVDA on server 2022

### DIFF
--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -36,7 +36,7 @@ env:
   # Cache details about available MSVC tooling for subsequent SCons invocations to the provided file.
   SCONS_CACHE_MSVC_CONFIG: ".scons_msvc_cache.json"
   defaultRunner: 'windows-2025'
-  supportedRunners: '["windows-2025", "windows-2022"]'
+  supportedRunners: '["windows-2022", "windows-2025"]'
   defaultArch: x86
   supportedArchitectures: '["x86"]'
   defaultPythonVersion: '3.13.7'
@@ -79,7 +79,7 @@ jobs:
       APIBackCompat: ${{ steps.releaseInfo.outputs.NVDA_API_COMPAT_TO }}
     steps:
     - name: Checkout NVDA
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         submodules: true
     - name: Install Python
@@ -151,7 +151,7 @@ jobs:
     needs: matrix
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         # Include gettext
         submodules: true
@@ -397,11 +397,11 @@ jobs:
         runner: ${{ fromJson(needs.matrix.outputs.supportedRunners) }}
         arch: ${{ fromJson(needs.matrix.outputs.supportedArchitectures) }}
         pythonVersion: ${{ fromJson(needs.matrix.outputs.supportedPythonVersions) }}
-      # A bug exists with windows 2022 notepad that prevents NVDA from focusing it.
-      # This causes our symbol pronunciation tests to fail on this runner.
-      exclude:
-        - runner: windows-2022
-          testSuite: symbols
+        # A bug exists with windows 2022 notepad that prevents NVDA from focusing it.
+        # This causes our symbol pronunciation tests to fail on this runner.
+        exclude:
+          - runner: windows-2022
+            testSuite: symbols
     env:
       uv-arch: ${{ matrix.arch == 'x64' && 'x86_64' || 'x86' }}
     steps:

--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -36,7 +36,7 @@ env:
   # Cache details about available MSVC tooling for subsequent SCons invocations to the provided file.
   SCONS_CACHE_MSVC_CONFIG: ".scons_msvc_cache.json"
   defaultRunner: 'windows-2025'
-  supportedRunners: '["windows-2025"]'
+  supportedRunners: '["windows-2019", "windows-2022", "windows-2025"]'
   defaultArch: x86
   supportedArchitectures: '["x86"]'
   defaultPythonVersion: '3.13.7'

--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -397,6 +397,11 @@ jobs:
         runner: ${{ fromJson(needs.matrix.outputs.supportedRunners) }}
         arch: ${{ fromJson(needs.matrix.outputs.supportedArchitectures) }}
         pythonVersion: ${{ fromJson(needs.matrix.outputs.supportedPythonVersions) }}
+      # A bug exists with windows 2022 notepad that prevents NVDA from focusing it.
+      # This causes our symbol pronunciation tests to fail on this runner.
+      exclude:
+        - runner: windows-2022
+          testSuite: symbols
     env:
       uv-arch: ${{ matrix.arch == 'x64' && 'x86_64' || 'x86' }}
     steps:

--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -36,7 +36,7 @@ env:
   # Cache details about available MSVC tooling for subsequent SCons invocations to the provided file.
   SCONS_CACHE_MSVC_CONFIG: ".scons_msvc_cache.json"
   defaultRunner: 'windows-2025'
-  supportedRunners: '["windows-2019", "windows-2022", "windows-2025"]'
+  supportedRunners: '["windows-2025", "windows-2022", "windows-2019"]'
   defaultArch: x86
   supportedArchitectures: '["x86"]'
   defaultPythonVersion: '3.13.7'

--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -36,7 +36,7 @@ env:
   # Cache details about available MSVC tooling for subsequent SCons invocations to the provided file.
   SCONS_CACHE_MSVC_CONFIG: ".scons_msvc_cache.json"
   defaultRunner: 'windows-2025'
-  supportedRunners: '["windows-2025", "windows-2022", "windows-2019"]'
+  supportedRunners: '["windows-2025", "windows-2022"]'
   defaultArch: x86
   supportedArchitectures: '["x86"]'
   defaultPythonVersion: '3.13.7'

--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -397,7 +397,7 @@ jobs:
         runner: ${{ fromJson(needs.matrix.outputs.supportedRunners) }}
         arch: ${{ fromJson(needs.matrix.outputs.supportedArchitectures) }}
         pythonVersion: ${{ fromJson(needs.matrix.outputs.supportedPythonVersions) }}
-        # A bug exists with windows 2022 notepad that prevents NVDA from focusing it.
+        # A bug exists with Windows 2022 notepad that prevents NVDA from focusing it.
         # This causes our symbol pronunciation tests to fail on this runner.
         exclude:
           - runner: windows-2022


### PR DESCRIPTION
### Link to issue number:
Requested in https://github.com/nvaccess/nvda/pull/18708#issuecomment-3199113055
Related to https://github.com/nvaccess/nvda/issues/18684

### Summary of the issue:
it was requested to run system tests on Windows Server 2022.

### Description of user facing changes:
None

### Description of developer facing changes:
NVDA is now systemd tested on Server 2022.

### Description of development approach:
- Added additional runner to the GitHub Actions matrix.
- Excluded symbols on windows-2022 with an explanatory comment.
- Visual Studio code intellisence whined about actions/checkout@v4, updated to v5

### Testing strategy:
System tests

### Known issues with pull request:
Nothing new apart from the symbols exclusion.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

<!-- Please keep the following -->
@coderabbitai summary
