### PR TITLE
support progress report for AI image descriptions download

### DIFF
--- a/source/_localCaptioner/captioner.py
+++ b/source/_localCaptioner/captioner.py
@@ -102,7 +102,10 @@ class VitGpt2ImageCaptioner(ImageCaptioner):
 		try:
 			self.encoderSession = ort.InferenceSession(encoderPath, sess_options=sessionOptions)
 			self.decoderSession = ort.InferenceSession(decoderPath, sess_options=sessionOptions)
-		except ort.capi.onnxruntime_pybind11_state.InvalidProtobuf as e:
+		except (
+			ort.capi.onnxruntime_pybind11_state.InvalidProtobuf,
+			ort.capi.onnxruntime_pybind11_state.NoSuchFile,
+		) as e:
 			raise FileNotFoundError(
 				"model file incomplete"
 				f" Please check whether the file is complete or re-download. Original error: {e}",
@@ -158,7 +161,7 @@ class VitGpt2ImageCaptioner(ImageCaptioner):
 
 			# Convert to id -> token format
 			vocab = {v: k for k, v in vocabData.items()}
-			log.info(f"Successfully loaded vocabulary with {len(vocab)} tokens")
+			log.debug(f"Successfully loaded vocabulary with {len(vocab)} tokens")
 			return vocab
 
 		except FileNotFoundError:

--- a/source/_localCaptioner/imageDescriber.py
+++ b/source/_localCaptioner/imageDescriber.py
@@ -151,9 +151,10 @@ class ImageDescriber:
 			)
 		except FileNotFoundError:
 			self.isModelLoaded = False
-			from gui._localCaptioner.messageDialogs import openDownloadDialog
+			from gui._localCaptioner.messageDialogs import ImageDescDownloader
 
-			wx.CallAfter(openDownloadDialog)
+			descDownloader = ImageDescDownloader()
+			wx.CallAfter(descDownloader.openDownloadDialog)
 		except Exception:
 			self.isModelLoaded = False
 			# Translators: error message when fail to load model

--- a/source/_localCaptioner/modelDownloader.py
+++ b/source/_localCaptioner/modelDownloader.py
@@ -151,7 +151,7 @@ class ModelDownloader:
 
 		try:
 			# Use HEAD request with automatic redirect following
-			response = self.session.head(url, timeout=30, allow_redirects=True)
+			response = self.session.head(url, timeout=10, allow_redirects=True)
 			response.raise_for_status()
 		except Exception as e:
 			if not self.cancelRequested:
@@ -163,7 +163,7 @@ class ModelDownloader:
 
 		try:
 			# If HEAD doesn't work, try GET with range header to get just 1 byte
-			response = self.session.get(url, headers={"Range": "bytes=0-0"}, timeout=30, allow_redirects=True)
+			response = self.session.get(url, headers={"Range": "bytes=0-0"}, timeout=10, allow_redirects=True)
 		except Exception as e:
 			if not self.cancelRequested:
 				log.warning(f"Failed to get remote file size (GET) for {url}: {e}")
@@ -480,7 +480,7 @@ class ModelDownloader:
 			url,
 			headers=headers,
 			stream=True,
-			timeout=30,
+			timeout=10,
 			allow_redirects=True,
 		)
 
@@ -499,7 +499,7 @@ class ModelDownloader:
 
 			# Make new request without range header
 			response.close()
-			response = self.session.get(url, stream=True, timeout=30, allow_redirects=True)
+			response = self.session.get(url, stream=True, timeout=10, allow_redirects=True)
 
 		response.raise_for_status()
 		return response
@@ -732,8 +732,7 @@ class ModelDownloader:
 					self.activeFutures.discard(future)
 
 				try:
-					# Use a short timeout to avoid blocking indefinitely
-					ok, msg = future.result(timeout=1.0)
+					ok, msg = future.result()
 					if ok:
 						successful.append(filePath)
 						log.debug(f"successful {filePath=}")

