### PR TITLE
Add linting for markdown files

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -7,9 +7,10 @@ The NVDA project is guided by a [product vision statement and set of principles]
 The vision and principles should be always considered when planning features and prioritizing work.
 
 There are several ways in which you can contribute to the NVDA project:
-- [Reporting issues](../projectDocs/issues/readme.md)
-- [Issue triage and investigation](../projectDocs/issues/triage.md)
-- [Testing](../projectDocs/testing/contributing.md)
-- [Translating NVDA](../projectDocs/translating/readme.md)
-- [Code or documentation contributions](../projectDocs/dev/contributing.md)
-- [Creating add-ons](../projectDocs/dev/addons.md)
+
+* [Reporting issues](../projectDocs/issues/readme.md)
+* [Issue triage and investigation](../projectDocs/issues/triage.md)
+* [Testing](../projectDocs/testing/contributing.md)
+* [Translating NVDA](../projectDocs/translating/readme.md)
+* [Code or documentation contributions](../projectDocs/dev/contributing.md)
+* [Creating add-ons](../projectDocs/dev/addons.md)

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -10,7 +10,9 @@
 	"gitignore": true,
 	// Lint *.md files recursively
 	"globs": [
-		"**.md"
+		"**.md",
+		// Our copying file is actually markdown
+		"copying.txt"
 	],
 	// Don't lint the following globs
 	"ignores": [

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,18 @@
+{
+	"gitignore": true,
+	"globs": [
+		"**.md"
+	],
+	"ignores": [
+		"tests/markdownTranslate/",
+		"projectDocs/issues/securityAdvisoryTemplate.md",
+		"miscDeps/",
+		"include/*/**",
+		".github/PULL_REQUEST_TEMPLATE/",
+		".github/ISSUE_TEMPLATE/",
+		".github/PULL_REQUEST_TEMPLATE.md",
+		".vscode",
+	],
+	"showFound": true
+
+}

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,18 +1,29 @@
+// A part of NonVisual Desktop Access (NVDA)
+// Copyright (C) 2025 NV Access Limited
+// This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+// For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
+//
+// Configuration of markdownlint-cli2, also used by markdownlint for VS Code
+// Lint rules are inherited from .markdownlint.jsonc
 {
+	// Ignore files specified in .gitignore
 	"gitignore": true,
+	// Lint *.md files recursively
 	"globs": [
 		"**.md"
 	],
+	// Don't lint the following globs
 	"ignores": [
-		"tests/markdownTranslate/",
-		"projectDocs/issues/securityAdvisoryTemplate.md",
-		"miscDeps/",
-		"include/*/**",
-		".github/PULL_REQUEST_TEMPLATE/",
-		".github/ISSUE_TEMPLATE/",
-		".github/PULL_REQUEST_TEMPLATE.md",
+		// Git submodules
 		".vscode",
-	],
-	"showFound": true
-
+		"include/*/**",
+		"miscDeps/",
+		// Issue/PR templates
+		".github/ISSUE_TEMPLATE/",
+		".github/PULL_REQUEST_TEMPLATE/",
+		".github/PULL_REQUEST_TEMPLATE.md",
+		"projectDocs/issues/securityAdvisoryTemplate.md",
+		// Old markdown files used for testing
+		"tests/markdownTranslate/"
+	]
 }

--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -9,5 +9,6 @@
 	},
 	"no-trailing-punctuation": false,
 	"link-fragments": false,
-	"fenced-code-language": false
+	"fenced-code-language": false,
+	"commands-show-output": false
 }

--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -26,5 +26,8 @@
 	"link-fragments": false,
 	// Many of our code blocks lack a language
 	// This should probably be fixed gradually
-	"fenced-code-language": false
+	"fenced-code-language": false,
+	"ul-style": {
+		"style": "asterisk"
+	}
 }

--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -1,14 +1,30 @@
+// A part of NonVisual Desktop Access (NVDA)
+// Copyright (C) 2025 NV Access Limited
+// This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+// For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
+//
+// Markdown linting rules.
 {
+	// Use ATX style headings. E.g.
+	// # This is a heading
 	"heading-style": {
 		"style": "atx"
 	},
+	// Don't complain about using tabs in markdown
 	"hard_tab": false,
+	// Don't complain about lines being too long
 	"line-length": false,
+	// Only complain about repeated headings in the same part of the document outline
+	// Needed for the changelog
+	// We could consider enabling this on a file-by-file basis
 	"no-duplicate-heading": {
 		"siblings_only": true
 	},
+	// Several of our markdown files include trailing punctuation in headings
 	"no-trailing-punctuation": false,
+	// Rule is incompatible with the anchor style we use in the user guide
 	"link-fragments": false,
-	"fenced-code-language": false,
-	"commands-show-output": false
+	// Many of our code blocks lack a language
+	// This should probably be fixed gradually
+	"fenced-code-language": false
 }

--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -1,0 +1,12 @@
+{
+	"heading-style": {
+		"style": "atx"
+	},
+	"hard_tab": false,
+	"line-length": false,
+	"no-duplicate-heading": {
+		"siblings_only": true
+	},
+	"no-trailing-punctuation": false,
+	"link-fragments": false
+}

--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -8,5 +8,6 @@
 		"siblings_only": true
 	},
 	"no-trailing-punctuation": false,
-	"link-fragments": false
+	"link-fragments": false,
+	"fenced-code-language": false
 }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -123,6 +123,13 @@ repos:
       # Override python interpreter from .python-versions as that is too strict for pre-commit.ci
       args: ["-p3.13"]
 
+- repo: https://github.com/DavidAnson/markdownlint-cli2
+  rev: v0.18.1
+  hooks:
+  - id: markdownlint-cli2
+    name: Lint markdown files
+    args: ["--fix"]
+
 - repo: local
   hooks:
     - id: checkPo

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,17 +1,21 @@
 # Citizen and Contributor Code of Conduct
 
 ## 1. Purpose
+
 A primary goal of NV Access and NVDA is to be inclusive to the largest number of contributors, with the most varied and diverse backgrounds possible. As such, we are committed to providing a friendly, safe and welcoming environment for all, regardless of gender, sexual orientation, ability, ethnicity, nationality, socioeconomic status, education, level of experience and religion (or lack thereof).
 This code of conduct outlines our expectations for all those who participate in our community, as well as the consequences for unacceptable behaviour.
 We invite all those who participate in the NVDA community to help us create safe and positive experiences for everyone. NVDA is a user driven initiative.
 
 ## 2. Open Source Citizenship
+
 A supplemental goal of this Code of Conduct is to increase open source citizenship by encouraging participants to recognise and strengthen the relationships between our actions and their effects on our community.
 Communities mirror the societies in which they exist and positive action is essential to counteract the many forms of inequality and abuses of power that exist in society.
 If you see someone who is making an extra effort to ensure our community is welcoming, friendly, and encourages all participants to contribute to the fullest extent, we want to know.
 
 ## 3. Expected Behaviour
+
 The following behaviours are expected and requested of all community members:
+
 * To participate in an authentic and active way. In doing so, you contribute to the health and longevity of this community.
 * To exercise consideration and respect in your speech and actions.
 * To attempt collaboration before conflict.
@@ -24,7 +28,9 @@ The following behaviours are expected and requested of all community members:
 * To be mindful of your surroundings and of your fellow participants. Alert NV Access staff if you notice a dangerous situation, someone in distress, or violations of this Code of Conduct, even if they seem inconsequential.
 
 ## 4. Unacceptable Behaviour
+
 The following behaviours are considered harassment and are unacceptable within our community:
+
 * Violence, threats of violence, inciting violence, glorifying violence, or violent language directed against another person.
 * Sexist, racist, homophobic, transphobic, ableist or otherwise discriminatory jokes and language.
 * Posting or displaying sexually explicit or violent material.
@@ -39,29 +45,36 @@ The following behaviours are considered harassment and are unacceptable within o
 * Religious or political proselytising.
 
 ## 5. Consequences of Unacceptable Behaviour
+
 Unacceptable behaviour from any community member, including sponsors and those with decision-making authority, will not be tolerated.
 Anyone asked to stop unacceptable behaviour is expected to comply immediately.
 If a community member engages in unacceptable behaviour, NV Access Staff may take any action they deem appropriate, up to and including a temporary ban or permanent expulsion from the community without warning (and without refund in the case of a paid event).
 NV Access Staff have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviours that they deem inappropriate, threatening, offensive, or harmful.
 
 ## 6. Reporting Guidelines
-If you are subject to or witness unacceptable behaviour, or have any other concerns, please notify NV Access staff as soon as possible via info@nvaccess.org. The information required for notifications includes PR/Issue Number, nature of breach, community member responsible, date and time of breach. Please note that the details of the reporter will not be disclosed, unless required to by law.
+
+If you are subject to or witness unacceptable behaviour, or have any other concerns, please notify NV Access staff as soon as possible via <info@nvaccess.org>. The information required for notifications includes PR/Issue Number, nature of breach, community member responsible, date and time of breach. Please note that the details of the reporter will not be disclosed, unless required to by law.
 
 ## 7. Addressing Grievances
-If you feel you have been falsely or unfairly accused of violating this Code of Conduct, you should notify NV Access at info@nvaccess.org with a concise description of your grievance.
+
+If you feel you have been falsely or unfairly accused of violating this Code of Conduct, you should notify NV Access at <info@nvaccess.org> with a concise description of your grievance.
 
 ## 8. Scope
+
 We expect all community participants (contributors, paid or otherwise; sponsors; and other guests) to abide by this Code of Conduct in all community venues--online and in-person--as well as in all one-on-one communications pertaining to community business.
 This code of conduct and its related procedures also applies to unacceptable behaviour occurring outside the scope of community activities when such behaviour has the potential to adversely affect the safety and well-being of community members.
 For others setting up or running an NVDA group of any kind, it is strongly recommended that a complementary Citizen and Contributor Code of Conduct is adopted.
 
 ## 9. Contact info
-info@nvaccess.org
+
+<info@nvaccess.org>
 
 ## 10. License and attribution
+
 The Citizen and Contributor Code of Conduct is distributed by NV Access Limited.
 Portions of text were derived from the GitHub sample Citizen and Contributor Code of Conduct, which is distributed under a Creative Commons Attribution-ShareAlike license.
 
 Revision history:
-- Revision 1.0 adopted by NV Access Limited on 2020-09-23
-- Revision 1.1 adopted by NV Access Limited on 2023-08-09
+
+* Revision 1.0 adopted by NV Access Limited on 2020-09-23
+* Revision 1.1 adopted by NV Access Limited on 2023-08-09

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -53,7 +53,9 @@ NV Access Staff have the right and responsibility to remove, edit, or reject com
 
 ## 6. Reporting Guidelines
 
-If you are subject to or witness unacceptable behaviour, or have any other concerns, please notify NV Access staff as soon as possible via <info@nvaccess.org>. The information required for notifications includes PR/Issue Number, nature of breach, community member responsible, date and time of breach. Please note that the details of the reporter will not be disclosed, unless required to by law.
+If you are subject to or witness unacceptable behaviour, or have any other concerns, please notify NV Access staff as soon as possible via <info@nvaccess.org>.
+The information required for notifications includes PR/Issue Number, nature of breach, community member responsible, date and time of breach.
+Please note that the details of the reporter will not be disclosed, unless required to by law.
 
 ## 7. Addressing Grievances
 

--- a/copying.txt
+++ b/copying.txt
@@ -105,17 +105,14 @@ portion of it, thus forming a work based on the Program, and copy and
 distribute such modifications or work under the terms of Section 1
 above, provided that you also meet all of these conditions:
 
-  
 **a)** You must cause the modified files to carry prominent notices
 stating that you changed the files and the date of any change.
 
-  
 **b)** You must cause any work that you distribute or publish, that in
 whole or in part contains or is derived from the Program or any part
 thereof, to be licensed as a whole at no charge to all third parties
 under the terms of this License.
 
-  
 **c)** If the modified program normally reads commands interactively
 when run, you must cause it, when started running for such interactive
 use in the most ordinary way, to print or display an announcement
@@ -152,12 +149,10 @@ the scope of this License.
 under Section 2) in object code or executable form under the terms of
 Sections 1 and 2 above provided that you also do one of the following:
 
-  
 **a)** Accompany it with the complete corresponding machine-readable
 source code, which must be distributed under the terms of Sections 1
 and 2 above on a medium customarily used for software interchange; or,
 
-  
 **b)** Accompany it with a written offer, valid for at least three
 years, to give any third party, for a charge no more than your cost of
 physically performing source distribution, a complete machine-readable
@@ -165,7 +160,6 @@ copy of the corresponding source code, to be distributed under the
 terms of Sections 1 and 2 above on a medium customarily used for
 software interchange; or,
 
-  
 **c)** Accompany it with the information you received as to the offer
 to distribute corresponding source code. (This alternative is allowed
 only for noncommercial distribution and only if you received the
@@ -277,7 +271,7 @@ the two goals of preserving the free status of all derivatives of our
 free software and of promoting the sharing and reuse of software
 generally.
 
-**NO WARRANTY**
+### NO WARRANTY
 
 **11.** BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO
 WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.
@@ -300,7 +294,6 @@ FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS), EVEN IF
 SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
 DAMAGES.
 
-
 ## Non-GPL Components in Plugins and Drivers
 
 Plugins and drivers, including those provided by third parties, are considered derivative works of NVDA and must therefore be licensed under the terms of the GNU General Public License version 2.
@@ -311,7 +304,6 @@ a. Any such component does not prevent the NVDA plugin or driver from being lice
 b. Any such component does not directly use and is not directly used by any portion of NVDA outside of that plugin or driver.
 For example, a speech synthesizer driver may use a speech synthesiser under a proprietary license.
 In contrast, in a plugin providing support for an application, the code which implements any interface provided by NVDA must be licensed under the GNU General Public License version 2.
-
 
 ## Microsoft Distributable Code
 
@@ -344,18 +336,18 @@ An Excluded License is one that requires, as a condition of use, modification or
 
 ## Third-Party Dependencies
 
-NVDA includes various third-party dependencies, each with its own license terms. 
+NVDA includes various third-party dependencies, each with its own license terms.
 Python pip modules with acceptable licences are automatically limited by our build system to include only BSD, MIT, Python, LGPLV3+ and Apache.
 
 In addition to these dependencies, the following are also included in NVDA:
 
-- eSpeak: GPL-3
-- LibLouis: LGPL-3
-- BrlAPI: LGPL-3
-- IAccessible 2: Simplified BSD 
-- Microsoft Detours: MIT 
-- Python: PSF
-- NSIS: zlib/libpng
+* eSpeak: GPL-3
+* LibLouis: LGPL-3
+* BrlAPI: LGPL-3
+* IAccessible 2: Simplified BSD
+* Microsoft Detours: MIT
+* Python: PSF
+* NSIS: zlib/libpng
 
 Furthermore, NVDA also utilises some static/binary dependencies, details of which can be found at the following URL:
 

--- a/copying.txt
+++ b/copying.txt
@@ -271,7 +271,7 @@ the two goals of preserving the free status of all derivatives of our
 free software and of promoting the sharing and reuse of software
 generally.
 
-### NO WARRANTY
+#### NO WARRANTY
 
 **11.** BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO
 WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.

--- a/extras/controllerClient/readme.md
+++ b/extras/controllerClient/readme.md
@@ -9,8 +9,9 @@ The client API is implemented as a dll (dynamic link library). The functions in 
 ## Compatibility notice
 
 Version 2.0 of the controller client was introduced in NVDA 2024.1, offering the following additional functions compared to version 1.0:
-- nvdaController_getProcessId
-- nvdaController_speakSsml
+
+* nvdaController_getProcessId
+* nvdaController_speakSsml
 
 These functions are supported in NVDA 2024.1 and newer. On older versions, they return error code 1717 (RPC_S_UNKNOWN_IF).
 
