### PR TITLE
Don't Save settings when shouldWriteToDisk returns False

### DIFF
--- a/source/characterProcessing.py
+++ b/source/characterProcessing.py
@@ -22,6 +22,7 @@ from typing import (
 	TypeVar,
 )
 
+import NVDAState
 from logHandler import log
 import globalVars
 import config
@@ -356,6 +357,9 @@ class SpeechSymbols:
 		@raise ValueError: If C{fileName} is C{None}
 			and L{load} or L{save} has not been called.
 		"""
+		if not NVDAState.shouldWriteToDisk():
+			log.debugWarning("Not saving speech symbols, as shouldWriteToDisk returned False.")
+			return
 		if fileName:
 			self.fileName = fileName
 		elif self.fileName:

--- a/source/config/__init__.py
+++ b/source/config/__init__.py
@@ -666,7 +666,8 @@ class ConfigManager(object):
 		@type name: str
 		@raise ValueError: If a profile with this name already exists.
 		"""
-		if globalVars.appArgs.secure:
+		if not NVDAState.shouldWriteToDisk():
+			log.debug("Not creating configuration profile, as shouldWriteToDisk returned False.")
 			return
 		if not name:
 			raise ValueError("Missing name.")
@@ -687,7 +688,8 @@ class ConfigManager(object):
 		@type name: str
 		@raise LookupError: If the profile doesn't exist.
 		"""
-		if globalVars.appArgs.secure:
+		if not NVDAState.shouldWriteToDisk():
+			log.debug("Not deleting profile, as shouldSaveToDisk returned False.")
 			return
 		fn = self._getProfileFn(name)
 		if not os.path.isfile(fn):
@@ -743,7 +745,8 @@ class ConfigManager(object):
 		@raise LookupError: If the profile doesn't exist.
 		@raise ValueError: If a profile with the new name already exists.
 		"""
-		if globalVars.appArgs.secure:
+		if not NVDAState.shouldWriteToDisk():
+			log.debug("Not renaming profile, as shouldWriteToDisk returned False.")
 			return
 		if newName == oldName:
 			return
@@ -920,8 +923,9 @@ class ConfigManager(object):
 		"""Save profile trigger information to disk.
 		This should be called whenever L{profilesToTriggers} is modified.
 		"""
-		if globalVars.appArgs.secure:
+		if not NVDAState.shouldWriteToDisk():
 			# Never save if running securely.
+			log.debug("Not saving profile triggers, as shouldWriteToDisk returned False.")
 			return
 		self.triggersToProfiles.parent.write()
 		log.info("Profile triggers saved")

--- a/source/gui/configProfiles.py
+++ b/source/gui/configProfiles.py
@@ -4,11 +4,11 @@
 # See the file COPYING for more details.
 
 import wx
+import NVDAState
 import config
 import api
 import gui
 from logHandler import log
-import globalVars
 from . import guiHelper
 import gui.contextHelp
 
