### PR TITLE
Update brlapi to 0.8.7 for python 3.13

### DIFF
--- a/projectDocs/dev/createDevEnvironment.md
+++ b/projectDocs/dev/createDevEnvironment.md
@@ -93,7 +93,7 @@ If you aren't sure, run `git submodule update` after every git pull, merge or ch
 * NVDA images and sounds
 * [Adobe Acrobat accessibility interface, version XI](https://download.macromedia.com/pub/developer/acrobat/AcrobatAccess.zip)
 * [Microsoft Detours](https://github.com/microsoft/Detours), commit `9764cebcb1a75940e68fa83d6730ffaf0f669401`
-* brlapi Python bindings, version 0.8.5 or later, distributed with [BRLTTY for Windows](https://brltty.app/download.html), version 6.6
+* brlapi Python bindings, version 0.8.7 or later, distributed with [BRLTTY for Windows](https://brltty.app/download.html), version 6.8
 * lilli.dll, version 2.1.0.0
 * Python interface to FTDI driver/chip
 * [Nullsoft Install System](https://nsis.sourceforge.io), version 3.11

--- a/tests/unit/test_braille/test_brailleDisplayDrivers.py
+++ b/tests/unit/test_braille/test_brailleDisplayDrivers.py
@@ -180,14 +180,6 @@ class TestGestureMap(unittest.TestCase):
 					self.assertRegex(gesture, braille.BrailleDisplayGesture.ID_PARTS_REGEX)
 
 
-@unittest.skipUnless(
-	sysconfig.get_platform() == "win32",
-	"BRLTTY is only supported on 32-bit Windows",
-)
-@unittest.skipUnless(
-	sys.version_info.major == 3 and sys.version_info.minor == 11,
-	"Skipping brlapi tests unless Python 3.11",
-)
 class TestBRLTTY(unittest.TestCase):
 	"""Tests the integrity of the bundled brlapi module."""
 

--- a/tests/unit/test_braille/test_brailleDisplayDrivers.py
+++ b/tests/unit/test_braille/test_brailleDisplayDrivers.py
@@ -5,8 +5,6 @@
 
 """Unit tests for braille display drivers."""
 
-import sysconfig
-import sys
 from brailleDisplayDrivers import seikantk
 import unittest
 import braille

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -45,6 +45,7 @@ We recommend using Windows 11, or if that is not possible, the latest Windows 10
   * Updated LibLouis Braille translator to [3.35.0](https://github.com/liblouis/liblouis/releases/tag/v3.35.0). (#18848, @LeonarddeR)
     * Added Japanese (Rokuten Kanji) Braille.
     * Improvements to Portuguese 8-dot, Greek International, Biblical Hebrew, Norwegian 8-dot and Unified English Braille.
+    * Updated BrlAPI for BRLTTY to version 0.8.7, and its corresponding python module to a Python 3.13 compatible build. (#18657, @LeonarddeR)
 
 ### Bug Fixes
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -45,7 +45,7 @@ We recommend using Windows 11, or if that is not possible, the latest Windows 10
   * Updated LibLouis Braille translator to [3.35.0](https://github.com/liblouis/liblouis/releases/tag/v3.35.0). (#18848, @LeonarddeR)
     * Added Japanese (Rokuten Kanji) Braille.
     * Improvements to Portuguese 8-dot, Greek International, Biblical Hebrew, Norwegian 8-dot and Unified English Braille.
-    * Updated BrlAPI for BRLTTY to version 0.8.7, and its corresponding python module to a Python 3.13 compatible build. (#18657, @LeonarddeR)
+  * Updated BrlAPI for BRLTTY to version 0.8.7, and its corresponding python module to a Python 3.13 compatible build. (#18657, @LeonarddeR)
 
 ### Bug Fixes
 

--- a/uv.lock
+++ b/uv.lock
@@ -624,7 +624,7 @@ unit-tests = [
 
 [[package]]
 name = "nvda-misc-deps"
-version = "20250419"
+version = "20250925"
 source = { editable = "miscDeps" }
 
 [[package]]


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Closes #18657
Merges changes from https://github.com/nvaccess/brltty/pull/1 and https://github.com/nvaccess/nvda-misc-deps/pull/39

### Summary of the issue:
BRLTTY needs to be updated for 64bit and python 3.13.
Since updating python it has been broken on alphas.

### Description of user facing changes:
BRLTTY restored usage restored

### Description of developer facing changes:
None

### Description of development approach:
Update commit from miscDeps built from https://github.com/nvaccess/brltty/pull/

### Testing strategy:
Unit tests re-enabled

### Known issues with pull request:
None
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
