### PR TITLE
Linearize release builds

### DIFF
--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -342,12 +342,12 @@ jobs:
         apiSigningToken: ${{ github.event_name == 'push' && secrets.API_SIGNING_TOKEN || '' }}
     - name: Create launcher
       shell: cmd
+      # Run launcher separately as we can't safely generate that in parallel to other scons targets (#18867)
       run: |
         PowerShell -Command "Set-ExecutionPolicy Bypass"
         PowerShell -Command "Set-PSRepository PSGallery -InstallationPolicy Trusted"
         PowerShell -Command "Install-Module -Name SignPath -Force"
         scons %sconsOutTargets% %sconsArgs% %sconsCores%
-        REM Run launcher separately as we can't safely generate that in parallel to other scons builds (#18867)
         scons launcher %sconsArgs% %sconsCores%
     - name: Upload launcher
       id: uploadLauncher

--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -102,7 +102,7 @@ jobs:
         key: ${{ env.SCONS_CACHE_KEY }}
     - name: Prepare source code
       shell: cmd
-      run: scons source %sconsArgs% ${{ !runner.debug && '--all-cores' || '-j1' }}
+      run: scons source %sconsArgs% %sconsCores%
     - name: Prepare for tests
       run: ci/scripts/tests/beforeTests.ps1
     - name: Cache scons build
@@ -346,9 +346,9 @@ jobs:
         PowerShell -Command "Set-ExecutionPolicy Bypass"
         PowerShell -Command "Set-PSRepository PSGallery -InstallationPolicy Trusted"
         PowerShell -Command "Install-Module -Name SignPath -Force"
-        scons %sconsOutTargets% %sconsArgs% ${{ !runner.debug && '--all-cores' || '-j1' }}
+        scons %sconsOutTargets% %sconsArgs% %sconsCores%
         :: Run launcher separately as we can't safely generate that in parallel to other scons builds (#18867)
-        scons launcher %sconsArgs% ${{ !runner.debug && '--all-cores' || '-j1' }}
+        scons launcher %sconsArgs% %sconsCores%
     - name: Upload launcher
       id: uploadLauncher
       uses: actions/upload-artifact@v4

--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -340,6 +340,9 @@ jobs:
       run: ci/scripts/setSconsArgs.ps1
       env:
         apiSigningToken: ${{ github.event_name == 'push' && secrets.API_SIGNING_TOKEN || '' }}
+    - name: Build scons targets
+      shell: cmd
+      run: scons %sconsOutTargets% %sconsArgs% %sconsCores%
     - name: Create launcher
       shell: cmd
       # Run launcher separately as we can't safely generate that in parallel to other scons targets (#18867)
@@ -347,7 +350,6 @@ jobs:
         PowerShell -Command "Set-ExecutionPolicy Bypass"
         PowerShell -Command "Set-PSRepository PSGallery -InstallationPolicy Trusted"
         PowerShell -Command "Install-Module -Name SignPath -Force"
-        scons %sconsOutTargets% %sconsArgs% %sconsCores%
         scons launcher %sconsArgs% %sconsCores%
     - name: Upload launcher
       id: uploadLauncher

--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -347,7 +347,7 @@ jobs:
         PowerShell -Command "Set-PSRepository PSGallery -InstallationPolicy Trusted"
         PowerShell -Command "Install-Module -Name SignPath -Force"
         scons %sconsOutTargets% %sconsArgs% %sconsCores%
-        :: Run launcher separately as we can't safely generate that in parallel to other scons builds (#18867)
+        REM Run launcher separately as we can't safely generate that in parallel to other scons builds (#18867)
         scons launcher %sconsArgs% %sconsCores%
     - name: Upload launcher
       id: uploadLauncher

--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -346,7 +346,9 @@ jobs:
         PowerShell -Command "Set-ExecutionPolicy Bypass"
         PowerShell -Command "Set-PSRepository PSGallery -InstallationPolicy Trusted"
         PowerShell -Command "Install-Module -Name SignPath -Force"
-        scons %sconsOutTargets% %sconsArgs% ${{ !runner.debug && '--all-cores' || '-j1'}}
+        scons %sconsOutTargets% %sconsArgs% ${{ !runner.debug && '--all-cores' || '-j1' }}
+        :: Run launcher separately as we can't safely generate that in parallel to other scons builds (#18867)
+        scons launcher %sconsArgs% ${{ !runner.debug && '--all-cores' || '-j1' }}
     - name: Upload launcher
       id: uploadLauncher
       uses: actions/upload-artifact@v4

