### PR TITLE
Fix some mouse gestures

### DIFF
--- a/source/mouseHandler.py
+++ b/source/mouseHandler.py
@@ -127,27 +127,23 @@ def internal_mouseEvent(msg, x, y, injected):
 	return True
 
 
-def executeMouseEvent(flags, x, y, data=0):
+def executeMouseEvent(flags: int, x: int, y: int, data: int = 0) -> None:
 	"""
-	Mouse events generated with this rapper for L{winUser.mouse_event}
-	will be ignored by NVDA.
-	Consult https://docs.microsoft.com/en-us/windows/desktop/api/winuser/nf-winuser-mouse_event
-	for detailed parameter documentation.
-	@param flags: Controls various aspects of mouse motion and button clicking.
-		The supplied value should be one or a combination of the C{winUser.MOUSEEVENTF_*} constants.
-	@type flags: int
-	@param x: The mouse's absolute position along the x-axis
+	Generates mouse events that will be ignored by NVDA.
+
+	.. seealso::
+		https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-mouse_event
+
+	:param flags: Controls various aspects of mouse motion and button clicking.
+		The supplied value should be one or a combination of the :var:`winUser.MOUSEEVENTF_*` constants.
+	:param x: The mouse's absolute position along the x-axis,
 		or its amount of motion since the last mouse event was generated.
-	@type x: int
-	@param y: The mouse's absolute position along the y-axis
+	:param y: The mouse's absolute position along the y-axis,
 		or its amount of motion since the last mouse event was generated.
-	@type y: int
-	@param data: Additional data depending on what flags are specified.
-		This defaults to 0.
-	@type data: int
+	:param data: Additional data depending on what flags are specified, default 0.
 	"""
 	with ignoreInjection():
-		winUser.mouse_event(flags, x, y, data, None)
+		winUser.mouse_event(flags, x, y, data, 0)
 
 
 def getMouseRestrictedToScreens(x, y, displays):

--- a/source/mouseHandler.py
+++ b/source/mouseHandler.py
@@ -4,7 +4,6 @@
 # See the file COPYING for more details.
 
 from dataclasses import dataclass
-from typing import Optional
 import time
 import wx
 import gui
@@ -334,7 +333,7 @@ def getLogicalButtonFlags() -> LogicalButtonFlags:
 def _doClick(
 	downFlag: int,
 	upFlag: int,
-	releaseDelay: Optional[float] = None,
+	releaseDelay: float | None = None,
 ):
 	executeMouseEvent(downFlag, 0, 0)
 	if releaseDelay:
@@ -342,7 +341,7 @@ def _doClick(
 	executeMouseEvent(upFlag, 0, 0)
 
 
-def doPrimaryClick(releaseDelay: Optional[float] = None):
+def doPrimaryClick(releaseDelay: float | None = None):
 	"""
 	Performs a primary mouse click at the current mouse pointer location.
 	The primary button is the one that usually activates or selects an item.
@@ -355,7 +354,7 @@ def doPrimaryClick(releaseDelay: Optional[float] = None):
 	_doClick(buttonFlags.primaryDown, buttonFlags.primaryUp, releaseDelay)
 
 
-def doSecondaryClick(releaseDelay: Optional[float] = None):
+def doSecondaryClick(releaseDelay: float | None = None):
 	"""
 	Performs a secondary mouse click at the current mouse pointer location.
 	The secondary button is the one that usually displays a context menu for an item when clicked.


### PR DESCRIPTION
### Link to issue number:

Follow-up to #18883
Fixes #18913 

### Summary of the issue:

Some gestures that control the mouse are broken. These include left/right mouse button lock/unlock, and navigator object default action.

### Description of user facing changes:

They work again.

### Description of developer facing changes:

None.

### Description of development approach:

Updated `mouseHandler.executeMouseEvent` to send `0` instead of `None` as the value of `dwExtraInfo`. This is necessary as `dwExtraInfo` is correctly declared as `ULONG_PTR` since #18883, so ctypes will not accept `None`.

### Testing strategy:

Ran from source and tested clicking and locking/unlocking the left and right mouse buttons, as well as activating the navigator object.

### Known issues with pull request:

None

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
