### PR TITLE
Fix up for "Split Turkish braille tables"

### DIFF
--- a/source/brailleTables/__tables.py
+++ b/source/brailleTables/__tables.py
@@ -561,7 +561,10 @@ addTable("th-g1.utb", _("Thai grade 1"), input=False, contracted=True, outputFor
 addTable("th-g2.ctb", _("Thai grade 2"), input=False, contracted=True)
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
-addTable("tr.ctb", _("Turkish grade 1"), inputForLangs={"tr"}, outputForLangs={"tr"})
+addTable("tr.ctb", _("Turkish 8 dot computer braille"))
+# Translators: The name of a braille table displayed in the
+# braille settings dialog.
+addTable("tr-g1.ctb", _("Turkish grade 1"), inputForLangs={"tr"}, outputForLangs={"tr"})
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("tr-g2.ctb", _("Turkish grade 2"), contracted=True)

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -35,6 +35,7 @@ Localisation data for emojis has been added for Belarusian and Bosnian.
 * Braille:
   * When braille word wrap is enabled, all braille cells will be used if the next character is a space. (#18016, @nvdaes)
   * NVDA no longer resets braille tables to automatic when changing its language. (#18538, @LeonarddeR)
+  * NVDA no longer handles Turkish grade 1 as Turkish 8 dot computer braille. (#18758, @OzancanKaratas)
   * The Dot Pad braille display driver now supports automatic detection of USB-connected devices.
   Note that this is disabled by default due to the device using generic USB identifiers, but can be enabled in braille settings. (#18444, @bramd)
 * When the selection covers more than one cell in Microsoft Excel, pressing `tab` or `enter` to move the active cell now reports the new active cell rather than the whole selection. (#6959, @CyrilleB79)


### PR DESCRIPTION
This pull request fixes the input/output mapping in the Turkish table in #18726.

@LeonarddeR, please review.

### Link to issue number:
None
### Summary of the issue:
The Turkish braille tables is incorrect in NVDA.
### Description of user facing changes:
The user will see the Turkish 8 dot computer braille, Turkish grade 1 and Turkish grade 2.
### Description of developer facing changes:
None
### Description of development approach:
Add original Turkish grade 1, and rename tr.ctb as Turkish 8 dot computer braille.
### Testing strategy:
Manual test using a braille display.
### Known issues with pull request:
None
### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

@coderabbitai summary