### PR TITLE
Remove deprecated code from Remote Access

### DIFF
--- a/source/_remoteClient/localMachine.py
+++ b/source/_remoteClient/localMachine.py
@@ -238,9 +238,9 @@ class LocalMachine:
 		if (
 			self.receivingBraille
 			and braille.handler.displaySize > 0
-			and len(cells) <= braille.handler.displaySize
+			and len(cells) <= braille.handler.displayDimensions.numCols
 		):
-			cells = cells + [0] * (braille.handler.displaySize - len(cells))
+			cells = cells + [0] * (braille.handler.displayDimensions.numCols - len(cells))
 			# Cache these cells in case we need them later
 			self._lastCells = cells
 			wx.CallAfter(braille.handler._writeCells, cells)

--- a/source/_remoteClient/localMachine.py
+++ b/source/_remoteClient/localMachine.py
@@ -20,7 +20,7 @@ muting and uses wxPython's CallAfter for thread synchronization.
 
 from enum import IntEnum, nonmember
 import os
-from typing import Any, Dict, List, Optional
+from typing import Any
 import winreg
 
 import winBindings.sas
@@ -126,7 +126,7 @@ class LocalMachine:
 
 		self.receivingBraille = False
 
-		self._cachedSizes: Optional[List[int]] = None
+		self._cachedSizes: list[int] | None = None
 		"""Cached braille display sizes from remote machines"""
 
 		self._showingLocalUiMessage: bool = False
@@ -220,7 +220,7 @@ class LocalMachine:
 		setSpeechCancelledToFalse()
 		wx.CallAfter(speech._manager.speak, sequence, priority)
 
-	def display(self, cells: List[int]) -> None:
+	def display(self, cells: list[int]) -> None:
 		"""Update the local braille display with cells from remote.
 
 		Safely writes braille cells from a remote machine to the local braille
@@ -248,7 +248,7 @@ class LocalMachine:
 			# Cache this cell array for after the local ui.message is dismissed
 			self._lastCells = cells
 
-	def brailleInput(self, **kwargs: Dict[str, Any]) -> None:
+	def brailleInput(self, **kwargs: dict[str, Any]) -> None:
 		"""Process braille input gestures from a remote machine.
 
 		Executes braille input commands locally using NVDA's input gesture system.
@@ -262,7 +262,7 @@ class LocalMachine:
 		except inputCore.NoInputGestureAction:
 			pass
 
-	def setBrailleDisplaySize(self, sizes: List[int]) -> None:
+	def setBrailleDisplaySize(self, sizes: list[int]) -> None:
 		"""Cache remote braille display sizes for size negotiation.
 
 		:param sizes: List of display sizes (cells) from remote machines
@@ -326,9 +326,9 @@ class LocalMachine:
 
 	def sendKey(
 		self,
-		vk_code: Optional[int] = None,
-		extended: Optional[bool] = None,
-		pressed: Optional[bool] = None,
+		vk_code: int | None = None,
+		extended: bool | None = None,
+		pressed: bool | None = None,
 	) -> None:
 		"""Simulate a keyboard event on the local machine.
 

--- a/source/_remoteClient/session.py
+++ b/source/_remoteClient/session.py
@@ -315,8 +315,8 @@ class FollowerSession(RemoteSession):
 			RemoteMessageType.SET_DISPLAY_SIZE,
 			self.setDisplaySize,
 		)
