### PR TITLE
Add csrss app module

### DIFF
--- a/source/appModules/csrss.py
+++ b/source/appModules/csrss.py
@@ -1,0 +1,21 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2025 NV Access Limited, Leonard de Ruijter
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+
+"""App module for the Client Server Runtime Process (csrss.exe).
+
+This app module provides a workaround for permission issues when attempting to
+determine the alive status of the csrss.exe process. The csrss.exe process is
+a critical Windows system process that manages console windows and GUI shutdown.
+"""
+
+import appModuleHandler
+
+
+class AppModule(appModuleHandler.AppModule):
+	isAlive = True
+	"""Due to security restrictions, NVDA typically cannot query the alive status of
+	this system process through normal means. Therefore, bypass these permission issues.
+	The process is essential and always alive anyway.
+	"""


### PR DESCRIPTION
### Link to issue number:
Fixes #18859
Related to #18870

### Summary of the issue:
Since winBindings and #18833, NVDA spits continuous debug warnings about the inability to get a process handle for csrss.exe

### Description of user facing changes:
No errors.

### Description of developer facing changes:
None

### Description of development approach:
Create a csrss appModule that always assumes csrss.exe to be alive.

1. CSRSS is an essential GUI process, therefore it can safely be considered always alive. It hosts the desktop object.
2. Before winBindings, the app module was also assumed always alive due to an obfuscated bug.

### Testing strategy:
Ensured that no continuous debug warnings are emitted

### Known issues with pull request:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
