### PR TITLE
Fix secure desktop handling

### DIFF
--- a/source/IAccessibleHandler/__init__.py
+++ b/source/IAccessibleHandler/__init__.py
@@ -602,7 +602,7 @@ def winEventToNVDAEvent(  # noqa: C901
 	return (NVDAEventName, obj)
 
 
-def processGenericWinEvent(eventID: int, window: int, objectID: int, childID: int):
+def processGenericWinEvent(eventID: int, window: int, objectID: int, childID: int) -> bool:
 	"""Converts the win event to an NVDA event,
 	Checks to see if this NVDAObject  equals the current focus.
 	If all goes well, then the event is queued and we return True
@@ -610,7 +610,7 @@ def processGenericWinEvent(eventID: int, window: int, objectID: int, childID: in
 	:param window: a win event's window handle
 	:param objectID: a win event's object ID
 	:param childID: a win event's child ID
-	:returns: True if the event was processed, False otherwise.
+	:return: True if the event was processed, False otherwise.
 	"""
 	if isMSAADebugLoggingEnabled():
 		log.debug(
@@ -684,7 +684,7 @@ def processFocusWinEvent(window: int, objectID: int, childID: int, force: bool =
 	:param objectID: a win event's object ID
 	:param childID: a win event's child ID
 	:param force: If True, the shouldAllowIAccessibleFocusEvent property of the object is ignored.
-	:returns: True if the focus is valid and was handled, False otherwise.
+	:return: True if the focus is valid and was handled, False otherwise.
 	"""
 	if isMSAADebugLoggingEnabled():
 		log.debug(
@@ -770,7 +770,7 @@ def processFocusNVDAEvent(obj, force=False):
 	return True
 
 
-def processDesktopSwitchWinEvent(window: int, objectID: int, childID: int):
+def processDesktopSwitchWinEvent(window: int, objectID: int, childID: int) -> None:
 	from winAPI.secureDesktop import _handleSecureDesktopChange
 
 	if isMSAADebugLoggingEnabled():

--- a/source/IAccessibleHandler/__init__.py
+++ b/source/IAccessibleHandler/__init__.py
@@ -602,20 +602,15 @@ def winEventToNVDAEvent(  # noqa: C901
 	return (NVDAEventName, obj)
 
 
-def processGenericWinEvent(eventID, window, objectID, childID):
+def processGenericWinEvent(eventID: int, window: int, objectID: int, childID: int):
 	"""Converts the win event to an NVDA event,
 	Checks to see if this NVDAObject  equals the current focus.
 	If all goes well, then the event is queued and we return True
-	@param eventID: a win event ID (type)
-	@type eventID: integer
-	@param window: a win event's window handle
-	@type window: integer
-	@param objectID: a win event's object ID
-	@type objectID: integer
-	@param childID: a win event's child ID
-	@type childID: integer
-	@returns: True if the event was processed, False otherwise.
-	@rtype: boolean
+	:param eventID: a win event ID (type)
+	:param window: a win event's window handle
+	:param objectID: a win event's object ID
+	:param childID: a win event's child ID
+	:returns: True if the event was processed, False otherwise.
 	"""
 	if isMSAADebugLoggingEnabled():
 		log.debug(
@@ -681,19 +676,15 @@ def processGenericWinEvent(eventID, window, objectID, childID):
 	return True
 
 
-def processFocusWinEvent(window, objectID, childID, force=False):
+def processFocusWinEvent(window: int, objectID: int, childID: int, force: bool = False) -> bool:
 	"""checks to see if the focus win event is not the same as the existing focus,
 	then converts the win event to an NVDA event (instantiating an NVDA Object) then calls
 	processFocusNVDAEvent. If all is ok it returns True.
-	@type window: integer
-	@param objectID: a win event's object ID
-	@type objectID: integer
-	@param childID: a win event's child ID
-	@type childID: integer
-	@param force: If True, the shouldAllowIAccessibleFocusEvent property of the object is ignored.
-	@type force: boolean
-	@returns: True if the focus is valid and was handled, False otherwise.
-	@rtype: boolean
+	:param window: a win event's window handle
+	:param objectID: a win event's object ID
+	:param childID: a win event's child ID
+	:param force: If True, the shouldAllowIAccessibleFocusEvent property of the object is ignored.
+	:returns: True if the focus is valid and was handled, False otherwise.
 	"""
 	if isMSAADebugLoggingEnabled():
 		log.debug(
@@ -779,7 +770,7 @@ def processFocusNVDAEvent(obj, force=False):
 	return True
 
 
-def processDesktopSwitchWinEvent(window, objectID, childID):
+def processDesktopSwitchWinEvent(window: int, objectID: int, childID: int):
 	from winAPI.secureDesktop import _handleSecureDesktopChange
 
 	if isMSAADebugLoggingEnabled():
@@ -787,12 +778,12 @@ def processDesktopSwitchWinEvent(window, objectID, childID):
 			f"Processing desktopSwitch winEvent: {getWinEventLogInfo(window, objectID, childID)}",
 		)
 	hDesk = user32.OpenInputDesktop(0, False, 0)
-	if hDesk != 0:
+	if hDesk is not None:
 		user32.CloseDesktop(hDesk)
 		core.callLater(200, _handleUserDesktop)
 	else:
-		# When hDesk == 0, the active desktop has changed.
-		# This is usually means the secure desktop has been launched,
+		# When hDesk == None, the active desktop has changed.
+		# This usually means the secure desktop has been launched,
 		# but the new desktop can also be a secondary desktop created through the Windows API.
 		# https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-createdesktopa
 		# This secondary desktop has some bugs, and as such is not properly supported (#14395).
@@ -1027,7 +1018,9 @@ def pumpAll():  # noqa: C901
 		alwaysAllowedObjects.append((focus.event_windowHandle, focus.event_objectID, focus.event_childID))
 
 	# Receive all the winEvents from the limiter for this cycle
-	winEvents = internalWinEventHandler.winEventLimiter.flushEvents(alwaysAllowedObjects)
+	winEvents: list[tuple[int, int, int, int]] = internalWinEventHandler.winEventLimiter.flushEvents(
+		alwaysAllowedObjects,
+	)
 
 	for winEvent in winEvents:
 		isEventOnCaret = winEvent[2] == winUser.OBJID_CARET

--- a/source/IAccessibleHandler/internalWinEventHandler.py
+++ b/source/IAccessibleHandler/internalWinEventHandler.py
@@ -66,7 +66,17 @@ _processDestroyWinEvent = None
 
 
 # C901: winEventCallback is too complex
-def winEventCallback(handle, eventID, window, objectID, childID, threadID, timestamp):  # noqa: C901
+def winEventCallback(
+	handle: int | None,
+	eventID: int,
+	window: int | None,
+	objectID: int,
+	childID: int,
+	threadID: int,
+	timestamp: int,
+) -> None:  # noqa: C901
+	if window is None:
+		window = 0
 	if isMSAADebugLoggingEnabled():
 		log.debug(
 			f"Hook received winEvent: {getWinEventLogInfo(window, objectID, childID, eventID, threadID)}",

--- a/source/IAccessibleHandler/orderedWinEventLimiter.py
+++ b/source/IAccessibleHandler/orderedWinEventLimiter.py
@@ -50,12 +50,12 @@ class OrderedWinEventLimiter(object):
 		threadID: int,
 	) -> bool:
 		"""Adds a winEvent to the limiter.
-		@param eventID: the winEvent type
-		@param window: the window handle of the winEvent
-		@param objectID: the objectID of the winEvent
-		@param childID: the childID of the winEvent
-		@param threadID: the threadID of the winEvent
-		@return: C{True} if the event was added, C{False} if it was discarded.
+		:param eventID: the winEvent type
+		:param window: the window handle of the winEvent
+		:param objectID: the objectID of the winEvent
+		:param childID: the childID of the winEvent
+		:param threadID: the threadID of the winEvent
+		:return: C{True} if the event was added, C{False} if it was discarded.
 		"""
 		if eventID == winUser.EVENT_OBJECT_FOCUS:
 			if objectID in (winUser.OBJID_SYSMENU, winUser.OBJID_MENU) and childID == 0:
@@ -83,13 +83,13 @@ class OrderedWinEventLimiter(object):
 	def flushEvents(
 		self,
 		alwaysAllowedObjects: Optional[List[IAccessibleObjectIdentifierType]] = None,
-	) -> List:
+	) -> list[tuple[int, int, int, int]]:
 		"""Returns a list of winEvents that have been added.
 		Due to limiting, it will not necessarily be all the winEvents that were originally added.
 		They are definitely guaranteed to be in the correct order though.
 		winEvents for objects listed in alwaysAllowedObjects will always be emitted,
 		Even if the winEvent limit for that thread has been exceeded.
-		@return Tuple[eventID,window,objectID,childID]
+		:return: a list of tuples with eventID,window,objectID,childID
 		"""
 		if self._lastMenuEvent is not None:
 			heapq.heappush(self._eventHeap, self._lastMenuEvent)

--- a/source/winConsoleHandler.py
+++ b/source/winConsoleHandler.py
@@ -157,7 +157,15 @@ def getConsoleVisibleLines():
 
 
 @winBindings.user32.WINEVENTPROC
-def consoleWinEventHook(handle, eventID, window, objectID, childID, threadID, timestamp):
+def consoleWinEventHook(
+	handle: int | None,
+	eventID: int,
+	window: int | None,
+	objectID: int,
+	childID: int,
+	threadID: int,
+	timestamp: int,
+) -> None:
 	from NVDAObjects.behaviors import KeyboardHandlerBasedTypedCharSupport
 
 	# We don't want to do anything with the event if the event is not for the window this console is in


### PR DESCRIPTION
### Link to issue number:
Fixes #18962 

### Summary of the issue:
NVDA no longer detects secure desktop switches.

### Description of user facing changes:
None

### Description of developer facing changes:
None

### Description of development approach:
Two other incarnations of the ctypes uses None for null handles problem. Handle them appropriately and add type hints in the process.

### Testing strategy:
Tested that the secure desktop is reported properly again.

### Known issues with pull request:
I think that a double check might be necessary for all functions that return and callbacks that take handles. It is pretty likely that we stumble upon more of those.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
