### PR TITLE
In Outlook Classic, when navigating messages, ensure that wrong info is not displayed in braille

### DIFF
--- a/source/appModules/outlook.py
+++ b/source/appModules/outlook.py
@@ -335,14 +335,12 @@ class ContactEditField(NVDAObject):
 		"""The auto-complete list is getting closed, set focus back to the edit field."""
 		if vision.handler:
 			vision.handler.handleGainFocus(self)
-		api.setNavigatorObject(self)
 		gesture.send()
 
 	def event_valueChange(self):
 		"""Set focus back to the edit field when an auto-complete list item is confirmed."""
 		if vision.handler:
 			vision.handler.handleGainFocus(self)
-		api.setNavigatorObject(self)
 		super().event_valueChange()
 
 

--- a/source/appModules/outlook.py
+++ b/source/appModules/outlook.py
@@ -335,13 +335,14 @@ class ContactEditField(NVDAObject):
 		"""The auto-complete list is getting closed, set focus back to the edit field."""
 		if vision.handler:
 			vision.handler.handleGainFocus(self)
-			api.setNavigatorObject(isFocus=True)
+			api.setNavigatorObject(self, isFocus=True)
 		gesture.send()
 
 	def event_valueChange(self):
 		"""Set focus back to the edit field when an auto-complete list item is confirmed."""
 		if vision.handler:
 			vision.handler.handleGainFocus(self)
+			api.setNavigatorObject(self, isFocus=True)
 		super().event_valueChange()
 
 

--- a/source/appModules/outlook.py
+++ b/source/appModules/outlook.py
@@ -335,6 +335,7 @@ class ContactEditField(NVDAObject):
 		"""The auto-complete list is getting closed, set focus back to the edit field."""
 		if vision.handler:
 			vision.handler.handleGainFocus(self)
+			api.setNavigatorObject(isFocus=True)
 		gesture.send()
 
 	def event_valueChange(self):

--- a/source/appModules/outlook.py
+++ b/source/appModules/outlook.py
@@ -335,7 +335,7 @@ class ContactEditField(NVDAObject):
 		"""The auto-complete list is getting closed, set focus back to the edit field."""
 		if vision.handler:
 			vision.handler.handleGainFocus(self)
-			api.setNavigatorObject(self, isFocus=True)
+			api.setNavigatorObject(self)
 		gesture.send()
 
 	def event_valueChange(self):

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -61,7 +61,7 @@ We recommend using Windows 11, or if that is not possible, the latest Windows 10
 * Fixed a case where braille output would fail with an error. (#19025, @LeonarddeR)
 * Battery time announcements now skip redundant "0 hours" and "0 minutes" and use proper singular/plural forms. (#9003, @hdzrvcc0X74)
 * Certain settings will no-longer erroneously be saved to disk when running NVDA from the launcher. (#18171)
-* In Outlook Classic, when navigating the list of messages, wrong information is no longer displayed in braille. (#18993, @nvdaes)
+* Incorrect information is no longer displayed in braille when navigating the list of messages in Outlook Classic. (#18993, @nvdaes)
 
 ### Changes for Developers
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -61,7 +61,7 @@ We recommend using Windows 11, or if that is not possible, the latest Windows 10
 * Fixed a case where braille output would fail with an error. (#19025, @LeonarddeR)
 * Battery time announcements now skip redundant "0 hours" and "0 minutes" and use proper singular/plural forms. (#9003, @hdzrvcc0X74)
 * Certain settings will no-longer erroneously be saved to disk when running NVDA from the launcher. (#18171)
-* In Outlook Classic, when navigating the list of messages, the navigator object is not moved from the focus, avoiding that wrong information appears in braille. (#18993, @nvdaes)
+* In Outlook Classic, when navigating the list of messages, wrong information is no longer displayed in braille. (#18993, @nvdaes)
 
 ### Changes for Developers
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -61,7 +61,7 @@ We recommend using Windows 11, or if that is not possible, the latest Windows 10
 * Fixed a case where braille output would fail with an error. (#19025, @LeonarddeR)
 * Battery time announcements now skip redundant "0 hours" and "0 minutes" and use proper singular/plural forms. (#9003, @hdzrvcc0X74)
 * Certain settings will no-longer erroneously be saved to disk when running NVDA from the launcher. (#18171)
-* In Outlook Classic, when navigating the list of messages, the navigator object is not moved from the focus, avoiding that wrong information appears in braille. (#19993, @nvdaes)
+* In Outlook Classic, when navigating the list of messages, the navigator object is not moved from the focus, avoiding that wrong information appears in braille. (#18993, @nvdaes)
 
 ### Changes for Developers
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -61,6 +61,7 @@ We recommend using Windows 11, or if that is not possible, the latest Windows 10
 * Fixed a case where braille output would fail with an error. (#19025, @LeonarddeR)
 * Battery time announcements now skip redundant "0 hours" and "0 minutes" and use proper singular/plural forms. (#9003, @hdzrvcc0X74)
 * Certain settings will no-longer erroneously be saved to disk when running NVDA from the launcher. (#18171)
+* In Outlook Classic, when navigating the list of messages, the navigator object is not moved from the focus, avoiding that wrong information appears in braille. (#19993, @nvdaes)
 
 ### Changes for Developers
 


### PR DESCRIPTION
- **Fix unexpected changes for navigator object and wrong updates in braille when navigating messages in Outlook Classic**
- **Update changelog**

<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
<!-- Use Closes/Fixes/Resolves #xxx to link this PR to the issue it is responding to. -->
Fixes #18993
### Summary of the issue:
When navigating the list of messages in Outlook Classic, the navigator object is moved from the focus, showing unexpected information in braille.
### Description of user facing changes:
The list of messages can be navigated in Outlook Classic, without receiving unexpected information in braille.
### Description of developer facing changes:
None.
### Description of development approach:
In the `ContactEditField` class of the Outlook app module, call to `api.setNavigatorObject` for the `event_valueChange`, has been modified setting `isFocus` to `True`
### Testing strategy:
- Navigate the list of messages and chek that unexpected information is not presented in braille.
- Compose messages using fields like To or CC, and check that side effects are not produced.
### Known issues with pull request:
The navigator object is still moved, so that the reported navigator object doesn't match the reported focus. 
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
