### PR TITLE
Fix legacy Windows console support

### DIFF
--- a/source/winConsoleHandler.py
+++ b/source/winConsoleHandler.py
@@ -4,6 +4,7 @@
 # See the file COPYING for more details.
 # Copyright (C) 2009-2025 NV Access Limited, Babbage B.V.
 
+from ctypes.wintypes import SMALL_RECT
 import gui
 import winUser
 import winBindings.kernel32
@@ -264,7 +265,7 @@ class WinConsoleTextInfo(textInfos.offsets.OffsetsTextInfo):
 			formatConfig = config.conf["documentFormatting"]
 		left, top = self._consoleCoordFromOffset(self._startOffset)
 		right, bottom = self._consoleCoordFromOffset(self._endOffset - 1)
-		rect = wincon.SMALL_RECT(left, top, right, bottom)
+		rect = SMALL_RECT(left, top, right, bottom)
 		if bottom - top > 0:  # offsets span multiple lines
 			rect.Left = 0
 			rect.Right = self.consoleScreenBufferInfo.dwSize.x - 1

--- a/source/wincon.py
+++ b/source/wincon.py
@@ -8,7 +8,6 @@ from ctypes import (
 	byref,
 	WinError,
 	create_unicode_buffer,
-	c_int,
 )
 from ctypes.wintypes import DWORD
 import winBindings.kernel32
@@ -86,7 +85,7 @@ def ReadConsoleOutputCharacter(handle, length, x, y):
 		== 0
 	):
 		raise WinError()
-	rawBytes = buf.value.encode('utf-16')
+	rawBytes = buf.value.encode("utf-16")
 	return textUtils.getTextFromRawBytes(
 		rawBytes,
 		numChars=len(rawBytes),

--- a/source/wincon.py
+++ b/source/wincon.py
@@ -67,8 +67,8 @@ CONSOLE_MOUSE_DOWN = 0x8
 
 def GetConsoleSelectionInfo():
 	info = _CONSOLE_SELECTION_INFO()
-	if winBindings.kernel32.GetConsoleSelectionInfo(byref(info)) == 0:  # noqa: F405
-		raise WinError()  # noqa: F405
+	if winBindings.kernel32.GetConsoleSelectionInfo(byref(info)) == 0:
+		raise WinError()
 	return info
 
 
@@ -99,38 +99,38 @@ def ReadConsoleOutput(handle, length, rect):
 	buf = BufType()
 	# rect=SMALL_RECT(x, y, x+length-1, y)
 	if (
-		winBindings.kernel32.ReadConsoleOutput(  # noqa: F405
+		winBindings.kernel32.ReadConsoleOutput(
 			handle,
 			buf,
 			_COORD(rect.Right - rect.Left + 1, rect.Bottom - rect.Top + 1),
 			_COORD(0, 0),
-			byref(rect),  # noqa: F405
+			byref(rect),
 		)
 		== 0
-	):  # noqa: F405
-		raise WinError()  # noqa: F405
+	):
+		raise WinError()
 	return buf
 
 
 def GetConsoleScreenBufferInfo(handle):
 	info = _CONSOLE_SCREEN_BUFFER_INFO()
-	if winBindings.kernel32.GetConsoleScreenBufferInfo(handle, byref(info)) == 0:  # noqa: F405
-		raise WinError()  # noqa: F405
+	if winBindings.kernel32.GetConsoleScreenBufferInfo(handle, byref(info)) == 0:
+		raise WinError()
 	return info
 
 
 def FreeConsole():
-	if winBindings.kernel32.FreeConsole() == 0:  # noqa: F405
-		raise WinError()  # noqa: F405
+	if winBindings.kernel32.FreeConsole() == 0:
+		raise WinError()
 
 
 def AttachConsole(processID):
-	if winBindings.kernel32.AttachConsole(processID) == 0:  # noqa: F405
-		raise WinError()  # noqa: F405
+	if winBindings.kernel32.AttachConsole(processID) == 0:
+		raise WinError()
 
 
 def GetConsoleWindow():
-	return winBindings.kernel32.GetConsoleWindow()  # noqa: F405
+	return winBindings.kernel32.GetConsoleWindow()
 
 
 def GetConsoleProcessList(maxProcessCount):
@@ -140,5 +140,5 @@ def GetConsoleProcessList(maxProcessCount):
 
 
 def SetConsoleCtrlHandler(handler, add):
-	if winBindings.kernel32.SetConsoleCtrlHandler(handler, add) == 0:  # noqa: F405
-		raise WinError()  # noqa: F405
+	if winBindings.kernel32.SetConsoleCtrlHandler(handler, add) == 0:
+		raise WinError()

--- a/source/wincon.py
+++ b/source/wincon.py
@@ -6,8 +6,11 @@
 
 from ctypes import (
 	byref,
+	cast,
 	WinError,
 	create_unicode_buffer,
+	c_char,
+	c_void_p,
 )
 from ctypes.wintypes import DWORD
 import winBindings.kernel32
@@ -85,10 +88,13 @@ def ReadConsoleOutputCharacter(handle, length, x, y):
 		== 0
 	):
 		raise WinError()
-	rawBytes = buf.value.encode("utf-16")
+	numRawBytes = numCharsRead.value * 2
+	rawBuf = (c_char * numRawBytes).from_address(
+		cast(buf, c_void_p).value or 0
+	)
 	return textUtils.getTextFromRawBytes(
-		rawBytes,
-		numChars=len(rawBytes),
+		rawBuf.raw,
+		numChars=numCharsRead.value,
 		encoding=textUtils.WCHAR_ENCODING,
 	)
 

--- a/source/wincon.py
+++ b/source/wincon.py
@@ -90,7 +90,7 @@ def ReadConsoleOutputCharacter(handle, length, x, y):
 		raise WinError()
 	numRawBytes = numCharsRead.value * 2
 	rawBuf = (c_char * numRawBytes).from_address(
-		cast(buf, c_void_p).value or 0
+		cast(buf, c_void_p).value or 0,
 	)
 	return textUtils.getTextFromRawBytes(
 		rawBuf.raw,


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
<!-- Use Closes/Fixes/Resolves #xxx to link this PR to the issue it is responding to. -->
Fixes #18970

### Summary of the issue:
With the move to 64 bit, some Legacy Windows console support  is incompatible with the well-defined ctypes definitions. E.g. GetConsoleProcessList and ReadConsoleOutputCharacter, causing ctypes argument errors and Legacy Windows console support to not function at all.


### Description of user facing changes:
Legacy Windows console support functions again.

### Description of developer facing changes:

### Description of development approach:
* `wincon.getConsoleProcessList`: correctly pass a DWORD array as the process list, rather than an int array.
* `wincon.readConsoleOutputCharacter`: Correctly pass a Unicode buffer (wchar array) rather than char array. However, then encode the buffer's contents to utf-16 bytes when passing to `textUtils.getTextFromRawBytes`.
 
### Testing strategy:
* In Windows terminal settings, choose to use Windows console host.
* In NvDA advanced settings, choose to use Legaticy Windows console support.
* Open a cmd prompt. Confirm that errors are no longer thrown, and that NvDA can read text with the review cursor, fetch the formatting with NvDA+f, and that new text written to the console is spoken.

### Known issues with pull request:
None known.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
