### PR TITLE
Fix utils._deprecate to give the right module name when not running from source

### DIFF
--- a/source/utils/_deprecate.py
+++ b/source/utils/_deprecate.py
@@ -136,8 +136,7 @@ def _getCallerModule(level: int = 0) -> ModuleType:
 		This can be used if calling from a helper function to skip the stack frame created by the helper.
 	:return: The module from which this function was called.
 	"""
-	# If not part of a module, the caller must be in ``__main__``.
-	return inspect.getmodule(inspect.stack()[level + 1].frame) or sys.modules["__main__"]
+	return sys.modules[inspect.stack()[level + 1].frame.f_globals["__name__"]]
 
 
 def handleDeprecations(

--- a/source/utils/_deprecate.py
+++ b/source/utils/_deprecate.py
@@ -136,7 +136,8 @@ def _getCallerModule(level: int = 0) -> ModuleType:
 		This can be used if calling from a helper function to skip the stack frame created by the helper.
 	:return: The module from which this function was called.
 	"""
-	return sys.modules[inspect.stack()[level + 1].frame.f_globals["__name__"]]
+	moduleName = inspect.stack()[level + 1].frame.f_globals["__name__"]
+	return sys.modules[moduleName]
 
 
 def handleDeprecations(


### PR DESCRIPTION
### Link to issue number:
Follow-up to #18571

### Summary of the issue:
The deprecation helper introduced in #18571 automatically detects the module it's being used in. This detection is broken when running a portable or installed copy.

### Description of user facing changes:
None.

### Description of developer facing changes:
The module is now reported correctly when emitting deprecation warnings.

### Description of development approach:
Rather than using `inspect.getmodule`, get `__name__` from the frame's globals.

### Testing strategy:
Tested importing `BLUETOOTH_ADDRESS` from `hwPortUtils` from source and in a portable (created with `scons dist`).

Applied the following patch and attempted importing `_remoteClient.client.seven` when running from source and portable.

```patch
diff --git a/source/_remoteClient/client.py b/source/_remoteClient/client.py
index 4691a226f..541ec8f2a 100644
--- a/source/_remoteClient/client.py
+++ b/source/_remoteClient/client.py
@@ -743,3 +743,8 @@ def connectedClientsCount(self) -> int:
                        stack_info=True,
                )
                return 0
+
+from utils._deprecate import handleDeprecations, RemovedSymbol
+__getattr__ = handleDeprecations(
+       RemovedSymbol("seven", 7)
+)
```

### Known issues with pull request:
None

### Code Review Checklist:
- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
