### PR TITLE
Fix freeze   when locking / unlocking user session in Windows

### DIFF
--- a/source/winUser.py
+++ b/source/winUser.py
@@ -554,7 +554,8 @@ def isDescendantWindow(parentHwnd, childHwnd):
 
 
 def getForegroundWindow() -> HWNDVal:
-	return _user32.GetForegroundWindow()
+	hwnd = _user32.GetForegroundWindow()
+	return hwnd or 0
 
 
 def setForegroundWindow(hwnd):
@@ -566,7 +567,8 @@ def setFocus(hwnd):
 
 
 def getDesktopWindow() -> HWNDVal:
-	return _user32.GetDesktopWindow()
+	hwnd = _user32.GetDesktopWindow()
+	return hwnd or 0
 
 
 def getControlID(hwnd):
@@ -617,8 +619,9 @@ def mouse_event(*args):
 	return _user32.mouse_event(*args)
 
 
-def getAncestor(hwnd, flags):
-	return _user32.GetAncestor(hwnd, flags)
+def getAncestor(hwnd: HWNDVal, flags: int) -> HWNDVal:
+	hwnd = _user32.GetAncestor(hwnd, flags)
+	return hwnd or 0
 
 
 def setCursorPos(x, y):
@@ -637,8 +640,9 @@ def getCaretPos():
 	return [point.x, point.y]
 
 
-def getTopWindow(hwnd):
-	return _user32.GetTopWindow(hwnd)
+def getTopWindow(hwnd: HWNDVal) -> HWNDVal:
+	hwnd = _user32.GetTopWindow(hwnd)
+	return hwnd or 0
 
 
 def getWindowText(hwnd):
@@ -647,8 +651,9 @@ def getWindowText(hwnd):
 	return buf.value
 
 
-def getWindow(window, relation):
-	return _user32.GetWindow(window, relation)
+def getWindow(window: HWNDVal , relation: int) -> HWNDVal:
+	hwnd = _user32.GetWindow(window, relation)
+	return hwnd or 0
 
 
 def isWindowVisible(window):
@@ -681,11 +686,12 @@ def SetLayeredWindowAttributes(hwnd, key, alpha, flags):
 	return _user32.SetLayeredWindowAttributes(hwnd, key, alpha, flags)
 
 
-def getPreviousWindow(hwnd):
+def getPreviousWindow(hwnd: HWNDVal) -> HWNDVal:
 	try:
-		return _user32.GetWindow(hwnd, GW_HWNDPREV)
+		hwnd = _user32.GetWindow(hwnd, GW_HWNDPREV)
 	except WindowsError:
 		return 0
+	return hwnd or 0
 
 
 def getKeyboardLayout(idThread=0):

--- a/source/winUser.py
+++ b/source/winUser.py
@@ -651,7 +651,7 @@ def getWindowText(hwnd):
 	return buf.value
 
 
-def getWindow(window: HWNDVal , relation: int) -> HWNDVal:
+def getWindow(window: HWNDVal, relation: int) -> HWNDVal:
 	hwnd = _user32.GetWindow(window, relation)
 	return hwnd or 0
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
<!-- Use Closes/Fixes/Resolves #xxx to link this PR to the issue it is responding to. -->
Fixes #19037

### Summary of the issue:
After switching to 64 bit,  when locking the user session with windows+l, or when cuming out of the lock screen, NVDA will freeze and become unusable. It was necessary to restart NVDA.

This was caused by NVDA going into an infinit loop when trying to detect if a given window was above or below the lock screen.  A loop would be calling winUser.GetWindow, and breaking when the window equals GWL_NOT_FOUND (0). However,  after switching to 64 bit, the value from winUser.getWindow when there was no window, was now None, not 0, so it never matched and the loop continued for ever.

winUser.getwindow internally calls user32's GetWindow, which with our new tightened winBindings ctypes definitions, was defined to return HWND, rather than just a default long. Problem is that ctypes always converts NULL pointers (including HWND) to None on return.
 
### Description of user facing changes:

### Description of developer facing changes:

### Description of development approach:
for all functions in our high-level winUser module that return a window handle,  ensure that 0 is returned instead of None if a null HWND is being returned. This keeps these high-level functions compatible with existing code, and therefore no longer breaks lock screen detection logic. Also add type hints for params and return for these particular functions.

### Testing strategy:
* [x] General smoke test of an installed signed binary copy.
* [x] With an installed signed binary copy running: Lock with windows+l. Verify that object navigation works within the lock screen and cannot escape.  Dismiss the lock screen and log back into Windows,  and verify that NVDA is still functional.

### Known issues with pull request:
None known.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
