### PR TITLE
fix runlint output dir

### DIFF
--- a/runlint.bat
+++ b/runlint.bat
@@ -16,3 +16,12 @@ if "%1" NEQ "" (
 ) else (
     call uv run --group lint --directory "%here%" ruff format %ruffFormatArgs%
 )
+if ERRORLEVEL 1 exit /b %ERRORLEVEL%
+
+rem Run pyright for type checking
+if "%1" NEQ "" (
+    call uv run --group lint --directory "%here%" pyright > %1/pyright-output.txt
+) else (
+    call uv run --group lint --directory "%here%" pyright
+)
+if ERRORLEVEL 1 exit /b %ERRORLEVEL%

--- a/runlint.bat
+++ b/runlint.bat
@@ -8,10 +8,11 @@ if #%hereOrig:~-1%# == #\# set here=%hereOrig:~0,-1%
 set ruffCheckArgs=
 set ruffFormatArgs=
 if "%1" NEQ "" set ruffCheckArgs=--output-file=%1/PR-lint.xml --output-format=junit
-if "%1" NEQ "" set ruffFormatArgs=--diff > %1/lint-diff.diff
+if "%1" NEQ "" set ruffFormatArgs=--diff
 call uv run --group lint --directory "%here%" ruff check --fix %ruffCheckArgs%
 if ERRORLEVEL 1 exit /b %ERRORLEVEL%
-call uv run --group lint --directory "%here%" ruff format %ruffFormatArgs%
-if ERRORLEVEL 1 exit /b %ERRORLEVEL%
-call uv run --group lint --directory "%here%" pyright --threads --level warning
-if ERRORLEVEL 1 exit /b %ERRORLEVEL%
+if "%1" NEQ "" (
+    call uv run --group lint --directory "%here%" ruff format %ruffFormatArgs% > %1/lint-diff.diff
+) else (
+    call uv run --group lint --directory "%here%" ruff format %ruffFormatArgs%
+)


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Raised from https://github.com/nvaccess/addon-datastore-validation/pull/47#discussion_r2354138658

### Summary of the issue:
When running `runlint.bat outputDir` the outputDir is not correctly written to for `ruff format`.
This is because
>The redirection operator > should not be part of the variable assignment. The redirection should be applied when the command is executed.

### Description of user facing changes:
None

### Description of developer facing changes:
Fixup for writing to a dir when performing ruff format

### Description of development approach:
CoPilot suggestion

### Testing strategy:
Tested running runlint.bat with an output dir
### Known issues with pull request:
none
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
