### PR TITLE
Fix bug when updating add-ons automatically

### DIFF
--- a/source/addonHandler/__init__.py
+++ b/source/addonHandler/__init__.py
@@ -801,7 +801,7 @@ class Addon(AddonBase):
 		self._importedAddonModules.clear()
 		for modName in set(sys.modules.keys()) - self._modulesBeforeInstall:
 			module = sys.modules[modName]
-			if module.__file__ and module.__file__.startswith(self.path):
+			if module.__name__ and module.__name__.startswith(self.path):
 				log.debug(f"Removing module {module} from cache of imported modules")
 				del sys.modules[modName]
 

--- a/source/gui/addonStoreGui/controls/messageDialogs.py
+++ b/source/gui/addonStoreGui/controls/messageDialogs.py
@@ -590,6 +590,9 @@ class UpdatableAddonsDialog(
 				wx.CallAfter(delayCreateDialog)
 
 			case AddonsAutomaticUpdate.UPDATE:
+
+				# Translators: Message shown when updating add-ons automatically
+				wx.CallAfter(ui.message, pgettext("addonStore", "Updating add-ons..."), SpeechPriority.NEXT)
 				threading.Thread(
 					name="AutomaticAddonUpdate",
 					target=_updateAddons,
@@ -608,9 +611,6 @@ def _updateAddons(addonsPendingUpdate: list[_AddonGUIModel]):
 	This function is treated as message box to prevent NVDA from exiting while the download/install is in progress.
 	"""
 	from ..viewModels.store import AddonStoreVM
-
-	# Translators: Message shown when updating add-ons automatically
-	ui.message(pgettext("addonStore", "Updating add-ons..."), SpeechPriority.NEXT)
 	listVMs = {AddonListItemVM(a, status=getStatus(a, _StatusFilterKey.UPDATE)) for a in addonsPendingUpdate}
 	AddonStoreVM.getAddons(
 		listVMs,

--- a/source/gui/addonStoreGui/controls/messageDialogs.py
+++ b/source/gui/addonStoreGui/controls/messageDialogs.py
@@ -590,7 +590,6 @@ class UpdatableAddonsDialog(
 				wx.CallAfter(delayCreateDialog)
 
 			case AddonsAutomaticUpdate.UPDATE:
-
 				# Translators: Message shown when updating add-ons automatically
 				wx.CallAfter(ui.message, pgettext("addonStore", "Updating add-ons..."), SpeechPriority.NEXT)
 				threading.Thread(
@@ -611,6 +610,7 @@ def _updateAddons(addonsPendingUpdate: list[_AddonGUIModel]):
 	This function is treated as message box to prevent NVDA from exiting while the download/install is in progress.
 	"""
 	from ..viewModels.store import AddonStoreVM
+
 	listVMs = {AddonListItemVM(a, status=getStatus(a, _StatusFilterKey.UPDATE)) for a in addonsPendingUpdate}
 	AddonStoreVM.getAddons(
 		listVMs,

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -39,7 +39,7 @@ We recommend using Windows 11, or if that is not possible, the latest Windows 10
 * When reporting the location of the caret in classic versions of Notepad and other Win32 edit controls, text position is now more accurate. (#18767, @LeonarddeR)
 * Fixed a problem where some SAPI 4 voices (e.g. IBM ViaVoice) start speaking in the maximum volume instead of the current volume when speaking capital letters. (#18866, @gexgd0419)
 * NVDA no longer fails to read the contents of wx Web View controls. (#17273, @LeonarddeR)
-* When NVDA is configured to update add-ons automatically without notifying about updates, add-ons can be properly updated. (#18965, @nvdaes)
+* When NVDA is configured to update add-ons automatically in the background, add-ons can be properly updated. (#18965, @nvdaes)
 
 ### Changes for Developers
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -39,6 +39,7 @@ We recommend using Windows 11, or if that is not possible, the latest Windows 10
 * When reporting the location of the caret in classic versions of Notepad and other Win32 edit controls, text position is now more accurate. (#18767, @LeonarddeR)
 * Fixed a problem where some SAPI 4 voices (e.g. IBM ViaVoice) start speaking in the maximum volume instead of the current volume when speaking capital letters. (#18866, @gexgd0419)
 * NVDA no longer fails to read the contents of wx Web View controls. (#17273, @LeonarddeR)
+* When NVDA is configured to update add-ons automatically without notifying about updates, add-ons can be properly updated. (#18965, @nvdaes)
 
 ### Changes for Developers
 


### PR DESCRIPTION
- **Fix bug when updating add-ons automatically**
- **Update changelog**

<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
<!-- Use Closes/Fixes/Resolves #xxx to link this PR to the issue it is responding to. -->
Fixes #18965 
### Summary of the issue:
When NVDA is configured to update add-ons automatically without provide notifications, add-ons aren't updated and an error is produced.
### Description of user facing changes:
NVDA can be configured to update add-ons automatically, and this should work as expected.
### Description of developer facing changes:
None.
### Description of development approach:
Use `wx.CallAfter` to present a message informing that add-ons are been updated, in the `_checkForUpdatableAddons`method of the `UpdatableAddonsDialog` class, just after the condition to check that add-ons should be updated automatically, ensuring that this can be run in the main thread.

Additionally, an error has been discovered and fixed in addonHandler, when installing an add-on which shows a message before installation.
### Testing strategy:
Tested locally with clipContentsDesigner (which asks a question before installation) and resourceMonitor.
### Known issues with pull request:
None.
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
