### PR TITLE
Fix x64 identification for update check

### DIFF
--- a/source/updateCheck.py
+++ b/source/updateCheck.py
@@ -215,8 +215,8 @@ def checkForUpdate(auto: bool = False) -> UpdateInfo | None:
 		# Check if the architecture is the most common: "AMD64"
 		# Available values of PROCESSOR_ARCHITECTURE found in:
 		# https://docs.microsoft.com/en-gb/windows/win32/winprog64/wow64-implementation-details
-		"x64": True,
 		"osArchitecture": os.environ["PROCESSOR_ARCHITECTURE"],
+		"x64": True,
 	}
 
 	if auto and allowUsageStats:

--- a/source/updateCheck.py
+++ b/source/updateCheck.py
@@ -215,7 +215,7 @@ def checkForUpdate(auto: bool = False) -> UpdateInfo | None:
 		# Check if the architecture is the most common: "AMD64"
 		# Available values of PROCESSOR_ARCHITECTURE found in:
 		# https://docs.microsoft.com/en-gb/windows/win32/winprog64/wow64-implementation-details
-		"x64": os.environ["PROCESSOR_ARCHITECTURE"] == "AMD64",
+		"x64": True,
 		"osArchitecture": os.environ["PROCESSOR_ARCHITECTURE"],
 	}
 

--- a/source/updateCheck.py
+++ b/source/updateCheck.py
@@ -215,8 +215,8 @@ def checkForUpdate(auto: bool = False) -> UpdateInfo | None:
 		# Check if the architecture is the most common: "AMD64"
 		# Available values of PROCESSOR_ARCHITECTURE found in:
 		# https://docs.microsoft.com/en-gb/windows/win32/winprog64/wow64-implementation-details
-		"x64": os.environ.get("PROCESSOR_ARCHITECTURE") == "AMD64",
-		"osArchitecture": os.environ.get("PROCESSOR_ARCHITECTURE"),
+		"x64": os.environ["PROCESSOR_ARCHITECTURE"] == "AMD64",
+		"osArchitecture": os.environ["PROCESSOR_ARCHITECTURE"],
 	}
 
 	if auto and allowUsageStats:

--- a/source/updateCheck.py
+++ b/source/updateCheck.py
@@ -213,10 +213,10 @@ def checkForUpdate(auto: bool = False) -> UpdateInfo | None:
 		"versionType": buildVersion.updateVersionType,
 		"osVersion": winVersionText,
 		# Check if the architecture is the most common: "AMD64"
-		# Available values of PROCESSOR_ARCHITEW6432 found in:
+		# Available values of PROCESSOR_ARCHITECTURE found in:
 		# https://docs.microsoft.com/en-gb/windows/win32/winprog64/wow64-implementation-details
-		"x64": os.environ.get("PROCESSOR_ARCHITEW6432") == "AMD64",
-		"osArchitecture": os.environ.get("PROCESSOR_ARCHITEW6432"),
+		"x64": os.environ.get("PROCESSOR_ARCHITECTURE") == "AMD64",
+		"osArchitecture": os.environ.get("PROCESSOR_ARCHITECTURE"),
 	}
 
 	if auto and allowUsageStats:

--- a/tests/unit/test_winVersion.py
+++ b/tests/unit/test_winVersion.py
@@ -89,7 +89,7 @@ class TestWinVersion(unittest.TestCase):
 	def test_winVerProcessorArchitecture(self):
 		# See if processor architecture matches what Windows says.
 		# Use os.environ to guard against platform.machine() giving odd results.
-		actualArchitecture = os.environ.get("PROCESSOR_ARCHITECTURE", os.environ["PROCESSOR_ARCHITECTURE"])
+		actualArchitecture = os.environ["PROCESSOR_ARCHITECTURE"]
 		self.assertEqual(winVersion.getWinVer().processorArchitecture, actualArchitecture)
 
 	def test_winVerUnknownWin11BuildToReleaseName(self):

--- a/tests/unit/test_winVersion.py
+++ b/tests/unit/test_winVersion.py
@@ -89,7 +89,7 @@ class TestWinVersion(unittest.TestCase):
 	def test_winVerProcessorArchitecture(self):
 		# See if processor architecture matches what Windows says.
 		# Use os.environ to guard against platform.machine() giving odd results.
-		actualArchitecture = os.environ.get("PROCESSOR_ARCHITEW6432", os.environ["PROCESSOR_ARCHITECTURE"])
+		actualArchitecture = os.environ.get("PROCESSOR_ARCHITECTURE", os.environ["PROCESSOR_ARCHITECTURE"])
 		self.assertEqual(winVersion.getWinVer().processorArchitecture, actualArchitecture)
 
 	def test_winVerUnknownWin11BuildToReleaseName(self):


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Fixes #18983

### Summary of the issue:
NVDA incorrectly identified the OS architecture as 32bit when running as a 64bit process.
This caused the update check to return 2025.3 as the expected NVDA version, as NVDA falsely said the system was 32bit.

### Description of user facing changes:
Update check works for alphas

### Description of developer facing changes:
None

### Description of development approach:
Fix PROCESSOR_ARCHITEW6432 usages

### Testing strategy:
test update check on alphas

### Known issues with pull request:

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
