### PR TITLE
Fix 64-bit uninstaller

### DIFF
--- a/uninstaller/uninst.nsi
+++ b/uninstaller/uninst.nsi
@@ -75,6 +75,7 @@ System::Call 'kernel32::GetUserDefaultUILanguage() i .r0'
 StrCmp $0 "3076" 0 +2
 StrCpy $0 "1028"
 StrCpy $LANGUAGE $0
+SetRegView 64
 ReadRegStr $INSTDIR ${INSTDIR_REG_ROOT} "${INSTDIR_REG_KEY}" "InstallDir"
 FunctionEnd
 


### PR DESCRIPTION
### Link to issue number:

Fixes #19029

### Summary of the issue:

The uninstaller for 64-bit builds of NVDA doesn't work.

### Description of user facing changes:

The uninstaller works again.

### Description of developer facing changes:

None.

### Description of development approach:

Tell NSIS that the NVDA install path should be retrieved from a 64-bit view of the registry.

### Testing strategy:

Build a launcher. Install it in Windows Sandbox. Uninstall it.

### Known issues with pull request:

None.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
