### PR TITLE
Fix Remote Access as follower

### DIFF
--- a/source/_remoteClient/input.py
+++ b/source/_remoteClient/input.py
@@ -4,7 +4,7 @@
 # See the file COPYING for more details.
 
 import ctypes
-from enum import IntEnum, IntFlag
+from enum import IntEnum
 
 import api
 import baseObject
@@ -16,23 +16,6 @@ import vision
 from winBindings import user32
 
 
-class InputType(IntEnum):
-	"""Values permissible as the `type` field in an `INPUT` struct.
-
-	.. seealso::
-		https://learn.microsoft.com/en-us/windows/win32/api/winuser/ns-winuser-input
-	"""
-
-	MOUSE = 0
-	"""The event is a mouse event. Use the mi structure of the union."""
-
-	KEYBOARD = 1
-	"""The event is a keyboard event. Use the ki structure of the union."""
-
-	HARDWARE = 2
-	"""The event is a hardware event. Use the hi structure of the union."""
-
-
 class VKMapType(IntEnum):
 	"""Type of mapping to be performed between virtual key code and virtual scan code.
 
@@ -42,30 +25,6 @@ class VKMapType(IntEnum):
 
 	VK_TO_VSC = 0
 	"""Maps a virtual key code to a scan code."""
-
-
-class KeyEventFlag(IntFlag):
-	"""Specifies various aspects of a keystroke in a KEYBDINPUT struct.
-
-	.. seealso::
-		https://learn.microsoft.com/en-us/windows/win32/api/winuser/ns-winuser-keybdinput
-	"""
-
-	EXTENDED_KEY = 0x0001
-	"""If specified, the wScan scan code consists of a sequence of two bytes, where the first byte has a value of 0xE0."""
-
-	KEY_UP = 0x0002
-	"""If specified, the key is being released. If not specified, the key is being pressed. """
-
-	SCAN_CODE = 0x0008
-	"""If specified, wScan identifies the key and wVk is ignored. """
-
-	UNICODE = 0x0004
-	"""If specified, the system synthesizes a VK_PACKET keystroke.
-
-	.. warning::
-		Must only be combined with :const:`KEY_UP`.
-	"""
 
 
 class BrailleInputGesture(braille.BrailleDisplayGesture, brailleInput.BrailleInputGesture):
@@ -173,8 +132,8 @@ def sendKey(vk: int | None = None, scan: int | None = None, extended: bool = Fal
 	else:  # No scancode provided, try to get one
 		i.ii.ki.wScan = user32.MapVirtualKey(vk, VKMapType.VK_TO_VSC)
 	if not pressed:
-		i.ii.ki.dwFlags |= KeyEventFlag.KEY_UP
+		i.ii.ki.dwFlags |= user32.KEYEVENTF.KEYUP
 	if extended:
-		i.ii.ki.dwFlags |= KeyEventFlag.EXTENDED_KEY
-	i.type = InputType.KEYBOARD
+		i.ii.ki.dwFlags |= user32.KEYEVENTF.EXTENDEDKEY
+	i.type = user32.INPUT_TYPE.KEYBOARD
 	user32.SendInput(1, ctypes.byref(i), ctypes.sizeof(user32.INPUT))

--- a/source/_remoteClient/input.py
+++ b/source/_remoteClient/input.py
@@ -125,15 +125,15 @@ def sendKey(vk: int | None = None, scan: int | None = None, extended: bool = Fal
 	:param extended: Whether this is an extended key, defaults to False
 	:param pressed: ``True`` if key pressed; ``False`` if released, defaults to True
 	"""
-	i = user32.INPUT()
-	i.ii.ki.wVk = vk
+	input = user32.INPUT()
+	input.ii.ki.wVk = vk
 	if scan:
-		i.ii.ki.wScan = scan
+		input.ii.ki.wScan = scan
 	else:  # No scancode provided, try to get one
-		i.ii.ki.wScan = user32.MapVirtualKey(vk, VKMapType.VK_TO_VSC)
+		input.ii.ki.wScan = user32.MapVirtualKey(vk, VKMapType.VK_TO_VSC)
 	if not pressed:
-		i.ii.ki.dwFlags |= user32.KEYEVENTF.KEYUP
+		input.ii.ki.dwFlags |= user32.KEYEVENTF.KEYUP
 	if extended:
-		i.ii.ki.dwFlags |= user32.KEYEVENTF.EXTENDEDKEY
-	i.type = user32.INPUT_TYPE.KEYBOARD
-	user32.SendInput(1, ctypes.byref(i), ctypes.sizeof(user32.INPUT))
+		input.ii.ki.dwFlags |= user32.KEYEVENTF.EXTENDEDKEY
+	input.type = user32.INPUT_TYPE.KEYBOARD
+	user32.SendInput(1, ctypes.byref(input), ctypes.sizeof(user32.INPUT))

--- a/source/brailleInput.py
+++ b/source/brailleInput.py
@@ -409,12 +409,12 @@ class BrailleInputHandler(AutoPropertyObject):
 			for ch in chars
 		)
 		for ch in chars:
-			for direction in (0, winUser.KEYEVENTF_KEYUP):
+			for direction in (0, winBindings.user32.KEYEVENTF.KEYUP):
 				input = winBindings.user32.INPUT()
-				input.type = winUser.INPUT_KEYBOARD
+				input.type = winBindings.user32.INPUT_TYPE.KEYBOARD
 				input.ii.ki = winBindings.user32.KEYBDINPUT()
 				input.ii.ki.wScan = ord(ch)
-				input.ii.ki.dwFlags = winUser.KEYEVENTF_UNICODE | direction
+				input.ii.ki.dwFlags = winBindings.user32.KEYEVENTF.UNICODE | direction
 				inputs.append(input)
 		winUser.SendInput(inputs)
 		focusObj = api.getFocusObject()

--- a/source/easeOfAccess.py
+++ b/source/easeOfAccess.py
@@ -80,17 +80,17 @@ def notify(signal):
 	inputs = []
 	# Release unwanted keys and press desired keys.
 	for vk, desired in keys:
-		input = winBindings.user32.INPUT(type=winUser.INPUT_KEYBOARD)
+		input = winBindings.user32.INPUT(type=winBindings.user32.INPUT_TYPE.KEYBOARD)
 		input.ii.ki.wVk = vk
 		if not desired:
-			input.ii.ki.dwFlags = winUser.KEYEVENTF_KEYUP
+			input.ii.ki.dwFlags = winBindings.user32.KEYEVENTF.KEYUP
 		inputs.append(input)
 	# Release desired keys and press unwanted keys.
 	for vk, desired in reversed(keys):
-		input = winBindings.user32.INPUT(type=winUser.INPUT_KEYBOARD)
+		input = winBindings.user32.INPUT(type=winBindings.user32.INPUT_TYPE.KEYBOARD)
 		input.ii.ki.wVk = vk
 		if desired:
-			input.ii.ki.dwFlags = winUser.KEYEVENTF_KEYUP
+			input.ii.ki.dwFlags = winBindings.user32.KEYEVENTF.KEYUP
 		inputs.append(input)
 	winUser.SendInput(inputs)
 

--- a/source/keyboardHandler.py
+++ b/source/keyboardHandler.py
@@ -647,7 +647,7 @@ class KeyboardInputGesture(inputCore.InputGesture):
 			# it is already too late.
 			with ignoreInjection():
 				winUser.keybd_event(winUser.VK_NONE, 0, 0, 0)
-				winUser.keybd_event(winUser.VK_NONE, 0, winUser.KEYEVENTF_KEYUP, 0)
+				winUser.keybd_event(winUser.VK_NONE, 0, user32.KEYEVENTF.KEYUP, 0)
 		# Now actually execute the script.
 		super().executeScript(script)
 

--- a/source/winBindings/user32.py
+++ b/source/winBindings/user32.py
@@ -57,6 +57,7 @@ from ctypes.wintypes import (
 	WPARAM,
 	ATOM,
 )
+from enum import IntEnum, IntFlag
 
 UINT_PTR = c_size_t
 ULONG_PTR = c_size_t
@@ -636,6 +637,30 @@ class MOUSEINPUT(Structure):
 	)
 
 
+class KEYEVENTF(IntFlag):
+	"""Specifies various aspects of a keystroke in a ``KEYBDINPUT`` struct.
+
+	.. seealso::
+		https://learn.microsoft.com/en-us/windows/win32/api/winuser/ns-winuser-keybdinput
+	"""
+
+	EXTENDEDKEY = 0x0001
+	"""If specified, the wScan scan code consists of a sequence of two bytes, where the first byte has a value of 0xE0."""
+
+	KEYUP = 0x0002
+	"""If specified, the key is being released. If not specified, the key is being pressed. """
+
+	SCANCODE = 0x0008
+	"""If specified, wScan identifies the key and wVk is ignored. """
+
+	UNICODE = 0x0004
+	"""If specified, the system synthesizes a VK_PACKET keystroke.
+
+	.. warning::
+		Must only be combined with :const:`KEY_UP`.
+	"""
+
+
 class KEYBDINPUT(Structure):
 	"""
 	Contains information about a simulated keyboard event.
@@ -678,6 +703,23 @@ class _INPUT_I(Union):
 		("ki", KEYBDINPUT),
 		("hi", HARDWAREINPUT),
 	)
+
+
+class INPUT_TYPE(IntEnum):
+	"""Values permissible as the ``type`` field in an ``INPUT`` struct.
+
+	.. seealso::
+		https://learn.microsoft.com/en-us/windows/win32/api/winuser/ns-winuser-input
+	"""
+
+	MOUSE = 0
+	"""The event is a mouse event. Use the mi structure of the union."""
+
+	KEYBOARD = 1
+	"""The event is a keyboard event. Use the ki structure of the union."""
+
+	HARDWARE = 2
+	"""The event is a hardware event. Use the hi structure of the union."""
 
 
 class INPUT(Structure):

--- a/source/winBindings/user32.py
+++ b/source/winBindings/user32.py
@@ -657,7 +657,7 @@ class KEYEVENTF(IntFlag):
 	"""If specified, the system synthesizes a VK_PACKET keystroke.
 
 	.. warning::
