### PR TITLE
Typing a dead key no longer throws an error

### DIFF
--- a/source/keyboardHandler.py
+++ b/source/keyboardHandler.py
@@ -531,10 +531,7 @@ class KeyboardInputGesture(inputCore.InputGesture):
 		vkChar = user32.MapVirtualKeyEx(self.vkCode, winUser.MAPVK_VK_TO_CHAR, getInputHkl())
 		# the highest bit of a 32 bit value denotes a dead key
 		DEAD_KEY_FLAG = 0x80000000
-		if (
-			vkChar > 0
-			and not (vkChar & DEAD_KEY_FLAG)
-		):
+		if vkChar > 0 and not (vkChar & DEAD_KEY_FLAG):
 			if vkChar == 43:  # "+"
 				# A gesture identifier can't include "+" except as a separator.
 				return "plus"

--- a/source/keyboardHandler.py
+++ b/source/keyboardHandler.py
@@ -529,10 +529,11 @@ class KeyboardInputGesture(inputCore.InputGesture):
 			# Unicode character from non-keyboard input.
 			return chr(self.scanCode)
 		vkChar = user32.MapVirtualKeyEx(self.vkCode, winUser.MAPVK_VK_TO_CHAR, getInputHkl())
+		# the highest bit of a 32 bit value denotes a dead key
+		DEAD_KEY_FLAG = 0x80000000
 		if (
 			vkChar > 0
-			# If the highest bit of this 32 bit value is set then it is a dead key.
-			and (vkChar >> 31) == 0
+			and not (vkChar & DEAD_KEY_FLAG)
 		):
 			if vkChar == 43:  # "+"
 				# A gesture identifier can't include "+" except as a separator.

--- a/source/keyboardHandler.py
+++ b/source/keyboardHandler.py
@@ -529,7 +529,11 @@ class KeyboardInputGesture(inputCore.InputGesture):
 			# Unicode character from non-keyboard input.
 			return chr(self.scanCode)
 		vkChar = user32.MapVirtualKeyEx(self.vkCode, winUser.MAPVK_VK_TO_CHAR, getInputHkl())
-		if vkChar > 0:
+		if (
+			vkChar > 0
+			# If the highest bit of this 32 bit value is set then it is a dead key.
+			and (vkChar >> 31) == 0
+		):
 			if vkChar == 43:  # "+"
 				# A gesture identifier can't include "+" except as a separator.
 				return "plus"


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
<!-- Use Closes/Fixes/Resolves #xxx to link this PR to the issue it is responding to. -->
Fixes #18908

### Summary of the issue:
After we moved to a tightened ctypes definition for user32.MapVirtualKeyEx, typing dead keys such as an acute on a German keyboard layout would throw an error such as:
```
  File "keyboardHandler.pyc", line 535, in _get_mainKeyName
ValueError: chr() arg not in range(0x110000)
```

### Description of user facing changes:
No longer throws an error when typing dead keys.

### Description of developer facing changes:

### Description of development approach:
KeyboardInputGesture.mainKeyName: As MapVirtualKeyEx now correctly returns an unsigned int we must be more explisit about filtering out dead keys. A dead key is denoted  when the highest bit is set.

### Testing strategy:
* Switched to German keyboard layout.
* Typed an acute (to the left of backspace). No error thrown.
* Typed an 'a'. 'a acute' was announced and typed.

### Known issues with pull request:
None known.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
