### PR TITLE
winUser.WinTimer: ensure timerFunc is correctly wrapped as a TIMERPROC even when None.

### DIFF
--- a/source/winUser.py
+++ b/source/winUser.py
@@ -820,13 +820,12 @@ class WinTimer(object):
 		self.elapse = elapse
 		# ensure timerFunc is a TIMERPROC, or is converted to a TIMERPROC,
 		# And ensuring that None is handled as the correctly typed null function pointer.
-		match timerFunc:
-			case winBindings.user32.TIMERPROC:
-				self.timerFunc = timerFunc
-			case None:
-				self.timerFunc = winBindings.user32.TIMERPROC(0)
-			case _:
-				self.timerFunc = winBindings.user32.TIMERPROC(timerFunc)
+		if isinstance(timerFunc, winBindings.user32.TIMERPROC):
+			self.timerFunc = timerFunc
+		elif timerFunc is None:
+			self.timerFunc = winBindings.user32.TIMERPROC(0)
+		else:
+			self.timerFunc = winBindings.user32.TIMERPROC(timerFunc)
 		self.ident = _user32.SetTimer(hwnd, idEvent, elapse, self.timerFunc)
 		if self.ident == 0:
 			raise WinError()

--- a/source/winUser.py
+++ b/source/winUser.py
@@ -819,7 +819,7 @@ class WinTimer(object):
 		self.idEvent = idEvent
 		self.elapse = elapse
 		# ensure timerFunc is a TIMERPROC, or is converted to a TIMERPROC,
-		# And ensuring that None is handled as the correctly typed null function pointer.
+		# and ensuring that None is handled as the correctly typed null function pointer.
 		if isinstance(timerFunc, winBindings.user32.TIMERPROC):
 			self.timerFunc = timerFunc
 		elif timerFunc is None:

--- a/source/winUser.py
+++ b/source/winUser.py
@@ -818,8 +818,16 @@ class WinTimer(object):
 		self.hwnd = hwnd
 		self.idEvent = idEvent
 		self.elapse = elapse
-		self.timerFunc = timerFunc
-		self.ident = _user32.SetTimer(hwnd, idEvent, elapse, timerFunc)
+		# ensure timerFunc is a TIMERPROC, or is converted to a TIMERPROC,
+		# And ensuring that None is handled as the correctly typed null function pointer.
+		match timerFunc:
+			case winBindings.user32.TIMERPROC:
+				self.timerFunc = timerFunc
+			case None:
+				self.timerFunc = winBindings.user32.TIMERPROC(0)
+			case _:
+				self.timerFunc = winBindings.user32.TIMERPROC(timerFunc)
+		self.ident = _user32.SetTimer(hwnd, idEvent, elapse, self.timerFunc)
 		if self.ident == 0:
 			raise WinError()
 		if not hwnd:


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
<!-- Use Closes/Fixes/Resolves #xxx to link this PR to the issue it is responding to. -->
Fixes #18907 
Fixes #18914

### Summary of the issue:
Tightening up ctypes definitions for 64 bit means that ctypes may be more picky with what can be passed as an argument. In particular passing None to an argument that should be a callback now will fail.
The correct way is now to pass Functype(0) where Functype is the callback's ctypes definition.
So far just one call has been identified in #18914: SetTimer takes a TIMERPROC.

### Description of user facing changes:
None.

### Description of developer facing changes:

### Description of development approach:
`winUser.WinTimer` now ensures that `timerFunc` is already, or is converted to, a `TIMERPROC`. Specifically ensuring `None` is converted to `TIMERPROC(0)`.

### Testing strategy:
* [x] The author of #18914 should confirm this fix.

### Known issues with pull request:
None known.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