--- a/ci/scripts/setSconsArgs.ps1
+++ b/ci/scripts/setSconsArgs.ps1
@@ -1,9 +1,5 @@
 $ErrorActionPreference = "Stop";
-$sconsOutTargets = "launcher developerGuide changes userGuide keyCommands client moduleList"
-# AppX is currently unmaintained and not built by default.
-if ($env:GITHUB_EVENT_NAME -eq "push" -and $env:feature_buildAppx) {
-	$sconsOutTargets += " appx"
-}
+$sconsOutTargets = "developerGuide changes userGuide keyCommands client moduleList"
 $sconsArgs = "version=$env:version"
 if ($env:release) {
 	$sconsArgs += " release=1"

--- a/ci/scripts/setSconsArgs.ps1
+++ b/ci/scripts/setSconsArgs.ps1
@@ -1,8 +1,16 @@
 $ErrorActionPreference = "Stop";
 $sconsOutTargets = "developerGuide changes userGuide keyCommands client moduleList"
 $sconsArgs = "version=$env:version"
+$sconsCores = "--all-cores"
+if ($env:RUNNER_DEBUG -eq "1") {
+	# Run scons linearly if we are in debug mode, so logs can be easily parsed
+	$sconsCores = "-j1"
+}
 if ($env:release) {
 	$sconsArgs += " release=1"
+	# Run scons linearly for release builds, so we can debug if something goes wrong,
+	# as we cannot safely re-run a released build
+	$sconsCores = "-j1"
 }
 if ($env:versionType) {
 	$sconsArgs += " updateVersionType=$env:versionType"
@@ -14,5 +22,7 @@ if ($env:GITHUB_EVENT_NAME -eq "push" -and $env:apiSigningToken) {
 $sconsArgs += " version_build=$([int]$env:GITHUB_RUN_NUMBER + [int]$env:START_BUILD_NUMBER)"
 Write-Output "sconsOutTargets=$sconsOutTargets" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 Write-Output "sconsArgs=$sconsArgs" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+Write-Output "sconsCores=$sconsCores" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 Write-Host "scons args: $sconsArgs"
 Write-Host "scons output targets: $sconsOutTargets"
+Write-Host "scons cores: $sconsCores"


### PR DESCRIPTION
### Link to issue number:
Fixes #18867

### Summary of the issue:
Documentation is getting built after the signing request, causing it to not be included in the launcher.
This caused the zh_TW (last docs file) to not be included in some beta builds

### Description of user facing changes:
None 

### Description of developer facing changes:

- Release builds may now take longer
- All builds including PR builds, snapshots, etc should safely contain all docs files

### Description of development approach:

* Refactored SCons parallelism: Added a new `sconsCores` variable in `setSconsArgs.ps1` to control the number of build cores, defaulting to `--all-cores` except for debug or release builds, which use `-j1` for easier log parsing and debugging.
* Updated workflow steps in `.github/workflows/testAndPublish.yml` to use the new `sconsCores` variable instead of inline logic for core selection, simplifying the build commands. [[1]](diffhunk://#diff-0228131759fc72c25ae13bc75628d794ff96d8aadef8aa21252bd315e3279b51L105-R105) [[2]](diffhunk://#diff-0228131759fc72c25ae13bc75628d794ff96d8aadef8aa21252bd315e3279b51L349-R351)
* Added export and logging of `sconsCores` to the environment and output in `setSconsArgs.ps1`, improving transparency of build configuration in CI logs.
* Removed `launcher` from the default `sconsOutTargets` in `setSconsArgs.ps1` and added a separate workflow step to build the launcher after other targets, preventing unsafe parallel builds of the launcher. [[1]](diffhunk://#diff-e627d750c249f53caef3ae05f40cd965a7e53632247af4328c3e9683884cf906L2-R13) [[2]](diffhunk://#diff-0228131759fc72c25ae13bc75628d794ff96d8aadef8aa21252bd315e3279b51L349-R351)
* appx snippet removed as per #18799

### Testing strategy:

Untested

### Known issues with pull request:

None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [ ] Security precautions taken.
