### PR TITLE
Crash dumps are no longer empty on 64 bit

### DIFF
--- a/nvdaHelper/local/crashDump.cpp
+++ b/nvdaHelper/local/crashDump.cpp
@@ -1,0 +1,46 @@
+#include <windows.h>
+#include <dbghelp.h>
+#include <string>
+
+/**
+ * @brief Writes a crash dump to the specified path.
+ *
+ * This function creates a minidump file at the given path containing information about the current process state.
+ * It is typically called from an unhandled exception filter.
+ *
+ * @param dumpPath The path to write the crash dump file.
+ * @param pExceptionPointers Exception pointers provided by the UnhandledExceptionFilter.
+ * @return true if the dump was written successfully, false otherwise.
+ */
+bool writeCrashDump(const wchar_t* dumpPath, EXCEPTION_POINTERS* pExceptionPointers) {
+	HANDLE hFile = CreateFileW(
+		dumpPath,
+		GENERIC_WRITE,
+		0,
+		nullptr,
+		CREATE_ALWAYS,
+		FILE_ATTRIBUTE_NORMAL,
+		nullptr
+	);
+	if (hFile == INVALID_HANDLE_VALUE) {
+		return false;
+	}
+
+	MINIDUMP_EXCEPTION_INFORMATION mdei;
+	mdei.ThreadId = GetCurrentThreadId();
+	mdei.ExceptionPointers = pExceptionPointers;
+	mdei.ClientPointers = FALSE;
+
+	// Write a small minidump
+	bool res = MiniDumpWriteDump(
+		GetCurrentProcess(),
+		GetCurrentProcessId(),
+		hFile,
+		MiniDumpNormal,
+		&mdei,
+		nullptr,
+		nullptr
+	);
+	CloseHandle(hFile);
+	return res;
+}

--- a/nvdaHelper/local/crashDump.cpp
+++ b/nvdaHelper/local/crashDump.cpp
@@ -1,3 +1,9 @@
+/*
+A part of NonVisual Desktop Access (NVDA)
+This file is covered by the GNU General Public License.
+See the file COPYING for more details.
+Copyright (C) 2025 NV Access Limited
+*/
 #include <windows.h>
 #include <dbghelp.h>
 #include <string>

--- a/nvdaHelper/local/nvdaHelperLocal.def
+++ b/nvdaHelper/local/nvdaHelperLocal.def
@@ -91,3 +91,4 @@ EXPORTS
 	wasSilence_terminate
 	isScreenFullyBlack
 	localListeningSocketExists
+	writeCrashDump

--- a/nvdaHelper/local/sconscript
+++ b/nvdaHelper/local/sconscript
@@ -99,6 +99,7 @@ localLib = env.SharedLibrary(
 		"wasapi.cpp",
 		"screenCurtain.cpp",
 		"remoteAccess.cpp",
+		"crashDump.cpp",
 	],
 	LIBS=[
 		"advapi32.lib",
@@ -114,6 +115,7 @@ localLib = env.SharedLibrary(
 		"Iphlpapi",
 		"Ws2_32",
 		"runtimeobject",
+		"dbghelp",
 	],
 )
 

--- a/source/NVDAHelper/localLib.py
+++ b/source/NVDAHelper/localLib.py
@@ -672,3 +672,16 @@ isScreenFullyBlack.restype = c_bool
 localListeningSocketExists = dll.localListeningSocketExists
 localListeningSocketExists.argtypes = (c_ushort, c_wchar_p)
 localListeningSocketExists.restype = c_bool
+
+writeCrashDump = dll.writeCrashDump
+"""
+Writes a crash dump to the specified path.
+:param dumpPath: Path to write the dump to.
+:param exceptionPointers: Pointer to an EXCEPTION_POINTERS structure from an UnhandledExceptionFilter callback.
+:return: True on success, False on failure.
+"""
+writeCrashDump.argtypes = (
+	c_wchar_p,  # dumpPath
+	c_void_p,  # exceptionPointers
+)
+writeCrashDump.restype = bool

