### PR TITLE
Improvements to battery reporting script

### DIFF
--- a/source/winAPI/_powerTracking.py
+++ b/source/winAPI/_powerTracking.py
@@ -219,14 +219,14 @@ def _getBatteryInformation(systemPowerStatus: SystemPowerStatus) -> List[str]:
 	if systemPowerStatus.BatteryLifeTime != BATTERY_LIFE_TIME_UNKNOWN:
 		nHours = systemPowerStatus.BatteryLifeTime // SECONDS_PER_HOUR
 		nMinutes = (systemPowerStatus.BatteryLifeTime % SECONDS_PER_HOUR) // SECONDS_PER_MIN
-		
+
 		# Skip if both hours and minutes are zero
 		if nHours == 0 and nMinutes == 0:
 			return text
-		
+
 		hourText = ""
 		minuteText = ""
-		
+
 		# Handle hours - only if greater than 0
 		if nHours > 0:
 			hourText = ngettext(
@@ -236,7 +236,7 @@ def _getBatteryInformation(systemPowerStatus: SystemPowerStatus) -> List[str]:
 				"{hours:d} hours",
 				nHours,
 			).format(hours=nHours)
-		
+
 		# Handle minutes - only if greater than 0
 		if nMinutes > 0:
 			minuteText = ngettext(
@@ -246,7 +246,7 @@ def _getBatteryInformation(systemPowerStatus: SystemPowerStatus) -> List[str]:
 				"{minutes:d} minutes",
 				nMinutes,
 			).format(minutes=nMinutes)
