### PR TITLE
Avoid runing AI image descriptions while screen curtain is enabled

### DIFF
--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -5104,6 +5104,7 @@ class GlobalCommands(ScriptableObject):
 		category=SCRCAT_IMAGE_DESC,
 		gesture="kb:NVDA+windows+,",
 	)
+	@gui.blockAction.when(gui.blockAction.Context.SCREEN_CURTAIN, gui.blockAction.Context.WINDOWS_LOCKED)
 	def script_runCaption(self, gesture: "inputCore.InputGesture"):
 		_localCaptioner._localCaptioner.runCaption(gesture)
 
@@ -5112,6 +5113,7 @@ class GlobalCommands(ScriptableObject):
 		description=pgettext("imageDesc", "Toggle image captioning"),
 		category=SCRCAT_IMAGE_DESC,
 	)
+	@gui.blockAction.when(gui.blockAction.Context.SCREEN_CURTAIN, gui.blockAction.Context.WINDOWS_LOCKED)
 	def script_toggleImageCaptioning(self, gesture: "inputCore.InputGesture"):
 		_localCaptioner._localCaptioner.toggleImageCaptioning(gesture)
 

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -5104,7 +5104,7 @@ class GlobalCommands(ScriptableObject):
 		category=SCRCAT_IMAGE_DESC,
 		gesture="kb:NVDA+windows+,",
 	)
-	@gui.blockAction.when(gui.blockAction.Context.SCREEN_CURTAIN, gui.blockAction.Context.WINDOWS_LOCKED)
+	@gui.blockAction.when(gui.blockAction.Context.SCREEN_CURTAIN)
 	def script_runCaption(self, gesture: "inputCore.InputGesture"):
 		_localCaptioner._localCaptioner.runCaption(gesture)
 
@@ -5113,7 +5113,7 @@ class GlobalCommands(ScriptableObject):
 		description=pgettext("imageDesc", "Toggle image captioning"),
 		category=SCRCAT_IMAGE_DESC,
 	)
-	@gui.blockAction.when(gui.blockAction.Context.SCREEN_CURTAIN, gui.blockAction.Context.WINDOWS_LOCKED)
+	@gui.blockAction.when(gui.blockAction.Context.SCREEN_CURTAIN)
 	def script_toggleImageCaptioning(self, gesture: "inputCore.InputGesture"):
 		_localCaptioner._localCaptioner.toggleImageCaptioning(gesture)
 

--- a/source/gui/blockAction.py
+++ b/source/gui/blockAction.py
@@ -39,6 +39,18 @@ def _isRemoteAccessDisabled() -> bool:
 	return not remoteRunning()
 
 
+def _isScreenCurtainEnabled() -> bool:
+	"""Whether screen curtain functionality is **enabled**."""
+	# Import late to avoid circular import
+	import vision
+	from visionEnhancementProviders.screenCurtain import ScreenCurtainProvider
+
+	screenCurtainId = ScreenCurtainProvider.getSettings().getId()
+	screenCurtainProviderInfo = vision.handler.getProviderInfo(screenCurtainId)
+	isScreenCurtainRunning = bool(vision.handler.getProviderInstance(screenCurtainProviderInfo))
+	return isScreenCurtainRunning
+
+
 @dataclass
 class _Context:
 	blockActionIf: Callable[[], bool]
@@ -85,6 +97,11 @@ class Context(_Context, Enum):
 		_isRemoteAccessDisabled,
 		# Translators: Reported when an action cannot be performed because Remote Access functionality is disabled.
 		pgettext("remote", "Action unavailable when Remote Access is disabled"),
+	)
+	SCREEN_CURTAIN = (
+		lambda: _isScreenCurtainEnabled(),
+		# Translators: Reported when an action cannot be performed because screen curtain is enabled.
+		_("Action unavailable while screen curtain is enabled"),
 	)
 
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
<!-- Use Closes/Fixes/Resolves #xxx to link this PR to the issue it is responding to. -->
Fixes #19045
### Summary of the issue:
Image Description not disabled while Screen Curtain is enabled 
### Description of user facing changes:
Users will be notified that AI image description is unavailable when they try to use it while the screen curtain is enabled.
### Description of developer facing changes:
The item of SCREEN_CURTAIN is added to `gui.blockAction.Context` ,  developers can use it in decoration to avoid actions when screen curtain is enabled.
### Description of development approach:
None
### Testing strategy:
Use AI image descriptions wile screen curtain is enabled.
### Known issues with pull request:
None
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
