### PR TITLE
Update information on API in developer guide

### DIFF
--- a/projectDocs/dev/developerGuide/developerGuide.md
+++ b/projectDocs/dev/developerGuide/developerGuide.md
@@ -12,7 +12,7 @@ This guide provides information concerning NVDA development, including translati
 
 The NVDA Add-on API includes all NVDA internals, except:
 
-* symbols that are prefixed with an underscore
+* symbols that are prefixed with an underscore (`_`)
 * [transitive imports](#APIImports)
 * [included pip packages](#APIIncludedPipPackages)
 

--- a/projectDocs/dev/developerGuide/developerGuide.md
+++ b/projectDocs/dev/developerGuide/developerGuide.md
@@ -45,7 +45,7 @@ from foo import Foo
 If `bar.py` imports `Foo` you cannot rely on importing `Foo` from `bar`.
 i.e. you must import it directly from `foo`.
 
-The following is not be supported in the API, as the import in `bar` could be removed at any time.
+The following is not supported in the API, as the import in `bar` could be removed at any time.
 
 ```python
 from bar import Foo

--- a/projectDocs/dev/developerGuide/developerGuide.md
+++ b/projectDocs/dev/developerGuide/developerGuide.md
@@ -53,7 +53,7 @@ from bar import Foo
 #### Stability of pip packages {#APIIncludedPipPackages}
 
 Pip packages may be updated, downgraded, or removed at any time.
-It is recommended to package any pip dependency you share with NVDA directly with your add-on.
+It is recommended to package any pip dependency you share with NVDA directly with your add-on, rather than using NVDA's version of the package.
 
 ### A Note About Python {#aboutPython}
 

--- a/projectDocs/dev/developerGuide/developerGuide.md
+++ b/projectDocs/dev/developerGuide/developerGuide.md
@@ -10,7 +10,11 @@ This guide provides information concerning NVDA development, including translati
 
 ### Add-on API stability {#API}
 
-The NVDA Add-on API includes all NVDA internals, except symbols that are prefixed with an underscore.
+The NVDA Add-on API includes all NVDA internals, except:
+
+* symbols that are prefixed with an underscore
+* [transitive imports](#APIImports)
+* [included pip packages](#APIIncludedPipPackages)
 
 The NVDA Add-on API changes over time, for example because of the addition of new features, removal or replacement of outdated libraries, deprecation of unused or replaced code and methodologies, and changes to Python.
 Important changes to the API are announced on the [NVDA API mailing list](https://groups.google.com/a/nvaccess.org/g/nvda-api/about).
@@ -26,6 +30,31 @@ Deprecated API features may have a scheduled removal date, a future breaking rel
 Deprecations may also have no scheduled removal date, and will remain supported until it is no longer reasonable.
 Note, the roadmap for removals is 'best effort' and may be subject to change.
 Please open a GitHub issue if the described add-on API changes result in the API no longer meeting the needs of an add-on you develop or maintain.
+
+#### Stability of transitive imports in the API {#APIImports}
+
+Make sure to import your code from the original module by checking the NVDA source code.
+
+e.g. if a class is located at `foo.py`.
+you should import it as follows:
+
+```python
+from foo import Foo
+```
+
+If `bar.py` imports `Foo` you cannot rely on importing `Foo` from `bar`.
+i.e. you must import it directly from `foo`.
+
+The following is not be supported in the API, as the import in `bar` could be removed at any time.
+
+```python
+from bar import Foo
+```
+
+#### Stability of pip packages {#APIIncludedPipPackages}
+
+Pip packages may be updated, downgraded, or removed at any time.
+It is recommended to package any pip dependency you share with NVDA directly with your add-on.
 
 ### A Note About Python {#aboutPython}
 

--- a/projectDocs/dev/developerGuide/developerGuide.md
+++ b/projectDocs/dev/developerGuide/developerGuide.md
@@ -35,8 +35,7 @@ Please open a GitHub issue if the described add-on API changes result in the API
 
 Make sure to import your code from the original module by checking the NVDA source code.
 
-e.g. if a class is located at `foo.py`.
-you should import it as follows:
+e.g. if a class is located at `foo.py`, you should import it as follows:
 
 ```python
 from foo import Foo


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
None

### Summary of the issue:

In practice, there have been exceptions to the NVDA API not documented in the developer guide.

Notably:

- Preserving transitive imports: imports may be removed/updated in modules. Developers should always import from the original source module, rather than rely on an import from another module.
- pip packages. Add-ons should rely on their own versions of pip packages. One exception to consider is updating wxPython, which in the past we have considered an API breaking change in itself.

### Description of user facing changes:

None

### Description of developer facing changes:

Refer to diff
