### PR TITLE
Replace some internal deprecated usage with correct symbols

### DIFF
--- a/source/systemUtils.py
+++ b/source/systemUtils.py
@@ -150,7 +150,7 @@ def execElevated(path, params=None, wait=False, handleAlreadyElevated=False):
 
 	if params is not None:
 		params = subprocess.list2cmdline(params)
-	sei = shellapi.SHELLEXECUTEINFO(lpFile=path, lpParameters=params, nShow=winUser.SW_HIDE)
+	sei = winBindings.shell32.SHELLEXECUTEINFO(lpFile=path, lpParameters=params, nShow=winUser.SW_HIDE)
 	# IsUserAnAdmin is apparently deprecated so may not work above Windows 8
 	if not handleAlreadyElevated or not winBindings.shell32.IsUserAnAdmin():
 		sei.lpVerb = "runas"

--- a/source/touchHandler.py
+++ b/source/touchHandler.py
@@ -94,35 +94,35 @@ POINTER_MESSAGE_FLAG_CONFIDENCE = 0x200
 POINTER_MESSAGE_FLAG_CANCELED = 0x400
 
 
-class POINTER_INFO(Structure):  # noqa: F405
+class POINTER_INFO(Structure):
 	_fields_ = [
-		("pointerType", DWORD),  # noqa: F405
-		("pointerId", c_uint32),  # noqa: F405
-		("frameId", c_uint32),  # noqa: F405
-		("pointerFlags", c_uint32),  # noqa: F405
-		("sourceDevice", HANDLE),  # noqa: F405
-		("hwndTarget", HWND),  # noqa: F405
-		("ptPixelLocation", POINT),  # noqa: F405
-		("ptHimetricLocation", POINT),  # noqa: F405
-		("ptPixelLocationRaw", POINT),  # noqa: F405
-		("ptHimetricLocationRaw", POINT),  # noqa: F405
-		("dwTime", DWORD),  # noqa: F405
-		("historyCount", c_uint32),  # noqa: F405
-		("inputData", c_int),  # noqa: F405
-		("dwKeyStates", DWORD),  # noqa: F405
-		("PerformanceCount", c_uint64),  # noqa: F405
+		("pointerType", DWORD),
+		("pointerId", c_uint32),
+		("frameId", c_uint32),
+		("pointerFlags", c_uint32),
+		("sourceDevice", HANDLE),
+		("hwndTarget", HWND),
+		("ptPixelLocation", POINT),
+		("ptHimetricLocation", POINT),
+		("ptPixelLocationRaw", POINT),
+		("ptHimetricLocationRaw", POINT),
+		("dwTime", DWORD),
+		("historyCount", c_uint32),
+		("inputData", c_int),
+		("dwKeyStates", DWORD),
+		("PerformanceCount", c_uint64),
 	]
 
 
-class POINTER_TOUCH_INFO(Structure):  # noqa: F405
+class POINTER_TOUCH_INFO(Structure):
 	_fields_ = [
 		("pointerInfo", POINTER_INFO),
-		("touchFlags", c_uint32),  # noqa: F405
-		("touchMask", c_uint32),  # noqa: F405
-		("rcContact", RECT),  # noqa: F405
-		("rcContactRaw", RECT),  # noqa: F405
-		("orientation", c_uint32),  # noqa: F405
-		("pressure", c_uint32),  # noqa: F405
+		("touchFlags", c_uint32),
+		("touchMask", c_uint32),
+		("rcContact", RECT),
+		("rcContactRaw", RECT),
+		("orientation", c_uint32),
+		("pressure", c_uint32),
 	]
 
 
@@ -270,7 +270,7 @@ class TouchHandler(threading.Thread):
 				lpfnWndProc=self._cInputTouchWindowProc,
 				hInstance=self._appInstance,
 				lpszClassName="inputTouchWindowClass",
-			)  # noqa: F405
+			)
 			self._wca = user32.RegisterClassEx(byref(self._wc))
 			self._touchWindow = user32.CreateWindowEx(
 				0,
@@ -287,11 +287,11 @@ class TouchHandler(threading.Thread):
 				None,
 			)
 			user32.RegisterPointerInputTarget(self._touchWindow, PT_TOUCH)
-			winBindings.oleacc.AccSetRunningUtilityState(  # noqa: F405
+			winBindings.oleacc.AccSetRunningUtilityState(
 				self._touchWindow,
 				ANRUS_TOUCH_MODIFICATION_ACTIVE,
 				ANRUS_TOUCH_MODIFICATION_ACTIVE,
-			)  # noqa: F405
+			)
 			self.trackerManager = touchTracker.TrackerManager()
 			self.screenExplorer = screenExplorer.ScreenExplorer()
 			self.screenExplorer.updateReview = True