--- a/source/watchdog.py
+++ b/source/watchdog.py
@@ -248,26 +248,7 @@ def _crashHandler(exceptionInfo):
 
 	# Write a minidump.
 	dumpPath = os.path.join(os.path.dirname(globalVars.appArgs.logFileName), "nvda_crash.dmp")
-	try:
-		# Though we aren't using pythonic functions to write to the dump file,
-		# open it in binary mode as opening it in text mode (the default) doesn't make sense.
-		with open(dumpPath, "wb") as mdf:
-			mdExc = MINIDUMP_EXCEPTION_INFORMATION(
-				ThreadId=threadId,
-				ExceptionPointers=exceptionInfo,
-				ClientPointers=False,
-			)
-			if not winBindings.dbgHelp.MiniDumpWriteDump(
-				winBindings.kernel32.GetCurrentProcess(),
-				globalVars.appPid,
-				msvcrt.get_osfhandle(mdf.fileno()),
-				0,  # MiniDumpNormal
-				ctypes.byref(mdExc),
-				None,
-				None,
-			):
-				raise ctypes.WinError()
-	except:  # noqa: E722
+	if not NVDAHelper.localLib.writeCrashDump(dumpPath, exceptionInfo):
 		log.critical("NVDA crashed! Error writing minidump", exc_info=True)
 	else:
 		log.critical("NVDA crashed! Minidump written to %s" % dumpPath)
@@ -304,6 +285,7 @@ def initialize():
 		raise RuntimeError("already running")
 	isRunning = True
 	# Catch application crashes.
+	dumpPath = os.path.join(os.path.dirname(globalVars.appArgs.logFileName), "nvda_crash.dmp")
 	winBindings.kernel32.SetUnhandledExceptionFilter(_crashHandler)
 	winBindings.ole32.CoEnableCallCancellation(None)
 	# Cache cancelCallEvent.

--- a/source/watchdog.py
+++ b/source/watchdog.py
@@ -14,11 +14,9 @@ from typing import (
 import inspect
 from ctypes import windll
 import ctypes.wintypes
-import msvcrt
 import comtypes
 import winBindings.ole32
 import winBindings.dbgHelp
-from winBindings.dbgHelp import MINIDUMP_EXCEPTION_INFORMATION
 import winBindings.kernel32
 from winBindings.kernel32 import UnhandledExceptionFilter
 import winUser

--- a/source/watchdog.py
+++ b/source/watchdog.py
@@ -283,7 +283,6 @@ def initialize():
 		raise RuntimeError("already running")
 	isRunning = True
 	# Catch application crashes.
-	dumpPath = os.path.join(os.path.dirname(globalVars.appArgs.logFileName), "nvda_crash.dmp")
 	winBindings.kernel32.SetUnhandledExceptionFilter(_crashHandler)
 	winBindings.ole32.CoEnableCallCancellation(None)
 	# Cache cancelCallEvent.


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
<!-- Use Closes/Fixes/Resolves #xxx to link this PR to the issue it is responding to. -->
None.

### Summary of the issue:
On 64 bit, if NVDA crashed, a 0 byte nvda_crash.dmp would be created with no actual crash dump information, as MiniDumpWriteDump fails.

### Description of user facing changes:
A valid crash dump is now produced if NVDA crashes.

### Description of developer facing changes:

### Description of development approach:
Move creation of nvda_crash.dmp and filling it in with MiniDumpWriteDump into its own c++ utility function in nvdahelper.localLib, and call this from the UnhandledExceptionFilter in watchdog.py.

### Testing strategy:
Crashed NVDA by running the following in the Python console:
```
import ctypes
ctypes.windll.kernel32.DebugBreak()
```

Verified that an nvda_crash.dmp was created and that it could be opened in winDBG and exception information was viewable.
Also confirmed that nvda.log still contained the listing of all Python stacks.

### Known issues with pull request:
Although we already added what seemed to be correct definitions for MiniDumpWriteDump and related structures to winBindings.dbghelp, MiniDumpWriteDump still failed on 64 bit from Python with a memory access error. 
Moving this code to c++ solves the issue, but It is not quite understood exactly why.
Perhaps the native handle for the file from msvcrt.get_osfhandle is not correctly 64 bit?

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
