### PR TITLE
Move definitions for magnification.dll to winBindings

### DIFF
--- a/source/NVDAHelper/localLib.py
+++ b/source/NVDAHelper/localLib.py
@@ -666,7 +666,7 @@ calculateWordOffsets.argtypes = (
 )
 
 isScreenFullyBlack = dll.isScreenFullyBlack
-isScreenFullyBlack.argtypes = tuple()
+isScreenFullyBlack.argtypes = ()
 isScreenFullyBlack.restype = c_bool
 
 localListeningSocketExists = dll.localListeningSocketExists

--- a/source/visionEnhancementProviders/screenCurtain.py
+++ b/source/visionEnhancementProviders/screenCurtain.py
@@ -23,13 +23,19 @@ from typing import Optional, Type
 import nvwave
 import globalVars
 from NVDAHelper.localLib import isScreenFullyBlack
-from winBindings.magnification import MAGCOLOREFFECT
+from winBindings.magnification import MAGCOLOREFFECT as _MAGCOLOREFFECT
 from winBindings import magnification
+from utils import _deprecate
+
+__getattr__ = _deprecate.handleDeprecations(
+	_deprecate.MovedSymbol("Magnification", "winBindings", "magnification"),
+	_deprecate.MovedSymbol("MAGCOLOREFFECT", "winBindings.magnification", "MAGCOLOREFFECT"),
+)
 
 
 # homogeneous matrix for a 4-space transformation (red, green, blue, opacity).
 # https://docs.microsoft.com/en-gb/windows/win32/gdiplus/-gdiplus-using-a-color-matrix-to-transform-a-single-color-use
-TRANSFORM_BLACK = MAGCOLOREFFECT()  # empty transformation
+TRANSFORM_BLACK = _MAGCOLOREFFECT()  # empty transformation
 TRANSFORM_BLACK.transform[4][4] = 1.0  # retain as an affine transformation
 TRANSFORM_BLACK.transform[3][3] = 1.0  # retain opacity, while scaling other colours to zero (#12491)
 

--- a/source/visionEnhancementProviders/screenCurtain.py
+++ b/source/visionEnhancementProviders/screenCurtain.py
@@ -28,7 +28,6 @@ from winBindings import magnification
 from utils import _deprecate
 
 __getattr__ = _deprecate.handleDeprecations(
-	_deprecate.MovedSymbol("Magnification", "winBindings", "magnification"),
 	_deprecate.MovedSymbol("MAGCOLOREFFECT", "winBindings.magnification"),
 	_deprecate.MovedSymbol("isScreenFullyBlack", "NVDAHelper.localLib"),
 )

--- a/source/visionEnhancementProviders/screenCurtain.py
+++ b/source/visionEnhancementProviders/screenCurtain.py
@@ -22,14 +22,15 @@ from logHandler import log
 from typing import Optional, Type
 import nvwave
 import globalVars
-from NVDAHelper.localLib import isScreenFullyBlack
+from NVDAHelper.localLib import isScreenFullyBlack as _isScreenFullyBlack
 from winBindings.magnification import MAGCOLOREFFECT as _MAGCOLOREFFECT
 from winBindings import magnification
 from utils import _deprecate
 
 __getattr__ = _deprecate.handleDeprecations(
 	_deprecate.MovedSymbol("Magnification", "winBindings", "magnification"),
-	_deprecate.MovedSymbol("MAGCOLOREFFECT", "winBindings.magnification", "MAGCOLOREFFECT"),
+	_deprecate.MovedSymbol("MAGCOLOREFFECT", "winBindings.magnification"),
+	_deprecate.MovedSymbol("isScreenFullyBlack", "NVDAHelper.localLib"),
 )
 
 
@@ -292,7 +293,7 @@ class ScreenCurtainProvider(providerBase.VisionEnhancementProvider):
 		try:
 			magnification.MagSetFullscreenColorEffect(TRANSFORM_BLACK)
 			magnification.MagShowSystemCursor(False)
-			if not isScreenFullyBlack():
+			if not _isScreenFullyBlack():
 				raise RuntimeError("Screen is not black.")
 		except Exception as e:
 			magnification.MagUninitialize()

