### PR TITLE
Remote Access: Don't warn about ping messages

### DIFF
--- a/source/_remoteClient/transport.py
+++ b/source/_remoteClient/transport.py
@@ -525,6 +525,9 @@ class TCPTransport(Transport):
 		except ValueError:
 			log.warn(f"Received message with invalid type: {obj!r}")
 			return
+		if messageType is RemoteMessageType.PING:
+			# No handling is required
+			return
 		del obj["type"]
 		extensionPoint = self.inboundHandlers.get(messageType)
 		if not extensionPoint:


### PR DESCRIPTION
### Link to issue number:

Closes #18837

### Summary of the issue:

Remote Access logs a warning when i receives a message with type `ping`:

```log
WARNING - logging.Logger.warn (07:19:52.888) - Thread-3_connector_loop (13428):
Received message with unhandled type: ping {}
```

### Description of user facing changes:

None

### Description of developer facing changes:

No-longer log when `ping` messages are received.

### Description of development approach:

Return early from `_remoteClient.transport.TCPTransport.parse` if a message is received with type `_remoteClient.protocol.RemoteMessageType.PING`.

### Testing strategy:

### Known issues with pull request:

None

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