--- a/source/gui/_localCaptioner/messageDialogs.py
+++ b/source/gui/_localCaptioner/messageDialogs.py
@@ -66,6 +66,7 @@ class ImageDescDownloader:
 	def openFailDialog(self) -> None:
 		if self._shouldCancel:
 			return
+
 		confirmationButtons = (
 			DefaultButton.YES.value._replace(defaultFocus=True, fallbackAction=False),
 			DefaultButton.NO.value._replace(defaultFocus=False, fallbackAction=True),

--- a/source/gui/_localCaptioner/messageDialogs.py
+++ b/source/gui/_localCaptioner/messageDialogs.py
@@ -4,97 +4,160 @@
 # For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
 
 from gui.message import MessageDialog, DefaultButton, ReturnCode, DialogType
-from _localCaptioner.modelDownloader import ModelDownloader
+import gui
+from _localCaptioner.modelDownloader import ModelDownloader, ProgressCallback
 import threading
 from threading import Thread
 import wx
 import ui
 import _localCaptioner
 
-_downloadThread: Thread | None = None
 
+class ImageDescDownloader:
+	_downloadThread: Thread | None = None
+	isOpening: bool = False
 
-def onDownload() -> None:
-	modelDownloader = ModelDownloader()
-	(success, fail) = modelDownloader.downloadModelsMultithreaded()
-	if success:
-		wx.CallAfter(openSuccessDialog)
-	else:
-		wx.CallAfter(openFailDialog)
+	def __init__(self):
+		self.downloadDict: dict[str, tuple[int, int]] = {}
+		self.modelDownloader: ModelDownloader | None = None
+		self._shouldCancel = False
+		self._progressDialog: wx.ProgressDialog | None = None
+		self.filesToDownload = [
+			"onnx/encoder_model_quantized.onnx",
+			"onnx/decoder_model_merged_quantized.onnx",
+			"config.json",
+			"vocab.json",
+			"preprocessor_config.json",
+		]
 
+	def onDownload(self, progressCallback: ProgressCallback) -> None:
+		self.modelDownloader = ModelDownloader()
+		(success, fail) = self.modelDownloader.downloadModelsMultithreaded(
+			filesToDownload=self.filesToDownload, progressCallback=progressCallback
+		)
+		if len(fail) == 0:
+			wx.CallAfter(self.openSuccessDialog)
+		else:
+			wx.CallAfter(self.openFailDialog)
 
-def openSuccessDialog() -> None:
-	confirmationButton = (DefaultButton.OK.value._replace(defaultFocus=True, fallbackAction=True),)
+	def openSuccessDialog(self) -> None:
+		confirmationButton = (DefaultButton.OK.value._replace(defaultFocus=True, fallbackAction=True),)
+		self._stopped()
 
-	dialog = MessageDialog(
-		parent=None,
-		# Translators: title of dialog when download successfully
-		title=pgettext("imageDesc", "Download successful"),
-		message=pgettext(
-			"imageDesc",
-			# Translators: label of dialog when downloading image captioning
-			"Image captioning installed successfully.",
-		),
-		dialogType=DialogType.STANDARD,
-		buttons=confirmationButton,
-	)
+		dialog = MessageDialog(
+			parent=None,
+			# Translators: title of dialog when download successfully
+			title=pgettext("imageDesc", "Download successful"),
+			message=pgettext(
+				"imageDesc",
+				# Translators: label of dialog when downloading image captioning
+				"Image captioning installed successfully.",
+			),
+			dialogType=DialogType.STANDARD,
+			buttons=confirmationButton,
+		)
 
-	if dialog.ShowModal() == ReturnCode.OK:
-		# load image desc after successful download
-		if not _localCaptioner.isModelLoaded():
-			_localCaptioner.toggleImageCaptioning()
+		if dialog.ShowModal() == ReturnCode.OK:
+			# load image desc after successful download
+			if not _localCaptioner.isModelLoaded():
+				_localCaptioner.toggleImageCaptioning()
 
+	def openFailDialog(self) -> None:
+		if self._shouldCancel:
+			return
+		confirmationButtons = (
+			DefaultButton.YES.value._replace(defaultFocus=True, fallbackAction=False),
+			DefaultButton.NO.value._replace(defaultFocus=False, fallbackAction=True),
+		)
 
-def openFailDialog() -> None:
-	confirmationButtons = (
-		DefaultButton.YES.value._replace(defaultFocus=True, fallbackAction=True),
-		DefaultButton.NO,
-	)
+		dialog = MessageDialog(
+			parent=None,
+			# Translators: title of dialog when fail to download
+			title=pgettext("imageDesc", "Download failed"),
+			message=pgettext(
+				"imageDesc",
+				# Translators: label of dialog when fail to download image captioning
+				"Image captioning download failed. Would you like to retry?",
+			),
+			dialogType=DialogType.WARNING,
+			buttons=confirmationButtons,
+		)
 
-	dialog = MessageDialog(
-		parent=None,
-		# Translators: title of dialog when fail to download
-		title=pgettext("imageDesc", "Download failed"),
-		message=pgettext(
-			"imageDesc",
-			# Translators: label of dialog when fail to download image captioning
-			"Image captioning download failed. Would you like to retry?",
-		),
-		dialogType=DialogType.WARNING,
-		buttons=confirmationButtons,
-	)
+		if dialog.ShowModal() == ReturnCode.YES:
+			self.doDownload()
+		else:
+			self._stopped()
 
-	if dialog.ShowModal() == ReturnCode.YES:
-		global _downloadThread
-		_downloadThread = threading.Thread(target=onDownload, name="ModelDownloadMainThread", daemon=False)
-		_downloadThread.start()
+	def openDownloadDialog(self) -> None:
+		if ImageDescDownloader._downloadThread is not None and ImageDescDownloader._downloadThread.is_alive():
+			# Translators: message when image captioning is still downloading
+			ui.message(pgettext("imageDesc", "image captioning is still downloading, please wait..."))
+			return
+		if ImageDescDownloader.isOpening:
+			return
 
+		confirmationButtons = (
+			DefaultButton.YES.value._replace(defaultFocus=True, fallbackAction=False),
+			DefaultButton.NO.value._replace(defaultFocus=False, fallbackAction=True),
+		)
 
-def openDownloadDialog() -> None:
-	global _downloadThread
-	if _downloadThread is not None and _downloadThread.is_alive():
-		# Translators: message when image captioning is still downloading
-		ui.message(pgettext("imageDesc", "image captioning is still downloading, please wait..."))
-		return
+		dialog = MessageDialog(
+			parent=None,
+			# Translators: title of dialog when downloading Image captioning
+			title=pgettext("imageDesc", "Confirm download"),
+			message=pgettext(
+				"imageDesc",
+				# Translators: label of dialog when downloading image captioning
+				"Image captioning not installed. Would you like to install (235 MB)?",
+			),
+			dialogType=DialogType.WARNING,
+			buttons=confirmationButtons,
+		)
+		ImageDescDownloader.isOpening = True
 
-	confirmationButtons = (
-		DefaultButton.YES.value._replace(defaultFocus=True, fallbackAction=True),
-		DefaultButton.NO,
-	)
+		if dialog.ShowModal() == ReturnCode.YES:
+			self._progressDialog = wx.ProgressDialog(
+				# Translators: The title of the dialog displayed while downloading image descriptioner.
+				pgettext("imageDesc", "Downloading Image Descriptioner"),
+				# Translators: The progress message indicating that a connection is being established.
+				pgettext("imageDesc", "Connecting"),
+				style=wx.PD_CAN_ABORT | wx.PD_ELAPSED_TIME | wx.PD_REMAINING_TIME | wx.PD_AUTO_HIDE,
+				parent=gui.mainFrame,
+			)
+			self.doDownload()
+		else:
+			ImageDescDownloader.isOpening = False
 
-	dialog = MessageDialog(
-		parent=None,
-		# Translators: title of dialog when downloading Image captioning
-		title=pgettext("imageDesc", "Confirm download"),
-		message=pgettext(
-			"imageDesc",
-			# Translators: label of dialog when downloading image captioning
-			"Image captioning not installed. Would you like to install (235 MB)?",
-		),
-		dialogType=DialogType.WARNING,
-		buttons=confirmationButtons,
-	)
+	def doDownload(self):
+		def progressCallback(
+			fileName: str,
+			downloadedBytes: int,
+			totalBytes: int,
+			_percentage: float,
+		) -> None:
+			"""Callback function to capture progress data."""
+			self.downloadDict[fileName] = (downloadedBytes, totalBytes)
+			downloadedSum = sum(d for d, _ in self.downloadDict.values())
+			totalSum = sum(t for _, t in self.downloadDict.values())
+			ratio = downloadedSum / totalSum if totalSum > 0 else 0.0
+			totalProgress = int(ratio * 100)
+			# update progress when downloading all files to prevent premature stop
+			if len(self.downloadDict) == len(self.filesToDownload):
+				# Translators: The progress message indicating that a download is in progress.
+				cont, skip = self._progressDialog.Update(totalProgress, pgettext("imageDesc", "downloading"))
+				if not cont:
+					self._shouldCancel = True
+					self._stopped()
 
-	if dialog.ShowModal() == ReturnCode.YES:
-		_downloadThread = threading.Thread(target=onDownload, name="ModelDownloadMainThread", daemon=False)
-		_downloadThread.start()
+		ImageDescDownloader._downloadThread = threading.Thread(
+			target=self.onDownload, name="ModelDownloadMainThread", daemon=False, args=(progressCallback,)
+		)
+		ImageDescDownloader._downloadThread.start()
+
+	def _stopped(self):
+		self.modelDownloader.requestCancel()
+		ImageDescDownloader._downloadThread = None
+		self._progressDialog.Hide()
+		self._progressDialog.Destroy()
+		self._progressDialog = None
+		ImageDescDownloader.isOpening = False

--- a/source/gui/_localCaptioner/messageDialogs.py
+++ b/source/gui/_localCaptioner/messageDialogs.py
@@ -33,7 +33,8 @@ class ImageDescDownloader:
 	def onDownload(self, progressCallback: ProgressCallback) -> None:
 		self.modelDownloader = ModelDownloader()
 		(success, fail) = self.modelDownloader.downloadModelsMultithreaded(
-			filesToDownload=self.filesToDownload, progressCallback=progressCallback
+			filesToDownload=self.filesToDownload,
+			progressCallback=progressCallback,
 		)
 		if len(fail) == 0:
 			wx.CallAfter(self.openSuccessDialog)
@@ -150,7 +151,10 @@ class ImageDescDownloader:
 					self._stopped()
 
 		ImageDescDownloader._downloadThread = threading.Thread(
-			target=self.onDownload, name="ModelDownloadMainThread", daemon=False, args=(progressCallback,)
+			target=self.onDownload,
+			name="ModelDownloadMainThread",
+			daemon=False,
+			args=(progressCallback,),
 		)
 		ImageDescDownloader._downloadThread.start()
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
<!-- Use Closes/Fixes/Resolves #xxx to link this PR to the issue it is responding to. -->
Resolves #19019
### Summary of the issue:
No progress of AI Image Descriptions download shown 
### Description of user facing changes:
User can get progress notice during AI Image descriptions model downloading 
### Description of developer facing changes:
Reduce timeouts in modelDownloader to avoid excessive waiting for users when the network is poor during multi-threaded downloads

remove timeout option in future.result() in modelDownloader to avoid raise timeout error when download success

Use OOP to introduce progress reporting in `_localCaptioner.messageDialogs`.
### Description of development approach:
None
### Testing strategy:
Make sure AI image descriptions models are not installed and enable AI image descriptions  in settings panel. Click buttons in image descriptions message dialog to test model download by hand.  
### Known issues with pull request:
None
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
