### PR TITLE
Copy the system config when updating from 32- to 64-bit NVDA

### DIFF
--- a/source/config/__init__.py
+++ b/source/config/__init__.py
@@ -318,10 +318,10 @@ def setSystemConfigToCurrentConfig():
 			raise RuntimeError("Slave failure")
 
 
-def _setSystemConfig(fromPath):
+def _setSystemConfig(fromPath, *, prefix=sys.prefix):
 	import installer
 
-	toPath = os.path.join(sys.prefix, "systemConfig")
+	toPath = os.path.join(prefix, "systemConfig")
 	log.debug("Copying config to systemconfig dir: %s", toPath)
 	if os.path.isdir(toPath):
 		installer.tryRemoveFile(toPath)

--- a/source/installer.py
+++ b/source/installer.py
@@ -923,6 +923,9 @@ def install(shouldCreateDesktopShortcut: bool = True, shouldRunAtLogon: bool = T
 		NVDAState._configInLocalAppDataEnabled(),
 	)
 	if shouldCleanX86:
+		oldSystemConfigPath = os.path.join(installDirX86, "systemConfig")
+		if os.path.isdir(oldSystemConfigPath):
+			config._setSystemConfig(oldSystemConfigPath, prefix=installDir)
 		tryRemoveFile(installDirX86, rebootOK=True)
 	COMRegistrationFixes.fixCOMRegistrations()
 


### PR DESCRIPTION
### Link to issue number:

Fixes #19022

### Summary of the issue:

When updating frm 32-bit NVDA to 64-bit NVDA, the system config is lost.

### Description of user facing changes:

The system config is retained when updating from 32- to 64-bit NVDA.

### Description of developer facing changes:

None

### Description of development approach:

Add a keyword-only parameter, `prefix`, to `config._setSystemConfig`, which by default is set to `sys.prefix` so as not to break existing callers.
In the installer, if `shouldCleanX86` is `True` and the x86 copy has a `systemConfig` directory, use `config._setSystemConfig` to copy the 32-bit copy's system config to the 64-bit directory before deleting the 32-bit copy's directory.

### Testing strategy:

Installed nvda_snapshot_alpha-52864,2772fde8. Changed the user configuration, and used the "Use currently saved settings during sign-in and on secure screens (requires administrator privileges)" button to copy the config to the system profile. Checked that the expected files were in `C:\Program Files (x86)\nvda\systemConfig`.

Ran a launcher built from this branch. Installed NVDA. Checked that the same contents were present in `C:\Program Files\nvda\systemConfig`.

Performed the abovesteps, but without changing the system config, and ensured that the upgrade process worked as expected and no `systemConfig` directory was created.

### Known issues with pull request:

None

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
