### PR TITLE
Fix touch handler

### DIFF
--- a/source/touchHandler.py
+++ b/source/touchHandler.py
@@ -10,8 +10,9 @@ In order to use touch features, NVDA must be installed on a touchscreen computer
 
 import threading
 from ctypes import *  # noqa: F403
-from ctypes import windll
+from ctypes import cast, windll
 from ctypes.wintypes import *  # noqa: F403
+from ctypes.wintypes import LPCWSTR
 import re
 import winBindings.user32
 import gui
@@ -247,7 +248,7 @@ class TouchHandler(threading.Thread):
 			self._wca = windll.user32.RegisterClassExW(byref(self._wc))  # noqa: F405
 			self._touchWindow = windll.user32.CreateWindowExW(
 				0,
-				cast(self._wca, LPCWSTR),  # noqa: F405
+				cast(self._wca, LPCWSTR),
 				"NVDA touch input",
 				0,
 				0,

--- a/source/touchHandler.py
+++ b/source/touchHandler.py
@@ -247,7 +247,7 @@ class TouchHandler(threading.Thread):
 			self._wca = windll.user32.RegisterClassExW(byref(self._wc))  # noqa: F405
 			self._touchWindow = windll.user32.CreateWindowExW(
 				0,
-				self._wca,
+				cast(self._wca, LPCWSTR),  # noqa: F405
 				"NVDA touch input",
 				0,
 				0,


### PR DESCRIPTION
### Link to issue number:
Follow-up to #18207

### Summary of the issue:
Alphas are broken due to a problem with touch handler.

### Description of user facing changes:
Alphas work again.

### Description of developer facing changes:
None.

### Description of development approach:
Cast `TouchHandler._wca` to `LPCWSTR` when passing to `CreateWindowExW`.

This is needed because the `lpClassName` parameter of `CreateWindowExW` can accept a class atom, but ctypes doesn't know this.
This wasn't previously a problem because ctypes didn't have type information for `CreateWindowExW`, so happily sent the arguments.

### Testing strategy:
Built and self-signed NVDA. Installed and observed that NVDA didn't crash and my touchscreen worked.

### Known issues with pull request:
None.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