@@ -110,7 +110,7 @@ class ProfilesDialog(
 		self.Bind(wx.EVT_BUTTON, self.onClose, id=wx.ID_CLOSE)
 		self.EscapeId = wx.ID_CLOSE
 
-		if globalVars.appArgs.secure:
+		if not NVDAState.shouldWriteToDisk():
 			for item in newButton, triggersButton, self.renameButton, self.deleteButton:
 				item.Disable()
 		self.onProfileListChoice(None)
@@ -242,7 +242,7 @@ class ProfilesDialog(
 			label = _("Manual activate")
 		self.changeStateButton.Label = label
 		self.changeStateButton.Enabled = enable
-		if globalVars.appArgs.secure:
+		if not NVDAState.shouldWriteToDisk():
 			return
 		self.deleteButton.Enabled = enable
 		self.renameButton.Enabled = enable

--- a/source/inputCore.py
+++ b/source/inputCore.py
@@ -43,7 +43,7 @@ import globalVars
 import languageHandler
 import controlTypes
 import extensionPoints
-from NVDAState import WritePaths
+from NVDAState import WritePaths, shouldWriteToDisk
 
 
 InputGestureBindingClassT = TypeVar("InputGestureBindingClassT")
@@ -438,6 +438,9 @@ class GlobalGestureMap:
 		"""Save this gesture map to disk.
 		@precondition: L{load} must have been called.
 		"""
+		if not shouldWriteToDisk():
+			log.debug("Not saving user gesture map, as shouldWriteToDisk returned false.")
+			return
 		if not self.fileName:
 			raise ValueError("No file name")
 		out = configobj.ConfigObj(self.export(), encoding="UTF-8")

--- a/source/speechDictHandler/__init__.py
+++ b/source/speechDictHandler/__init__.py
@@ -10,7 +10,7 @@ from logHandler import log
 import os
 import codecs
 
-from NVDAState import WritePaths
+from NVDAState import WritePaths, shouldWriteToDisk
 from . import dictFormatUpgrade
 
 
@@ -118,6 +118,9 @@ class SpeechDict(list):
 		return
 
 	def save(self, fileName=None):
+		if not shouldWriteToDisk():
+			log.debugWarning("Not writing dictionary, as shouldWriteToDisk returned False.")
+			return
 		if not fileName:
 			fileName = getattr(self, "fileName", None)
 		if not fileName:

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -60,6 +60,7 @@ We recommend using Windows 11, or if that is not possible, the latest Windows 10
 * When NVDA is configured to update add-ons automatically in the background, add-ons can be properly updated. (#18965, @nvdaes)
 * Fixed a case where braille output would fail with an error. (#19025, @LeonarddeR)
 * Battery time announcements now skip redundant "0 hours" and "0 minutes" and use proper singular/plural forms. (#9003, @hdzrvcc0X74)
+* Certain settings will no-longer erroneously be saved to disk when running NVDA from the launcher. (#18171)
 
 ### Changes for Developers
 


### PR DESCRIPTION
### Link to issue number:

Resolves #18171

### Summary of the issue:

Some configuration can still be written to disk when running from the launcher.

### Description of user facing changes:

These configurations can no-longer be saved to disk from the launcher.

### Description of developer facing changes:

None

### Description of development approach:

* [x] Speech dictionaries: return early from `speechDictHandler.SpeechDict.save` if `shouldWriteToDisk` returns `False`.
* [x] Punctuation/symbol pronunciation: Return early from `characterProcessing.SymbolPronunciations.save` if `shouldWriteToDisk` returns `False`.
* [x] Input gestures: return early from `inputCore.GlobalGestureMap.save` if `shouldWriteToDisk` returns `False`.
* [x] Configuration profiles: Use `not NVDAState.shouldWriteToDisk()` rather than `globalVars.appArgs.secure` when deciding whether to force the config profiles dialog's new, triggers, rename and delete buttons to be disabled.
  * [x] Create: Use `not NVDAState.shouldWriteToDisk()` rather than `globalVars.appArgs.secure` when deciding whether to return early from `config.ConfigManager.createProfile`.
  * [x] Modify: Use `not NVDAState.shouldWriteToDisk()` rather than `globalVars.appArgs.secure` when deciding whether to return early from `config.ConfigManager.saveProfileTriggers`.
  * [x] Rename: Use `not NVDAState.shouldWriteToDisk()` rather than `globalVars.appArgs.secure` when deciding whether to return early from `config.ConfigManager.renameProfile`.
  * [x] Delete: Use `not NVDAState.shouldWriteToDisk()` rather than `globalVars.appArgs.secure` when deciding whether to return early from `config.ConfigManager.deleteProfile`.

### Testing strategy:

#### Speech dictionaries:

* Build a launcher.
* Run the launcher, and ensure that existing speech dictentries work as expected.
* Add a newentry and press Ok.
* Ensure the new entry works as expected.
* Restart NVDA, and ensure that the new entries were not persisted.

#### Symbol pronunciations

* Run from source. Modify a symbol. Ensure that the new pronunciation works as expected.
* Restart the source copy. Ensure the modification has persisted.
* Create a launcher. Run it. Modify a symbol. Ensure that the new pronunciation works as expected.
* Start the instaled copy of NVDA. Ensure that the modified symbol has not been persisted.

#### Input gestures:

* Build a launcher.
* Create a new gesture in the installed copy (in my case, `NVDA+conrol+shift+t` to report the time. Check that it works. Restart NVDA and use the gesture t ensure it has been persisted to disk.
* Start the launcher. Use the new gesture to ensure it works in the launcher.
* Add a new gesture (in my case, `NVDA+control+shift+r` to report the time. Perfor the gesture to ensure that it works as expected.
* Check the log outpu to ensure that a message was logged about gestures not being saved.
* Restart the installed copy. Ensure that the gesture created in the launcher copy does not work, but the gesture created in the installed copy does.

#### Config profiles

* Build a launcher.
* From the installed copy, create a new configuration profile.
* Run the launcher. Open the config profiles dialog. Attempt to create, update or delete a profile.
* From the NVDA Python Console, attempt to call all of `config.conf.createProfile`, `config.conf.renameProfile`, `config.conf.deleteProfile`, and `config.conf.saveProfileTriggers`. Observe the log to ensre the functions return early.

### Known issues with pull request:

None.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
