### PR TITLE
Only flag x64 if AMD64

### DIFF
--- a/source/updateCheck.py
+++ b/source/updateCheck.py
@@ -215,8 +215,8 @@ def checkForUpdate(auto: bool = False) -> UpdateInfo | None:
 		# Check if the architecture is the most common: "AMD64"
 		# Available values of PROCESSOR_ARCHITECTURE found in:
 		# https://docs.microsoft.com/en-gb/windows/win32/winprog64/wow64-implementation-details
+		"x64": os.environ["PROCESSOR_ARCHITECTURE"] == "AMD64",
 		"osArchitecture": os.environ["PROCESSOR_ARCHITECTURE"],
-		"x64": True,
 	}
 
 	if auto and allowUsageStats:


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Fixup of #19020

### Summary of the issue:

Since migrating alphas to 64bit, the NV Access server has been updated to refer 32bit OSs to 2025.3 rather than the latest NVDA version.
However, this was implemented incorrectly, checking the `x64` parameter rather than `osArchitecture`. 
Historically the `x64` parameter is used to determine if the OS is AMD64, not if the OS supports 64-bit software, which includes ARM based OSs.
#19020 changed updateCheck to always send True for 64-bit OSs, whereas it should continue to only send the flag if AMD64 and instead the server should be fixed

### Description of user facing changes:
None (with server side changes implemented)

### Description of developer facing changes:
None

### Description of development approach:
Restore update check behaviour to before 64-bit alphas

### Testing strategy:
Test on prod

### Known issues with pull request:

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
