### PR TITLE
And more winBindings

### DIFF
--- a/source/NVDAHelper/__init__.py
+++ b/source/NVDAHelper/__init__.py
@@ -781,7 +781,7 @@ class _RemoteLoader:
 		try:
 			loaderPath = os.path.join(loaderDir, "nvdaHelperRemoteLoader.exe")
 			log.debug(f"Starting {loaderPath}")
-			winKernel.CreateProcessAsUser(token, None, loaderPath, None, None, True, None, None, None, si, pi)
+			winKernel.CreateProcessAsUser(token, None, loaderPath, None, None, True, 0, None, None, si, pi)
 			# We don't need the thread handle.
 			winKernel.closeHandle(pi.hThread)
 			self._process = pi.hProcess

--- a/source/NVDAHelper/__init__.py
+++ b/source/NVDAHelper/__init__.py
@@ -36,6 +36,7 @@ import winBindings.oleaut32
 import winBindings.kernel32
 import winBindings.advapi32
 import winBindings.rpcrt4
+import winBindings.shlwapi
 import globalVars
 from NVDAState import ReadPaths
 
@@ -253,7 +254,7 @@ def _lookupKeyboardLayoutNameWithHexString(layoutString):
 				)
 				== 0
 			):  # noqa: F405
-				windll.shlwapi.SHLoadIndirectString(buf.value, buf, 1023, None)
+				winBindings.shlwapi.SHLoadIndirectString(buf.value, buf, 1023, None)
 				return buf.value
 			if winBindings.advapi32.RegQueryValueEx(key, "Layout Text", None, None, buf, byref(bufSize)) == 0:
 				return buf.value

--- a/source/NVDAHelper/__init__.py
+++ b/source/NVDAHelper/__init__.py
@@ -768,13 +768,13 @@ class _RemoteLoader:
 		with open("nul", "wb") as nul:
 			nulHandle = self._duplicateAsInheritable(msvcrt.get_osfhandle(nul.fileno()))
 		# Set the process to start with the appropriate std* handles.
