### PR TITLE
File Explorer app module: remove support for Windows 8.x Start screen workarounds

### DIFF
--- a/source/appModules/explorer.py
+++ b/source/appModules/explorer.py
@@ -149,11 +149,6 @@ class ExplorerToolTip(ToolTip):
 			super().event_show()
 
 
-class GridListTileElement(UIA):
-	role = controlTypes.Role.TABLECELL
-	description = None
-
-
 class GridGroup(UIA):
 	"""A group in the Windows 8 Start Menu."""
 
@@ -281,8 +276,6 @@ class AppModule(appModuleHandler.AppModule):
 
 		if isinstance(obj, UIA):
 			uiaClassName = obj.UIAElement.cachedClassName
-			elif uiaClassName == "GridListTileElement":
-				clsList.insert(0, GridListTileElement)
 			elif uiaClassName == "GridGroup":
 				clsList.insert(0, GridGroup)
 			# Multitasking view frame window

--- a/source/appModules/explorer.py
+++ b/source/appModules/explorer.py
@@ -45,15 +45,6 @@ class MultitaskingViewFrameListItem(UIA):
 			return super(MultitaskingViewFrameListItem, self).container
 
 
-# Support for Win8 start screen search suggestions.
-class SuggestionListItem(UIA):
-	def event_UIA_elementSelected(self):
-		speech.cancelSpeech()
-		if api.setNavigatorObject(self, isFocus=True):
-			self.reportFocus()
-			super().event_UIA_elementSelected()
-
-
 # Windows 8 hack: Class to disable incorrect focus on windows 8 search box
 # (containing the already correctly focused edit field)
 class SearchBoxClient(IAccessible):
@@ -334,8 +325,6 @@ class AppModule(appModuleHandler.AppModule):
 				clsList.insert(0, GridGroup)
 			elif uiaClassName == "ImmersiveLauncher" and role == controlTypes.Role.PANE:
 				clsList.insert(0, ImmersiveLauncher)
