### PR TITLE
Fix waitable timer

### DIFF
--- a/source/hwIo/ioThread.py
+++ b/source/hwIo/ioThread.py
@@ -207,7 +207,7 @@ class IoThread(threading.Thread):
 		winKernel.setWaitableTimer(
 			handle,
 			dueTime,
-			completionRoutine=self._internalApc,
+			completionRoutine=ctypes.cast(self._internalApc, winBindings.kernel32.PTIMERAPCROUTINE),
 			arg=internalParam,
 		)
 

--- a/source/winKernel.py
+++ b/source/winKernel.py
@@ -29,6 +29,7 @@ import winBindings.advapi32
 import winBindings.kernel32
 from winBindings.kernel32 import (
 	FILETIME as _FILETIME,
+	PTIMERAPCROUTINE as _PTIMERAPCROUTINE,
 	SYSTEMTIME as _SYSTEMTIME,
 	TIME_ZONE_INFORMATION as _TIME_ZONE_INFORMATION,
 )
@@ -176,30 +177,31 @@ def createWaitableTimer(securityAttributes=None, manualReset=False, name=None):
 	return res
 
 
-def setWaitableTimer(handle, dueTime, period=0, completionRoutine=None, arg=None, resume=False):
+def setWaitableTimer(
+	handle: int,
+	dueTime: int,
+	period: int = 0,
+	completionRoutine: _PTIMERAPCROUTINE = _PTIMERAPCROUTINE(None),
+	arg: int | None = None,
+	resume: bool = False,
+):
 	"""Wrapper to the kernel32 SETWaitableTimer function.
 	Consult https://msdn.microsoft.com/en-us/library/windows/desktop/ms686289.aspx for Microsoft's documentation.
-	@param handle: A handle to the timer object.
-	@type handle: int
-	@param dueTime: Relative time (in miliseconds).
+	:param handle: A handle to the timer object.
+	:param dueTime: Relative time (in miliseconds).
 		Note that the original function requires relative time to be supplied as a negative nanoseconds value.
-	@type dueTime: int
-	@param period: Defaults to 0, timer is only executed once.
+	:param period: Defaults to 0, timer is only executed once.
 		Value should be supplied in miliseconds.
-	@type period: int
-	@param completionRoutine: The function to be executed when the timer elapses.
-	@type completionRoutine: L{PAPCFUNC}
-	@param arg: Defaults to C{None}; a pointer to a structure that is passed to the completion routine.
-	@type arg: L{ctypes.c_void_p}
-	@param resume: Defaults to C{False}; the system is not restored.
+	:param completionRoutine: The function to be executed when the timer elapses.
+	:param arg: Defaults to C{None}; a pointer to a structure that is passed to the completion routine.
+	:param resume: Defaults to C{False}; the system is not restored.
 		If this parameter is TRUE, restores a system in suspended power conservation mode
 		when the timer state is set to signaled.
-	@type resume: bool
 	"""
 	res = winBindings.kernel32.SetWaitableTimer(
 		handle,
 		# due time is in 100 nanosecond intervals, relative time should be negated.
-		byref(LARGE_INTEGER(dueTime * -10000)),
+		LARGE_INTEGER(dueTime * -10000),
 		period,
 		completionRoutine,
 		arg,

--- a/source/winKernel.py
+++ b/source/winKernel.py
@@ -181,7 +181,7 @@ def setWaitableTimer(
 	handle: int,
 	dueTime: int,
 	period: int = 0,
-	completionRoutine: _PTIMERAPCROUTINE = _PTIMERAPCROUTINE(0),
+	completionRoutine: _PTIMERAPCROUTINE | None = None,
 	arg: int | None = None,
 	resume: bool = False,
 ):
@@ -192,12 +192,14 @@ def setWaitableTimer(
 		Note that the original function requires relative time to be supplied as a negative nanoseconds value.
 	:param period: Defaults to 0, timer is only executed once.
 		Value should be supplied in miliseconds.
-	:param completionRoutine: The function to be executed when the timer elapses.
+	:param completionRoutine: An optional function to be executed when the timer elapses.
 	:param arg: Defaults to C{None}; a pointer to a structure that is passed to the completion routine.
 	:param resume: Defaults to C{False}; the system is not restored.
 		If this parameter is TRUE, restores a system in suspended power conservation mode
 		when the timer state is set to signaled.
 	"""
+	if completionRoutine is None:
+		completionRoutine = _PTIMERAPCROUTINE(0)
 	res = winBindings.kernel32.SetWaitableTimer(
 		handle,
 		# due time is in 100 nanosecond intervals, relative time should be negated.

--- a/source/winKernel.py
+++ b/source/winKernel.py
@@ -181,7 +181,7 @@ def setWaitableTimer(
 	handle: int,
 	dueTime: int,
 	period: int = 0,
-	completionRoutine: _PTIMERAPCROUTINE = _PTIMERAPCROUTINE(None),
+	completionRoutine: _PTIMERAPCROUTINE = _PTIMERAPCROUTINE(0),
 	arg: int | None = None,
 	resume: bool = False,
 ):

--- a/source/winKernel.py
+++ b/source/winKernel.py
@@ -188,7 +188,7 @@ def setWaitableTimer(
 	"""Wrapper to the kernel32 SETWaitableTimer function.
 
 	Consult https://learn.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-setwaitabletimer for Microsoft's documentation.
-	
+
 	:param handle: A handle to the timer object.
 	:param dueTime: Relative time (in milliseconds).
 		Note that the original function requires relative time to be supplied as a negative nanoseconds value.

--- a/source/winKernel.py
+++ b/source/winKernel.py
@@ -186,17 +186,18 @@ def setWaitableTimer(
 	resume: bool = False,
 ):
 	"""Wrapper to the kernel32 SETWaitableTimer function.
-	Consult https://msdn.microsoft.com/en-us/library/windows/desktop/ms686289.aspx for Microsoft's documentation.
+
+	Consult https://learn.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-setwaitabletimer for Microsoft's documentation.
+	
 	:param handle: A handle to the timer object.
-	:param dueTime: Relative time (in miliseconds).
+	:param dueTime: Relative time (in milliseconds).
 		Note that the original function requires relative time to be supplied as a negative nanoseconds value.
 	:param period: Defaults to 0, timer is only executed once.
-		Value should be supplied in miliseconds.
+		Value should be supplied in milliseconds.
 	:param completionRoutine: An optional function to be executed when the timer elapses.
-	:param arg: Defaults to C{None}; a pointer to a structure that is passed to the completion routine.
-	:param resume: Defaults to C{False}; the system is not restored.
-		If this parameter is TRUE, restores a system in suspended power conservation mode
-		when the timer state is set to signaled.
+	:param arg: A pointer to a structure that is passed to the completion routine, defaults to ``None``. .
+	:param resume: Whether to restore a system in suspended power conservation mode when the timer state is set to signaled, defaults to ``False``.
+		If the system does not support a restore, the call succeeds, but ``GetLastError`` returns ``ERROR_NOT_SUPPORTED``.
 	"""
 	if completionRoutine is None:
 		completionRoutine = _PTIMERAPCROUTINE(0)


### PR DESCRIPTION
### Link to issue number:
Fixes #18949 

### Summary of the issue:
Braille display drivers that use a waitable timer to reset the waiting for acknowledgement packets timer currently raise errors.

### Description of user facing changes:
NO longer errors.

### Description of developer facing changes:
None

### Description of development approach:
When calling `setWaitableTimer`, cast the APC to type `PTIMERAPCROUTINE`. While `PTIMERAPCROUTINE` requires more parameters than `PAPCFUNC`, we always used a `PAPCFUNC` instance in the past without problems.

### Testing strategy:
- Test str from #18949 
- 
### Known issues with pull request:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
