### PR TITLE
Fix uploading artifact for releases

### DIFF
--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -704,7 +704,8 @@ jobs:
       env:
         GH_TOKEN: ${{ github.token }}
       run: |
+        NVDA_EXE_NAME=$(ls output/nvda*.exe | head -n 1)
         gh release upload ${{ github.ref_name }} \
             --repo ${{ github.repository }} \
             --clobber \
-            output/nvda*.exe#Installer
+            $NVDA_EXE_NAME#Installer


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Fixup of #18732

### Summary of the issue:

The release failed as we were unable to use a star import to upload release assets to GitHub

https://github.com/nvaccess/nvda/actions/runs/17196535198/job/48780625010

### Description of development approach:

Get the name of the file before trying to upload it

