### PR TITLE
remove CI/CD handling for temp 64bit branch

### DIFF
--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -15,9 +15,6 @@ on:
       - master
       - beta
       - rc
-      # Temporarily enabled during the 64bit migration
-      - wip-buildX64
-
 
   workflow_dispatch:
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Follow up to #18207 

### Summary of the issue:

We have merged the branch from #18207, we no longer need branch specific CI/CD builds for 64bit
