### PR TITLE
Increase token limit for duplication check

### DIFF
--- a/.github/workflows/issueDuplication.yml
+++ b/.github/workflows/issueDuplication.yml
@@ -32,6 +32,11 @@ jobs:
         with:
           model: openai/gpt-4.1
           enable-github-mcp: true
+          # The average issue body uses around 500 tokens
+          # https://platform.openai.com/tokenizer
+          # The max for free tier is 8000 tokens per request.
+          # https://docs.github.com/en/github-models/use-github-models/prototyping-with-ai-models#rate-limits
+          max-tokens: 2000
           github-mcp-token: ${{ secrets.MCP_PAT_TOKEN }}
           system-prompt: |
             Given an issue title and text,


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Fixup of #18763 

### Summary of the issue:

The default token limit for the `ai-inference` action is 200, but the average NVDA issue body is 500 tokens.


https://platform.openai.com/tokenizer


### Description of development approach:

up token limit

The max for free tier is 8000 tokens per request.
https://docs.github.com/en/github-models/use-github-models/prototyping-with-ai-models#rate-limits
