### PR TITLE
Check files are signed after Submit-SigningRequest

### DIFF
--- a/ci/scripts/setSconsArgs.ps1
+++ b/ci/scripts/setSconsArgs.ps1
@@ -2,16 +2,9 @@ $ErrorActionPreference = "Stop";
 $sconsDocsOutTargets = "developerGuide changes userGuide keyCommands user_docs"
 $sconsLauncherOutTargets = "launcher client moduleList"
 $sconsArgs = "version=$env:version"
-$sconsCores = "--all-cores"
-if ($env:RUNNER_DEBUG -eq "1") {
-	# Run scons linearly if we are in debug mode, so logs can be easily parsed
-	$sconsCores = "-j1"
-}
+$sconsCores = "-j1"
 if ($env:release) {
 	$sconsArgs += " release=1"
-	# Run scons linearly for release builds, so we can debug if something goes wrong,
-	# as we cannot safely re-run a released build
-	$sconsCores = "-j1"
 }
 if ($env:versionType) {
 	$sconsArgs += " updateVersionType=$env:versionType"

--- a/ci/scripts/sign.ps1
+++ b/ci/scripts/sign.ps1
@@ -8,11 +8,7 @@ param(
 	[string]$FileToSign
 )
 
-if ((Split-Path -Leaf -Path (Split-Path -Parent -Path $FileToSign)) -eq "output" -and (Split-Path -Leaf -Path $FileToSign) -like "nvda_*.exe") {
-	Write-output "Intentionlly not signing NVDA launcher!"
-} else {
 Submit-SigningRequest -ApiToken $ApiToken -InputArtifactPath $FileToSign -OutputArtifactPath $FileToSign -OrganizationId "12147e94-bba9-4fef-b29b-300398e90c5a" -ProjectSlug "NVDA" -SigningPolicySlug "release_signing_policy" -WaitForCompletion -Force -ErrorAction Stop
-}
 
 $authenticodeSignature = Get-AuthenticodeSignature -FilePath $FileToSign
 if (($authenticodeSignature).Status -ne 'Valid') {

--- a/ci/scripts/sign.ps1
+++ b/ci/scripts/sign.ps1
@@ -8,8 +8,8 @@ param(
 	[string]$FileToSign
 )
 
-if ((Split-Path -Path $FileToSign -Leaf) -eq "IAccessible2proxy.dll") {
-	Write-output "Intentionlly not signing IAccessible2proxy.dll!"
+if ((Split-Path -Leaf -Path (Split-Path -Parent -Path $FileToSign)) -eq "output" -and (Split-Path -Leaf -Path $FileToSign) -like "nvda_*.exe") {
+	Write-output "Intentionlly not signing NVDA launcher!"
 } else {
 Submit-SigningRequest -ApiToken $ApiToken -InputArtifactPath $FileToSign -OutputArtifactPath $FileToSign -OrganizationId "12147e94-bba9-4fef-b29b-300398e90c5a" -ProjectSlug "NVDA" -SigningPolicySlug "release_signing_policy" -WaitForCompletion -Force -ErrorAction Stop
 }

--- a/ci/scripts/sign.ps1
+++ b/ci/scripts/sign.ps1
@@ -8,7 +8,7 @@ param(
 	[string]$FileToSign
 )
 
-Submit-SigningRequest -ApiToken $ApiToken -InputArtifactPath $FileToSign -OutputArtifactPath $FileToSign -OrganizationId "12147e94-bba9-4fef-b29b-300398e90c5a" -ProjectSlug "NVDA" -SigningPolicySlug "release_signing_policy" -WaitForCompletion -Force
+Submit-SigningRequest -ApiToken $ApiToken -InputArtifactPath $FileToSign -OutputArtifactPath $FileToSign -OrganizationId "12147e94-bba9-4fef-b29b-300398e90c5a" -ProjectSlug "NVDA" -SigningPolicySlug "release_signing_policy" -WaitForCompletion -Force -ErrorAction Stop
 
 $authenticodeSignature = Get-AuthenticodeSignature -FilePath $FileToSign
 if (($authenticodeSignature).Status -ne 'Valid') {

--- a/ci/scripts/sign.ps1
+++ b/ci/scripts/sign.ps1
@@ -11,13 +11,9 @@ param(
 Submit-SigningRequest -ApiToken $ApiToken -InputArtifactPath $FileToSign -OutputArtifactPath $FileToSign -OrganizationId "12147e94-bba9-4fef-b29b-300398e90c5a" -ProjectSlug "NVDA" -SigningPolicySlug "release_signing_policy" -WaitForCompletion -Force -ErrorAction Stop
 
 $authenticodeSignature = Get-AuthenticodeSignature -FilePath $FileToSign
-if (($authenticodeSignature).Status -ne 'Valid') {
-	Write-Error "The signature of $FileToSign is not valid."
-	Write-Output @"
-FAIL: Signature is not valid.
-
+Write-Output @"
 <details>
-<summary>Signature details</summary>
+<summary>Signature details for $FileToSign</summary>
 
 $($authenticodeSignature | ConvertTo-Html -fragment -Property Path, SignatureType, Status, StatusMessage)
 
@@ -45,6 +41,9 @@ $(
 
 </details>
 "@ >> $env:GITHUB_STEP_SUMMARY
+
+if (($authenticodeSignature).Status -ne 'Valid') {
+	Write-Error "The signature of $FileToSign is not valid."
 	exit 1
 } else {
 	Write-Output "Successfully signed $FileToSign."

--- a/ci/scripts/sign.ps1
+++ b/ci/scripts/sign.ps1
@@ -11,9 +11,13 @@ param(
 Submit-SigningRequest -ApiToken $ApiToken -InputArtifactPath $FileToSign -OutputArtifactPath $FileToSign -OrganizationId "12147e94-bba9-4fef-b29b-300398e90c5a" -ProjectSlug "NVDA" -SigningPolicySlug "release_signing_policy" -WaitForCompletion -Force -ErrorAction Stop
 
 $authenticodeSignature = Get-AuthenticodeSignature -FilePath $FileToSign
-Write-Output @"
+if (($authenticodeSignature).Status -ne 'Valid') {
+	Write-Error "The signature of $FileToSign is not valid."
+	Write-Output @"
+FAIL: Signature is not valid.
+
 <details>
-<summary>Signature details for $FileToSign</summary>
+<summary>Signature details</summary>
 
 $($authenticodeSignature | ConvertTo-Html -fragment -Property Path, SignatureType, Status, StatusMessage)
 
@@ -41,9 +45,6 @@ $(
 
 </details>
 "@ >> $env:GITHUB_STEP_SUMMARY
-
-if (($authenticodeSignature).Status -ne 'Valid') {
-	Write-Error "The signature of $FileToSign is not valid."
 	exit 1
 } else {
 	Write-Output "Successfully signed $FileToSign."

--- a/ci/scripts/sign.ps1
+++ b/ci/scripts/sign.ps1
@@ -8,7 +8,11 @@ param(
 	[string]$FileToSign
 )
 
+if ((Split-Path -Path $FileToSign -Leaf) -eq "IAccessible2proxy.dll") {
+	Write-output "Intentionlly not signing IAccessible2proxy.dll!"
+} else {
 Submit-SigningRequest -ApiToken $ApiToken -InputArtifactPath $FileToSign -OutputArtifactPath $FileToSign -OrganizationId "12147e94-bba9-4fef-b29b-300398e90c5a" -ProjectSlug "NVDA" -SigningPolicySlug "release_signing_policy" -WaitForCompletion -Force -ErrorAction Stop
+}
 
 $authenticodeSignature = Get-AuthenticodeSignature -FilePath $FileToSign
 if (($authenticodeSignature).Status -ne 'Valid') {

--- a/ci/scripts/sign.ps1
+++ b/ci/scripts/sign.ps1
@@ -8,13 +8,11 @@ param(
 	[string]$FileToSign
 )
 
-Write-Host "Signing $FileToSign ... " -NoNewline
-
 Submit-SigningRequest -ApiToken $ApiToken -InputArtifactPath $FileToSign -OutputArtifactPath $FileToSign -OrganizationId "12147e94-bba9-4fef-b29b-300398e90c5a" -ProjectSlug "NVDA" -SigningPolicySlug "release_signing_policy" -WaitForCompletion -Force
 
 $authenticodeSignature = Get-AuthenticodeSignature -FilePath $FileToSign
 if (($authenticodeSignature).Status -ne 'Valid') {
-	Write-Host "Failure"
+	Write-Error "The signature of $FileToSign is not valid."
 	Write-Output @"
 FAIL: Signature is not valid.
 
@@ -49,5 +47,5 @@ $(
 "@ >> $env:GITHUB_STEP_SUMMARY
 	exit 1
 } else {
-	Write-Host "Success"
+	Write-Output "Successfully signed $FileToSign."
 }


### PR DESCRIPTION
### Link to issue number:
Fixes #19099
Supersedes #18384

### Summary of the issue:

Some files are not signed some of the time

### Description of user facing changes:

None

### Description of developer facing changes:

In the case of alpha, beta, rc, stable and try builds, failure to sign the launcher or most of our executables will fail the build.
All CI builds now run serially to avoid race conditions.

### Description of development approach:

Set the `ErrorAction` common parameter on `Send-SigningRequest` to `Stop` to cause the signing script to fail if the cmd-let fails.
Use `Get-AuthenticodeSignature` to verify the signature of files after `Submit-SigningRequest` returns.

### Testing strategy:

CI

* [x] Successful signing: https://github.com/nvaccess/nvda/actions/runs/18733609673
  * Note that this run's failure was due to a system test failure
  * Checked that the launcher and all `dll` and `exe` files are signed. Found unsigned `exe`s and `dll` s by unzipping the controller client and launcher into the same directory, and running:
    
    ```ps1
    (Get-ChildItem -Recurse -Include *.exe, *.dll -Name | Get-AuthenticodeSignature | where-object {$_.Status -ne 'Valid'}).Path
    ```

    The following files do not have valid signatures:

    * `app\brailleDisplayDrivers\lilli.dll`
    * `app\miscDeps\tools\msgfmt.exe`
    * `app\synthDrivers\espeak.dll`
    * `app\synthDrivers\sonic.dll`
    * `app\brlapi-0.8.dll`
    * `app\libgcc_s_dw2-1.dll`
    * `app\wxbase32u_net_vc140.dll`
    * `app\wxbase32u_vc140.dll`
    * `app\wxmsw32u_aui_vc140.dll`
    * `app\wxmsw32u_core_vc140.dll`
    * `app\wxmsw32u_html_vc140.dll`
    * `app\wxmsw32u_stc_vc140.dll`
    * `Banner.dll`
    * `System.dll`

    However, as best as I can tell, we never attempt to sign these files.

* [x] Intentionally don't sign a DLL: https://github.com/nvaccess/nvda/actions/runs/18703904287
* [x] Intentionally don't sign the launcher: https://github.com/nvaccess/nvda/actions/runs/18707118372

### Known issues with pull request:

None

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