--- a/source/visionEnhancementProviders/screenCurtain.py
+++ b/source/visionEnhancementProviders/screenCurtain.py
@@ -24,12 +24,7 @@ from logHandler import log
 from typing import Optional, Type
 import nvwave
 import globalVars
-import NVDAHelper
-
-
-isScreenFullyBlack = NVDAHelper.localLib.isScreenFullyBlack
-isScreenFullyBlack.argtypes = ()
-isScreenFullyBlack.restype = BOOL
+from NVDAHelper.localLib import isScreenFullyBlack
 
 
 class MAGCOLOREFFECT(Structure):

--- a/source/winBindings/magnification.py
+++ b/source/winBindings/magnification.py
@@ -7,6 +7,8 @@
 
 from ctypes import POINTER, WINFUNCTYPE, Structure, WinError, c_float, windll
 from ctypes.wintypes import BOOL
+from _ctypes import CFuncPtr
+from typing import Any
 
 dll = windll.Magnification
 
@@ -25,7 +27,7 @@ class MAGCOLOREFFECT(Structure):
 PMAGCOLOREFFECT = POINTER(MAGCOLOREFFECT)
 
 
-def _errCheck(result, func, args):
+def _errCheck[T: tuple[Any]](result: int, func: CFuncPtr, args: T) -> T:
 	if result == 0:
 		raise WinError()
 	return args

--- a/source/winBindings/magnification.py
+++ b/source/winBindings/magnification.py
@@ -1,0 +1,58 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2025 NV Access Limited
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
+
+"""Functions exported by magnification.dll, and supporting data structures and enumerations."""
+
+from ctypes import POINTER, WINFUNCTYPE, Structure, WinError, c_float, windll
+from ctypes.wintypes import BOOL
+
+
+class MAGCOLOREFFECT(Structure):
+	_fields_ = (("transform", c_float * 5 * 5),)
+
+
+def _errCheck(result, func, args):
+	if result == 0:
+		raise WinError()
+	return args
+
+
+_magnification = windll.Magnification
+# Set full screen color effect
+_MagSetFullscreenColorEffectFuncType = WINFUNCTYPE(BOOL, POINTER(MAGCOLOREFFECT))
+_MagSetFullscreenColorEffectArgTypes = ((1, "effect"),)
+MagSetFullscreenColorEffect = _MagSetFullscreenColorEffectFuncType(
+	("MagSetFullscreenColorEffect", _magnification),
+	_MagSetFullscreenColorEffectArgTypes,
+)
+MagSetFullscreenColorEffect.errcheck = _errCheck
+
+# Get full screen color effect
+_MagGetFullscreenColorEffectFuncType = WINFUNCTYPE(BOOL, POINTER(MAGCOLOREFFECT))
+_MagGetFullscreenColorEffectArgTypes = ((2, "effect"),)
+MagGetFullscreenColorEffect = _MagGetFullscreenColorEffectFuncType(
+	("MagGetFullscreenColorEffect", _magnification),
+	_MagGetFullscreenColorEffectArgTypes,
+)
+MagGetFullscreenColorEffect.errcheck = _errCheck
+
+# show system cursor
+_MagShowSystemCursorFuncType = WINFUNCTYPE(BOOL, BOOL)
+_MagShowSystemCursorArgTypes = ((1, "showCursor"),)
+MagShowSystemCursor = _MagShowSystemCursorFuncType(
+	("MagShowSystemCursor", _magnification),
+	_MagShowSystemCursorArgTypes,
+)
+MagShowSystemCursor.errcheck = _errCheck
+
+# initialize
+_MagInitializeFuncType = WINFUNCTYPE(BOOL)
+MagInitialize = _MagInitializeFuncType(("MagInitialize", _magnification))
+MagInitialize.errcheck = _errCheck
+
+# uninitialize
+_MagUninitializeFuncType = WINFUNCTYPE(BOOL)
+MagUninitialize = _MagUninitializeFuncType(("MagUninitialize", _magnification))
+MagUninitialize.errcheck = _errCheck

