### PR TITLE
Lazy load heavy deps for AI image descriptions

### DIFF
--- a/source/_localCaptioner/captioner/__init__.py
+++ b/source/_localCaptioner/captioner/__init__.py
@@ -1,0 +1,53 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2025 NV Access Limited, Tianze
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
+
+import json
+
+from logHandler import log
+from .base import ImageCaptioner
+
+
+def imageCaptionerFactory(
+	configPath: str,
+	encoderPath: str | None = None,
+	decoderPath: str | None = None,
+	monomericModelPath: str | None = None,
+) -> ImageCaptioner:
+	"""Initialize the image caption generator.
+
+	:param monomericModelPath: Path to a single merged model file.
+	:param encoderPath: Path to the encoder model file.
+	:param decoderPath: Path to the decoder model file.
+	:param configPath: Path to the configuration file.
+	:raises ValueError: If neither a single model nor both encoder and decoder are provided.
+	:raises FileNotFoundError: If config file not found.
+	:raises NotImplementedError: if model architecture is unsupported
+	:raises Exception: If config.json fail to load.
+	:return: instance of ImageCaptioner
+	"""
+	if not monomericModelPath and not (encoderPath and decoderPath):
+		raise ValueError(
+			"You must provide either 'monomericModelPath' or both 'encoderPath' and 'decoderPath'.",
+		)
+
+	try:
+		with open(configPath, "r", encoding="utf-8") as f:
+			config = json.load(f)
+	except FileNotFoundError:
+		raise FileNotFoundError(
+			f"Caption model config file {configPath} not found, "
+			"please download models and config file first!",
+		)
+	except Exception:
+		log.exception("config file not found")
+		raise
+
+	modelArchitecture = config["architectures"][0]
+	if modelArchitecture == "VisionEncoderDecoderModel":
+		from .vitGpt2 import VitGpt2ImageCaptioner
+
+		return VitGpt2ImageCaptioner(encoderPath, decoderPath, configPath)
+	else:
+		raise NotImplementedError("Unsupported model architectures")

--- a/source/_localCaptioner/captioner/base.py
+++ b/source/_localCaptioner/captioner/base.py
@@ -1,0 +1,24 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2025 NV Access Limited, Tianze
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
+
+from abc import ABC, abstractmethod
+
+
+class ImageCaptioner(ABC):
+	"""Abstract interface for image caption generation.
+
+	Supports generate caption for image
+	"""
+
+	@abstractmethod
+	def generateCaption(self, image: str | bytes, maxLength: int | None = None) -> str:
+		"""
+		Generate a caption for the given image.
+
+		:param image: Image file path or binary data.
+		:param maxLength: Optional maximum length for the generated caption.
+		:return: The generated image caption as a string.
+		"""
+		pass

--- a/tests/unit/test_localCaptioner/test_captioner.py
+++ b/tests/unit/test_localCaptioner/test_captioner.py
@@ -25,7 +25,7 @@ from PIL import Image
 import io
 import shutil
 
-from _localCaptioner.captioner import VitGpt2ImageCaptioner
+from _localCaptioner.captioner.vitGpt2 import VitGpt2ImageCaptioner
 from _localCaptioner import modelConfig
 
 modelConfig.initialize()


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
<!-- Use Closes/Fixes/Resolves #xxx to link this PR to the issue it is responding to. -->
Fixes #19031
### Summary of the issue:
import numpy directly may cause high memory useage when AI image descriptions is disabled. 

### Description of user facing changes:
The memory usage caused by NumPy will only occur when the AI image descriptions is loaded.
### Description of developer facing changes:

Move captioner.py into a captioner/ package to support lazy import of large libraries such as numpy and onnxruntime. This reduces startup time and memory usage to some extent.

### Description of development approach:
None
### Testing strategy:
Observe memory useage and start time of NVDA
### Known issues with pull request:
None
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