-		braille.filter_displaySize.register(
-			self.localMachine.handleFilterDisplaySize,
+		braille.filter_displayDimensions.register(
+			self.localMachine._handleFilterDisplayDimensions,
 		)
 		self.transport.registerInbound(
 			RemoteMessageType.BRAILLE_INPUT,

--- a/source/_remoteClient/session.py
+++ b/source/_remoteClient/session.py
@@ -396,7 +396,7 @@ class FollowerSession(RemoteSession):
 	def handleClientDisconnected(self, client: dict[str, Any]) -> None:
 		super().handleClientDisconnected(client)
 		if client["connection_type"] == connectionInfo.ConnectionMode.LEADER.value:
-			log.info("Leader client disconnected: %r", client)
+			log.info(f"Leader client disconnected: {client!r}")
 			del self.leaders[client["id"]]
 		elif client["connection_type"] == connectionInfo.ConnectionMode.FOLLOWER.value:
 			self.followers.discard(client["id"])
@@ -407,7 +407,7 @@ class FollowerSession(RemoteSession):
 		self.leaderDisplaySizes = (
 			sizes if sizes else [info.get("braille_numCells", 0) for info in self.leaders.values()]
 		)
-		log.debug("Setting follower display size to: %r", self.leaderDisplaySizes)
+		log.debug(f"Setting follower display size to: {self.leaderDisplaySizes!r}")
 		self.localMachine.setBrailleDisplaySize(self.leaderDisplaySizes)
 
 	def handleBrailleInfo(
@@ -597,11 +597,7 @@ class LeaderSession(RemoteSession):
 		if displayDimensions is None:
 			displayDimensions = braille.handler.displayDimensions
 		displaySize = displayDimensions.numCols
-		log.debug(
-			"Sending braille info to follower - display: %s, width: %d",
-			display.name if display else "None",
-			displaySize,
-		)
+		log.debug(f"Sending braille info to follower - display: {display.name}, width: {displaySize}")
 		self.transport.send(
 			type=RemoteMessageType.SET_BRAILLE_INFO,
 			name=display.name,

--- a/source/_remoteClient/session.py
+++ b/source/_remoteClient/session.py
@@ -590,16 +590,17 @@ class LeaderSession(RemoteSession):
 	def sendBrailleInfo(
 		self,
 		display: braille.BrailleDisplayDriver | None = None,
-		displaySize: int | None = None,
+		displayDimensions: braille.DisplayDimensions | None = None,
 	) -> None:
 		if display is None:
 			display = braille.handler.display
-		if displaySize is None:
-			displaySize = braille.handler.displaySize
+		if displayDimensions is None:
+			displayDimensions = braille.handler.displayDimensions
+		displaySize = displayDimensions.numCols
 		log.debug(
-			"Sending braille info to follower - display: %s, size: %d",
+			"Sending braille info to follower - display: %s, width: %d",
 			display.name if display else "None",
-			displaySize if displaySize else 0,
+			displaySize,
 		)
 		self.transport.send(
 			type=RemoteMessageType.SET_BRAILLE_INFO,


### PR DESCRIPTION
### Link to issue number:

Closes #18831

### Summary of the issue:

Remote Access was using the deprecated `braille.filter_displaySize` extension point.

It was also using `displaySize` instead of `displayDimensions.numCols`, meaning that in the case that a user with a multi-line display was controlling a computer with a single-line display that was wider than the leader's display, braille from the follower would wrap at the width of the leader display. While this would not result in information loss, it was unexpected behaviour.

### Description of user facing changes:

In remote access sessions where one or more users have multi-line braille displays connected, only the width of these displays will be considered when finding the shared display width. For instance, if leader connects with a DotPad (8x20 cells) and follower connects with a Hims Brailleedge 40 (1x40 cells), the display width for the session will be constrained to 20 cells.

### Description of developer facing changes:

None

### Description of development approach:

Replace usage of `braill.filter_displaySize` with `braille.filter_displayDimensions` in `_remoteClient.session`. Also renamed `_remoteClient.localMachine.LocalMachine.handleFilterDisplaySize` to `_handleFilterDisplayDimensions`.

Replace usages of `braille.handler.displaySize` with `braille.handler.displayDimension.numCols` where appropriate in `_remoteClient`.

### Testing strategy:

Created a session in which the leader was using a DotPad and the follower was using a Brailleedge40.

### Known issues with pull request:

Users may desire the existing behaviour of all rows of multi-line displays being considered.

We cannot support multi-line displays over Remote Access without changing the protocol. NV Access does not have a clear policy on when we can change the Remote Access Protocol and in what ways.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
