### PR TITLE
Show local ui.messages in braille when controlling a remote computer

### DIFF
--- a/source/_remoteClient/client.py
+++ b/source/_remoteClient/client.py
@@ -545,8 +545,7 @@ class RemoteClient:
 			if script in self.localScripts:
 				wx.CallAfter(script, gesture)
 				return False
-		if self.localMachine._showingLocalUiMessage:
-			braille.handler._dismissMessage()
+		self.localMachine._dismissLocalBrailleMessage()
 		self.leaderTransport.send(
 			RemoteMessageType.KEY,
 			vk_code=vkCode,

--- a/source/_remoteClient/client.py
+++ b/source/_remoteClient/client.py
@@ -46,6 +46,7 @@ class RemoteClient:
 	followerSession: Optional[FollowerSession]
 	keyModifiers: Set[KeyModifier]
 	hostPendingModifiers: Set[KeyModifier]
+	hostPendingNonmodifier: KeyModifier | None
 	_connecting: bool
 	leaderTransport: Optional[RelayTransport]
 	followerTransport: Optional[RelayTransport]
@@ -59,6 +60,7 @@ class RemoteClient:
 		log.info("Initializing NVDA Remote client")
 		self.keyModifiers = set()
 		self.hostPendingModifiers = set()
+		self.hostPendingNonmodifiers = None
 		self.localScripts = set()
 		self.localMachine = LocalMachine()
 		self.followerSession = None
@@ -524,6 +526,9 @@ class RemoteClient:
 		if not pressed and keyCode in self.hostPendingModifiers:
 			self.hostPendingModifiers.discard(keyCode)
 			return True
+		if not pressed and keyCode == self.hostPendingNonmodifier:
+			self.hostPendingNonmodifier = None
+			return True
 		gesture = KeyboardInputGesture(
 			self.keyModifiers,
 			keyCode[0],
@@ -540,6 +545,8 @@ class RemoteClient:
 			if script in self.localScripts:
 				wx.CallAfter(script, gesture)
 				return False
+		if self.localMachine._showingLocalUiMessage:
+			braille.handler._dismissMessage()
 		self.leaderTransport.send(
 			RemoteMessageType.KEY,
 			vk_code=vkCode,
@@ -590,6 +597,7 @@ class RemoteClient:
 		self.setReceivingBraille(self.sendingKeys)
 		if gesture is not None:
 			self.hostPendingModifiers = gesture.modifiers
+			self.hostPendingNonmodifier = (gesture.vkCode, gesture.isExtended)
 		else:
 			self.hostPendingModifiers = set()
 		# Translators: Presented when sending keyboard keys from the controlling computer to the controlled computer.

--- a/source/_remoteClient/localMachine.py
+++ b/source/_remoteClient/localMachine.py
@@ -112,7 +112,12 @@ class LocalMachine:
 		self._cachedSizes: Optional[List[int]] = None
 		"""Cached braille display sizes from remote machines"""
 
+		self._showingLocalUiMessage: bool = False
+		self._oldReceivingBraille: bool = False
+
 		braille.decide_enabled.register(self.handleDecideEnabled)
+		braille._pre_showBrailleMessage.register(self._handleShowBrailleMessage)
+		braille._post_dismissBrailleMessage.register(self._handleDismissBrailleMessage)
 
 	def terminate(self) -> None:
 		"""Clean up resources when the local machine controller is terminated.
@@ -254,7 +259,19 @@ class LocalMachine:
 
 		:return: False if receiving remote braille, True otherwise
 		"""
-		return not self.receivingBraille
+		return not self.receivingBraille or self._showingLocalUiMessage
+
+	def _handleShowBrailleMessage(self):
+		tones.beep(750, 100)
+		self._showingLocalUiMessage = True
+		self._oldReceivingBraille, self.receivingBraille = self.receivingBraille, False
+		braille.handler.enabled
+
+	def _handleDismissBrailleMessage(self):
+		tones.beep(250, 100)
+		self._showingLocalUiMessage = False
+		self.receivingBraille = self._oldReceivingBraille
+		braille.handler.enabled
 
 	def sendKey(
 		self,

--- a/source/_remoteClient/localMachine.py
+++ b/source/_remoteClient/localMachine.py
@@ -274,13 +274,10 @@ class LocalMachine:
 		return not self.receivingBraille or self._showingLocalUiMessage
 
 	def _handleDecideDisabledIncludesMessages(self) -> bool:
-		"""Determine if the local braille display should be enabled.
+		"""Determine if the local display being disabled should exclude ui.message.
 
-		:return: False if receiving remote braille, True otherwise
+		:return: ``True`` if we should block UI messages; ``False`` if we should let them show.
 		"""
-		log.info(
-			f"Deciding if disabled braille includes messages. {self.receivingBraille=} returning {not self.receivingBraille}",
-		)
 		return not self.receivingBraille
 
 	def _handleShowBrailleMessage(self):

--- a/source/_remoteClient/localMachine.py
+++ b/source/_remoteClient/localMachine.py
@@ -114,6 +114,7 @@ class LocalMachine:
 
 		self._showingLocalUiMessage: bool = False
 		self._oldReceivingBraille: bool = False
+		self._lastCells: list[int] = []
 
 		braille.decide_enabled.register(self.handleDecideEnabled)
 		braille._pre_showBrailleMessage.register(self._handleShowBrailleMessage)
@@ -214,6 +215,7 @@ class LocalMachine:
 			and len(cells) <= braille.handler.displaySize
 		):
 			cells = cells + [0] * (braille.handler.displaySize - len(cells))
+			self._lastCells = cells
 			wx.CallAfter(braille.handler._writeCells, cells)
 
 	def brailleInput(self, **kwargs: Dict[str, Any]) -> None:
@@ -272,6 +274,7 @@ class LocalMachine:
 		self._showingLocalUiMessage = False
 		self.receivingBraille = self._oldReceivingBraille
 		braille.handler.enabled
+		self.display(self._lastCells)
 
 	def sendKey(
 		self,

--- a/source/_remoteClient/localMachine.py
+++ b/source/_remoteClient/localMachine.py
@@ -300,13 +300,13 @@ class LocalMachine:
 		"""
 		return not self.receivingBraille
 
-	def _handleShowBrailleMessage(self):
+	def _handleShowBrailleMessage(self) -> None:
 		"""Prepare to display a local `ui.message`."""
 		tones.beep(750, 100)
 		self._oldReceivingBraille, self.receivingBraille = self.receivingBraille, False
 		self._showingLocalUiMessage = True
 
-	def _handleDismissBrailleMessage(self):
+	def _handleDismissBrailleMessage(self) -> None:
 		"""Handle returning from showing a local `ui.message`."""
 		tones.beep(250, 100)
 		self.receivingBraille = self._oldReceivingBraille

--- a/source/_remoteClient/localMachine.py
+++ b/source/_remoteClient/localMachine.py
@@ -244,6 +244,9 @@ class LocalMachine:
 			# Cache these cells in case we need them later
 			self._lastCells = cells
 			wx.CallAfter(braille.handler._writeCells, cells)
+		elif not self.receivingBraille and self._showingLocalUiMessage:
+			# Cache this cell array for after the local ui.message is dismissed
+			self._lastCells = cells
 
 	def brailleInput(self, **kwargs: Dict[str, Any]) -> None:
 		"""Process braille input gestures from a remote machine.

--- a/source/_remoteClient/localMachine.py
+++ b/source/_remoteClient/localMachine.py
@@ -311,6 +311,12 @@ class LocalMachine:
 		self.receivingBraille = self._oldReceivingBraille
 		self.display(self._lastCells)
 
+	def _dismissLocalBrailleMessage(self) -> None:
+		"""Dismiss a local ``ui.message``, if one is being shown."""
+		if not self._showingLocalUiMessage:
+			return
+		braille.handler._dismissMessage()
+
 	def sendKey(
 		self,
 		vk_code: Optional[int] = None,

--- a/source/_remoteClient/localMachine.py
+++ b/source/_remoteClient/localMachine.py
@@ -302,16 +302,13 @@ class LocalMachine:
 
 	def _handleShowBrailleMessage(self) -> None:
 		"""Prepare to display a local `ui.message`."""
-		tones.beep(750, 100)
 		self._oldReceivingBraille, self.receivingBraille = self.receivingBraille, False
 		self._showingLocalUiMessage = True
 
 	def _handleDismissBrailleMessage(self) -> None:
 		"""Handle returning from showing a local `ui.message`."""
-		tones.beep(250, 100)
-		self.receivingBraille = self._oldReceivingBraille
 		self._showingLocalUiMessage = False
-		braille.handler.enabled
+		self.receivingBraille = self._oldReceivingBraille
 		self.display(self._lastCells)
 
 	def sendKey(

--- a/source/_remoteClient/session.py
+++ b/source/_remoteClient/session.py
@@ -620,7 +620,6 @@ class LeaderSession(RemoteSession):
 		from globalCommands import commands
 
 		if isinstance(gesture, (braille.BrailleDisplayGesture, brailleInput.BrailleInputGesture)):
-			log.info(f"{gesture=}; {gesture.script=}; {self.localMachine._showingLocalUiMessage=}")
 			if self.localMachine._showingLocalUiMessage and gesture.script in (
 				commands.script_braille_routeTo,
 				commands.script_braille_scrollBack,

--- a/source/_remoteClient/session.py
+++ b/source/_remoteClient/session.py
@@ -621,15 +621,12 @@ class LeaderSession(RemoteSession):
 		from globalCommands import commands
 
 		if isinstance(gesture, (braille.BrailleDisplayGesture, brailleInput.BrailleInputGesture)):
-			if self.localMachine._showingLocalUiMessage:
-				if gesture.script in (
-					commands.script_braille_routeTo,
-					commands.script_braille_scrollBack,
-					commands.script_braille_scrollForward,
-				):
-					return True
-				else:
-					braille.handler._dismissMessage()
+			if self.localMachine._showingLocalUiMessage and gesture.script in (
+				commands.script_braille_routeTo,
+				commands.script_braille_scrollBack,
+				commands.script_braille_scrollForward,
+			):
+				return True
 			dict = {
 				key: gesture.__dict__[key]
 				for key in gesture.__dict__
@@ -670,6 +667,7 @@ class LeaderSession(RemoteSession):
 				dict["space"] = gesture.space
 			if hasattr(gesture, "routingIndex") and "routingIndex" not in dict:
 				dict["routingIndex"] = gesture.routingIndex
+			self.localMachine._dismissLocalBrailleMessage()
 			self.transport.send(type=RemoteMessageType.BRAILLE_INPUT, **dict)
 			return False
 		else:

--- a/source/_remoteClient/session.py
+++ b/source/_remoteClient/session.py
@@ -621,12 +621,15 @@ class LeaderSession(RemoteSession):
 		from globalCommands import commands
 
 		if isinstance(gesture, (braille.BrailleDisplayGesture, brailleInput.BrailleInputGesture)):
-			if self.localMachine._showingLocalUiMessage and gesture.script in (
-				commands.script_braille_routeTo,
-				commands.script_braille_scrollBack,
-				commands.script_braille_scrollForward,
-			):
-				return True
+			if self.localMachine._showingLocalUiMessage:
+				if gesture.script in (
+					commands.script_braille_routeTo,
+					commands.script_braille_scrollBack,
+					commands.script_braille_scrollForward,
+				):
+					return True
+				else:
+					braille.handler._dismissMessage()
 			dict = {
 				key: gesture.__dict__[key]
 				for key in gesture.__dict__

--- a/source/_remoteClient/session.py
+++ b/source/_remoteClient/session.py
@@ -626,7 +626,6 @@ class LeaderSession(RemoteSession):
 				commands.script_braille_scrollBack,
 				commands.script_braille_scrollForward,
 			):
-				tones.beep(500, 100)
 				return True
 			dict = {
 				key: gesture.__dict__[key]

--- a/source/_remoteClient/session.py
+++ b/source/_remoteClient/session.py
@@ -617,7 +617,17 @@ class LeaderSession(RemoteSession):
 		:return: False if gesture was processed and sent, True otherwise
 		:note: Extracts gesture details and script info before sending
 		"""
+		from globalCommands import commands
+
 		if isinstance(gesture, (braille.BrailleDisplayGesture, brailleInput.BrailleInputGesture)):
+			log.info(f"{gesture=}; {gesture.script=}; {self.localMachine._showingLocalUiMessage=}")
+			if self.localMachine._showingLocalUiMessage and gesture.script in (
+				commands.script_braille_routeTo,
+				commands.script_braille_scrollBack,
+				commands.script_braille_scrollForward,
+			):
+				tones.beep(500, 100)
+				return True
 			dict = {
 				key: gesture.__dict__[key]
 				for key in gesture.__dict__

--- a/source/_remoteClient/session.py
+++ b/source/_remoteClient/session.py
@@ -617,6 +617,7 @@ class LeaderSession(RemoteSession):
 		:return: False if gesture was processed and sent, True otherwise
 		:note: Extracts gesture details and script info before sending
 		"""
+		# Import late to avoid circular import
 		from globalCommands import commands
 
 		if isinstance(gesture, (braille.BrailleDisplayGesture, brailleInput.BrailleInputGesture)):

--- a/source/braille.py
+++ b/source/braille.py
@@ -2708,7 +2708,6 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 	def _refreshEnabled(self, block: bool = False) -> None:
 		currentEnabled = bool(self.displaySize) and decide_enabled.decide()
 		if self._enabled != currentEnabled:
-			log.info(f"{self._enabled=}, {currentEnabled=}")
 			self._enabled = currentEnabled
 			if currentEnabled is False:
 				if block:
@@ -2716,7 +2715,6 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 
 					wxCallOnMain(self._handleEnabledDecisionFalse)
 				else:
-					log.info("Queueing handleEnabledDecisionFalse.", stack_info=True)
 					wx.CallAfter(self._handleEnabledDecisionFalse)
 
 	def _set_enabled(self, value):
@@ -2728,7 +2726,6 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 		"""When a decider handler decides to disable the braille handler, ensure braille doesn't continue.
 		This should be called from the main thread to avoid wx assertions.
 		"""
-		log.info("Handle enabled decision false called.", stack_info=True)
 		if self._cursorBlinkTimer:
 			# A blinking cursor should be stopped
 			self._cursorBlinkTimer.Stop()
@@ -3030,7 +3027,6 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 		@precondition: A message is currently being displayed.
 		@postcondition: The display returns to the main buffer.
 		"""
-		log.info("Dismiss message called.", stack_info=True)
 		self.buffer.clear()
 		self.buffer = self.mainBuffer
 		if self._messageCallLater:

--- a/source/braille.py
+++ b/source/braille.py
@@ -74,6 +74,7 @@ from winAPI.secureDesktop import post_secureDesktopStateChange
 from textUtils import isUnicodeNormalized, UnicodeNormalizationOffsetConverter
 import hwIo
 from editableText import EditableText
+from gui.guiHelper import wxCallOnMain
 
 if TYPE_CHECKING:
 	from NVDAObjects import NVDAObject
@@ -2711,8 +2712,6 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 			self._enabled = currentEnabled
 			if currentEnabled is False:
 				if block:
-					from gui.guiHelper import wxCallOnMain
-
 					wxCallOnMain(self._handleEnabledDecisionFalse)
 				else:
 					wx.CallAfter(self._handleEnabledDecisionFalse)

--- a/source/braille.py
+++ b/source/braille.py
@@ -2396,6 +2396,9 @@ the local braille handler should be disabled as long as the system is in control
 Handlers are called without arguments.
 """
 
+_pre_showBrailleMessage = extensionPoints.Action()
+_post_dismissBrailleMessage = extensionPoints.Action()
+
 
 class BrailleHandler(baseObject.AutoPropertyObject):
 	# TETHER_AUTO, TETHER_FOCUS, TETHER_REVIEW and tetherValues
@@ -2960,6 +2963,7 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 		If a key is pressed the message will be dismissed by the next text being written to the display.
 		@postcondition: The message is displayed.
 		"""
+		_pre_showBrailleMessage.notify()
 		if (
 			not self.enabled
 			or config.conf["braille"]["showMessages"] == ShowMessages.DISABLED
@@ -3005,6 +3009,7 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 			self._messageCallLater = None
 		if shouldUpdate:
 			self.update()
+		_post_dismissBrailleMessage.notify()
 
 	def handleGainFocus(self, obj: "NVDAObject", shouldAutoTether: bool = True) -> None:
 		if not self.enabled or config.conf["braille"]["mode"] == BrailleMode.SPEECH_OUTPUT.value:

--- a/source/braille.py
+++ b/source/braille.py
@@ -2706,7 +2706,16 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 		self._refreshEnabled()
 		return self._enabled
 
-	def _refreshEnabled(self, block: bool = False) -> None:
+	def _refreshEnabled(self, *, block: bool = False) -> None:
+		"""Refresh the state of the enabled property.
+
+		If it has gone from ``True`` to ``False``,
+		actions such as dismissing the current message (if any),
+		and clearing the cursor blink interval are performed.
+		These actions are performed synchronously or asynchronously depending on the value of :param:`block`.
+
+		:param block: Whether this operation should be blocking, defaults to False
+		"""
 		currentEnabled = bool(self.displaySize) and decide_enabled.decide()
 		if self._enabled != currentEnabled:
 			self._enabled = currentEnabled

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -41,6 +41,7 @@ We recommend using Windows 11, or if that is not possible, the latest Windows 10
 * Added a button to the About dialog to copy the NVDA version number to the clipboard. (#18667)
 * When entering a secure desktop, an installed copy of NVDA will automatically disable Braille temporarily, so that the secure desktop copy can access the braille display. (#2315, @LeonarddeR)
 * The length of beeps used when "Line indentation reporting" is set to "Tones" or "Both Speech and Tones" has been reduced. (#18898)
+* When controlling a computer via Remote Access with a braille display connected, messages spoken from the local computer are also shown in braille. (#18004)
 * Component updates:
   * Updated LibLouis Braille translator to [3.35.0](https://github.com/liblouis/liblouis/releases/tag/v3.35.0). (#18848, @LeonarddeR)
     * Added Japanese (Rokuten Kanji) Braille.


### PR DESCRIPTION
### Link to issue number:

Fixes #18004

### Summary of the issue:

Currently, when controlling a remote computer via NVDA Remote Access, messages emitted via `ui.message` on the local computer are not displayed on the refreshable braille display. This is problematic because Remote Access outputs some status messages via `ui.message`, and this bug means that braille-only users are unable to perceive these messages.

### Description of user facing changes:

These messages are now shown in braille.

### Description of developer facing changes:

None.

### Description of development approach:

* Add `_pre_showBrailleMessage`, `_post_dismissBrailleMessage` and `_decide_disabledIncludesMessage` extension points.
* Allow `BrailleHandler.message` to show a message if `enabled` is `False` and `_decide_disabledIncludesMessage.decide()` is also `False`.
* Set Remote Access to not receive braille when showing a `ui.message`, as detected by the aforementioned extension points.
* Temporarily enable `braille.handler` when showing a ui.message, as detected by the aforementioned extension points.
* Process braille display scrolling and routing locally when showing a `ui.message`, as these keys are used to pan through and dismiss the message.
* Add a `hostPendingNonmodifier` attribute to `_RemoteClient.client.RemoteClient`, to track the non-modifier key of the toggle gesture.
* When processing key input, also block the `hostPendingNonmodifier` from being sent.
* When controlling the remote computer, dismiss a `ui.message` shown by the local computer on keyboard or braille display input.
  * This input is also sent to the remote computer, unlike routing or panning keys if a local message is being shown.

### Testing strategy:

Ensure that the "Controlling remote computer" message can be read and interacted with in braille.

Trigger local `ui.message` while controlling the remote computer (via `wx.CallLater` in the NVDA Python Console), and ensure the message can be read and interacted with in braille. Did this with short and long messages (to ensure panning works).

Performed these tests with "Show messages" set to "Use timeout", "Show indefinitely" and "Disabled" (in the latter case confirming that messages weren't shown).

### Known issues with pull request:

The display contents changing on the remote computer does not cause the message to be dismissed. This is because we cannot tell the difference between a contentful display change, and something like the cursor flashing.

Some users may prefer the old behaviour. We could possibly make this configurable, though I think doing so may be premature since we don't know if users will want the option.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
