### PR TITLE
Fix Chrome system tests

### DIFF
--- a/source/_remoteClient/secureDesktop.py
+++ b/source/_remoteClient/secureDesktop.py
@@ -313,7 +313,7 @@ class SecureDesktopHandler:
 		if self._mapFile is not None:
 			if not closeHandle(self._mapFile):
 				log.debugWarning(
-					f"Error closing handle to IPC file mapping. {GetLastError()}: {FormatError()}"
+					f"Error closing handle to IPC file mapping. {GetLastError()}: {FormatError()}",
 				)
 		log.info("Secure desktop cleanup completed")
 
@@ -384,7 +384,7 @@ class SecureDesktopHandler:
 			log.error(f"Couldn't map view of file. {GetLastError()}: {FormatError()}")
 			if not closeHandle(mapFile):
 				log.debugWarning(
-					f"Error closing handle to IPC file mapping. {GetLastError()}: {FormatError()}"
+					f"Error closing handle to IPC file mapping. {GetLastError()}: {FormatError()}",
 				)
 			return
 		buffer = (WCHAR * self._IPC_MAXLEN).from_address(bufferAddress)
@@ -410,7 +410,7 @@ class SecureDesktopHandler:
 				log.debugWarning(f"Error unmapping IPC shared memory. {GetLastError()}: {FormatError()}")
 			if not closeHandle(mapFile):
 				log.debugWarning(
-					f"Error closing handle to IPC file mapping. {GetLastError()}: {FormatError()}"
+					f"Error closing handle to IPC file mapping. {GetLastError()}: {FormatError()}",
 				)
 			self.sdServer.close()
 			self.sdServer = None
@@ -482,7 +482,7 @@ class SecureDesktopHandler:
 		if self._mapFile is not None:
 			if not closeHandle(self._mapFile):
 				log.debugWarning(
-					"Failed to close handle to memory mapped IPC file. {GetLastError()}: {FormatError()}"
+					"Failed to close handle to memory mapped IPC file. {GetLastError()}: {FormatError()}",
 				)
 			self._mapFile = None
 
@@ -552,7 +552,7 @@ class SecureDesktopHandler:
 				log.debugWarning(f"Failed to unmap view of IPC file. {GetLastError()}: {FormatError()}")
 			if not closeHandle(mapFile):
 				log.debugWarning(
-					f"Failed to close handle to IPC file mapping. {GetLastError()}: {FormatError()}"
+					f"Failed to close handle to IPC file mapping. {GetLastError()}: {FormatError()}",
 				)
 
 	def _onLeaderDisplayChange(self, **kwargs: Any) -> None:

--- a/tests/system/libraries/ChromeLib.py
+++ b/tests/system/libraries/ChromeLib.py
@@ -185,10 +185,14 @@ class ChromeLib:
 				"alt+d",
 			)  # focus the address bar, chrome shortcut
 			if expectedAddressBarSpeech not in moveToAddressBarSpeech:
-				builtIn.log(
-					f"Didn't read '{expectedAddressBarSpeech}' after alt+d, instead got: {moveToAddressBarSpeech}",
-				)
-				return False
+				# The "Ask Google about this page" button is sometimes spoken,
+				# which clobbers the expected output
+				moveToAddressBarSpeech = _NvdaLib.getSpeechAfterKey("nvda+tab")  # report current focus.
+				if expectedAddressBarSpeech not in moveToAddressBarSpeech:
+					builtIn.log(
+						f"Didn't read '{expectedAddressBarSpeech}' after alt+d, instead got: {moveToAddressBarSpeech}",
+					)
+					return False
 
 		afterControlF6Speech = _NvdaLib.getSpeechAfterKey("control+F6")  # focus web content, chrome shortcut.
 		if ChromeLib._testCaseTitle not in afterControlF6Speech:


### PR DESCRIPTION
### Link to issue number:

None

### Summary of the issue:

A recent update to chrome has introduced a "Ask Google about this page" option in the omnibox (address bar). This option is sometimes spoken, even though it isn't focused, when focusing the address bar. This causes system tests which rely on Chrome to fail, as they are unable to recognise that the address bar has been focused.
This breaks some tests in the Chrome, symbols, and image descriptions system test suites.

### Description of user facing changes:

None.

### Description of developer facing changes:

System tests work again.

### Description of development approach:

When setting up a system test that uses Chrome, after sending `alt+d` to focus the address bar, if the speech is not what we expect, try reporting the focused object (`NVDA+tab`) to double-check.
This works because "Address and search bar" speech is cancelled by the "Ask Google about this page" speech, so the system tests are unaware where the focus has landed. By explicitly checking the current focus, we work around this issue.

### Testing strategy:

Ran the Chrome system test "checkbox labelled by inner element" locally, with and without this patch, to ensure that it was broken on my machine without the patch, and fixed with it.
Ran in CI.

### Known issues with pull request:

This does not fix the underlying issue, which will still likely inconvenience users. However, as this is stopping us being able to create snapshot, beta, rc or release builds, this fix needed to be prioritised..

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