-		
+
 		# Combine hours and minutes appropriately
 		if hourText and minuteText:
 			text.append(

--- a/source/winAPI/_powerTracking.py
+++ b/source/winAPI/_powerTracking.py
@@ -218,24 +218,48 @@ def _getBatteryInformation(systemPowerStatus: SystemPowerStatus) -> List[str]:
 	SECONDS_PER_MIN = 60
 	if systemPowerStatus.BatteryLifeTime != BATTERY_LIFE_TIME_UNKNOWN:
 		nHours = systemPowerStatus.BatteryLifeTime // SECONDS_PER_HOUR
-		hourText = ngettext(
-			# Translators: This is the hour string part of the estimated remaining runtime of the laptop battery.
-			# E.g. if the full string is "1 hour and 34 minutes remaining", this string is "1 hour".
-			"{hours:d} hour",
-			"{hours:d} hours",
-			nHours,
-		).format(hours=nHours)
 		nMinutes = (systemPowerStatus.BatteryLifeTime % SECONDS_PER_HOUR) // SECONDS_PER_MIN
-		minuteText = ngettext(
-			# Translators: This is the minute string part of the estimated remaining runtime of the laptop battery.
-			# E.g. if the full string is "1 hour and 34 minutes remaining", this string is "34 minutes".
-			"{minutes:d} minute",
-			"{minutes:d} minutes",
-			nMinutes,
-		).format(minutes=nMinutes)
-		text.append(
-			# Translators: This is the main string for the estimated remaining runtime of the laptop battery.
-			# E.g. hourText is replaced by "1 hour" and minuteText by "34 minutes".
-			_("{hourText} and {minuteText} remaining").format(hourText=hourText, minuteText=minuteText),
-		)
+		
+		# Skip if both hours and minutes are zero
+		if nHours == 0 and nMinutes == 0:
+			return text
+		
+		hourText = ""
+		minuteText = ""
+		
+		# Handle hours - only if greater than 0
+		if nHours > 0:
+			hourText = ngettext(
+				# Translators: This is the hour string part of the estimated remaining runtime of the laptop battery.
+				# E.g. if the full string is "1 hour and 34 minutes remaining", this string is "1 hour".
+				"{hours:d} hour",
+				"{hours:d} hours",
+				nHours,
+			).format(hours=nHours)
+		
+		# Handle minutes - only if greater than 0
+		if nMinutes > 0:
+			minuteText = ngettext(
+				# Translators: This is the minute string part of the estimated remaining runtime of the laptop battery.
+				# E.g. if the full string is "1 hour and 34 minutes remaining", this string is "34 minutes".
+				"{minutes:d} minute",
+				"{minutes:d} minutes",
+				nMinutes,
+			).format(minutes=nMinutes)
+		
+		# Combine hours and minutes appropriately
+		if hourText and minuteText:
+			text.append(
+				# Translators: This is the main string for the estimated remaining runtime of the laptop battery.
+				# E.g. hourText is replaced by "1 hour" and minuteText by "34 minutes".
+				_("{hourText} and {minuteText} remaining").format(hourText=hourText, minuteText=minuteText),
+			)
+		elif hourText:
+			text.append(
+				_("{hourText} remaining").format(hourText=hourText),
+			)
+		elif minuteText:
+			text.append(
+				_("{minuteText} remaining").format(minuteText=minuteText),
+			)
 	return text

--- a/source/winAPI/_powerTracking.py
+++ b/source/winAPI/_powerTracking.py
@@ -219,7 +219,7 @@ def _getBatteryInformation(systemPowerStatus: SystemPowerStatus) -> List[str]:
 	if systemPowerStatus.BatteryLifeTime != BATTERY_LIFE_TIME_UNKNOWN:
 		nHours = systemPowerStatus.BatteryLifeTime // SECONDS_PER_HOUR
 		nMinutes = (systemPowerStatus.BatteryLifeTime % SECONDS_PER_HOUR) // SECONDS_PER_MIN
-
+		
 		# Skip if no time, as it likely means the status check is inaccurate
 		if systemPowerStatus.BatteryLifeTime == 0:
 			return text
@@ -227,10 +227,10 @@ def _getBatteryInformation(systemPowerStatus: SystemPowerStatus) -> List[str]:
 			# Translators: Reported when battery time is less than 1 minute.
 			text.append(_("Less than 1 minute remaining"))
 			return text
-
+		
 		hourText: str | None = None
 		minuteText: str | None = None
-
+		
 		# Handle hours - only if greater than 0
 		if nHours > 0:
 			hourText = ngettext(
@@ -240,7 +240,7 @@ def _getBatteryInformation(systemPowerStatus: SystemPowerStatus) -> List[str]:
 				"{hours:d} hours",
 				nHours,
 			).format(hours=nHours)
-
+		
 		# Handle minutes - only if greater than 0
 		if nMinutes > 0:
 			minuteText = ngettext(
@@ -250,7 +250,7 @@ def _getBatteryInformation(systemPowerStatus: SystemPowerStatus) -> List[str]:
 				"{minutes:d} minutes",
 				nMinutes,
 			).format(minutes=nMinutes)
-
+		
 		# Combine hours and minutes appropriately
 		if hourText is not None and minuteText is not None:
 			text.append(

--- a/source/winAPI/_powerTracking.py
+++ b/source/winAPI/_powerTracking.py
@@ -219,7 +219,7 @@ def _getBatteryInformation(systemPowerStatus: SystemPowerStatus) -> List[str]:
 	if systemPowerStatus.BatteryLifeTime != BATTERY_LIFE_TIME_UNKNOWN:
 		nHours = systemPowerStatus.BatteryLifeTime // SECONDS_PER_HOUR
 		nMinutes = (systemPowerStatus.BatteryLifeTime % SECONDS_PER_HOUR) // SECONDS_PER_MIN
-		
+
 		# Skip if no time, as it likely means the status check is inaccurate
 		if systemPowerStatus.BatteryLifeTime == 0:
 			return text
@@ -227,10 +227,10 @@ def _getBatteryInformation(systemPowerStatus: SystemPowerStatus) -> List[str]:
 			# Translators: Reported when battery time is less than 1 minute.
 			text.append(_("Less than 1 minute remaining"))
 			return text
-		
+
 		hourText: str | None = None
 		minuteText: str | None = None
-		
+
 		# Handle hours - only if greater than 0
 		if nHours > 0:
 			hourText = ngettext(
@@ -240,7 +240,7 @@ def _getBatteryInformation(systemPowerStatus: SystemPowerStatus) -> List[str]:
 				"{hours:d} hours",
 				nHours,
 			).format(hours=nHours)
-		
+
 		# Handle minutes - only if greater than 0
 		if nMinutes > 0:
 			minuteText = ngettext(
@@ -250,7 +250,7 @@ def _getBatteryInformation(systemPowerStatus: SystemPowerStatus) -> List[str]:
 				"{minutes:d} minutes",
 				nMinutes,
 			).format(minutes=nMinutes)
-		
+
 		# Combine hours and minutes appropriately
 		if hourText is not None and minuteText is not None:
 			text.append(

--- a/source/winAPI/_powerTracking.py
+++ b/source/winAPI/_powerTracking.py
@@ -220,12 +220,16 @@ def _getBatteryInformation(systemPowerStatus: SystemPowerStatus) -> List[str]:
 		nHours = systemPowerStatus.BatteryLifeTime // SECONDS_PER_HOUR
 		nMinutes = (systemPowerStatus.BatteryLifeTime % SECONDS_PER_HOUR) // SECONDS_PER_MIN
 		
-		# Skip if both hours and minutes are zero
+		# Skip if no time, as it likely means the status check is inaccurate
+		if systemPowerStatus.BatteryLifeTime == 0:
+			return text
 		if nHours == 0 and nMinutes == 0:
+			# Translators: Reported when battery time is less than 1 minute.
+			text.append(_("Less than 1 minute remaining"))
 			return text
 		
-		hourText = ""
-		minuteText = ""
+		hourText: str | None = None
+		minuteText: str | None = None
 		
 		# Handle hours - only if greater than 0
 		if nHours > 0:
@@ -248,17 +252,17 @@ def _getBatteryInformation(systemPowerStatus: SystemPowerStatus) -> List[str]:
 			).format(minutes=nMinutes)
 		
 		# Combine hours and minutes appropriately
-		if hourText and minuteText:
+		if hourText is not None and minuteText is not None:
 			text.append(
 				# Translators: This is the main string for the estimated remaining runtime of the laptop battery.
 				# E.g. hourText is replaced by "1 hour" and minuteText by "34 minutes".
 				_("{hourText} and {minuteText} remaining").format(hourText=hourText, minuteText=minuteText),
 			)
-		elif hourText:
+		elif hourText is not None:
 			text.append(
 				_("{hourText} remaining").format(hourText=hourText),
 			)
-		elif minuteText:
+		elif minuteText is not None:
 			text.append(
 				_("{minuteText} remaining").format(minuteText=minuteText),
 			)

--- a/source/winAPI/_powerTracking.py
+++ b/source/winAPI/_powerTracking.py
@@ -260,10 +260,14 @@ def _getBatteryInformation(systemPowerStatus: SystemPowerStatus) -> List[str]:
 			)
 		elif hourText is not None:
 			text.append(
+				# Translators: Reported when only hours remaining for battery life.
+				# E.g. "2 hours remaining"
 				_("{hourText} remaining").format(hourText=hourText),
 			)
 		elif minuteText is not None:
 			text.append(
+				# Translators: Reported when only minutes remaining for battery life.
+				# E.g. "30 minutes remaining"
 				_("{minuteText} remaining").format(minuteText=minuteText),
 			)
 	return text

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -58,6 +58,7 @@ We recommend using Windows 11, or if that is not possible, the latest Windows 10
 * NVDA no longer fails to read the contents of wx Web View controls. (#17273, @LeonarddeR)
 * When NVDA is configured to update add-ons automatically in the background, add-ons can be properly updated. (#18965, @nvdaes)
 * Fixed bug when trying to access the Add-on Store from certain environments such as corporate networks. (#18354)
+* Battery time announcements now skip redundant "0 hours" and "0 minutes" and use proper singular/plural forms. (#9003, @hdzrvcc0X74)
 
 ### Changes for Developers
 


### PR DESCRIPTION
### Link to issue number:

Fixes #9003.

### Summary of the issue:

Battery time script was reporting redundant "0 hours" and "0 minutes", and using plural forms for single hours and minutes.

### Description of user facing changes:

NVDA will no longer speak remaining time when it reaches zero, for both hours and minutes.

### Description of developer facing changes:

None.

### Description of development approach:

- Added logic to skip time reporting when both hours and minutes are zero
- Separated hour and minute handling to only display non-zero values
- Used proper singular/plural forms via ngettext for 1 hour/1 minute cases

### Testing strategy:

Manually tested running from source.

### Known issues with pull request:

None.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