--- a/source/winBindings/magnification.py
+++ b/source/winBindings/magnification.py
@@ -8,9 +8,21 @@
 from ctypes import POINTER, WINFUNCTYPE, Structure, WinError, c_float, windll
 from ctypes.wintypes import BOOL
 
+dll = windll.Magnification
+
 
 class MAGCOLOREFFECT(Structure):
+	"""
+	Describes a color transformation matrix that a magnifier control uses to apply a color effect to magnified screen content.
+
+	.. seealso::
+		https://learn.microsoft.com/en-us/windows/win32/api/magnification/ns-magnification-magcoloreffect
+	"""
+
 	_fields_ = (("transform", c_float * 5 * 5),)
+
+
+PMAGCOLOREFFECT = POINTER(MAGCOLOREFFECT)
 
 
 def _errCheck(result, func, args):
@@ -19,40 +31,56 @@ def _errCheck(result, func, args):
 	return args
 
 
-_magnification = windll.Magnification
-# Set full screen color effect
-_MagSetFullscreenColorEffectFuncType = WINFUNCTYPE(BOOL, POINTER(MAGCOLOREFFECT))
-_MagSetFullscreenColorEffectArgTypes = ((1, "effect"),)
-MagSetFullscreenColorEffect = _MagSetFullscreenColorEffectFuncType(
-	("MagSetFullscreenColorEffect", _magnification),
-	_MagSetFullscreenColorEffectArgTypes,
+MagSetFullscreenColorEffect = WINFUNCTYPE(BOOL, PMAGCOLOREFFECT)(
+	("MagSetFullscreenColorEffect", dll),
+	((1, "pEffect"),),
 )
+"""
+Changes the color transformation matrix associated with the full-screen magnifier.
+
+.. seealso::
+	https://learn.microsoft.com/en-us/windows/win32/api/magnification/nf-magnification-magsetfullscreencoloreffect
+"""
 MagSetFullscreenColorEffect.errcheck = _errCheck
 
-# Get full screen color effect
-_MagGetFullscreenColorEffectFuncType = WINFUNCTYPE(BOOL, POINTER(MAGCOLOREFFECT))
-_MagGetFullscreenColorEffectArgTypes = ((2, "effect"),)
-MagGetFullscreenColorEffect = _MagGetFullscreenColorEffectFuncType(
-	("MagGetFullscreenColorEffect", _magnification),
-	_MagGetFullscreenColorEffectArgTypes,
+MagGetFullscreenColorEffect = WINFUNCTYPE(BOOL, PMAGCOLOREFFECT)(
+	("MagGetFullscreenColorEffect", dll),
+	((2, "effect"),),
 )
+"""
+Retrieves the color transformation matrix associated with the full-screen magnifier.
+
+.. seealso::
+	https://learn.microsoft.com/en-us/windows/win32/api/magnification/nf-magnification-maggetfullscreencoloreffect
+"""
 MagGetFullscreenColorEffect.errcheck = _errCheck
 
-# show system cursor
-_MagShowSystemCursorFuncType = WINFUNCTYPE(BOOL, BOOL)
-_MagShowSystemCursorArgTypes = ((1, "showCursor"),)
-MagShowSystemCursor = _MagShowSystemCursorFuncType(
-	("MagShowSystemCursor", _magnification),
-	_MagShowSystemCursorArgTypes,
+MagShowSystemCursor = WINFUNCTYPE(BOOL, BOOL)(
+	("MagShowSystemCursor", dll),
+	((1, "showCursor"),),
 )
+"""
+Shows or hides the system cursor.
+
+.. seealso::
+	https://learn.microsoft.com/en-us/windows/win32/api/magnification/nf-magnification-magshowsystemcursor
+"""
 MagShowSystemCursor.errcheck = _errCheck
 
-# initialize
-_MagInitializeFuncType = WINFUNCTYPE(BOOL)
-MagInitialize = _MagInitializeFuncType(("MagInitialize", _magnification))
+MagInitialize = WINFUNCTYPE(BOOL)(("MagInitialize", dll))
+"""
+Creates and initializes the magnifier run-time objects.
+
+.. seealso::
+	https://learn.microsoft.com/en-us/windows/win32/api/magnification/nf-magnification-maginitialize
+"""
 MagInitialize.errcheck = _errCheck
 
-# uninitialize
-_MagUninitializeFuncType = WINFUNCTYPE(BOOL)
-MagUninitialize = _MagUninitializeFuncType(("MagUninitialize", _magnification))
+MagUninitialize = WINFUNCTYPE(BOOL)(("MagUninitialize", dll))
+"""
+Destroys the magnifier run-time objects.
+
+.. seealso::
+	https://learn.microsoft.com/en-us/windows/win32/api/magnification/nf-magnification-maguninitialize
+"""
 MagUninitialize.errcheck = _errCheck

--- a/tests/unit/test_visionEnhancementProviders/test_magnificationAPI.py
+++ b/tests/unit/test_visionEnhancementProviders/test_magnificationAPI.py
@@ -7,8 +7,9 @@
 
 import unittest
 
-from visionEnhancementProviders.screenCurtain import TRANSFORM_BLACK, MAGCOLOREFFECT
+from visionEnhancementProviders.screenCurtain import TRANSFORM_BLACK
 from winBindings import magnification
+from winBindings.magnification import MAGCOLOREFFECT
 
 
 class _Test_MagnificationAPI(unittest.TestCase):

--- a/tests/unit/test_visionEnhancementProviders/test_magnificationAPI.py
+++ b/tests/unit/test_visionEnhancementProviders/test_magnificationAPI.py
@@ -7,15 +7,16 @@
 
 import unittest
 
-from visionEnhancementProviders.screenCurtain import Magnification, TRANSFORM_BLACK, MAGCOLOREFFECT
+from visionEnhancementProviders.screenCurtain import TRANSFORM_BLACK, MAGCOLOREFFECT
+from winBindings import magnification
 
 
 class _Test_MagnificationAPI(unittest.TestCase):
 	def setUp(self):
-		self.assertTrue(Magnification.MagInitialize())
+		self.assertTrue(magnification.MagInitialize())
 
 	def tearDown(self):
-		self.assertTrue(Magnification.MagUninitialize())
+		self.assertTrue(magnification.MagUninitialize())
 
 
 class Test_ScreenCurtain(_Test_MagnificationAPI):
@@ -32,7 +33,7 @@ class Test_ScreenCurtain(_Test_MagnificationAPI):
 
 	def setUp(self):
 		super().setUp()
-		resultEffect = Magnification.MagGetFullscreenColorEffect()
+		resultEffect = magnification.MagGetFullscreenColorEffect()
 		if not self._isIdentityMatrix(resultEffect):
 			# If the resultEffect is not the identity matrix, skip the test.
 			# This is because a full screen colour effect is already set external to testing.
@@ -43,9 +44,9 @@ class Test_ScreenCurtain(_Test_MagnificationAPI):
 		return
 
 	def test_setAndConfirmBlackFullscreenColorEffect(self):
-		result = Magnification.MagSetFullscreenColorEffect(TRANSFORM_BLACK)
+		result = magnification.MagSetFullscreenColorEffect(TRANSFORM_BLACK)
 		self.assertTrue(result)
-		resultEffect = Magnification.MagGetFullscreenColorEffect()
+		resultEffect = magnification.MagGetFullscreenColorEffect()
 		for i in range(5):
 			for j in range(5):
 				with self.subTest(i=i, j=j):
@@ -58,9 +59,9 @@ class Test_ScreenCurtain(_Test_MagnificationAPI):
 
 class Test_Mouse(_Test_MagnificationAPI):
 	def test_MagShowSystemCursor(self):
-		result = Magnification.MagShowSystemCursor(True)
+		result = magnification.MagShowSystemCursor(True)
 		self.assertTrue(result)
 
 	def test_MagHideSystemCursor(self):
-		result = Magnification.MagShowSystemCursor(False)
+		result = magnification.MagShowSystemCursor(False)
 		self.assertTrue(result)

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -150,6 +150,11 @@ Use `winBindings.mmeapi.WAVEFORMATEX` instead. (#18207)
   Use the `ListViewWindowStyle` enumeration instead. (#18926 , @LeonarddeR)
 * The `INPUT_MOUSE`, `INPUT_KEYBOARD`, `KEYEVENTF_KEYUP` and `KEYEVENTF_UNICODE` constants from `winUser` are deprecated.
 Use `INPUT_TYPE.MOUSE`, `INPUT_TYPE.KEYBOARD`, `KEYEVENTF.KEYUP` and `KEYEVENTF.UNICODE` from `winBindings.user32` instead. (#18947)
+* `visionEnhancementProviders.screenCurtain.MAGCOLOREFFECT` is deprecated.
+Use `winBindings.magnification.MAGCOLOREFFECT` instead. (#18958)
+* `visionEnhancementProviders.screenCurtain.Magnification` is deprecated.
+Use `winBindings.magnification` instead.
+Note that this is a module, not a class, so some API consumers may be unable to use the automatic migration provided. (#18958)
 
 <!-- Beyond this point, Markdown should not be linted, as we don't modify old change log sections. -->
 <!-- markdownlint-disable -->

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -76,6 +76,8 @@ Use the `int` configuration key `[reportSpellingErrors2]` instead. (#17997, @Cyr
 * The `inputButtonCaps` property on `hwIo.hid.Hid` objects now correctly returns an array of `hidpi.HIDP_BUTTON_CAPS` structures rather than HIDP_VALUE_CAPS` structures. (#18902)
 * `speech.speech.IDT_TONE_DURATION` has been removed.
   Call `speech.speech.getIndentToneDuration` instead. (#18898)
+* `visionEnhancementProviders.screenCurtain.Magnification` has been removed.
+All public symbols defined on this class are now accessible from `winBindings.magnification`. (#18958)
 
 #### Deprecations
 
@@ -152,9 +154,6 @@ Use `winBindings.mmeapi.WAVEFORMATEX` instead. (#18207)
 Use `INPUT_TYPE.MOUSE`, `INPUT_TYPE.KEYBOARD`, `KEYEVENTF.KEYUP` and `KEYEVENTF.UNICODE` from `winBindings.user32` instead. (#18947)
 * `visionEnhancementProviders.screenCurtain.MAGCOLOREFFECT` is deprecated.
 Use `winBindings.magnification.MAGCOLOREFFECT` instead. (#18958)
-* `visionEnhancementProviders.screenCurtain.Magnification` is deprecated.
-Use `winBindings.magnification` instead.
-Note that this is a module, not a class, so some API consumers may be unable to use the automatic migration provided. (#18958)
 * `visionEnhancementProviders.screenCurtain.isScreenFullyBlack` is deprecated.
 Use `NVDAHelper.localLib.isScreenFullyBlack` instead. (#18958)
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -155,6 +155,8 @@ Use `winBindings.magnification.MAGCOLOREFFECT` instead. (#18958)
 * `visionEnhancementProviders.screenCurtain.Magnification` is deprecated.
 Use `winBindings.magnification` instead.
 Note that this is a module, not a class, so some API consumers may be unable to use the automatic migration provided. (#18958)
+* `visionEnhancementProviders.screenCurtain.isScreenFullyBlack` is deprecated.
+Use `NVDAHelper.localLib.isScreenFullyBlack` instead. (#18958)
 
 <!-- Beyond this point, Markdown should not be linted, as we don't modify old change log sections. -->
 <!-- markdownlint-disable -->


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
Screen curtain defined ctypes bindings to magnification.dll from the Windows API.

### Description of user facing changes:
None.

### Description of developer facing changes:
Moved definitions to `winBindings.magnification`.

### Description of development approach:
Move definitions to `source/winBindings/magnification.py`. Remove from `Magnification` class. Add deprecation handling code. Tidy definitions to not use so many temporary definitions.

Note that these definitions use ctypes' function prototype syntax. This was carried across from the old definitions. We plan to move to this syntax anyway.

### Testing strategy:
Ran from source. Tried enabling temporary and regular screen curtain. Tried importing deprecated symbols.

### Known issues with pull request:
None

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
