### PR TITLE
Add document for 3rd party issue reporting

### DIFF
--- a/projectDocs/issues/readme.md
+++ b/projectDocs/issues/readme.md
@@ -1,4 +1,4 @@
-## Reporting issues or feature requests
+# Reporting issues or feature requests
 
 Issues can be [reported via GitHub](https://github.com/nvaccess/nvda/issues/new/choose).
 Please read the [issue template guide](./githubIssueTemplateExplanationAndExamples.md) for help filling out the appropriate template.
@@ -9,6 +9,6 @@ Do not report security issues via GitHub, instead follow our [security policy](.
 
 Issues with translations should be reported to the [NVDA Translators list](https://groups.io/g/nvda-translations).
 
-If you are reporting an issue with an application or website, please consider reporting the issue to the authors of the application/website first.
+If you are reporting an issue with an application or website, please consider reporting the issue to the [authors of the application/website](./thirdPartyReporting.md) first.
 
 If you are a developer reporting an issue with your application/website, please include a minimal reproducible sample and details of the specification not being handled correctly.

--- a/projectDocs/issues/thirdPartyReporting.md
+++ b/projectDocs/issues/thirdPartyReporting.md
@@ -37,7 +37,7 @@ This includes Windows and other Microsoft products such as Office.
 * LibreOffice
   * [LibreOffice Bugzilla](https://bugs.documentfoundation.org/).
 * Microsoft Office
-  * [Microsoft Office Support](#microsoft).
+  * [Microsoft Office Support](#Microsoft).
 
 ## Common Websites
 

--- a/projectDocs/issues/thirdPartyReporting.md
+++ b/projectDocs/issues/thirdPartyReporting.md
@@ -3,7 +3,7 @@
 When NVDA users encounter issues that are caused by third-party software, it is often most effective to report these problems directly to the maintainers of the affected software.
 Below is a list of common third-party products and frameworks, along with links to their official issue trackers or support channels.
 
-Note: When reporting issues upstream, please provide as much detail as possible, including:
+Note: When reporting issues, please provide as much detail as possible, including:
 
 * Steps to reproduce the issue
 * NVDA version and configuration
@@ -11,7 +11,7 @@ Note: When reporting issues upstream, please provide as much detail as possible,
 * Application or website version
 * Any relevant logs or error messages
 
-Once you have opened an issue, if a related NVDA issue exists, share a link to the issue or issue reference number.
+Once you have opened an issue on the other project, if a related NVDA issue exists, share a link to the third-party issue you created on the NVDA issue so we can keep track of it.
 
 For NVDA-specific triage, see our [issue triage documentation](./README.md).
 

--- a/projectDocs/issues/thirdPartyReporting.md
+++ b/projectDocs/issues/thirdPartyReporting.md
@@ -1,0 +1,61 @@
+# Third Party Issue Reporting Resources
+
+When NVDA users encounter issues that are caused by third-party software, it is often most effective to report these problems directly to the maintainers of the affected software.
+Below is a list of common third-party products and frameworks, along with links to their official issue trackers or support channels.
+
+Note: When reporting issues upstream, please provide as much detail as possible, including:
+
+* Steps to reproduce the issue
+* NVDA version and configuration
+* Operating system and version
+* Application or website version
+* Any relevant logs or error messages
+
+Once you have opened an issue, if a related NVDA issue exists, share a link to the issue or issue reference number.
+
+For NVDA-specific triage, see our [issue triage documentation](./README.md).
+
+## Microsoft
+
+This includes Windows and other Microsoft products such as Office.
+
+* [Microsoft Feedback Hub](https://support.microsoft.com/en-au/windows/send-feedback-to-microsoft-with-the-feedback-hub-app-f59187f8-8739-22d6-ba93-f66612949332) for direct issue reporting.
+* [Microsoft Accessibility Desk](https://www.microsoft.com/en-au/accessibility/disability-answer-desk) for accessibility support.
+* [Microsoft Support](https://support.microsoft.com/) for general support.
+
+## Web Browsers
+
+* Mozilla Firefox
+  * [Firefox Bugzilla](https://bugzilla.mozilla.org/)
+* Google Chrome / Chromium
+  * [Chromium Issue Tracker](https://issues.chromium.org/issues)
+* Microsoft Edge
+  * [Edge Feedback](https://techcommunity.microsoft.com/t5/microsoft-edge-insider/ct-p/MicrosoftEdgeInsider)
+
+## Office Suites
+
+* LibreOffice
+  * [LibreOffice Bugzilla](https://bugs.documentfoundation.org/).
+* Microsoft Office
+  * [Microsoft Office Support](#microsoft).
+
+## Common Websites
+
+* Google Services (Gmail, Docs, etc.)
+  * [Google Accessibility Support](https://support.google.com/accessibility/)
+  * [Google Issue Tracker](https://developers.google.com/issue-tracker)
+
+## Adobe products
+
+For all Adobe products including Acrobat, Reader, Creative Cloud, Photoshop and Illustrator.
+
+* [Adobe bug tracker and feature request form](https://www.adobe.com/products/wishform.html).
+
+## Application Frameworks
+
+* Qt
+  * [Qt Bug Tracker](https://bugreports.qt.io/)
+* Electron
+  * [Electron GitHub Issues](https://www.electronjs.org/docs/latest/development/issues#how-to-contribute-in-issues)
+* Java (Swing, JavaFX)
+  * [OpenJDK Bug System](https://bugs.openjdk.org/)


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
None

### Summary of the issue:
We regularly need to encourage contributors to report issues upstream to third parties.
Having a centralised document with links to places to report issues with  3rd party software would be helpful
### Description of user facing changes:
Adds a document for places to report upstream issues