### PR TITLE
Allow NVDA x64 to run on clean installs of Windows

### DIFF
--- a/nvdaHelper/localWin10/sconscript
+++ b/nvdaHelper/localWin10/sconscript
@@ -63,7 +63,11 @@ if len(vcRedistDirs) == 0:
 		"Could not locate vc redistributables. Perhaps the Universal Windows Platform component in visual Studio is not installed"
 	)
 vcRedistDirs.sort(reverse=True)
-for fn in ("msvcp140.dll", "vccorlib140.dll", "vcruntime140.dll"):
+vcRedistLibs= ["msvcp140.dll", "vccorlib140.dll", "vcruntime140.dll", "vcruntime140_1.dll"]
+# TODO: Delete when we drop support for x86
+if targetArch == "x86":
+	vcRedistLibs.remove("vcruntime140_1.dll")
+for fn in vcRedistLibs:
 	for vcRedistDir in vcRedistDirs:
 		path = os.path.join(vcRedistDir, fn)
 		if os.path.isfile(path):

--- a/nvdaHelper/localWin10/sconscript
+++ b/nvdaHelper/localWin10/sconscript
@@ -63,7 +63,7 @@ if len(vcRedistDirs) == 0:
 		"Could not locate vc redistributables. Perhaps the Universal Windows Platform component in visual Studio is not installed"
 	)
 vcRedistDirs.sort(reverse=True)
-vcRedistLibs= ["msvcp140.dll", "vccorlib140.dll", "vcruntime140.dll", "vcruntime140_1.dll"]
+vcRedistLibs = ["msvcp140.dll", "vccorlib140.dll", "vcruntime140.dll", "vcruntime140_1.dll"]
 # TODO: Delete when we drop support for x86
 if targetArch == "x86":
 	vcRedistLibs.remove("vcruntime140_1.dll")

--- a/nvdaHelper/localWin10/sconscript
+++ b/nvdaHelper/localWin10/sconscript
@@ -46,10 +46,16 @@ localWin10Lib = env.SharedLibrary(
 # Therefore, we must include it.
 # VS keeps changing the path to reflect the latest major.minor.build version which we canot easily find out.
 # Therefore  Search these versioned directories from newest to oldest  to collect all the files we need.
+# We also need to get the right DLLs based on the build architecture
 msvc = env.get("MSVC_VERSION")
 vcRedistDirs = glob.glob(
 	os.path.join(
-		find_vc_pdir(msvc, env), rf"Redist\MSVC\{msvc[:2]}*\x86\Microsoft.VC{msvc.replace('.', '')}.CRT"
+		find_vc_pdir(msvc, env),
+		"Redist",
+		"MSVC",
+		f"{msvc[:2]}*",
+		targetArch if (targetArch := env["TARGET_ARCH"]) != "x86_64" else "x64",
+		f"Microsoft.VC{msvc.replace('.', '')}.CRT",
 	)
 )
 if len(vcRedistDirs) == 0:


### PR DESCRIPTION
### Link to issue number:
Fixes #18827

### Summary of the issue:
On clean copies of Windows (such as Windows Sandbox), 64 bit builds of NVDA fail to run.

### Description of user facing changes:
These builds now run.

### Description of developer facing changes:
None.

### Description of development approach:
In https://github.com/nvaccess/nvda/pull/18814#issuecomment-3227651255 we identified that NVDA wasn't running because `vcruntime140.dll` couldn't be loaded. Inspection of this DLL revealed that it was a PE32 executable.
Updated the build script to copy C Runtime DLLs from the appropriate architecture directory based on the build architecture.
Attempted running a 64 bit launcher in Windows Sandbox. NVDA starts but importing `wx` fails:

```log
core failure
Traceback (most recent call last):
  File "nvda.pyw", line 309, in <module>
  File "core.pyc", line 713, in main
  File "NVDAHelper\__init__.pyc", line 40, in <module>
  File "eventHandler.pyc", line 13, in <module>
  File "api.pyc", line 14, in <module>
  File "textInfos\__init__.pyc", line 31, in <module>
  File "locationHelper.pyc", line 12, in <module>
  File "wx\__init__.pyc", line 17, in <module>
  File "wx\core.pyc", line 12, in <module>
  File "<loader>", line 15, in <module>
  File "<loader>", line 13, in __load
ImportError: (DLL load failed while importing _core: The specified module could not be found.) 'C:\\Users\\WDAGUtilityAccount\\AppData\\Local\\Temp\\nslFB31.tmp\\app\\wx._core.pyd'
```

After some investigation with [procmon](https://learn.microsoft.com/en-us/sysinternals/downloads/procmon) and [Dependencies](https://github.com/lucasg/Dependencies) I worked out that 64 bit wx requires `vcruntime140_1.dll`.

Added `vcruntime140_1.dll` to the list of C Runtime DLLs to be included in the build. This is deleted if building for x86 as this file doesn't exist for the x86 runtime. I chose to go in this direction as this code is easier to remove when we drop x86 support.

### Testing strategy:

Built x86 and x86_64 launchers and ran them in separate Windows Sandboxes.

### Known issues with pull request:

None

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