@@ -22,35 +23,36 @@ Before providing information to the end user (e.g. via `nvdaController_speakText
 ## How to get it?
 
 You can build locally or download pre-built, details:
-- **Built with the release:**
-  - Download the `*controllerClient.zip` from the releases folder: e.g. [Latest stable](https://download.nvaccess.org/releases/stable/)
-- **Latest, in development version:**
-  - The libraries are built by GitHub Actions (our CI).
-  - Downloads are available from the artifacts tab.
-- **Build them yourself:**
-  - Follow the project `readme.txt` for general build requirements/dependencies.
-  - Run `scons source client`
-  - Build output can be found in `./build/[x86|x64|arm64]/client/`
+
+* **Built with the release:**
+  * Download the `*controllerClient.zip` from the releases folder: e.g. [Latest stable](https://download.nvaccess.org/releases/stable/)
+* **Latest, in development version:**
+  * The libraries are built by GitHub Actions (our CI).
+  * Downloads are available from the artifacts tab.
+* **Build them yourself:**
+  * Follow the project `readme.txt` for general build requirements/dependencies.
+  * Run `scons source client`
+  * Build output can be found in `./build/[x86|x64|arm64]/client/`
 
 ## What is Included?
 
 * `*.dll` file, which you can distribute with your application.
 * `*.lib` and `*.exp`
-  - The import and export libraries for `nvdaControllerClient` DLL.
-  - Used when linking with C/C++ code.
+  * The import and export libraries for `nvdaControllerClient` DLL.
+  * Used when linking with C/C++ code.
 * `nvdaController.h`
-  - A C header file containing declarations for all the provided functions.
+  * A C header file containing declarations for all the provided functions.
 
 The **`extras/controllerClient/examples` directory** also contains example usage:
 
 * `example_python.py`
-  - an example Python program that uses the NVDA controller client API.
+  * an example Python program that uses the NVDA controller client API.
 * `example_c.c`
-  - The source code for an example C program that uses the NVDA controller client API.
+  * The source code for an example C program that uses the NVDA controller client API.
 * `example_csharp`
-  - The source code for an example C# project on NET Standard 2.0 that uses the NVDA controller client API.
+  * The source code for an example C# project on NET Standard 2.0 that uses the NVDA controller client API.
 * `example_rust`
-  - The source code for an example Rust crate providing access to the NVDA controller client API, including example code.
+  * The source code for an example Rust crate providing access to the NVDA controller client API, including example code.
 
 Running these examples requires a copy of **`nvdaControllerClient.dll`** in its path that matches the architecture of the example.
 For example, if you want to test the Python example on an X64 version of Python, you need the **`x64/nvdaControllerClient.dll`** file.

--- a/include/espeak.md
+++ b/include/espeak.md
@@ -98,6 +98,8 @@ It is also different from the build approach within NVDA.
 
 1. Feed the SSML into `espeak-ng.exe`
 
+   <!-- markdownlint-disable commands-show-output -->
    ```sh
    $ cat /c/work/test-espeak-ssml.txt | ./espeak-ng.exe --stdin -m
    ```
+   <!-- markdown-lint-restore -->

--- a/include/espeak.md
+++ b/include/espeak.md
@@ -98,8 +98,7 @@ It is also different from the build approach within NVDA.
 
 1. Feed the SSML into `espeak-ng.exe`
 
-   <!-- markdownlint-disable commands-show-output -->
    ```sh
    $ cat /c/work/test-espeak-ssml.txt | ./espeak-ng.exe --stdin -m
+   # eSpeak-NG should output speech
    ```
-   <!-- markdown-lint-restore -->

--- a/include/readme.md
+++ b/include/readme.md
@@ -1,51 +1,63 @@
-## Updating dependencies
+# Updating dependencies
+
 Updates should be reflected in the [createDevEnvironment guide](../projectDocs/dev/createDevEnvironment.md) and the [change log](../user_docs/en/changes.t2t).
 
-### Detours
-https://github.com/microsoft/Detours
+## Detours
+
+<https://github.com/microsoft/Detours>
 
 Fetch latest from main.
 Test using [the steps here](../projectDocs/design/displayModel.md).
 An example control is the file properties dialog from file explorer.
 
-### eSpeak
-https://github.com/espeak-ng/espeak-ng
+## eSpeak
+
+<https://github.com/espeak-ng/espeak-ng>
 
 [eSpeak guide](./espeak.md)
 
-### ia2
-https://github.com/LinuxA11y/IAccessible2
+## ia2
+
+<https://github.com/LinuxA11y/IAccessible2>
 
 Fetch latest from master.
 
-### javaAccessBridge32
+## javaAccessBridge32
+
 [javaAccessBridge32-bin readme](https://github.com/nvaccess/javaAccessBridge32-bin)
 
-### liblouis
+## liblouis
+
 TODO
 
-### nsis
+## nsis
+
 [NSIS-build readme](https://github.com/nvaccess/NSIS-build)
 
-### nvda_dmp
+## nvda_dmp
+
 TODO
 
-### nvda-cldr
+## nvda-cldr
+
 [nvda-cldr readme](https://github.com/nvaccess/nvda-cldr)
 
-### sonic
-https://github.com/waywardgeek/sonic
+## sonic
+
+<https://github.com/waywardgeek/sonic>
 
 Fetch latest from master.
 Used to boost in rate eSpeak.
 
-### w3c-aria-practices
-https://github.com/w3c/aria-practices
+## w3c-aria-practices
+
+<https://github.com/w3c/aria-practices>
 
 Fetch latest from master.
 Used in chrome system tests.
 
-### wil
-https://github.com/microsoft/wil/
+## wil
+
+<https://github.com/microsoft/wil/>
 
 Fetch latest from master.

--- a/nvdaHelper/readme.md
+++ b/nvdaHelper/readme.md
@@ -1,87 +1,100 @@
-## NVDA Helper
+# NVDA Helper
 
 Parts of NVDA Helper are used to capture and cache information, in-process, within web browsers and other applications.
 This cache is called a virtual buffer.
 While virtual buffers apply to several different application types, it may first be easiest to think about how they
 work with browsers, the rest of this document will take a web browser centric view unless specified otherwise.
 
-### Output
+## Output
+
 Internal code is built into several DLLs:
-- `nvdaHelperLocal.dll`
-- `nvdaHelperLocalWin10.dll`
-- `nvdaHelperRemote.dll`
-- Several COM proxy dlls
-- `UIARemote.dll`
+
+* `nvdaHelperLocal.dll`
+* `nvdaHelperLocalWin10.dll`
+* `nvdaHelperRemote.dll`
+* Several COM proxy dlls
+* `UIARemote.dll`
 
 The `*local*.dll`'s are built for x86 (ie to match NVDA's arch), others are built for x86, x64, and arm64.
 
-#### COM proxy dlls
+### COM proxy dlls
+
 Several COM Proxy DLLs are built from IDL files. A COM Proxy tells windows how to marshal data over COM when calling
  the target API interface.
 For instance:
-- IAccessible2 IDL files are built into `IAccessible2Proxy.dll`
-- ISimpleDOM IDL files are built into `ISimpleDOM.dll`
 
-#### nvdaHelperLocalWin10.dll
+* IAccessible2 IDL files are built into `IAccessible2Proxy.dll`
+* ISimpleDOM IDL files are built into `ISimpleDOM.dll`
+
+### nvdaHelperLocalWin10.dll
+
 Contains code specific to Windows 10 and above, that aides in accessing newer technologies such as Windows OneCore speech synthesis, the Windows in-built OCR service.
 This code is mostly C++/WinRT.
 
-#### nvdaHelperLocal.dll
+### nvdaHelperLocal.dll
+
 This dll is loaded directly in to NVDA. It provides the following features:
-*  client stub methods for several RPC interfaces allowing NVDA to execute code in-process. These interfaces include nvdaInprocUtils, vbufBackends, and displayModel, which are implemented in nvdaHelperRemote.dll.
+
+* client stub methods for several RPC interfaces allowing NVDA to execute code in-process. These interfaces include nvdaInprocUtils, vbufBackends, and displayModel, which are implemented in nvdaHelperRemote.dll.
 * Server stub methods for several RPC interfaces allowing in-process code to execute code in NVDA. These interfaces include nvdaController and nvdaControllerInternal.
 * Functions to aide NVDA in hooking platform dlls to make their calls easier to cancel
 * Several small utility functions that assist in processing text (which are faster in c++).
 
-#### NVDAHelperRemote.dll
+### NVDAHelperRemote.dll
+
 This dll injects itself into other processes on the system, allowing for in-process code execution by NVDA.
 It provides the following features:
+
 * Server stub methods for several RPC interfaces, including NVDAInprocUtils, VBufBackends and displayModel.
 * Client stub methods for several RPC interfaces, allowing in-process code to execute code back in NVDA. These interfaces include NVDAController and NVDAControllerInternal
 
-#### UIARemote.dll
+### UIARemote.dll
+
 This dll is loaded by NVDA, providing utility functions that perform certain tasks or batch procedures on Microsoft UI Automation elements.
 It makes use of the UI Automation Remote Operations capabilities in Windows 11, allowing to declaratively define code  to  access and manipulate UI Automation elements, that will be Just-In-Time compiled by Windows and executed in the process providing the UI Automation elements.
 
-### Configuring Visual Studio
+## Configuring Visual Studio
+
 The following steps won't prepare a buildable solution, but it will enable intellisense.
 You should still build on the command line to verify errors.
 
-- Ensure you have built NVDA on the command line first.
-- From the files menu select: `Create a new project from existing code`
-- "Welcome to the Create Project from Existing Code Files Wizard"
-  - "What type of project would you like to create?": `Visual C++`
-  - Press next.
-- "Specify Project Location and Source Files"
-  - "Project file location": `<repo root>/nvdaHelper/`
-  - Project name: `nvdaHelper`
-  - Add files to the project from these folders: `checked`
-  - One **checked** item: `<path to nvdaHelper>`
-  - Files types to add to the project: **use default**
-  - Show all files in Solution Explorer: *use default (checked)**
-  - Press next
-- "Specify Project Settings"
-  - "How do you want to build the project?": Select `use external build system`
-  - Press next
--  Specify Debug Configuration Settings
-  - Build command line: `scons source`
-  - Preprocessor definitions (/D): `WIN32;_WINDOWS;_USRDLL;NVDAHELPER_EXPORTS;UNICODE;_CRT_SECURE_NO_DEPRECATE;LOGLEVEL=15;_WIN32_WINNT=_WIN32_WINNT_WIN10;NOMINMAX`
-  - Include search paths (/I): `../include;../miscDeps/include;./;../build\x86_64;../include/minhook/include`
-  - Forced Included files (/FI): `winuser.h`
-  - Press next
--  Specify Debug Configuration Settings
-  - "Same as Debug configuration": **Checked**
-- Press Finish
-- Set the C++ standard:
-  - In the project menu, select Properties
-  - Select "Configuration:" `All Configurations`
-  - Under "Configuration Properties" select NMake
-  - Set additional Options -> `/std:c++20`
+* Ensure you have built NVDA on the command line first.
+* From the files menu select: `Create a new project from existing code`
+* "Welcome to the Create Project from Existing Code Files Wizard"
+  * "What type of project would you like to create?": `Visual C++`
+  * Press next.
+* "Specify Project Location and Source Files"
+  * "Project file location": `<repo root>/nvdaHelper/`
+  * Project name: `nvdaHelper`
+  * Add files to the project from these folders: `checked`
+  * One **checked** item: `<path to nvdaHelper>`
+  * Files types to add to the project: **use default**
+  * Show all files in Solution Explorer: *use default (checked)**
+  * Press next
+* "Specify Project Settings"
+  * "How do you want to build the project?": Select `use external build system`
+  * Press next
+* Specify Debug Configuration Settings
+  * Build command line: `scons source`
+  * Preprocessor definitions (/D): `WIN32;_WINDOWS;_USRDLL;NVDAHELPER_EXPORTS;UNICODE;_CRT_SECURE_NO_DEPRECATE;LOGLEVEL=15;_WIN32_WINNT=_WIN32_WINNT_WIN10;NOMINMAX`
+  * Include search paths (/I): `../include;../miscDeps/include;./;../build\x86_64;../include/minhook/include`
+  * Forced Included files (/FI): `winuser.h`
+  * Press next
+* Specify Debug Configuration Settings
+  * "Same as Debug configuration": **Checked**
+* Press Finish
+* Set the C++ standard:
+  * In the project menu, select Properties
+  * Select "Configuration:" `All Configurations`
+  * Under "Configuration Properties" select NMake
+  * Set additional Options -> `/std:c++20`
 
-#### To confirm these settings
-- Build NVDA normally
-- Look for lines in the build output that start with `cl`
-  - EG
+### To confirm these settings
+
+* Build NVDA normally
+* Look for lines in the build output that start with `cl`
+  * EG
+
   ```
   cl /Fobuild\x86\vbufBackends\gecko_ia2\gecko_ia2.obj /c build\x86\vbufBackends\gecko_ia2\gecko_ia2.cpp
   /TP /EHsc /nologo /std:c++20 /permissive- /Od /MT /W3 /WX
@@ -89,12 +102,14 @@ You should still build on the command line to verify errors.
   /Iinclude /Imiscdeps\include /Ibuild\x86
   /Z7
   ```
-- This shows the:
-  - defines beginning with `/D`
-  - includes directories beginning with `/I`
-  - Additional options like `/std:c++20`
 
-### Compiling NVDAHelper with Debugging Options
+* This shows the:
+  * defines beginning with `/D`
+  * includes directories beginning with `/I`
+  * Additional options like `/std:c++20`
+
+## Compiling NVDAHelper with Debugging Options
+
 Among other things, preparing the source tree builds the NVDAHelper libraries.
 If trying to debug nvdaHelper, you can control various debugging options by building with the `nvdaHelperDebugFlags` and `nvdaHelperLogLevel` command line variables.
 
@@ -121,10 +136,11 @@ Instead, `scons symbolsArchive` will package them as a separate archive.
 By default, builds also do not use any compiler optimizations.
 Please see the `release` keyword argument for what compiler optimizations it will enable.
 
-### Building nvdaHelper developer documentation
+## Building nvdaHelper developer documentation
+
 [Refer to this section](../projectDocs/dev/buildingDevDocumentation.md#building-nvdahelper-developer-documentation)
 
-### Virtual Buffer Backends
+## Virtual Buffer Backends
 
 This code runs within the target applications process, it is responsible for building the virtual buffer.
 The base classes are in the `storage.h` and `storage.cpp`.
@@ -145,7 +161,7 @@ Given an identifier, a `controlFieldNode` can be looked up using `controlFieldNo
 Though, take care, looking up nodes is only possible after that part of the tree has been rendered.
 The `controlFieldNode`s are added to the buffer via `addControlFieldNode`, which also adds these nodes to the map.
 
-### Gecko IA2
+## Gecko IA2
 
 This is a virtual buffer backend implementation used for Firefox and Chrome.
 When `fillVBuf` is called, it recursively descends through the child elements that we care about, creating either
@@ -153,14 +169,15 @@ When `fillVBuf` is called, it recursively descends through the child elements th
 This code is responsible for interacting with the IA2 accessibility API, these calls should be minimised for
  performance reasons.
 
+## Overview of calling to remote code.
 
-### Overview of calling to remote code.
+* NVDA's python code calls into the local DLL (`NVDAHelperLocal.dll`).
+* Generated RPC Wrappers are called
+* The RPC Wrappers call through to the "remote in-process DLL" (ie `nvdaHelperRemote.dll`)
 
-- NVDA's python code calls into the local DLL (`NVDAHelperLocal.dll`).
-- Generated RPC Wrappers are called
-- The RPC Wrappers call through to the "remote in-process DLL" (ie `nvdaHelperRemote.dll`)
+### Build notes
 
-#### Build notes
 IDL/ACF files are input to MSRPCStubs to generate headers in `build/<arch>`
-- See `MSRPCStubs` in `*scons*` files.
-- Note these set a prefix, making whole word searches for methods difficult.
+
+* See `MSRPCStubs` in `*scons*` files.
+* Note these set a prefix, making whole word searches for methods difficult.

--- a/projectDocs/community/readme.md
+++ b/projectDocs/community/readme.md
@@ -1,3 +1,5 @@
+# NVDA Community
+
 ## Get support
 
 Whether you are a beginner, an advanced user, a new or a long time developer; or if you represent an organization wishing to know more or to contribute to NVDA: you can get support through the included documentation as well as several communication channels dedicated to the NVDA screen reader.

--- a/projectDocs/community/releaseProcess.md
+++ b/projectDocs/community/releaseProcess.md
@@ -6,37 +6,40 @@ These guidelines may be broken under special circumstances.
 Any concerns should be discussed via [GitHub Discussion](https://github.com/nvaccess/nvda/discussions), issue or pull request.
 
 ## Release Workflow
+
 This is the general release workflow.
 Information for specific community groups is provided in later sections.
 The production of a release consists of the following:
+
 1. [Alpha Phase](#alpha-phase) (~7 weeks)
-    - Development is done in parallel to the release process for the prior version once beta phase begins.
-    - e.g. NVDA 2020.2 is in alpha while NVDA 2020.1 is going from beta to the final release.
-    - The add-on API for the release is unstable.
-    Add-ons targeting this release should use "dev" channel.
+   * Development is done in parallel to the release process for the prior version once beta phase begins.
+   * e.g. NVDA 2020.2 is in alpha while NVDA 2020.1 is going from beta to the final release.
+   * The add-on API for the release is unstable.
+   Add-ons targeting this release should use "dev" channel.
 1. [Beta phase](#beta-phase) (~4 weeks)
-    - Beta1 is released 1 week after the most recent final release.
+    * Beta1 is released 1 week after the most recent final release.
     There is an exception for `20XX.1` releases.
     The first `20XX.1` beta release will occur when all planned API breaking changes have been made.
-    - A new beta is released weekly as required
-    - Translations should be relatively stable.
+    * A new beta is released weekly as required
+    * Translations should be relatively stable.
     Translators may wish to start working on the release, however further changes to translation strings will occur.
-    - The add-on API should be relatively stable.
+    * The add-on API should be relatively stable.
     Add-on authors may wish to start testing the new API, however further changes to the API may occur.
     Add-ons targeting this release should use "dev" or "beta" channel.
 1. [Release candidate phase](#Release-Candidate-phase) (~3 weeks)
-    - Once a beta has been stable for one week (no issues reported), the 2 week [translation freeze begins](#translatable-string-freeze).
+    * Once a beta has been stable for one week (no issues reported), the 2 week [translation freeze begins](#translatable-string-freeze).
     There should be no further translatable string changes, unless, if required, another freeze will be announced.
-    - Once the translation freeze ends, [a release candidate (RC)](#release-candidate) is created.
-    - A new RC is released weekly as required.
+    * Once the translation freeze ends, [a release candidate (RC)](#release-candidate) is created.
+    * A new RC is released weekly as required.
     The final RC should be identical to the final release.
-    - The add-on API for RC should be stable.
+    * The add-on API for RC should be stable.
     Add-ons targeting this release can use "stable" channel.
 1. Final release
-    - When an RC has been stable for one week (no issues reported), the final release is created
-    - If required, a [follow up patch release](#patch-release) may occur.
+    * When an RC has been stable for one week (no issues reported), the final release is created
+    * If required, a [follow up patch release](#patch-release) may occur.
 
 ### Alpha phase
+
 * Contributions are made following the [dev contributing guide](../dev/contributing.md).
 * Once a pull request has been reviewed and approved by at least one NV Access employee and all relevant build checks have passed, NV Access will squash merge the pull request into master.
 * If the merging of a pull request to `master` causes any build checks on `master` to fail, the pull request is reverted without question.
@@ -48,34 +51,37 @@ This is however unlikely to be an issue as build checks on the pull request itse
 * Automatic 'alpha snapshots' are made available to the public for very early testing. See [testing guide](../testing/contributing.md).
 
 ### Beta phase
+
 * A commit without any known serious issues, will be selected from the 'master' branch and merged into 'beta', this draws the line for features included in the release.
 * Documentation changes will be reviewed. A release summary will be added to the change log for the beta.
 * A tagged 'beta release' will be created for wider testing.
 * New pull requests may be now considered for squash merging straight to beta.
-  - If addressing regression introduced in this release.
-  - If addressing a bug in a "must have" feature for this release.
-  - If addressing a critical Operating System change out of our control.
+  * If addressing regression introduced in this release.
+  * If addressing a bug in a "must have" feature for this release.
+  * If addressing a critical Operating System change out of our control.
 * As appropriate new tagged beta releases will be published once a week.
 * As necessary `beta` will be merged back into master.
-  - For critical pull requests or translation merges.
+  * For critical pull requests or translation merges.
 * If a merged pull request that reached beta has been identified as causing a regression, new bug, or does not work as originally reported:
-  - The pull request may be reverted at the discretion of the lead developers.
-  - It may be fixed by a collaborator if the bug is trivial enough.
-  - Once a PR is reverted from `beta`, a replacement PR is very unlikely to be accepted into the current release.
-  - Use the [PR revert template](../../.github/PULL_REQUEST_TEMPLATE/revert.md) when reverting.
+  * The pull request may be reverted at the discretion of the lead developers.
+  * It may be fixed by a collaborator if the bug is trivial enough.
+  * Once a PR is reverted from `beta`, a replacement PR is very unlikely to be accepted into the current release.
+  * Use the [PR revert template](../../.github/PULL_REQUEST_TEMPLATE/revert.md) when reverting.
 
 ### Release Candidate phase
 
 #### Translatable String Freeze
-- The beta branch will enter a 2 week translatable string freeze.
-- Translators should ensure their translation is up to date a day before the translatable string freeze ends in order for it to be included in the upcoming final release.
+
+* The beta branch will enter a 2 week translatable string freeze.
+* Translators should ensure their translation is up to date a day before the translatable string freeze ends in order for it to be included in the upcoming final release.
 The lead developers will announce the deadline when the freeze begins, if in doubt check the [NVDA-Translations message board](https://groups.io/g/nvda-translations/) for the "language freeze" announcement.
 Work submitted after this time will not be included in the upcoming release.
-- No changes to text strings that affect translations are allowed during the freeze. Minor spelling or grammatical fixes may be made to documentation files, but `gettext` strings in the code should not be changed at all.
-- Only critical bug fixes and translation updates should be committed to the beta branch at this stage.
+* No changes to text strings that affect translations are allowed during the freeze. Minor spelling or grammatical fixes may be made to documentation files, but `gettext` strings in the code should not be changed at all.
+* Only critical bug fixes and translation updates should be committed to the beta branch at this stage.
 In this case the translation period will need to be extended by an appropriate amount of time.
 
 #### Release Candidate
+
 * After the translatable string freeze, the `rc` branch will be created based on the beta branch.
 * The first release candidate will immediately be released from the `rc` branch.
 * After this, only critical bug fixes should be committed to the `rc` branch.
@@ -83,15 +89,18 @@ In this case the translation period will need to be extended by an appropriate a
 * The final release can only be made if there have been no significant changes and at least 1 week since the last release candidate.
 
 ### Representation on GitHub
+
 * For most items, an issue will be filed and discussed before a pull request is submitted.
 * If priority should be given to an issue for inclusion in a specific release, its milestone should be set to the appropriate release milestone (e.g. 2014.4).
 * Once a pull request is squash merged to the master branch, the milestone for the issue (if any) and pull request should be set to the next release milestone (e.g. 2013.2) and it should be closed as fixed.
 * Issues/pull requests for bug fixes for an rc should have their milestone set to the relevant release (e.g. 2013.2).
 
 ### Scheduled Releases
+
 * In the past NVDA has been released 4 times per year. This is not expected to change drastically. The exact date for each release will be determined by the lead developers.
 
 ### Patch Release
+
 * Under rare circumstances, a patch release (e.g. 2013.1.1) may be made.
 * A patch release may only include fixes for crashes and major security issues.
 * Patch releases are made from the `rc` branch.

--- a/projectDocs/design/displayModel.md
+++ b/projectDocs/design/displayModel.md
@@ -6,16 +6,20 @@ information during the rendering of GUI applications.
 For information on working in this area see the `NVDAHelper/readme.md` file.
 
 ## Testing GDI applications
+
 To test:
-- Use `NVDA+numPad 7` to enter screen review mode.
-- Use the number pad to read lines (7, 8, 9), read words, (4, 5, 6), or characters (1, 2, 3).
+
+* Use `NVDA+numPad 7` to enter screen review mode.
+* Use the number pad to read lines (7, 8, 9), read words, (4, 5, 6), or characters (1, 2, 3).
 
 Additionally
-- Use `NVDA+shift+f` to report formatting.
+
+* Use `NVDA+shift+f` to report formatting.
 
 Note:
-- For color reporting enable the option (via Document formatting panel) _"report color"_.
-- To report transparencies in color enable the option (via advanced settings panel) _"Report transparent color values"_.
+
+* For color reporting enable the option (via Document formatting panel) _"report color"_.
+* To report transparencies in color enable the option (via advanced settings panel) _"Report transparent color values"_.
 
 There are several simple test applications available:
-https://github.com/nvaccess/testDisplayModel
+<https://github.com/nvaccess/testDisplayModel>

--- a/projectDocs/design/hidBrailleTechnicalNotes.md
+++ b/projectDocs/design/hidBrailleTechnicalNotes.md
@@ -1,14 +1,17 @@
-HID Braille Developer Notes
+# HID Braille Developer Notes
 
 ## HID (Human Interface Device)
+
 The HID specification standardizes the low-level communication with a USB or Bluetooth device, plus the types of input and output controls on the device.
 Example devices being keyboards, mice, screens, and now Braille Displays.
 
 ### Definitions
+
 In this document, device means a piece of hardware that connects to a computer via a connection such as USB or Bluetooth.
 The device may contain one or more Controls for a human to physically communicate with the device, such as buttons or keys for input, or LEDs or cells of raised Braille pins for output.
 
 There are also several terms in HID which may be confusing to those just beginning to familiarise themselves with this technology.
+
 * Descriptors
 * Usage pages
 * Usages
@@ -19,17 +22,20 @@ There are also several terms in HID which may be confusing to those just beginni
 These terms are described in the subsections below.
 
 #### HID descriptors
+
 At connection time, a HID device must expose a block of data over the connection called a descriptor.
 This is machine-readable data that describes all the input and output controls supported by the device, including their type and number of elements etc.
 It also defines the size of data blocks (or reports) that can be written to and read from the device.
 A descriptor can be read by a human (either as raw values or with some kind of decompiler) but from the point of view of Windows, the descriptor is opaque, and other more high-level Windows APIs should be used to communicate with the device, which will do all the type checking for you.
 
 #### HID Usage Pages
+
 The HID specification groups controls into categories which it refers to as pages.
 Each page has its own unique number, and is referred to as a usage Page.
 A Usage Page may represent a specific device type such as a keyboard, joystick or Braille display, or may be more general such as a generic Buttons page.
 
 #### HID Usages
+
 A Usage represents a type of control (key, button, braille cell, LED).
 The Usage is assigned its own constant name, and a unique number relative to the particular Usage Page in the standard it is found on.
 A Usage defines information about the control such as whether it is a boolean button, static or dynamic value, flag, or selector (1 of many).
@@ -38,6 +44,7 @@ The specification itself may or may not define other aspects of the data type su
 Usage IDs are also used to uniquely identify collections of controls or values.
 
 #### HID reports
+
 A report is a block of data that is read from or written to the HID device.
 It has a size specified by the HID descriptor, and contains a report ID as the first byte.
 On Windows, when fetching a new report with `ReadFile`, the report ID is automatically written into the data block by Windows, and most likely never needs to be known by the developer user as other high-level Windows APIs that can extract data from reports will use this report ID byte internally.
@@ -45,6 +52,7 @@ When writing reports with `WriteFile` however, the developer user must set the a
 On Windows the report ID can be found in the `HIDP_VALUE_CAPS` (value capabilities) structure for that value, fetched from the HID descriptor with `HidP_GetValueCaps`.
 
 #### HID collections
+
 HID controls are grouped into collections.
 Some examples might be all the keys on a keyboard, or all the cells in a line of Braille.
 Each defined collection has a Usage Page and a Usage ID so it can be uniquely identified.
@@ -52,6 +60,7 @@ All HID devices have a top-level collection, which is the main point of entry fo
 These other collections are known as Linked collections.
 
 #### Caps
+
 A shortening of the word Capabilities used by particular Windows APIs and structures for HID.
 E.g. `HidP_GetCaps` gets the capabilities of the HID device.
 These include things like the number of input buttons or output values on the device, the size of reports, and the Usage and Usage Page for the device.
@@ -59,37 +68,45 @@ Similarly `HidP_GetButtonCaps` gets the capabilities of all buttons on the devic
 Capabilities of buttons and values include such things as their Usage and Usage Page, whether they represent a range of Usages, and whether they have a NULL state etc.
 
 ### General pattern for supporting HID on Windows
+
 #### Enumerating HID devices
+
 * Fetch the class guid for HID devices with `HidD_GetHidGuid`
 * Fetch the device information set for the local machine with `SetupDiGetClassDevs`, specifying the HID class guid as the class guid.
- * Keep calling `SetupDiEnumDeviceInterfaces`, increasing memberIndex each time, to enumerate over all available devices fetching a `SP_DEVICE_INTERFACE_DATA` structure for each, until the function returns false, which means there are no more devices left to enumerate.
+  * Keep calling `SetupDiEnumDeviceInterfaces`, increasing memberIndex each time, to enumerate over all available devices fetching a `SP_DEVICE_INTERFACE_DATA` structure for each, until the function returns false, which means there are no more devices left to enumerate.
 * For each data structure fetched, call `SetupDiGetDeviceInterfaceDetail` to get a `SP_DEVICE_INTERFACE_DETAIL_DATA` structure.
 * The `SP_DEVICE_INTERFACE_DETAIL_DATA` structure's devicePath member  is the path that should be used to open the device for reading / writing later.
 * Some other properties such as hardwareID may be required to further identify the device, these can be fetched with `SetupDiGetDeviceRegistryProperty`.
 * For an implementation see `listHidDevices` in NVDA's source/hwPortUtils.py
 
 #### Opening a HID device
+
 * Use `CreateFile` to open a HID device, giving it the DevicePath as the file path.
  Note overlapped IO is possible; See `CreateFile` documentation.
- * If this device may need to be opened by other processes at the same time, you will want to specify `FILE_SHARE_READ | FILE_SHARE_WRITE` as well.
+  * If this device may need to be opened by other processes at the same time, you will want to specify `FILE_SHARE_READ | FILE_SHARE_WRITE` as well.
 * Once the open device handle is no longer needed, it can be closed with `CloseHandle`.
 * For an implementation see the `Hid` class in NVDA's source/hwIo/base.py
 
 #### Fetching device attributes
+
 * To fetch info such as vendorID, productID and versionNumber, call `HidD_GetAttributes` on the open device handle.
 * To fetch the manufacturer string, use `HidD_GetManufacturerString` giving the open device handle.
 * To fetch the product string, use `HidD_GetProductString` giving the open device handle.
 
 #### Fetching the HID descriptor
+
 Fetching device capabilities, getting data from reports and setting data in reports all requires the device's HID descriptor.
 Windows represents the HID descriptor as an opaque value referred to as the preparsed data.
+
 * Fetch the device's preparsed data with `HidD_GetPreparsedData`, giving it the open device handle.
 Note this must be freed once it is no longer needed with `HidD_FreePreparsedData`.
 
 #### Fetching device capabilities
+
 * To find out a top-level collection's Usage Page, Usage, number of input and output values, and report sizes, fetch a `HIDP_CAPS` structure for the device with `HidP_GetCaps`, giving the open device handle and the preparsed data.
 
 #### Fetching value / button capabilities
+
 type information of input buttons and values and output values on a device (such as their Usage ID, size and number of items) can be found out through a `HIDP_VALUE_CAPS` structure for each.
 An array of these structures can be fetched with `HidP_GetValueCaps` for input or output values, and `HidP_GetButtonCaps` for buttons.
 Sometimes a `HIDP_VALUE_CAPS` structure can represent a range of buttons or values, where minimum and maximum Usage IDs and Data indices are exposed, rather than a specific value.
@@ -97,12 +114,15 @@ Examples of these might be the way that Braille dot input keys are exposed.
 There is only one `HIDP_VALUE_CAPS` structure, covering values from dot1 to dot8.
 
 #### Reading data from the device
+
 * Use `ReadFile` to read the next available input report from the device.
 The size of data to read in bytes must be equal to the `InputReportByteLength` member of the device's `HIDP_CAPS` structure.
- * Use functions such as `HidP_GetData` and `HidP_GetUsages` to extract the current value of buttons and other values set in the report.
+  * Use functions such as `HidP_GetData` and `HidP_GetUsages` to extract the current value of buttons and other values set in the report.
 
 #### Writing data to the device
+
 To set the value of particular controls on the device:
+
 * Create an output report by allocating a block of memory of size OutputReportByteLength from the device's HIDP_CAPS structure, using something like `malloc`.
 * Set the report ID (the first byte) to the report ID found in the `HIDP_VALUE_CAPS` structure for the value/s you want to set.
 This obviously means you can only set values who share the same report ID in a single report.
@@ -111,7 +131,9 @@ This obviously means you can only set values who share the same report ID in a s
 The size in bytes sent must be equal to the `OutputReportByteLength` of the device's `HIDP_CAPS` structure.
 
 ## HID Braille specification
+
 ### Background
+
 Braille Display devices allow being controlled by Screen Readers using a variety of connections such as Serial, USB and Bluetooth.
 The protocols used over these channels have traditionally been Braille Display manufacturer specific.
 This has meant that in order for a Screen Reader to support a particular Braille display, it must have specific logic in the Screen Reader that knows how to speak the required device-specific protocol.
@@ -121,6 +143,7 @@ With the introduction of the HID (Human Interface Device) standard for USB (and 
 In 2018, The HID specification was extended to define the concept of a Braille Display device, including setting of braille cells, and the standardizing of common buttons found on Braille displays such as routing keys, Braille dot input keys, braille space and panning keys.
 A new Usage Page was added to the HID specification: HID_USAGE_PAGE_BRAILLE (0x41).
 This page contains new Usage IDs such as:
+
 * BRAILLE_DISPLAY (0x1): the usage ID for the HID device's top-level collection.
 * Collections such as BRAILLE_ROW (for containing braille cells)
 * 8_dot_BRAILLE_CELL (0x3) and 6_dot_braille_cell (0x4), which is an output value that represents a physical braille cell on a device.
@@ -131,10 +154,12 @@ This page contains new Usage IDs such as:
 details for the number of collections, usages, and reports must be queried at run time and may vary between devices and even with device firmware updates.
 
 ### Pattern for talking with a HID braille device
+
 #### Initialization
+
 * Follow the general instructions for enumerating and opening a HID device,  plus fetching device and value capabilities as mentioned earlier in this document.
 * Ensure the Hid device is truly a Braille display by checking that the `HIDP_CAPS.UsagePage` of the HID device's top-level collection is set to `HID_USAGE_PAGE_BRAILLE` (0x41).
- * Find the correct output `HIDP_VALUE_CAPS` structure which represents the array of braille cells.
+  * Find the correct output `HIDP_VALUE_CAPS` structure which represents the array of braille cells.
 I.e.
 the Usage ID is either EIGHT_DOT_BRAILLE_CELL or six_dot_braille_cell.
 The `ReportCount` member of this struct states the number of cells for the device.
@@ -146,14 +171,16 @@ In other words, the index within its collection.
 this is needed in some implementations to work out which routing key a value represents, as the Usage ID for the value will be just ROUTING_KEY and the collection will be one of the ROUTER_SET_* collection Usage IDs.
 
 #### Writing cells to the device
+
 * Create a HID output report (block of memory), setting the report ID (first byte) to the value of the ReportID member of the Braille cell `HIDP_VALUE_CAPS` structure found at construction time.
 * Call `HidP_SetUsageValueArray` to place the data (braille cell dot patterns) into the report at the appropriate place, Using the Usage ID and collection number etc from the cell `HIDP_VALUE_CAPS` structure.
 * Send the report to the Braille display using `WriteFile`.
 The number of bytes written will be the value of `HIDP_CAPS.OutputReportByteLength`.
 
 #### Receive input (key / button presses)
+
 * Read an input report of size `InputReportByteLength` with `ReadFile` (or an overlapped IO callback)
- * `HidP_GetData` can be used to extract all `HIDP_DATA` structures from the report.
+  * `HidP_GetData` can be used to extract all `HIDP_DATA` structures from the report.
 these represent the state of all input buttons and other controls.
 * Using the `DataIndex` member of each retrieved data item, lookup the original `HIDP_VALUE_CAPS` structure for that data index to find out its Usage Page and Usage ID.
 This will denote the actual button pressed or changed value.
@@ -161,8 +188,9 @@ If you only need to find out what buttons are pressed, but not any further data 
 But this would not be useful for buttons such as routing keys as you need to know specifically which routing key was pressed.
 
 ## References:
-* USB HID article on wikipedia: https://en.wikipedia.org/wiki/USB_human_interface_device_class
-* Introduction to Human Interface Devices (HID), Windows Driver docs: https://docs.microsoft.com/en-us/windows-hardware/drivers/hid/
-* Interpreting HID Reports, Windows driver docs: https://docs.microsoft.com/en-us/windows-hardware/drivers/hid/interpreting-hid-reports
-* HID Usages, Windows driver docs: https://docs.microsoft.com/en-us/windows-hardware/drivers/hid/hid-usages
-* HID Usage Tables 1.22 (Contains HID Braille page): https://www.usb.org/document-library/hid-usage-tables-122
+
+* USB HID article on wikipedia: <https://en.wikipedia.org/wiki/USB_human_interface_device_class>
+* Introduction to Human Interface Devices (HID), Windows Driver docs: <https://docs.microsoft.com/en-us/windows-hardware/drivers/hid/>
+* Interpreting HID Reports, Windows driver docs: <https://docs.microsoft.com/en-us/windows-hardware/drivers/hid/interpreting-hid-reports>
+* HID Usages, Windows driver docs: <https://docs.microsoft.com/en-us/windows-hardware/drivers/hid/hid-usages>
+* HID Usage Tables 1.22 (Contains HID Braille page): <https://www.usb.org/document-library/hid-usage-tables-122>

--- a/projectDocs/design/startupShutdown.md
+++ b/projectDocs/design/startupShutdown.md
@@ -4,31 +4,31 @@
 
 1. For an installed copy:
     1. Ctrl+Alt+N (Desktop shortcut)
-        - test: `startupShutdownNVDA.Starts from desktop shortcut`
+        * test: `startupShutdownNVDA.Starts from desktop shortcut`
     1. Automatically via Ease of Access on the Windows sign-in screen (at boot or signing out of a previous session)
     1. Automatically via Ease of Access on User Account Control (UAC) screens
     1. Automatically by Ease of Access after signing in to Windows
 1. For an installed copy, portable copy, installer:
     1. An exiting instance of NVDA starting a new process (see shutting down procedures)
     1. By running the exe.
-        - This can be triggered by a user or external process such as an existing NVDA instance
-        - test: `startupShutdownNVDA.Starts`
+        * This can be triggered by a user or external process such as an existing NVDA instance
+        * test: `startupShutdownNVDA.Starts`
 1. For source: eg runnvda.bat
 
 ## NVDA can be shutdown by:
 
 1. UI within NVDA, with and without an ExitDialog prompt (uses `triggerNVDAExit`):
     1. NVDA+q
-        - test: `startupShutdownNVDA.Quits from keyboard, Restarts`
+        * test: `startupShutdownNVDA.Quits from keyboard, Restarts`
     1. An input gesture to restart
     1. After changing some settings (eg installed add-ons or UI language), user prompted on dialog exit.
     1. Via the NVDA menu -> Exit
-        - test: `startupShutdownNVDA.Quits from menu`
+        * test: `startupShutdownNVDA.Quits from menu`
 1. A process sending `WM_QUIT`, eg a new NVDA process starting
 1. A handled crash (directly causes a new process to start, terminates unsafely)
-    - test: `startupShutdownNVDA.Restarts on crash, Restarts on braille crash`
+    * test: `startupShutdownNVDA.Restarts on crash, Restarts on braille crash`
 1. An unhandled crash (terminates unsafely)
-    - requires manual testing/confirmation
+    * requires manual testing/confirmation
 1. An external command which kills the process (terminates unsafely)
 1. Windows shutting down (terminates unsafely) (uses `wx.EVT_END_SESSION`)
 
@@ -41,20 +41,21 @@ Check the [manual test guide](../../tests/manual/nvdaUI/startupShutdown.md).
 These notes are aimed at developers, wishing to understand technical aspects of the NVDA start and exit.
 
 1. No more than one NVDA process instance should be running at the same time. Interactions with itself could cause severe issues, some (non-exhaustive list) examples of sub-systems where this would be a problem:
-   - NVDA config files
-   - Global (OS level) keyboard hook
-   - Changed / incompatible in-process code
+   * NVDA config files
+   * Global (OS level) keyboard hook
+   * Changed / incompatible in-process code
 2. As such, we want to be able to detect running instances, cause them to exit, and confirm they have exited.
 
 ### Exit hooks/triggers
 
 There are 3 ways that NVDA receives a request to exit:
 
-- From internally calling [triggerNVDAExit](#When-exiting-from-triggerNVDAExit)
-- Receiving [WM_QUIT](#When-exiting-from-WM_QUIT) Windows message
-- Receiving [wx.EVT_END_SESSION](#When-exiting-from-wxEVT_END_SESSION) due to Windows session ending
+* From internally calling [triggerNVDAExit](#When-exiting-from-triggerNVDAExit)
+* Receiving [WM_QUIT](#When-exiting-from-WM_QUIT) Windows message
+* Receiving [wx.EVT_END_SESSION](#When-exiting-from-wxEVT_END_SESSION) due to Windows session ending
 
 ### When exiting from `triggerNVDAExit`
+
 * Called from within NVDA.
 * A function in the core module
 * Only executes the code once, uses a lock and flag to ensure this
@@ -67,24 +68,26 @@ There are 3 ways that NVDA receives a request to exit:
     1. Now that windows are closed, a new NVDA instance is started if requested
 
 ### When exiting from `WM_QUIT`
+
 * [A Windows Message](https://docs.microsoft.com/en-us/windows/win32/winmsg/wm-quit) received from an external process, such as another NVDA process.
 * NVDA accepts `WM_QUIT` messages from other processes and creates a [named window](https://docs.microsoft.com/en-us/windows/win32/learnwin32/creating-a-window#creating-the-window) that can be discovered.
 * `WM_QUIT` is handled by `wx`, which force closes all wx windows (other UI features like the systray icon are not windows, and remain) and then exits the main loop.
 `triggerNVDAExit` is a more expansive check than how wxWidgets handles `WM_QUIT`
 * We subsequently run `triggerNVDAExit` to ensure that clean up code isn't missed, and pump the queue to execute it.
 * Using a custom message has been considered:
-  - Would allow custom handling (eg just `triggerNVDAExit`)
-  - Unfortunately, older NVDA versions will only be aware of `WM_QUIT`, so we'd need to send `WM_QUIT` to these versions.
-  - Sending the custom message, waiting for a timeout, then sending `WM_QUIT` adds a significant wait time
-  - Identifying the running version (to selectively send the message) requires maintaining 2 message windows in NVDA (one for legacy behaviour) and adds complexity
+  * Would allow custom handling (eg just `triggerNVDAExit`)
+  * Unfortunately, older NVDA versions will only be aware of `WM_QUIT`, so we'd need to send `WM_QUIT` to these versions.
+  * Sending the custom message, waiting for a timeout, then sending `WM_QUIT` adds a significant wait time
+  * Identifying the running version (to selectively send the message) requires maintaining 2 message windows in NVDA (one for legacy behaviour) and adds complexity
 
 ### When exiting from `wx.EVT_END_SESSION`
+
 * This is a [wxCloseEvent](https://docs.wxwidgets.org/3.0/classwx_close_event.html) triggered by a Windows session ending.
 * On `wx.EVT_END_SESSION`, we save the config and play the exit sound.
 * Other actions are not performed as we have limited time to perform an action for this event.
-    * NVDA is expected to run as long as possible during the sign out process.
-    * This is achieved through the [Windows API](https://docs.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-setprocessshutdownparameters), by setting the shutdown priority to the lowest reserved value for non-system applications, `0x100`.
-    * [SHUTDOWN_NORETRY](https://docs.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-setprocessshutdownparameters) ensures that NVDA does not show up in the blocked shutdown list dialog.
+  * NVDA is expected to run as long as possible during the sign out process.
+  * This is achieved through the [Windows API](https://docs.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-setprocessshutdownparameters), by setting the shutdown priority to the lowest reserved value for non-system applications, `0x100`.
+  * [SHUTDOWN_NORETRY](https://docs.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-setprocessshutdownparameters) ensures that NVDA does not show up in the blocked shutdown list dialog.
     If it were, the user would have no way of reading the dialog and fixing the issue.
 
 ### Replacing an existing NVDA instance

--- a/projectDocs/design/technicalDesignOverview.md
+++ b/projectDocs/design/technicalDesignOverview.md
@@ -8,25 +8,29 @@ Please see the code documentation for the relevant classes for more information.
 ## Terminology
 
 ### Abbreviations
- * API: Application programming interface
- * GUI: Graphical user interface
+
+* API: Application programming interface
+* GUI: Graphical user interface
 
 ### Definitions
- * Caret: The system cursor; i.e.
+
+* Caret: The system cursor; i.e.
 the cursor generally moved when you use the normal cursor keys.
- * Script: A function which is executed in response to input from the user such  as key presses from the keyboard, manipulating braille display controls and taps on touchscreens.
+* Script: A function which is executed in response to input from the user such  as key presses from the keyboard, manipulating braille display controls and taps on touchscreens.
 Also known as a command.
- * Widget: An individual component in a GUI with which a user can interact;
- e.g. a button, an editable text field, a list box, etc.
+* Widget: An individual component in a GUI with which a user can interact;
+e.g. a button, an editable text field, a list box, etc.
 Also known as a control or object.
 
 ## General
 
 ### Programming Languages
+
 NVDA is primarily written in the [Python programming language](http://www.python.org/), which allows for rapid development among other benefits.
 Code that needs to be [injected into other processes](#in-process-code) is written in C++ for high performance.
 
 ### Accessibility APIs
+
 In order to make graphical widgets accessible to assistive technologies, operating systems and applications can use special purpose accessibility APIs.
 These APIs provide information about the widget such as its name, type/role (button, check box, editable text field, etc.), description, value, states (checked, unavailable, invisible, etc.) and keyboard shortcut.
 Accessibility APIs also provide events to allow assistive technologies to monitor changes, such as when the focus changes, properties of an object (such as name, description, value, and state) change, etc.
@@ -37,32 +41,34 @@ Several accessibility APIs are used, including Microsoft Active Accessibility (M
 **Note:** IAccessible2 was not created by Microsoft, see [Wikipedia for more background](https://en.wikipedia.org/wiki/IAccessible2).
 
 See also:
-- [Stack Overflow: "What is the difference between IAccessible, IAccessible2, UIAutomation and MSAA?"](https://stackoverflow.com/a/55130227)
-- [The Linux Foundation IA2 reference](https://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/)
-- [IA2 event constants](https://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/_accessible_event_i_d_8idl.html)
-  - From the perspective of Windows, the IA2 event constants are considered custom "application specific" event IDs.
-- [IA2 Project (IDL files)](https://github.com/LinuxA11y/IAccessible2)
-- [Windows event constants](https://docs.microsoft.com/en-us/windows/win32/winauto/event-constants)
 
+* [Stack Overflow: "What is the difference between IAccessible, IAccessible2, UIAutomation and MSAA?"](https://stackoverflow.com/a/55130227)
+* [The Linux Foundation IA2 reference](https://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/)
+* [IA2 event constants](https://accessibility.linuxfoundation.org/a11yspecs/ia2/docs/html/_accessible_event_i_d_8idl.html)
+  * From the perspective of Windows, the IA2 event constants are considered custom "application specific" event IDs.
+* [IA2 Project (IDL files)](https://github.com/LinuxA11y/IAccessible2)
+* [Windows event constants](https://docs.microsoft.com/en-us/windows/win32/winauto/event-constants)
 
 #### Tools for investigating Accessibility APIs
 
-- Using [NVDA Object Navigation](https://download.nvaccess.org/documentation/userGuide.html#ObjectNavigation) and [logging developer information](https://download.nvaccess.org/documentation/userGuide.html#LogViewer).
-- [Accessibility Viewer (aViewer)](https://github.com/ThePacielloGroup/aviewer/)
-	- handles MSAA, IA2, UIA but can be a bit buggy
-	- tends to provide user friendly display strings that make it harder to map back to raw values
-- [Accessibility Insights for Windows - Accessibility Insights](https://accessibilityinsights.io/docs/en/windows/overview/#:~:text=Accessibility%20Insights%20for%20Windows%20helps%20developers%20find%20and,the%20element%20or%20setting%20keyboard%20focus%20on%20it.)
-	- Good for UIA, doesn't support MSAA / IA2
-- [Inspect.exe (Windows SDK)](https://docs.microsoft.com/en-us/windows/win32/winauto/inspect-objects)
-	- Handles MSAA and UIA, but not IA2
+* Using [NVDA Object Navigation](https://download.nvaccess.org/documentation/userGuide.html#ObjectNavigation) and [logging developer information](https://download.nvaccess.org/documentation/userGuide.html#LogViewer).
+* [Accessibility Viewer (aViewer)](https://github.com/ThePacielloGroup/aviewer/)
+  * handles MSAA, IA2, UIA but can be a bit buggy
+  * tends to provide user friendly display strings that make it harder to map back to raw values
+* [Accessibility Insights for Windows - Accessibility Insights](https://accessibilityinsights.io/docs/en/windows/overview/#:~:text=Accessibility%20Insights%20for%20Windows%20helps%20developers%20find%20and,the%20element%20or%20setting%20keyboard%20focus%20on%20it.)
+  * Good for UIA, doesn't support MSAA / IA2
+* [Inspect.exe (Windows SDK)](https://docs.microsoft.com/en-us/windows/win32/winauto/inspect-objects)
+  * Handles MSAA and UIA, but not IA2
 
 ### Native APIs
+
 Some widgets do not expose sufficient information via accessibility APIs to make them fully accessible.
 For example, MSAA, which is the accessibility API used by most standard Windows controls, does not provide the ability to obtain the location of the cursor or retrieve individual units of text in editable text fields.
 However, some widgets provide their own native APIs (not specific to accessibility) which can be used to obtain this information.
 NVDA makes use of these APIs where possible; e.g. in standard edit controls.
 
 ### Operating System Functions
+
 Aside from accessibility and native APIs, Windows provides many functions which can be used to obtain information and perform tasks.
 Information that can be obtained includes the class name of a window, the current foreground window and system battery status.
 Tasks that can be performed include moving/clicking the mouse and sending key presses.
@@ -70,21 +76,25 @@ Tasks that can be performed include moving/clicking the mouse and sending key pr
 ### Logging
 
 #### Logging in secure mode
+
 `logHandler.initialize` prevents logging in [secure mode](https://download.nvaccess.org/documentation/userGuide.html#SecureMode).
 This is because it is a security concern to log during secure mode (e.g. passwords are logged on [secure screens](https://download.nvaccess.org/documentation/userGuide.html#SecureScreens).
 To change this for testing, use the [serviceDebug](https://download.nvaccess.org/documentation/userGuide.html#SystemWideParameters) system wide parameter to prevent secure mode on secure screens.
 When logging from a secure screen, `nvda.log` files are generated in the System profile's `%TEMP%` directory.
 
 ## NVDA Components
+
 NVDA is built with an extensible, modular, object oriented, abstract design.
 It is divided into several distinct components.
 
 ### Launcher
+
 The launcher is the module which the user executes to start NVDA.
 It is contained in the file `nvda.pyw`.
 Refer to [startupShutdown documentation](./startupShutdown.md).
 
 ### Core
+
 The core (in the function `core.main`) loads the configuration, initialises all other components and then enters the main loop.
 In each iteration of the main loop, the core pumps the [API](#api-handlers) and [input](#input-handlers) handlers, [registered generators](#registered-generators) and the main queue.
 All events, scripts, etc. are indirectly queued to this main queue by API and input handlers, so pumping the main queue causes these to be executed.
@@ -93,10 +103,12 @@ The main loop continues to iterate / sleep until NVDA is instructed to exit eith
 Once NVDA is instructed to exit, the core terminates all other components, saves the configuration if appropriate and then exits.
 
 #### Event and Script Handling
+
 Rather than queuing scripts and events directly to the main queue, this is abstracted using the `eventHandler` and `scriptHandler` modules.
 Input and API handlers use these modules to queue or directly execute scripts and events.
 
 #### Registered Generators
+
 Some tasks need to run in the background without causing NVDA to block (freeze) while waiting for them to complete.
 They need to execute code regularly, but at no specific time interval.
 NVDA allows Python generator functions to be registered for this purpose.
@@ -105,17 +117,20 @@ Examples of this include the say all and speak spelling functionality.
 They are registered using `queueHandler.registerGeneratorObject`.
 
 ### Input Handlers
+
 The input handlers handle input from various sources.
 Currently, there are three main input handler modules: `keyboardHandler`, `mouseHandler` and `touchHandler`. [Braille display drivers](#output-drivers) can also handle input.
 These handlers listen for input and generate appropriate [input gestures](#input-gestures) and events.
 
 ### Input Gestures
+
 An input gesture is an abstract representation of a single piece of input from the user; e.g. a key press.
 All input gestures derive from the base `inputCore.InputGesture` class.
 This allows all input to be handled in a consistent, unified way.
 For example, any input gesture can be bound to any script, both in code and by the user.
 
 ### API Handlers
+
 These handle initialisation, listening for events and termination for specific accessibility and native APIs.
 They also contain utility functions useful for working with their API.
 When an event is received for a widget, an appropriate [NVDA object](#nvda-objects) is fetched or constructed and an event is then queued for that NVDA object.
@@ -124,17 +139,20 @@ To introduce support for a new API, a developer just creates another API handler
 API handler modules include `IAccessibleHandler` for MSAA/IAccessible and IAccessible2, `JABHandler` for Java Access Bridge and `UIAHandler` for UI Automation.
 
 ### Output Modules
+
 Separate modules encapsulate the handling of output functionality.
 Currently, there are two main output modules: `speech` and `braille`.
 There is also the `tones` module, which is used to output tones/beeps, and `nvWave` module used to play wave files indicating specific events.
 
 ### Output Drivers
+
 Synth drivers are drivers to allow NVDA to utilise particular speech synthesisers.
 They are derived from the `synthDriverHandler.SynthDriver` base class.
 Braille display drivers are drivers to allow NVDA to utilise particular braille displays.
 They are derived from the `braille.BrailleDisplayDriver` base class.
 
 ### NVDA Objects
+
 An NVDA object (`NVDAObject`) is an abstract representation of a single widget in NVDA.
 All NVDA objects derive from the base `NVDAObjects.NVDAObject` class.
 Methods and properties are used to query information about, handle events from and execute actions on the widget represented by the NVDA object in an abstract way.
@@ -150,6 +168,7 @@ These allow both the user and code to navigate the entire Operating System and i
 The root of the tree being the Desktop, whose children is all the top-level windows for all open applications, each containing further subtrees of more widgets representing an application's user interface.
 
 ### Text Ranges
+
 When working with editable text controls, NVDA needs to be able to obtain information about the text in the widget.
 Aside from just retrieving the entire text, proper navigation requires retrieval of specific units of text (e.g. paragraphs, lines, words and characters), as well as the ability to find and set the location of the caret and selection.
 Also, if the widget supports formatting, NVDA should be able to retrieve text attributes such as font name, size, bold, italic, underline and whether there is a spelling error.
@@ -158,6 +177,7 @@ Just as NVDA objects provide an abstract representation of a widget, TextInfo ob
 These objects are derived from the `textInfos.TextInfo` base class.
 
 TextInfo objects contain properties and methods to:
+
 * Move or expand the range by units such as character, word, line and paragraph
 * compare the start and end of a range with itself or another range
 * Fetch the text and formatting of the range
@@ -165,16 +185,19 @@ TextInfo objects contain properties and methods to:
 You can fetch a TextInfo object from an NVDA object via its `makeTextInfo` method, passing in the particular `textInfos.POSITION_*` constant depending on whether you want to fetch a range representing the position of the caret, selection, start or end of the text, or the entire text.
 
 ### Global Commands
+
 The global commands object (`globalCommands.GlobalCommands`) contains built-in global scripts; i.e.
 they can be executed everywhere.
 For example, the review, report current focus and date/time scripts are all located in global commands.
 
 ### Plugins
+
 NVDA allows third-parties to extend NVDA's functionality through plugins and add-ons.
 These may define custom NVDA objects for specific applications, add global features and add support for new braille displays and speech synthesizers.
 There are three plugin types: appModules, globalPlugins and drivers, with drivers further divided between speech synthesizer and braille display support.
 
 #### App Modules
+
 Generally, most widgets may appear in any application and an [NVDA object](#nvda-objects) should therefore be included in the main `NVDAObjects` package.
 However, there are sometimes cases where a widget is implemented specifically for one application, as well as cases where a single event must be overridden or a script must be provided only in one application.
 An app module provides support specific to an application for these cases.
@@ -185,6 +208,7 @@ Usually the App Module should be named the same as the executable for which it s
 In cases where this is problematic (one App Module should support multiple applications, the binary is named in a way which conflicts with the Python import system) you can add an entry to the `appModules.EXECUTABLE_NAMES_TO_APP_MODS` where the binary name is the key and the name of the App Module is the value.
 
 #### Global Plugins
+
 Aside from application specific customisation using [app modules](#app-modules), it is also possible to extend NVDA on a global level.
 For example, new global commands can be added, behaviour can be changed and new GUI toolkits can be supported.
 This can be done using global plugins.
@@ -194,6 +218,7 @@ More specifically, global plugins receive events for all [NVDA objects](#nvda-ob
 They can also implement their own global [NVDA Objects](#nvda-objects).
 
 ### Tree Interceptors
+
 Sometimes, it is necessary to intercept events and scripts for an entire hierarchy (or tree) of [NVDA objects](#nvda-objects).
 For example, this is necessary to seamlessly handle complex documents which consist of many objects.
 This can be done using a tree interceptor.
@@ -203,17 +228,20 @@ Tree interceptors are created when a TreeInterceptor class is returned from the 
 Tree interceptors are used mostly for web documents, where all events and scripts for NVDA objects within a document need to be handled by the document (root NVDA object) itself.
 
 #### Browse mode documents
+
 Complex documents such as web pages are very often not flat; i.e. information does not simply run from top to bottom.
 Because of this, complex document browsers often do not provide a way to navigate documents using the caret, and even when they do, it is often problematic.
 Therefore, screen readers need to create their own flat representation of a document from the object hierarchy provided by the browser and allow the user to navigate this flat representation.
 Browse mode documents are a subclass of `TreeInterceptor` that provide scripts that allow navigating the document in a linear fashion.
 
 ##### Virtual buffers
+
 Due to the extreme slowness of performing large numbers of [out-of-process](#out-of-process-code) queries, some complex documents are accessed by NVDA by using [in-process code](#in-process-code), which collects all the content of a document in one go, and allows NVDA to search and fetch parts of this cached content on demand.
 These are known as virtual buffers.
 A virtual buffer (VirtualBuffer) in NVDA is derived from the `virtualBuffers.VirtualBuffer` base class and is a type of [browse mode document](##browse-mode-documents).
 
 ### GUI
+
 NVDA has its own graphical user interface to allow for easy configuration and other user interaction.
 This code is primarily contained in the `gui` package.
 [wxPython](http://www.wxpython.org/) is used as the GUI toolkit.
@@ -250,19 +278,22 @@ PR [#12181](https://github.com/nvaccess/nvda/pull/12181) is an example of fixing
 When event handlers are firing unexpectedly or failing to fire, refer to the [wxWidgets documentation for event propagation](https://wiki.wxpython.org/EventPropagation).
 
 Notably:
+
 * Event handlers stop propagation.
-   - If `event.Skip()` is called in an event handler, propagation will continue.
+  * If `event.Skip()` is called in an event handler, propagation will continue.
 * `wx.CommandEvents`, a subset of wxEvents, will propagate up to the parent dialog by default.
-   - If a child control performs an event, a parent event handler may fire.
-   PR [#13117](https://github.com/nvaccess/nvda/pull/13117) is an example of a bug caused by this being fixed.
+  * If a child control performs an event, a parent event handler may fire.
+  PR [#13117](https://github.com/nvaccess/nvda/pull/13117) is an example of a bug caused by this being fixed.
 
 ### Configuration management
+
 NVDA includes an extensive configuration management facility including various preferences dialogs, ability to apply a given configuration in apps and so forth.
 The base configuration options, as well as routines that manage configuration profiles and other management routines are housed in the `config` package, and NVDA uses [ConfigObj](http://www.voidspace.org.uk/python/configobj.html) to store configuration options.
 
 ## Special Object Functions
 
 ### Events
+
 NVDA object, global plugin, app module and tree interceptor instances can all contain special methods which handle events for NVDA Objects.
 These methods are all named beginning with "`event_`"; e.g. `event_gainFocus` and `event_nameChange`.
 These events are generally executed by a call to `eventHandler.executeEvent`, which is in turn generally called resultant to events queued by [API Handlers](#api-handlers).
@@ -274,6 +305,7 @@ Although an event is always for a particular NVDA object, it first has a chance 
 If an event is handled by one of these, meaning that an `event_*` method was found and executed, the event stops there and does not go further, unless the method that handled it specifically calls the `nextHandler` function object passed to it.
 
 The chain of handlers is as follows:
+
 * The first found global plugin
 * The next found global plugin (until no more are found)
 * The app module containing the NVDA object the event is for, I.e. fetched from the NVDA object's `appModule` property.
@@ -281,6 +313,7 @@ The chain of handlers is as follows:
 * The NVDA object itself.
 
 ### Scripts
+
 NVDA object, global plugin, app module and tree interceptor instances can all contain special methods called scripts which are executed in response to [input gestures](#input-gestures) from the user.
 These methods are all named beginning with "script_"; e.g. `script_reportCurrentFocus` and `script_dateTime`.
 Script methods are passed the input gesture that triggered them.
@@ -292,6 +325,7 @@ Similar to events, input gestures have a chance to be handled by a script at one
 But unlike events, once an input gesture finds and executes a script, there is no clean way to have the input gesture handled by a subsequent level.
 
 The chain of handlers is as follows:
+
 * The first found global plugin
 * The next found global plugin (until no more are found)
 * The app module containing the currently focused NVDA object, I.e. fetched from the NVDA object's `appModule` property
@@ -299,20 +333,23 @@ The chain of handlers is as follows:
 * The currently focused NVDA object
 * the first ancestor (parent) of the currently focused NVDAObject, if the found script's `canPropagate` property is `True`
 * the next ancestor of the currently focused NVDAObject, if the found script's `canPropagate` property is `True`...
- * Global commands
+  * Global commands
 
 ## Inter-process Communication
+
 In general terms, every running application or service on a computer, including NVDA, is a separate process.
 No process can access data in another process except via special operating system mechanisms.
 This is called inter-process communication (IPC).
 
 ### Out-of-process Code
+
 NVDA functions primarily out-of-process.
 That is, events and queries for information from other processes must be marshalled (communicated) between NVDA and the process in question using IPC.
 This is many times slower than queries and events managed in the same process.
 However, for the majority of screen reader functionality, this performance hit is insignificant.
 
 ### In-process Code
+
 When large numbers of queries need to be made in one hit, working [out-of-process](#out-of-process-code) is far too slow.
 A noteworthy example is rendering a web page into a flat representation, as is done by [virtual buffers](#virtual-buffers).
 In these cases, code can be "injected" into the remote process.

--- a/projectDocs/design/unreachableObjects.md
+++ b/projectDocs/design/unreachableObjects.md
@@ -50,7 +50,7 @@ Inspecting this should give you a fair idea of where the issue is occurring.
 1. All unreachable objects will now be stored in `gc.garbage`.
    It may be a very large list.
    Some tricks for narrowing this list down:
-   - From the log, you can get the memory address (`id`) of the object.
+   * From the log, you can get the memory address (`id`) of the object.
      Then use:
 
      ``` python
@@ -61,7 +61,7 @@ Inspecting this should give you a fair idea of where the issue is occurring.
      		obj = o
      ```
 
-   - Listing the types collected, look for the type(s) matching the log message:
+   * Listing the types collected, look for the type(s) matching the log message:
 
      ``` python
      for index, o in enumerate(gc.garbage):
@@ -84,4 +84,4 @@ Inspecting this should give you a fair idea of where the issue is occurring.
 
 Some examples of common issues:
 
-- Exceptions caught and assigned to a local variable.
+* Exceptions caught and assigned to a local variable.

--- a/projectDocs/design/unreachableObjects.md
+++ b/projectDocs/design/unreachableObjects.md
@@ -1,10 +1,12 @@
 # Garbage collection errors
+
 NVDA's `garbageHandler.py` monitors Python's cyclic garbage collector and reports
 on objects that are unreachable.
 Cyclic references are typically a symptom of bad design, and can cause major problems for certain objects.
 For instance, cyclic references involving COM objects may cause a deadlock if the garbage collector happens to break the cycle and release the COM object in the wrong thread.
 
 ## How to know about a cyclic reference?
+
 The log may contain messages like the following.
 
 ```py
@@ -32,12 +34,15 @@ Inspecting this should give you a fair idea of where the issue is occurring.
 
 1. Open the NVDA Python console `NVDA+control+z`
 1. Enable saving all objects:
+
    ``` python
    import gc
    gc.set_debug(gc.DEBUG_SAVEALL)
    ```
+
 1. Reproduce the unreachable object error.
 1. If garbage collection errors have not yet been logged, force a collect by calling:
+
    ``` python
    gc.collect()
    ```
@@ -47,6 +52,7 @@ Inspecting this should give you a fair idea of where the issue is occurring.
    Some tricks for narrowing this list down:
    - From the log, you can get the memory address (`id`) of the object.
      Then use:
+
      ``` python
      memoryAddress = 0xabcd123
      obj = None
@@ -54,21 +60,28 @@ Inspecting this should give you a fair idea of where the issue is occurring.
      	if memoryAddress == id(o)
      		obj = o
      ```
+
    - Listing the types collected, look for the type(s) matching the log message:
+
      ``` python
      for index, o in enumerate(gc.garbage):
      	print(index, type(o))
      ```
+
 1. Once you have a reference (`obj`) to the unreachable object, see what other objects refer to an object you can call.
    You can do this by using `gc.get_referrers`.
    The python console has a reference to `obj`, there may be a lot of output.
    You can reduce this by looking at the types and following the most relevant.
+
    ``` python
    for index, o in enumerate(gc.get_referrers(obj)):
    	print(index, type(o))
    ```
+
 1. Continue following the references to build a picture of the cycle.
 
 ## Typical problems
+
 Some examples of common issues:
+
 - Exceptions caught and assigned to a local variable.

--- a/projectDocs/dev/addons.md
+++ b/projectDocs/dev/addons.md
@@ -1,4 +1,6 @@
-### Important links
+# NVDA Add-ons
+
+## Important links
 
 * [Changes in the latest release](https://download.nvaccess.org/documentation/changes.html)
 * [NVDA Add-on API Mailing List](https://groups.google.com/a/nvaccess.org/g/nvda-api)
@@ -10,7 +12,7 @@ This website is considered legacy software, using the NVDA Add-on Store instead 
 * [NVDA add-ons community template](https://github.com/nvdaaddons/AddonTemplate): A repository for generating add-ons using a template
 * The NVDA repository [Wiki](https://github.com/nvaccess/nvda/wiki) contains more guides and documentation.
 
-### Documentation
+## Documentation
 
 * [NVDA release process](../community/releaseProcess.md)
 * [NVDA Developer Guide](https://download.nvaccess.org/documentation/developerGuide.html)
@@ -18,14 +20,14 @@ This website is considered legacy software, using the NVDA Add-on Store instead 
 * [NVDA Add-on Development Community Guide](https://github.com/nvdaaddons/DevGuide/wiki/NVDA-Add-on-Development-Guide)
 * [NVDA ControllerClient manual (NVDA API for external applications to directly speak or braille messages, etc.)](../../extras/controllerClient)
 
-### Communication channels
+## Communication channels
 
-#### NV Access
+### NV Access
 
 * [GitHub discussions](https://github.com/nvaccess/nvda/discussions)
 * [NVDA Add-on API Mailing List](https://groups.google.com/a/nvaccess.org/g/nvda-api)
 
-#### NVDA Community
+### NVDA Community
 
 * [NVDA Developers Mailing List](https://groups.io/g/nvda-devel)
 * [NVDA Add-ons Mailing List](https://groups.io/g/nvda-addons)

--- a/projectDocs/dev/buildSystemNotes.md
+++ b/projectDocs/dev/buildSystemNotes.md
@@ -17,6 +17,7 @@ Version numbers for dependencies should be used to lock in a version.
 ### Entry points to the build system
 
 These are the only files expected to be executed directly by a user/developer:
+
 - `scons.bat`
 - `runnvda.bat`
 - `rununittests.bat`
@@ -39,6 +40,7 @@ Ensures the build environment is clean, and there are no conflicts with other in
 
 NVDA and its build system have many Python dependencies.
 Using `uv` means:
+
 - Updating is easier than git submodules.
 - Developers need to sync/update their submodules less often.
 - More consistency for dependencies.

--- a/projectDocs/dev/buildSystemNotes.md
+++ b/projectDocs/dev/buildSystemNotes.md
@@ -18,12 +18,12 @@ Version numbers for dependencies should be used to lock in a version.
 
 These are the only files expected to be executed directly by a user/developer:
 
-- `scons.bat`
-- `runnvda.bat`
-- `rununittests.bat`
-- `runsystemtests.bat`
-- `runlint.bat`
-- `runlicensecheck.bat`
+* `scons.bat`
+* `runnvda.bat`
+* `rununittests.bat`
+* `runsystemtests.bat`
+* `runlint.bat`
+* `runlicensecheck.bat`
 
 **Note:** The `runnvda.bat` script uses `uv run`, which executes `nvda.pyw` as a GUI application by default.
 This is the more common and expected way to run NVDA.
@@ -41,11 +41,11 @@ Ensures the build environment is clean, and there are no conflicts with other in
 NVDA and its build system have many Python dependencies.
 Using `uv` means:
 
-- Updating is easier than git submodules.
-- Developers need to sync/update their submodules less often.
-- More consistency for dependencies.
-- IDE's can be configured more easily, for NVDA development as well as for development of add-ons.
-- No conflict between NVDA dependencies and Python packages already installed globally on the
+* Updating is easier than git submodules.
+* Developers need to sync/update their submodules less often.
+* More consistency for dependencies.
+* IDE's can be configured more easily, for NVDA development as well as for development of add-ons.
+* No conflict between NVDA dependencies and Python packages already installed globally on the
   developer's system.
-- Don't interfere with the developer's system. Installing packages globally may break things
+* Don't interfere with the developer's system. Installing packages globally may break things
   outside of NVDA.

--- a/projectDocs/dev/buildingDevDocumentation.md
+++ b/projectDocs/dev/buildingDevDocumentation.md
@@ -1,6 +1,8 @@
+# Building Developer Documentation for NVDA
+
 Before building developer documentation, [create your developer environment](./createDevEnvironment.md).
 
-### Building developer documentation
+## Building developer documentation
 
 To generate the NVDA developer guide, type:
 
@@ -18,7 +20,7 @@ scons devDocs
 
 The documentation will be placed in the `NVDA` folder in the output directory.
 
-### Building nvdaHelper developer documentation
+## Building nvdaHelper developer documentation
 
 To generate developer documentation for nvdaHelper (not included in the devDocs target):
 

--- a/projectDocs/dev/codingStandards.md
+++ b/projectDocs/dev/codingStandards.md
@@ -72,7 +72,7 @@ Files can be checked out locally using CRLF if needed for Windows development us
 For example:
 
 ```py
- Translators: The name of a category of NVDA commands.
+# Translators: The name of a category of NVDA commands.
 SCRCAT_TEXTREVIEW = _("Text review")
 ```
 

--- a/projectDocs/dev/codingStandards.md
+++ b/projectDocs/dev/codingStandards.md
@@ -1,4 +1,4 @@
-## Code Style
+# Code Style
 
 In general, Python contributions to NVDA should follow the [PEP 8 style guide](https://peps.python.org/pep-0008/), except where it contradicts the specific guidance below.
 
@@ -8,13 +8,13 @@ Authors should do their best to adhere to these standards in order to have the b
 In limited circumstances, NV Access may accept contributions that do not follow these coding standards.
 If there is a reason you are unable to follow these standards in a contribution to NVDA, please make note of this when opening your PR.
 
-### Encoding
+## Encoding
 
 * Python files should be encoded in UTF-8.
 * Text files should be committed with `LF` line endings.
 Files can be checked out locally using CRLF if needed for Windows development using [git](https://git-scm.com/book/en/v2/Customizing-Git-Git-Configuration#_core_autocrlf).
 
-### Indentation
+## Indentation
 
 * Indentation must be done with tabs (one per level), not spaces.
 * When splitting a single statement over multiple lines, just indent one or more additional levels.
@@ -22,7 +22,7 @@ Files can be checked out locally using CRLF if needed for Windows development us
   * Be aware that this requires a new-line after an opening parenthesis/bracket/brace if you intend
     to split the statement over multiple lines.
 
-### Identifier Names
+## Identifier Names
 
 * Use descriptive names
   * name constants to avoid "magic numbers" and hint at intent or origin of the value.
@@ -64,7 +64,7 @@ Files can be checked out locally using CRLF if needed for Windows development us
       def _formatMember(self): pass
   ```
 
-### Translatable Strings
+## Translatable Strings
 
 * All strings that could be presented to the user should be marked as translatable using the `_()` function
   * e.g. `_("Text review")`.
@@ -72,7 +72,7 @@ Files can be checked out locally using CRLF if needed for Windows development us
 For example:
 
 ```py
-# Translators: The name of a category of NVDA commands.
+ Translators: The name of a category of NVDA commands.
 SCRCAT_TEXTREVIEW = _("Text review")
 ```
 
@@ -94,7 +94,7 @@ self.copySettingsButton = wx.Button(
 )
 ```
 
-### Imports
+## Imports
 
 * Unused imports should be removed where possible.
   * Anything imported into a (sub)module can also be imported from that submodule.
@@ -105,7 +105,7 @@ self.copySettingsButton = wx.Button(
   This will override and define the symbols imported when performing a star import, e.g. `from module import *`.
   * Otherwise, with a comment like `# noqa: <explanation>`.
 
-### Considering future backwards compatibility
+## Considering future backwards compatibility
 
 When writing new code, consider how the code can be moved in future while retaining backwards compatibility.
 Refer to the [limitations to retaining backwards compatibility](./deprecations.md#limitations-to-retaining-backwards-compatibility).
@@ -117,7 +117,7 @@ Any module level variables should be prefixed with an underscore and be encapsul
 * Avoid code which executes at import time.
 Instead use initializer functions.
 
-### Docstrings
+## Docstrings
 
 Docstrings should use [Sphinx format without types](https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html), and follow [PEP 257 conventions](https://peps.python.org/pep-0257/).
 
@@ -139,7 +139,7 @@ To learn more about reStructuredText, Sphinx and Python, check out the following
 * [Sphynx' custom reStructuredText Directives](https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html)
 * [Sphynx' Python Domain](https://www.sphinx-doc.org/en/master/usage/domains/python.html)
 
-### Type hints
+## Type hints
 
 All new code contributions to NVDA should use [PEP 484-style type hints](https://peps.python.org/pep-0484/).
 Type hints make reasoning about code much easier, and allow static analysis tools to catch common errors.
@@ -149,7 +149,7 @@ Type hints make reasoning about code much easier, and allow static analysis tool
 * Prefer union shorthand (`X | Y`) over explicitly using `typing.Union`.
   * Corollary: prefer `T | None` over `typing.Optional[T]`.
 
-### Calling non-python code
+## Calling non-python code
 
 When using parts of the Windows API, or parts of NVDA implemented in C++, it is necessary to use the [ctypes](https://docs.python.org/3/library/ctypes.html) library.
 
@@ -160,7 +160,7 @@ When using parts of the Windows API, or parts of NVDA implemented in C++, it is 
   * E.g. `winBindings.kernel32`.
 * Ctypes code for nvdaHelper should be defined in the `NVDAHelper.localLib` module.
 
-### Language choices
+## Language choices
 
 The NVDA community is large and diverse, and we have a responsibility to make everyone feel welcome in it.
 As our [contributor code of conduct](../../CODE_OF_CONDUCT.md) says:

--- a/projectDocs/dev/contributing.md
+++ b/projectDocs/dev/contributing.md
@@ -1,89 +1,91 @@
-## Code/Docs contributions
+# Code/Docs contributions
 
 If you are new to the project, or looking for some way to help take a look at:
-- [label:"good first issue"](https://github.com/nvaccess/nvda/issues?q=label%3A%22good+first+issue%22)
-- [label:component/documentation](https://github.com/nvaccess/nvda/issues?q=label%3Acomponent%2Fdocumentation)
-- [label:closed/needs-new-author](https://github.com/nvaccess/nvda/issues?q=label%3Aclosed%2Fneeds-new-author)
-- [label:Abandoned](https://github.com/nvaccess/nvda/issues?q=label%3AAbandoned)
 
-### Guidelines:
-- For anything other than minor bug fixes, please comment on an existing issue or create a new issue providing details about your proposed change.
-- Unrelated changes should be addressed in separate issues.
-- Include information about use cases, design, user experience, etc.
-  - This allows us to discuss these aspects and any other concerns that might arise, thus potentially avoiding a great deal of wasted time.
-- It is recommended to wait for acceptance of your proposal before you start coding.
-  - A `triaged` label is an indicator that an issue is ready for a fix.
-  - A triaged issue should have a priority, as a developer, consider focusing on higher priority issues (p1-p3) instead of lower priority issues (p4-p5).
-  - Please understand that we very likely will not accept changes that are not discussed first.
-  - Consider starting a [GitHub discussion](https://github.com/nvaccess/nvda/discussions) or [mailing list topic](https://groups.io/g/nvda-devel/topics) to see if there is interest.
-- A minor/trivial change which definitely wouldn't require design, user experience or implementation discussion, you can just create a pull request rather than using an issue first.
-  - e.g. a fix for a typo/obvious coding error or a simple synthesizer/braille display driver
-  - This should be fairly rare.
-- If in doubt, use an issue first. Use this issue to discuss the alternatives you have considered in regards to implementation, design, and user experience. Then give people time to offer feedback.
-- Issues with translations should be reported to the [NVDA Translators list](https://groups.io/g/nvda-translations).
+* [label:"good first issue"](https://github.com/nvaccess/nvda/issues?q=label%3A%22good+first+issue%22)
+* [label:component/documentation](https://github.com/nvaccess/nvda/issues?q=label%3Acomponent%2Fdocumentation)
+* [label:closed/needs-new-author](https://github.com/nvaccess/nvda/issues?q=label%3Aclosed%2Fneeds-new-author)
+* [label:Abandoned](https://github.com/nvaccess/nvda/issues?q=label%3AAbandoned)
 
+## Guidelines:
 
-### Overview of contribution process:
+* For anything other than minor bug fixes, please comment on an existing issue or create a new issue providing details about your proposed change.
+* Unrelated changes should be addressed in separate issues.
+* Include information about use cases, design, user experience, etc.
+  * This allows us to discuss these aspects and any other concerns that might arise, thus potentially avoiding a great deal of wasted time.
+* It is recommended to wait for acceptance of your proposal before you start coding.
+  * A `triaged` label is an indicator that an issue is ready for a fix.
+  * A triaged issue should have a priority, as a developer, consider focusing on higher priority issues (p1-p3) instead of lower priority issues (p4-p5).
+  * Please understand that we very likely will not accept changes that are not discussed first.
+  * Consider starting a [GitHub discussion](https://github.com/nvaccess/nvda/discussions) or [mailing list topic](https://groups.io/g/nvda-devel/topics) to see if there is interest.
+* A minor/trivial change which definitely wouldn't require design, user experience or implementation discussion, you can just create a pull request rather than using an issue first.
+  * e.g. a fix for a typo/obvious coding error or a simple synthesizer/braille display driver
+  * This should be fairly rare.
+* If in doubt, use an issue first. Use this issue to discuss the alternatives you have considered in regards to implementation, design, and user experience. Then give people time to offer feedback.
+* Issues with translations should be reported to the [NVDA Translators list](https://groups.io/g/nvda-translations).
+
+## Overview of contribution process:
 
 1. [Setup your development environment](./createDevEnvironment.md).
-    - Alternatively, you can use GitHub Actions to build NVDA for you, without setting up a local development environment, by following [our CI/CD README](../../ci/README.md).
+   * Alternatively, you can use GitHub Actions to build NVDA for you, without setting up a local development environment, by following [our CI/CD README](../../ci/README.md).
 1. Ensure the issue you plan to fix is [triaged](../issues/triage.md)
 1. Create a branch for the contribution, to be used for a pull request.
-	- Pull requests should be based on the latest commit in the official master branch.
+	* Pull requests should be based on the latest commit in the official master branch.
 	This helps reduce the chance of merge conflicts.
-	- If you are adding a feature or changing something that will be noticeable to the user, you should update the [User Guide accordingly](./userGuideStandards.md).
+	* If you are adding a feature or changing something that will be noticeable to the user, you should update the [User Guide accordingly](./userGuideStandards.md).
 	New commands, drivers, settings, dialogs, etc. must be documented.
 1. [Build NVDA](./buildingNVDA.md) and run from source
 1. [Manually test the change](../testing/readme.md)
 1. [Run automated tests](../testing/automated.md)
-	- Run `rununittests` (`rununittests.bat`) before you open your Pull Request, and make sure all the unit tests pass.
-	- If possible for your PR, please consider creating a set of unit or system tests to test your changes.
-	- The lint check ensures your changes comply with our code style expectations.
+	* Run `rununittests` (`rununittests.bat`) before you open your Pull Request, and make sure all the unit tests pass.
+	* If possible for your PR, please consider creating a set of unit or system tests to test your changes.
+	* The lint check ensures your changes comply with our code style expectations.
 	Use `runlint.bat`.
-	- Run `scons checkPot` to ensure translatable strings have comments for the translators
-	- Run `runlicensecheck.bat` to check that you don't introduce any new python dependencies with incompatible licenses.
+	* Run `scons checkPot` to ensure translatable strings have comments for the translators
+	* Run `runlicensecheck.bat` to check that you don't introduce any new python dependencies with incompatible licenses.
 1. [Create a change log entry](#change-log-entry)
 1. Create a Pull Request (PR)
 	1. Filling out the template:
-		- [Template guide](./githubPullRequestTemplateExplanationAndExamples.md)
-		- Please fill out the Pull Request template, including the checklist of considerations.
+		* [Template guide](./githubPullRequestTemplateExplanationAndExamples.md)
+		* Please fill out the Pull Request template, including the checklist of considerations.
 		The checklist asks you to confirm that you have thought about each of the items, if any of the items are missing it is helpful to explain elsewhere in the PR why it has been left out.
 	1. Submission process:
-		- If you would like to publish unfinished work to seek early feedback or demonstrate an approach, open a draft pull request.
+		* If you would like to publish unfinished work to seek early feedback or demonstrate an approach, open a draft pull request.
 		When you would like a code review or response from NV Access, mark the PR as "ready for review".
-		- All pull requests submitted must have their "Allow edits from maintainers" checkbox ticked.
+		* All pull requests submitted must have their "Allow edits from maintainers" checkbox ticked.
 		This is the GitHub default for new pull requests, except for organisation forks.
 		Organisation forks must invite NV Access developers to collaborate directly.
-		- Consider if the PR should be made against `beta` or `rc` in the case of addressing bugs introduced in the current release cycle.
+		* Consider if the PR should be made against `beta` or `rc` in the case of addressing bugs introduced in the current release cycle.
 	1. CI/CD testing:
-		- Every time a PR has a commit pushed to it, CI/CD checks will be run
-		- [pre-commit.ci](https://pre-commit.ci/) will apply linting fixes.
-			- re-run pre-commit on a pull request by commenting `pre-commit.ci run`.
-			- prevent pre-commit from pushing by putting `[skip ci]`, `[ci skip]`, `[skip pre-commit.ci]`, or `[pre-commit.ci skip]` in the commit message.
-		- GitHub Actions will build a copy of NVDA when changes are pushed to your PR.
+		* Every time a PR has a commit pushed to it, CI/CD checks will be run
+		* [pre-commit.ci](https://pre-commit.ci/) will apply linting fixes.
+			* re-run pre-commit on a pull request by commenting `pre-commit.ci run`.
+			* prevent pre-commit from pushing by putting `[skip ci]`, `[ci skip]`, `[skip pre-commit.ci]`, or `[pre-commit.ci skip]` in the commit message.
+		* GitHub Actions will build a copy of NVDA when changes are pushed to your PR.
 		A build artifact will be created for a successful build to allow for testing the PR.
-		- GitHub Actions will run system tests and other tests.
+		* GitHub Actions will run system tests and other tests.
 		If these fail, please review them.
 		Sometimes system tests fail unexpectedly.
 		If you believe the failure is unrelated, feel free to ignore it unless it is raised by a reviewer.
-		- Security checks will be run.
+		* Security checks will be run.
 1. Participate in the code review process
-	- This process requires core NVDA developers to understand the intent of the change, read the code changes, asking questions or suggesting changes.
+	* This process requires core NVDA developers to understand the intent of the change, read the code changes, asking questions or suggesting changes.
 	Please participate in this process, answering questions, and discussing the changes.
-	- Being proactive will really help to speed up the process of code review.
-	- When the PR is approved it will be merged, and the change will be active in the next alpha build.
-	- If issues are raised with your PR, it may be marked as a draft.
+	* Being proactive will really help to speed up the process of code review.
+	* When the PR is approved it will be merged, and the change will be active in the next alpha build.
+	* If issues are raised with your PR, it may be marked as a draft.
 	Please mark it as ready for review when you have addressed the review comments.
-	- CoPilot AI can review your code.
-	  - CoPilot reviews may be automatically or manually requested by reviewers
-	  - Please participate in the review process, the AI can respond to review comments, questions and feedback.
-	  - Some comments may not be helpful due to the nature of AI, and some might be useful.
+	* CoPilot AI can review your code.
+	  * CoPilot reviews may be automatically or manually requested by reviewers
+	  * Please participate in the review process, the AI can respond to review comments, questions and feedback.
+	  * Some comments may not be helpful due to the nature of AI, and some might be useful.
 	  Please indicate comments which you intend to ignore and why.
 1. Feedback from alpha users
-	- After a PR is merged, watch for feedback from alpha users / testers.
+	* After a PR is merged, watch for feedback from alpha users / testers.
 	You may have to follow up to address bugs or missed use-cases.
 
-#### Change log entry
+### Change log entry
+
 An entry intended to explain changes in NVDA to end users.
 Your proposed entry should be added to the [`changes.md` file](../../user_docs/en/changes.md) which is converted to HTML.
 Change log entries are not required for changes with no/minor user impact or no developer impact.
@@ -97,6 +99,7 @@ Optionally, you may also include your GitHub username after the issue numbers: `
 Our processing will automatically link the issue number to the GitHub page, and your GitHub username to your contributions to NVDA.
 
 For instance:
+
 ```md
 ### New Features
 
@@ -116,10 +119,13 @@ The sections are:
 * Changes for developers
 
 ## Code Style
+
 Please ensure you follow [our coding standards document](./codingStandards.md).
 
 ## Technical design
+
 Please checkout our [technical design overview](../design/technicalDesignOverview.md).
 
 ## Copyright headers
+
 Please refer to our guide on creating or updating [copyright headers](./copyrightHeaders.md)

--- a/projectDocs/dev/contributing.md
+++ b/projectDocs/dev/contributing.md
@@ -21,7 +21,9 @@ If you are new to the project, or looking for some way to help take a look at:
 * A minor/trivial change which definitely wouldn't require design, user experience or implementation discussion, you can just create a pull request rather than using an issue first.
   * e.g. a fix for a typo/obvious coding error or a simple synthesizer/braille display driver
   * This should be fairly rare.
-* If in doubt, use an issue first. Use this issue to discuss the alternatives you have considered in regards to implementation, design, and user experience. Then give people time to offer feedback.
+* If in doubt, use an issue first.
+Use this issue to discuss the alternatives you have considered in regards to implementation, design, and user experience.
+Then give people time to offer feedback.
 * Issues with translations should be reported to the [NVDA Translators list](https://groups.io/g/nvda-translations).
 
 ## Overview of contribution process:

--- a/projectDocs/dev/copyrightHeaders.md
+++ b/projectDocs/dev/copyrightHeaders.md
@@ -1,3 +1,5 @@
+# Copyright Headers in NVDA Source Code
+
 In NVDA files, which are licensed under the terms of a modified GNU General Public License, use the following copyright header:
 
 ```py
@@ -8,9 +10,10 @@ In NVDA files, which are licensed under the terms of a modified GNU General Publ
 ```
 
 Replacing:
-- `<YOUR NAME>` with your name.
-- `<CREATED YEAR>` the year the file was created
-- `<LAST UPDATED YEAR>` when the file was last updated.
+
+* `<YOUR NAME>` with your name.
+* `<CREATED YEAR>` the year the file was created
+* `<LAST UPDATED YEAR>` when the file was last updated.
 For new files this can be missing.
 e.g. a file created in 2025 might have `# Copyright (C) 2025`
 

--- a/projectDocs/dev/createDevEnvironment.md
+++ b/projectDocs/dev/createDevEnvironment.md
@@ -59,22 +59,22 @@ Install the python version listed in [.python-versions](../../.python-versions)
 #### Microsoft Visual Studio
 
 * Microsoft Visual Studio 2022
-	* To replicate the production build environment, use the [version of Visual Studio 2022 that GitHub Actions is using](https://github.com/actions/runner-images/tree/main/images/windows).
-	* If you don't use the Visual Studio IDE itself, you can download the [build tools](https://aka.ms/vs/17/release/vs_BuildTools.exe).
-	* If you do intend to use the Visual Studio IDE (not required for NVDA development), you can download [the community version](https://visualstudio.microsoft.com/vs/community/).
-		* The Professional and Enterprise versions are also supported.
-		* Preview versions are *not* supported.
+  * To replicate the production build environment, use the [version of Visual Studio 2022 that GitHub Actions is using](https://github.com/actions/runner-images/tree/main/images/windows).
+  * If you don't use the Visual Studio IDE itself, you can download the [build tools](https://aka.ms/vs/17/release/vs_BuildTools.exe).
+  * If you do intend to use the Visual Studio IDE (not required for NVDA development), you can download [the community version](https://visualstudio.microsoft.com/vs/community/).
+    * The Professional and Enterprise versions are also supported.
+    * Preview versions are *not* supported.
 * When installing Visual Studio, additional components must be included:
-	* You can automatically fetch these using [NVDAs .vsconfig](../../.vsconfig) using the [import feature of the VS installer](https://learn.microsoft.com/en-us/visualstudio/install/import-export-installation-configurations?view=vs-2022#import-a-configuration).
-	* In the list on the Workloads tab, in the Desktop grouping:
-		* Desktop development with C++.
-			* Once selected, ensure "C++ Clang tools for Windows" is included under the optional grouping.
-	* On the Individual components tab, ensure the following items are selected:
-		* Windows 11 SDK (10.0.26100.0)
-		* MSVC v143 - VS 2022 C++ ARM64/ARM64EC build tools
-		* MSVC v143 - VS 2022 C++ x64/x86 build tools
-		* C++ ATL for v143 build tools (x86 & x64)
-		* C++ ATL for v143 build tools (ARM64/ARM64EC)
+  * You can automatically fetch these using [NVDAs .vsconfig](../../.vsconfig) using the [import feature of the VS installer](https://learn.microsoft.com/en-us/visualstudio/install/import-export-installation-configurations?view=vs-2022#import-a-configuration).
+  * In the list on the Workloads tab, in the Desktop grouping:
+    * Desktop development with C++.
+      * Once selected, ensure "C++ Clang tools for Windows" is included under the optional grouping.
+  * On the Individual components tab, ensure the following items are selected:
+    * Windows 11 SDK (10.0.26100.0)
+    * MSVC v143 - VS 2022 C++ ARM64/ARM64EC build tools
+    * MSVC v143 - VS 2022 C++ x64/x86 build tools
+    * C++ ATL for v143 build tools (x86 & x64)
+    * C++ ATL for v143 build tools (ARM64/ARM64EC)
 
 ### Git Submodules
 

--- a/projectDocs/dev/deprecations.md
+++ b/projectDocs/dev/deprecations.md
@@ -1,11 +1,12 @@
-
 # Deprecations
 
 ## Background
+
 The NVDA API must maintain compatibility with add-ons throughout yearly development cycles.
 The first release of a year, i.e. `20XX.1`, is when the NVDA API can introduce breaking changes.
 
 ## Deprecations
+
 Where possible, ensure the NVDA API maintains backwards compatibility.
 If no removal is required or proposed, backwards compatibility can be maintained via the following snippet:
 
@@ -65,18 +66,20 @@ As a result, it not possible to retain backwards compatibility for module level 
 For example, if there is a global variable named `currentState` in `exampleModule.py`, `currentState` cannot be deprecated.
 
 This is because:
+
 * `__getattr__` only fetches variables which are not defined on the module level.
 As such, setting an attribute that is fetched via `__getattr__` will prevent `__getattr__` from fetching the attribute.
 Any future gets will fetch the newly assigned value.
 * Python does not have an equivalent module level `__setattr__` like the `__getattr__` example.
 * Encapsulating a module level variable into another data structure changes the import behaviour.
-	- e.g. if `exampleModule` became a class, so `exampleModule.currentState` was a class level variable with the same namespace as the deprecated symbol, `exampleModule` may not be importable in the same manner.
+  * e.g. if `exampleModule` became a class, so `exampleModule.currentState` was a class level variable with the same namespace as the deprecated symbol, `exampleModule` may not be importable in the same manner.
 
 As a result, module level variables should be avoided.
 
 ## Testing backwards compatibility
 
 To ensure a module retains the same symbol names being importable, check across versions what is imported using the NVDA python console.
+
 ```python
 import controlTypes
 dir(controlTypes)
@@ -87,4 +90,5 @@ Changes different to moving or renaming symbols need to be considered carefully 
 Any API breaking changes such as deprecations marked for removal should be commented with the year of intended removal, and notes on how to implement the API change as an add-on developer and NVDA developer.
 
 ## Announcements
+
 Deprecations should be announced via the [NVDA API mailing list](https://groups.google.com/a/nvaccess.org/g/nvda-api/about).

--- a/projectDocs/dev/developerGuide/developerGuide.md
+++ b/projectDocs/dev/developerGuide/developerGuide.md
@@ -1023,7 +1023,7 @@ When uploading to the Add-on Store certain requirements apply:
   * Add-on versions are expected to be unique for the addon name and channel, meaning that a beta, stable and dev version of the same add-on cannot share a version number.
   This is so there can be a unique ordering of newest to oldest.
   * The suggested convention is to increment the patch version number for dev versions, increment the minor version number for beta versions, and increment the major version number for stable versions.
-* author (string, required): The author of this add-on, preferably in the form Full Name \<email address\>; e.g. `Michael Curran <mick@example.com>`.
+* author (string, required): The author of this add-on, preferably in the form `Full Name <email address>`; e.g. `Michael Curran <mick@example.com>`.
 * description (string): A sentence or two describing what the add-on does.
 * changelog (string): A list of changes between previous and latest add-on releases.
   * This is used to inform users about changes included in the add-on release.

--- a/projectDocs/dev/developerGuide/developerGuide.md
+++ b/projectDocs/dev/developerGuide/developerGuide.md
@@ -2,8 +2,6 @@
 
 [TOC]
 
-
-
 ## Introduction {#introduction}
 
 This guide provides information concerning NVDA development, including translation and the development of components for NVDA.
@@ -371,6 +369,7 @@ If the class your looking for does not exist, create this section.
    Unmapping the original shortcut is only required if this shortcut does not match any other remapped locale shortcut.
 
 ## Plugins {#plugins}
+
 ### Overview {#pluginsOverview}
 
 Plugins allow you to customize the way NVDA behaves overall or within a particular application.
@@ -1024,7 +1023,7 @@ When uploading to the Add-on Store certain requirements apply:
   * Add-on versions are expected to be unique for the addon name and channel, meaning that a beta, stable and dev version of the same add-on cannot share a version number.
   This is so there can be a unique ordering of newest to oldest.
   * The suggested convention is to increment the patch version number for dev versions, increment the minor version number for beta versions, and increment the major version number for stable versions.
-* author (string, required): The author of this add-on, preferably in the form Full Name <email address>; e.g. Michael Curran <<mick@example.com>>.
+* author (string, required): The author of this add-on, preferably in the form Full Name \<email address\>; e.g. `Michael Curran <mick@example.com>`.
 * description (string): A sentence or two describing what the add-on does.
 * changelog (string): A list of changes between previous and latest add-on releases.
   * This is used to inform users about changes included in the add-on release.
@@ -1253,12 +1252,13 @@ Pressing control+l clears the output.
 
 The result of the last executed command is stored in the "_" global variable.
 This shadows the gettext function which is stored as a built-in with the same name.
-It can be unshadowed by executing "del _" and avoided altogether by executing "_ = _".
+It can be unshadowed by executing `del _` and avoided altogether by executing `_ = _`.
 
 Closing the console window (with escape or alt+F4) simply hides it.
 This allows the user to return to the session as it was left when it was closed, including history and variables.
 
 ### Namespace {#PythonConsoleNamespace}
+
 #### Automatic Imports {#pythonConsoleAutoImports}
 
 For convenience, the following modules and variables are automatically imported in the console:
@@ -1649,20 +1649,16 @@ Its fields are as follows:
 | `returnCode` | `ReturnCode` or `None` | `None` | Value to return when a modal dialog is closed. If `None`, the button's ID will be used. |
 
 1. Setting `defaultFocus` only overrides the default focus:
-
-  * If no buttons have this property, the first button will be the default focus.
-  * If multiple buttons have this property, the last one will be the default focus.
+   * If no buttons have this property, the first button will be the default focus.
+   * If multiple buttons have this property, the last one will be the default focus.
 
 2. `fallbackAction` only sets whether to override the fallback action:
-
-  * This button will still be the fallback action if the dialog's fallback action is set to `EscapeCode.CANCEL_OR_AFFIRMATIVE` (the default) and its ID is `ReturnCode.CANCEL` (or whatever the value of `GetAffirmativeId()` is (`ReturnCode.OK`, by default), if there is no button with `id=ReturnCode.CANCEL`), even if it is added with `fallbackAction=False`.
-    To set a dialog to have no fallback action, use `setFallbackAction(EscapeCode.NO_FALLBACK)`.
-  * If multiple buttons have this property, the last one will be the fallback action.
-
+   * This button will still be the fallback action if the dialog's fallback action is set to `EscapeCode.CANCEL_OR_AFFIRMATIVE` (the default) and its ID is `ReturnCode.CANCEL` (or whatever the value of `GetAffirmativeId()` is (`ReturnCode.OK`, by default), if there is no button with `id=ReturnCode.CANCEL`), even if it is added with `fallbackAction=False`.
+     To set a dialog to have no fallback action, use `setFallbackAction(EscapeCode.NO_FALLBACK)`.
+   * If multiple buttons have this property, the last one will be the fallback action.
 3. Buttons with `fallbackAction=True` and `closesDialog=False` are not supported:
-
-  * When adding a button with `fallbackAction=True` and `closesDialog=False`, `closesDialog` will be set to `True`.
-  * If you attempt to call `setFallbackAction` with the ID of a button that does not close the dialog, `ValueError` will be raised.
+   * When adding a button with `fallbackAction=True` and `closesDialog=False`, `closesDialog` will be set to `True`.
+   * If you attempt to call `setFallbackAction` with the ID of a button that does not close the dialog, `ValueError` will be raised.
 
 A number of pre-configured buttons are available for you to use from the `DefaultButton` enumeration, complete with pre-translated labels.
 None of these buttons will explicitly set themselves as the fallback action.

--- a/projectDocs/dev/featureFlags.md
+++ b/projectDocs/dev/featureFlags.md
@@ -2,23 +2,27 @@
 
 NVDA makes judicious use of feature flags to enable and disable features that are in early development.
 The following are provided to streamline the creation of new feature flags:
-- A config spec type
-- A GUI control type
+
+* A config spec type
+* A GUI control type
 
 ## Background
+
 When providing a feature flag it is important to understand the importance of providing a "default" state.
 A boolean feature, must have 3 states selectable by the user:
-- `True`
-- `False`
-- `Default` (NVDA developer recommendation)
+
+* `True`
+* `False`
+* `Default` (NVDA developer recommendation)
 
 This allows a choice between the following use-cases to be made at any point in time:
-- **Explicitly opt-in** to the feature, regardless of the default behavior.
+
+* **Explicitly opt-in** to the feature, regardless of the default behavior.
 An early adopter may choose to do this to test the feature and provide feedback.
-- **Explicitly opt-out** of the feature, regardless of the default behavior.
+* **Explicitly opt-out** of the feature, regardless of the default behavior.
 A user may find the pre-existing behavior acceptable, and wants the maximum delay to adopt the new feature.
 They may be prioritising stability, or anticipating this feature flag receives a permanent home in NVDA settings.
-- **Explicitly choose the default** (NVDA developer recommended) behavior.
+* **Explicitly choose the default** (NVDA developer recommended) behavior.
 Noting, that in this case it is important that the user must be able to select one of the other options first,
 and return to the default behavior at any point in time.
 
@@ -35,6 +39,7 @@ those who have tried and found the feature to be unstable and decided they would
 stable.
 
 ## Feature Flag Enum
+
 To aid static typing in NVDA, `enum` classes are used.
 `BoolFlag` is provided, the majority of feature flags are expected to use this.
 However, if more values are required (E.G. `AllowUiaInMSWord` has options `WHEN_NECESSARY`, `WHERE_SUITABLE`, `ALWAYS`, in addition to `DEFAULT`), then a new `enum` class can be defined.
@@ -70,6 +75,7 @@ class AllowUiaInMSWordFlag(DisplayStringEnum):
 ```
 
 ## Config Spec
+
 In `configSpec.py` specify the new config key, ideally in the category that is most relevant to the feature.
 Placing it in a category rather than a catch-all feature flags category, allows for the option to become
 permanent without having to write config upgrade code to move it from section to another.
@@ -82,6 +88,7 @@ permanent without having to write config upgrade code to move it from section to
 
 The `featureFlag` type is a custom spec type.
 It will produce a `config.FeatureFlag` class instance when the key is accessed.
+
 ```python
 newFlagValue: config.FeatureFlag = config.conf["virtualBuffers"]["newOptionForUsers"]
 
@@ -97,15 +104,17 @@ if flagValue == AllowUiaInMSWordFlag.ALWAYS:
 ```
 
 ## GUI
+
 A control (`gui.nvdaControls.FeatureFlagCombo`) is provided to simplify exposing the feature flag to the user.
 
 ### Usage:
-Note the comments in the example:
-- `creation`
-- `is default`
-- `reset to default value`
-- `save GUI value to config`
 
+Note the comments in the example:
+
+* `creation`
+* `is default`
+* `reset to default value`
+* `save GUI value to config`
 
 ```python
 import collections
@@ -144,4 +153,5 @@ self.loadChromeVbufWhenBusyCombo.saveCurrentValueToConf()
 ```
 
 ## User Guide Documentation
+
 Refer to [User Guide Standards](./userGuideStandards.md#feature-settings)

--- a/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
+++ b/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
@@ -56,9 +56,9 @@ This should allow someone else to reproduce your testing.
 
 More broadly, try to answer the following questions:
 
-- How have you tested to ensure that your change works as intended?
-- Have you ensured testing coverage across all supported operating systems?
-- Have you considered possible regressions (related features or behaviours that may break)?
+* How have you tested to ensure that your change works as intended?
+* Have you ensured testing coverage across all supported operating systems?
+* Have you considered possible regressions (related features or behaviours that may break)?
 
 Please use this section as an opportunity to try to convince us (and yourself) that your proposed change should be merged.
 
@@ -70,9 +70,9 @@ Example:
 
 > In NVDA settings ensure that:
 >
-> - Keyboard category
->   - "speak typed characters" is unchecked
->   - "speak typed words" is checked
+> * Keyboard category
+>   * "speak typed characters" is unchecked
+>   * "speak typed words" is checked
 >
 > 1. Open notepad
 > 2. Type "hello"
@@ -80,8 +80,8 @@ Example:
 >
 > Expect "hello" to be announced.
 
-- If many NVDA settings are required, consider attaching a sample `nvda.ini` file to the PR.
-- If a complicated document is required to test with a 3rd party application, consider attaching it to the PR for others to test with.
+* If many NVDA settings are required, consider attaching a sample `nvda.ini` file to the PR.
+* If a complicated document is required to test with a 3rd party application, consider attaching it to the PR for others to test with.
 
 ### Known issues with pull request:
 
@@ -107,48 +107,48 @@ Doing so may pre-empt questions from the reviewer ensuring you are on the same p
 
 Discuss under "testing strategy" heading:
 
-- Unit tests
-  - Describe the coverage of automated unit tests?
-  - Is the changed code covered already, or can it be covered by automated unit tests?
-- System tests
-  - Describe the coverage of automated system tests?
-  - Is the changed code covered already, or can it be covered by automated system tests?
-- Manual tests
-  - Have you followed any relevant test plans in [the manual test documentation](../../tests/manual/README.md)?
-  - How did you manually test the change?
-    - Be clear on steps another user can take to replicate your testing.
-    - Clearly describing this helps alpha testers, and future developers.
-  - Is this a commonly tested part of NVDA?
+* Unit tests
+  * Describe the coverage of automated unit tests?
+  * Is the changed code covered already, or can it be covered by automated unit tests?
+* System tests
+  * Describe the coverage of automated system tests?
+  * Is the changed code covered already, or can it be covered by automated system tests?
+* Manual tests
+  * Have you followed any relevant test plans in [the manual test documentation](../../tests/manual/README.md)?
+  * How did you manually test the change?
+    * Be clear on steps another user can take to replicate your testing.
+    * Clearly describing this helps alpha testers, and future developers.
+  * Is this a commonly tested part of NVDA?
   If so, please add your manual test steps to [the manual test documentation](../../tests/manual/README.md).
-  - As a reviewer, please use this description to replicate the testing (if possible).
+  * As a reviewer, please use this description to replicate the testing (if possible).
 
 ### API is compatible with existing add-ons
 
-- If this is not a `.1` breaking release, ensure that all API changes are backwards compatible with existing add-ons.
-- Ensure proposed API changes are included in the change log under "Changes for Developers".
-- See [Deprecations](./deprecations.md) for more information.
+* If this is not a `.1` breaking release, ensure that all API changes are backwards compatible with existing add-ons.
+* Ensure proposed API changes are included in the change log under "Changes for Developers".
+* See [Deprecations](./deprecations.md) for more information.
 
 ### Documentation
 
-- Change log entries
+* Change log entries
   [Ensure there is a change log entry if required](./contributing.md#change-log-entry).
-- User Documentation
+* User Documentation
   Does the user documentation need updating?
-- Context sensitive help for GUI changes.
+* Context sensitive help for GUI changes.
   New GUI options require context sensitive help assignment.
-- Developer / Technical Documentation
+* Developer / Technical Documentation
   Does the developer or technical documentation need updating?
 
 ### UX of all users considered
 
-- Users of NVDA are diverse, and rely on different parts of NVDA.
+* Users of NVDA are diverse, and rely on different parts of NVDA.
   Ensure the change caters to users of the following:
-  - Speech
-  - Braille
-  - Low Vision
-  - Different web browsers (Firefox, Chrome, Edge)
-  - Localization in other languages / culture than English
-- When one of these can not be supported with this change, highlight it under the "Known issues" heading.
+  * Speech
+  * Braille
+  * Low Vision
+  * Different web browsers (Firefox, Chrome, Edge)
+  * Localization in other languages / culture than English
+* When one of these can not be supported with this change, highlight it under the "Known issues" heading.
 
 ### Security precautions taken
 

--- a/projectDocs/dev/readme.md
+++ b/projectDocs/dev/readme.md
@@ -1,4 +1,6 @@
-### Important links
+# Developing NVDA
+
+## Important links
 
 * [Refer to contributing.md](./contributing.md) for contributing code/documentation to NVDA.
 * [Refer to addons.md](./addons.md) for key links for add-on development.
@@ -8,7 +10,7 @@ This includes information on reporting issues, triaging issues, testing, transla
 * The NVDA repository [Wiki](https://github.com/nvaccess/nvda/wiki) contains more guides and documentation.
 * [NVDA development snapshots](https://download.nvaccess.org/snapshots/alpha/): Automatically generated builds of the project in its current state of development
 
-### Documentation
+## Documentation
 
 * [NVDA Developer Guide](https://download.nvaccess.org/documentation/developerGuide.html)
 * [Technical design overview](../design/technicalDesignOverview.md)
@@ -17,16 +19,16 @@ This includes information on reporting issues, triaging issues, testing, transla
 * [NVDA ControllerClient manual (NVDA API for external applications to directly speak or braille messages, etc.)](https://github.com/nvaccess/nvda/tree/master/extras/controllerClient)
 * [Release process](../community/releaseProcess.md)
 
-### Communication channels
+## Communication channels
 
-#### NV Access
+### NV Access
 
 * [NVDA on GitHub](https://github.com/nvaccess/nvda)
-	* Report [NVDA issues and feature requests on GitHub](https://github.com/nvaccess/nvda/issues).
-	* Start a [GitHub discussion with the development community](https://github.com/nvaccess/nvda/discussions).
+  * Report [NVDA issues and feature requests on GitHub](https://github.com/nvaccess/nvda/issues).
+  * Start a [GitHub discussion with the development community](https://github.com/nvaccess/nvda/discussions).
 * [NVDA Developers Mailing List](https://groups.io/g/nvda-devel)
 
-#### NVDA Community
+### NVDA Community
 
 * [NVDA Community Gitter channel](https://gitter.im/nvaccess/NVDA) (Instant Messaging)
 * [Other sources including groups and profiles on social media channels, language-specific websites and mailing lists etc.](https://github.com/nvaccess/nvda/wiki/Connect)

--- a/projectDocs/dev/selfSignedBuild.md
+++ b/projectDocs/dev/selfSignedBuild.md
@@ -2,7 +2,8 @@
 
 These instructions are based on Microsoft documentation to [create a self-signed certificate](https://docs.microsoft.com/en-us/windows/msix/package/create-certificate-package-signing).
 
-### WARNING
+## WARNING
+
 Copies of NVDA signed by a self-signed certificate will not function on systems where it is not installed as a trusted root certificate, so this is only suitable for personal use.
 
 Following are instructions on how to generate and install a self-signed certificate.
@@ -11,17 +12,19 @@ If the private key is compromised, this poses a serious security risk to your sy
 
 Do not forget to [remove the certificate](#remove-the-certificate) when you are done testing.
 
-### Create a self-signed certificate
+## Create a self-signed certificate
 
 Using [PKI](https://docs.microsoft.com/en-us/windows/msix/package/create-certificate-package-signing#prerequisite), create a self signed build with a custom name (`FriendlyName`) and publisher (`Subject`).
 Other parameters are determined by [MS docs](https://docs.microsoft.com/en-us/windows/msix/package/create-certificate-package-signing#use-new-selfsignedcertificate-to-create-a-certificate).
 
 From PowerShell:
+
 ```ps1
 New-SelfSignedCertificate -FriendlyName "LocalNVDA" -Type Custom -Subject "CN=Test NVDA Build, O=NVDA Dev, C=US" -KeyUsage DigitalSignature -CertStoreLocation "Cert:\CurrentUser\My" -TextExtension @("2.5.29.37={text}1.3.6.1.5.5.7.3.3", "2.5.29.19={text}")
 ```
 
 This should output a thumbprint. Example Output:
+
 ```ps1
    PSParentPath: Microsoft.PowerShell.Security\Certificate::CurrentUser\My
 
@@ -30,31 +33,34 @@ Thumbprint                                Subject
 148CB69869B802A36B3D8D801BA8D9D0F3C1484F  CN=Test NVDA Build, O=NVDA Dev, C=US
 ```
 
-### Export certificate as PFX
+## Export certificate as PFX
 
 This [method uses a password](https://docs.microsoft.com/en-us/windows/msix/package/create-certificate-package-signing#password-usage) to handle access.
 
 Use PowerShell.
 Replace the following in this PowerShell script:
+
 - `<nvdaRepositoryRoot>`: the root of your NVDA repository.
 - `<Password>`: a password for the exported certificate file.
 - `<Certificate Thumbprint>`: The thumbprint from [creating the certificate](#create-a-self-signed-certificate).
+
 ```ps1
 cd <nvdaRepositoryRoot>
 $password = ConvertTo-SecureString -Force -AsPlainText -String <Password>
 Export-PfxCertificate -FilePath local.pfx -Password $password -cert "Cert:\CurrentUser\My\<Certificate Thumbprint>"
 ```
 
-### Import the certificate
+## Import the certificate
 
 Import the certificate to the Local Machine in the "Trusted Root Certification Authorities" store.
 
-Run PowerShell as Administrator, execute [Import-PfxCertificate
-](https://docs.microsoft.com/en-us/powershell/module/pki/import-pfxcertificate).
+Run PowerShell as Administrator, execute [Import-PfxCertificate](https://docs.microsoft.com/en-us/powershell/module/pki/import-pfxcertificate).
 
 Replace the following in the PowerShell script:
+
 - `<nvdaRepositoryRoot>`: the root of your NVDA repository.
 - `<Password>`: your password for the exported certificate file.
+
 ```ps1
 cd <nvdaRepositoryRoot>
 $password = ConvertTo-SecureString -Force -AsPlainText -String <Password>
@@ -62,6 +68,7 @@ Import-PfxCertificate -Password $password -CertStoreLocation "Cert:\LocalMachine
 ```
 
 This should output the same thumbprint. Example Output:
+
 ```ps1
    PSParentPath: Microsoft.PowerShell.Security\Certificate::LocalMachine\TrustedPublisher
 
@@ -70,7 +77,7 @@ Thumbprint                                Subject
 148CB69869B802A36B3D8D801BA8D9D0F3C1484F  CN=Test NVDA Build, O=NV Access Dev, C=US
 ```
 
-#### Note for older versions of Windows
+### Note for older versions of Windows
 
 On any supported version of Windows, you can manage certifications through the "Certificate Manager".
 
@@ -78,20 +85,22 @@ Importing A Windows 11 certificate via PowerShell may fail on older versions of 
 On Windows 10, open the certificate file and go through the installation dialog.
 Install it to "Local Machine", in the store: "Trusted Root Certification Authorities".
 
-### Using the certificate
+## Using the certificate
 
 When running a scons command, append `certFile=local.pfx certPassword=<Password>`.
 
-#### Example: building a self-signed installer
+### Example: building a self-signed installer
 
 From Command Prompt in your NVDA source directory:
+
 ```cmd
 scons launcher certFile=local.pfx certPassword=<Password>
 ```
 
-##### Confirming the certificate is installed correctly
+#### Confirming the certificate is installed correctly
 
 View the certificate for the NVDA launcher:
+
 1. Open file properties on the launcher (`output/nvda_*.exe`)
 1. Navigate to Digital Signatures tab
 1. Open certificate signature
@@ -103,7 +112,7 @@ View the certificate for the NVDA launcher:
       - **General tab:** "Ensures software came from software publisher. Protects software from alteration after publication"
       - **Certification Path tab, Certificate Status:** "This certificate is OK."
 
-### Remove the certificate
+## Remove the certificate
 
 After being finished with testing, remove the certificate from the Local Machine "Trusted Root Certification Authorities" store.
 Leaving the certificate installed is potentially a security risk.
@@ -112,7 +121,9 @@ The certificate will still be in `Cert:\CurrentUser\My\<Certificate Thumbprint>`
 
 Use PowerShell, running as administrator.
 Replace the following in this PowerShell script:
+
 - `<Certificate Thumbprint>`: The thumbprint from [creating the certificate](#create-a-self-signed-certificate).
+
 ```ps1
 Remove-Item -DeleteKey -Path "Cert:\LocalMachine\Root\<Certificate Thumbprint>"
 ```

--- a/projectDocs/dev/selfSignedBuild.md
+++ b/projectDocs/dev/selfSignedBuild.md
@@ -40,9 +40,9 @@ This [method uses a password](https://docs.microsoft.com/en-us/windows/msix/pack
 Use PowerShell.
 Replace the following in this PowerShell script:
 
-- `<nvdaRepositoryRoot>`: the root of your NVDA repository.
-- `<Password>`: a password for the exported certificate file.
-- `<Certificate Thumbprint>`: The thumbprint from [creating the certificate](#create-a-self-signed-certificate).
+* `<nvdaRepositoryRoot>`: the root of your NVDA repository.
+* `<Password>`: a password for the exported certificate file.
+* `<Certificate Thumbprint>`: The thumbprint from [creating the certificate](#create-a-self-signed-certificate).
 
 ```ps1
 cd <nvdaRepositoryRoot>
@@ -58,8 +58,8 @@ Run PowerShell as Administrator, execute [Import-PfxCertificate](https://docs.mi
 
 Replace the following in the PowerShell script:
 
-- `<nvdaRepositoryRoot>`: the root of your NVDA repository.
-- `<Password>`: your password for the exported certificate file.
+* `<nvdaRepositoryRoot>`: the root of your NVDA repository.
+* `<Password>`: your password for the exported certificate file.
 
 ```ps1
 cd <nvdaRepositoryRoot>
@@ -105,12 +105,12 @@ View the certificate for the NVDA launcher:
 1. Navigate to Digital Signatures tab
 1. Open certificate signature
 1. Open View Certificate
-   - If the certificate is not imported correctly:
-      - **General tab:** "This CA Root certificate is not trusted because it is not in the Trusted Root Certification Authorities store."
-      - **Certification Path tab, Certificate Status:** "This CA Root certificate is not trusted because it is not in the Trusted Root Certification Authorities store."
-   - If the certificate is imported correctly:
-      - **General tab:** "Ensures software came from software publisher. Protects software from alteration after publication"
-      - **Certification Path tab, Certificate Status:** "This certificate is OK."
+   * If the certificate is not imported correctly:
+      * **General tab:** "This CA Root certificate is not trusted because it is not in the Trusted Root Certification Authorities store."
+      * **Certification Path tab, Certificate Status:** "This CA Root certificate is not trusted because it is not in the Trusted Root Certification Authorities store."
+   * If the certificate is imported correctly:
+      * **General tab:** "Ensures software came from software publisher. Protects software from alteration after publication"
+      * **Certification Path tab, Certificate Status:** "This certificate is OK."
 
 ## Remove the certificate
 
@@ -122,7 +122,7 @@ The certificate will still be in `Cert:\CurrentUser\My\<Certificate Thumbprint>`
 Use PowerShell, running as administrator.
 Replace the following in this PowerShell script:
 
-- `<Certificate Thumbprint>`: The thumbprint from [creating the certificate](#create-a-self-signed-certificate).
+* `<Certificate Thumbprint>`: The thumbprint from [creating the certificate](#create-a-self-signed-certificate).
 
 ```ps1
 Remove-Item -DeleteKey -Path "Cert:\LocalMachine\Root\<Certificate Thumbprint>"

--- a/projectDocs/dev/userGuideStandards.md
+++ b/projectDocs/dev/userGuideStandards.md
@@ -1,15 +1,17 @@
 # User Guide Standards
+
 This document aims to create a standard style guide for writing documentation in the User Guide.
 
 The principles outlined in ["The Documentation System" guide for reference materials](https://documentation.divio.com/reference.html) are encouraged when working on the User Guide and this document.
 
 ## General standards
-- Key commands (e.g. `NVDA+control+upArrow`):
-  - should be written in lowerCamelCase
-  - encapsulated in monospace code-block formatting
-  - NVDA should be capitalized
-- When referring to Windows terminology, follow the [Windows style guide](https://docs.microsoft.com/en-us/style-guide/welcome/).
-  - For instance, instead of "system tray" refer to "notification area"
+
+* Key commands (e.g. `NVDA+control+upArrow`):
+  * should be written in lowerCamelCase
+  * encapsulated in monospace code-block formatting
+  * NVDA should be capitalized
+* When referring to Windows terminology, follow the [Windows style guide](https://docs.microsoft.com/en-us/style-guide/welcome/).
+  * For instance, instead of "system tray" refer to "notification area"
 
 ## Feature settings
 
@@ -38,6 +40,7 @@ If necessary, a description of a common use case that is supported by each optio
 ```
 
 ## Generation of Key Commands
+
 Generation of the Key Commands document requires certain commands to be included in the User Guide.
 These commands must begin at the start of the line and take the form:
 
@@ -51,9 +54,11 @@ The other commands are used to select content containing key commands to be incl
 Appropriate headings from the User Guide will be included implicitly.
 
 ### Specifying the title
+
 The `KC:title` command must appear first and specifies the title of the Key Commands document.
 
 For example:
+
 ```md
 <!-- KC:title: NVDA Key Commands -->
 ```
@@ -79,6 +84,7 @@ It specifies the header row for a table summarising the settings indicated by th
 In order, it must consist of a name column, a column for each keyboard layout and a description column.
 
 For example:
+
 ```md
 <!-- KC:settingsSection: || Name | Desktop key | Laptop key | Description | -->
 ```
@@ -95,6 +101,7 @@ It must be followed by:
 * A line describing the setting.
 
 For example:
+
 ```md
 <!-- KC:setting -->
 #### Braille Tethered To

--- a/projectDocs/issues/githubIssueTemplateExplanationAndExamples.md
+++ b/projectDocs/issues/githubIssueTemplateExplanationAndExamples.md
@@ -15,13 +15,14 @@ We currently have the following templates:
 * For [feature requests](#feature-request-template)
 * For [bug reports](#bug-report-template)
 * For [special case issues](#special-case-issue-template) that cannot easily be categorised as either a bug report or a feature request
-* For security vulnerabilities (please note that these are reported differently, for more information see https://github.com/nvaccess/nvda/blob/master/security.md)
+* For security vulnerabilities (please note that these are reported differently, for more information see <https://github.com/nvaccess/nvda/blob/master/security.md>)
 * For developer facing changes:
   * This template is intended for developers to document improvements or maintenance to NVDA's code base that do not have user facing changes.
   * This may include API changes, technical debt removal, refactoring and maintenance tasks.
   * Note there is no further guide for this - it is expected that developers can use the template appropriately.
 
 ## General information
+
 The following information applies to all issues and pull requests.
 
 At the start of the template there is an HTML comment block which points to this wiki page, it can
@@ -38,11 +39,13 @@ Github does not allow all
 however, zip files are allowed, so you can always zip your file and attach that instead.
 
 #### Logs
+
 In most cases an NVDA log file is incredibly helpful when trying to understand/fix an issue, please
 remember to attach one.
 More [instructions are available on the wiki](https://github.com/nvaccess/nvda/wiki/LogFilesAndCrashDumps). If you are getting a crash dump file (nvda_crash.dmp) please also include it.
 
 #### Screenshots
+
 While we welcome **images/screenshots** to help explain a problem, be aware that many of the
 developers of NVDA are blind and will greatly appreciate this image being described in text.
 Most tools allow you to copy text out of them.
@@ -60,18 +63,22 @@ Then fill in each of the following headings which match those that are found in 
 short description of how to fill in each section.
 
 ### Is your feature request related to a problem? Please describe.
+
 This section should provide a clear and concise description of what the problem is.
 Ex. I'm always frustrated when [...]
 
 ### Describe the solution you'd like
+
 A clear and concise description of what you want to happen.
 If you can provide technical details about how to address the problem, please do so.
 Feel free to add a subheading.
 
 ### Describe alternatives you've considered
+
 A clear and concise description of any alternative solutions or features you've considered.
 
 ### Additional context
+
 Add any other context for the feature request here.
 This might list the application name and version number that the feature is expected to work with
 (EG Firefox or Microsoft Word).
@@ -93,28 +100,31 @@ While you are working out the steps required, please make a copy of your
 [NVDA log to attach to the issue](https://github.com/nvaccess/nvda/wiki/LogFilesAndCrashDumps).
 
 *Example:*
+
 > 1. Open Chrome
-> 1. Browse to www.google.com
+> 1. Browse to <www.google.com>
 > 1. Type "Hello"
 > 1. Press Enter
 
 ### Actual behavior:
+
 This section should tell us what actually happens when these steps are taken.
 Please describe verbatim what NVDA does, ideally use speech viewer to copy the speech from NVDA.
 This helps developers to be sure they are reproducing the same issue as you.
 
 *Example:*
 > An NVDA error sound is heard.
-
+>
 > NVDA Speech:
 > "button enable sound"
 
 ### Expected behavior:
+
 This section should tell us what you expect to happen when these steps are taken.
 
 *Example:*
 > There should be no error sound, and the page should change to show the search results.
-
+>
 > NVDA Speech:
 > "checkbox enable sound"
 
@@ -131,23 +141,27 @@ This helps us to be able to reproduce the issue, or help us to investigate why t
 for some users and not others.
 
 #### NVDA installed/portable/running from source:
+
 This tells us how you are using NVDA.
 
 *Example:*
 > Installed
 
 #### NVDA version:
+
 The version of NVDA that you are using when demonstrating the issue.
 This can be copied from the about option, in the NVDA help menu.
 
 *Example:*
 > alpha-15370,21fd217a
-
+>
 > release 2020.4
 
 #### Windows version:
+
 The version of Windows that you are using.
 You can copy this from the "System Information" application:
+
 1. Press `Windows+r` to open the run dialog
 1. Type `msinfo32` and press enter
 1. From the "System summary" treeview item, press tab to get to the right pane.
@@ -158,18 +172,21 @@ You can copy this from the "System Information" application:
 > Windows 10 Version 1607 Build 14393.1066
 
 #### Name and version of other software in use when reproducing the issue:
+
 Typically, you can get this information from the "About" dialog of the software.
 
 *Example:*
 > Chrome version: 67.0.3396.87
 
 #### Other information about your system:
+
 This is other information about your setup that you think might be relevant to us.
 
 *Example:*
 > Running Windows 10 in a VM
 
 ### Other questions:
+
 This section has sub-sections, asking about the basic investigation steps you may have completed.
 Please feel free to add more information here to tell us about what you have tried.
 
@@ -184,6 +201,7 @@ introduced issue.
 It can help us determine if changes in NVDA or other software introduced the problem.
 
 *Example:*
+
 > * NVDA 2018.1 - no error sound
 > * NVDA 2018.2 - has error sound
 
@@ -207,14 +225,15 @@ functionality.
 Thus, it is recommended to run the fixing tool whenever focus problems, performance problems on
 websites or navigation problems in focus or browse mode on different interfaces are encountered.
 
-
 ## Special Case Issue template
 
 ### Detailed description of the issue
+
 Provide a detailed description of the issue you are reporting.
 Include specific details to help us understand the context.
 
 ### Why are the other templates not appropriate in this case?
+
 Explain why this issue cannot be addressed using the standard bug report or feature request templates.
 
 ### Have you asked for advice on how to report this issue via a community discussion? If so, please link to the discussion
@@ -226,20 +245,25 @@ Include links to discussion threads if applicable, for example:
 * <https://groups.google.com/a/nvaccess.org/g/nvda-users>
 
 ### Steps to reproduce or illustrate the issue (if applicable)
+
 If possible, provide steps to demonstrate or reproduce the issue.
 Refer to [Steps to reproduce](#steps-to-reproduce) for more information.
 If this or the following sections are not applicable, write "N/A."
 
 ### Expected outcome or behaviour (if applicable)
+
 Describe what you expected to happen or how you expect the project to handle this kind of issue.
 
 ### Logs, screenshots and other attachments (if applicable)
+
 Attach any relevant logs or files that would help in diagnosing or understanding the issue.
 Refer to [Attachments / Images](#attachments--images) for more information.
 
 ### System configuration or software environment (if applicable)
+
 Include details about your environment where relevant (e.g., operating system, NVDA version, other relevant software).
 Refer to [System configuration](#system-configuration) for more information.
 
 ### Additional information (if applicable)
+
 Provide any additional context or information that you think may be helpful for understanding or resolving the issue.

--- a/projectDocs/issues/readme.md
+++ b/projectDocs/issues/readme.md
@@ -1,4 +1,4 @@
-## Reporting issues or feature requests
+# Reporting issues or feature requests
 
 Issues can be [reported via GitHub](https://github.com/nvaccess/nvda/issues/new/choose).
 Please read the [issue template guide](./githubIssueTemplateExplanationAndExamples.md) for help filling out the appropriate template.

--- a/projectDocs/issues/triage.md
+++ b/projectDocs/issues/triage.md
@@ -1,22 +1,24 @@
+# Triaging NVDA issues
+
 ## Intent
 
 This page intends to outline some of the information that might be helpful to those trying to triage issues.
 
 Most of the issues raised on the NVDA GitHub repository fall into one of the following categories:
 
-- adding support to new applications
-- adding new features in NVDA
-- adding new features to support 3rd party applications better
-- adding support for new (web) accessibility standards
-- bug reports
+* adding support to new applications
+* adding new features in NVDA
+* adding new features to support 3rd party applications better
+* adding support for new (web) accessibility standards
+* bug reports
 
 Firstly we want to catch high priority issues and ensure that they are attended to first.
 This might be things like:
 
-- a crash of NVDA
-- synthesisers not working correctly
-- an error in an existing feature.
-- an essential function of an application ceased working with NVDA
+* a crash of NVDA
+* synthesisers not working correctly
+* an error in an existing feature.
+* an essential function of an application ceased working with NVDA
 
 Secondly, we want to ensure that there is enough information on the issue so that it can be well understood and work can start when it comes to the front of the queue. The sooner we do this, the more likely it is that we will get the information we need.
 Most of the information required is asked for in the Github issue templates, so this is a great place to start.
@@ -53,25 +55,25 @@ This is the kind of information that might help when investigating the issue fur
 
 ### Regressions
 
-- How is the regression triggered? We may call this the steps to reproduce, perhaps even STR for short. What this means is, that we are looking for the set of steps to make the bug happen on our own system.
-- What happens / what is the actual behaviour? Some examples might be:
-	- a crash
-	- a freeze
-	- an error noise
-	- A log message
-	- If there was an error noise or log message, was there any unexpected behaviour aside from this? For example, did NVDA fail to report something it should have?
-- Even if it seems obvious, what should happen instead?
-	- Its worth clarifying this with the user, it helps to make sure everyone is on the same page, and that we truly understand what the issue is about.
-- What version of NVDA was being used. Its good to get something like: stable, beta, rc, alpha. But much better to get the exact version of NVDA, retrieved from the NVDA menu by going to "Help" then "About". "alpha-28931,186a8d70"
-- In which version of NVDA did this work as expected?
+* How is the regression triggered? We may call this the steps to reproduce, perhaps even STR for short. What this means is, that we are looking for the set of steps to make the bug happen on our own system.
+* What happens / what is the actual behaviour? Some examples might be:
+  * a crash
+  * a freeze
+  * an error noise
+  * A log message
+  * If there was an error noise or log message, was there any unexpected behaviour aside from this? For example, did NVDA fail to report something it should have?
+* Even if it seems obvious, what should happen instead?
+  * Its worth clarifying this with the user, it helps to make sure everyone is on the same page, and that we truly understand what the issue is about.
+* What version of NVDA was being used. Its good to get something like: stable, beta, rc, alpha. But much better to get the exact version of NVDA, retrieved from the NVDA menu by going to "Help" then "About". "alpha-28931,186a8d70"
+* In which version of NVDA did this work as expected?
 Knowing the last version where this worked in NVDA is very helpful for triage.
 If an issue is a recent regression in alpha, i.e. an unreleased issue, it is fixed with a higher priority.
-- If some other software is needed to reproduce the issue, it helps to know what that software is and what version is being used with NVDA. It's also useful if a test case / document is provided.
-- Some behaviour is specific to operating systems or versions of operating systems. Sometimes a bug can only be reproduced on that particular version of the operating system. So its important to get this information as well. Similar to the NVDA version information, more specific is better. For instance its good if we know the issue occurred on: 'Windows 7', 'Windows 10 Insider'. But even better is to know the version and build too: 'Windows 10, fast insider, version 1703, build 16170.1000'.
-- A copy of the (debug) log
-- If it exists, a crash dump file.
-- Can anyone else reproduce the issue?
-- Has anyone else tried and failed to reproduce the issue?
+* If some other software is needed to reproduce the issue, it helps to know what that software is and what version is being used with NVDA. It's also useful if a test case / document is provided.
+* Some behaviour is specific to operating systems or versions of operating systems. Sometimes a bug can only be reproduced on that particular version of the operating system. So its important to get this information as well. Similar to the NVDA version information, more specific is better. For instance its good if we know the issue occurred on: 'Windows 7', 'Windows 10 Insider'. But even better is to know the version and build too: 'Windows 10, fast insider, version 1703, build 16170.1000'.
+* A copy of the (debug) log
+* If it exists, a crash dump file.
+* Can anyone else reproduce the issue?
+* Has anyone else tried and failed to reproduce the issue?
 
 This in particular can be quite time consuming for NV Access, but would be an excellent way for members of the community to contribute. By checking if you can reproduce issues on whatever system configurations you have around, or perhaps using VMs as well and reporting back the results.
 
@@ -91,15 +93,15 @@ In a way this is like a combination of both a bug and a new feature request, and
 
 However, the most important pieces of information for this kind of request are:
 
-- How to reproduce the behaviour?
-- What exactly is the current behaviour?
-- What is wrong with the current behaviour?
-- What should NVDA do instead?
+* How to reproduce the behaviour?
+* What exactly is the current behaviour?
+* What is wrong with the current behaviour?
+* What should NVDA do instead?
 
 Essentially this boils down to:
 
-- What is the use case / user stories?
-- How does it differ from the intended use case of the feature?
+* What is the use case / user stories?
+* How does it differ from the intended use case of the feature?
 
 ## Use cases / user stories
 
@@ -112,24 +114,24 @@ Here is an example from a recent Github issue:
 
 ### Who
 
-- Who does it affect? (for instance: Braille users, Speech users, developers working on accessibility for their websites/apps, NVDA developers)
-- Knowing who, helps to give an estimate on how many users this will help.
-- It also can help to highlight differences in requirements for different users. This happens when we are unable to define the same use case for two groups of users.
+* Who does it affect? (for instance: Braille users, Speech users, developers working on accessibility for their websites/apps, NVDA developers)
+* Knowing who, helps to give an estimate on how many users this will help.
+* It also can help to highlight differences in requirements for different users. This happens when we are unable to define the same use case for two groups of users.
 
 ### What
 
-- This can be a step by step of what they expect to do, and the kind of output they expect along the way.
-- Things to consider here:
- - Does this need to work with other software? If so, what version?
- - Particularly when working with other software, it's helpful if an example document or file can be provided. Perhaps a relevant test case?
+* This can be a step by step of what they expect to do, and the kind of output they expect along the way.
+* Things to consider here:
+  * Does this need to work with other software? If so, what version?
+  * Particularly when working with other software, it's helpful if an example document or file can be provided. Perhaps a relevant test case?
 
 ### Why
 
 Often the hardest one, but also the most valuable.
 
-- Why do they want to do this?
-- What does it help them to achieve?
-- It's valuable because it brings further understanding about the background that led to the what.
+* Why do they want to do this?
+* What does it help them to achieve?
+* It's valuable because it brings further understanding about the background that led to the what.
 Perhaps once we have this background, a simpler what can be proposed.
 
 ## Summarise the issue
@@ -146,6 +148,7 @@ NV Access can grant people who help triage issues the ability to label issues.
 Labelling issues help indicate the priority and current state, helping NV Access and the community to decide on how to prioritise it.
 
 ### Types of issues
+
 Issues can generally be labelled `bug` or `feature`.
 We also have a label for `enhancement`, think of this as a more internal facing change. For instance, editing code comments to provide clearer / more complete information, or extending an internal framework/API to unblock other issues.
 
@@ -182,30 +185,30 @@ This can be indicated with adding the label `blocked/needs-technical-investigati
 
 Bugs/regressions are given priorities based on an estimate of their severity and impact.
 
-- `P1`:
-  - `P1s` should always be fixed ASAP, in the current milestone, or the next.
-  - Crash, freeze, instability or performance issue that affects most users.
-  - A medium or higher severity ([CVSS 4+](https://www.first.org/cvss/v4.0/specification-document)) security issue.
+* `P1`:
+  * `P1s` should always be fixed ASAP, in the current milestone, or the next.
+  * Crash, freeze, instability or performance issue that affects most users.
+  * A medium or higher severity ([CVSS 4+](https://www.first.org/cvss/v4.0/specification-document)) security issue.
   Note that security issues should not be reported publicly, and so labelling should not apply here.
-  - A `P1` causes the inability to perform a popular task or majority of tasks in NVDA or a popular app.
-- `P2`:
-  - Crash, freeze, instability or performance issue that affects a small subset of users. It may be uncommon or difficult to reproduce.
-  - A low severity ([CVSS <4](https://www.first.org/cvss/v4.0/specification-document)) security issue.
+  * A `P1` causes the inability to perform a popular task or majority of tasks in NVDA or a popular app.
+* `P2`:
+  * Crash, freeze, instability or performance issue that affects a small subset of users. It may be uncommon or difficult to reproduce.
+  * A low severity ([CVSS <4](https://www.first.org/cvss/v4.0/specification-document)) security issue.
   Note that security issues should not be reported publicly, and so labelling should not apply here.
-  - Popular documented feature does not work as expected
-  - Popular task not supported and no work around
-  - Misleading information or misleading handling from a popular task or feature
-- `P3`:
-  - Crash, freeze, instability or performance issue that affects one user, i.e. it cannot be reproduced by anyone else.
-  - Feature does not work as expected
-  - Task not supported and no work around
-  - Misleading information or misleading handling
-- `P4`:
-  - Useful popular feature request or enhancement
-  - UX inefficient (e.g. double speaking)
-  - Web standard not followed causing app/web authors to require workarounds
-- `P5`
-  - Other feature requests affecting a small subset of users
+  * Popular documented feature does not work as expected
+  * Popular task not supported and no work around
+  * Misleading information or misleading handling from a popular task or feature
+* `P3`:
+  * Crash, freeze, instability or performance issue that affects one user, i.e. it cannot be reproduced by anyone else.
+  * Feature does not work as expected
+  * Task not supported and no work around
+  * Misleading information or misleading handling
+* `P4`:
+  * Useful popular feature request or enhancement
+  * UX inefficient (e.g. double speaking)
+  * Web standard not followed causing app/web authors to require workarounds
+* `P5`
+  * Other feature requests affecting a small subset of users
 
 ## Legacy issues
 
@@ -228,12 +231,12 @@ Our goal is to be transparent about our priorities without dismissing the real-w
 
 When triaging an issue related to a feature that involves a deprecated technology or is otherwise no longer under active development by the core team:
 
-- Migration blockers: Ensure that there is information in the issue on what prevents the user from using the modern alternative (e.g. UIA in Word).
+* Migration blockers: Ensure that there is information in the issue on what prevents the user from using the modern alternative (e.g. UIA in Word).
 If the user identifies a specific gap or bug in the modern technology (e.g. "I can't use UIA because it doesn't read table headers correctly"), a new issue must be created to track that specific blocker and linked to the legacy issue.
-- Identify and label: Identify if the issue is tied to a specific legacy component and apply the relevant label.
+* Identify and label: Identify if the issue is tied to a specific legacy component and apply the relevant label.
 Apply the labels `legacy/community-support` and `help wanted`.
-- Keep open for community: These issues should remain open as this keeps them visible and searchable, acknowledging their validity and creating an opportunity for a community member to contribute a fix.
-- User impact priority: Assign a priority appropriate for the impact on users. This represents the immediate-term pain being caused by the issue.
+* Keep open for community: These issues should remain open as this keeps them visible and searchable, acknowledging their validity and creating an opportunity for a community member to contribute a fix.
+* User impact priority: Assign a priority appropriate for the impact on users. This represents the immediate-term pain being caused by the issue.
 
 ## NV Access staff-created tickets
 
@@ -244,9 +247,9 @@ To that end, we kindly request that community members refrain from closing or co
 
 Community members are welcome and encouraged to interact with staff tickets in the following ways:
 
-- Commenting on issues to provide feedback, suggestions, or additional context.
-- Discussing proposed changes or feature requests.
-- Submitting pull requests that address the issue or implement the requested changes, once issues have been triaged.
+* Commenting on issues to provide feedback, suggestions, or additional context.
+* Discussing proposed changes or feature requests.
+* Submitting pull requests that address the issue or implement the requested changes, once issues have been triaged.
 
 By refraining from closing or consolidating staff tickets, we can ensure that the NV Access team maintains control over their internal workflow and prioritisation, while still benefiting from the valuable insights and contributions of the community.
 
@@ -260,7 +263,6 @@ To request triage permissions, email <info@nvaccess.org>.
 A consistent history of helpful activity in the repository is expected, for example helping debug issues, asking for missing information, providing constructive feedback on pull requests, submitting well-documented pull requests, constructively participating in discussions, mentoring new contributors or improving documentation.
 Candidates will be considered on a case by case basis.
 
-
 ### Handling disagreements
 
 If conflict arises between how best to triage an issue, please defer to NV Access and keep the issue in an open, untriaged state i.e. with the labels "needs triage" and "blocked/needs-product-decision".
@@ -271,9 +273,10 @@ If a strong disagreement arises over the status of an issue (e.g. its priority, 
 This is counter-productive and creates a negative atmosphere.
 
 The correct procedure is to:
-1.  **Stop:** Leave the issue in its current state.
-2.  **Label:** Apply the `blocked/needs-product-decision` label.
-3.  **Escalate:** Add a comment explaining the disagreement and tag a relevant NV Access staff member to make a final decision.
+
+1. **Stop:** Leave the issue in its current state.
+2. **Label:** Apply the `blocked/needs-product-decision` label.
+3. **Escalate:** Add a comment explaining the disagreement and tag a relevant NV Access staff member to make a final decision.
 
 This moves the debate from a public power struggle to a productive internal resolution.
 

--- a/projectDocs/issues/triage.md
+++ b/projectDocs/issues/triage.md
@@ -55,21 +55,32 @@ This is the kind of information that might help when investigating the issue fur
 
 ### Regressions
 
-* How is the regression triggered? We may call this the steps to reproduce, perhaps even STR for short. What this means is, that we are looking for the set of steps to make the bug happen on our own system.
+* How is the regression triggered?
+We may call this the steps to reproduce, perhaps even STR for short.
+What this means is, that we are looking for the set of steps to make the bug happen on our own system.
 * What happens / what is the actual behaviour? Some examples might be:
   * a crash
   * a freeze
   * an error noise
   * A log message
-  * If there was an error noise or log message, was there any unexpected behaviour aside from this? For example, did NVDA fail to report something it should have?
+  * If there was an error noise or log message, was there any unexpected behaviour aside from this?
+  For example, did NVDA fail to report something it should have?
 * Even if it seems obvious, what should happen instead?
   * Its worth clarifying this with the user, it helps to make sure everyone is on the same page, and that we truly understand what the issue is about.
-* What version of NVDA was being used. Its good to get something like: stable, beta, rc, alpha. But much better to get the exact version of NVDA, retrieved from the NVDA menu by going to "Help" then "About". "alpha-28931,186a8d70"
+* What version of NVDA was being used.?
+It's good to get something like: stable, beta, rc, alpha.
+But much better to get the exact version of NVDA, retrieved from the NVDA menu by going to" Help" then "About".
+E.g. "alpha-28931,186a8d70".
 * In which version of NVDA did this work as expected?
 Knowing the last version where this worked in NVDA is very helpful for triage.
 If an issue is a recent regression in alpha, i.e. an unreleased issue, it is fixed with a higher priority.
-* If some other software is needed to reproduce the issue, it helps to know what that software is and what version is being used with NVDA. It's also useful if a test case / document is provided.
-* Some behaviour is specific to operating systems or versions of operating systems. Sometimes a bug can only be reproduced on that particular version of the operating system. So its important to get this information as well. Similar to the NVDA version information, more specific is better. For instance its good if we know the issue occurred on: 'Windows 7', 'Windows 10 Insider'. But even better is to know the version and build too: 'Windows 10, fast insider, version 1703, build 16170.1000'.
+* If some other software is needed to reproduce the issue, it helps to know what that software is and what version is being used with NVDA.
+It's also useful if a test case / document is provided.
+* Some behaviour is specific to operating systems or versions of operating systems.
+Sometimes a bug can only be reproduced on that particular version of the operating system, so its important to get this information as well.
+Similar to the NVDA version information, more specific is better.
+For instance its good if we know the issue occurred on: 'Windows 7', 'Windows 10 Insider'.
+But even better is to know the version and build too: 'Windows 10, fast insider, version 1703, build 16170.1000'.
 * A copy of the (debug) log
 * If it exists, a crash dump file.
 * Can anyone else reproduce the issue?
@@ -114,9 +125,11 @@ Here is an example from a recent Github issue:
 
 ### Who
 
-* Who does it affect? (for instance: Braille users, Speech users, developers working on accessibility for their websites/apps, NVDA developers)
+* Who does it affect?
+For instance: Braille users, Speech users, developers working on accessibility for their websites/apps, NVDA developers.
 * Knowing who, helps to give an estimate on how many users this will help.
-* It also can help to highlight differences in requirements for different users. This happens when we are unable to define the same use case for two groups of users.
+* It also can help to highlight differences in requirements for different users.
+This happens when we are unable to define the same use case for two groups of users.
 
 ### What
 
@@ -192,7 +205,8 @@ Bugs/regressions are given priorities based on an estimate of their severity and
   Note that security issues should not be reported publicly, and so labelling should not apply here.
   * A `P1` causes the inability to perform a popular task or majority of tasks in NVDA or a popular app.
 * `P2`:
-  * Crash, freeze, instability or performance issue that affects a small subset of users. It may be uncommon or difficult to reproduce.
+  * Crash, freeze, instability or performance issue that affects a small subset of users.
+  It may be uncommon or difficult to reproduce.
   * A low severity ([CVSS <4](https://www.first.org/cvss/v4.0/specification-document)) security issue.
   Note that security issues should not be reported publicly, and so labelling should not apply here.
   * Popular documented feature does not work as expected
@@ -236,7 +250,8 @@ If the user identifies a specific gap or bug in the modern technology (e.g. "I c
 * Identify and label: Identify if the issue is tied to a specific legacy component and apply the relevant label.
 Apply the labels `legacy/community-support` and `help wanted`.
 * Keep open for community: These issues should remain open as this keeps them visible and searchable, acknowledging their validity and creating an opportunity for a community member to contribute a fix.
-* User impact priority: Assign a priority appropriate for the impact on users. This represents the immediate-term pain being caused by the issue.
+* User impact priority: Assign a priority appropriate for the impact on users.
+This represents the immediate-term pain being caused by the issue.
 
 ## NV Access staff-created tickets
 

--- a/projectDocs/product_vision.md
+++ b/projectDocs/product_vision.md
@@ -1,13 +1,16 @@
-## Product Vision
+# Product Vision
+
 A world where blind and vision impaired people can independently and fully interact with the Windows Operating System and popular third party applications, enabling them to participate in and contribute to society.
 Blind and vision impaired people are empowered to control their own destiny and ensure this vision, through being able to significantly contribute to the technology that makes this possible.
 All blind and vision impaired people deserve these rights and opportunities, no matter the language they speak, their geographic location, economic status, or sensory, physical, cognitive, or mental abilities.
 
 ## Product description
+
 NVDA (NonVisual Desktop Access) is software that allows blind and vision impaired people to independently interact with the Windows Operating System and popular third party applications by outputting content in either synthetic speech or via a refreshable Braille Display.
 Developed by NV Access in partnership with a dedicated open source community, NVDA enables blind and vision impaired people to increase their chances at education and employment, and to participate in and contribute to society.
 
 ## Guiding Principles
+
 1. Freely Available to all: To ensure that NVDA is available to anyone who needs to access the Windows Operating system, no matter their economic status:
     * NVDA is free of charge for anyone who needs to access a computer.
     * NVDA can be downloaded, copied, shared, and used on any amount of computers.

--- a/projectDocs/testing/automated.md
+++ b/projectDocs/testing/automated.md
@@ -1,9 +1,9 @@
-## Running Automated Tests
+# Running Automated Tests
 
 If you make a change to the NVDA code, you should run NVDA's automated tests.
 These tests help to ensure that code changes do not unintentionally break functionality that was previously working.
 
-### Pre-commit hooks
+## Pre-commit hooks
 
 [Pre-commit hooks](https://pre-commit.com/) can be used to automatically run linting, translatable string checks and unit tests on files staged for commit.
 This will automatically apply lint fixes where possible, and will cancel the commit on lint issues and other test failures.
@@ -20,7 +20,7 @@ Alternatively, set up pre-commit scripts globally:
 To skip pre-commit hooks from triggering, use the `--no-verify` CLI option.
 Example: `git commit -m "message" --no-verify`.
 
-#### Manually running pre-commit hooks
+### Manually running pre-commit hooks
 
 You can run pre-commit hooks manually with [`pre commit run`](https://pre-commit.com/#pre-commit-run).
 
@@ -28,7 +28,7 @@ You can run pre-commit hooks manually with [`pre commit run`](https://pre-commit
 - You can also compare two revisions:
 `uv run pre-commit run --from-ref origin/master --to-ref HEAD`
 
-### Translatable string checks
+## Translatable string checks
 
 To run the translatable string checks (which check that all translatable strings have translator comments), run:
 
@@ -36,7 +36,7 @@ To run the translatable string checks (which check that all translatable strings
 scons checkPot
 ```
 
-### Linting your changes
+## Linting your changes
 
 Our linting process involves running [Ruff](https://docs.astral.sh/ruff) to pick up Python linting issues and auto-apply fixes where possible.
 
@@ -50,7 +50,7 @@ runlint.bat
 
 To be warned about linting errors faster, you may wish to integrate Ruff and pyright with your IDE or other development tools you are using.
 
-### Unit Tests
+## Unit Tests
 
 Unit tests can be run with the `rununittests.bat` script.
 Internally this script uses the [xmlrunner](https://github.com/pycontribs/xmlrunner) wrapper around the [unittest](https://docs.python.org/3/library/unittest.html) framework to execute the tests.
@@ -66,14 +66,15 @@ rununittests -k test_cursorManager.TestMove -k test_cursorManager.TestSelection
 
 Please refer to [unittest's documentation](https://docs.python.org/3/library/unittest.html#command-line-interface) for further information on how to filter tests.
 
-### System Tests
+## System Tests
+
 System tests can be run with the `runsystemtests.bat --include <TAG>` script.
 To run all tests standard tests for developers use `runsystemtests.bat --include NVDA`.
 Internally this script uses the Robot test framework to execute the tests.
 Any arguments given to `runsystemtests.bat` are forwarded onto Robot.
 For more details (including filtering and exclusion of tests) see `tests/system/readme.md`.
 
-### License checks
+## License checks
 
 NVDA uses GPLv2 which is incompatible with certain licenses like Apache.
 Run `runlicensecheck.bat` to check that you don't introduce any new python dependencies with incompatible licenses.

--- a/projectDocs/testing/automated.md
+++ b/projectDocs/testing/automated.md
@@ -24,8 +24,8 @@ Example: `git commit -m "message" --no-verify`.
 
 You can run pre-commit hooks manually with [`pre commit run`](https://pre-commit.com/#pre-commit-run).
 
-- You can filter files with `--files` and `--all-files`
-- You can also compare two revisions:
+* You can filter files with `--files` and `--all-files`
+* You can also compare two revisions:
 `uv run pre-commit run --from-ref origin/master --to-ref HEAD`
 
 ## Translatable string checks

--- a/projectDocs/testing/contributing.md
+++ b/projectDocs/testing/contributing.md
@@ -14,22 +14,24 @@ Although the automated tests pass, these builds have likely had no user testing.
 The latest final release will be identical to the final RC release of the release cycle.
 
 ## Manual testing
+
 User / community testing is particularly important for languages other than English.
 
 NVDA includes [manual test plans](../../tests/manual/README.md) to guide testers in smoke testing features of NVDA.
 
 There are several approaches you may take for testing:
-- Unfocused usage: Just use NVDA as you normally would, and try to complete everyday tasks.
-- Recent change focused testing: By following the changes that are being made to NVDA and purposefully testing these changes and looking for edge-cases.
-- Regression testing: Testing older features and behavior to look for unintended regressions in behavior that don't seem related to recent changes.
-- Pull request testing.
+
+* Unfocused usage: Just use NVDA as you normally would, and try to complete everyday tasks.
+* Recent change focused testing: By following the changes that are being made to NVDA and purposefully testing these changes and looking for edge-cases.
+* Regression testing: Testing older features and behavior to look for unintended regressions in behavior that don't seem related to recent changes.
+* Pull request testing.
 Testing pull requests can be done
 	1. Go to the pull request page.
 	1. Navigate to the linked "Details of continuous integration", this is towards the end of the PR, as part of the checks and approval status.
 	1. Go to the "Artifacts" tab
 	1. Download the NVDA installer, named something like `output\nvda_snapshot_pr15335-28962,a2970e3f.exe`
 	1. The pull request should contain some information on how to test this change.
-- Confirming bugs.
+* Confirming bugs.
 By following the [issue triage process](../issues/triage.md) you can help confirm bugs and debug issues.
 
 Forming a group can help you to get good coverage, brainstorm on what should be tested, and perhaps learn new ways to use NVDA.

--- a/projectDocs/testing/readme.md
+++ b/projectDocs/testing/readme.md
@@ -1,4 +1,6 @@
-### Important links
+# Testing NVDA
+
+## Important links
 
 * [How to contribute to NVDA by testing](./contributing.md)
 * [Reporting issues on GitHub](../issues/readme.md)
@@ -6,7 +8,7 @@
 * The NVDA repository [Wiki](https://github.com/nvaccess/nvda/wiki) contains more guides and documentation.
 * [NVDA development snapshots](https://download.nvaccess.org/snapshots/alpha/): Automatically generated builds of the project in its current state of development
 
-### Documentation
+## Documentation
 
 * [NVDA User Guide](https://download.nvaccess.org/documentation/userGuide.html)
 * [Changes in the latest release](https://download.nvaccess.org/documentation/changes.html)
@@ -14,7 +16,7 @@
 * [Automated tests for developers](./automated.md)
 * [Release process](../community/releaseProcess.md)
 
-### Community communication channels
+## Community communication channels
 
 * [NVDA Users Mailing List](https://groups.google.com/a/nvaccess.org/g/nvda-users)
 * [NVDA Developers Mailing List](https://groups.io/g/nvda-devel)

--- a/projectDocs/translating/crowdin.md
+++ b/projectDocs/translating/crowdin.md
@@ -37,6 +37,7 @@ Poedit is a desktop application which is commonly used to translate files.
 It is fairly accessible and is used by many blind and vision impaired translators.
 
 The workflow for translating with Poedit involves:
+
 1. Downloading the translation file using NVDA's l10n utility
 1. Opening the translation file in Poedit, translating one or more strings, and saving the file.
 1. Uploading the translation file back to Crowdin.
@@ -74,6 +75,7 @@ E.g.
 ```sh
 l10nUtil.exe downloadTranslationFile fr nvda.po
 ```
+
 The first time you will be asked for an authorization token.
 Please visit [your Crowdin settings API page](https://crowdin.com/settings#api-key) and create a Personal Access Token.
 Ensure that it has at least the translations scope.
@@ -115,16 +117,20 @@ After translating the file with Poedit, upload the file back to Crowdin.
 ```
 l10nUtil.exe uploadTranslationFile <language> <crowdinFilePath> [<localFilePath>]
 ```
+
 E.g.
+
 ```
 l10nUtil.exe uploadTranslationFile fr nvda.po
 ```
 
 If you had previously saved a copy of the downloaded file before translation, then you will also want to include this in the command, so that l10nUtil only uploads the strings you have actually changed:
 E.g.
+
 ```
 l10nUtil.exe uploadTranslationFile fr nvda.po --old nvda_old.po
 ```
+
 Where `nvda_old.po` was the saved copy.
 
 ## Translating NVDA's interface
@@ -140,16 +146,16 @@ Where `nvda_old.po` was the saved copy.
 
 You will come across several messages that have additional characters or punctuation as part of the message, this section will explain how they should be treated.
 
-- `%d`, digits
-- `%s`, string
-- `%.2f`, a number to 2 digits after the comma, for example 5.25
-- `{keyword}`, the text around the keyword should be translated, but the word should be left as is.
+* `%d`, digits
+* `%s`, string
+* `%.2f`, a number to 2 digits after the comma, for example 5.25
+* `{keyword}`, the text around the keyword should be translated, but the word should be left as is.
 
 #### Examples
 
-- `%d percent`: this means that `%d` will be replaced by a number when the program is running, and you only need to translate the word `percent`.
-- `subject: %s`: here `%s` means that another string will be substituted.
-- `{color} on {backgroundColor}`: In this case, the word `on` should be translated.
+* `%d percent`: this means that `%d` will be replaced by a number when the program is running, and you only need to translate the word `percent`.
+* `subject: %s`: here `%s` means that another string will be substituted.
+* `{color} on {backgroundColor}`: In this case, the word `on` should be translated.
 The rest should be left alone or rearranged in order to suit the language.
 This will be presented as "black on white", "yellow on black", etc.
 
@@ -169,16 +175,16 @@ Strings can have multiple versions depending on the plural form of the subject.
 
 Example:
 
-- `with %s item`
-- English plural form:
-  - Multiple: `with %s items`
-- Arabic plural forms:
-  - Zero: `تتضمن %s من العناصر`
-  - One: `تتضمّن %s من العناصر`
-  - Two: `تتضمَّن عنصرين %s`
-  - Few: `تتضمَّن %s عناصر`
-  - Many: `تتضمَّن %s من العناصر`
-  - Other: `تتضمَّن %s من العناصر`
+* `with %s item`
+* English plural form:
+  * Multiple: `with %s items`
+* Arabic plural forms:
+  * Zero: `تتضمن %s من العناصر`
+  * One: `تتضمّن %s من العناصر`
+  * Two: `تتضمَّن عنصرين %s`
+  * Few: `تتضمَّن %s عناصر`
+  * Many: `تتضمَّن %s من العناصر`
+  * Other: `تتضمَّن %s من العناصر`
 
 In the [Crowdin web interface](https://support.crowdin.com/online-editor/), these can be set for each language using the "Form" section which replaces the standard translation edit box.
 
@@ -186,12 +192,12 @@ In PoEdit, the standard translation edit box has tabs for each plural form.
 [Object navigation](https://download.nvaccess.org/documentation/userGuide.html#ObjectNavigation) is required to move focus to each tab button for the plural form.
 You can do this by:
 
-- By moving to the previous focus object from the edit box, you can cycle through each plural form tab button by continuing to more backward.
-  - Desktop: `NVDA+numpad4`
-  - Laptop: `NVDA+shift+leftArrow`
-- Activate the current object once the desired tab button is reached.
-  - Desktop: `NVDA+numpadEnter`
-  - Laptop: `NVDA+enter`
+* By moving to the previous focus object from the edit box, you can cycle through each plural form tab button by continuing to more backward.
+  * Desktop: `NVDA+numpad4`
+  * Laptop: `NVDA+shift+leftArrow`
+* Activate the current object once the desired tab button is reached.
+  * Desktop: `NVDA+numpadEnter`
+  * Laptop: `NVDA+enter`
 
 If the number of plural forms for your language is incorrect please message the [translators mailing list](https://groups.io/g/nvda-translations) or <info@nvaccess.org>.
 
@@ -202,6 +208,7 @@ Translation strings can be grouped by a tag to differentiate contexts.
 Translator comments provide additional context information.
 
 The string `none` is defined three times:
+
 * without any context to report a lack of background pattern in Microsoft Excel
 * with the context tag `symbolLevel`
 * with the context tag `espeakVarient`
@@ -212,8 +219,8 @@ In Crowdin, this information appears at the end of the context section.
 ### Testing the interface translation
 
 1. To test the current interface messages, save the current nvda.po file in Poedit, and copy the nvda.mo file to the following location: `nvdadir/locale/langcode/LC_MESSAGES`
-    - `nvdadir`: the directory where NVDA has been installed
-    - `langcode`: the ISO 639-1 language code for your language (e.g. en for English, es for Spanish, etc.)
+    * `nvdadir`: the directory where NVDA has been installed
+    * `langcode`: the ISO 639-1 language code for your language (e.g. en for English, es for Spanish, etc.)
 1. Restart NVDA, then go to the NVDA menu, go to Preferences and choose General Settings, or press `NVDA+control+g` to open General Settings.
 1. From the language list, select your language (if it is listed), press `enter` and say yes when you're asked to restart NVDA.
 1. The messages you have translated should now be heard or brailled in your native language provided that the synthesizer you are using supports your language or a braille code for your language exists.
@@ -245,6 +252,7 @@ Content may still however contain inline markdown syntax such as links, inline c
 This syntax must be kept intact when translating.
 
 All strings for translation contain translator notes which include:
+
 * Line: the original line number in the markdown file.
 * prefix: any structural markdown on the line before this content.
 * Suffix: any structural markdown on the line after this content.
@@ -252,6 +260,7 @@ All strings for translation contain translator notes which include:
 ### Verifying your translation
 
 When ever you have saved the xliff file with Poedit, you can use the NVDA l10nUtil program to generate the html version of the documentation file. E.g.
+
 ```
 l10nUtil.exe xliff2html -t [userGuide|changes|keyCommands] <xliff file> <output html file>
 ```

--- a/projectDocs/translating/github.md
+++ b/projectDocs/translating/github.md
@@ -6,9 +6,9 @@ This guide provides technical steps on how to translate symbols and character de
 
 For detailed information on the format of these files, please refer to the following sections in the developer guide:
 
-- `characterDescriptions.dic`: [Translating Character Descriptions](https://download.nvaccess.org/documentation/developerGuide.html#characterDescriptions)
-- `symbols.dic`: [Translating Symbols](https://download.nvaccess.org/documentation/developerGuide.html#symbolPronunciation)
-- `gestures.ini`: [Translating Gestures](https://download.nvaccess.org/documentation/developerGuide.html#TranslatingGestures)
+* `characterDescriptions.dic`: [Translating Character Descriptions](https://download.nvaccess.org/documentation/developerGuide.html#characterDescriptions)
+* `symbols.dic`: [Translating Symbols](https://download.nvaccess.org/documentation/developerGuide.html#symbolPronunciation)
+* `gestures.ini`: [Translating Gestures](https://download.nvaccess.org/documentation/developerGuide.html#TranslatingGestures)
 
 To keep these files up to date, translators must be concious of changes in NVDA.
 For changes to `symbols.dic` and `characterDescriptions.dic`, please subscribe to the read-only [NVDA localisation mailing list](https://groups.google.com/a/nvaccess.org/g/nvda-l10n).
@@ -21,21 +21,21 @@ New gestures will be announced there, and localisations can be added to `gesture
 ## Process
 
 1. Be notified of potential localisation changes:
-    - For `gestures.ini`: Check the latest beta's changes for any new gestures added.
-    - For `symbols.dic` and `characterDescriptions.dic`:
-        - Receive a notification from the [NVDA localisation mailing list](https://groups.google.com/a/nvaccess.org/g/nvda-l10n)
-        - This will occur when the first beta is being prepared.
+    * For `gestures.ini`: Check the latest beta's changes for any new gestures added.
+    * For `symbols.dic` and `characterDescriptions.dic`:
+        * Receive a notification from the [NVDA localisation mailing list](https://groups.google.com/a/nvaccess.org/g/nvda-l10n)
+        * This will occur when the first beta is being prepared.
         There may be subsequent notifications during the beta period.
-        - Changes to these files are relatively infrequent, so the mailing list will be low traffic, many releases may go by without changes.
-        - Sample email:
-            - The lines prefixed with `+` refer to additions.
-            - The lines prefixed with `-` refer to removals.
-            - The lines prefixed with `@@` refer to the location of the changes:
-                - The first number(s) corresponds to the original location of the line.
+        * Changes to these files are relatively infrequent, so the mailing list will be low traffic, many releases may go by without changes.
+        * Sample email:
+            * The lines prefixed with `+` refer to additions.
+            * The lines prefixed with `-` refer to removals.
+            * The lines prefixed with `@@` refer to the location of the changes:
+                * The first number(s) corresponds to the original location of the line.
                 The second number(s) corresponds to the new location in the file.
                 This can be useful for finding where to make the changes when referencing the English file.
-                - e.g. `@@ -2 +2 @@` means the 2nd line has changed, and remained in the same place in both files.
-                - e.g. `@@ -13,0 +14,2 @@ complexSymbols:` means the 13th line has changed, originally there was 0 lines here, and 2 new lines have been added.
+                * e.g. `@@ -2 +2 @@` means the 2nd line has changed, and remained in the same place in both files.
+                * e.g. `@@ -13,0 +14,2 @@ complexSymbols:` means the 13th line has changed, originally there was 0 lines here, and 2 new lines have been added.
                 You can find the 2 new lines in the new English file starting at line 14.
                 The section header `complexSymbols` is included where possible to help give context.
 
@@ -53,46 +53,46 @@ New gestures will be announced there, and localisations can be added to `gesture
             ```
 
 1. Find the relevant file to edit in the GitHub directory
-    - Visit [source/locale](https://github.com/nvaccess/nvda/tree/beta/source/locale)
-    - Open the directory with your language code
-        - English example: <https://github.com/nvaccess/nvda/tree/beta/source/locale/en>
-        - Format (replace `{lang}`): `https://github.com/nvaccess/nvda/tree/beta/source/locale/{lang}`
-    - Find the relevant file:
-        - `symbols.dic`, `characterDescriptions.dic` or `gestures.ini`
-        - English example: <https://github.com/nvaccess/nvda/blob/beta/source/locale/en/symbols.dic>
-        - Format (replace `{lang}` and `{fileName}`): `https://github.com/nvaccess/nvda/blob/beta/source/locale/{lang}/{fileName}`
+    * Visit [source/locale](https://github.com/nvaccess/nvda/tree/beta/source/locale)
+    * Open the directory with your language code
+        * English example: <https://github.com/nvaccess/nvda/tree/beta/source/locale/en>
+        * Format (replace `{lang}`): `https://github.com/nvaccess/nvda/tree/beta/source/locale/{lang}`
+    * Find the relevant file:
+        * `symbols.dic`, `characterDescriptions.dic` or `gestures.ini`
+        * English example: <https://github.com/nvaccess/nvda/blob/beta/source/locale/en/symbols.dic>
+        * Format (replace `{lang}` and `{fileName}`): `https://github.com/nvaccess/nvda/blob/beta/source/locale/{lang}/{fileName}`
 1. If the relevant file doesn't exist yet, create a new one.
-    - To create a new file use the "add file" button from your language's directory.
-        - English example: <https://github.com/nvaccess/nvda/new/beta/source/locale/en>
-        - Format (replace `{lang}`): `https://github.com/nvaccess/nvda/new/beta/source/locale/{lang}`
-    - `characterDescriptions.dic`: Copy and paste desired contents from the [English example](https://raw.githubusercontent.com/nvaccess/nvda/refs/heads/beta/source/locale/en/characterDescriptions.dic).
+    * To create a new file use the "add file" button from your language's directory.
+        * English example: <https://github.com/nvaccess/nvda/new/beta/source/locale/en>
+        * Format (replace `{lang}`): `https://github.com/nvaccess/nvda/new/beta/source/locale/{lang}`
+    * `characterDescriptions.dic`: Copy and paste desired contents from the [English example](https://raw.githubusercontent.com/nvaccess/nvda/refs/heads/beta/source/locale/en/characterDescriptions.dic).
     Note you should translate all the content you copy.
-    - `symbols.dic`: Copy and paste desired contents from the [English example](https://raw.githubusercontent.com/nvaccess/nvda/refs/heads/beta/source/locale/en/symbols.dic).
+    * `symbols.dic`: Copy and paste desired contents from the [English example](https://raw.githubusercontent.com/nvaccess/nvda/refs/heads/beta/source/locale/en/symbols.dic).
     Note you should translate all the content you copy.
-    - `gestures.ini`: This file doesn't require a base file, gestures can be added as needed.
+    * `gestures.ini`: This file doesn't require a base file, gestures can be added as needed.
 1. Edit the relevant file
-    - Tab to the "edit file" button to open the editor for the file.
-    - If it's your first time doing this, GitHub will ask you to fork this repository.
+    * Tab to the "edit file" button to open the editor for the file.
+    * If it's your first time doing this, GitHub will ask you to fork this repository.
     Click "Fork this repository".
-    - Ensure indentation formatting is using tabs not spaces.
-        - You may need to change the indent mode to tabs.
-        - From the code editor, press `NVDA+space` to switch to browse mode, then press `shift+c` until you get to the "Indent mode" combo-box.
-        - Press `enter` to activate it, then press `downArrow` to select "Tabs".
-        - You can then press `NVDA+space` to switch to browse mode, then `e` to get back to the code editor, and `enter` to focus it in focus mode.
-        - The tab key should then insert the tab character, rather than spaces.
-    - English example: <https://github.com/nvaccess/nvda/edit/beta/source/locale/en/symbols.dic>
-    - Format (replace `{lang}` and `{fileName}`): `https://github.com/nvaccess/nvda/edit/beta/source/locale/{lang}/{fileName}`
-    - Refer to [background](#background) for more information on the format of the files
+    * Ensure indentation formatting is using tabs not spaces.
+        * You may need to change the indent mode to tabs.
+        * From the code editor, press `NVDA+space` to switch to browse mode, then press `shift+c` until you get to the "Indent mode" combo-box.
+        * Press `enter` to activate it, then press `downArrow` to select "Tabs".
+        * You can then press `NVDA+space` to switch to browse mode, then `e` to get back to the code editor, and `enter` to focus it in focus mode.
+        * The tab key should then insert the tab character, rather than spaces.
+    * English example: <https://github.com/nvaccess/nvda/edit/beta/source/locale/en/symbols.dic>
+    * Format (replace `{lang}` and `{fileName}`): `https://github.com/nvaccess/nvda/edit/beta/source/locale/{lang}/{fileName}`
+    * Refer to [background](#background) for more information on the format of the files
 1. Submit your changes
-    - Press `control+s` or the "commit changes" button to open a dialog to save and propose the changes.
-    - Update the commit message to add your language to the end: "Update filename for language"
-    - Press "Propose changes"
-    - A new window should open proposing your changes
-    - The proposal will contain a description with a large template.
+    * Press `control+s` or the "commit changes" button to open a dialog to save and propose the changes.
+    * Update the commit message to add your language to the end: "Update filename for language"
+    * Press "Propose changes"
+    * A new window should open proposing your changes
+    * The proposal will contain a description with a large template.
     Feel free to ignore or delete it.
-    - Press "Create pull request".
+    * Press "Create pull request".
 1. Await feedback from NV Access
-    - NV Access will provide feedback if any further work is required.
-    - You will receive a notification when your proposal is accepted - the request will be merged and closed.
-    - After merging, the changes will become available in [beta builds](https://download.nvaccess.org/snapshots/beta/) for testing.
+    * NV Access will provide feedback if any further work is required.
+    * You will receive a notification when your proposal is accepted - the request will be merged and closed.
+    * After merging, the changes will become available in [beta builds](https://download.nvaccess.org/snapshots/beta/) for testing.
     The changes will also be made available in the next [beta release](https://download.nvaccess.org/releases/beta/).

--- a/projectDocs/translating/readme.md
+++ b/projectDocs/translating/readme.md
@@ -30,8 +30,8 @@ Start by subscribing to the translation list above so that you can get help and 
 
 The current process for translation is split between multiple processes:
 
-- [Crowdin](./crowdin.md) for the NVDA interface and user documentation
-- [Github](./github.md) for Character Descriptions, Symbols and Gestures.
+* [Crowdin](./crowdin.md) for the NVDA interface and user documentation
+* [Github](./github.md) for Character Descriptions, Symbols and Gestures.
 
 Read [Files to be Localized](#files-to-be-localized) to learn the translation for process for these.
 
@@ -46,10 +46,10 @@ If your language is no longer maintained, you can request to be the new maintain
 
 ## Files to be Localized
 
-- nvda.po: NVDA's interface messages, see [Translating using Crowdin](./crowdin.md) for more information.
-- characterDescriptions.dic: names of characters in your language, see [Translating Character Descriptions](https://download.nvaccess.org/documentation/developerGuide.html#characterDescriptions) for more info.
-- symbols.dic: names of symbols and punctuation in your language, see [Translating Symbols](https://download.nvaccess.org/documentation/developerGuide.html#symbolPronunciation) for more information.
-- gestures.ini: remapping of gestures for your language, see [Translating Gestures](https://download.nvaccess.org/documentation/developerGuide.html#TranslatingGestures) for more information.
-- userGuide.md: the User Guide, see [Translating using Crowdin](./crowdin.md) for more information.
-- changes.md (optional): a list of changes between releases, see [Translating using Crowdin](./crowdin.md) for more information.
-- Add-ons (optional, out of date): a set of optional features that users can install, see [Translating Addons](https://github.com/nvaccess/nvda/wiki/TranslatingAddons) for more information.
+* nvda.po: NVDA's interface messages, see [Translating using Crowdin](./crowdin.md) for more information.
+* characterDescriptions.dic: names of characters in your language, see [Translating Character Descriptions](https://download.nvaccess.org/documentation/developerGuide.html#characterDescriptions) for more info.
+* symbols.dic: names of symbols and punctuation in your language, see [Translating Symbols](https://download.nvaccess.org/documentation/developerGuide.html#symbolPronunciation) for more information.
+* gestures.ini: remapping of gestures for your language, see [Translating Gestures](https://download.nvaccess.org/documentation/developerGuide.html#TranslatingGestures) for more information.
+* userGuide.md: the User Guide, see [Translating using Crowdin](./crowdin.md) for more information.
+* changes.md (optional): a list of changes between releases, see [Translating using Crowdin](./crowdin.md) for more information.
+* Add-ons (optional, out of date): a set of optional features that users can install, see [Translating Addons](https://github.com/nvaccess/nvda/wiki/TranslatingAddons) for more information.

--- a/source/UIAHandler/_remoteOps/readme.md
+++ b/source/UIAHandler/_remoteOps/readme.md
@@ -1,11 +1,14 @@
 # UI Automation Remote Operations for NVDA
 
 ## Introduction
+
 If you have code that makes more than a few UI Automation calls all in a row, you may want to consider rewriting the code as a Remote Operation.
 This will allow Windows to execute the code all in one cross-process call, thereby significantly speeding up execution.
 
 Following is a simple example of a remote operation.
+
 ### Example 1: Fetching the names of all ancestors of a UI Automation element
+
 ```py
 import api
 from UIAHandler import UIA
@@ -45,10 +48,12 @@ print(f"{names=}")
 ```
 
 ## Building a remote operation
+
 To build a remote operation, you define a function decorated by the `Operation.buildFunction` decorator.
 This function must take a `RemoteAPI` object as its one and only argument.
 The function will use methods on the `RemoteAPI` object to declare all its actions and logic.
 Avoid using any other APIs, function calls or control flow.
+
 ```py
 op = Operation()
 @op.buildFunction
@@ -57,7 +62,9 @@ def code(ra: RemoteAPI):
 ```
 
 ### Returning values
+
 To return a value or values from a remote operation, use the `ra.Return` method, passing one or more remote values as arguments:
+
 ```py
 op = Operation()
 @op.buildFunction
@@ -72,22 +79,27 @@ Note that all build functions must return at least one value.
 Otherwise, `Operation.execute` will raise a `NoReturnException`.
 
 ### All operations require at least one element or text range
+
 The primary reason for writing a remote operation is to perform actions upon one or more UI automation elements or text ranges.
 And as a remote operation is executed in a remote provider, it needs to be connection bound, meaning that it needs to be associated with at least one element or text range from that provider process.
 Therefore, all remote operations require at least one element (via ra.newElement) or text range (via ra.newTextRange) to be declared.
 Also, all elements and text ranges in the operation must be from the same provider process.
 
 ### Declarative style and control flow
+
 When building a remote operation, the actions are specified in a declarative style.
 In other words, the code internally builds up a set of low-level instructions under the hood which will later be executed remotely.
 This is most evident when specifying control flow such as a while loop:
+
 ```py
 counter = ra.newInt(0)
 with ra.whileBlock(lambda: counter < 5):
 	counter += 1
 ```
+
 From Python's point of view, the body of the declared while loop is only run once, as it is only being declared, not executed.
 Similarly, for if-else blocks:
+
 ```py
 condition = ra.newBool(True)
 with ra.ifblock(condition):
@@ -102,9 +114,11 @@ But the most important thing to remember here is that you should avoid using any
 The remote API has all the control flow you need, such as ifBlock, elseBlock, whileBlock, tryBlock, again covered in later sections.
 
 ### Method arguments
+
 When providing arguments to methods, you can use remote values previously declared in the operation, or you can use literal Python values.
 When using literal Python values, these will be automatically remoted as special constant values for you.
 For example:
+
 ```py
 textRange = ra.newTextRange(UIATextRange)
 textRange.move(TextUnit_Word, 1)
@@ -113,8 +127,11 @@ textRange.move(TextUnit_Word, 1)
 In this example, the values TextUnit_Word and 1 will be automatically remoted.
 
 ### Basic remote types
+
 #### Equality checks
+
 All types support equality checks:
+
 ```py
 i = ra.newBool(True)
 j = ra.newBool(False)
@@ -122,7 +139,9 @@ k = i == j
 ```
 
 #### Setting a specific value
+
 All types have a `set` method which allows you to set the remote variable to a specific value:
+
 ```py
 i = ra.newBool(False)
 # i is initialised as false.
@@ -134,13 +153,16 @@ For most types, `set` will copy the value, i.e. setting `a` to `b` and then mani
 However, for certain types such as elements, text ranges and arrays, these are held by reference and therefore manipulating the value it was set two will change the underlying object for both variables.
 
 #### Booleans
+
 ```py
 a = ra.newBool(True)
 b = ra.newBool(False)
 ```
 
 ##### Logical operators
+
 Booleans support logical operations:
+
 * and: `a & b`
 * or: `a | b`
 * Inverse: `a.inverse()`
@@ -149,7 +171,9 @@ Unfortunately the Python language does not allow overriding `!=`, `and` and `or`
 Thus why the above operators were chosen.
 
 #### Ints and floats
+
 Remote operations support declaring and manipulating int and float types.
+
 ```py
 myInt = ra.newInt(5)
 myFloat = ra.newFloat(7.2)
@@ -160,8 +184,10 @@ There is also unsigned int (`ra.newUint`) but the only place you may need to use
 Please note that remote operations do not allow ints and floats to be converted to one another.
 
 ##### Arithmetic
+
 Ints, uints and floats all support the standard arithmetic operations: add, subtract, multiply, divide and modulo.
 There are both binary and in-place operators for these.
+
 ```py
 i = ra.newInt(5)
 j = ra.newInt(6)
@@ -183,7 +209,9 @@ o %= j
 ```
 
 ##### Comparison operators
+
 Ints and floats support comparisons, returning a boolean: less, less equals, equals, greater equals and greater.
+
 ```py
 i = ra.newInt(5)
 j = ra.newInt(6)
@@ -195,12 +223,15 @@ o = i > j
 ```
 
 #### Strings
+
 ```py
 s = ra.newString("Hello")
 ```
 
 ##### Concatenation
+
 Strings can be concatenated to create a new string:
+
 ```py
 s = ra.newString("Hello ")
 t = ra.newString("world")
@@ -208,6 +239,7 @@ u = s + t
 ```
 
 Or they can be concatenated in-place:
+
 ```py
 s = ra.newString("Hello ")
 t = ra.newString("world")
@@ -215,14 +247,19 @@ s += t
 ```
 
 ### UIA elements
+
 #### Declaring an element
+
 To create a new remote element, call `ra.newElement`, giving it an existing `IUIAutomationElement` comtypes pointer as its argument:
+
 ```py
 element = ra.newElement(UIAElement)
 ```
 
 #### Fetching element properties
+
 To fetch properties from an element, use `getPropertyValue`:
+
 ```py
 name = element.getPropertyValue(UIA_NamePropertyId)
 controlType = element.getPropertyValue(UIA_ControlTypePropertyId)
@@ -231,7 +268,9 @@ controlType = element.getPropertyValue(UIA_ControlTypePropertyId)
 Any of the standard UI Automation property IDs can be used here.
 
 #### Navigating the element tree
+
 To navigate to other elements in the tree from this element, use the following methods on the element:
+
 * `getParentElement`
 * `getFirstchildElement`
 * `getLastChildElement`
@@ -239,7 +278,9 @@ To navigate to other elements in the tree from this element, use the following m
 * `getNextSiblingElement`
 
 #### Pointing to another element
+
 To make an element point to another physical UI Automation element, call its `set` method with another remote element as an argument:
+
 ```py
 parent = element.getParentElement()
 element.set(parent)
@@ -248,8 +289,11 @@ element.set(parent)
 This is useful when walking the element tree in a loop.
 
 ### UI Automation text ranges
+
 #### Declaring a text range
+
 To create a new remote text range, call `ra.newTextRange`, giving it an existing IUIAutomationTextRange comtypes pointer as its argument:
+
 ```py
 textRange = ra.newElement(UIATextRange)
 ```
@@ -257,7 +301,9 @@ textRange = ra.newElement(UIATextRange)
 Note that under the hood the text range is automatically cloned after it has been remoted, so that any manipulation of the remote text range (such as moving its ends) is not reflected in the original IUIAutomationTextRange you gave it.
 
 #### Retrieving text, comparison and manipulation
+
 The majority of methods found on `IUIAutomationTextRange` are available on remote text ranges, including:
+
 * `getText`
 * `compareEndpoints`
 * `moveEndpointByUnit`
@@ -268,6 +314,7 @@ The majority of methods found on `IUIAutomationTextRange` are available on remot
 
 Refer to the `RemoteTextRange` class in remoteAPI.py, or official [IUIAutomationTextRange documentation](https://learn.microsoft.com/en-us/windows/win32/api/uiautomationclient/nn-uiautomationclient-iuiautomationtextrange) for all the call signatures.
 But as an example, here is an algorithm that can count the number of words in a text range:
+
 ```py
 wordCount = ra.newInt(0)
 textRange = ra.newTextRange(UIATextRange)
@@ -282,10 +329,12 @@ ra.Return(wordcount)
 ```
 
 #### Text range logical adapter to improve logic and readability
+
 The verboseness of many of the compare and move text range methods can make it hard to quickly read the code and gain a good idea of what the algorithm is actually doing.
 It is also quite tricky to write an algorithm that is easily reversed.
 Therefore remote text ranges have a `getLogicalAdapter` method, taking a single boolean `reverse` argument which returns a special object which wraps a remote text range, and provides friendly start and end properties, which take the reversal into account.
 Here is an example of how you could write an algorithm to fetch the first 20 words in the text range, either from the start or end:
+
 ```py
 textRange = ra.newTextRange(UIATextRange)
 words = ra.newArray()
@@ -320,13 +369,16 @@ They can also be compared with `<`, `<=`, `==`, `>=`, and `>`.
 If you still want the comparison delta (like with `compareEndpoints`), the properties also have a `compareWith` method, which takes another endpoint and gives back a number less than 0, equal to 0 or greater than 0.
 
 ### control flow
+
 The remoteAPI object has methods for control flow that return Python context managers, so that they can be used as `with` statements.
 
 #### if-else
+
 To conditionally perform actions, place them in a `with` statement using `ra.ifBlock`.
 `ifBlock` takes one argument, which is a remote boolean.
 If this argument is evaluated to True during execution, then the actions within the `with` statement are executed.
 An optional `with` statement using `ra.elseBlock` can directly follow the `ifBlock` `with` statement, and if the condition evaluates to False, then the actions within the `elseBlock` `with` statement will be executed instead.
+
 ```py
 i = ra.newInt(5)
 j = ra.newInt(6)
@@ -337,8 +389,10 @@ with ra.elseBlock():
 ```
 
 #### While loops
+
 To keep performing some actions while a condition is True, place the actions in a `with` statement using `ra.whileBlock`.
 `whileBlock` takes one argument, which is a lambda that will return a remote boolean.
+
 ```py
 counter = ra.newInt(0)
 with ra.whileBlock(lambda: counter < 5):
@@ -352,10 +406,12 @@ Please note that the condition of the while loop must be placed in a lambda as i
 If this was not done, the instructions that produced the final boolean condition would appear before the loop and never get re-run on subsequent iterations.
 
 #### try-catch
+
 If an action causes an error, it is possible to catch the error by placing those actions in a `with` statement using the `ra.tryBlock` method.
 When using `ra.tryBlock`, a second `with` statement using `ra.catchBlock` must follow straight after.
 If an error occurs within the `tryBlock` `with` statement, then execution jumps to the `catchBlock` `with` statement.
 You can capture the exact error code as the value of the `with` statement.
+
 ```py
 with ra.tryBlock():
 	# do stuff...
@@ -367,16 +423,21 @@ If it is an element or text range method that causes the error, the error code w
 Other errors such as divide by 0 have their own error codes.
 
 ### Higher-level algorithms
+
 #### Looping over a range of numbers
+
 Although you can use a while loop and a counter to loop over a range of numbers, the library provides a helper method `ra.forEachNumInRange` which takes start, stop, and optional step arguments.
 This method can be used in a `with` statement to loop over a range of numbers like so:
+
 ```py
 with ra.forEachNumInRange(0, 10, 2) as num:
 	# do something with num
 ```
 
 #### Looping over arrays
+
 To simplifying looping over each item in an array, the library provides `ra.forEachItemInArray` which can be used in a `with` statement like such:
+
 ```py
 array = ra.newArray()
 # Populate the array...
@@ -386,12 +447,14 @@ with ra.forEachItemInArray(array) as item:
 ```
 
 ## Executing an operation
+
 Once an operation is built, you will want to actually execute it on the remote provider.
 To execute the operation, call `Operation.execute`.
 This method takes no arguments, and returns any values previously returned with `ra.Return`.
 These values are brought back to NVDA and converted to real Python types.
 
 ### Instruction limits
+
 So as to not freeze a remote provider, Microsoft has placed a limit on how many instructions can be executed for one operation.
 Currently this limit is 10,000.
 This seems a lot, but once you are dealing with many while loop iterations containing a lot of actions, it is very easy to to hit this limit.
@@ -401,14 +464,17 @@ Assuming your algorithm was written appropriately, you could then re-execute it,
 To aide in writing algorithms that can handle this instruction limit and continue to execute where it left off, there are several features of this Remote Operations library that can be used.
 
 #### Automatic retry
+
 `Operation.execute` takes a `maxTries` keyword argument which is set to 1 by default, meaning that the operation will only be executed once, and if the instruction  limit is hit, then `InstructionLimitExceededException` is raised.
 However, if `maxTries` is greater than 1, `Operation.execute` will automatically retry  more times until the operation executes without hitting the limit, or when `maxTries` is reached.
 
 This in itself however is not too useful unless some other changes are made to the algorithm itself, so that it is suitable for running multiple times by remembering where it left off.
 
 #### Static values
+
 Most `ra.newXXX` methods take a `static` keyword argument which is set to `False` by default.
 However, if set to `True`, subsequent executions of the operation will initialize the value to what it was when the last execution finished.
+
 ```py
 counter = ra.newInt(0, static=True)
 with ra.whileBlock(lambda: counter < 20000):
@@ -426,11 +492,13 @@ Also, currently it is impossible to mark arrays as `static`, as arrays cannot be
 Again, in future the library could be extended to support this, but it would involve having to marshal out all items, and marshal them back in, appending them to the array one at a time, which would also be costly.
 
 #### Building iterable functions
+
 A common use of remote operations is to walk a text range or element tree, and collect data which would be returned in an array.
 However, as arrays can not be marked as `static`, this would involve a lot of extra code to handle execution continuation after the instruction limit is reached.
 Therefore the library supports a `Operation.buildIterableFunction` decorator, which can be used in place of `Operator.buildFunction`.
 Within a function that uses this decorator, rather than using ra.Return to return value and halt, you can use `ra.Yield` which will yield a value and continue to execute (until the instruction limit is reached of course).
 To actually execute an iterable function though, instead of using `Operation.execute`, you use `Operation.iterExecute` as the generator to a `for` loop, which will iterate over the yielded values.
+
 ```py
 op = Operation()
 
@@ -451,13 +519,16 @@ The above example will print 0, 1000, 2000, 3000...
 Although the `for` loop will see each yielded value separately, they will only physically yield either when the instruction limit is reached, and or when the execution finally reaches the end, which still means that as many actions as possible are executed in one cross-process call.
 
 ## Debugging
+
 It can be tricky to debug a remote operation as it executes in the remote provider.
 Therefore the library contains several features which can help.
 
 ### Dumping instructions
+
 The library can dump all the instructions to NVDA's log each time an operation is built, by setting the Operation's `enableCompiletimeLogging` keyword argument to True.
 Even if left as False, instructions will still be automatically dumped to NVDA's log if there is an uncaught error while executing, or the instruction limit is reached and it has run out of tries.
 Following is code for a simple remote operation, followed by a dump of its instructions.
+
 ```py
 counter = ra.newInt(0, static=True)
 with ra.whileBlock(lambda: counter < 20000):
@@ -467,6 +538,7 @@ with ra.whileBlock(lambda: counter < 20000):
 ```
 
 And now the instruction dump:
+
 ```
 --- Begin ---
 static:
@@ -522,6 +594,7 @@ main:
 ```
 
 Looking at the dump we can see the library stores instructions in three specific sections:
+
 * `static`: for initializing static instructions. this section is replaced before each execution.
 * `const`: This section holds values which have been automatically remoted, and are used through out the rest of the instructions.
 * `main`: the instructions implementing the main logic of the operation.
@@ -533,10 +606,12 @@ We can see that yielding values is actually implemented by the library internall
 and finally, we can see that the modulo (%) operator is actually emulated by the equation: `a - (a / b) * b`, as the low-level remote operations framework does not actually support modulo.
 
 ### Adding compiletime comments
+
 It is possible to add comments to the instruction dump when building an operation by using `ra.addCompiletimeComment`.
 It takes a single argument which is a literal string value.
 
 ### Runtime remote logging
+
 Setting an Operation's `enableRuntimeLogging` keyword argument to True enables remote logging at execution time.
 `ra.logRuntimeMessage` can be called to log a message at runtime.
 It takes one or more literal strings and or remote values, and concatinates them together remotely.
@@ -546,6 +621,7 @@ After the operation is executed, the remote log is marshalled back and dumped to
 Though be aware that as remote logging itself involves creating and manipulating remote values, then the number of instructions can change quite significantly with remote logging enabled.
 
 ### Local mode
+
 When unit testing this library, or in a scenario where remote operations is unavailable but you want to use the exact same algorithm but locally, you can set the Operation's `localMode` keyword argument to True.
 This causes all instructions to be executed locally, rather than in a remote provider.
 This will of course be significantly slower, as every instruction that manipulates an element or text range will be itself one cross-process call.

--- a/source/brailleDisplayDrivers/albatross/readme.md
+++ b/source/brailleDisplayDrivers/albatross/readme.md
@@ -67,9 +67,9 @@ use status cells at the moment.
 
 ## Driver requirements
 
-- support for both 46 and 80 cells models
-- support for both automatic and manual detection
-- when connected allows device plugging out and in, and power switching off and
+* support for both 46 and 80 cells models
+* support for both automatic and manual detection
+* when connected allows device plugging out and in, and power switching off and
 on so that display content is up-to-date and buttons work as expected after
 these operations.
 
@@ -86,10 +86,10 @@ to format data which is meant to be displayed on the braille line.
 
 Important main functions of `BrailleDisplayDriver` are:
 
-- `_readHandling`; performs connecting/reconnecting to the device, and all read
+* `_readHandling`; performs connecting/reconnecting to the device, and all read
 operations during connection
-- `_somethingToWrite`; performs all write operations to the display
-- `display`; prepares data to be displayed on the braille line
+* `_somethingToWrite`; performs all write operations to the display
+* `display`; prepares data to be displayed on the braille line
 
 In `gestures.py` numeric values of pressed buttons are interpreted as gestures
 so that they can be forwarded to NVDA input system.

--- a/source/brailleDisplayDrivers/albatross/readme.md
+++ b/source/brailleDisplayDrivers/albatross/readme.md
@@ -1,8 +1,8 @@
-## Albatross
+# Albatross
 
 This module contains driver for Caiku Albatross 46 and 80 braille displays.
 
-### General
+## General
 
 Different to many other displays, Albatross models do not wait for the driver
 to send a query of their presence to the device. Instead, the device continuously sends
@@ -65,7 +65,7 @@ length of display (0 for 46 and 1 for 80 cells model).
 Note: This driver ignores status cells related settings because NVDA does not
 use status cells at the moment.
 
-### Driver requirements
+## Driver requirements
 
 - support for both 46 and 80 cells models
 - support for both automatic and manual detection
@@ -73,7 +73,7 @@ use status cells at the moment.
 on so that display content is up-to-date and buttons work as expected after
 these operations.
 
-### Design
+## Design
 
 Driver has modular structure:
 

--- a/source/comInterfaces/readme.md
+++ b/source/comInterfaces/readme.md
@@ -1,3 +1,5 @@
+# COM Interfaces
+
 The comInterfaces package is generated via SCons.
 The logic for this is in `comInterfaces_sconscript`, which uses `comtypes.gen` to read `*.tlb`
 files or via interface IDs.

--- a/source/fonts/readme.md
+++ b/source/fonts/readme.md
@@ -1,19 +1,17 @@
-## Fonts
+# Fonts
 
 This folder contains fonts (and their projects files) used by NVDA.
 
-### FreeMono-FixedBraille.ttf
+## FreeMono-FixedBraille.ttf
 
 This font is based on the `FreeMono.ttf` font in the `freefont-20100919-ttf` folder.
-Its fontforge project is `freeMono-fixedBraille.sfd`
+Its fontforge project is `freeMono-fixedBraille.sfd`.
 
 Many of the braille characters in `FreeMono.ttf` were offset (in different directions).
-This meant that the characters appeared to jump around when they were updated, such as when displaying the caret
-position.
+This meant that the characters appeared to jump around when they were updated, such as when displaying the caret position.
 This font, `FreeMono-FixedBraille.ttf`, adjusts all braille characters to a common position.
 The dot positions are based on the final 8 dot braille character, ⣿ (all pins up) `U+28FF`.
 
-### Editing
+## Editing
 
-The free outline font editor, George Williams's FontForge
-https://github.com/fontforge/fontforge/releases is used for editing the fonts via the `*.sfd` file.
+The free outline font editor, George Williams's FontForge <https://github.com/fontforge/fontforge/releases> is used for editing the fonts via the `*.sfd` file.

--- a/source/visionEnhancementProviders/readme.md
+++ b/source/visionEnhancementProviders/readme.md
@@ -1,10 +1,11 @@
-## Vision Enhancement Providers
+# Vision Enhancement Providers
 
 These modules use the "vision framework" to augment visual information presented to the user.
 For more information about the implementation of a provider see vision.providerBase.VisionEnhancementProvider
 (in source/vision/providerBase.py)
 
 Two of the built-in examples are:
+
 - NVDA Highlighter which will react to changes in focus and draw a rectangle outline around the focused object.
 - Screen Curtain which when enabled makes the screen black for privacy reasons.
 
@@ -22,21 +23,21 @@ VisionEnhancementProvider = MyProviderClass
 print(VisionEnhancementProvider.__qualname__) # prints: MyProviderClass
 ```
 
-### Provider settings
+## Provider settings
 
 Providers must provide an VisionEnhancementProviderSettings object (via VisionEnhancementProvider.getSettings).
 This VisionEnhancementProviderSettings instance then provides the DriverSettings objects via the supportedSettings
 property.
 These are used to save / load settings for the provider.
 
-### Providing a GUI
+## Providing a GUI
 
 A GUI can be built automatically from the DriverSettings objects accessed via the VisionEnhancementProviderSettings.
 Alternatively the provider can supply a custom settings panel implementation via the getSettingsPanelClass class method.
 A custom settings panel must return a class type derived from `gui.settingsDialogs.SettingsPanel` which will take responsibility for building the GUI.
 For an example see NVDAHighlighter or ScreenCurtain.
 
-#### Automatic GUI building
+### Automatic GUI building
 
 The provider settings (described above) are also used to automatically construct a GUI for the provider when
 getSettingsPanelClass returns None.

--- a/source/visionEnhancementProviders/readme.md
+++ b/source/visionEnhancementProviders/readme.md
@@ -6,8 +6,8 @@ For more information about the implementation of a provider see vision.providerB
 
 Two of the built-in examples are:
 
-- NVDA Highlighter which will react to changes in focus and draw a rectangle outline around the focused object.
-- Screen Curtain which when enabled makes the screen black for privacy reasons.
+* NVDA Highlighter which will react to changes in focus and draw a rectangle outline around the focused object.
+* Screen Curtain which when enabled makes the screen black for privacy reasons.
 
 A vision enhancement provider module should have a class called `VisionEnhancementProvider`.
 To make identifying a provider that is causing errors easier, name your provider class something descriptive and set

--- a/tests/manual/hardware/hardwareSupport.md
+++ b/tests/manual/hardware/hardwareSupport.md
@@ -7,9 +7,9 @@ NVDA is currently migrating to only 64bit hardware support, and currently recomm
 
 ## Notes
 
-- Ensure all test results are documented, including screenshots or logs for failures.
-- Focus on identifying edge cases and compatibility issues during the migration process.
-- Prioritize testing on hardware configurations most commonly used by NVDA users.
+* Ensure all test results are documented, including screenshots or logs for failures.
+* Focus on identifying edge cases and compatibility issues during the migration process.
+* Prioritize testing on hardware configurations most commonly used by NVDA users.
 
 ## Generic Steps
 
@@ -23,28 +23,28 @@ Test using Edge, Notepad and the NVDA GUI.
 
 ARM Variations to consider:
 
-- ARMv8 Architecture
-- ARMv9 Architecture
-- ARM A-Profile (Application Profile): ARMv9-A and ARMv8-A
-- ARM R-Profile (Real-Time Profile): ARMv8-R
-- ARM M-Profile (Microcontroller Profile): ARMv8-M
-- Custom ARM Implementations (e.g., vendor-specific modifications of ARM cores)
+* ARMv8 Architecture
+* ARMv9 Architecture
+* ARM A-Profile (Application Profile): ARMv9-A and ARMv8-A
+* ARM R-Profile (Real-Time Profile): ARMv8-R
+* ARM M-Profile (Microcontroller Profile): ARMv8-M
+* Custom ARM Implementations (e.g., vendor-specific modifications of ARM cores)
 
 ### 2. x64 Hardware
 
 x64 variations to consider:
 
-- AMD64
-- Intel 64
+* AMD64
+* Intel 64
 
 ### 3. Virtual Machines
 
 Virtual Machines to consider:
 
-- Hyper-V
-- VirtualBox
-- VMWare
-- Parallels
+* Hyper-V
+* VirtualBox
+* VMWare
+* Parallels
 
 ### 4. CoPilot PCs
 
@@ -54,5 +54,5 @@ CoPilot PCs use a new form of architecture known as an NPU.
 
 1. Run the NVDA installer on 32-bit hardware.
 2. Observe and document the results.
-    - Expected Result using 64bit NVDA: Installation fails gracefully with a clear message indicating that 32-bit systems are no longer supported.
-    - Expected Result using 32bit NVDA: Installation occurs successfully
+    * Expected Result using 64bit NVDA: Installation fails gracefully with a clear message indicating that 32-bit systems are no longer supported.
+    * Expected Result using 32bit NVDA: Installation occurs successfully

--- a/tests/manual/hardware/updatingTo64bit.md
+++ b/tests/manual/hardware/updatingTo64bit.md
@@ -7,8 +7,8 @@ Verify proper cleanup of the x86 directory and ensure 32-bit Windows systems do 
 
 ## Additional Notes
 
-- Ensure testing on various Windows versions (i.e. Windows 8.1, Windows 10 and Windows 11).
-- Validate that user settings and configurations are preserved during the update process.
+* Ensure testing on various Windows versions (i.e. Windows 8.1, Windows 10 and Windows 11).
+* Validate that user settings and configurations are preserved during the update process.
 
 ## Test Cases
 
@@ -16,8 +16,8 @@ Verify proper cleanup of the x86 directory and ensure 32-bit Windows systems do 
 
 #### Preconditions
 
-- Install a 32-bit version of NVDA on a 64-bit Windows system.
-- Consider testing both the last 32-bit version of NVDA and a significantly older 32-bit version of NVDA.
+* Install a 32-bit version of NVDA on a 64-bit Windows system.
+* Consider testing both the last 32-bit version of NVDA and a significantly older 32-bit version of NVDA.
 
 #### Steps
 
@@ -30,15 +30,15 @@ Verify proper cleanup of the x86 directory and ensure 32-bit Windows systems do 
 
 #### Expected Results
 
-- The update completes without errors.
-- The x86 directory is cleaned up.
-- NVDA runs as a 64-bit application.
+* The update completes without errors.
+* The x86 directory is cleaned up.
+* NVDA runs as a 64-bit application.
 
 ### 2. Update on 32-bit Windows
 
 #### Preconditions
 
-- Install the 32-bit version of NVDA on a 32-bit Windows system.
+* Install the 32-bit version of NVDA on a 32-bit Windows system.
 
 #### Steps
 
@@ -47,14 +47,14 @@ Verify proper cleanup of the x86 directory and ensure 32-bit Windows systems do 
 
 #### Expected Results
 
-- No update prompt is displayed for the 64-bit version.
-- NVDA continues to function as a 32-bit application.
+* No update prompt is displayed for the 64-bit version.
+* NVDA continues to function as a 32-bit application.
 
 ### 3. Manual Installation of 64-bit NVDA on 32-bit Windows
 
 #### Preconditions
 
-- Use a 32-bit Windows system.
+* Use a 32-bit Windows system.
 
 #### Steps
 
@@ -63,5 +63,5 @@ Verify proper cleanup of the x86 directory and ensure 32-bit Windows systems do 
 
 #### Expected Results
 
-- The installer prevents the installation of the 64-bit version on a 32-bit system.
-- An appropriate error message is displayed.
+* The installer prevents the installation of the 64-bit version on a 32-bit system.
+* An appropriate error message is displayed.

--- a/tests/manual/nvdaUI/addonStore.md
+++ b/tests/manual/nvdaUI/addonStore.md
@@ -96,8 +96,8 @@ Add-ons can be filtered by display name, publisher and description.
 
 1. Start the install of an incompatible add-on bundle.
 You can do this by:
-    - opening an `.nvda-addon` file while NVDA is running
-    - using the "install from external source" button
+    * opening an `.nvda-addon` file while NVDA is running
+    * using the "install from external source" button
 1. Confirm the warning message about add-on compatibility.
 1. Proceed with the installation.
 
@@ -131,24 +131,24 @@ This process allows you to mock an update for an add-on.
 For example: "Clock".
 1. Go to the "addons" folder in your [NVDA user configuration folder](#editing-user-configuration)
 1. To mock an old release, we need to edit 2 files:
-    - Add-on Store JSON metadata
-        - Example: `source\userConfig\addons\clock.json`
-        - Edit "addonVersionNumber" and "addonVersionName": decrease the major release value number.
-    - Add-on manifest
-        - Example: `source\userConfig\addons\clock\manifest.ini`
-        - Edit "version": decrease the major release value number to match earlier edits.
+    * Add-on Store JSON metadata
+        * Example: `source\userConfig\addons\clock.json`
+        * Edit "addonVersionNumber" and "addonVersionName": decrease the major release value number.
+    * Add-on manifest
+        * Example: `source\userConfig\addons\clock\manifest.ini`
+        * Edit "version": decrease the major release value number to match earlier edits.
 
 #### Using a script
 
 1. [Install an add-on from the Add-on Store](#install-add-on)
 For example: "Clock".
 1. From PowerShell, call the following script to make the add-on updatable.
-   - `tests\manual\nvdaUI\createUpdatableAddons.ps1 $addonName $configPath`
-   - Replace `$configPath` with your [NVDA user configuration folder](#editing-user-configuration).
+   * `tests\manual\nvdaUI\createUpdatableAddons.ps1 $addonName $configPath`
+   * Replace `$configPath` with your [NVDA user configuration folder](#editing-user-configuration).
    This script defaults to using the installed user config folder in `%APPDATA%`.
-   - Example when running from source: `tests\manual\nvdaUI\createUpdatableAddons.ps1 clock source\userConfig`
-   - Example when running an installed copy: `tests\manual\nvdaUI\createUpdatableAddons.ps1 clock`
-   - Note this script sets the add-on version to 0.0.0.
+   * Example when running from source: `tests\manual\nvdaUI\createUpdatableAddons.ps1 clock source\userConfig`
+   * Example when running an installed copy: `tests\manual\nvdaUI\createUpdatableAddons.ps1 clock`
+   * Note this script sets the add-on version to 0.0.0.
 
 ### Updating from add-on originally installed via Add-on Store
 
@@ -163,12 +163,12 @@ For example: "Clock".
 For example: "Clock".
 1. Go to the "addons" folder in your [NVDA user configuration folder](#editing-user-configuration)
 1. To mock an externally loaded older release, we need to edit 2 files:
-   - Add-on Store JSON metadata
-     - Example: `source\userConfig\addons\clock.json`
-     - Delete this file.
-   - Add-on manifest
-     - Example: `source\userConfig\addons\clock\manifest.ini`
-     - Edit "version": decrease the major release value number to match earlier edits.
+   * Add-on Store JSON metadata
+     * Example: `source\userConfig\addons\clock.json`
+     * Delete this file.
+   * Add-on manifest
+     * Example: `source\userConfig\addons\clock\manifest.ini`
+     * Edit "version": decrease the major release value number to match earlier edits.
 1. Open the add-on store
 1. Ensure the same add-on you edited is available on the add-on store with the status "update".
 1. Install the add-on again to test the "update" path.
@@ -182,12 +182,12 @@ This means using the latest add-on store version might be a downgrade or sidegra
 For example: "Clock".
 1. Go to the "addons" folder in your [NVDA user configuration folder](#editing-user-configuration)
 1. To mock an externally loaded release, with an invalid version, we need to edit 2 files:
-    - Add-on Store JSON metadata
-        - Example: `source\userConfig\addons\clock.json`
-        - Delete this file.
-    - Add-on manifest
-        - Example: `source\userConfig\addons\clock\manifest.ini`
-        - Edit "version": to something invalid e.g. "foo".
+    * Add-on Store JSON metadata
+        * Example: `source\userConfig\addons\clock.json`
+        * Delete this file.
+    * Add-on manifest
+        * Example: `source\userConfig\addons\clock\manifest.ini`
+        * Edit "version": to something invalid e.g. "foo".
 1. Open the add-on store
 1. Ensure the same add-on you edited is available on the add-on store with the status "Migrate to add-on store".
 1. Install the add-on again to test the "migrate" path.
@@ -223,9 +223,9 @@ For example: "Clock".
         ```
 
 1. Test various buttons:
-    - Press "Update All": Ensure NVDA installs the add-ons.
-    - Press "Close": Ensure that NVDA prompts for restart if any add-ons have been installed, enabled, disabled or removed
-    - Press "Open Add-on Store": Ensure NVDA opens to the Updatable tab in the Add-on Store
+    * Press "Update All": Ensure NVDA installs the add-ons.
+    * Press "Close": Ensure that NVDA prompts for restart if any add-ons have been installed, enabled, disabled or removed
+    * Press "Open Add-on Store": Ensure NVDA opens to the Updatable tab in the Add-on Store
 
 ### Automatic updating
 
@@ -292,9 +292,9 @@ There are several scenarios which need to be tested for updating NVDA with incom
 This is an advanced test scenario which requires 3 versions of NVDA to test with.
 Typically, this requires a contributor creating 3 different versions of the same patch of NVDA, with different versions of `addonAPIVersion.CURRENT` and `addonAPIVersion.BACK_COMPAT_TO`
 
-- X.1 e.g `CURRENT=2023.1`, `BACK_COMPAT_TO=2023.1`
-- X.2 e.g `CURRENT=2023.2`, `BACK_COMPAT_TO=2023.1`
-- (X+1).1 e.g `CURRENT=2024.1`, `BACK_COMPAT_TO=2024.1`
+* X.1 e.g `CURRENT=2023.1`, `BACK_COMPAT_TO=2023.1`
+* X.2 e.g `CURRENT=2023.2`, `BACK_COMPAT_TO=2023.1`
+* (X+1).1 e.g `CURRENT=2024.1`, `BACK_COMPAT_TO=2024.1`
 
 | Test Name | Upgrade from | Upgrade to | Test notes |
 |---|---|---|---|
@@ -310,6 +310,6 @@ Typically, this requires a contributor creating 3 different versions of the same
 
 Where you can find your NVDA user configuration folder:
 
-- For installed copies: `%APPDATA%\nvda`
-- For source copies: `source\userConfig`
-- Inside a portable copy directory: `userConfig`
+* For installed copies: `%APPDATA%\nvda`
+* For source copies: `source\userConfig`
+* Inside a portable copy directory: `userConfig`

--- a/tests/manual/nvdaUI/addonStore.md
+++ b/tests/manual/nvdaUI/addonStore.md
@@ -1,7 +1,9 @@
+# Manual Add-on Store Tests
 
 ## Browsing add-ons
 
 ### Filter add-ons by channel
+
 Add-ons can be filtered by channel: e.g. stable, beta, dev, external.
 
 1. Open the add-on store
@@ -9,6 +11,7 @@ Add-ons can be filtered by channel: e.g. stable, beta, dev, external.
 1. Filter by each channel grouping, ensure expected add-ons are displayed.
 
 ### Filtering by add-on information
+
 Add-ons can be filtered by display name, publisher and description.
 
 1. Open the add-on store
@@ -19,35 +22,38 @@ Add-ons can be filtered by display name, publisher and description.
 1. Ensure the list of add-ons refreshes to all add-ons, unfiltered.
 
 ### Filtering where no add-ons are found
+
 1. Open the add-on store
 1. Jump to the search text field (`alt+s`)
 1. Search for a string which yields no add-ons.
 1. Ensure the add-on information dialog  states "no add-on selected".
 
 ### Browsing incompatible add-ons available for download
+
 1. Open the Add-on Store
 1. Change to the "Available add-ons" tab
 1. Enable the "Include incompatible add-ons" filter
 1. Ensure add-ons with status "incompatible" are included in the list with the available add-ons.
 
 ### Sorting the add-ons list by column
+
 1. Open the Add-on Store
 1. Sort by column:
    1. Using the combo-box:
-     1. Jump to the sort by column field (`alt+m`)
-     1. Select different columns (ascending or descending order)
+      1. Jump to the sort by column field (`alt+m`)
+      1. Select different columns (ascending or descending order)
    1. Alternatively, perform a left mouse click on different columns
 1. Ensure that the add-ons list is sorted accordingly
 1. Change to different tabs, and repeat the previous steps.
 
 ### Failure to fetch add-ons available for download
+
 1. Disable your internet connection
 1. Go to your [NVDA user configuration folder](#editing-user-configuration)
 1. To delete the current cache of available add-on store add-ons, delete the file: `addonStore\_cachedCompatibleAddons.json`
 1. Open the Add-on Store
 1. Ensure a warning is displayed: "Unable to fetch latest compatible add-ons"
 1. Ensure installed add-ons are still available in the add-on store.
-
 
 ## Installing add-ons
 
@@ -87,6 +93,7 @@ Add-ons can be filtered by display name, publisher and description.
 1. Proceed with the installation.
 
 ### Install and override incompatible add-on from external source
+
 1. Start the install of an incompatible add-on bundle.
 You can do this by:
     - opening an `.nvda-addon` file while NVDA is running
@@ -95,6 +102,7 @@ You can do this by:
 1. Proceed with the installation.
 
 ### Enable and override compatibility for an installed add-on
+
 1. Browse incompatible disabled add-ons in the add-on store
 1. Press enable on a disabled add-on
 1. Confirm the warning message about add-on compatibility.
@@ -103,12 +111,12 @@ You can do this by:
 1. Confirm the add-on is enabled in the add-ons store
 
 ### Failure to download add-on
+
 1. Open the Add-on Store
 1. Filter by available add-ons.
 1. Disable your internet connection
 1. Press install on a cached add-on
 1. Ensure a warning is displayed: "Unable download add-on"
-
 
 ## Updating add-ons
 
@@ -131,15 +139,16 @@ For example: "Clock".
         - Edit "version": decrease the major release value number to match earlier edits.
 
 #### Using a script
+
 1. [Install an add-on from the Add-on Store](#install-add-on)
 For example: "Clock".
 1. From PowerShell, call the following script to make the add-on updatable.
-  - `tests\manual\nvdaUI\createUpdatableAddons.ps1 $addonName $configPath`
-  - Replace `$configPath` with your [NVDA user configuration folder](#editing-user-configuration).
-  This script defaults to using the installed user config folder in `%APPDATA%`.
-  - Example when running from source: `tests\manual\nvdaUI\createUpdatableAddons.ps1 clock source\userConfig`
-  - Example when running an installed copy: `tests\manual\nvdaUI\createUpdatableAddons.ps1 clock`
-  - Note this script sets the add-on version to 0.0.0.
+   - `tests\manual\nvdaUI\createUpdatableAddons.ps1 $addonName $configPath`
+   - Replace `$configPath` with your [NVDA user configuration folder](#editing-user-configuration).
+   This script defaults to using the installed user config folder in `%APPDATA%`.
+   - Example when running from source: `tests\manual\nvdaUI\createUpdatableAddons.ps1 clock source\userConfig`
+   - Example when running an installed copy: `tests\manual\nvdaUI\createUpdatableAddons.ps1 clock`
+   - Note this script sets the add-on version to 0.0.0.
 
 ### Updating from add-on originally installed via Add-on Store
 
@@ -154,17 +163,18 @@ For example: "Clock".
 For example: "Clock".
 1. Go to the "addons" folder in your [NVDA user configuration folder](#editing-user-configuration)
 1. To mock an externally loaded older release, we need to edit 2 files:
-    - Add-on Store JSON metadata
-        - Example: `source\userConfig\addons\clock.json`
-      - Delete this file.
-    - Add-on manifest
-        - Example: `source\userConfig\addons\clock\manifest.ini`
-        - Edit "version": decrease the major release value number to match earlier edits.
+   - Add-on Store JSON metadata
+     - Example: `source\userConfig\addons\clock.json`
+     - Delete this file.
+   - Add-on manifest
+     - Example: `source\userConfig\addons\clock\manifest.ini`
+     - Edit "version": decrease the major release value number to match earlier edits.
 1. Open the add-on store
 1. Ensure the same add-on you edited is available on the add-on store with the status "update".
 1. Install the add-on again to test the "update" path.
 
 ### Migrating from add-on installed externally with invalid version
+
 This tests a path where an add-on was previously installed, but we are uncertain of the version.
 This means using the latest add-on store version might be a downgrade or sidegrade.
 
@@ -200,14 +210,18 @@ For example: "Clock".
 1. Ensure Automatic update notifications are enabled in the Add-on Store panel
 1. Trigger the update notification manually, or alternatively wait for the notification to occur
     1. From the NVDA Python console, find the scheduled thread
+
         ```py
         import schedule
         schedule.jobs
         ```
+
     1. Replace `i` with the index of the scheduled thread to find the job
+
         ```py
         schedule.jobs[i].run()
         ```
+
 1. Test various buttons:
     - Press "Update All": Ensure NVDA installs the add-ons.
     - Press "Close": Ensure that NVDA prompts for restart if any add-ons have been installed, enabled, disabled or removed
@@ -220,6 +234,7 @@ Full automatic updating is not currently supported.
 ## Other add-on actions
 
 ### Disabling an add-on
+
 1. Find a running add-on in the add-on store
 1. Press the disable button
 1. Exit the add-on store dialog
@@ -227,6 +242,7 @@ Full automatic updating is not currently supported.
 1. Confirm the add-on is disabled in the add-ons store
 
 ### Enabling an add-on
+
 1. Find a disabled add-on in the add-on store
 1. Press the enable button
 1. Exit the add-on store dialog
@@ -234,6 +250,7 @@ Full automatic updating is not currently supported.
 1. Confirm the add-on is disabled in the add-ons store
 
 ### Removing an add-on
+
 1. Find an installed add-on in the add-on store
 1. Press the remove button
 1. Exit the add-on store dialog
@@ -241,6 +258,7 @@ Full automatic updating is not currently supported.
 1. Confirm the add-on is removed in the add-ons store
 
 ### Browse an add-ons help
+
 1. Find an installed add-on in the add-on store
 1. Press the "add-on help" button
 1. A window should open with the help documentation
@@ -260,6 +278,7 @@ Full automatic updating is not currently supported.
 ### Accelerators for other GUI items
 
 For "Action" button and "Other details" text field controls:
+
 1. Check visually that the letter indicating an accelerator key is underlined on the control's label.
 1. Tab to another control and check that `alt+<letter>` allows to move the focus back to the control.
 1. From another control tab to the control and check that `alt+<letter>` is reported.
@@ -272,10 +291,10 @@ For "Action" button and "Other details" text field controls:
 There are several scenarios which need to be tested for updating NVDA with incompatible add-ons.
 This is an advanced test scenario which requires 3 versions of NVDA to test with.
 Typically, this requires a contributor creating 3 different versions of the same patch of NVDA, with different versions of `addonAPIVersion.CURRENT` and `addonAPIVersion.BACK_COMPAT_TO`
+
 - X.1 e.g `CURRENT=2023.1`, `BACK_COMPAT_TO=2023.1`
 - X.2 e.g `CURRENT=2023.2`, `BACK_COMPAT_TO=2023.1`
 - (X+1).1 e.g `CURRENT=2024.1`, `BACK_COMPAT_TO=2024.1`
-
 
 | Test Name | Upgrade from | Upgrade to | Test notes |
 |---|---|---|---|
@@ -290,6 +309,7 @@ Typically, this requires a contributor creating 3 different versions of the same
 ## Editing User Configuration
 
 Where you can find your NVDA user configuration folder:
+
 - For installed copies: `%APPDATA%\nvda`
 - For source copies: `source\userConfig`
 - Inside a portable copy directory: `userConfig`

--- a/tests/manual/nvdaUI/remote.md
+++ b/tests/manual/nvdaUI/remote.md
@@ -8,20 +8,20 @@ Remote  enables remote assistance functionality between two computers running NV
 
 ### Host Configuration
 
-- Windows 11 Pro
-- Memory: at least 16GB
-- Processor: at least 4 core
-- NVDA Version: latest
-- NVDA Remote Version: 2.6.4 (installed via addon store)
+* Windows 11 Pro
+* Memory: at least 16GB
+* Processor: at least 4 core
+* NVDA Version: latest
+* NVDA Remote Version: 2.6.4 (installed via addon store)
 
 ### Guest Configuration
 
-- Another computer similar to the host or VMware Windows 11 Home running on the host with similar specs to the host computer
-- Storage: 64GB disk
-- Memory: 16GB
-- Processor: 8 core
-- NVDA Version: Custom build from <https://github.com/nvda-art/nvda> (remote branch)
-- Base Position: latest
+* Another computer similar to the host or VMware Windows 11 Home running on the host with similar specs to the host computer
+* Storage: 64GB disk
+* Memory: 16GB
+* Processor: 8 core
+* NVDA Version: Custom build from <https://github.com/nvda-art/nvda> (remote branch)
+* Base Position: latest
 
 ## Pre-Test Setup
 

--- a/tests/manual/nvdaUI/startupShutdown.md
+++ b/tests/manual/nvdaUI/startupShutdown.md
@@ -11,7 +11,7 @@ Prerequisites:
 
 Steps:
 
-1. Press (or emulate) Ctrl+Alt+N, observe NVDA starts up
+1. Press (or emulate) `control+alt+n`, observe NVDA starts up
 
 Variation:
 
@@ -62,7 +62,7 @@ Steps:
 Steps:
 
 1. Press `win+r`
-1. Enter \<path to nvda.exe\>
+1. Enter `<path to nvda.exe>`
 1. Press enter
 1. Observe NVDA starts
 

--- a/tests/manual/nvdaUI/startupShutdown.md
+++ b/tests/manual/nvdaUI/startupShutdown.md
@@ -1,78 +1,100 @@
+# Startup / Shutdown Tests
+
 Instructions for testing startup / shutdown.
 
-### Start from shortcut
+## Start from shortcut
+
 Prerequisites:
- - NVDA installed
- - Shortcut enabled during installation
+
+- NVDA installed
+- Shortcut enabled during installation
 
 Steps:
- 1. Press (or emulate) Ctrl+Alt+N, observe NVDA starts up
+
+1. Press (or emulate) Ctrl+Alt+N, observe NVDA starts up
 
 Variation:
+
 - At step 1. A version of NVDA is already running. Observe running version exits before installed version starts up.
 
-### Windows Sign-in screen, automatic start
+## Windows Sign-in screen, automatic start
+
 Prerequisites:
- - NVDA installed
- - Enable "Use NVDA during sign-in"
+
+- NVDA installed
+- Enable "Use NVDA during sign-in"
 
 Steps:
- 1. Sign out (not lock) Windows
- 1. Observe NVDA announces the Windows sign-in screen
 
-### UAC, automatic start
+1. Sign out (not lock) Windows
+1. Observe NVDA announces the Windows sign-in screen
+
+## UAC, automatic start
+
 Prerequisites:
- - NVDA installed
- - An active Windows session (i.e. not signed out, locked)
- - The NVDA installed copy is running
+
+- NVDA installed
+- An active Windows session (i.e. not signed out, locked)
+- The NVDA installed copy is running
 
 Steps:
- 1. Open the Start menu
- 1. Type notepad
- 1. Open context menu for notepad and choose `Run as Administrator`.
- 1. When the UAC dialog appears, verify that NVDA launches on this secure desktop and reports the dialog.
 
-### Windows Successful sign-in, automatic start
+1. Open the Start menu
+1. Type notepad
+1. Open context menu for notepad and choose `Run as Administrator`.
+1. When the UAC dialog appears, verify that NVDA launches on this secure desktop and reports the dialog.
+
+## Windows Successful sign-in, automatic start
+
 Prerequisites:
- - NVDA installed
- - Enable "Start NVDA after I sign in"
+
+- NVDA installed
+- Enable "Start NVDA after I sign in"
 
 Steps:
- 1. Start Windows
- 1. Sign in
- 1. Observe NVDA starts
 
-### Running the *.exe
+1. Start Windows
+1. Sign in
+1. Observe NVDA starts
+
+## Running the *.exe
 
 Steps:
- 1. Press `win+r`
- 1. Enter <path to nvda.exe>
- 1. Press enter
- 1. Observe NVDA starts
+
+1. Press `win+r`
+1. Enter \<path to nvda.exe\>
+1. Press enter
+1. Observe NVDA starts
 
 Variation:
-- using an installer (launcher)
-   -  eg: `C:\Users\username\Downloads\nvda_2021.1.exe`
-- using an installed copy
-   - just type `nvda` in place of the .exe
-- using a portable copy
-   - find and use the path to `nvda.exe`, located within the portable copy directory
-   - the installer allows you to create an installed copy and a portable copy
 
-### Running from source (runnvda.bat)
+- using an installer (launcher)
+  - eg: `C:\Users\username\Downloads\nvda_2021.1.exe`
+- using an installed copy
+  - just type `nvda` in place of the .exe
+- using a portable copy
+  - find and use the path to `nvda.exe`, located within the portable copy directory
+  - the installer allows you to create an installed copy and a portable copy
+
+## Running from source (runnvda.bat)
+
 Prerequisites
+
 - clone project and build NVDA (see [project readme](https://github.com/nvaccess/nvda/blob/master/readme.md#getting-the-source-code)).
 
 Steps:
- 1. Run `runnvda.bat` from cmd
- 1. Observe NVDA starts
 
-### An input gesture to restart
+1. Run `runnvda.bat` from cmd
+1. Observe NVDA starts
+
+## An input gesture to restart
 
 Prerequisite:
+
 - Input gesture for "Restarts NVDA!" is assigned
 
 Steps:
- 1. Press (or emulate) the input gesture
- 1. Observe that NVDA exits
- 1. Observe that a new instance is started
+
+1. Press (or emulate) the input gesture
+1. Observe that NVDA exits
+1. Observe that a new instance is started

--- a/tests/manual/nvdaUI/startupShutdown.md
+++ b/tests/manual/nvdaUI/startupShutdown.md
@@ -6,8 +6,8 @@ Instructions for testing startup / shutdown.
 
 Prerequisites:
 
-- NVDA installed
-- Shortcut enabled during installation
+* NVDA installed
+* Shortcut enabled during installation
 
 Steps:
 
@@ -15,14 +15,14 @@ Steps:
 
 Variation:
 
-- At step 1. A version of NVDA is already running. Observe running version exits before installed version starts up.
+* At step 1. A version of NVDA is already running. Observe running version exits before installed version starts up.
 
 ## Windows Sign-in screen, automatic start
 
 Prerequisites:
 
-- NVDA installed
-- Enable "Use NVDA during sign-in"
+* NVDA installed
+* Enable "Use NVDA during sign-in"
 
 Steps:
 
@@ -33,9 +33,9 @@ Steps:
 
 Prerequisites:
 
-- NVDA installed
-- An active Windows session (i.e. not signed out, locked)
-- The NVDA installed copy is running
+* NVDA installed
+* An active Windows session (i.e. not signed out, locked)
+* The NVDA installed copy is running
 
 Steps:
 
@@ -48,8 +48,8 @@ Steps:
 
 Prerequisites:
 
-- NVDA installed
-- Enable "Start NVDA after I sign in"
+* NVDA installed
+* Enable "Start NVDA after I sign in"
 
 Steps:
 
@@ -68,19 +68,19 @@ Steps:
 
 Variation:
 
-- using an installer (launcher)
-  - eg: `C:\Users\username\Downloads\nvda_2021.1.exe`
-- using an installed copy
-  - just type `nvda` in place of the .exe
-- using a portable copy
-  - find and use the path to `nvda.exe`, located within the portable copy directory
-  - the installer allows you to create an installed copy and a portable copy
+* using an installer (launcher)
+  * eg: `C:\Users\username\Downloads\nvda_2021.1.exe`
+* using an installed copy
+  * just type `nvda` in place of the .exe
+* using a portable copy
+  * find and use the path to `nvda.exe`, located within the portable copy directory
+  * the installer allows you to create an installed copy and a portable copy
 
 ## Running from source (runnvda.bat)
 
 Prerequisites
 
-- clone project and build NVDA (see [project readme](https://github.com/nvaccess/nvda/blob/master/readme.md#getting-the-source-code)).
+* clone project and build NVDA (see [project readme](https://github.com/nvaccess/nvda/blob/master/readme.md#getting-the-source-code)).
 
 Steps:
 
@@ -91,7 +91,7 @@ Steps:
 
 Prerequisite:
 
-- Input gesture for "Restarts NVDA!" is assigned
+* Input gesture for "Restarts NVDA!" is assigned
 
 Steps:
 

--- a/tests/system/readme.md
+++ b/tests/system/readme.md
@@ -1,11 +1,11 @@
-## NVDA system tests
+# NVDA system tests
 
-### Dependencies
+## Dependencies
 
 This build system uses the Robot test framework to execute the system tests.
 Dependencies such as Robot are automatically installed for you when NVDA's build system Python virtual environment is set up, when running any of the high-level commands such as runsystemtests.bat, thus a developer should usually not have to worry about dependencies.
 
-### Running the tests
+## Running the tests
 
 You can run the tests with `runsystemtests.bat --include <TAG>`.
 This will run against the source copy of NVDA.
@@ -21,6 +21,7 @@ runsystemtests --include chrome --test "starts" ...
 
 A shorter alternative for `--include` is `-i`.
 E.G. to run all tests with the chrome tag use:
+
 ```
 runsystemtests -i "chrome" ...
 ```
@@ -30,28 +31,31 @@ Note: For tests based on Chrome, be sure that no previous instance of Chrome is 
 Other options exist for specifying tests to run (e.g. by suite, tag, etc).
 Consult `runsystemtests --help`
 
-### Tags are required
+## Tags are required
 
 Running this script with no arguments won't run any tests, instead an error will be given:
+
 ```
 [ ERROR ] Suite 'Robot' contains no tests matching tag 'fakeTagToEnforceUsageOfInclude' and not matching tag 'excluded from build'.
 ```
+
 This is to prevent accidental running of the installer tests.
 Instead, the tags should be explicitly included, to run all (except installer) tests.
 Examples:
-- All tests tagged with NVDA: `runsystemtests.bat --include NVDA`
-- All Chrome tests: `runsystemtests.bat --include chrome`
+
+* All tests tagged with NVDA: `runsystemtests.bat --include NVDA`
+* All Chrome tests: `runsystemtests.bat --include chrome`
 
 This is implemented by supplying an unused tag `fakeTagToEnforceUsageOfInclude` to RobotFramework via the
 `tests\system\robotArgs.robot` file.
 
-### Getting the results
+## Getting the results
 
 The process is displayed in the command prompt, for more information consider the [Robot report and NVDA logs](#logs)
 `report.html`, `log.html`, and `output.xml` files.
 The logs from NVDA are saved to the `nvdaTestRunLogs` folder
 
-### Excluding tests
+## Excluding tests
 
 It is possible to exclude/disable a flaky test, i.e. intermittent test failures, or a test that needs
 to be disabled until there is time to investigate.
@@ -68,19 +72,19 @@ checkbox labelled by inner element
 When the tests are run, the option `--exclude excluded_from_build` is given to Robot internally.
 See [description of test args](#test-args)
 
-### Test args
+## Test args
+
 Common arguments are kept in the `tests\system\robotArgs.robot` file.
 
-The `whichNVDA` argument allows the tests to be run against an installed copy
-of NVDA (first ensure it is compatible with the tests). Note valid values are:
-* "installed" - when running against the installed version of NVDA, you are likely to get errors in the log unless
-the tests are run from an administrator command prompt.
+The `whichNVDA` argument allows the tests to be run against an installed copy of NVDA (first ensure it is compatible with the tests). Note valid values are:
+
+* "installed" - when running against the installed version of NVDA, you are likely to get errors in the log unless the tests are run from an administrator command prompt.
 * "source"
 
 The `installDir` argument performs a smoke test on the installation process given a path to the installer exe. For example `--variable installDir:".\path\to\nvda_installer.exe"`.
 This should be used with `--variable whichNVDA:installed --include installer`.
 
-### Overview
+## Overview
 
 Robot Framework loads and parses the test files and their libraries.
 In our case, generally in the 'setup', NVDA is started as a new process.
@@ -95,59 +99,63 @@ The `libraries` directory contains files providing "robot keyword" libraries.
 Most notably, the NvdaLib library contains methods for starting NVDA and speech can be retrieved via the `NVDASpyLib` returned by the module function `getSpyLib()` which is a remote library.
 The `nvdaSettingsFiles` directory contains various NVDA config files that are used to construct the NVDA profile in the `%TEMP%` directory.
 
-### How the test setup works
+## How the test setup works
 
 This section will not go into the details of robot framework, or robot remote server,
 these have their own documentation.
 An overview of the files:
-- The `SystemTestSpy` package is responsible for setting up the global plugin and synth driver.
-- `libraries/NvdaLib` abstracts the setup and running / exiting of NVDA.
-- `speechSpyGlobalPlugin` module creates a RobotFramework Remote Server which gets connected to via the `NvdaLib` library. To make running remote functions easier, methods are created on the remote spy instance which wrap calls to `run_keyword`.
+
+* The `SystemTestSpy` package is responsible for setting up the global plugin and synth driver.
+* `libraries/NvdaLib` abstracts the setup and running / exiting of NVDA.
+* `speechSpyGlobalPlugin` module creates a RobotFramework Remote Server which gets connected to via the `NvdaLib` library. To make running remote functions easier, methods are created on the remote spy instance which wrap calls to `run_keyword`.
 
 An NVDA sandbox profile is setup in the `%TEMP%` directory like so:
-- `nvdaProfile/`
-  - `nvda.ini` copied from `nvdaSettingsFiles`
-  - `scratchpad/`
-    - `globalPlugins/speechSpyGlobalPlugin/`
-      - `__init__.py` copied from `speechSpyGlobalPlugin.py`
-      - `blockUntilConditionMet.py`
-      - `libs/`
-        - `xmlrpc` from Python install
-        - `robotRemoteServer.py` from Python install
-        - Any other dependencies required.
-    - `synthDrivers/`
-      - `speechSpySynthDriver.py`
+
+* `nvdaProfile/`
+  * `nvda.ini` copied from `nvdaSettingsFiles`
+  * `scratchpad/`
+    * `globalPlugins/speechSpyGlobalPlugin/`
+      * `__init__.py` copied from `speechSpyGlobalPlugin.py`
+      * `blockUntilConditionMet.py`
+      * `libs/`
+        * `xmlrpc` from Python install
+        * `robotRemoteServer.py` from Python install
+        * Any other dependencies required.
+    * `synthDrivers/`
+      * `speechSpySynthDriver.py`
 
 For each test, the NVDA configuration file is overwritten.
 NVDA is started with the `-c` option to specify this profile directory to be used for config.
 
-### Logs
+## Logs
+
 Both Robot Framework and NVDA logs are captured in the `testOutput` directory in the repo root.
 NVDA logs (NVDA log, stdOut, and stdErr for each test) are under the `nvdaTestRunLogs` directory.
 The log files are named by suite and test name.
 
-### Comparing changes to NVDA Settings
+## Comparing changes to NVDA Settings
+
 `.\runsettingsdiff.bat` is a tool used to compare the settings dialog by reading text and generating screenshots for comparison.  The default behaviour is to run using the source code and output to `.\tests\system\settingsCache\source`.
 
+### Usage
 
-#### Usage
 To check for unreleased changes to the settings dialogs, one can use this tool to compare against two copies of NVDA.
 
 The following arguments should be used with the script.
 
 Default arguments used are stored  in `.\tests\system\guiDiff.robot`
 
-- `--variable whichNVDA:[installed|source]` to decide where to run NVDA from
-- `--variable cacheFolder:[filePath]` screenshots and text files of each settings panel are generated in `$cacheFolder\$currentVersion`
-- `--variable currentVersion:[nvdaVersion]` where `[nvdaVersion]` is used to name the generated screenshot and cache folder
-- `--variable compareVersion:[nvdaVersion]` using a `$nvdaVersion` that this script has already been run against, run the system tests and fail if there are differences between the read text. This generates a multiline diff.
+* `--variable whichNVDA:[installed|source]` to decide where to run NVDA from
+* `--variable cacheFolder:[filePath]` screenshots and text files of each settings panel are generated in `$cacheFolder\$currentVersion`
+* `--variable currentVersion:[nvdaVersion]` where `[nvdaVersion]` is used to name the generated screenshot and cache folder
+* `--variable compareVersion:[nvdaVersion]` using a `$nvdaVersion` that this script has already been run against, run the system tests and fail if there are differences between the read text. This generates a multiline diff.
 
 #### Example usage to compare settings between NVDA 2020.4 and the current source
 
 1. Install NVDA 2020.4
 1. Run `.\runsettingsdiff.bat -v whichNVDA:installed -v currentVersion:2020.4`
 1. Run `.\runsettingsdiff.bat -v whichNVDA:source -v currentVersion:source -v compareVersion:2020.4`
-   - The test will fail and display a diff of any read changes
+   * The test will fail and display a diff of any read changes
 1. Use a diff tool to compare folders:
-   - `diff ./tests/system/settingsCache/2020.4 ./tests/system/settingsCache/source`
-   - [ImageMagick Compare](https://imagemagick.org/script/compare.php) can be used to compare images
+   * `diff ./tests/system/settingsCache/2020.4 ./tests/system/settingsCache/source`
+   * [ImageMagick Compare](https://imagemagick.org/script/compare.php) can be used to compare images

--- a/tests/system/readme.md
+++ b/tests/system/readme.md
@@ -76,7 +76,8 @@ See [description of test args](#test-args)
 
 Common arguments are kept in the `tests\system\robotArgs.robot` file.
 
-The `whichNVDA` argument allows the tests to be run against an installed copy of NVDA (first ensure it is compatible with the tests). Note valid values are:
+The `whichNVDA` argument allows the tests to be run against an installed copy of NVDA (first ensure it is compatible with the tests).
+Note valid values are:
 
 * "installed" - when running against the installed version of NVDA, you are likely to get errors in the log unless the tests are run from an administrator command prompt.
 * "source"
@@ -107,7 +108,8 @@ An overview of the files:
 
 * The `SystemTestSpy` package is responsible for setting up the global plugin and synth driver.
 * `libraries/NvdaLib` abstracts the setup and running / exiting of NVDA.
-* `speechSpyGlobalPlugin` module creates a RobotFramework Remote Server which gets connected to via the `NvdaLib` library. To make running remote functions easier, methods are created on the remote spy instance which wrap calls to `run_keyword`.
+* `speechSpyGlobalPlugin` module creates a RobotFramework Remote Server which gets connected to via the `NvdaLib` library.
+To make running remote functions easier, methods are created on the remote spy instance which wrap calls to `run_keyword`.
 
 An NVDA sandbox profile is setup in the `%TEMP%` directory like so:
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -90,6 +90,8 @@ Use `winBindings.mmeapi.WAVEFORMATEX` instead. (#18207)
 * `hwPortUtils.ERROR_INSUFFICIENT_BUFFER` and `hwPortUtils.ERROR_NO_MORE_ITEMS` are deprecated.
   Use `winAPI.SystemErrorCodes.INSUFFICIENT_BUFFER` and `winAPI.SystemErrorCodes.NO_MORE_ITEMS` instead. (#18571)
 
+<!-- Beyond this point, Markdown should not be linted, as we don't modify old change log sections. -->
+<!-- markdownlint-disable -->
 ## 2025.3
 
 This release includes improvements to Remote Access, SAPI5 voices, braille and the Add-on Store.

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -92,6 +92,7 @@ Use `winBindings.mmeapi.WAVEFORMATEX` instead. (#18207)
 
 <!-- Beyond this point, Markdown should not be linted, as we don't modify old change log sections. -->
 <!-- markdownlint-disable -->
+
 ## 2025.3
 
 This release includes improvements to Remote Access, SAPI5 voices, braille and the Add-on Store.

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -4,8 +4,6 @@
 
 <!-- KC:title: NVDA NVDA_VERSION Commands Quick Reference -->
 
-
-
 ## Introduction {#Introduction}
 
 Welcome to NVDA!
@@ -299,6 +297,7 @@ To open NVDA's general settings dialog directly, press `NVDA+control+g`.
 Many settings screens have keystrokes to open them directly, such as `NVDA+control+s` for synthesizer, or `NVDA+control+v` for other voice options.
 
 ### Add-ons {#Addons}
+
 Add-ons are programs which provide new or changed functionality for NVDA.
 Add-ons are developed by the NVDA community, or external companies and are unaffiliated with NV Access.
 As with any software, it is important to trust the developer of an add-on before using it.
@@ -316,6 +315,7 @@ When the Add-on Store opens, it shows "Available add-ons" if no add-ons are inst
 When add-ons are installed, the Add-on Store opens to the "Installed add-ons" tab.
 
 #### Available add-ons {#AvailableAddons}
+
 When the window first opens, add-ons may take a few seconds to load.
 NVDA will read the name of the first add-on once the list of add-ons finishes loading.
 Available add-ons are listed alphabetically in a multi-column list.
@@ -329,6 +329,7 @@ To browse the list and find out about a specific add-on:
 1. To return to the list of add-ons, press `alt+a`, or `shift+tab` until reaching the list.
 
 #### Searching for add-ons {#SearchingForAddons}
+
 As well as browsing all available add-ons, it is possible to filter the add-ons shown.
 To search, press `alt+s` to jump to the "Search" field and type the text to search for.
 Searching checks for matches in the add-on ID, display name, publisher, author and description fields.
@@ -353,6 +354,7 @@ During the installation process, add-ons may display dialogs that you will need 
 1. Press `enter` to restart NVDA.
 
 #### Managing installed add-ons {#ManagingInstalledAddons}
+
 Press `control+tab` to move between the tabs of the Add-on Store.
 The tabs include: "Installed add-ons", "Updatable add-ons", "Available add-ons" and "Installed incompatible add-ons".
 Each of the tabs are set out similar to each other, as a list of add-ons, a panel for more details on the selected add-on, and a button to perform actions for the selected add-on.
@@ -364,6 +366,7 @@ These changes will only take effect once NVDA is restarted.
 Note that in the Add-on Store window `escape` works the same as the Close button.
 
 #### Updating add-ons {#UpdatingAddons}
+
 When an update to an add-on you have installed is available, it will be listed in the "Updatable add-ons" tab.
 Press `control+tab` to get to this tab from anywhere in the Add-on Store.
 The status of the add-on will be listed as "Update available".
@@ -410,6 +413,7 @@ You can make bug reports or feature requests via [GitHub](https://github.com/nva
 The [contribution guidelines](https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md) contain valuable information for contributing to the community.
 
 ## More Setup Options {#MoreSetupOptions}
+
 ### Installation Options {#InstallingNVDA}
 
 If installing NVDA directly from the downloaded NVDA launcher, press the Install NVDA button.
@@ -490,6 +494,7 @@ Portable and temporary copies of NVDA have the following restrictions:
 * Audio ducking is not supported.
 
 ## Using NVDA {#GettingStartedWithNVDA}
+
 ### Launching NVDA {#LaunchingNVDA}
 
 If you have installed NVDA with the installer, then starting NVDA is as simple as either pressing control+alt+n, or choosing NVDA from the NVDA menu under Programs on the Start Menu.
@@ -529,6 +534,7 @@ Note: pressing on "yes" or "no" will save this setting and the dialog will never
 However, you can enable or disable the data gathering process manually in NVDA's general settings panel. For changing this setting manually, you can check or uncheck the checkbox called [Allow the NVDA project to gather NVDA usage statistics](#GeneralSettingsGatherUsageStats).
 
 ### About NVDA keyboard commands {#AboutNVDAKeyboardCommands}
+
 #### The NVDA Modifier Key {#TheNVDAModifierKey}
 
 Most NVDA-specific keyboard commands consist of pressing a particular key called the NVDA modifier key in conjunction with one or more other keys.
@@ -1472,6 +1478,7 @@ To recognize the text in the current navigator object using Windows OCR, press N
 NVDA provides its own extra features for some applications to make certain tasks easier or to provide access to functionality which is not otherwise accessible to screen reader users.
 
 ### Microsoft Word {#MicrosoftWord}
+
 #### Automatic Column and Row Header Reading {#WordAutomaticColumnAndRowHeaderReading}
 
 NVDA is able to automatically announce appropriate row and column headers when navigating around tables in Microsoft Word.
@@ -1516,6 +1523,7 @@ Pressing twice shows the information in a browsable message.
 All comments for the document, along with other tracked changes, can also be listed in the NVDA Elements List when selecting Annotations as the type.
 
 ### Microsoft Excel {#MicrosoftExcel}
+
 #### Automatic Column and Row Header Reading {#ExcelAutomaticColumnAndRowHeaderReading}
 
 NVDA is able to automatically announce appropriate row and column headers when navigating around Excel worksheets.
@@ -4044,6 +4052,7 @@ You can browse available incompatible add-ons using the [available and updatable
 You can browse installed incompatible add-ons using the [incompatible add-ons tab](#AddonStoreFilterStatus).
 
 ## Extra Tools {#ExtraTools}
+
 ### Log Viewer {#LogViewer}
 
 The log viewer, found under Tools in the NVDA menu, allows you to view the logging output that has occurred since the latest session of NVDA was started.
@@ -5500,6 +5509,7 @@ Make sure to lift your hand entirely off the device when navigating with NVDA, a
 <!-- KC:endInclude -->
 
 ## Advanced Topics {#AdvancedTopics}
+
 ### Secure Mode {#SecureMode}
 
 System administrators may wish to configure NVDA to restrict unauthorized system access.
@@ -5607,7 +5617,6 @@ Following are the command line options for NVDA:
 ### Uninstalling NVDA {#UninstallingNVDA}
 
 NVDA's uninstaller is called `uninstall.exe` and resides under the NVDA installation directory, `%ProgramFiles(x86)%\nvda` on 64-bit Windows, or `%ProgramFiles%\nvda` on 32-bit Windows.
-
 
 Note: It is possible to stop NVDA from starting automatically without needing to uninstall NVDA.
 To stop NVDA starting automatically, please refer to the options: [Start NVDA after I sign in](#GeneralSettingsStartAfterLogOn) and [Use NVDA during sign-in](#GeneralSettingsStartOnLogOnScreen) in NVDA's general settings.

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -117,7 +117,7 @@ These steps assume some familiarity with navigating a web page.
 
 * Open your web browser (Press the `Windows` key, type the word "internet" without quotes, and press `enter`)
 * Load the NV Access download page (Press `alt+d`, type the following address and press `enter`):
-https://www.nvaccess.org/download
+<https://www.nvaccess.org/download>
 * Activate the "download" button
 * The browser may or may not prompt for an action after downloading, and then start the download
 * Depending on the browser, the file may run automatically after it downloads
@@ -2005,10 +2005,12 @@ For example, the latin letter "h" can also be presented as "𝐡" (bold), "ℎ" 
 This aspect of normalization also aids in reading equations in the Microsoft Word equation editor.
 
 1. Normalization to composed characters.
-For example, the character "ü" (u with umlaut/diaeresis), a common character in languages like German and Turkish can be represented in two forms:
-  1. One stand alone unicode character (ü)
-  1. A decomposition into two characters (ü), namely the normal latin letter u and a diaeresis modifier
-  Unicode normalization ensures that only one form will be used throughout all speech output, which is the one character variant.
+   For example, the character "ü" (u with umlaut/diaeresis), a common character in languages like German and Turkish can be represented in two forms:
+
+   1. One stand alone unicode character (ü)
+   1. A decomposition into two characters (ü), namely the normal latin letter u and a diaeresis modifier
+
+   Unicode normalization ensures that only one form will be used throughout all speech output, which is the one character variant.
 
 1. Decomposition of some ligatures, Including "ĳ" (ligature ij) to their two letter form ("ij").
 
@@ -2047,7 +2049,7 @@ This edit field allows you to type the amount that the pitch of the voice will c
 This value is a percentage, where a negative value lowers the pitch and a positive value raises it.
 For no pitch change you would use 0.
 Usually, NVDA raises the pitch slightly for any capital letter, but some synthesizers may not support this well.
-In case pitch change for capitals is not supported, consider [Say "cap" before capitals](#SpeechSettingsSayCapBefore) and/or [ Beep for capitals](#SpeechSettingsBeepForCaps) instead.
+In case pitch change for capitals is not supported, consider [Say "cap" before capitals](#SpeechSettingsSayCapBefore) and/or [Beep for capitals](#SpeechSettingsBeepForCaps) instead.
 
 ##### Say "cap" before capitals {#SpeechSettingsSayCapBefore}
 
@@ -3807,10 +3809,12 @@ In this case, the other person has either started the connection via a relay ser
 
 1. For Server, choose "Use existing".
 1. In the Host field, Enter the host address (and port if also given).
-  * You may include the port to connect on by appending a colon (":") and the port number to the host address.
-For example, `example.com:1234`.
+
+   * You may include the port to connect on by appending a colon (":") and the port number to the host address.
+     For example, `example.com:1234`.
+
 1. In the Key field, enter the key provided.
-Be careful to type the key exactly as given.
+   Be careful to type the key exactly as given.
 1. Press OK.
 
 #### Starting a Connection Via a Relay Server {#RemoteAccessConnectRelay}
@@ -3819,12 +3823,16 @@ If allowing another person to connect to you over the internet, the easiest opti
 
 1. For Server, choose "Use existing".
 1. For host, provide the host name of a relay server, such as `nvdaremote.com`.
-You will need to provide this address to the other person.
-  * You may include the port to connect on by appending a colon (":") and the port number to the host.
-For example, `example.com:1234`.
+   You will need to provide this address to the other person.
+
+   * You may include the port to connect on by appending a colon (":") and the port number to the host.
+     For example, `example.com:1234`.
+
 1. For key: come up with a long, hard to guess key, or press the "Generate Key" button to have one automatically generated.
-You will need to provide this to the other person.
-  * Note that the key acts as both the identifier for the session and the password, so it is very important it is hard to guess.
+   You will need to provide this to the other person.
+
+   * Note that the key acts as both the identifier for the session and the password, so it is very important it is hard to guess.
+
 1. Press OK.
 1. Provide the connection details (such as host and key) to the other person so they can connect.
 
@@ -3838,15 +3846,19 @@ You will need to provide this external IP to the other person.
 1. If connecting over a local network, you will need to provide the other person with your local IP.
 Locating this is not covered in this documentation.
 1. For Port, enter the port you want to use for incoming Remote connections.
-The other person will also need this.
-  * This should be a port that is not used by any other services.
-  * By default, Remote Access uses port 6837.
-  * If connecting over the internet, the port may need to be forwarded.
-  This documentation does not cover how to forward ports.
-  You may need to contact your network administrator to do this.
+   The other person will also need this.
+
+   * This should be a port that is not used by any other services.
+   * By default, Remote Access uses port 6837.
+   * If connecting over the internet, the port may need to be forwarded.
+     This documentation does not cover how to forward ports.
+     You may need to contact your network administrator to do this.
+
 1. For key: come up with a long, hard to guess key, or press the "Generate Key" button to have one automatically generated.
-You will need to provide this to the other person.
-  * Note that the key acts as both the identifier for the session and the password, so it is very important it is hard to guess.
+   You will need to provide this to the other person.
+
+   * Note that the key acts as both the identifier for the session and the password, so it is very important it is hard to guess.
+
 1. Press OK.
 1. Provide the connection details (such as host and key) to the other person so they can connect.
 
@@ -5608,7 +5620,7 @@ Following are the command line options for NVDA:
 |None |`--no-sr-flag` |Don't change the global system screen reader flag|
 |None |`--install` |Installs NVDA (starting the newly installed copy)|
 |None |`--install-silent` |Silently installs NVDA (does not start the newly installed copy)|
-|None |`--enable-start-on-logon=True|False` |When installing, enable NVDA's [Use NVDA during Windows sign-in](#StartAtWindowsLogon)|
+|None |`--enable-start-on-logon=True|False` |When installing, enable NVDA's [Use NVDA during Windows sign-in](#StartAtWindowsLogon)| <!-- markdownlint-disable-line MD055 MD056 -->
 |None |`--copy-portable-config` |When installing, copy the portable configuration from the provided path (`--config-path`, `-c`) to the current user account|
 |None |`--create-portable` |Creates a portable copy of NVDA (and starts the new copy). Requires `--portable-path` to be specified|
 |None |`--create-portable-silent` |Creates a portable copy of NVDA (without starting the new copy). Requires `--portable-path` to be specified. This option suppresses warnings when writing to non-empty directories and may overwrite files without warning.|


### PR DESCRIPTION
### Link to issue number:
Fixes #16453

### Summary of the issue:
Currently, NVDA's markdown files are not linted, and are quite messy and inconsistent as a result.

### Description of user facing changes:
None

### Description of developer facing changes:
Added a pre-commit hook that lints markdown files.

### Description of development approach:
Linted all markdown files that aren't part of submodules or archival copies.
Turned off lint rules that were inappropriate for our repo as I went.
Added the final config to `.markdownlint.jsonc` (widely supported), and config specific to the pre-commit hook and VS Code plugin to `.markdownlint-cli2.jsonc`.

### Testing strategy:
Reran markdownlint over the repo, and ensured no issues were found.

### Known issues with pull request:

Some rules are disabled pragmatically, even though they would be useful:

* "link-fragments": Checks that link fragments point to an actual anchor in the document. Incompatible with the anchors we use in the user guide. A custom rule for this may already exist, or we could write our own fairly easily.
* "fenced-code-language": Mandates a language be declared on fenced code blocks. Disabled as many of our code blocks lack it. Should probably be fixed gradually.

Additionally:

* Our style is to have one sentence per line. This is currently not enforced. This would be tricky to get write, but someone may have already written a custom rule for it.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
