### PR TITLE
Fix report time

### DIFF
--- a/source/winKernel.py
+++ b/source/winKernel.py
@@ -323,6 +323,8 @@ def GetDateFormatEx(Locale, dwFlags, date, lpFormat):
 
 
 def GetTimeFormatEx(Locale, dwFlags, date, lpFormat):
+	if dwFlags is None:
+		dwFlags = 0
 	if date is not None:
 		date = _SYSTEMTIME(date.year, date.month, 0, date.day, date.hour, date.minute, date.second, 0)
 		lpTime = byref(date)


### PR DESCRIPTION
### Link to issue number:
Fixes #18959

### Summary of the issue:
Report current time gesture (`NVDA+f12`) doesn't work.

### Description of user facing changes:
Works again.

### Description of developer facing changes:
None.

### Description of development approach:
Set `dwFlags` to `0` if `None` is passed.

### Testing strategy:
Manual testing

### Known issues with pull request:
None.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