-			elif uiaClassName == "ListViewItem" and obj.UIAAutomationId.startswith("Suggestion_"):
-				clsList.insert(0, SuggestionListItem)
 			# Multitasking view frame window
 			elif (
 				# Windows 10 and earlier

--- a/source/appModules/explorer.py
+++ b/source/appModules/explorer.py
@@ -45,12 +45,6 @@ class MultitaskingViewFrameListItem(UIA):
 			return super(MultitaskingViewFrameListItem, self).container
 
 
-# Windows 8 hack: Class to disable incorrect focus on windows 8 search box
-# (containing the already correctly focused edit field)
-class SearchBoxClient(IAccessible):
-	shouldAllowIAccessibleFocusEvent = False
-
-
 # Class for menu items  for Windows Places and Frequently used Programs (in start menu)
 # Also used for desktop items
 class SysListView32EmittingDuplicateFocusEvents(IAccessible):
@@ -252,14 +246,6 @@ class AppModule(appModuleHandler.AppModule):
 	def chooseNVDAObjectOverlayClasses(self, obj, clsList):  # NOQA: C901
 		windowClass = obj.windowClassName
 		role = obj.role
-
-		if (
-			windowClass in ("Search Box", "UniversalSearchBand")
-			and role == controlTypes.Role.PANE
-			and isinstance(obj, IAccessible)
-		):
-			clsList.insert(0, SearchBoxClient)
-			return  # Optimization: return early to avoid comparing class names and roles that will never match.
 
 		if windowClass == "ToolbarWindow32":
 			if role != controlTypes.Role.POPUPMENU:

--- a/source/appModules/explorer.py
+++ b/source/appModules/explorer.py
@@ -149,21 +149,6 @@ class ExplorerToolTip(ToolTip):
 			super().event_show()
 
 
-class GridTileElement(UIA):
-	role = controlTypes.Role.TABLECELL
-
-	def _get_description(self):
-		name = self.name
-		descriptionStrings = []
-		for child in self.children:
-			description = child.basicText
-			if not description or description == name:
-				continue
-			descriptionStrings.append(description)
-		return " ".join(descriptionStrings)
-		return description
-
-
 class GridListTileElement(UIA):
 	role = controlTypes.Role.TABLECELL
 	description = None
@@ -296,8 +281,6 @@ class AppModule(appModuleHandler.AppModule):
 
 		if isinstance(obj, UIA):
 			uiaClassName = obj.UIAElement.cachedClassName
-			if uiaClassName == "GridTileElement":
-				clsList.insert(0, GridTileElement)
 			elif uiaClassName == "GridListTileElement":
 				clsList.insert(0, GridListTileElement)
 			elif uiaClassName == "GridGroup":

--- a/source/appModules/explorer.py
+++ b/source/appModules/explorer.py
@@ -149,20 +149,6 @@ class ExplorerToolTip(ToolTip):
 			super().event_show()
 
 
-class GridGroup(UIA):
-	"""A group in the Windows 8 Start Menu."""
-
-	presentationType = UIA.presType_content
-
-	# Normally the name is the first tile which is rather redundant
-	# However some groups have custom header text which should be read instead
-	def _get_name(self):
-		child = self.firstChild
-		if isinstance(child, UIA):
-			if child.UIAAutomationId == "GridListGroupHeader":
-				return child.name
-
-
 class StartButton(IAccessible):
 	"""For Windows 8.1 and 10 Start buttons to be recognized as proper buttons
 	and to suppress selection announcement."""
@@ -276,10 +262,8 @@ class AppModule(appModuleHandler.AppModule):
 
 		if isinstance(obj, UIA):
 			uiaClassName = obj.UIAElement.cachedClassName
-			elif uiaClassName == "GridGroup":
-				clsList.insert(0, GridGroup)
 			# Multitasking view frame window
-			elif (
+			if (
 				# Windows 10 and earlier
 				(uiaClassName == "MultitaskingViewFrame" and role == controlTypes.Role.WINDOW)
 				# Windows 11 where a pane window receives focus when switching tasks

--- a/source/appModules/explorer.py
+++ b/source/appModules/explorer.py
@@ -189,13 +189,6 @@ class GridGroup(UIA):
 				return child.name
 
 
-class ImmersiveLauncher(UIA):
-	# When the Windows 8 start screen opens, focus correctly goes to the first tile,
-	# but then incorrectly back to the root of the window.
-	# Ignore focus events on this object.
-	shouldAllowUIAFocusEvent = False
-
-
 class StartButton(IAccessible):
 	"""For Windows 8.1 and 10 Start buttons to be recognized as proper buttons
 	and to suppress selection announcement."""
@@ -323,8 +316,6 @@ class AppModule(appModuleHandler.AppModule):
 				clsList.insert(0, GridListTileElement)
 			elif uiaClassName == "GridGroup":
 				clsList.insert(0, GridGroup)
-			elif uiaClassName == "ImmersiveLauncher" and role == controlTypes.Role.PANE:
-				clsList.insert(0, ImmersiveLauncher)
 			# Multitasking view frame window
 			elif (
 				# Windows 10 and earlier

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -109,6 +109,7 @@ Use the `int` configuration key `[reportSpellingErrors2]` instead. (#17997, @Cyr
 All public symbols defined on this class are now accessible from `winBindings.magnification`. (#18958)
 * `gui.nvdaControls.TabbableScrolledPanel` has been removed.
 Use `wx.lib.scrolledpanel.ScrolledPanel` directly instead. (#17751)
+* The following Windows 8.x Start screen support symbols have been removed from `appModules.explorer` (File Explorer) app module with no replacement: `SuggestionListItem`, `SearchBoxClient`, `GridTileElement`, `GridListTileElement`, `GridGroup`, `ImmersiveLauncher`. (#18757, @josephsl)
 
 #### Deprecations
 


### PR DESCRIPTION

### Link to issue number:
Closes #18757 

### Summary of the issue:
NVDA includes Windows 8.x Start screen workarounds which are no longer needed.

### Description of user facing changes:
None

### Description of developer facing changes:
Revmoes Windows 8.x Start screen support symbols from the File Explorer app modules: `SuggestionListItem`, `SearchBoxClient`, `GridTileElement`, `GridListTileElement`, `GridGroup`, `ImmersiveLauncher`.

### Description of development approach:
Removed the no longer used Windows 8.x Start screen attributes, test it after compiling NVDA on Windows 10/11.

### Testing strategy:
Manual: make sure Windows 10/11 File Explorer support code such as notificaiton area and UI property objects do not cause errors for NVDA.

### Known issues with pull request:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
