### PR TITLE
Fix liblouis access violation errors

### DIFF
--- a/source/louisHelper.py
+++ b/source/louisHelper.py
@@ -145,7 +145,13 @@ def terminate():
 	louis.liblouis.lou_free()
 
 
-def translate(tableList, inbuf, typeform=None, cursorPos=None, mode=0):
+def translate(
+	tableList: list[str],
+	inbuf: str,
+	typeform: list[int] | None = None,
+	cursorPos: int | None = None,
+	mode: int = 0,
+) -> tuple[list[int], list[int], list[int], int | None]:
 	"""
 	Convenience wrapper for louis.translate that:
 	* returns a list of integers instead of a string with cells, and

--- a/source/louisHelper.py
+++ b/source/louisHelper.py
@@ -94,6 +94,8 @@ def _resolveTable(tablesList: bytes, base: bytes | None) -> int | None:
 	except LookupError:
 		log.exception()
 		return None
+	# Terminate the list of paths
+	paths.append(None)
 	if _isDebug():
 		log.debug(f"Storing paths in an array of {len(paths)} null terminated strings")
 	# Keeping a reference to the last returned value to ensure the returned

--- a/source/louisHelper.py
+++ b/source/louisHelper.py
@@ -97,7 +97,9 @@ def _resolveTable(tablesList: bytes, base: bytes | None) -> int | None:
 	# Terminate the list of paths
 	paths.append(None)
 	if _isDebug():
-		log.debug(f"Storing paths in an array of {len(paths)} null terminated strings")
+		log.debug(
+			f"Storing paths in a null terminated array of length {len(paths)} with null terminated strings",
+		)
 	# Keeping a reference to the last returned value to ensure the returned
 	# value is not GC'ed before it is copied on liblouis' side.
 	_resolveTable._lastRes = arr = (c_char_p * len(paths))(*paths)

--- a/source/louisHelper.py
+++ b/source/louisHelper.py
@@ -1,7 +1,7 @@
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-# Copyright (C) 2018-2024 NV Access Limited, Babbage B.V., Julien Cochuyt, Leonard de Ruijter
+# Copyright (C) 2018-2025 NV Access Limited, Babbage B.V., Julien Cochuyt, Leonard de Ruijter
 
 """Helper module to ease communication to and from liblouis."""
 

--- a/tests/unit/test_brailleTables.py
+++ b/tests/unit/test_brailleTables.py
@@ -2,7 +2,7 @@
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-# Copyright (C) 2018-2019 NV Access Limited, Babbage B.V.
+# Copyright (C) 2018-2025 NV Access Limited, Babbage B.V., Leonard de Ruijter
 
 """Unit tests for the brailleTables module."""
 

--- a/tests/unit/test_brailleTables.py
+++ b/tests/unit/test_brailleTables.py
@@ -8,23 +8,38 @@
 
 import unittest
 import brailleTables
+import louisHelper
 import os.path
 
 
-class TestFBrailleTables(unittest.TestCase):
+class TestBrailleTables(unittest.TestCase):
 	"""Tests for braille table files and their existence."""
 
 	def test_tableExistence(self):
 		"""Tests whether all defined tables exist."""
 		tables = brailleTables.listTables()
 		for table in tables:
-			self.assertTrue(
-				os.path.isfile(os.path.join(brailleTables.TABLES_DIR, table.fileName)),
-				msg="{table} table not found".format(table=table.displayName),
-			)
+			with self.subTest(table=table.fileName):
+				self.assertTrue(
+					os.path.isfile(os.path.join(brailleTables.TABLES_DIR, table.fileName)),
+					msg="{table} table not found".format(table=table.displayName),
+				)
 
 	def test_renamedTableExistence(self):
 		"""Tests whether all defined renamed tables are part of the actual list of tables."""
 		tableNames = [table.fileName for table in brailleTables.listTables()]
 		for name in brailleTables.RENAMED_TABLES.values():
-			self.assertIn(name, tableNames)
+			with self.subTest(name=name):
+				self.assertIn(name, tableNames)
+
+
+class TestTranslate(unittest.TestCase):
+	"""Ensures that all tables can be used for translation."""
+
+	def test_translate(self):
+		tables = brailleTables.listTables()
+		for table in tables:
+			if not table.output:
+				continue
+			with self.subTest(table=table.fileName):
+				louisHelper.translate([table.fileName, "braille-patterns.cti"], "test")

--- a/tests/unit/test_brailleTables.py
+++ b/tests/unit/test_brailleTables.py
@@ -8,6 +8,7 @@
 
 import unittest
 import brailleTables
+import louis
 import louisHelper
 import os.path
 
@@ -37,9 +38,25 @@ class TestTranslate(unittest.TestCase):
 	"""Ensures that all tables can be used for translation."""
 
 	def test_translate(self):
+		"""Tests whether all tables can be used for translation."""
 		tables = brailleTables.listTables()
 		for table in tables:
 			if not table.output:
 				continue
 			with self.subTest(table=table.fileName):
-				louisHelper.translate([table.fileName, "braille-patterns.cti"], "test")
+				try:
+					louisHelper.translate([table.fileName, "braille-patterns.cti"], "test")
+				except Exception as e:
+					self.fail(f"Translation failed for {table.displayName}: {e}")
+
+	def test_backtranslate(self):
+		"""Tests whether all tables can be used for back-translation."""
+		tables = brailleTables.listTables()
+		for table in tables:
+			if not table.input:
+				continue
+			with self.subTest(table=table.fileName):
+				try:
+					louis.backTranslate([table.fileName, "braille-patterns.cti"], "⠞⠑⠎⠞")
+				except Exception as e:
+					self.fail(f"Back-translation failed for {table.displayName}: {e}")

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -57,7 +57,7 @@ We recommend using Windows 11, or if that is not possible, the latest Windows 10
 * Fixed a problem where some SAPI 4 voices (e.g. IBM ViaVoice) start speaking in the maximum volume instead of the current volume when speaking capital letters. (#18866, @gexgd0419)
 * NVDA no longer fails to read the contents of wx Web View controls. (#17273, @LeonarddeR)
 * When NVDA is configured to update add-ons automatically in the background, add-ons can be properly updated. (#18965, @nvdaes)
-* Fixed a case that became more prevalent in 64 -bit NVDA where braille output would fail with an error. (#19025, @LeonarddeR)
+* Fixed a case where braille output would fail with an error. (#19025, @LeonarddeR)
 
 ### Changes for Developers
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -57,6 +57,7 @@ We recommend using Windows 11, or if that is not possible, the latest Windows 10
 * Fixed a problem where some SAPI 4 voices (e.g. IBM ViaVoice) start speaking in the maximum volume instead of the current volume when speaking capital letters. (#18866, @gexgd0419)
 * NVDA no longer fails to read the contents of wx Web View controls. (#17273, @LeonarddeR)
 * When NVDA is configured to update add-ons automatically in the background, add-ons can be properly updated. (#18965, @nvdaes)
+* Fixed a case that became more prevalent in 64 -bit NVDA were braille output would fail with an error. (#19025 , @LeonarddeR)
 
 ### Changes for Developers
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -57,7 +57,7 @@ We recommend using Windows 11, or if that is not possible, the latest Windows 10
 * Fixed a problem where some SAPI 4 voices (e.g. IBM ViaVoice) start speaking in the maximum volume instead of the current volume when speaking capital letters. (#18866, @gexgd0419)
 * NVDA no longer fails to read the contents of wx Web View controls. (#17273, @LeonarddeR)
 * When NVDA is configured to update add-ons automatically in the background, add-ons can be properly updated. (#18965, @nvdaes)
-* Fixed a case that became more prevalent in 64 -bit NVDA were braille output would fail with an error. (#19025 , @LeonarddeR)
+* Fixed a case that became more prevalent in 64 -bit NVDA where braille output would fail with an error. (#19025, @LeonarddeR)
 
 ### Changes for Developers
 


### PR DESCRIPTION
### Link to issue number:
Fixes #19025 

### Summary of the issue:
Translation can cause access violations on 64 bit version of NVDA.

### Description of user facing changes:
Errors are hopefully fixed

### Description of developer facing changes:
None

### Description of development approach:
Our table resolver was returning an array of tables, but that array was not terminated with a NULLPTR as expected by liblouis. Added the None/NULLPTR to the end of the array.

### Testing strategy:
Unit tests. The new unit test throws access violations and no longer does so after this patch.

### Known issues with pull request:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
