### PR TITLE
Moving mouse with audio coordinates no longer throws an error

### DIFF
--- a/source/contentRecog/uwpOcr.py
+++ b/source/contentRecog/uwpOcr.py
@@ -5,7 +5,12 @@
 
 """Recognition of text using the UWP OCR engine included in Windows 10 and later."""
 
+from ctypes import (
+	cast,
+	POINTER,
+)
 import json
+from winBindings.gdi32 import RGBQUAD
 import NVDAHelper
 from NVDAHelper.localWin10 import (
 	uwpOcr_getLanguages,
@@ -124,7 +129,15 @@ class UwpOcr(ContentRecognizer):
 		if not self._handle:
 			onResult(RuntimeError("UWP OCR initialization failed"))
 			return
-		uwpOcr_recognize(self._handle, pixels, imgInfo.recogWidth, imgInfo.recogHeight)
+		uwpOcr_recognize(
+			self._handle,
+			# pixels, as fetched from screenBitmap.captureImage is a 2d array of RGBQUAD values.
+			# However uwpOcr_recognize expects a 1d array (pointer).
+			# These are identical in memory, so we can just cast.
+			cast(pixels, POINTER(RGBQUAD)),
+			imgInfo.recogWidth,
+			imgInfo.recogHeight
+		)
 
 	def cancel(self):
 		self._onResult = None

--- a/source/contentRecog/uwpOcr.py
+++ b/source/contentRecog/uwpOcr.py
@@ -136,7 +136,7 @@ class UwpOcr(ContentRecognizer):
 			# These are identical in memory, so we can just cast.
 			cast(pixels, POINTER(RGBQUAD)),
 			imgInfo.recogWidth,
-			imgInfo.recogHeight
+			imgInfo.recogHeight,
 		)
 
 	def cancel(self):

--- a/source/screenBitmap.py
+++ b/source/screenBitmap.py
@@ -64,7 +64,7 @@ class ScreenBitmap(object):
 			winGDI.SRCCOPY,
 		)
 		# Fetch the pixels from our memory bitmap and store them in a buffer to be returned
-		buffer = (winBindings.gdi32.RGBQUAD * (self.width * self.height))()
+		buffer = (winBindings.gdi32.RGBQUAD * self.width * self.height)()
 		winBindings.gdi32.GetDIBits(
 			self._memDC,
 			self._memBitmap,


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
<!-- Use Closes/Fixes/Resolves #xxx to link this PR to the issue it is responding to. -->
Fixes #18929

### Summary of the issue:
when moving the mouse with play audio coordinates with brightness enabled, NVDA fails to read what is under the mouse, fails to play the audio beeps, and logs an error:
 
This is due to the fact that screenBitmap.captureImage was recently changed to return a 1d array of RGBQUAD values, rather than a 2d array. The change was to fix an incompatibility with argument types of uwpOCR_recognize.
However, mouseHandler.playAudioCoordinates still expects a 2d array.


### Description of user facing changes:
Mouse movement  with play audio coordinates and brightness works and does not throw an error.

### Description of developer facing changes:

### Description of development approach:
screenBitmap.captureImage again returns a 2d array, keeping it backward compatible and fixes the mouse movement bug.

uwpOCR recognize: the pixels array provided from screenBitmap.captureImage is a 2d array. However uwpOCR_recognise expects pixels to be a 1d array. these are  exactly the same memory layout, so we now just cast to a POINTER(RGBQUAD).

### Testing strategy:
* Turned on play audio coordinates with mouse moves. Turned on detect brightness. Moved the mouse around the screen, ensuring audio coordinates beeps played and there were no errors in the log.
Did an OCR recogise of the screen with NvDA+r, and ensured that the results were readable and no error was logged.

### Known issues with pull request:
None known.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
