### PR TITLE
Earlier discard of MULTISELECTABLE state

### DIFF
--- a/source/controlTypes/processAndLabelStates.py
+++ b/source/controlTypes/processAndLabelStates.py
@@ -33,6 +33,11 @@ def _processPositiveStates(
 		positiveStates.discard(State.VISITED)
 		positiveStates.discard(State.INTERNAL_LINK)
 	positiveStates.discard(State.SELECTABLE)
+
+	import config
+
+	if not config.conf["presentation"]["reportMultiSelect"]:
+		positiveStates.discard(State.MULTISELECTABLE)
 	positiveStates.discard(State.FOCUSABLE)
 	positiveStates.discard(State.CHECKABLE)
 	if State.DRAGGING in positiveStates:
@@ -41,8 +46,6 @@ def _processPositiveStates(
 	if role == Role.COMBOBOX:
 		# Combo boxes inherently have a popup, so don't report it.
 		positiveStates.discard(State.HASPOPUP)
-	import config
-
 	if not config.conf["documentFormatting"]["reportClickable"] or role in clickableRoles:
 		# This control is clearly clickable according to its role,
 		# or reporting clickable just isn't useful,
@@ -73,8 +76,6 @@ def _processPositiveStates(
 			and State.SELECTABLE in states
 		):
 			positiveStates.discard(State.SELECTED)
-			positiveStates.discard(State.MULTISELECTABLE)
-		elif not config.conf["presentation"]["reportMultiSelect"]:
 			positiveStates.discard(State.MULTISELECTABLE)
 	if role not in (Role.EDITABLETEXT, Role.CHECKBOX):
 		positiveStates.discard(State.READONLY)

--- a/source/controlTypes/processAndLabelStates.py
+++ b/source/controlTypes/processAndLabelStates.py
@@ -5,9 +5,11 @@
 
 from typing import Dict, List, Optional, Set
 
-from .role import Role, clickableRoles
-from .state import State, STATES_SORTED, STATES_LINK_TYPE
+import config
+
 from .outputReason import OutputReason
+from .role import Role, clickableRoles
+from .state import STATES_LINK_TYPE, STATES_SORTED, State
 
 
 def _processPositiveStates(
@@ -33,9 +35,6 @@ def _processPositiveStates(
 		positiveStates.discard(State.VISITED)
 		positiveStates.discard(State.INTERNAL_LINK)
 	positiveStates.discard(State.SELECTABLE)
-
-	import config
-
 	if not config.conf["presentation"]["reportMultiSelect"]:
 		positiveStates.discard(State.MULTISELECTABLE)
 	positiveStates.discard(State.FOCUSABLE)


### PR DESCRIPTION
### Link to issue number:
Fixes #18961 

### Summary of the issue:
NVDA still announces multiselectable when it should be disabled.

### Description of user facing changes:
No longer announce multiselect state.

### Description of developer facing changes:
None

### Description of development approach:
Ensure the state is always discarded when the config flag is disabled.

### Testing strategy:
STR from #18961 

### Known issues with pull request:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
