### PR TITLE
Fix WindowFromAccessibleObject

### DIFF
--- a/source/IAccessibleHandler/__init__.py
+++ b/source/IAccessibleHandler/__init__.py
@@ -368,7 +368,7 @@ def accessibleObjectFromPoint(x, y):
 	return normalizeIAccessible(pacc, child), child
 
 
-def windowFromAccessibleObject(ia):
+def windowFromAccessibleObject(ia) -> int:
 	try:
 		return oleacc.WindowFromAccessibleObject(ia)
 	except WindowsError:

--- a/source/IAccessibleHandler/__init__.py
+++ b/source/IAccessibleHandler/__init__.py
@@ -371,7 +371,8 @@ def accessibleObjectFromPoint(x, y):
 def windowFromAccessibleObject(ia):
 	try:
 		return oleacc.WindowFromAccessibleObject(ia)
-	except:  # noqa: E722 Bare except
+	except WindowsError:
+		log.debugWarning("windowFromAccessibleObject failed", exc_info=True)
 		return 0
 
 

--- a/source/oleacc.py
+++ b/source/oleacc.py
@@ -313,15 +313,15 @@ def AccessibleObjectFromEvent_safe(hwnd, objectID, childID, timeout=2):
 
 def WindowFromAccessibleObject(pacc):
 	"""
-	Retreaves the handle of the window this IAccessible object belongs to.
+	Retrieves the handle of the window this IAccessible object belongs to.
 	@param pacc: the IAccessible object who's window you want to fetch.
 	@type pacc: POINTER(IAccessible)
 	@return: the window handle.
 	@rtype: int
 	"""
-	hwnd = c_int()  # noqa: F405
+	hwnd = HWND()  # noqa: F405
 	winBindings.oleacc.WindowFromAccessibleObject(pacc, byref(hwnd))  # noqa: F405
-	return hwnd.value
+	return hwnd.value or 0
 
 
 def AccessibleObjectFromPoint(x, y):

--- a/source/oleacc.py
+++ b/source/oleacc.py
@@ -5,6 +5,7 @@
 
 from ctypes import *  # noqa: F403
 from ctypes.wintypes import *  # noqa: F403
+from ctypes.wintypes import HWND
 from comtypes import *  # noqa: F403
 from comtypes.automation import *  # noqa: F403
 import comtypes.client
@@ -311,15 +312,14 @@ def AccessibleObjectFromEvent_safe(hwnd, objectID, childID, timeout=2):
 	return (obj, childID)
 
 
-def WindowFromAccessibleObject(pacc):
+def WindowFromAccessibleObject(pacc) -> int:
 	"""
 	Retrieves the handle of the window this IAccessible object belongs to.
-	@param pacc: the IAccessible object who's window you want to fetch.
-	@type pacc: POINTER(IAccessible)
-	@return: the window handle.
-	@rtype: int
+	:param pacc: the IAccessible object who's window you want to fetch.
+	:type pacc: POINTER(IAccessible)
+	:return: the window handle.
 	"""
-	hwnd = HWND()  # noqa: F405
+	hwnd = HWND()
 	winBindings.oleacc.WindowFromAccessibleObject(pacc, byref(hwnd))  # noqa: F405
 	return hwnd.value or 0
 


### PR DESCRIPTION
### Link to issue number:
Fixes #18871 

### Summary of the issue:
During the winBindings conversion of oleacc, there was an oversight in passing the right argument type to WindowFromAccessibleObject.

### Description of user facing changes:
#18871 no longer reproducible

### Description of developer facing changes:
None

### Description of development approach:
1. Pass a HWND instead of a c_int to WindowFromAccessibleObject
2. WindowFromAccessibleObject is only expected to throw a Windows Error. Change the bare except accordingly and also log a debug warning.

### Testing strategy:
STR from #18871 

### Known issues with pull request:
None known

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