@@ -299,11 +299,11 @@ class TouchHandler(threading.Thread):
 			self.threadExc = e
 		finally:
 			self.initializedEvent.set()
-		msg = MSG()  # noqa: F405
+		msg = MSG()
 		while user32.GetMessage(byref(msg), None, 0, 0):
-			user32.TranslateMessage(byref(msg))  # noqa: F405
-			user32.DispatchMessage(byref(msg))  # noqa: F405
-		winBindings.oleacc.AccSetRunningUtilityState(self._touchWindow, ANRUS_TOUCH_MODIFICATION_ACTIVE, 0)  # noqa: F405
+			user32.TranslateMessage(byref(msg))
+			user32.DispatchMessage(byref(msg))
+		winBindings.oleacc.AccSetRunningUtilityState(self._touchWindow, ANRUS_TOUCH_MODIFICATION_ACTIVE, 0)
 		user32.UnregisterPointerInputTarget(self._touchWindow, PT_TOUCH)
 		user32.DestroyWindow(self._touchWindow)
 		user32.UnregisterClass(self._wca, self._appInstance)
@@ -350,7 +350,7 @@ class TouchHandler(threading.Thread):
 		@param obj: The NVDAObject with which the user is interacting.
 		@type obj: L{NVDAObjects.NVDAObject}
 		"""
-		winBindings.oleacc.AccNotifyTouchInteraction(  # noqa: F405
+		winBindings.oleacc.AccNotifyTouchInteraction(
 			gui.mainFrame.Handle,
 			obj.windowHandle,  # noqa: F405
 			obj.location.center.toPOINT(),

--- a/source/visionEnhancementProviders/NVDAHighlighter.py
+++ b/source/visionEnhancementProviders/NVDAHighlighter.py
@@ -32,6 +32,7 @@ from locationHelper import RectLTWH
 from collections import namedtuple
 import threading
 from winAPI.messageWindow import WindowMessage
+import winBindings.gdi32
 import winGDI
 import weakref
 from colors import RGB
@@ -94,7 +95,7 @@ class HighlightWindow(CustomWindow):
 	def _get__wClass(cls):
 		wClass = super()._wClass
 		wClass.style = winUser.CS_HREDRAW | winUser.CS_VREDRAW
-		wClass.hbrBackground = winGDI.gdi32.CreateSolidBrush(COLORREF(cls.transparentColor))
+		wClass.hbrBackground = winBindings.gdi32.CreateSolidBrush(cls.transparentColor)
 		return wClass
 
 	def updateLocationForDisplays(self):

--- a/source/visionEnhancementProviders/NVDAHighlighter.py
+++ b/source/visionEnhancementProviders/NVDAHighlighter.py
@@ -24,7 +24,7 @@ from gui.settingsDialogs import (
 )
 import api
 from ctypes import byref, WinError
-from ctypes.wintypes import COLORREF, MSG
+from ctypes.wintypes import MSG
 import winUser
 from logHandler import log
 from mouseHandler import getTotalWidthAndHeightAndMinimumPosition

--- a/source/winBindings/bthprops.py
+++ b/source/winBindings/bthprops.py
@@ -8,7 +8,7 @@
 from ctypes import POINTER, Structure, c_ulonglong, sizeof, windll
 from ctypes.wintypes import BOOL, DWORD, HANDLE, ULONG, WCHAR
 
-from winKernel import SYSTEMTIME
+from winBindings.kernel32 import SYSTEMTIME
 
 cpl = windll["bthprops.cpl"]
 

--- a/source/windowUtils.py
+++ b/source/windowUtils.py
@@ -16,7 +16,7 @@ import winBindings.kernel32
 import winBindings.user32
 import winBindings.gdi32
 import winUser
-from winUser import WNDCLASSEXW, WNDPROC
+from winBindings.user32 import WNDCLASSEXW, WNDPROC
 from logHandler import log
 from abc import abstractmethod
 from baseObject import AutoPropertyObject


### PR DESCRIPTION

<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
<!-- Use Closes/Fixes/Resolves #xxx to link this PR to the issue it is responding to. -->
None.

### Summary of the issue:
NvDA internally still uses some deprecated/moved symbols. They should be called from their correct locations.
 
### Description of user facing changes:
None.

### Description of developer facing changes:

### Description of development approach:
* access symbols directly from winBindings.gdi32 and winBindings.user32
* winBindings.bthProps: import SYSTEMTIME from winBindings.kernel32
* touchHandler:  Use symbols from user32 not winUser. Fix imports.
* systemUtils: SHELLEXECUTEINFO moved from shellapi to winBindings.shell32

### Testing strategy:
* [x] Run try build. Test touch gestures. Ensure no deprecation warnings in log.

### Known issues with pull request:

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