-		si = winKernel.STARTUPINFO(
+		si = winBindings.advapi32.STARTUPINFO(
 			dwFlags=winKernel.STARTF_USESTDHANDLES,
 			hSTDInput=pipeRead,
 			hSTDOutput=nulHandle,
 			hSTDError=nulHandle,
 		)
-		pi = winKernel.PROCESS_INFORMATION()
+		pi = winBindings.advapi32.PROCESS_INFORMATION()
 		# Even if we have uiAccess privileges, they will not be inherited by default.
 		# Therefore, explicitly specify our own process token, which causes them to be inherited.
 		token = winKernel.OpenProcessToken(winKernel.GetCurrentProcess(), winKernel.MAXIMUM_ALLOWED)

--- a/source/NVDAObjects/IAccessible/__init__.py
+++ b/source/NVDAObjects/IAccessible/__init__.py
@@ -512,6 +512,10 @@ class IAccessible(Window):
 	@type IAccessibleChildID: int
 	"""
 
+	# For Windowless RichEdit.
+	# https://learn.microsoft.com/en-us/windows/win32/api/textserv/nl-textserv-itextservices
+	IID_ITextServices = GUID("{8D33F740-CF58-11CE-A89D-00AA006CADC5}")
+
 	IAccessibleTableUsesTableCellIndexAttrib = (
 		False  #: Should the table-cell-index IAccessible2 object attribute be used rather than indexInParent?
 	)
@@ -721,15 +725,6 @@ class IAccessible(Window):
 			winConsole.findExtraOverlayClasses(self, clsList)
 
 		# Support for Windowless richEdit
-		if not hasattr(IAccessible, "IID_ITextServices"):
-			try:
-				IAccessible.IID_ITextServices = ctypes.cast(
-					ctypes.windll.msftedit.IID_ITextServices,
-					ctypes.POINTER(GUID),
-				).contents
-			except WindowsError:
-				log.debugWarning("msftedit not available, couldn't retrieve IID_ITextServices")
-				IAccessible.IID_ITextServices = None
 		if IAccessible.IID_ITextServices:
 			try:
 				pDoc = self.IAccessibleObject.QueryInterface(IServiceProvider).QueryService(

--- a/source/NVDAObjects/window/excel.py
+++ b/source/NVDAObjects/window/excel.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import abc
 import ctypes
 import enum
+import winBindings.gdi32
 
 from typing import Any
 from collections.abc import Callable
@@ -2245,9 +2246,9 @@ class ExcelFormControl(ExcelBase):
 		self.excelApplicationObject = self.parent.excelWorksheetObject.Application
 		hDC = ctypes.windll.user32.GetDC(None)
 		# pixels per inch along screen width
-		px = ctypes.windll.gdi32.GetDeviceCaps(hDC, LOGPIXELSX)
+		px = winBindings.gdi32.GetDeviceCaps(hDC, LOGPIXELSX)
 		# pixels per inch along screen height
-		py = ctypes.windll.gdi32.GetDeviceCaps(hDC, LOGPIXELSY)
+		py = winBindings.gdi32.GetDeviceCaps(hDC, LOGPIXELSY)
 		ctypes.windll.user32.ReleaseDC(None, hDC)
 		zoom = self.excelApplicationObject.ActiveWindow.Zoom
 		zoomRatio = zoom / 100

--- a/source/config/__init__.py
+++ b/source/config/__init__.py
@@ -13,7 +13,6 @@ For the latter two actions, one can perform actions prior to and/or after they t
 from enum import Enum
 import globalVars
 import winreg
-import ctypes
 import os
 import sys
 import errno

--- a/source/config/__init__.py
+++ b/source/config/__init__.py
@@ -26,6 +26,7 @@ from configobj.validate import Validator
 from logHandler import log
 import logging
 from logging import DEBUG
+import winBindings.shell32
 from shlobj import FolderId, SHGetKnownFolderPath
 import baseObject
 import easeOfAccess
@@ -396,7 +397,7 @@ def _setStartOnLogonScreen(enable: bool) -> None:
 
 def setSystemConfigToCurrentConfig():
 	fromPath = WritePaths.configDir
-	if ctypes.windll.shell32.IsUserAnAdmin():
+	if winBindings.shell32.IsUserAnAdmin():
 		_setSystemConfig(fromPath)
 	else:
 		import systemUtils

--- a/source/fileUtils.py
+++ b/source/fileUtils.py
@@ -14,6 +14,7 @@ import winKernel
 import shlobj
 from functools import wraps
 import systemUtils
+import winBindings.version
 
 
 @contextmanager
@@ -78,17 +79,17 @@ def getFileVersionInfo(name, *attributes):
 		raise RuntimeError("The file %s does not exist" % name)
 	fileVersionInfo = {}
 	# Get size needed for buffer (0 if no info)
-	size = ctypes.windll.version.GetFileVersionInfoSizeW(name, None)
+	size = winBindings.version.GetFileVersionInfoSize(name, None)
 	if not size:
 		raise RuntimeError("No version information")
 	# Create buffer
 	res = ctypes.create_string_buffer(size)
 	# Load file informations into buffer res
-	ctypes.windll.version.GetFileVersionInfoW(name, None, size, res)
+	winBindings.version.GetFileVersionInfo(name, 0, size, res)
 	r = ctypes.c_void_p()
 	l = ctypes.c_uint()  # noqa: E741
 	# Look for codepages
-	ctypes.windll.version.VerQueryValueW(
+	winBindings.version.VerQueryValue(
 		res,
 		"\\VarFileInfo\\Translation",
 		ctypes.byref(r),
@@ -100,7 +101,7 @@ def getFileVersionInfo(name, *attributes):
 	codepage = array.array("H", ctypes.string_at(r.value, 4))
 	codepage = "%04x%04x" % tuple(codepage)
 	for attr in attributes:
-		if not ctypes.windll.version.VerQueryValueW(
+		if not winBindings.version.VerQueryValue(
 			res,
 			"\\StringFileInfo\\%s\\%s" % (codepage, attr),
 			ctypes.byref(r),

--- a/source/fonts/__init__.py
+++ b/source/fonts/__init__.py
@@ -8,6 +8,7 @@ from logHandler import log
 import os
 
 import winBindings.gdi32
+from utils import _deprecate
 
 
 """
@@ -62,3 +63,8 @@ def importFonts():
 
 	log.debug("Loading fonts.")
 	_imported = addFonts(fontsDir)
+
+
+__getattr__ = _deprecate.handleDeprecations(
+	_deprecate.MovedSymbol("gdi32", "winBindings.gdi32", "dll"),
+)

--- a/source/fonts/__init__.py
+++ b/source/fonts/__init__.py
@@ -6,7 +6,6 @@ from typing import List
 import globalVars
 from logHandler import log
 import os
-from ctypes import WinDLL
 
 import winBindings.gdi32
 

--- a/source/fonts/__init__.py
+++ b/source/fonts/__init__.py
@@ -3,13 +3,14 @@
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 from typing import List
-
 import globalVars
 from logHandler import log
 import os
 from ctypes import WinDLL
 
-gdi32 = WinDLL("gdi32.dll")
+import winBindings.gdi32
+
+
 """
 Loads custom fonts for use in NVDA.
 """
@@ -39,7 +40,7 @@ def addFonts(_fontSearchPath) -> List[str]:
 def _addFontResource(fontPath: str) -> int:
 	# from wingdi.h
 	FR_PRIVATE = 0x10
-	res = gdi32.AddFontResourceExW(
+	res = winBindings.gdi32.AddFontResourceEx(
 		fontPath,
 		# Only this process can use the font.
 		# The system will take care of unloading the font when the process ends.

--- a/source/gui/installerGui.py
+++ b/source/gui/installerGui.py
@@ -4,7 +4,6 @@
 # Copyright (C) 2011-2025 NV Access Limited, Babbage B.v., Cyrille Bougot, Julien Cochuyt, Accessolutions,
 # Bill Dengler, Joseph Lee, Takuya Nishimoto
 
-import ctypes
 import os
 import subprocess
 import sys
@@ -13,6 +12,7 @@ import winUser
 import wx
 import config
 import core
+from winBindings import shell32
 import globalVars
 import installer
 from logHandler import log
@@ -25,16 +25,12 @@ import ui
 from NVDAState import WritePaths
 from .message import DialogType, MessageDialog, ReturnCode, displayDialogAsModal
 
-_IsUserAnAdmin = ctypes.windll.shell32.IsUserAnAdmin
-_IsUserAnAdmin.argtypes = []
-_IsUserAnAdmin.restype = ctypes.wintypes.BOOL
-
 
 def _shouldWarnBeforeUpdate() -> bool:
 	"""Whether or not a warning about being unable to complete installation when connected as follower should be shown to the user."""
 	from _remoteClient import _remoteClient
 
-	return _remoteClient is not None and _remoteClient.isConnectedAsFollower and not _IsUserAnAdmin()
+	return _remoteClient is not None and _remoteClient.isConnectedAsFollower and not shell32.IsUserAnAdmin()
 
 
 def _canPortableConfigBeCopied() -> bool:

--- a/source/screenBitmap.py
+++ b/source/screenBitmap.py
@@ -1,14 +1,14 @@
-# screenBitmap.py
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2011-2017 NV Access Limited
-# This file is covered by the GNU General Public License.
-# See the file COPYING for more details.
+# Copyright (C) 2011-2025 NV Access Limited
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
 
 """Functionality to capture and work with bitmaps of the screen."""
 
 import ctypes
 import winGDI
 import winBindings.gdi32
+from utils import _deprecate
 
 user32 = ctypes.windll.user32
 
@@ -81,3 +81,8 @@ class ScreenBitmap(object):
 def rgbPixelBrightness(p):
 	"""Converts a RGBQUAD pixel in to  one grey-scale brightness value."""
 	return int((0.3 * p.rgbBlue) + (0.59 * p.rgbGreen) + (0.11 * p.rgbRed))
+
+
+__getattr__ = _deprecate.handleDeprecations(
+	_deprecate.MovedSymbol("gdi32", "winBindings.gdi32", "dll"),
+)

--- a/source/screenBitmap.py
+++ b/source/screenBitmap.py
@@ -8,9 +8,9 @@
 
 import ctypes
 import winGDI
+import winBindings.gdi32
 
 user32 = ctypes.windll.user32
-gdi32 = ctypes.windll.gdi32
 
 
 class ScreenBitmap(object):
@@ -26,12 +26,12 @@ class ScreenBitmap(object):
 		# Fetch the device context for the screen
 		self._screenDC = user32.GetDC(0)
 		# Create a memory device context with which we can copy screen content to on request.
-		self._memDC = gdi32.CreateCompatibleDC(self._screenDC)
+		self._memDC = winBindings.gdi32.CreateCompatibleDC(self._screenDC)
 		# Create a new bitmap of the chosen size, and set this as the memory device context's bitmap, so that what is drawn is captured.
-		self._memBitmap = gdi32.CreateCompatibleBitmap(self._screenDC, width, height)
-		self._oldBitmap = gdi32.SelectObject(self._memDC, self._memBitmap)
+		self._memBitmap = winBindings.gdi32.CreateCompatibleBitmap(self._screenDC, width, height)
+		self._oldBitmap = winBindings.gdi32.SelectObject(self._memDC, self._memBitmap)
 		# We always want standard RGB data
-		bmInfo = winGDI.BITMAPINFO()
+		bmInfo = winBindings.gdi32.BITMAPINFO()
 		bmInfo.bmiHeader.biSize = ctypes.sizeof(bmInfo)
 		bmInfo.bmiHeader.biWidth = width
 		bmInfo.bmiHeader.biHeight = height * -1
@@ -41,9 +41,9 @@ class ScreenBitmap(object):
 		self._bmInfo = bmInfo
 
 	def __del__(self):
-		gdi32.SelectObject(self._memDC, self._oldBitmap)
-		gdi32.DeleteObject(self._memBitmap)
-		gdi32.DeleteDC(self._memDC)
+		winBindings.gdi32.SelectObject(self._memDC, self._oldBitmap)
+		winBindings.gdi32.DeleteObject(self._memBitmap)
+		winBindings.gdi32.DeleteDC(self._memDC)
 		user32.ReleaseDC(0, self._screenDC)
 
 	def captureImage(self, x, y, w, h):
@@ -51,7 +51,7 @@ class ScreenBitmap(object):
 		Captures the part of the screen starting at x,y and extends by w (width) and h (height), and stretches/shrinks it to fit in to the object's bitmap size.
 		"""
 		# Copy the requested content from the screen in to our memory device context, stretching/shrinking its size to fit.
-		gdi32.StretchBlt(
+		winBindings.gdi32.StretchBlt(
 			self._memDC,
 			0,
 			0,
@@ -65,8 +65,8 @@ class ScreenBitmap(object):
 			winGDI.SRCCOPY,
 		)
 		# Fetch the pixels from our memory bitmap and store them in a buffer to be returned
-		buffer = (winGDI.RGBQUAD * self.width * self.height)()
-		gdi32.GetDIBits(
+		buffer = (winBindings.gdi32.RGBQUAD * self.width * self.height)()
+		winBindings.gdi32.GetDIBits(
 			self._memDC,
 			self._memBitmap,
 			0,

--- a/source/shellapi.py
+++ b/source/shellapi.py
@@ -6,35 +6,12 @@
 from ctypes import *  # noqa: F403
 from ctypes.wintypes import *  # noqa: F403
 from typing import Optional
-
+import winBindings.shell32
 
 shell32 = windll.shell32  # noqa: F405
 
 
-class SHELLEXECUTEINFOW(Structure):  # noqa: F405
-	_fields_ = (
-		("cbSize", DWORD),  # noqa: F405
-		("fMask", ULONG),  # noqa: F405
-		("hwnd", HWND),  # noqa: F405
-		("lpVerb", LPCWSTR),  # noqa: F405
-		("lpFile", LPCWSTR),  # noqa: F405
-		("lpParameters", LPCWSTR),  # noqa: F405
-		("lpDirectory", LPCWSTR),  # noqa: F405
-		("nShow", c_int),  # noqa: F405
-		("hInstApp", HINSTANCE),  # noqa: F405
-		("lpIDList", LPVOID),  # noqa: F405
-		("lpClass", LPCWSTR),  # noqa: F405
-		("hkeyClass", HKEY),  # noqa: F405
-		("dwHotKey", DWORD),  # noqa: F405
-		("hIconOrMonitor", HANDLE),  # noqa: F405
-		("hProcess", HANDLE),  # noqa: F405
-	)
-
-	def __init__(self, **kwargs):
-		super(SHELLEXECUTEINFOW, self).__init__(cbSize=sizeof(self), **kwargs)  # noqa: F405
-
-
-SHELLEXECUTEINFO = SHELLEXECUTEINFOW
+SHELLEXECUTEINFO = SHELLEXECUTEINFOW = winBindings.shell32.SHELLEXECUTEINFOW  # noqa: F405
 
 SEE_MASK_NOCLOSEPROCESS = 0x00000040
 
@@ -49,12 +26,12 @@ def ShellExecute(
 ) -> None:
 	if not file:
 		raise RuntimeError("file cannot be None")
-	if shell32.ShellExecuteW(hwnd, operation, file, parameters, directory, showCmd) <= 32:
+	if winBindings.shell32.ShellExecute(hwnd, operation, file, parameters, directory, showCmd) <= 32:
 		raise WinError()  # noqa: F405
 
 
 def ShellExecuteEx(execInfo):
-	if not shell32.ShellExecuteExW(byref(execInfo)):  # noqa: F405
+	if not winBindings.shell32.ShellExecuteEx(byref(execInfo)):  # noqa: F405
 		raise WinError()  # noqa: F405
 
 
@@ -83,9 +60,7 @@ class SHFILEOPSTRUCT(Structure):  # noqa: F405
 
 SHCNE_ASSOCCHANGED = 0x08000000
 SHCNF_IDLIST = 0x0
-shell32.SHChangeNotify.argtypes = [c_long, c_uint, c_void_p, c_void_p]  # noqa: F405
-shell32.SHChangeNotify.restype = None
 
 
 def SHChangeNotify(wEventId, uFlags, dwItem1, dwItem2):
-	shell32.SHChangeNotify(wEventId, uFlags, dwItem1, dwItem2)
+	winBindings.shell32.SHChangeNotify(wEventId, uFlags, dwItem1, dwItem2)

--- a/source/shellapi.py
+++ b/source/shellapi.py
@@ -13,7 +13,7 @@ from utils import _deprecate
 __getattr__ = _deprecate.handleDeprecations(
 	_deprecate.MovedSymbol("SHELLEXECUTEINFO", "winBindings.shell32"),
 	_deprecate.MovedSymbol("SHELLEXECUTEINFOW", "winBindings.shell32"),
-	_deprecate.movedSymbol("shell32", "winBindings.shell32", "dll"),
+	_deprecate.MovedSymbol("shell32", "winBindings.shell32", "dll"),
 )
 
 SEE_MASK_NOCLOSEPROCESS = 0x00000040

--- a/source/shellapi.py
+++ b/source/shellapi.py
@@ -7,11 +7,14 @@ from ctypes import *  # noqa: F403
 from ctypes.wintypes import *  # noqa: F403
 from typing import Optional
 import winBindings.shell32
+from utils import _deprecate
 
-shell32 = windll.shell32  # noqa: F405
 
-
-SHELLEXECUTEINFO = SHELLEXECUTEINFOW = winBindings.shell32.SHELLEXECUTEINFOW  # noqa: F405
+__getattr__ = _deprecate.handleDeprecations(
+	_deprecate.MovedSymbol("SHELLEXECUTEINFO", "winBindings.shell32"),
+	_deprecate.MovedSymbol("SHELLEXECUTEINFOW", "winBindings.shell32"),
+	_deprecate.movedSymbol("shell32", "winBindings.shell32", "dll"),
+)
 
 SEE_MASK_NOCLOSEPROCESS = 0x00000040
 

--- a/source/shlobj.py
+++ b/source/shlobj.py
@@ -18,6 +18,7 @@ import functools
 from typing import Optional, Union
 
 
+import winBindings.shell32
 import winBindings.ole32
 
 
@@ -54,7 +55,7 @@ def SHGetKnownFolderPath(
 	guid = comtypes.GUID(folderGuid)
 
 	pathPointer = ctypes.c_wchar_p()
-	res = ctypes.windll.shell32.SHGetKnownFolderPath(
+	res = winBindings.shell32.SHGetKnownFolderPath(
 		comtypes.byref(guid),
 		dwFlags,
 		hToken,

--- a/source/shlobj.py
+++ b/source/shlobj.py
@@ -20,19 +20,6 @@ from typing import Optional, Union
 
 import winBindings.shell32
 import winBindings.ole32
-from utils import _deprecate
-
-
-__getattr__ = _deprecate.handleDeprecations(
-	_deprecate.MovedSymbol(
-		"SHELLEXECUTEINFO",
-		"winBindings.shell32",
-	),
-	_deprecate.MovedSymbol(
-		"SHELLEXECUTEINFOW",
-		"winBindings.shell32",
-	),
-)
 
 
 class FolderId(str, Enum):

--- a/source/shlobj.py
+++ b/source/shlobj.py
@@ -20,6 +20,19 @@ from typing import Optional, Union
 
 import winBindings.shell32
 import winBindings.ole32
+from utils import _deprecate
+
+
+__getattr__ = _deprecate.handleDeprecations(
+	_deprecate.MovedSymbol(
+		"SHELLEXECUTEINFO",
+		"winBindings.shell32",
+	),
+	_deprecate.MovedSymbol(
+		"SHELLEXECUTEINFOW",
+		"winBindings.shell32",
+	),
+)
 
 
 class FolderId(str, Enum):

--- a/source/synthDrivers/sapi4.py
+++ b/source/synthDrivers/sapi4.py
@@ -14,6 +14,7 @@ import time
 import winreg
 import winBindings.ole32
 import winBindings.user32
+import winBindings.winmm
 from winBindings.mmeapi import WAVEFORMATEX
 from comtypes import CoCreateInstance, CoInitialize, COMObject, COMError, GUID, hresult, ReturnHRESULT
 from ctypes import (
@@ -1226,9 +1227,8 @@ def _mmDeviceEndpointIdToWaveOutId(targetEndpointId: str) -> int:
 		currEndpointId = create_string_buffer(targetEndpointIdByteCount)
 		currEndpointIdByteCount = DWORD()
 		# Defined in mmeapi.h
-		winmm = windll.winmm
-		waveOutMessage = winmm.waveOutMessage
-		waveOutGetNumDevs = winmm.waveOutGetNumDevs
+		waveOutMessage = winBindings.winmm.waveOutMessage
+		waveOutGetNumDevs = winBindings.winmm.waveOutGetNumDevs
 		for devID in range(waveOutGetNumDevs()):
 			# Get the length of this device's endpoint ID string.
 			mmr = waveOutMessage(

--- a/source/systemUtils.py
+++ b/source/systemUtils.py
@@ -26,6 +26,7 @@ from typing import (
 
 import winBindings.advapi32
 import winBindings.kernel32
+import winBindings.shell32
 import winKernel
 import winreg
 import shellapi
@@ -152,7 +153,7 @@ def execElevated(path, params=None, wait=False, handleAlreadyElevated=False):
 		params = subprocess.list2cmdline(params)
 	sei = shellapi.SHELLEXECUTEINFO(lpFile=path, lpParameters=params, nShow=winUser.SW_HIDE)
 	# IsUserAnAdmin is apparently deprecated so may not work above Windows 8
-	if not handleAlreadyElevated or not ctypes.windll.shell32.IsUserAnAdmin():
+	if not handleAlreadyElevated or not winBindings.shell32.IsUserAnAdmin():
 		sei.lpVerb = "runas"
 	if wait:
 		sei.fMask = shellapi.SEE_MASK_NOCLOSEPROCESS

--- a/source/systemUtils.py
+++ b/source/systemUtils.py
@@ -24,6 +24,7 @@ from typing import (
 	TypeVar,
 )
 
+import winBindings.advapi32
 import winBindings.kernel32
 import winKernel
 import winreg
@@ -74,7 +75,7 @@ def hasUiAccess():
 	)
 	try:
 		val = ctypes.wintypes.DWORD()
-		ctypes.windll.advapi32.GetTokenInformation(
+		winBindings.advapi32.GetTokenInformation(
 			token,
 			TokenUIAccess,
 			ctypes.byref(val),
@@ -126,7 +127,7 @@ def getProcessLogonSessionId(processHandle: int) -> int:
 		raise ctypes.WinError()
 	try:
 		val = TokenOrigin()
-		if not ctypes.windll.advapi32.GetTokenInformation(
+		if not winBindings.advapi32.GetTokenInformation(
 			token,
 			TOKEN_ORIGIN,
 			ctypes.byref(val),

--- a/source/ui.py
+++ b/source/ui.py
@@ -21,6 +21,7 @@ from comtypes import IUnknown
 from comtypes import automation
 from comtypes import COMError
 from html import escape
+import winBindings.mshtml
 
 import nh3
 from logHandler import log
@@ -219,7 +220,7 @@ def browseableMessage(
 	dialogArgsVar = automation.VARIANT(d)
 	gui.mainFrame.prePopup()
 	try:
-		windll.mshtml.ShowHTMLDialogEx(
+		winBindings.mshtml.ShowHTMLDialogEx(
 			gui.mainFrame.Handle,
 			moniker,
 			HTMLDLG_MODELESS,

--- a/source/ui.py
+++ b/source/ui.py
@@ -16,7 +16,6 @@ from ctypes import (
 	POINTER,
 )
 import comtypes.client
-from comtypes import IUnknown
 from comtypes import automation
 from comtypes import COMError
 from html import escape

--- a/source/ui.py
+++ b/source/ui.py
@@ -12,7 +12,6 @@ See L{gui} for the graphical user interface.
 
 import os
 from ctypes import (
-	windll,
 	byref,
 	POINTER,
 )
@@ -22,6 +21,8 @@ from comtypes import automation
 from comtypes import COMError
 from html import escape
 import winBindings.mshtml
+import winBindings.urlmon
+from objidl import IMoniker
 
 import nh3
 from logHandler import log
@@ -170,9 +171,9 @@ def browseableMessage(
 		_warnBrowsableMessageComponentFailure(title)
 		raise LookupError(htmlFileName)
 
-	moniker = POINTER(IUnknown)()
+	moniker = POINTER(IMoniker)()
 	try:
-		windll.urlmon.CreateURLMonikerEx(0, htmlFileName, byref(moniker), URL_MK_UNIFORM)
+		winBindings.urlmon.CreateURLMonikerEx(None, htmlFileName, byref(moniker), URL_MK_UNIFORM)
 	except OSError as e:
 		log.error(f"OS error during URL moniker creation: {e}")
 		_warnBrowsableMessageComponentFailure(title)

--- a/source/utils/_deprecate.py
+++ b/source/utils/_deprecate.py
@@ -14,7 +14,6 @@ from types import ModuleType
 from typing import Any
 
 import NVDAState
-from logHandler import log
 
 
 class DeprecatedSymbol(ABC):
@@ -156,6 +155,9 @@ def handleDeprecations(
 	def module_getattr(attrName: str) -> Any:
 		if NVDAState._allowDeprecatedAPI():
 			if attrName in deprecatedSymbols:
+				# Import late to avoid circular import
+				from logHandler import log
+
 				deprecatedSymbol = deprecatedSymbols[attrName]
 				# TODO: #17783: switch to using warnings.warn when NVDA's support for it matures.
 				log.warning(

--- a/source/visionEnhancementProviders/NVDAHighlighter.py
+++ b/source/visionEnhancementProviders/NVDAHighlighter.py
@@ -32,7 +32,6 @@ from collections import namedtuple
 import threading
 from winAPI.messageWindow import WindowMessage
 import winGDI
-from winBindings import gdi32
 import weakref
 from colors import RGB
 import core

--- a/source/visionEnhancementProviders/NVDAHighlighter.py
+++ b/source/visionEnhancementProviders/NVDAHighlighter.py
@@ -32,6 +32,7 @@ from collections import namedtuple
 import threading
 from winAPI.messageWindow import WindowMessage
 import winGDI
+from winBindings import gdi32
 import weakref
 from colors import RGB
 import core

--- a/source/winAPI/_wtsApi32.py
+++ b/source/winAPI/_wtsApi32.py
@@ -31,7 +31,7 @@ from ctypes.wintypes import (
 	LPWSTR,
 	BOOL,
 )
-
+import winBindings.wtsapi32
 
 WTS_CURRENT_SERVER_HANDLE = HANDLE(0)
 """ WTS_CURRENT_SERVER_HANDLE WtsApi32.h#L36
@@ -44,12 +44,7 @@ WTS_CURRENT_SESSION = DWORD(-1)
 
 # WTSFreeMemory Definition
 WTSFreeMemoryT = Callable[[c_void_p], None]
-WTSFreeMemory: WTSFreeMemoryT = windll.wtsapi32.WTSFreeMemory
-"""WtsApi32.h#L1245"""
-WTSFreeMemory.argtypes = (
-	c_void_p,  # [in] PVOID pMemory
-)
-WTSFreeMemory.restype = None
+WTSFreeMemory: WTSFreeMemoryT = winBindings.wtsapi32.WTSFreeMemory
 
 
 class WTS_INFO_CLASS(IntEnum):
@@ -168,15 +163,7 @@ WTSQuerySessionInformationT = Callable[
 	],
 	bool,
 ]
-WTSQuerySessionInformation: WTSQuerySessionInformationT = windll.wtsapi32.WTSQuerySessionInformationW
-WTSQuerySessionInformation.argtypes = (
-	HANDLE,  # [in] HANDLE hServer
-	DWORD,  # [ in] DWORD SessionId
-	c_int,  # [ in]  WTS_INFO_CLASS WTSInfoClass,
-	POINTER(LPWSTR),  # [out] LPWSTR * ppBuffer,
-	POINTER(DWORD),  # [out] DWORD * pBytesReturned
-)
-WTSQuerySessionInformation.restype = BOOL  # On Failure, the return value is zero.
+WTSQuerySessionInformation: WTSQuerySessionInformationT = winBindings.wtsapi32.WTSQuerySessionInformation
 
 
 class _WTS_LockState(IntEnum):

--- a/source/winAPI/_wtsApi32.py
+++ b/source/winAPI/_wtsApi32.py
@@ -16,7 +16,6 @@ from enum import (
 from typing import Callable
 import ctypes  # Use for ctypes.Union to prevent name collision with typing.Union
 from ctypes import (
-	windll,
 	c_void_p,
 	c_wchar,
 	c_int,
@@ -29,7 +28,6 @@ from ctypes.wintypes import (
 	LONG,
 	LARGE_INTEGER,
 	LPWSTR,
-	BOOL,
 )
 import winBindings.wtsapi32
 

--- a/source/winBindings/advapi32.py
+++ b/source/winBindings/advapi32.py
@@ -96,6 +96,13 @@ RegQueryValueEx.restype = LONG
 
 
 class STARTUPINFOW(Structure):
+	"""
+	Specifies the window station, desktop, standard handles, and appearance of the main window for a process at creation time.
+
+	..seealso:
+		https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/ns-processthreadsapi-startupinfow
+	"""
+
 	_fields_ = (
 		("cb", DWORD),
 		("lpReserved", LPWSTR),
@@ -125,6 +132,13 @@ STARTUPINFO = STARTUPINFOW
 
 
 class PROCESS_INFORMATION(Structure):
+	"""
+	Contains information about a newly created process and its primary thread.
+
+	..seealso::
+		https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/ns-processthreadsapi-process_information
+	"""
+
 	_fields_ = (
 		("hProcess", HANDLE),
 		("hThread", HANDLE),
@@ -134,6 +148,13 @@ class PROCESS_INFORMATION(Structure):
 
 
 class SECURITY_ATTRIBUTES(Structure):
+	"""
+	Contains the security descriptor for an object and specifies whether the handle retrieved by specifying this structure is inheritable.
+
+	..seealso::
+		https://learn.microsoft.com/en-us/previous-versions/windows/desktop/legacy/aa379560(v=vs.85)
+	"""
+
 	_fields_ = (
 		("nLength", DWORD),
 		("lpSecurityDescriptor", LPVOID),
@@ -145,7 +166,7 @@ CreateProcessAsUser = dll.CreateProcessAsUserW
 """
 Creates a new process and its primary thread. The new process runs in the security context of the user represented by the specified token.
 .. seealso::
-	https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-createprocessasuserw
+	https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-createprocessasuserw
 """
 CreateProcessAsUser.argtypes = (
 	HANDLE,  # hToken

--- a/source/winBindings/advapi32.py
+++ b/source/winBindings/advapi32.py
@@ -23,7 +23,6 @@ from ctypes.wintypes import (
 	LPCWSTR,
 	LPWSTR,
 	LPVOID,
-	LPBYTE,
 )
 
 __all__ = (
@@ -141,6 +140,7 @@ class SECURITY_ATTRIBUTES(Structure):
 		("bInheritHandle", BOOL),
 	)
 
+
 CreateProcessAsUser = dll.CreateProcessAsUserW
 """
 Creates a new process and its primary thread. The new process runs in the security context of the user represented by the specified token.
@@ -148,17 +148,17 @@ Creates a new process and its primary thread. The new process runs in the securi
 	https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-createprocessasuserw
 """
 CreateProcessAsUser.argtypes = (
-	HANDLE,      # hToken
-	LPCWSTR,     # lpApplicationName
-	LPWSTR,      # lpCommandLine
-	POINTER(SECURITY_ATTRIBUTES),      # lpProcessAttributes
-	POINTER(SECURITY_ATTRIBUTES),      # lpThreadAttributes
-	BOOL,        # bInheritHandles
-	DWORD,       # dwCreationFlags
-	LPVOID,      # lpEnvironment
-	LPCWSTR,     # lpCurrentDirectory
-	POINTER(STARTUPINFOW),    # lpStartupInfo
-	POINTER(PROCESS_INFORMATION),    # lpProcessInformation
+	HANDLE,  # hToken
+	LPCWSTR,  # lpApplicationName
+	LPWSTR,  # lpCommandLine
+	POINTER(SECURITY_ATTRIBUTES),  # lpProcessAttributes
+	POINTER(SECURITY_ATTRIBUTES),  # lpThreadAttributes
+	BOOL,  # bInheritHandles
+	DWORD,  # dwCreationFlags
+	LPVOID,  # lpEnvironment
+	LPCWSTR,  # lpCurrentDirectory
+	POINTER(STARTUPINFOW),  # lpStartupInfo
+	POINTER(PROCESS_INFORMATION),  # lpProcessInformation
 )
 CreateProcessAsUser.restype = BOOL
 
@@ -169,10 +169,10 @@ Retrieves a specified type of information about an access token.
 	https://learn.microsoft.com/en-us/windows/win32/api/securitybaseapi/nf-securitybaseapi-gettokeninformation
 """
 GetTokenInformation.argtypes = (
-	HANDLE,      # TokenHandle
-	DWORD,       # TOKEN_INFORMATION_CLASS
-	LPVOID,      # TokenInformation
-	DWORD,       # TokenInformationLength
-	POINTER(DWORD), # ReturnLength
+	HANDLE,  # TokenHandle
+	DWORD,  # TOKEN_INFORMATION_CLASS
+	LPVOID,  # TokenInformation
+	DWORD,  # TokenInformationLength
+	POINTER(DWORD),  # ReturnLength
 )
 GetTokenInformation.restype = BOOL

--- a/source/winBindings/gdi32.py
+++ b/source/winBindings/gdi32.py
@@ -1,0 +1,31 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2025 NV Access Limited
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
+
+"""Functions exported by gdi32.dll, and supporting data structures and enumerations."""
+
+from ctypes import (
+	c_int,
+	windll,
+)
+from ctypes.wintypes import (
+	HDC,
+)
+
+
+dll = windll.gdi32
+
+
+GetDeviceCaps = dll.GetDeviceCaps
+"""
+Retrieves device-specific information for the specified device.
+
+.. seealso::
+	https://learn.microsoft.com/en-us/windows/win32/api/wingdi/nf-wingdi-getdevicecaps
+"""
+GetDeviceCaps.restype = c_int
+GetDeviceCaps.argtypes = (
+	HDC,    # hdc: A handle to the DC
+	c_int,  # nIndex: The item to be returned
+)

--- a/source/winBindings/gdi32.py
+++ b/source/winBindings/gdi32.py
@@ -138,6 +138,13 @@ StretchBlt.argtypes = (
 
 
 class RGBQUAD(Structure):
+	"""
+	Describes a color consisting of relative intensities of red, green, and blue.
+
+	..seealso::
+		https://learn.microsoft.com/en-us/windows/win32/api/wingdi/ns-wingdi-rgbquad
+	"""
+
 	_fields_ = [
 		("rgbBlue", c_ubyte),
 		("rgbGreen", c_ubyte),
@@ -163,6 +170,13 @@ class BITMAPINFOHEADER(Structure):
 
 
 class BITMAPINFO(Structure):
+	"""
+	Defines the dimensions and color information for a DIB.
+
+	..seealso::
+		https://learn.microsoft.com/en-us/windows/win32/api/wingdi/ns-wingdi-bitmapinfo
+	"""
+
 	_fields_ = [
 		("bmiHeader", BITMAPINFOHEADER),
 		("bmiColors", (RGBQUAD * 1)),

--- a/source/winBindings/gdi32.py
+++ b/source/winBindings/gdi32.py
@@ -41,7 +41,7 @@ Retrieves device-specific information for the specified device.
 """
 GetDeviceCaps.restype = c_int
 GetDeviceCaps.argtypes = (
-	HDC,    # hdc: A handle to the DC
+	HDC,  # hdc: A handle to the DC
 	c_int,  # nIndex: The item to be returned
 )
 
@@ -68,7 +68,7 @@ Creates a bitmap compatible with the device that is associated with the specifie
 """
 CreateCompatibleBitmap.restype = HBITMAP
 CreateCompatibleBitmap.argtypes = (
-	HDC,    # hdc: A handle to a device context
+	HDC,  # hdc: A handle to a device context
 	c_int,  # cx: The bitmap width, in pixels
 	c_int,  # cy: The bitmap height, in pixels
 )
@@ -83,7 +83,7 @@ Selects an object into the specified device context (DC).
 """
 SelectObject.restype = HGDIOBJ
 SelectObject.argtypes = (
-	HDC,      # hdc: A handle to the DC
+	HDC,  # hdc: A handle to the DC
 	HGDIOBJ,  # h: A handle to the object to be selected
 )
 
@@ -123,12 +123,12 @@ Copies a bitmap from a source rectangle into a destination rectangle, stretching
 """
 StretchBlt.restype = BOOL
 StretchBlt.argtypes = (
-	HDC,    # hdcDest: A handle to the destination device context
+	HDC,  # hdcDest: A handle to the destination device context
 	c_int,  # xDest: The x-coordinate, in logical units, of the upper-left corner of the destination rectangle
 	c_int,  # yDest: The y-coordinate, in logical units, of the upper-left corner of the destination rectangle
 	c_int,  # wDest: The width, in logical units, of the destination rectangle
 	c_int,  # hDest: The height, in logical units, of the destination rectangle
-	HDC,    # hdcSrc: A handle to the source device context
+	HDC,  # hdcSrc: A handle to the source device context
 	c_int,  # xSrc: The x-coordinate, in logical units, of the upper-left corner of the source rectangle
 	c_int,  # ySrc: The y-coordinate, in logical units, of the upper-left corner of the source rectangle
 	c_int,  # wSrc: The width, in logical units, of the source rectangle
@@ -178,13 +178,15 @@ Retrieves the bits of the specified compatible bitmap and copies them into a buf
 """
 GetDIBits.restype = c_int
 GetDIBits.argtypes = (
-	HDC,      # hdc: A handle to the device context
+	HDC,  # hdc: A handle to the device context
 	HBITMAP,  # hbm: A handle to the bitmap
-	UINT,     # start: The first scan line to retrieve
-	UINT,     # cLines: The number of scan lines to retrieve
-	LPVOID,   # lpvBits: A pointer to a buffer to receive the bitmap data
-	POINTER(BITMAPINFO), # lpbmi: A pointer to a BITMAPINFO structure that specifies the desired format for the DIB data
-	UINT,     # usage: The format of the bmiColors member of the BITMAPINFO structure
+	UINT,  # start: The first scan line to retrieve
+	UINT,  # cLines: The number of scan lines to retrieve
+	LPVOID,  # lpvBits: A pointer to a buffer to receive the bitmap data
+	POINTER(
+		BITMAPINFO
+	),  # lpbmi: A pointer to a BITMAPINFO structure that specifies the desired format for the DIB data
+	UINT,  # usage: The format of the bmiColors member of the BITMAPINFO structure
 )
 
 
@@ -211,6 +213,6 @@ Adds the font resource from the specified file to the system.
 AddFontResourceEx.restype = c_int
 AddFontResourceEx.argtypes = (
 	LPCWSTR,  # name: A pointer to a null-terminated string that contains a valid font file name
-	DWORD,    # fl: The characteristics of the font to be added to the system
-	c_void_p, # res: Reserved. Must be zero
+	DWORD,  # fl: The characteristics of the font to be added to the system
+	c_void_p,  # res: Reserved. Must be zero
 )

--- a/source/winBindings/gdi32.py
+++ b/source/winBindings/gdi32.py
@@ -184,7 +184,7 @@ GetDIBits.argtypes = (
 	UINT,  # cLines: The number of scan lines to retrieve
 	LPVOID,  # lpvBits: A pointer to a buffer to receive the bitmap data
 	POINTER(
-		BITMAPINFO
+		BITMAPINFO,
 	),  # lpbmi: A pointer to a BITMAPINFO structure that specifies the desired format for the DIB data
 	UINT,  # usage: The format of the bmiColors member of the BITMAPINFO structure
 )

--- a/source/winBindings/gdi32.py
+++ b/source/winBindings/gdi32.py
@@ -154,13 +154,20 @@ class RGBQUAD(Structure):
 
 
 class BITMAPINFOHEADER(Structure):
+	"""
+	Contains information about the dimensions and color format of a device-independent bitmap (DIB).
+
+	..seealso::
+		https://learn.microsoft.com/en-us/windows/win32/api/wingdi/ns-wingdi-bitmapinfoheader
+	"""
+
 	_fields_ = [
 		("biSize", DWORD),
 		("biWidth", LONG),
 		("biHeight", LONG),
 		("biPlanes", WORD),
 		("biBitCount", WORD),
-		("biCompression", WORD),
+		("biCompression", DWORD),
 		("biSizeImage", DWORD),
 		("biXPelsPerMeter", LONG),
 		("biYPelsPerMeter", LONG),

--- a/source/winBindings/gdi32.py
+++ b/source/winBindings/gdi32.py
@@ -6,11 +6,26 @@
 """Functions exported by gdi32.dll, and supporting data structures and enumerations."""
 
 from ctypes import (
+	Structure,
+	c_ubyte,
 	c_int,
+	c_void_p,
+	POINTER,
 	windll,
 )
 from ctypes.wintypes import (
+	BOOL,
+	WORD,
+	LONG,
+	COLORREF,
+	DWORD,
+	HBITMAP,
+	HBRUSH,
 	HDC,
+	HGDIOBJ,
+	LPCWSTR,
+	LPVOID,
+	UINT,
 )
 
 
@@ -28,4 +43,174 @@ GetDeviceCaps.restype = c_int
 GetDeviceCaps.argtypes = (
 	HDC,    # hdc: A handle to the DC
 	c_int,  # nIndex: The item to be returned
+)
+
+
+CreateCompatibleDC = dll.CreateCompatibleDC
+"""
+Creates a memory device context (DC) compatible with the specified device.
+
+.. seealso::
+	https://learn.microsoft.com/en-us/windows/win32/api/wingdi/nf-wingdi-createcompatibledc
+"""
+CreateCompatibleDC.restype = HDC
+CreateCompatibleDC.argtypes = (
+	HDC,  # hdc: A handle to an existing DC
+)
+
+
+CreateCompatibleBitmap = dll.CreateCompatibleBitmap
+"""
+Creates a bitmap compatible with the device that is associated with the specified device context.
+
+.. seealso::
+	https://learn.microsoft.com/en-us/windows/win32/api/wingdi/nf-wingdi-createcompatiblebitmap
+"""
+CreateCompatibleBitmap.restype = HBITMAP
+CreateCompatibleBitmap.argtypes = (
+	HDC,    # hdc: A handle to a device context
+	c_int,  # cx: The bitmap width, in pixels
+	c_int,  # cy: The bitmap height, in pixels
+)
+
+
+SelectObject = dll.SelectObject
+"""
+Selects an object into the specified device context (DC).
+
+.. seealso::
+	https://learn.microsoft.com/en-us/windows/win32/api/wingdi/nf-wingdi-selectobject
+"""
+SelectObject.restype = HGDIOBJ
+SelectObject.argtypes = (
+	HDC,      # hdc: A handle to the DC
+	HGDIOBJ,  # h: A handle to the object to be selected
+)
+
+
+DeleteObject = dll.DeleteObject
+"""
+Deletes a logical pen, brush, font, bitmap, region, or palette, freeing all system resources associated with the object.
+
+.. seealso::
+	https://learn.microsoft.com/en-us/windows/win32/api/wingdi/nf-wingdi-deleteobject
+"""
+DeleteObject.restype = BOOL
+DeleteObject.argtypes = (
+	HGDIOBJ,  # ho: A handle to a logical pen, brush, font, bitmap, region, or palette
+)
+
+
+DeleteDC = dll.DeleteDC
+"""
+Deletes the specified device context (DC).
+
+.. seealso::
+	https://learn.microsoft.com/en-us/windows/win32/api/wingdi/nf-wingdi-deletedc
+"""
+DeleteDC.restype = BOOL
+DeleteDC.argtypes = (
+	HDC,  # hdc: A handle to the device context
+)
+
+
+StretchBlt = dll.StretchBlt
+"""
+Copies a bitmap from a source rectangle into a destination rectangle, stretching or compressing the bitmap to fit the dimensions of the destination rectangle.
+
+.. seealso::
+	https://learn.microsoft.com/en-us/windows/win32/api/wingdi/nf-wingdi-stretchblt
+"""
+StretchBlt.restype = BOOL
+StretchBlt.argtypes = (
+	HDC,    # hdcDest: A handle to the destination device context
+	c_int,  # xDest: The x-coordinate, in logical units, of the upper-left corner of the destination rectangle
+	c_int,  # yDest: The y-coordinate, in logical units, of the upper-left corner of the destination rectangle
+	c_int,  # wDest: The width, in logical units, of the destination rectangle
+	c_int,  # hDest: The height, in logical units, of the destination rectangle
+	HDC,    # hdcSrc: A handle to the source device context
+	c_int,  # xSrc: The x-coordinate, in logical units, of the upper-left corner of the source rectangle
+	c_int,  # ySrc: The y-coordinate, in logical units, of the upper-left corner of the source rectangle
+	c_int,  # wSrc: The width, in logical units, of the source rectangle
+	c_int,  # hSrc: The height, in logical units, of the source rectangle
+	DWORD,  # rop: The raster operation to be performed
+)
+
+
+class RGBQUAD(Structure):
+	_fields_ = [
+		("rgbBlue", c_ubyte),
+		("rgbGreen", c_ubyte),
+		("rgbRed", c_ubyte),
+		("rgbReserved", c_ubyte),
+	]
+
+
+class BITMAPINFOHEADER(Structure):
+	_fields_ = [
+		("biSize", DWORD),
+		("biWidth", LONG),
+		("biHeight", LONG),
+		("biPlanes", WORD),
+		("biBitCount", WORD),
+		("biCompression", WORD),
+		("biSizeImage", DWORD),
+		("biXPelsPerMeter", LONG),
+		("biYPelsPerMeter", LONG),
+		("biClrUsed", DWORD),
+		("biClrImportant", DWORD),
+	]
+
+
+class BITMAPINFO(Structure):
+	_fields_ = [
+		("bmiHeader", BITMAPINFOHEADER),
+		("bmiColors", (RGBQUAD * 1)),
+	]
+
+
+GetDIBits = dll.GetDIBits
+"""
+Retrieves the bits of the specified compatible bitmap and copies them into a buffer as a DIB using the specified format.
+
+.. seealso::
+	https://learn.microsoft.com/en-us/windows/win32/api/wingdi/nf-wingdi-getdibits
+"""
+GetDIBits.restype = c_int
+GetDIBits.argtypes = (
+	HDC,      # hdc: A handle to the device context
+	HBITMAP,  # hbm: A handle to the bitmap
+	UINT,     # start: The first scan line to retrieve
+	UINT,     # cLines: The number of scan lines to retrieve
+	LPVOID,   # lpvBits: A pointer to a buffer to receive the bitmap data
+	POINTER(BITMAPINFO), # lpbmi: A pointer to a BITMAPINFO structure that specifies the desired format for the DIB data
+	UINT,     # usage: The format of the bmiColors member of the BITMAPINFO structure
+)
+
+
+CreateSolidBrush = dll.CreateSolidBrush
+"""
+Creates a logical brush that has the specified solid color.
+
+.. seealso::
+	https://learn.microsoft.com/en-us/windows/win32/api/wingdi/nf-wingdi-createsolidbrush
+"""
+CreateSolidBrush.restype = HBRUSH
+CreateSolidBrush.argtypes = (
+	COLORREF,  # color: The color of the brush
+)
+
+
+AddFontResourceEx = dll.AddFontResourceExW
+"""
+Adds the font resource from the specified file to the system.
+
+.. seealso::
+	https://learn.microsoft.com/en-us/windows/win32/api/wingdi/nf-wingdi-addfontresourceexw
+"""
+AddFontResourceEx.restype = c_int
+AddFontResourceEx.argtypes = (
+	LPCWSTR,  # name: A pointer to a null-terminated string that contains a valid font file name
+	DWORD,    # fl: The characteristics of the font to be added to the system
+	c_void_p, # res: Reserved. Must be zero
 )

--- a/source/winBindings/gdiplus.py
+++ b/source/winBindings/gdiplus.py
@@ -45,7 +45,7 @@ class GdiplusStartupInput(Structure):
 
 
 class GdiplusStartupOutput(Structure):
-	_fields = [
+	_fields_ = [
 		("NotificationHookProc", c_void_p),
 		("NotificationUnhookProc", c_void_p),
 	]

--- a/source/winBindings/gdiplus.py
+++ b/source/winBindings/gdiplus.py
@@ -36,6 +36,13 @@ dll = windll.gdiplus
 
 
 class GdiplusStartupInput(Structure):
+	"""
+	Holds a block of arguments that are required by the GdiplusStartup function.
+
+	..seealso::
+		https://learn.microsoft.com/en-us/windows/win32/api/gdiplusinit/ns-gdiplusinit-gdiplusstartupinput
+	"""
+
 	_fields_ = [
 		("GdiplusVersion", c_uint32),
 		("DebugEventCallback", c_void_p),
@@ -45,6 +52,13 @@ class GdiplusStartupInput(Structure):
 
 
 class GdiplusStartupOutput(Structure):
+	"""
+	Stores a pointer to a hook function and a pointer to an unhook function as returned by GdiplusStartup.
+
+	..seealso::
+		https://learn.microsoft.com/en-us/windows/win32/api/gdiplusinit/ns-gdiplusinit-GdiplusStartupOutput
+	"""
+
 	_fields_ = [
 		("NotificationHookProc", c_void_p),
 		("NotificationUnhookProc", c_void_p),

--- a/source/winBindings/gdiplus.py
+++ b/source/winBindings/gdiplus.py
@@ -90,7 +90,7 @@ GdipCreateFromHDC.restype = GpStatus
 GdipCreateFromHDC.argtypes = (
 	HDC,  # hdc: Handle to a device context
 	POINTER(
-		POINTER(GpGraphics)
+		POINTER(GpGraphics),
 	),  # graphics: Pointer to a variable that receives a pointer to the new Graphics object
 )
 

--- a/source/winBindings/gdiplus.py
+++ b/source/winBindings/gdiplus.py
@@ -10,7 +10,6 @@ from ctypes import (
 	c_float,
 	c_int,
 	c_uint32,
-	c_ulong,
 	c_void_p,
 	POINTER,
 	windll,
@@ -18,12 +17,13 @@ from ctypes import (
 )
 from ctypes.wintypes import (
 	BOOL,
+	DWORD,
 	HDC,
 )
 
 
 ULONG_PTR = c_size_t
-ARGB = c_ulong
+ARGB = DWORD
 REAL = c_float
 GpUnit = c_int
 GpStatus = c_int

--- a/source/winBindings/gdiplus.py
+++ b/source/winBindings/gdiplus.py
@@ -1,0 +1,185 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2025 NV Access Limited
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
+
+"""Functions exported by gdiplus.dll, and supporting data structures and enumerations."""
+
+from ctypes import (
+	Structure,
+	c_float,
+	c_int,
+	c_uint32,
+	c_ulong,
+	c_void_p,
+	POINTER,
+	windll,
+	c_size_t,
+)
+from ctypes.wintypes import (
+	BOOL,
+	HDC,
+)
+
+
+ULONG_PTR = c_size_t
+ARGB = c_ulong
+REAL = c_float
+GpUnit = c_int
+GpStatus = c_int
+GpPen = c_void_p
+GpGraphics = c_void_p
+GpDashStyle = c_int
+
+
+dll = windll.gdiplus
+
+
+class GdiplusStartupInput(Structure):
+	_fields_ = [
+		("GdiplusVersion", c_uint32),
+		("DebugEventCallback", c_void_p),
+		("SuppressBackgroundThread", BOOL),
+		("SuppressExternalCodecs", BOOL),
+	]
+
+
+class GdiplusStartupOutput(Structure):
+	_fields = [
+		("NotificationHookProc", c_void_p),
+		("NotificationUnhookProc", c_void_p),
+	]
+
+
+GdiplusStartup = dll.GdiplusStartup
+"""
+Initializes Windows GDI+.
+
+.. seealso::
+	https://learn.microsoft.com/en-us/windows/win32/api/gdiplusinit/nf-gdiplusinit-gdiplusstartup
+"""
+GdiplusStartup.restype = c_int
+GdiplusStartup.argtypes = (
+	POINTER(ULONG_PTR),  # token: A pointer to a ULONG_PTR that receives a token
+	POINTER(GdiplusStartupInput),          # input: A pointer to a GdiplusStartupInput structure
+	POINTER(GdiplusStartupOutput),          # output: A pointer to a GdiplusStartupOutput structure
+)
+
+
+GdiplusShutdown = dll.GdiplusShutdown
+"""
+Cleans up resources used by Windows GDI+.
+
+.. seealso::
+	https://learn.microsoft.com/en-us/windows/win32/api/gdiplusinit/nf-gdiplusinit-gdiplusshutdown
+"""
+GdiplusShutdown.restype = None
+GdiplusShutdown.argtypes = (
+	ULONG_PTR,  # token: A token that was returned by a previous call to GdiplusStartup
+)
+
+
+GdipCreateFromHDC = dll.GdipCreateFromHDC
+"""
+Creates a Graphics object that is associated with a specified device context.
+
+.. seealso::
+	https://learn.microsoft.com/en-us/windows/win32/api/gdiplusgraphics/nf-gdiplusgraphics-graphics-graphics(inhdc)
+"""
+GdipCreateFromHDC.restype = GpStatus
+GdipCreateFromHDC.argtypes = (
+	HDC,                # hdc: Handle to a device context
+	POINTER(POINTER(GpGraphics)),    # graphics: Pointer to a variable that receives a pointer to the new Graphics object
+)
+
+
+GdipCreatePen1 = dll.GdipCreatePen1
+"""
+Creates a Pen object that has specified color, width, and style.
+
+.. seealso::
+	https://learn.microsoft.com/en-us/windows/win32/api/gdipluspen/nf-gdipluspen-pen-pen(inconstcolor__inreal__inunit)
+"""
+GdipCreatePen1.restype = GpStatus
+GdipCreatePen1.argtypes = (
+	ARGB,                # color: ARGB color
+	REAL,              # width: Width of the pen
+	GpUnit,                # unit: Unit of measure for the pen width
+	POINTER(POINTER(GpPen)),    # pen: Pointer to a variable that receives a pointer to the new Pen object
+)
+
+
+GdipSetPenDashStyle = dll.GdipSetPenDashStyle
+"""
+Sets the dash style of a Pen object.
+
+.. seealso::
+	https://learn.microsoft.com/en-us/windows/win32/api/gdipluspen/nf-gdipluspen-pen-setdashstyle
+"""
+GdipSetPenDashStyle.restype = GpStatus
+GdipSetPenDashStyle.argtypes = (
+	POINTER(GpPen),  # pen: Pointer to the Pen object
+	GpDashStyle,     # dashStyle: Element of the DashStyle enumeration
+)
+
+
+GdipDrawLine = dll.GdipDrawLine
+"""
+Draws a line.
+
+.. seealso::
+	https://learn.microsoft.com/en-us/windows/win32/api/gdiplusgraphics/nf-gdiplusgraphics-graphics-drawline(inconstpen_inreal_inreal_inreal_inreal)
+"""
+GdipDrawLine.restype = GpStatus
+GdipDrawLine.argtypes = (
+	POINTER(GpGraphics),  # graphics: Pointer to the Graphics object
+	POINTER(GpPen),  # pen: Pointer to a pen that is used to draw the line
+	REAL,   # x1: x-coordinate of the starting point of the line
+	REAL,   # y1: y-coordinate of the starting point of the line
+	REAL,   # x2: x-coordinate of the ending point of the line
+	REAL,   # y2: y-coordinate of the ending point of the line
+)
+
+
+GdipDrawRectangle = dll.GdipDrawRectangle
+"""
+Draws a rectangle.
+
+.. seealso::
+	https://learn.microsoft.com/en-us/windows/win32/api/gdiplusgraphics/nf-gdiplusgraphics-graphics-drawrectangle(inconstpen_inreal_inreal_inreal_inreal)
+"""
+GdipDrawRectangle.restype = GpStatus
+GdipDrawRectangle.argtypes = (
+	POINTER(GpGraphics),  # graphics: Pointer to the Graphics object
+	POINTER(GpPen),  # pen: Pointer to a pen that is used to draw the rectangle
+	REAL,   # x: x-coordinate of the upper-left corner of the rectangle
+	REAL,   # y: y-coordinate of the upper-left corner of the rectangle
+	REAL,   # width: Width of the rectangle
+	REAL,   # height: Height of the rectangle
+)
+
+
+GdipDeletePen = dll.GdipDeletePen
+"""
+Deletes a Pen object.
+
+.. seealso::
+	https://learn.microsoft.com/en-us/windows/win32/api/gdipluspen/nf-gdipluspen-pen-pen
+"""
+GdipDeletePen.restype = GpStatus
+GdipDeletePen.argtypes = (
+	POINTER(GpPen),  # pen: Pointer to the Pen object to be deleted
+)
+
+
+GdipDeleteGraphics = dll.GdipDeleteGraphics
+"""
+Deletes a Graphics object.
+
+.. seealso::
+	https://learn.microsoft.com/en-us/windows/win32/api/gdiplusgraphics/nf-gdiplusgraphics-graphics-graphics
+"""
+GdipDeleteGraphics.restype = GpStatus
+GdipDeleteGraphics.argtypes = (
+	POINTER(GpGraphics),  # graphics: Pointer to the Graphics object to be deleted
+)

--- a/source/winBindings/gdiplus.py
+++ b/source/winBindings/gdiplus.py
@@ -61,8 +61,8 @@ Initializes Windows GDI+.
 GdiplusStartup.restype = c_int
 GdiplusStartup.argtypes = (
 	POINTER(ULONG_PTR),  # token: A pointer to a ULONG_PTR that receives a token
-	POINTER(GdiplusStartupInput),          # input: A pointer to a GdiplusStartupInput structure
-	POINTER(GdiplusStartupOutput),          # output: A pointer to a GdiplusStartupOutput structure
+	POINTER(GdiplusStartupInput),  # input: A pointer to a GdiplusStartupInput structure
+	POINTER(GdiplusStartupOutput),  # output: A pointer to a GdiplusStartupOutput structure
 )
 
 
@@ -88,8 +88,10 @@ Creates a Graphics object that is associated with a specified device context.
 """
 GdipCreateFromHDC.restype = GpStatus
 GdipCreateFromHDC.argtypes = (
-	HDC,                # hdc: Handle to a device context
-	POINTER(POINTER(GpGraphics)),    # graphics: Pointer to a variable that receives a pointer to the new Graphics object
+	HDC,  # hdc: Handle to a device context
+	POINTER(
+		POINTER(GpGraphics)
+	),  # graphics: Pointer to a variable that receives a pointer to the new Graphics object
 )
 
 
@@ -102,10 +104,10 @@ Creates a Pen object that has specified color, width, and style.
 """
 GdipCreatePen1.restype = GpStatus
 GdipCreatePen1.argtypes = (
-	ARGB,                # color: ARGB color
-	REAL,              # width: Width of the pen
-	GpUnit,                # unit: Unit of measure for the pen width
-	POINTER(POINTER(GpPen)),    # pen: Pointer to a variable that receives a pointer to the new Pen object
+	ARGB,  # color: ARGB color
+	REAL,  # width: Width of the pen
+	GpUnit,  # unit: Unit of measure for the pen width
+	POINTER(POINTER(GpPen)),  # pen: Pointer to a variable that receives a pointer to the new Pen object
 )
 
 
@@ -119,7 +121,7 @@ Sets the dash style of a Pen object.
 GdipSetPenDashStyle.restype = GpStatus
 GdipSetPenDashStyle.argtypes = (
 	POINTER(GpPen),  # pen: Pointer to the Pen object
-	GpDashStyle,     # dashStyle: Element of the DashStyle enumeration
+	GpDashStyle,  # dashStyle: Element of the DashStyle enumeration
 )
 
 
@@ -134,10 +136,10 @@ GdipDrawLine.restype = GpStatus
 GdipDrawLine.argtypes = (
 	POINTER(GpGraphics),  # graphics: Pointer to the Graphics object
 	POINTER(GpPen),  # pen: Pointer to a pen that is used to draw the line
-	REAL,   # x1: x-coordinate of the starting point of the line
-	REAL,   # y1: y-coordinate of the starting point of the line
-	REAL,   # x2: x-coordinate of the ending point of the line
-	REAL,   # y2: y-coordinate of the ending point of the line
+	REAL,  # x1: x-coordinate of the starting point of the line
+	REAL,  # y1: y-coordinate of the starting point of the line
+	REAL,  # x2: x-coordinate of the ending point of the line
+	REAL,  # y2: y-coordinate of the ending point of the line
 )
 
 
@@ -152,10 +154,10 @@ GdipDrawRectangle.restype = GpStatus
 GdipDrawRectangle.argtypes = (
 	POINTER(GpGraphics),  # graphics: Pointer to the Graphics object
 	POINTER(GpPen),  # pen: Pointer to a pen that is used to draw the rectangle
-	REAL,   # x: x-coordinate of the upper-left corner of the rectangle
-	REAL,   # y: y-coordinate of the upper-left corner of the rectangle
-	REAL,   # width: Width of the rectangle
-	REAL,   # height: Height of the rectangle
+	REAL,  # x: x-coordinate of the upper-left corner of the rectangle
+	REAL,  # y: y-coordinate of the upper-left corner of the rectangle
+	REAL,  # width: Width of the rectangle
+	REAL,  # height: Height of the rectangle
 )
 
 

--- a/source/winBindings/mshtml.py
+++ b/source/winBindings/mshtml.py
@@ -6,13 +6,13 @@
 """Functions exported by mshtml.dll, and supporting data structures and enumerations."""
 
 from ctypes import (
-	c_wchar_p,
 	windll,
 	POINTER,
 )
 from ctypes.wintypes import (
 	DWORD,
 	HWND,
+	LPWSTR,
 )
 from comtypes import HRESULT
 from comtypes.automation import VARIANT
@@ -35,6 +35,6 @@ ShowHTMLDialogEx.argtypes = (
 	POINTER(IMoniker),  # pMk: IMoniker interface pointer for the URL
 	DWORD,  # dwDialogFlags: Dialog behavior flags
 	POINTER(VARIANT),  # pvarArgIn: VARIANT pointer for input arguments
-	c_wchar_p,  # pchOptions: Dialog options string
+	LPWSTR,  # pchOptions: Dialog options string
 	POINTER(VARIANT),  # pvarArgOut: VARIANT pointer for output arguments (can be NULL)
 )

--- a/source/winBindings/mshtml.py
+++ b/source/winBindings/mshtml.py
@@ -31,10 +31,10 @@ Creates a modeless HTML dialog box.
 """
 ShowHTMLDialogEx.restype = HRESULT
 ShowHTMLDialogEx.argtypes = (
-	HWND,       # hwndParent: Handle to the parent window
-	POINTER(IMoniker),   # pMk: IMoniker interface pointer for the URL
-	DWORD,      # dwDialogFlags: Dialog behavior flags
-	POINTER(VARIANT),   # pvarArgIn: VARIANT pointer for input arguments
+	HWND,  # hwndParent: Handle to the parent window
+	POINTER(IMoniker),  # pMk: IMoniker interface pointer for the URL
+	DWORD,  # dwDialogFlags: Dialog behavior flags
+	POINTER(VARIANT),  # pvarArgIn: VARIANT pointer for input arguments
 	c_wchar_p,  # pchOptions: Dialog options string
-	POINTER(VARIANT),   # pvarArgOut: VARIANT pointer for output arguments (can be NULL)
+	POINTER(VARIANT),  # pvarArgOut: VARIANT pointer for output arguments (can be NULL)
 )

--- a/source/winBindings/mshtml.py
+++ b/source/winBindings/mshtml.py
@@ -1,0 +1,40 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2025 NV Access Limited
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
+
+"""Functions exported by mshtml.dll, and supporting data structures and enumerations."""
+
+from ctypes import (
+	c_wchar_p,
+	windll,
+	POINTER,
+)
+from ctypes.wintypes import (
+	DWORD,
+	HWND,
+)
+from comtypes import HRESULT
+from comtypes.automation import VARIANT
+from objidl import IMoniker
+
+
+dll = windll.mshtml
+
+
+ShowHTMLDialogEx = dll.ShowHTMLDialogEx
+"""
+Creates a modeless HTML dialog box.
+
+.. seealso::
+	https://learn.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/platform-apis/aa741859(v=vs.85)
+"""
+ShowHTMLDialogEx.restype = HRESULT
+ShowHTMLDialogEx.argtypes = (
+	HWND,       # hwndParent: Handle to the parent window
+	POINTER(IMoniker),   # pMk: IMoniker interface pointer for the URL
+	DWORD,      # dwDialogFlags: Dialog behavior flags
+	POINTER(VARIANT),   # pvarArgIn: VARIANT pointer for input arguments
+	c_wchar_p,  # pchOptions: Dialog options string
+	POINTER(VARIANT),   # pvarArgOut: VARIANT pointer for output arguments (can be NULL)
+)

--- a/source/winBindings/shell32.py
+++ b/source/winBindings/shell32.py
@@ -17,6 +17,7 @@ from ctypes import (
 	windll,
 )
 from ctypes.wintypes import (
+	LPCVOID,
 	ULONG,
 	BOOL,
 	HANDLE,
@@ -57,7 +58,7 @@ Retrieves the full path of a known folder identified by the folder's KNOWNFOLDER
 SHGetKnownFolderPath.restype = HRESULT
 SHGetKnownFolderPath.argtypes = (
 	POINTER(GUID),  # rfid: Reference to the KNOWNFOLDERID that identifies the folder
-	c_uint,  # dwFlags: Flags that specify special retrieval options
+	DWORD,  # dwFlags: Flags that specify special retrieval options
 	HANDLE,  # hToken: Access token that represents a particular user (can be NULL)
 	POINTER(c_wchar_p),  # ppszPath: Address of a pointer to a null-terminated Unicode string
 )
@@ -80,7 +81,7 @@ ShellExecute.argtypes = (
 )
 
 
-class SHELLEXECUTEINFOW(Structure):  # noqa: F405
+class SHELLEXECUTEINFOW(Structure):
 	"""
 	Contains information used by ShellExecuteEx.
 
@@ -89,25 +90,25 @@ class SHELLEXECUTEINFOW(Structure):  # noqa: F405
 	"""
 
 	_fields_ = (
-		("cbSize", DWORD),  # noqa: F405
-		("fMask", ULONG),  # noqa: F405
-		("hwnd", HWND),  # noqa: F405
-		("lpVerb", LPCWSTR),  # noqa: F405
-		("lpFile", LPCWSTR),  # noqa: F405
-		("lpParameters", LPCWSTR),  # noqa: F405
-		("lpDirectory", LPCWSTR),  # noqa: F405
-		("nShow", c_int),  # noqa: F405
-		("hInstApp", HINSTANCE),  # noqa: F405
-		("lpIDList", LPVOID),  # noqa: F405
-		("lpClass", LPCWSTR),  # noqa: F405
-		("hkeyClass", HKEY),  # noqa: F405
-		("dwHotKey", DWORD),  # noqa: F405
-		("hIconOrMonitor", HANDLE),  # noqa: F405
-		("hProcess", HANDLE),  # noqa: F405
+		("cbSize", DWORD),
+		("fMask", ULONG),
+		("hwnd", HWND),
+		("lpVerb", LPCWSTR),
+		("lpFile", LPCWSTR),
+		("lpParameters", LPCWSTR),
+		("lpDirectory", LPCWSTR),
+		("nShow", c_int),
+		("hInstApp", HINSTANCE),
+		("lpIDList", LPVOID),
+		("lpClass", LPCWSTR),
+		("hkeyClass", HKEY),
+		("dwHotKey", DWORD),
+		("hIconOrMonitor", HANDLE),
+		("hProcess", HANDLE),
 	)
 
 	def __init__(self, **kwargs):
-		super(SHELLEXECUTEINFOW, self).__init__(cbSize=sizeof(self), **kwargs)  # noqa: F405
+		super(SHELLEXECUTEINFOW, self).__init__(cbSize=sizeof(self), **kwargs)
 
 
 SHELLEXECUTEINFO = SHELLEXECUTEINFOW
@@ -135,6 +136,6 @@ SHChangeNotify.restype = None
 SHChangeNotify.argtypes = (
 	c_long,  # wEventId: Describes the event that has occurred
 	c_uint,  # uFlags: Flags that indicate the meaning of the dwItem1 and dwItem2 parameters
-	c_void_p,  # dwItem1: Optional first item identifier
-	c_void_p,  # dwItem2: Optional second item identifier
+	LPCVOID,  # dwItem1: Optional first item identifier
+	LPCVOID,  # dwItem2: Optional second item identifier
 )

--- a/source/winBindings/shell32.py
+++ b/source/winBindings/shell32.py
@@ -1,0 +1,131 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2025 NV Access Limited
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
+
+"""Functions exported by shell32.dll, and supporting data structures and enumerations."""
+
+from ctypes import (
+	POINTER,
+	sizeof,
+	Structure,
+	c_long,
+	c_int,
+	c_uint,
+	c_void_p,
+	c_wchar_p,
+	windll,
+)
+from ctypes.wintypes import (
+	ULONG,
+	BOOL,
+	HANDLE,
+	LPVOID,
+	DWORD,
+	HINSTANCE,
+	HKEY,
+	HWND,
+	INT,
+	LPCWSTR,
+)
+from comtypes import (
+	GUID,
+	HRESULT,
+)
+
+
+dll = windll.shell32
+
+
+IsUserAnAdmin = dll.IsUserAnAdmin
+"""
+Tests whether the current user is a member of the Administrator's group.
+
+.. seealso::
+	https://learn.microsoft.com/en-us/windows/win32/api/shlobj/nf-shlobj-isuseranadmin
+"""
+IsUserAnAdmin.restype = BOOL
+IsUserAnAdmin.argtypes = ()
+
+SHGetKnownFolderPath = dll.SHGetKnownFolderPath
+"""
+Retrieves the full path of a known folder identified by the folder's KNOWNFOLDERID.
+
+.. seealso::
+	https://learn.microsoft.com/en-us/windows/win32/api/shlobj_core/nf-shlobj_core-shgetknownfolderpath
+"""
+SHGetKnownFolderPath.restype = HRESULT
+SHGetKnownFolderPath.argtypes = (
+	POINTER(GUID),               # rfid: Reference to the KNOWNFOLDERID that identifies the folder
+	c_uint,                 # dwFlags: Flags that specify special retrieval options
+	HANDLE,                 # hToken: Access token that represents a particular user (can be NULL)
+	POINTER(c_wchar_p),     # ppszPath: Address of a pointer to a null-terminated Unicode string
+)
+
+ShellExecute = dll.ShellExecuteW
+"""
+Performs an operation on a specified file.
+
+.. seealso::
+	https://learn.microsoft.com/en-us/windows/win32/api/shellapi/nf-shellapi-shellexecutew
+"""
+ShellExecute.restype = c_void_p  # Returns HINSTANCE (handle)
+ShellExecute.argtypes = (
+	HWND,       # hwnd: Handle to the parent window
+	LPCWSTR,    # lpOperation: String that specifies the operation to perform (can be NULL)
+	LPCWSTR,    # lpFile: String that specifies the file or object on which to execute
+	LPCWSTR,    # lpParameters: String that specifies the parameters to be passed (can be NULL)
+	LPCWSTR,    # lpDirectory: String that specifies the default directory (can be NULL)
+	INT,        # nShowCmd: Flags that specify how an application is to be displayed
+)
+
+
+class SHELLEXECUTEINFOW(Structure):  # noqa: F405
+	_fields_ = (
+		("cbSize", DWORD),  # noqa: F405
+		("fMask", ULONG),  # noqa: F405
+		("hwnd", HWND),  # noqa: F405
+		("lpVerb", LPCWSTR),  # noqa: F405
+		("lpFile", LPCWSTR),  # noqa: F405
+		("lpParameters", LPCWSTR),  # noqa: F405
+		("lpDirectory", LPCWSTR),  # noqa: F405
+		("nShow", c_int),  # noqa: F405
+		("hInstApp", HINSTANCE),  # noqa: F405
+		("lpIDList", LPVOID),  # noqa: F405
+		("lpClass", LPCWSTR),  # noqa: F405
+		("hkeyClass", HKEY),  # noqa: F405
+		("dwHotKey", DWORD),  # noqa: F405
+		("hIconOrMonitor", HANDLE),  # noqa: F405
+		("hProcess", HANDLE),  # noqa: F405
+	)
+
+	def __init__(self, **kwargs):
+		super(SHELLEXECUTEINFOW, self).__init__(cbSize=sizeof(self), **kwargs)  # noqa: F405
+
+
+ShellExecuteEx = dll.ShellExecuteExW
+"""
+Performs an operation on a specified file with extended options.
+
+.. seealso::
+	https://learn.microsoft.com/en-us/windows/win32/api/shellapi/nf-shellapi-shellexecuteexw
+"""
+ShellExecuteEx.restype = BOOL
+ShellExecuteEx.argtypes = (
+	POINTER(SHELLEXECUTEINFOW),   # pExecInfo: Pointer to a SHELLEXECUTEINFO structure
+)
+
+SHChangeNotify = dll.SHChangeNotify
+"""
+Notifies the system of an event that an application has performed.
+
+.. seealso::
+	https://learn.microsoft.com/en-us/windows/win32/api/shlobj_core/nf-shlobj_core-shchangenotify
+"""
+SHChangeNotify.restype = None
+SHChangeNotify.argtypes = (
+	c_long,     # wEventId: Describes the event that has occurred
+	c_uint,     # uFlags: Flags that indicate the meaning of the dwItem1 and dwItem2 parameters
+	c_void_p,   # dwItem1: Optional first item identifier
+	c_void_p,   # dwItem2: Optional second item identifier
+)

--- a/source/winBindings/shell32.py
+++ b/source/winBindings/shell32.py
@@ -102,6 +102,7 @@ class SHELLEXECUTEINFOW(Structure):  # noqa: F405
 	def __init__(self, **kwargs):
 		super(SHELLEXECUTEINFOW, self).__init__(cbSize=sizeof(self), **kwargs)  # noqa: F405
 
+SHELLEXECUTEINFO = SHELLEXECUTEINFOW
 
 ShellExecuteEx = dll.ShellExecuteExW
 """

--- a/source/winBindings/shell32.py
+++ b/source/winBindings/shell32.py
@@ -56,10 +56,10 @@ Retrieves the full path of a known folder identified by the folder's KNOWNFOLDER
 """
 SHGetKnownFolderPath.restype = HRESULT
 SHGetKnownFolderPath.argtypes = (
-	POINTER(GUID),               # rfid: Reference to the KNOWNFOLDERID that identifies the folder
-	c_uint,                 # dwFlags: Flags that specify special retrieval options
-	HANDLE,                 # hToken: Access token that represents a particular user (can be NULL)
-	POINTER(c_wchar_p),     # ppszPath: Address of a pointer to a null-terminated Unicode string
+	POINTER(GUID),  # rfid: Reference to the KNOWNFOLDERID that identifies the folder
+	c_uint,  # dwFlags: Flags that specify special retrieval options
+	HANDLE,  # hToken: Access token that represents a particular user (can be NULL)
+	POINTER(c_wchar_p),  # ppszPath: Address of a pointer to a null-terminated Unicode string
 )
 
 ShellExecute = dll.ShellExecuteW
@@ -71,12 +71,12 @@ Performs an operation on a specified file.
 """
 ShellExecute.restype = c_void_p  # Returns HINSTANCE (handle)
 ShellExecute.argtypes = (
-	HWND,       # hwnd: Handle to the parent window
-	LPCWSTR,    # lpOperation: String that specifies the operation to perform (can be NULL)
-	LPCWSTR,    # lpFile: String that specifies the file or object on which to execute
-	LPCWSTR,    # lpParameters: String that specifies the parameters to be passed (can be NULL)
-	LPCWSTR,    # lpDirectory: String that specifies the default directory (can be NULL)
-	INT,        # nShowCmd: Flags that specify how an application is to be displayed
+	HWND,  # hwnd: Handle to the parent window
+	LPCWSTR,  # lpOperation: String that specifies the operation to perform (can be NULL)
+	LPCWSTR,  # lpFile: String that specifies the file or object on which to execute
+	LPCWSTR,  # lpParameters: String that specifies the parameters to be passed (can be NULL)
+	LPCWSTR,  # lpDirectory: String that specifies the default directory (can be NULL)
+	INT,  # nShowCmd: Flags that specify how an application is to be displayed
 )
 
 
@@ -102,6 +102,7 @@ class SHELLEXECUTEINFOW(Structure):  # noqa: F405
 	def __init__(self, **kwargs):
 		super(SHELLEXECUTEINFOW, self).__init__(cbSize=sizeof(self), **kwargs)  # noqa: F405
 
+
 SHELLEXECUTEINFO = SHELLEXECUTEINFOW
 
 ShellExecuteEx = dll.ShellExecuteExW
@@ -113,7 +114,7 @@ Performs an operation on a specified file with extended options.
 """
 ShellExecuteEx.restype = BOOL
 ShellExecuteEx.argtypes = (
-	POINTER(SHELLEXECUTEINFOW),   # pExecInfo: Pointer to a SHELLEXECUTEINFO structure
+	POINTER(SHELLEXECUTEINFOW),  # pExecInfo: Pointer to a SHELLEXECUTEINFO structure
 )
 
 SHChangeNotify = dll.SHChangeNotify
@@ -125,8 +126,8 @@ Notifies the system of an event that an application has performed.
 """
 SHChangeNotify.restype = None
 SHChangeNotify.argtypes = (
-	c_long,     # wEventId: Describes the event that has occurred
-	c_uint,     # uFlags: Flags that indicate the meaning of the dwItem1 and dwItem2 parameters
-	c_void_p,   # dwItem1: Optional first item identifier
-	c_void_p,   # dwItem2: Optional second item identifier
+	c_long,  # wEventId: Describes the event that has occurred
+	c_uint,  # uFlags: Flags that indicate the meaning of the dwItem1 and dwItem2 parameters
+	c_void_p,  # dwItem1: Optional first item identifier
+	c_void_p,  # dwItem2: Optional second item identifier
 )

--- a/source/winBindings/shell32.py
+++ b/source/winBindings/shell32.py
@@ -42,7 +42,7 @@ IsUserAnAdmin = dll.IsUserAnAdmin
 Tests whether the current user is a member of the Administrator's group.
 
 .. seealso::
-	https://learn.microsoft.com/en-us/windows/win32/api/shlobj/nf-shlobj-isuseranadmin
+	https://learn.microsoft.com/en-us/windows/win32/api/shlobj_core/nf-shlobj_core-isuseranadmin
 """
 IsUserAnAdmin.restype = BOOL
 IsUserAnAdmin.argtypes = ()
@@ -81,6 +81,13 @@ ShellExecute.argtypes = (
 
 
 class SHELLEXECUTEINFOW(Structure):  # noqa: F405
+	"""
+	Contains information used by ShellExecuteEx.
+
+	..seealso::
+		https://learn.microsoft.com/en-us/windows/win32/api/shellapi/ns-shellapi-shellexecuteinfow
+	"""
+
 	_fields_ = (
 		("cbSize", DWORD),  # noqa: F405
 		("fMask", ULONG),  # noqa: F405

--- a/source/winBindings/shlwapi.py
+++ b/source/winBindings/shlwapi.py
@@ -1,0 +1,35 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2025 NV Access Limited
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
+
+"""Functions exported by shlwapi.dll, and supporting data structures and enumerations."""
+
+from ctypes import (
+	c_uint,
+	c_void_p,
+	c_wchar_p,
+	c_wchar,
+	POINTER,
+	HRESULT,
+	windll,
+)
+
+
+dll = windll.shlwapi
+
+
+SHLoadIndirectString = dll.SHLoadIndirectString
+"""
+Extracts a specified text resource when given an indirect string.
+
+.. seealso::
+	https://learn.microsoft.com/en-us/windows/win32/api/shlwapi/nf-shlwapi-shloadindirectstring
+"""
+SHLoadIndirectString.restype = HRESULT
+SHLoadIndirectString.argtypes = (
+	c_wchar_p,  # pszSource: The indirect string to extract
+	POINTER(c_wchar),  # pszOutBuf: Buffer to receive the extracted string
+	c_uint,     # cchOutBuf: Size of the output buffer in characters
+	c_void_p,   # ppvReserved: Reserved, must be NULL
+)

--- a/source/winBindings/shlwapi.py
+++ b/source/winBindings/shlwapi.py
@@ -30,6 +30,6 @@ SHLoadIndirectString.restype = HRESULT
 SHLoadIndirectString.argtypes = (
 	c_wchar_p,  # pszSource: The indirect string to extract
 	POINTER(c_wchar),  # pszOutBuf: Buffer to receive the extracted string
-	c_uint,     # cchOutBuf: Size of the output buffer in characters
-	c_void_p,   # ppvReserved: Reserved, must be NULL
+	c_uint,  # cchOutBuf: Size of the output buffer in characters
+	c_void_p,  # ppvReserved: Reserved, must be NULL
 )

--- a/source/winBindings/urlmon.py
+++ b/source/winBindings/urlmon.py
@@ -6,7 +6,6 @@
 """Functions exported by urlmon.dll, and supporting data structures and enumerations."""
 
 from ctypes import (
-	c_void_p,
 	c_wchar_p,
 	windll,
 	POINTER,
@@ -30,8 +29,12 @@ Creates a URL moniker from a full or partial URL string.
 """
 CreateURLMonikerEx.restype = HRESULT
 CreateURLMonikerEx.argtypes = (
-	POINTER(IMoniker),   # pMkCtx: Pointer to the IMoniker interface of the URL moniker to use as the base for relative URLs (can be NULL)
+	POINTER(
+		IMoniker
+	),  # pMkCtx: Pointer to the IMoniker interface of the URL moniker to use as the base for relative URLs (can be NULL)
 	c_wchar_p,  # szURL: String value that contains the URL to be parsed
-	POINTER(POINTER(IMoniker)),   # ppmk: Address of an IMoniker pointer variable that receives the interface pointer to the new URL moniker
-	DWORD,      # dwFlags: Flags that control the creation of the URL moniker
+	POINTER(
+		POINTER(IMoniker)
+	),  # ppmk: Address of an IMoniker pointer variable that receives the interface pointer to the new URL moniker
+	DWORD,  # dwFlags: Flags that control the creation of the URL moniker
 )

--- a/source/winBindings/urlmon.py
+++ b/source/winBindings/urlmon.py
@@ -30,11 +30,11 @@ Creates a URL moniker from a full or partial URL string.
 CreateURLMonikerEx.restype = HRESULT
 CreateURLMonikerEx.argtypes = (
 	POINTER(
-		IMoniker
+		IMoniker,
 	),  # pMkCtx: Pointer to the IMoniker interface of the URL moniker to use as the base for relative URLs (can be NULL)
 	c_wchar_p,  # szURL: String value that contains the URL to be parsed
 	POINTER(
-		POINTER(IMoniker)
+		POINTER(IMoniker),
 	),  # ppmk: Address of an IMoniker pointer variable that receives the interface pointer to the new URL moniker
 	DWORD,  # dwFlags: Flags that control the creation of the URL moniker
 )

--- a/source/winBindings/urlmon.py
+++ b/source/winBindings/urlmon.py
@@ -1,0 +1,37 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2025 NV Access Limited
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
+
+"""Functions exported by urlmon.dll, and supporting data structures and enumerations."""
+
+from ctypes import (
+	c_void_p,
+	c_wchar_p,
+	windll,
+	POINTER,
+)
+from ctypes.wintypes import (
+	DWORD,
+)
+from comtypes import HRESULT
+from objidl import IMoniker
+
+
+dll = windll.urlmon
+
+
+CreateURLMonikerEx = dll.CreateURLMonikerEx
+"""
+Creates a URL moniker from a full or partial URL string.
+
+.. seealso::
+	https://learn.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/platform-apis/ms775103(v=vs.85)
+"""
+CreateURLMonikerEx.restype = HRESULT
+CreateURLMonikerEx.argtypes = (
+	POINTER(IMoniker),   # pMkCtx: Pointer to the IMoniker interface of the URL moniker to use as the base for relative URLs (can be NULL)
+	c_wchar_p,  # szURL: String value that contains the URL to be parsed
+	POINTER(POINTER(IMoniker)),   # ppmk: Address of an IMoniker pointer variable that receives the interface pointer to the new URL moniker
+	DWORD,      # dwFlags: Flags that control the creation of the URL moniker
+)

--- a/source/winBindings/urlmon.py
+++ b/source/winBindings/urlmon.py
@@ -6,12 +6,12 @@
 """Functions exported by urlmon.dll, and supporting data structures and enumerations."""
 
 from ctypes import (
-	c_wchar_p,
 	windll,
 	POINTER,
 )
 from ctypes.wintypes import (
 	DWORD,
+	LPCWSTR,
 )
 from comtypes import HRESULT
 from objidl import IMoniker
@@ -32,7 +32,7 @@ CreateURLMonikerEx.argtypes = (
 	POINTER(
 		IMoniker,
 	),  # pMkCtx: Pointer to the IMoniker interface of the URL moniker to use as the base for relative URLs (can be NULL)
-	c_wchar_p,  # szURL: String value that contains the URL to be parsed
+	LPCWSTR,  # szURL: String value that contains the URL to be parsed
 	POINTER(
 		POINTER(IMoniker),
 	),  # ppmk: Address of an IMoniker pointer variable that receives the interface pointer to the new URL moniker

--- a/source/winBindings/version.py
+++ b/source/winBindings/version.py
@@ -30,8 +30,8 @@ Determines whether the operating system can retrieve version information for a s
 """
 GetFileVersionInfoSize.restype = DWORD
 GetFileVersionInfoSize.argtypes = (
-	c_wchar_p,      # lptstrFilename: Pointer to a null-terminated string that specifies the name of the file
-	POINTER(DWORD), # lpdwHandle: Pointer to a variable that the function sets to zero (can be NULL)
+	c_wchar_p,  # lptstrFilename: Pointer to a null-terminated string that specifies the name of the file
+	POINTER(DWORD),  # lpdwHandle: Pointer to a variable that the function sets to zero (can be NULL)
 )
 
 GetFileVersionInfo = dll.GetFileVersionInfoW
@@ -43,9 +43,9 @@ Retrieves version information for the specified file.
 """
 GetFileVersionInfo.restype = BOOL
 GetFileVersionInfo.argtypes = (
-	c_wchar_p, # lptstrFilename: Pointer to a null-terminated string that specifies the name of the file
-	DWORD,     # dwHandle: This parameter is ignored
-	DWORD,     # dwLen: Specifies the size, in bytes, of the buffer pointed to by the lpData parameter
+	c_wchar_p,  # lptstrFilename: Pointer to a null-terminated string that specifies the name of the file
+	DWORD,  # dwHandle: This parameter is ignored
+	DWORD,  # dwLen: Specifies the size, in bytes, of the buffer pointed to by the lpData parameter
 	c_void_p,  # lpData: Pointer to a buffer that receives the file-version information
 )
 
@@ -58,8 +58,12 @@ Retrieves specified version information from the specified version-information r
 """
 VerQueryValue.restype = BOOL
 VerQueryValue.argtypes = (
-	c_void_p,           # pBlock: Pointer to the buffer containing the version-information resource
-	c_wchar_p,          # lpSubBlock: Pointer to a null-terminated string that specifies the version-information value to retrieve
-	POINTER(c_void_p),  # lplpBuffer: When the function returns, points to the address of the requested version information
-	POINTER(c_uint),    # puLen: When the function returns, points to the length, in characters, of the requested version information
+	c_void_p,  # pBlock: Pointer to the buffer containing the version-information resource
+	c_wchar_p,  # lpSubBlock: Pointer to a null-terminated string that specifies the version-information value to retrieve
+	POINTER(
+		c_void_p
+	),  # lplpBuffer: When the function returns, points to the address of the requested version information
+	POINTER(
+		c_uint
+	),  # puLen: When the function returns, points to the length, in characters, of the requested version information
 )

--- a/source/winBindings/version.py
+++ b/source/winBindings/version.py
@@ -1,0 +1,65 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2025 NV Access Limited
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
+
+"""Functions exported by version.dll, and supporting data structures and enumerations."""
+
+from ctypes import (
+	POINTER,
+	c_uint,
+	c_void_p,
+	c_wchar_p,
+	windll,
+)
+from ctypes.wintypes import (
+	BOOL,
+	DWORD,
+)
+
+
+dll = windll.version
+
+
+GetFileVersionInfoSize = dll.GetFileVersionInfoSizeW
+"""
+Determines whether the operating system can retrieve version information for a specified file.
+
+.. seealso::
+	https://learn.microsoft.com/en-us/windows/win32/api/winver/nf-winver-getfileversioninfosizew
+"""
+GetFileVersionInfoSize.restype = DWORD
+GetFileVersionInfoSize.argtypes = (
+	c_wchar_p,      # lptstrFilename: Pointer to a null-terminated string that specifies the name of the file
+	POINTER(DWORD), # lpdwHandle: Pointer to a variable that the function sets to zero (can be NULL)
+)
+
+GetFileVersionInfo = dll.GetFileVersionInfoW
+"""
+Retrieves version information for the specified file.
+
+.. seealso::
+	https://learn.microsoft.com/en-us/windows/win32/api/winver/nf-winver-getfileversioninfow
+"""
+GetFileVersionInfo.restype = BOOL
+GetFileVersionInfo.argtypes = (
+	c_wchar_p, # lptstrFilename: Pointer to a null-terminated string that specifies the name of the file
+	DWORD,     # dwHandle: This parameter is ignored
+	DWORD,     # dwLen: Specifies the size, in bytes, of the buffer pointed to by the lpData parameter
+	c_void_p,  # lpData: Pointer to a buffer that receives the file-version information
+)
+
+VerQueryValue = dll.VerQueryValueW
+"""
+Retrieves specified version information from the specified version-information resource.
+
+.. seealso::
+	https://learn.microsoft.com/en-us/windows/win32/api/winver/nf-winver-verqueryvaluew
+"""
+VerQueryValue.restype = BOOL
+VerQueryValue.argtypes = (
+	c_void_p,           # pBlock: Pointer to the buffer containing the version-information resource
+	c_wchar_p,          # lpSubBlock: Pointer to a null-terminated string that specifies the version-information value to retrieve
+	POINTER(c_void_p),  # lplpBuffer: When the function returns, points to the address of the requested version information
+	POINTER(c_uint),    # puLen: When the function returns, points to the length, in characters, of the requested version information
+)

--- a/source/winBindings/version.py
+++ b/source/winBindings/version.py
@@ -7,14 +7,16 @@
 
 from ctypes import (
 	POINTER,
-	c_uint,
-	c_void_p,
-	c_wchar_p,
 	windll,
 )
 from ctypes.wintypes import (
 	BOOL,
 	DWORD,
+	LPCVOID,
+	LPCWSTR,
+	LPDWORD,
+	LPVOID,
+	PUINT,
 )
 
 
@@ -30,8 +32,8 @@ Determines whether the operating system can retrieve version information for a s
 """
 GetFileVersionInfoSize.restype = DWORD
 GetFileVersionInfoSize.argtypes = (
-	c_wchar_p,  # lptstrFilename: Pointer to a null-terminated string that specifies the name of the file
-	POINTER(DWORD),  # lpdwHandle: Pointer to a variable that the function sets to zero (can be NULL)
+	LPCWSTR,  # lptstrFilename: Pointer to a null-terminated string that specifies the name of the file
+	LPDWORD,  # lpdwHandle: Pointer to a variable that the function sets to zero (can be NULL)
 )
 
 GetFileVersionInfo = dll.GetFileVersionInfoW
@@ -43,10 +45,10 @@ Retrieves version information for the specified file.
 """
 GetFileVersionInfo.restype = BOOL
 GetFileVersionInfo.argtypes = (
-	c_wchar_p,  # lptstrFilename: Pointer to a null-terminated string that specifies the name of the file
+	LPCWSTR,  # lptstrFilename: Pointer to a null-terminated string that specifies the name of the file
 	DWORD,  # dwHandle: This parameter is ignored
 	DWORD,  # dwLen: Specifies the size, in bytes, of the buffer pointed to by the lpData parameter
-	c_void_p,  # lpData: Pointer to a buffer that receives the file-version information
+	LPVOID,  # lpData: Pointer to a buffer that receives the file-version information
 )
 
 VerQueryValue = dll.VerQueryValueW
@@ -58,12 +60,10 @@ Retrieves specified version information from the specified version-information r
 """
 VerQueryValue.restype = BOOL
 VerQueryValue.argtypes = (
-	c_void_p,  # pBlock: Pointer to the buffer containing the version-information resource
-	c_wchar_p,  # lpSubBlock: Pointer to a null-terminated string that specifies the version-information value to retrieve
+	LPCVOID,  # pBlock: Pointer to the buffer containing the version-information resource
+	LPCWSTR,  # lpSubBlock: Pointer to a null-terminated string that specifies the version-information value to retrieve
 	POINTER(
-		c_void_p,
+		LPVOID,
 	),  # lplpBuffer: When the function returns, points to the address of the requested version information
-	POINTER(
-		c_uint,
-	),  # puLen: When the function returns, points to the length, in characters, of the requested version information
+	PUINT,  # puLen: When the function returns, points to the length, in characters, of the requested version information
 )

--- a/source/winBindings/version.py
+++ b/source/winBindings/version.py
@@ -61,9 +61,9 @@ VerQueryValue.argtypes = (
 	c_void_p,  # pBlock: Pointer to the buffer containing the version-information resource
 	c_wchar_p,  # lpSubBlock: Pointer to a null-terminated string that specifies the version-information value to retrieve
 	POINTER(
-		c_void_p
+		c_void_p,
 	),  # lplpBuffer: When the function returns, points to the address of the requested version information
 	POINTER(
-		c_uint
+		c_uint,
 	),  # puLen: When the function returns, points to the length, in characters, of the requested version information
 )

--- a/source/winBindings/winmm.py
+++ b/source/winBindings/winmm.py
@@ -1,0 +1,50 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2025 NV Access Limited
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
+
+"""Functions exported by winmm.dll, and supporting data structures and enumerations."""
+
+from ctypes import (
+	c_size_t,
+	windll,
+	c_long,
+)
+from ctypes.wintypes import (
+	DWORD,
+	HANDLE,
+	UINT,
+)
+
+
+DWORD_PTR = c_size_t
+MMRESULT = c_long
+
+
+dll = windll.winmm
+
+
+waveOutGetNumDevs = dll.waveOutGetNumDevs
+"""
+Retrieves the number of waveform-audio output devices present in the system.
+
+.. seealso::
+	https://learn.microsoft.com/en-us/windows/win32/api/mmeapi/nf-mmeapi-waveoutgetnumdevs
+"""
+waveOutGetNumDevs.restype = UINT
+waveOutGetNumDevs.argtypes = ()
+
+waveOutMessage = dll.waveOutMessage
+"""
+Sends a message to the given waveform-audio output device.
+
+.. seealso::
+	https://learn.microsoft.com/en-us/windows/win32/api/mmeapi/nf-mmeapi-waveoutmessage
+"""
+waveOutMessage.restype = MMRESULT
+waveOutMessage.argtypes = (
+	HANDLE,     # hWaveOut: Handle to the waveform-audio output device
+	UINT,       # uMsg: Message to send
+	DWORD_PTR,   # dw1: Message parameter (DWORD_PTR)
+	DWORD_PTR,   # dw2: Message parameter (DWORD_PTR)
+)

--- a/source/winBindings/winmm.py
+++ b/source/winBindings/winmm.py
@@ -11,7 +11,6 @@ from ctypes import (
 	c_long,
 )
 from ctypes.wintypes import (
-	DWORD,
 	HANDLE,
 	UINT,
 )
@@ -43,8 +42,8 @@ Sends a message to the given waveform-audio output device.
 """
 waveOutMessage.restype = MMRESULT
 waveOutMessage.argtypes = (
-	HANDLE,     # hWaveOut: Handle to the waveform-audio output device
-	UINT,       # uMsg: Message to send
-	DWORD_PTR,   # dw1: Message parameter (DWORD_PTR)
-	DWORD_PTR,   # dw2: Message parameter (DWORD_PTR)
+	HANDLE,  # hWaveOut: Handle to the waveform-audio output device
+	UINT,  # uMsg: Message to send
+	DWORD_PTR,  # dw1: Message parameter (DWORD_PTR)
+	DWORD_PTR,  # dw2: Message parameter (DWORD_PTR)
 )

--- a/source/winBindings/wtsapi32.py
+++ b/source/winBindings/wtsapi32.py
@@ -43,9 +43,9 @@ Retrieves session information for the specified session on the specified Remote 
 """
 WTSQuerySessionInformation.restype = BOOL
 WTSQuerySessionInformation.argtypes = (
-	HANDLE,             # hServer: Handle to the Remote Desktop Session Host server
-	DWORD,              # SessionId: Session identifier
-	c_int,              # WTSInfoClass: Type of information to retrieve (WTS_INFO_CLASS)
-	POINTER(LPWSTR),    # ppBuffer: Pointer to a variable that receives a pointer to the requested information
-	POINTER(DWORD),     # pBytesReturned: Pointer to a variable that receives the size of the data returned
+	HANDLE,  # hServer: Handle to the Remote Desktop Session Host server
+	DWORD,  # SessionId: Session identifier
+	c_int,  # WTSInfoClass: Type of information to retrieve (WTS_INFO_CLASS)
+	POINTER(LPWSTR),  # ppBuffer: Pointer to a variable that receives a pointer to the requested information
+	POINTER(DWORD),  # pBytesReturned: Pointer to a variable that receives the size of the data returned
 )

--- a/source/winBindings/wtsapi32.py
+++ b/source/winBindings/wtsapi32.py
@@ -1,0 +1,51 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2025 NV Access Limited
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
+
+"""Functions exported by wtsapi32.dll, and supporting data structures and enumerations."""
+
+from ctypes import (
+	POINTER,
+	c_int,
+	c_void_p,
+	windll,
+)
+from ctypes.wintypes import (
+	BOOL,
+	DWORD,
+	HANDLE,
+	LPWSTR,
+)
+
+
+dll = windll.wtsapi32
+
+
+WTSFreeMemory = dll.WTSFreeMemory
+"""
+Frees memory allocated by a Windows Terminal Services function.
+
+.. seealso::
+	https://learn.microsoft.com/en-us/windows/win32/api/wtsapi32/nf-wtsapi32-wtsfreememory
+"""
+WTSFreeMemory.restype = None
+WTSFreeMemory.argtypes = (
+	c_void_p,  # pMemory: Pointer to the memory to free
+)
+
+WTSQuerySessionInformation = dll.WTSQuerySessionInformationW
+"""
+Retrieves session information for the specified session on the specified Remote Desktop Session Host server.
+
+.. seealso::
+	https://learn.microsoft.com/en-us/windows/win32/api/wtsapi32/nf-wtsapi32-wtsquerysessioninformationw
+"""
+WTSQuerySessionInformation.restype = BOOL
+WTSQuerySessionInformation.argtypes = (
+	HANDLE,             # hServer: Handle to the Remote Desktop Session Host server
+	DWORD,              # SessionId: Session identifier
+	c_int,              # WTSInfoClass: Type of information to retrieve (WTS_INFO_CLASS)
+	POINTER(LPWSTR),    # ppBuffer: Pointer to a variable that receives a pointer to the requested information
+	POINTER(DWORD),     # pBytesReturned: Pointer to a variable that receives the size of the data returned
+)

--- a/source/winGDI.py
+++ b/source/winGDI.py
@@ -12,40 +12,12 @@ from ctypes.wintypes import LONG, DWORD, WORD, BOOL
 from contextlib import contextmanager
 
 user32 = windll.user32
-gdi32 = windll.gdi32
 gdiplus = windll.gdiplus
 
 
-class RGBQUAD(Structure):
-	_fields_ = [
-		("rgbBlue", c_ubyte),
-		("rgbGreen", c_ubyte),
-		("rgbRed", c_ubyte),
-		("rgbReserved", c_ubyte),
-	]
-
-
-class BITMAPINFOHEADER(Structure):
-	_fields_ = [
-		("biSize", DWORD),
-		("biWidth", LONG),
-		("biHeight", LONG),
-		("biPlanes", WORD),
-		("biBitCount", WORD),
-		("biCompression", WORD),
-		("biSizeImage", DWORD),
-		("biXPelsPerMeter", LONG),
-		("biYPelsPerMeter", LONG),
-		("biClrUsed", DWORD),
-		("biClrImportant", DWORD),
-	]
-
-
-class BITMAPINFO(Structure):
-	_fields_ = [
-		("bmiHeader", BITMAPINFOHEADER),
-		("bmiColors", (RGBQUAD * 1)),
-	]
+from winBindings.gdi32 import RGBQUAD
+from winBindings.gdi32 import BITMAPINFOHEADER
+from winBindings.gdi32 import BITMAPINFO
 
 
 BI_RGB = 0

--- a/source/winGDI.py
+++ b/source/winGDI.py
@@ -14,7 +14,6 @@ from ctypes import (
 )
 from contextlib import contextmanager
 from winBindings import gdiplus
-from winBindings import gdi32
 from utils import _deprecate
 
 __getattr__ = _deprecate.handleDeprecations(
@@ -47,7 +46,6 @@ user32 = windll.user32
 BI_RGB = 0
 SRCCOPY = 0x00CC0020
 DIB_RGB_COLORS = 0
-
 
 
 # GDI+ dash style enumeration

--- a/source/winGDI.py
+++ b/source/winGDI.py
@@ -13,30 +13,32 @@ from ctypes import (
 	byref,
 )
 from contextlib import contextmanager
-from winBindings import gdiplus
+import winBindings.gdiplus
 from utils import _deprecate
 
 __getattr__ = _deprecate.handleDeprecations(
+	_deprecate.MovedSymbol("gdiplus", "winBindings.gdiplus", "dll"),
 	_deprecate.MovedSymbol(
 		"GdiplusStartupInput",
-		"gdiplus",
+		"winBindings.gdiplus",
 	),
 	_deprecate.MovedSymbol(
 		"GdiplusStartupOutput",
-		"gdiplus",
+		"winBindings.gdiplus",
 	),
 	_deprecate.MovedSymbol(
 		"RGBQUAD",
-		"gdi32",
+		"winBindings.gdi32",
 	),
 	_deprecate.MovedSymbol(
 		"BITMAPINFOHEADER",
-		"gdi32",
+		"winBindings.gdi32",
 	),
 	_deprecate.MovedSymbol(
 		"BITMAPINFO",
-		"gdi32",
+		"winBindings.gdi32",
 	),
+	_deprecate.MovedSymbol("gdi32", "winBindings.gdi32", "dll"),
 )
 
 
@@ -66,26 +68,26 @@ def gdiPlusInitialize():
 	global gdipToken
 	if gdipToken:
 		return  # Already initialized
-	gdipToken = gdiplus.ULONG_PTR()
-	startupInput = gdiplus.GdiplusStartupInput()
+	gdipToken = winBindings.gdiplus.ULONG_PTR()
+	startupInput = winBindings.gdiplus.GdiplusStartupInput()
 	startupInput.GdiplusVersion = 1
-	startupOutput = gdiplus.GdiplusStartupOutput()
-	gdiplus.GdiplusStartup(byref(gdipToken), byref(startupInput), byref(startupOutput))
+	startupOutput = winBindings.gdiplus.GdiplusStartupOutput()
+	winBindings.gdiplus.GdiplusStartup(byref(gdipToken), byref(startupInput), byref(startupOutput))
 
 
 def gdiPlusTerminate():
 	global gdipToken
 	if not gdipToken:
 		return  # Not initialized
-	gdiplus.GdiplusShutdown(gdipToken)
+	winBindings.gdiplus.GdiplusShutdown(gdipToken)
 	gdipToken = None
 
 
 @contextmanager
 def GDIPlusGraphicsContext(hdc):
 	"""Creates a GDI+ graphics context from a device context handle."""
-	gpGraphics = POINTER(gdiplus.GpGraphics)()
-	gpStatus = gdiplus.GdipCreateFromHDC(hdc, byref(gpGraphics))
+	gpGraphics = POINTER(winBindings.gdiplus.GpGraphics)()
+	gpStatus = winBindings.gdiplus.GdipCreateFromHDC(hdc, byref(gpGraphics))
 	if gpStatus:
 		# See https://docs.microsoft.com/en-us/windows/desktop/api/Gdiplustypes/ne-gdiplustypes-status
 		# for a list of applicable status codes
@@ -93,7 +95,7 @@ def GDIPlusGraphicsContext(hdc):
 	try:
 		yield gpGraphics
 	finally:
-		gdiplus.GdipDeleteGraphics(gpGraphics)
+		winBindings.gdiplus.GdipDeleteGraphics(gpGraphics)
 
 
 @contextmanager
@@ -108,21 +110,21 @@ def GDIPlusPen(color, width, dashStyle=DashStyleSolid):
 		Defaults to C{DashStyleSolid}, which draws solid lines.
 	@type dashStyle: int
 	"""
-	gpPen = POINTER(gdiplus.GpPen)()
-	gpStatus = gdiplus.GdipCreatePen1(color, width, UnitPixel, byref(gpPen))
+	gpPen = POINTER(winBindings.gdiplus.GpPen)()
+	gpStatus = winBindings.gdiplus.GdipCreatePen1(color, width, UnitPixel, byref(gpPen))
 	if gpStatus:
 		raise RuntimeError("GdipCreatePen1 failed with status code %d" % gpStatus)
-	gpStatus = gdiplus.GdipSetPenDashStyle(gpPen, dashStyle)
+	gpStatus = winBindings.gdiplus.GdipSetPenDashStyle(gpPen, dashStyle)
 	if gpStatus:
 		raise RuntimeError("GdipSetPenDashStyle failed with status code %d" % gpStatus)
 	try:
 		yield gpPen
 	finally:
-		gdiplus.GdipDeletePen(gpPen)
+		winBindings.gdiplus.GdipDeletePen(gpPen)
 
 
 def gdiPlusDrawRectangle(gpGraphics, gpPen, left, top, width, height):
-	gpStatus = gdiplus.GdipDrawRectangle(
+	gpStatus = winBindings.gdiplus.GdipDrawRectangle(
 		gpGraphics,
 		gpPen,
 		float(left),

--- a/source/winKernel.py
+++ b/source/winKernel.py
@@ -13,7 +13,7 @@ When working on this file, consider moving to winAPI.
 import contextlib
 import ctypes
 import ctypes.wintypes
-from ctypes import byref, sizeof, Structure, windll, WinError
+from ctypes import byref, sizeof, Structure, WinError
 from ctypes.wintypes import BOOL, DWORD, HANDLE, LARGE_INTEGER, LCID, LPVOID, WORD
 from typing import (
 	TYPE_CHECKING,
@@ -48,11 +48,11 @@ __getattr__ = _deprecate.handleDeprecations(
 		"PROCESS_INFORMATION",
 		"winBindings.advapi32",
 	),
+	_deprecate.MovedSymbol("advapi32", "winBindings.advapi32", "dll"),
 )
 
 
 kernel32 = ctypes.windll.kernel32
-advapi32 = windll.advapi32
 
 # Constants
 INFINITE = 0xFFFFFFFF
@@ -431,10 +431,6 @@ def CreatePipe(pipeAttributes, size):
 	):
 		raise ctypes.WinError()
 	return read.value, write.value
-
-
-STARTUPINFO = STARTUPINFOW = winBindings.advapi32.STARTUPINFOW
-PROCESS_INFORMATION = winBindings.advapi32.PROCESS_INFORMATION
 
 
 def CreateProcessAsUser(

--- a/source/winKernel.py
+++ b/source/winKernel.py
@@ -428,42 +428,8 @@ def CreatePipe(pipeAttributes, size):
 	return read.value, write.value
 
 
-class STARTUPINFOW(Structure):
-	_fields_ = (
-		("cb", DWORD),
-		("lpReserved", LPWSTR),
-		("lpDesktop", LPWSTR),
-		("lpTitle", LPWSTR),
-		("dwX", DWORD),
-		("dwY", DWORD),
-		("dwXSize", DWORD),
-		("dwYSize", DWORD),
-		("dwXCountChars", DWORD),
-		("dwYCountChars", DWORD),
-		("dwFillAttribute", DWORD),
-		("dwFlags", DWORD),
-		("wShowWindow", WORD),
-		("cbReserved2", WORD),
-		("lpReserved2", POINTER(c_byte)),
-		("hSTDInput", HANDLE),
-		("hSTDOutput", HANDLE),
-		("hSTDError", HANDLE),
-	)
-
-	def __init__(self, **kwargs):
-		super(STARTUPINFOW, self).__init__(cb=sizeof(self), **kwargs)
-
-
-STARTUPINFO = STARTUPINFOW
-
-
-class PROCESS_INFORMATION(Structure):
-	_fields_ = (
-		("hProcess", HANDLE),
-		("hThread", HANDLE),
-		("dwProcessID", DWORD),
-		("dwThreadID", DWORD),
-	)
+STARTUPINFO = STARTUPINFOW = winBindings.advapi32.STARTUPINFOW
+PROCESS_INFORMATION = winBindings.advapi32.PROCESS_INFORMATION
 
 
 def CreateProcessAsUser(
@@ -480,7 +446,7 @@ def CreateProcessAsUser(
 	processInformation,
 ):
 	if (
-		advapi32.CreateProcessAsUserW(
+		winBindings.advapi32.CreateProcessAsUser(
 			token,
 			applicationName,
 			commandLine,

--- a/source/winKernel.py
+++ b/source/winKernel.py
@@ -28,22 +28,28 @@ if TYPE_CHECKING:
 
 import winBindings.advapi32
 import winBindings.kernel32
+from utils import _deprecate
 
 
-def __getattr__(attrName: str) -> Any:
-	"""Module level `__getattr__` used to preserve backward compatibility."""
-	import NVDAState
-
-	if attrName == "SYSTEM_POWER_STATUS" and NVDAState._allowDeprecatedAPI():
-		from logHandler import log
-		from winAPI._powerTracking import SystemPowerStatus
-
-		log.warning(
-			"winKernel.SYSTEM_POWER_STATUS is deprecated, "
-			"use winAPI._powerTracking.SystemPowerStatus instead.",
-		)
-		return SystemPowerStatus
-	raise AttributeError(f"module {repr(__name__)} has no attribute {repr(attrName)}")
+__getattr__ = _deprecate.handleDeprecations(
+	_deprecate.MovedSymbol(
+		"SYSTEM_POWER_STATUS",
+		"winAPI._powerTracking",
+		"SystemPowerStatus",
+	),
+	_deprecate.MovedSymbol(
+		"STARTUPINFO",
+		"winBindings.advapi32",
+	),
+	_deprecate.MovedSymbol(
+		"STARTUPINFOW",
+		"winBindings.advapi32",
+	),
+	_deprecate.MovedSymbol(
+		"PROCESS_INFORMATION",
+		"winBindings.advapi32",
+	),
+)
 
 
 kernel32 = ctypes.windll.kernel32

--- a/source/winKernel.py
+++ b/source/winKernel.py
@@ -13,11 +13,10 @@ When working on this file, consider moving to winAPI.
 import contextlib
 import ctypes
 import ctypes.wintypes
-from ctypes import byref, c_byte, POINTER, sizeof, Structure, windll, WinError
-from ctypes.wintypes import BOOL, DWORD, HANDLE, LARGE_INTEGER, LCID, LPWSTR, LPVOID, WORD
+from ctypes import byref, sizeof, Structure, windll, WinError
+from ctypes.wintypes import BOOL, DWORD, HANDLE, LARGE_INTEGER, LCID, LPVOID, WORD
 from typing import (
 	TYPE_CHECKING,
-	Any,
 	Optional,
 	Union,
 )

--- a/source/windowUtils.py
+++ b/source/windowUtils.py
@@ -14,6 +14,7 @@ import ctypes.wintypes
 import weakref
 import winBindings.kernel32
 import winBindings.user32
+import winBindings.gdi32
 import winUser
 from winUser import WNDCLASSEXW, WNDPROC
 from logHandler import log
@@ -130,7 +131,7 @@ def getWindowScalingFactor(window: int) -> int:
 	except:  # noqa: E722
 		log.debug("GetDpiForWindow failed, using GetDeviceCaps instead")
 		dc = user32.GetDC(window)
-		winDpi: int = ctypes.windll.gdi32.GetDeviceCaps(dc, LOGPIXELSX)
+		winDpi: int = winBindings.gdi32.GetDeviceCaps(dc, LOGPIXELSX)
 		ret = user32.ReleaseDC(window, dc)
 		if ret != 1:
 			log.error("Unable to release the device context.")

--- a/tests/unit/test_installer.py
+++ b/tests/unit/test_installer.py
@@ -131,7 +131,7 @@ class testFollowerWarning(unittest.TestCase):
 		isUserAnAdmin: bool,
 		expectedReturn: bool,
 	):
-		with patch("gui.installerGui._IsUserAnAdmin", return_value=isUserAnAdmin):
+		with patch("winBindings.shell32.IsUserAnAdmin", return_value=isUserAnAdmin):
 			with patch(
 				"_remoteClient.client.RemoteClient",
 				isConnectedAsFollower=isConnectedAsFollower,

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -94,6 +94,22 @@ Use `winBindings.mmeapi.WAVEFORMATEX` instead. (#18207)
 * `hwPortUtils.dummy`, `hwPortUtils.INVALID_HANDLE_VALUE` and `hwPortUtils.ValidHandle` are deprecated, with no planned replacement. (#18571)
 * `hwPortUtils.ERROR_INSUFFICIENT_BUFFER` and `hwPortUtils.ERROR_NO_MORE_ITEMS` are deprecated.
   Use `winAPI.SystemErrorCodes.INSUFFICIENT_BUFFER` and `winAPI.SystemErrorCodes.NO_MORE_ITEMS` instead. (#18571)
+* `fonts.gdi32`, `screenBitmap.gdi32` and `winGDI.gdi32` are deprecated.
+  Use `winBindings.gdi32.dll` instead. (#18860)
+* `shellapi.shell32` is deprecated.
+  Use `winBindings.shell32.dll` instead. (#18860)
+* The following symbols have been moved from `shellapi` to `winBindings.shell32`: `SHELLEXECUTEINFO`, `SHELLEXECUTEINFOW`.
+  Access to these symbols via `shellapi` is deprecated. (#18860)
+* `winGDI.gdiplus` is deprecated.
+  Use `winBindings.gdiplus.dll` instead. (#18860)
+* The following symbols have been moved from `winGDI` to `winBindings.gdi32`: `RGBQUAD`, `BITMAPINFOHEADER`, `BITMAPINFO`.
+  Access to these symbols via `winGDI` is deprecated. (#18860)
+* The following symbols have been moved from `winGDI` to `winBindings.gdiplus`: `GdiplusStartupInput`, `GdiplusStartupOutput`.
+  Access to these symbols via `winGDI` is deprecated. (#18860)
+* The following symbols have been moved from `winKernel` to `winBindings.advapi32`: `PROCESS_INFORMATION`, `STARTUPINFO`, `STARTUPINFOW`.
+  Access to these symbols via `winKernel` is deprecated. (#18860)
+* `winKernel.advapi32` is deprecated.
+  Use `winBindings.advapi32.dll` instead. (#18860)
 
 <!-- Beyond this point, Markdown should not be linted, as we don't modify old change log sections. -->
 <!-- markdownlint-disable -->


### PR DESCRIPTION
- **Add / use winBindings defintions for shlwapi.dll**
- **Add / use winBindings definitions for GetDeviceCaps from gdi32.dll**
- **Add / use winBindings definitions for mshtml.dll**
- **Add / use winBindings required definitions for urlmon.dll**
- **Add / use winBindings required definitions from wtsapi32.dll**
- **Add / use winBindings required definitions from winmm.dll**
- **Add / use winbindings defintions for CreateProcessAsUser and GetTokenInformation from advapi32.dll. Completing all required functions from this dll. Also moved STARTUPINFO and PROCESS_INFORMATION structures from winKernel to winBindings.advapi32**
- **IAccessible NVDAObject: hardcode IID_ITextServices rather than looking it up in msftedi.dll. It never changes.**
- **Add / use winBindings required definitions for version.dll**
- **Add / use winBindings required defintions for shell32.dll. Move ShellExecutInfo structure from shlobj to winBindings.shell32.**
- **Add / use all remaining winBindings definitions from gdi32.dll**
- **Add / use winBindings required defintions for gdiplus.dll. Move some structures from wingdi.py to winBindings.gdiplus**
- **Add deprecation handling for some moved structs**

<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
<!-- Use Closes/Fixes/Resolves #xxx to link this PR to the issue it is responding to. -->
None.

### Summary of the issue:
Raw ctypes calls may not be 64 bit compatible. They should be replaced.
 

### Description of user facing changes:
None.

### Description of development approach:
Replaced more raw ctyps calls with winBindings definitions.
With this PR and previous PRs, 146 functions have now been replaced, with 118 to go.

### Testing strategy:
General smoke testing.

### Known issues with pull request:

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
