### PR TITLE
Add support for IE and Edge wxWebView controls

### DIFF
--- a/source/NVDAObjects/IAccessible/__init__.py
+++ b/source/NVDAObjects/IAccessible/__init__.py
@@ -715,6 +715,10 @@ class IAccessible(Window):
 			from . import webKit
 
 			webKit.findExtraOverlayClasses(self, clsList)
+		elif windowClassName == "wxWindowNR":
+			from . import wx as wxObjects
+
+			wxObjects.findExtraOverlayClasses(self, clsList)
 		elif windowClassName.startswith("Chrome_"):
 			from . import chromium
 

--- a/source/NVDAObjects/IAccessible/wx.py
+++ b/source/NVDAObjects/IAccessible/wx.py
@@ -63,4 +63,4 @@ class WxWebView(IAccessible):
 						break
 
 			case _:
-				log.warning("Unexpected inner control in wxWebView: %r", firstChild.windowClassName)
+				log.warning(f"Unexpected inner control in wxWebView: {firstChild.windowClassName}")

--- a/source/NVDAObjects/IAccessible/wx.py
+++ b/source/NVDAObjects/IAccessible/wx.py
@@ -1,0 +1,63 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2025 NV Access Limited, Leonard de Ruijter
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+
+"""Improvements for wxWidgets objects."""
+
+import api
+import eventHandler
+import winUser
+
+from . import IAccessible, getNVDAObjectFromEvent
+from logHandler import log
+import windowUtils
+from .. import NVDAObject
+
+
+def findExtraOverlayClasses(obj: IAccessible, clsList: list[NVDAObject]):
+	if obj.name == "wxWebView":
+		clsList.insert(0, WxWebView)
+
+
+class WxWebView(IAccessible):
+	def event_gainFocus(self) -> None:
+		super().event_gainFocus()
+		firstChild = self.firstChild
+		if not firstChild:
+			return
+		match firstChild.windowClassName:
+			case "Shell Embedding":
+				# This is an IE webview.
+				try:
+					obj = getNVDAObjectFromEvent(
+						windowUtils.findDescendantWindow(
+							firstChild.windowHandle,
+							className="Internet Explorer_Server",
+						),
+						winUser.OBJID_CLIENT,
+						winUser.CHILDID_SELF,
+					)
+					obj.setFocus()
+				except LookupError:
+					log.warning("Could not find Internet Explorer_Server in wxWebView")
+			case "Chrome_WidgetWin_0":
+				# This is a Edge WebView2 control.
+				# First focus might fail when the inner window is not yet created.
+				while not eventHandler.isPendingEvents("gainFocus"):
+					# Wait for the window and refocus when it is there.
+					try:
+						windowUtils.findDescendantWindow(
+							firstChild.windowHandle,
+							className="Chrome_RenderWidgetHostHWND",
+						)
+					except LookupError:
+						api.processPendingEvents()
+						continue
+					else:
+						self.shouldAllowIAccessibleFocusEvent = False
+						self.setFocus()
+						break
+
+			case _:
+				log.warning("Unexpected inner control in wxWebView: %r", firstChild.windowClassName)

--- a/source/NVDAObjects/IAccessible/wx.py
+++ b/source/NVDAObjects/IAccessible/wx.py
@@ -55,6 +55,8 @@ class WxWebView(IAccessible):
 						api.processPendingEvents()
 						continue
 					else:
+						# Suppress IAccessible focus event handling for the refocus below.
+						# This prevents duplicate or unwanted focus events when refocusing the inner window.
 						self.shouldAllowIAccessibleFocusEvent = False
 						self.setFocus()
 						break

--- a/source/NVDAObjects/IAccessible/wx.py
+++ b/source/NVDAObjects/IAccessible/wx.py
@@ -56,7 +56,8 @@ class WxWebView(IAccessible):
 						continue
 					else:
 						# Suppress IAccessible focus event handling for the refocus below.
-						# This prevents duplicate or unwanted focus events when refocusing the inner window.
+						# This prevents duplicate or unwanted focus events of the Web View parent control,
+						# since we're actually interested in the focus event from the inner document that focus is propagated to.
 						self.shouldAllowIAccessibleFocusEvent = False
 						self.setFocus()
 						break

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -35,6 +35,7 @@ We recommend using Windows 11, or if that is not possible, the latest Windows 10
 * When unicode normalization is enabled for speech, navigating by character will again correctly announce combining diacritic characters like acute ( &#x0301; ). (#18722, @LeonarddeR)
 * Fixed cases where NVDA was unable to retrieve information for an application, such as product name, version and architecture. (#18826, @LeonarddeR)
 * When reporting the location of the caret in classic versions of Notepad and other Win32 edit controls, text position is now more accurate. (#18767, @LeonarddeR)
+* NVDA no longer fails to read the contents of wx Web View controls. (#17273, @LeonarddeR)
 
 ### Changes for Developers
 


### PR DESCRIPTION
### Link to issue number:
Fixes #17273

### Summary of the issue:
NVDA has focus issues in WX Web View controls.

### Description of user facing changes:
WX Web View controls in applications will no enter browse mode correctly.

### Description of developer facing changes:
None

### Description of development approach:
There are actually two approaches, one for every known supported backend on Windows:

1. For IE, find the inner Internet Explorer server window and focus it. It will never get focus automatically, so this is the fix with the greatest positive impact.
2. For Edge WebView2, wait for the Chrome_RenderWidgetHostHWND window to be created, and refocus the webview after creation. Refocussing the webview again will properly propagate focus to the Edge Web view, at least on recent wx.

### Testing strategy:
Test test script from #17273. Ensure to test the IE and Edge backends.

### Known issues with pull request:
Edge Web View 2 sometimes loads with UIA browse mode, then quickly switches back to IA2 when pressing tab. I don't think this issue is related to the current fix, though.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