-		Must only be combined with :const:`KEY_UP`.
+		Must only be combined with :const:`KEYUP`.
 	"""
 
 

--- a/source/winUser.py
+++ b/source/winUser.py
@@ -116,6 +116,10 @@ __getattr__ = _deprecate.handleDeprecations(
 	_deprecate.MovedSymbol("KeyBdInput", "winBindings.user32", "KEYBDINPUT"),
 	_deprecate.MovedSymbol("HardwareInput", "winBindings.user32", "HARDWAREINPUT"),
 	_deprecate.MovedSymbol("MouseInput", "winBindings.user32", "MOUSEINPUT"),
+	_deprecate.MovedSymbol("INPUT_MOUSE", "winBindings.user32", "INPUT_TYPE", "MOUSE"),
+	_deprecate.MovedSymbol("INPUT_KEYBOARD", "winBindings.user32", "INPUT_TYPE", "KEYBOARD"),
+	_deprecate.MovedSymbol("KEYEVENTF_KEYUP", "winBindings.user32", "KEYEVENTF", "KEYUP"),
+	_deprecate.MovedSymbol("KEYEVENTF_UNICODE", "winBindings.user32", "KEYEVENTF", "UNICODE"),
 )
 """Module __getattr__ to handle backward compatibility."""
 
@@ -768,14 +772,6 @@ def getSystemStickyKeys():
 	sk = STICKYKEYS()
 	_user32.SystemParametersInfo(SPI_GETSTICKYKEYS, 0, byref(sk), 0)
 	return sk
-
-
-# START SENDINPUT TYPE DECLARATIONS
-INPUT_MOUSE = 0  # The event is a mouse event. Use the mi structure of the union.
-INPUT_KEYBOARD = 1  # The event is a keyboard event. Use the ki structure of the union.
-KEYEVENTF_KEYUP = 0x0002
-KEYEVENTF_UNICODE = 0x04
-# END SENDINPUT TYPE DECLARATIONS
 
 
 def SendInput(inputs):

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -148,6 +148,8 @@ Use `winBindings.mmeapi.WAVEFORMATEX` instead. (#18207)
 * `winKernel.kernel32` is now `winBindings.kernel32.dll`. (#18896)
 * The `LVS_*` constants from `NVDAObjects.IAccessible.sysListView32` are deprecated.
   Use the `ListViewWindowStyle` enumeration instead. (#18926 , @LeonarddeR)
+* The `INPUT_MOUSE`, `INPUT_KEYBOARD`, `KEYEVENTF_KEYUP` and `KEYEVENTF_UNICODE` constants from `winUser` are deprecated.
+Use `INPUT_TYPE.MOUSE`, `INPUT_TYPE.KEYBOARD`, `KEYEVENTF.KEYUP` and `KEYEVENTF.UNICODE` from `winBindings.user32` instead.
 
 <!-- Beyond this point, Markdown should not be linted, as we don't modify old change log sections. -->
 <!-- markdownlint-disable -->

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -149,7 +149,7 @@ Use `winBindings.mmeapi.WAVEFORMATEX` instead. (#18207)
 * The `LVS_*` constants from `NVDAObjects.IAccessible.sysListView32` are deprecated.
   Use the `ListViewWindowStyle` enumeration instead. (#18926 , @LeonarddeR)
 * The `INPUT_MOUSE`, `INPUT_KEYBOARD`, `KEYEVENTF_KEYUP` and `KEYEVENTF_UNICODE` constants from `winUser` are deprecated.
-Use `INPUT_TYPE.MOUSE`, `INPUT_TYPE.KEYBOARD`, `KEYEVENTF.KEYUP` and `KEYEVENTF.UNICODE` from `winBindings.user32` instead.
+Use `INPUT_TYPE.MOUSE`, `INPUT_TYPE.KEYBOARD`, `KEYEVENTF.KEYUP` and `KEYEVENTF.UNICODE` from `winBindings.user32` instead. (#18947)
 
 <!-- Beyond this point, Markdown should not be linted, as we don't modify old change log sections. -->
 <!-- markdownlint-disable -->


### PR DESCRIPTION
### Link to issue number:
Fixes #18938

### Summary of the issue:

Attempting to control NVDA via the Remote Access feature fails on recent alphas.

### Description of user facing changes:

It works again.

### Description of developer facing changes:

Some constants from `winUser` have been made enum members in `winBindings.user32`.

### Description of development approach:

* Removed the definitions of `INPUT`, `KEYBDINPUT`, `HARDWAREINPUT`, `MOUSEINPUT`, `INPUT_TYPE` and `KEYEVENTF` from `_remoteClient.input`.
* Changed Remote Access's keyboard code to use structures from `winBindings.user32`.
* Also moved duplicate constants from `winUser` and added deprecation code and notes to the user docs.

### Testing strategy:

Ran NVDA from source, and connected as follower. Controlled with another computer (running 2025.2rc1).

### Known issues with pull request:

None known.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
