### PR TITLE
Improve image captioner

### DIFF
--- a/source/_localCaptioner/captioner.py
+++ b/source/_localCaptioner/captioner.py
@@ -69,7 +69,7 @@ class VitGpt2ImageCaptioner(ImageCaptioner):
 		:raises Exception: If model initialization fails.
 		"""
 		import onnxruntime as ort
-		
+
 		# Load configuration file
 		try:
 			with open(configPath, "r", encoding="utf-8") as f:

--- a/source/_localCaptioner/captioner.py
+++ b/source/_localCaptioner/captioner.py
@@ -12,7 +12,6 @@ from abc import ABC, abstractmethod
 
 import numpy as np
 from PIL import Image
-import onnxruntime as ort
 
 from logHandler import log
 
@@ -69,6 +68,8 @@ class VitGpt2ImageCaptioner(ImageCaptioner):
 		:raises FileNotFoundError: If config file is not found.
 		:raises Exception: If model initialization fails.
 		"""
+		import onnxruntime as ort
+		
 		# Load configuration file
 		try:
 			with open(configPath, "r", encoding="utf-8") as f:

--- a/source/_localCaptioner/captioner.py
+++ b/source/_localCaptioner/captioner.py
@@ -68,6 +68,7 @@ class VitGpt2ImageCaptioner(ImageCaptioner):
 		:raises FileNotFoundError: If config file is not found.
 		:raises Exception: If model initialization fails.
 		"""
+		# Import late to avoid importing numpy at initialization
 		import onnxruntime as ort
 
 		# Load configuration file

--- a/source/_localCaptioner/imageDescriber.py
+++ b/source/_localCaptioner/imageDescriber.py
@@ -97,7 +97,7 @@ class ImageDescriber:
 		enable = config.conf["automatedImageDescriptions"]["enable"]
 		# Load model when initializing (may cause high memory usage)
 		if enable:
-			core.postNvdaStartup.register(self._loadModel)
+			core.postNvdaStartup.register(self.loadModelInBackground)
 
 	def terminate(self):
 		for t in [self.captionThread, self.loadModelThread]:
@@ -157,12 +157,12 @@ class ImageDescriber:
 		except Exception:
 			self.isModelLoaded = False
 			# Translators: error message when fail to load model
-			ui.message(pgettext("imageDesc", "failed to load image captioner"))
+			wx.CallAfter(ui.message, pgettext("imageDesc", "failed to load image captioner"))
 			log.exception("Failed to load image captioner model")
 		else:
 			self.isModelLoaded = True
 			# Translators: Message when successfully load the model
-			ui.message(pgettext("imageDesc", "image captioning on"))
+			wx.CallAfter(ui.message, pgettext("imageDesc", "image captioning on"))
 
 	def loadModelInBackground(self, localModelDirPath: str | None = None) -> None:
 		"""load model in child thread

--- a/source/_localCaptioner/imageDescriber.py
+++ b/source/_localCaptioner/imageDescriber.py
@@ -75,10 +75,10 @@ def _messageCaption(captioner: ImageCaptioner, imageData: bytes) -> None:
 		description = captioner.generateCaption(image=imageData)
 	except Exception:
 		# Translators: error message when an image description cannot be generated
-		ui.message(pgettext("imageDesc", "Failed to generate description"))
+		wx.CallAfter(ui.message, pgettext("imageDesc", "Failed to generate description"))
 		log.exception("Failed to generate caption")
 	else:
-		ui.message(description)
+		wx.CallAfter(ui.message, description)
 
 
 class ImageDescriber:

--- a/tests/system/robot/automatedImageDescriptions.robot
+++ b/tests/system/robot/automatedImageDescriptions.robot
@@ -16,12 +16,11 @@ Test Teardown	default teardown
 *** Keywords ***
 default teardown
 	${screenshotName}=	create_preserved_test_output_filename	failedTest.png
-	Run Keyword If Test Failed	Take Screenshot	${screenShotName}
+	Run Keyword If Test Failed	Take Screenshot	${screenshotName}
 	quit NVDA
 
 *** Test Cases ***
 automatedImageDescriptions
 	[Documentation]	Ensure that local captioner work
-	[Setup]	start NVDA	standard-doLoadMockModel.ini
 	NVDA_Caption	# run test
 

--- a/tests/system/robot/startupShutdownNVDA.robot
+++ b/tests/system/robot/startupShutdownNVDA.robot
@@ -17,7 +17,7 @@ Test Teardown	default teardown
 *** Keywords ***
 default teardown
 	${screenshotName}=	create_preserved_test_output_filename	failedTest.png
-	Run Keyword If Test Failed	Take Screenshot	${screenShotName}
+	Run Keyword If Test Failed	Take Screenshot	${screenshotName}
 	quit NVDA
 
 *** Test Cases ***

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -20,7 +20,7 @@ Windows 10 on ARM is also no longer supported.
   * Press `NVDA+Windows+,` to get an AI generated image description. (#18475, @tianzeshi-study)
   * This is generated locally on the device - no information is sent to the internet.
   * A new unassigned command is available for quickly opening the settings dialog for local image description. (#18475)
-  * Another new unassigned command is available for toggle image captioning. (#18475)
+  * Another new unassigned command is available to toggle image captioning. (#18475)
 
 * Added the possibility to report when multiple items can be selected in a list control.
 This can be enabled using the "Report when lists support multiple selection" setting in NVDA's object presentation settings. (#18365 @LeonarddeR)


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
<!-- Use Closes/Fixes/Resolves #xxx to link this PR to the issue it is responding to. -->
Follow up #18924
Fixes #19033
Fixes #19039
### Summary of the issue:

AI Image Descriptions turned on causes NVDA to load more slowly to some extent

the image description is not shown in braille 
### Description of user facing changes:
Improved NVDA startup speed to some extent when AI image descriptions is enabled. 

Show image description in braille 

Reduced NVDA memory usage to some extent.

### Description of developer facing changes:
Improve grammar and variable name

Show image description message in main thread

Load image descriptioner in background  

### Description of development approach:
nothing
### Testing strategy:
enable AI image descriptions,  restart NVDA, and observe startup times and braille displays
### Known issues with pull request:
numpy sstill import when init,may cause additional memory usage 
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [ ] Security precautions taken.
