### PR TITLE
Add Bluetooth Low Energy support for DotPad braille displays

### DIFF
--- a/source/_asyncioEventLoop/__init__.py
+++ b/source/_asyncioEventLoop/__init__.py
@@ -28,6 +28,14 @@ def initialize():
 	_state.asyncioThread.start()
 
 
+def isRunning() -> bool:
+	"""Determine whether the asyncio event loop is running.
+
+	:return: ``True`` if coroutines can be scheduled on it.
+	"""
+	return _state.asyncioThread is not None and _state.asyncioThread.is_alive()
+
+
 def terminate():
 	"""Terminate the asyncio event loop and cancel all running tasks."""
 	log.info("Terminating asyncio event loop")

--- a/source/_asyncioEventLoop/__init__.py
+++ b/source/_asyncioEventLoop/__init__.py
@@ -12,7 +12,7 @@ from threading import Thread
 
 from logHandler import log
 
-from .utils import runCoroutineSync
+from .utils import isRunning, runCoroutineSync  # noqa: F401 - re-exported
 
 from . import _state
 
@@ -26,14 +26,6 @@ def initialize():
 	asyncio.set_event_loop(_state.eventLoop)
 	_state.asyncioThread = Thread(target=_state.eventLoop.run_forever, daemon=True)
 	_state.asyncioThread.start()
-
-
-def isRunning() -> bool:
-	"""Determine whether the asyncio event loop is running.
-
-	:return: ``True`` if coroutines can be scheduled on it.
-	"""
-	return _state.asyncioThread is not None and _state.asyncioThread.is_alive()
 
 
 def terminate():

--- a/source/_asyncioEventLoop/_state.py
+++ b/source/_asyncioEventLoop/_state.py
@@ -13,7 +13,7 @@ from threading import Thread
 TERMINATE_TIMEOUT_SECONDS = 5
 """Time to wait for tasks to finish while terminating the event loop."""
 
-eventLoop: asyncio.BaseEventLoop
-"""The asyncio event loop used by NVDA."""
-asyncioThread: Thread
-"""Thread running the asyncio event loop."""
+eventLoop: asyncio.BaseEventLoop | None = None
+"""The asyncio event loop used by NVDA, or ``None`` before it is initialized."""
+asyncioThread: Thread | None = None
+"""Thread running the asyncio event loop, or ``None`` while it is not running."""

--- a/source/_asyncioEventLoop/utils.py
+++ b/source/_asyncioEventLoop/utils.py
@@ -18,7 +18,9 @@ def runCoroutine(coro: Coroutine) -> asyncio.Future:
 
 	:param coro: The coroutine to run.
 	"""
-	if _state.asyncioThread is None or not _state.asyncioThread.is_alive():
+	from . import isRunning
+
+	if not isRunning():
 		raise RuntimeError("Asyncio event loop thread is not running")
 	return asyncio.run_coroutine_threadsafe(coro, _state.eventLoop)
 

--- a/source/_asyncioEventLoop/utils.py
+++ b/source/_asyncioEventLoop/utils.py
@@ -13,13 +13,19 @@ from collections.abc import Coroutine
 from . import _state
 
 
+def isRunning() -> bool:
+	"""Determine whether the asyncio event loop is running.
+
+	:return: ``True`` if coroutines can be scheduled on it.
+	"""
+	return _state.asyncioThread is not None and _state.asyncioThread.is_alive()
+
+
 def runCoroutine(coro: Coroutine) -> asyncio.Future:
 	"""Schedule a coroutine to be run on the asyncio event loop.
 
 	:param coro: The coroutine to run.
 	"""
-	from . import isRunning
-
 	if not isRunning():
 		raise RuntimeError("Asyncio event loop thread is not running")
 	return asyncio.run_coroutine_threadsafe(coro, _state.eventLoop)

--- a/source/bdDetect.py
+++ b/source/bdDetect.py
@@ -1,7 +1,7 @@
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-# Copyright (C) 2013-2025 NV Access Limited, Babbage B.V., Leonard de Ruijter, Christian Comaschi
+# Copyright (C) 2013-2025 NV Access Limited, Babbage B.V., Leonard de Ruijter, Christian Comaschi, Dot Incorporated, Bram Duvigneau
 
 """Support for braille display detection.
 This allows devices to be automatically detected and used when they become available,
@@ -16,6 +16,7 @@ from dataclasses import dataclass, field
 from functools import partial
 import itertools
 import threading
+import time
 from concurrent.futures import ThreadPoolExecutor, Future
 from enum import StrEnum
 from typing import (
@@ -24,6 +25,10 @@ from typing import (
 )
 from collections import OrderedDict
 from collections.abc import Callable, Generator, Iterable, Iterator
+from bleak.backends.device import BLEDevice
+from bleak.backends.scanner import AdvertisementData
+import hwIo
+import hwIo.ble
 import hwPortUtils
 import NVDAState
 import braille
@@ -53,6 +58,8 @@ class ProtocolType(StrEnum):
 	"""Serial devices (COM ports)"""
 	CUSTOM = "custom"
 	"""Devices with a manufacturer specific protocol"""
+	BLE = "ble"
+	"""Bluetooth Low Energy devices using BLE commands and notifications"""
 
 
 class CommunicationType(StrEnum):
@@ -60,6 +67,8 @@ class CommunicationType(StrEnum):
 	"""Bluetooth devices"""
 	USB = "usb"
 	"""USB devices"""
+	BLE = "ble"
+	"""Bluetooth Low Energy devices"""
 
 
 class _DeviceTypeMeta(type):
@@ -170,8 +179,10 @@ Registered handlers should yield a tuple containing a driver name as str and Dev
 Handlers are called with these keyword arguments:
 @param usb: Whether the handler is expected to yield USB devices.
 @type usb: bool
-@param bluetooth: Whether the handler is expected to yield USB devices.
+@param bluetooth: Whether the handler is expected to yield Bluetooth devices.
 @type bluetooth: bool
+@param ble: Whether the handler is expected to yield BLE devices.
+@type ble: bool
 @param limitToDevices: Drivers to which detection should be limited.
 	``None`` if no driver filtering should occur.
 @type limitToDevices: Optional[List[str]]
@@ -180,6 +191,20 @@ Handlers are called with these keyword arguments:
 
 def _isDebug() -> bool:
 	return config.conf["debugLog"]["bdDetect"]
+
+
+def _stopBleScanner() -> None:
+	"""Stop the shared BLE scanner if BLE is initialized and a scan is running.
+
+	The scanner is created by ``hwIo.ble.initialize()`` at startup and is ``None``
+	in contexts where BLE is unavailable (e.g. unit tests), in which case there is
+	nothing to stop.
+	"""
+	scanner = hwIo.ble.scanner
+	if scanner is not None and scanner.isScanning:
+		if _isDebug():
+			log.debug("Stopping BLE scanner")
+		scanner.stop()
 
 
 def getDriversForConnectedUsbDevices(
@@ -407,12 +432,18 @@ class _Detector:
 		self._stopEvent = threading.Event()
 		self._detectUsb = True
 		self._detectBluetooth = True
+		self._detectBle = True
 		self._limitToDevices: list[str] | None = None
+		# Register for real-time BLE device discovery notifications.
+		# The scanner is None when BLE is unavailable (e.g. unit tests); skip registration then.
+		if hwIo.ble.scanner is not None:
+			hwIo.ble.scanner.deviceDiscovered.register(self._onBleDeviceDiscovered)
 
 	def _queueBgScan(
 		self,
 		usb: bool = False,
 		bluetooth: bool = False,
+		ble: bool = False,
 		limitToDevices: list[str] | None = None,
 		preferredDevice: DriverAndDeviceMatch | None = None,
 	):
@@ -421,6 +452,7 @@ class _Detector:
 		To explicitely cancel a scan in progress, use L{rescan}.
 		:param usb: Whether USB devices should be detected for this and subsequent scans.
 		:param bluetooth: Whether Bluetooth devices should be detected for this and subsequent scans.
+		:param ble: Whether BLE devices should be detected for this and subsequent scans.
 		:param limitToDevices: Drivers to which detection should be limited for this and subsequent scans.
 			``None`` if default driver filtering according to config should occur.
 		:param preferredDevice: An optional preferred device to use for detection before scanning.
@@ -428,15 +460,17 @@ class _Detector:
 		"""
 		if _isDebug():
 			log.debug(
-				"Queuing background scan: usb=%r, bluetooth=%r, limitToDevices=%r, preferredDevice=%r",
+				"Queuing background scan: usb=%r, bluetooth=%r, ble=%r, limitToDevices=%r, preferredDevice=%r",
 				usb,
 				bluetooth,
+				ble,
 				limitToDevices,
 				preferredDevice,
 			)
 
 		self._detectUsb = usb
 		self._detectBluetooth = bluetooth
+		self._detectBle = ble
 		if limitToDevices is None and config.conf["braille"]["auto"]["excludedDisplays"]:
 			limitToDevices = list(getBrailleDisplayDriversEnabledForDetection())
 			if limitToDevices and _isDebug():
@@ -456,6 +490,7 @@ class _Detector:
 			self._bgScan,
 			usb,
 			bluetooth,
+			ble,
 			limitToDevices,
 			preferredDevice,
 		)
@@ -471,6 +506,8 @@ class _Detector:
 			if _isDebug():
 				log.debug("Cancelling queued future for next background scan")
 			self._queuedFuture.cancel()
+		# Stop the BLE scanner if it's running
+		_stopBleScanner()
 
 	@staticmethod
 	def _bgScanUsb(
@@ -508,10 +545,23 @@ class _Detector:
 		if btDevsCache is not btDevs:
 			deviceInfoFetcher.btDevsCache = btDevsCache
 
+	@staticmethod
+	def _bgScanBle(
+		ble: bool = True,
+		limitToDevices: list[str] | None = None,
+	):
+		"""Handler for L{scanForDevices} that yields BLE devices.
+		See the L{scanForDevices} documentation for information about the parameters.
+		"""
+		if not ble:
+			return
+		yield from getDriversForBleDevices(limitToDevices)
+
 	def _bgScan(
 		self,
 		usb: bool,
 		bluetooth: bool,
+		ble: bool,
 		limitToDevices: list[str] | None,
 		preferredDevice: DriverAndDeviceMatch | None,
 	):
@@ -519,6 +569,7 @@ class _Detector:
 		this function should be run on a background thread.
 		:param usb: Whether USB devices should be detected for this particular scan.
 		:param bluetooth: Whether Bluetooth devices should be detected for this particular scan.
+		:param ble: Whether BLE devices should be detected for this particular scan.
 		:param limitToDevices: Drivers to which detection should be limited for this scan.
 			``None`` if no driver filtering should occur.
 		:param preferredDevice: An optional preferred device to use for detection before scanning.
@@ -526,21 +577,32 @@ class _Detector:
 		"""
 		if _isDebug():
 			log.debug(
-				"Starting background scan: usb=%r, bluetooth=%r, limitToDevices=%r, preferredDevice=%r",
+				"Starting background scan: usb=%r, bluetooth=%r, ble=%r, limitToDevices=%r, preferredDevice=%r",
 				usb,
 				bluetooth,
+				ble,
 				limitToDevices,
 				preferredDevice,
 			)
 		# Clear the stop event before a scan is started.
 		# Since a scan can take some time to complete, another thread can set the stop event to cancel it.
 		self._stopEvent.clear()
+
+		# Start BLE scanner if needed for this scan
+		if ble and hwIo.ble.scanner is not None and not hwIo.ble.scanner.isScanning:
+			if _isDebug():
+				log.debug("Starting BLE scanner for background scan")
+			hwIo.ble.scanner.start()
+			# Give the scanner some time to get initial results
+			time.sleep(0.2)
 		if preferredDevice:
 			if _isDebug():
 				log.debug("Trying preferred device first: %r", preferredDevice)
 			if braille.handler.setDisplayByName(preferredDevice[0], detected=preferredDevice[1]):
 				if _isDebug():
 					log.debug("Switched to preferred device: %r", preferredDevice[0])
+				# Device connected - stop BLE scanner to save resources
+				_stopBleScanner()
 				return
 			elif _isDebug():
 				log.debug("Failed to switch to preferred device, continuing scan: %r", preferredDevice)
@@ -551,6 +613,7 @@ class _Detector:
 		iterator = scanForDevices.iter(
 			usb=usb,
 			bluetooth=bluetooth,
+			ble=ble,
 			limitToDevices=limitToDevices,
 		)
 		for driver, match in iterator:
@@ -561,6 +624,8 @@ class _Detector:
 			if braille.handler.setDisplayByName(driver, detected=match):
 				if _isDebug():
 					log.debug("Switched to driver %r, match %r", driver, match)
+				# Device connected - stop BLE scanner to save resources
+				_stopBleScanner()
 				return
 			elif _isDebug():
 				log.debug("Failed to switch to driver %r, match %r. Continuing", driver, match)
@@ -571,12 +636,14 @@ class _Detector:
 		self,
 		usb: bool = True,
 		bluetooth: bool = True,
+		ble: bool = True,
 		limitToDevices: list[str] | None = None,
 		preferredDevice: DriverAndDeviceMatch | None = None,
 	):
 		"""Stop a current scan when in progress, and start scanning from scratch.
 		:param usb: Whether USB devices should be detected for this and subsequent scans.
 		:param bluetooth: Whether Bluetooth devices should be detected for this and subsequent scans.
+		:param ble: Whether BLE devices should be detected for this and subsequent scans.
 		:param limitToDevices: Drivers to which detection should be limited for this and subsequent scans.
 			``None`` if default driver filtering according to config should occur.
 		:param preferredDevice: An optional preferred device to use for detection before scanning.
@@ -588,13 +655,18 @@ class _Detector:
 		self._queueBgScan(
 			usb=usb,
 			bluetooth=bluetooth,
+			ble=ble,
 			limitToDevices=limitToDevices,
 			preferredDevice=preferredDevice,
 		)
 
 	def handleWindowMessage(self, msg=None, wParam=None):
 		if msg == winUser.WM_DEVICECHANGE and wParam == DBT_DEVNODES_CHANGED:
-			self.rescan(bluetooth=self._detectBluetooth, limitToDevices=self._limitToDevices)
+			self.rescan(
+				bluetooth=self._detectBluetooth,
+				ble=self._detectBle,
+				limitToDevices=self._limitToDevices,
+			)
 
 	def pollBluetoothDevices(self):
 		"""Poll bluetooth devices that might be in range.
@@ -604,11 +676,92 @@ class _Detector:
 			return
 		if not deviceInfoFetcher.btDevsCache:
 			return
-		self._queueBgScan(bluetooth=self._detectBluetooth, limitToDevices=self._limitToDevices)
+		self._queueBgScan(
+			bluetooth=self._detectBluetooth,
+			ble=self._detectBle,
+			limitToDevices=self._limitToDevices,
+		)
+
+	def _getBleDeviceMatch(self, device: BLEDevice) -> DriverAndDeviceMatch | None:
+		"""Check if BLE device matches any registered driver.
+
+		:param device: The BLE device to check
+		:return: Tuple of (driver_name, DeviceMatch) if match found, None otherwise
+		"""
+		# Create DeviceMatch for this device
+		match = DeviceMatch(
+			ProtocolType.BLE,
+			device.name or device.address,
+			device.address,
+			{
+				"name": device.name or "",
+				"address": device.address,
+				"provider": CommunicationType.BLE,
+			},
+		)
+
+		# Check against registered drivers (respect limitToDevices filter)
+		driversToCheck = (
+			((driver, devs) for driver, devs in _driverDevices.items() if driver in self._limitToDevices)
+			if self._limitToDevices
+			else _driverDevices.items()
+		)
+
+		for driver, devs in driversToCheck:
+			matchFunc = devs.get(CommunicationType.BLE)
+			if callable(matchFunc) and matchFunc(match):
+				return (driver, match)
+
+		return None
+
+	def _onBleDeviceDiscovered(
+		self,
+		device: BLEDevice,
+		advertisementData: AdvertisementData,
+		isNew: bool,
+	) -> None:
+		"""Handler for real-time BLE device discoveries.
+
+		Immediately attempts to connect when a new BLE device matching
+		a registered driver is discovered, providing much faster connection
+		than waiting for periodic app-switch polling.
+
+		:param device: The BLE device that was discovered
+		:param advertisementData: Advertisement data from the device
+		:param isNew: True if this is the first time seeing this device
+		"""
+		# Only react to newly discovered devices
+		if not isNew:
+			return
+
+		# Check if BLE detection is enabled
+		if not self._detectBle:
+			return
+
+		# Find matching driver for this device
+		match = self._getBleDeviceMatch(device)
+		if not match:
+			return
+
+		# Queue scan with this device as preferred
+		driver, deviceMatch = match
+		if _isDebug():
+			log.debug(
+				f"New BLE device {device.name or device.address} matches driver {driver}, "
+				f"queueing connection attempt",
+			)
+
+		self._queueBgScan(
+			ble=True,
+			limitToDevices=self._limitToDevices,
+			preferredDevice=(driver, deviceMatch),
+		)
 
 	def terminate(self):
 		appModuleHandler.post_appSwitch.unregister(self.pollBluetoothDevices)
 		messageWindow.pre_handleWindowMessage.unregister(self.handleWindowMessage)
+		if hwIo.ble.scanner is not None:
+			hwIo.ble.scanner.deviceDiscovered.unregister(self._onBleDeviceDiscovered)
 		self._stopBgScan()
 		# Clear the cache of bluetooth devices so new devices can be picked up with a new instance.
 		deviceInfoFetcher.btDevsCache = None
@@ -656,6 +809,86 @@ def getConnectedUsbDevicesForDriver(driver: str) -> Iterator[DeviceMatch]:
 		yield match
 
 
+def getDriversForBleDevices(
+	limitToDevices: list[str] | None = None,
+) -> Iterator[DriverAndDeviceMatch]:
+	"""Get any matching drivers for BLE devices.
+	:param limitToDevices: Drivers to which detection should be limited.
+		``None`` if no driver filtering should occur.
+	:return: Generator of pairs of drivers and device information.
+	"""
+	if limitToDevices and _isDebug():
+		log.debug("Limiting BLE device detection to drivers: %r", limitToDevices)
+
+	# Check if any drivers support BLE before starting the scanner
+	driversToCheck = (
+		((driver, devs) for driver, devs in _driverDevices.items() if driver in limitToDevices)
+		if limitToDevices
+		else _driverDevices.items()
+	)
+	hasBleDrivers = any(callable(devs.get(CommunicationType.BLE)) for _, devs in driversToCheck)
+	if not hasBleDrivers:
+		if _isDebug():
+			log.debug("No drivers with BLE support registered, skipping BLE scan")
+		return
+
+	# Use the module-level singleton scanner
+	scanner = hwIo.ble.scanner
+	if scanner is None:
+		# BLE not initialized (e.g. unit tests); no BLE devices to report.
+		return
+	if not scanner.isScanning:
+		if _isDebug():
+			log.debugWarning("BLE scanner not running, results may be incomplete")
+
+	scanResults = scanner.results()
+	for device in scanResults:
+		# Create DeviceMatch for each BLE device
+		# id: Display name for UI (device name if available, otherwise address)
+		# port: BLE address for unique identification and connection
+		# deviceInfo: All information as strings for backwards compatibility
+		match = DeviceMatch(
+			ProtocolType.BLE,
+			device.name or device.address,
+			device.address,
+			{
+				"name": device.name or "",
+				"address": device.address,
+				"provider": CommunicationType.BLE,
+			},
+		)
+
+		for driver, devs in _driverDevices.items():
+			if limitToDevices and driver not in limitToDevices:
+				if _isDebug():
+					log.debug("Skipping excluded driver %r for BLE device match: %r", driver, match)
+				continue
+
+			matchFunc = devs[CommunicationType.BLE]
+			if not callable(matchFunc):
+				if _isDebug():
+					log.debugWarning(
+						"Skipping non-callable matchFunc %r for BLE device match: %r",
+						matchFunc,
+						match,
+					)
+				continue
+
+			if matchFunc(match):
+				if _isDebug():
+					log.debug("Found BLE device match: %r for driver %r", match, driver)
+				yield (driver, match)
+
+
+def getBleDevicesForDriver(driver: str) -> Iterator[DeviceMatch]:
+	"""Get any BLE devices associated with a particular driver.
+	:param driver: The name of the driver.
+	:return: Generator of device information for matching BLE devices.
+	"""
+	for _driverName, match in getDriversForBleDevices(limitToDevices=[driver]):
+		yield match
+
+
 def getPossibleBluetoothDevicesForDriver(driver: str) -> Iterator[DeviceMatch]:
 	"""Get any possible Bluetooth devices associated with a particular driver.
 	@param driver: The name of the driver.
@@ -696,6 +929,7 @@ def driverHasPossibleDevices(driver: str) -> bool:
 			itertools.chain(
 				getConnectedUsbDevicesForDriver(driver),
 				getPossibleBluetoothDevicesForDriver(driver),
+				getBleDevicesForDriver(driver),
 			),
 			None,
 		),
@@ -749,6 +983,7 @@ def initialize():
 
 	scanForDevices.register(_Detector._bgScanUsb)
 	scanForDevices.register(_Detector._bgScanBluetooth)
+	scanForDevices.register(_Detector._bgScanBle)
 
 	# Add devices
 	for display in getSupportedBrailleDisplayDrivers():
@@ -761,8 +996,11 @@ def initialize():
 def terminate():
 	global deviceInfoFetcher
 	_driverDevices.clear()
+	scanForDevices.unregister(_Detector._bgScanBle)
 	scanForDevices.unregister(_Detector._bgScanBluetooth)
 	scanForDevices.unregister(_Detector._bgScanUsb)
+	# Stop BLE scanner if running
+	_stopBleScanner()
 	deviceInfoFetcher = None
 
 
@@ -861,6 +1099,15 @@ class DriverRegistrar:
 		devs = self._getDriverDict()
 		devs[CommunicationType.BLUETOOTH] = matchFunc
 
+	def addBleDevices(self, matchFunc: MatchFuncT):
+		"""Associate BLE devices with the driver on this instance.
+		@param matchFunc: A function which determines whether a given BLE device matches.
+			It takes a L{DeviceMatch} as its only argument
+			and returns a C{bool} indicating whether it matched.
+		"""
+		devs = self._getDriverDict()
+		devs[CommunicationType.BLE] = matchFunc
+
 	def addDeviceScanner(
 		self,
 		scanFunc: Callable[..., Iterable[DriverAndDeviceMatch]],
@@ -872,8 +1119,10 @@ class DriverRegistrar:
 			The callable is called with these keyword arguments:
 			@param usb: Whether the handler is expected to yield USB devices.
 			@type usb: bool
-			@param bluetooth: Whether the handler is expected to yield USB devices.
+			@param bluetooth: Whether the handler is expected to yield Bluetooth devices.
 			@type bluetooth: bool
+			@param ble: Whether the handler is expected to yield BLE devices.
+			@type ble: bool
 			@param limitToDevices: Drivers to which detection should be limited.
 				``None`` if no driver filtering should occur.
 			@type limitToDevices: Optional[List[str]]

--- a/source/bdDetect.py
+++ b/source/bdDetect.py
@@ -213,6 +213,28 @@ def _stopBleScanner() -> None:
 			log.debugWarning("Failed to stop BLE scanner", exc_info=True)
 
 
+def _getBleMatchers(limitToDevices: list[str] | None = None) -> list[tuple[str, MatchFuncT]]:
+	"""Get the BLE match functions of the drivers in scope.
+
+	Resolving these once keeps the work out of the loop over discovered devices,
+	which would otherwise repeat it for every device.
+
+	:param limitToDevices: Drivers to which detection should be limited.
+		``None`` if no driver filtering should occur.
+	:return: Pairs of driver name and the function deciding whether a device is theirs.
+	"""
+	matchers: list[tuple[str, MatchFuncT]] = []
+	for driver, devs in _driverDevices.items():
+		if limitToDevices and driver not in limitToDevices:
+			continue
+		# The driver dict is a defaultdict, so subscripting would add an empty entry
+		# for every driver without BLE support.
+		matchFunc = devs.get(CommunicationType.BLE)
+		if callable(matchFunc):
+			matchers.append((driver, matchFunc))
+	return matchers
+
+
 def _hasBleDrivers(limitToDevices: list[str] | None = None) -> bool:
 	"""Determine whether any driver in scope has registered BLE devices.
 
@@ -220,11 +242,7 @@ def _hasBleDrivers(limitToDevices: list[str] | None = None) -> bool:
 		``None`` if no driver filtering should occur.
 	:return: ``True`` if at least one driver in scope can match BLE devices.
 	"""
-	return any(
-		callable(devs.get(CommunicationType.BLE))
-		for driver, devs in _driverDevices.items()
-		if not limitToDevices or driver in limitToDevices
-	)
+	return bool(_getBleMatchers(limitToDevices))
 
 
 def _bleDeviceToMatch(device: BLEDevice) -> DeviceMatch:
@@ -866,7 +884,8 @@ def getDriversForBleDevices(
 	if limitToDevices and _isDebug():
 		log.debug("Limiting BLE device detection to drivers: %r", limitToDevices)
 
-	if not _hasBleDrivers(limitToDevices):
+	matchers = _getBleMatchers(limitToDevices)
+	if not matchers:
 		if _isDebug():
 			log.debug("No drivers with BLE support registered, skipping BLE scan")
 		return
@@ -879,22 +898,11 @@ def getDriversForBleDevices(
 		if _isDebug():
 			log.debugWarning("BLE scanner not running, results may be incomplete")
 
-	scanResults = scanner.results()
-	for device in scanResults:
+	# Devices are the outer loop, as in the USB and Bluetooth equivalents above, so that
+	# the device discovered first is offered first rather than whichever driver registered first.
+	for device in scanner.results():
 		match = _bleDeviceToMatch(device)
-
-		for driver, devs in _driverDevices.items():
-			if limitToDevices and driver not in limitToDevices:
-				if _isDebug():
-					log.debug("Skipping excluded driver %r for BLE device match: %r", driver, match)
-				continue
-
-			# The driver dict is a defaultdict, so subscripting would add an empty entry
-			# for every driver without BLE support.
-			matchFunc = devs.get(CommunicationType.BLE)
-			if not callable(matchFunc):
-				continue
-
+		for driver, matchFunc in matchers:
 			if matchFunc(match):
 				if _isDebug():
 					log.debug("Found BLE device match: %r for driver %r", match, driver)

--- a/source/bdDetect.py
+++ b/source/bdDetect.py
@@ -26,6 +26,7 @@ from collections import OrderedDict
 from collections.abc import Callable, Generator, Iterable, Iterator
 from bleak.backends.device import BLEDevice
 from bleak.backends.scanner import AdvertisementData
+from bleak.exc import BleakError
 import hwIo
 import hwIo.ble
 import hwPortUtils
@@ -201,7 +202,11 @@ def _stopBleScanner() -> None:
 	if scanner is not None and scanner.isScanning:
 		if _isDebug():
 			log.debug("Stopping BLE scanner")
-		scanner.stop()
+		try:
+			scanner.stop()
+		except (BleakError, OSError):
+			# Detection has to carry on regardless of what the Bluetooth stack is doing.
+			log.debugWarning("Failed to stop BLE scanner", exc_info=True)
 
 
 def _hasBleDrivers(limitToDevices: list[str] | None = None) -> bool:
@@ -629,7 +634,12 @@ class _Detector:
 		):
 			if _isDebug():
 				log.debug("Starting BLE scanner for background scan")
-			hwIo.ble.scanner.start()
+			try:
+				hwIo.ble.scanner.start()
+			except (BleakError, OSError):
+				# Bleak refuses to scan without a usable adapter. Only BLE is lost here,
+				# so the USB and Bluetooth parts of this scan must still run.
+				log.debugWarning("Could not start BLE scanner", exc_info=True)
 			# A scanner that was just started has no results yet, so the BLE part of the
 			# scan below finds nothing. Devices that advertise afterwards reach us through
 			# the scanner's deviceDiscovered action, which queues a scan for them.

--- a/source/bdDetect.py
+++ b/source/bdDetect.py
@@ -16,7 +16,6 @@ from dataclasses import dataclass, field
 from functools import partial
 import itertools
 import threading
-import time
 from concurrent.futures import ThreadPoolExecutor, Future
 from enum import StrEnum
 from typing import (
@@ -631,9 +630,9 @@ class _Detector:
 			if _isDebug():
 				log.debug("Starting BLE scanner for background scan")
 			hwIo.ble.scanner.start()
-			# Without a moment to collect advertisements the scan below sees nothing,
-			# delaying any connection until the next scan.
-			time.sleep(0.2)
+			# A scanner that was just started has no results yet, so the BLE part of the
+			# scan below finds nothing. Devices that advertise afterwards reach us through
+			# the scanner's deviceDiscovered action, which queues a scan for them.
 		if preferredDevice:
 			if _isDebug():
 				log.debug("Trying preferred device first: %r", preferredDevice)

--- a/source/bdDetect.py
+++ b/source/bdDetect.py
@@ -1,7 +1,7 @@
 # A part of NonVisual Desktop Access (NVDA)
-# This file is covered by the GNU General Public License.
-# See the file COPYING for more details.
-# Copyright (C) 2013-2025 NV Access Limited, Babbage B.V., Leonard de Ruijter, Christian Comaschi, Dot Incorporated, Bram Duvigneau
+# Copyright (C) 2013-2026 NV Access Limited, Babbage B.V., Leonard de Ruijter, Christian Comaschi, Dot Incorporated, Bram Duvigneau
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
 
 """Support for braille display detection.
 This allows devices to be automatically detected and used when they become available,
@@ -178,15 +178,12 @@ scanForDevices = extensionPoints.Chain[DriverAndDeviceMatch]()
 A Chain that can be iterated to scan for devices.
 Registered handlers should yield a tuple containing a driver name as str and DeviceMatch
 Handlers are called with these keyword arguments:
-@param usb: Whether the handler is expected to yield USB devices.
-@type usb: bool
-@param bluetooth: Whether the handler is expected to yield Bluetooth devices.
-@type bluetooth: bool
-@param ble: Whether the handler is expected to yield BLE devices.
-@type ble: bool
-@param limitToDevices: Drivers to which detection should be limited.
+
+:param usb: Whether the handler is expected to yield USB devices.
+:param bluetooth: Whether the handler is expected to yield Bluetooth devices.
+:param ble: Whether the handler is expected to yield BLE devices.
+:param limitToDevices: Drivers to which detection should be limited.
 	``None`` if no driver filtering should occur.
-@type limitToDevices: Optional[List[str]]
 """
 
 
@@ -471,8 +468,7 @@ class _Detector:
 		self._detectBluetooth = True
 		self._detectBle = True
 		self._limitToDevices: list[str] | None = None
-		# Register for real-time BLE device discovery notifications.
-		# The scanner is None when BLE is unavailable (e.g. unit tests); skip registration then.
+		# The scanner is None outside a running NVDA, such as in unit tests.
 		if hwIo.ble.scanner is not None:
 			hwIo.ble.scanner.deviceDiscovered.register(self._onBleDeviceDiscovered)
 
@@ -543,7 +539,6 @@ class _Detector:
 			if _isDebug():
 				log.debug("Cancelling queued future for next background scan")
 			self._queuedFuture.cancel()
-		# Stop the BLE scanner if it's running
 		_stopBleScanner()
 
 	@staticmethod
@@ -587,8 +582,8 @@ class _Detector:
 		ble: bool = True,
 		limitToDevices: list[str] | None = None,
 	):
-		"""Handler for L{scanForDevices} that yields BLE devices.
-		See the L{scanForDevices} documentation for information about the parameters.
+		"""Handler for :data:`scanForDevices` that yields BLE devices.
+		See the :data:`scanForDevices` documentation for information about the parameters.
 		"""
 		if not ble:
 			return
@@ -625,9 +620,8 @@ class _Detector:
 		# Since a scan can take some time to complete, another thread can set the stop event to cancel it.
 		self._stopEvent.clear()
 
-		# Start BLE scanner if needed for this scan.
-		# Scanning uses the Bluetooth radio continuously, so only do so
-		# when a driver in scope can actually match a BLE device.
+		# Scanning occupies the Bluetooth radio continuously,
+		# so only do so when a driver in scope can actually match a BLE device.
 		if (
 			ble
 			and _hasBleDrivers(limitToDevices)
@@ -637,7 +631,8 @@ class _Detector:
 			if _isDebug():
 				log.debug("Starting BLE scanner for background scan")
 			hwIo.ble.scanner.start()
-			# Give the scanner some time to get initial results
+			# Without a moment to collect advertisements the scan below sees nothing,
+			# delaying any connection until the next scan.
 			time.sleep(0.2)
 		if preferredDevice:
 			if _isDebug():
@@ -645,7 +640,7 @@ class _Detector:
 			if braille.handler.setDisplayByName(preferredDevice[0], detected=preferredDevice[1]):
 				if _isDebug():
 					log.debug("Switched to preferred device: %r", preferredDevice[0])
-				# Device connected - stop BLE scanner to save resources
+				# Connected, so the radio is no longer needed.
 				_stopBleScanner()
 				return
 			elif _isDebug():
@@ -668,7 +663,7 @@ class _Detector:
 			if braille.handler.setDisplayByName(driver, detected=match):
 				if _isDebug():
 					log.debug("Switched to driver %r, match %r", driver, match)
-				# Device connected - stop BLE scanner to save resources
+				# Connected, so the radio is no longer needed.
 				_stopBleScanner()
 				return
 			elif _isDebug():
@@ -734,7 +729,6 @@ class _Detector:
 		"""
 		match = _bleDeviceToMatch(device)
 
-		# Check against registered drivers (respect limitToDevices filter)
 		driversToCheck = (
 			((driver, devs) for driver, devs in _driverDevices.items() if driver in self._limitToDevices)
 			if self._limitToDevices
@@ -764,20 +758,16 @@ class _Detector:
 		:param advertisementData: Advertisement data from the device
 		:param isNew: True if this is the first time seeing this device
 		"""
-		# Only react to newly discovered devices
 		if not isNew:
 			return
 
-		# Check if BLE detection is enabled
 		if not self._detectBle:
 			return
 
-		# Find matching driver for this device
 		match = self._getBleDeviceMatch(device)
 		if not match:
 			return
 
-		# Queue scan with this device as preferred
 		driver, deviceMatch = match
 		if _isDebug():
 			log.debug(
@@ -785,9 +775,8 @@ class _Detector:
 				f"queueing connection attempt",
 			)
 
-		# Preserve the USB and Bluetooth detection state,
-		# as _queueBgScan stores its arguments as the state for subsequent scans.
-		# Omitting them here would permanently disable USB and Bluetooth detection.
+		# _queueBgScan stores its arguments as the state for subsequent scans,
+		# so omitting these would permanently disable USB and Bluetooth detection.
 		self._queueBgScan(
 			usb=self._detectUsb,
 			bluetooth=self._detectBluetooth,
@@ -859,16 +848,14 @@ def getDriversForBleDevices(
 	if limitToDevices and _isDebug():
 		log.debug("Limiting BLE device detection to drivers: %r", limitToDevices)
 
-	# Check if any drivers support BLE before inspecting the scan results
 	if not _hasBleDrivers(limitToDevices):
 		if _isDebug():
 			log.debug("No drivers with BLE support registered, skipping BLE scan")
 		return
 
-	# Use the module-level singleton scanner
 	scanner = hwIo.ble.scanner
 	if scanner is None:
-		# BLE not initialized (e.g. unit tests); no BLE devices to report.
+		# BLE is not initialized outside a running NVDA, such as in unit tests.
 		return
 	if not scanner.isScanning:
 		if _isDebug():
@@ -884,8 +871,8 @@ def getDriversForBleDevices(
 					log.debug("Skipping excluded driver %r for BLE device match: %r", driver, match)
 				continue
 
-			# Drivers without BLE support have no entry here.
-			# Note that _driverDevices maps to a defaultdict, so subscripting would add empty entries.
+			# The driver dict is a defaultdict, so subscripting would add an empty entry
+			# for every driver without BLE support.
 			matchFunc = devs.get(CommunicationType.BLE)
 			if not callable(matchFunc):
 				continue
@@ -1015,7 +1002,6 @@ def terminate():
 	scanForDevices.unregister(_Detector._bgScanBle)
 	scanForDevices.unregister(_Detector._bgScanBluetooth)
 	scanForDevices.unregister(_Detector._bgScanUsb)
-	# Stop BLE scanner if running
 	_stopBleScanner()
 	deviceInfoFetcher = None
 
@@ -1117,9 +1103,10 @@ class DriverRegistrar:
 
 	def addBleDevices(self, matchFunc: MatchFuncT):
 		"""Associate BLE devices with the driver on this instance.
-		@param matchFunc: A function which determines whether a given BLE device matches.
-			It takes a L{DeviceMatch} as its only argument
-			and returns a C{bool} indicating whether it matched.
+
+		:param matchFunc: A function which determines whether a given BLE device matches.
+			It takes a :class:`DeviceMatch` as its only argument
+			and returns a ``bool`` indicating whether it matched.
 		"""
 		devs = self._getDriverDict()
 		devs[CommunicationType.BLE] = matchFunc
@@ -1130,19 +1117,12 @@ class DriverRegistrar:
 		moveToStart: bool = False,
 	):
 		"""Register a callable to scan devices.
-		This adds a handler to L{scanForDevices}.
-		@param scanFunc: Callable that should yield a tuple containing a driver name as str and DeviceMatch.
-			The callable is called with these keyword arguments:
-			@param usb: Whether the handler is expected to yield USB devices.
-			@type usb: bool
-			@param bluetooth: Whether the handler is expected to yield Bluetooth devices.
-			@type bluetooth: bool
-			@param ble: Whether the handler is expected to yield BLE devices.
-			@type ble: bool
-			@param limitToDevices: Drivers to which detection should be limited.
-				``None`` if no driver filtering should occur.
-			@type limitToDevices: Optional[List[str]]
-		@param moveToStart: If C{True}, the registered callable will be moved to the start
+		This adds a handler to :data:`scanForDevices`.
+
+		:param scanFunc: Callable that should yield a tuple containing a driver name as str and DeviceMatch.
+			The callable is called with the same keyword arguments as the handlers of
+			:data:`scanForDevices`, which documents them.
+		:param moveToStart: If ``True``, the registered callable will be moved to the start
 			of the list of registered handlers.
 			Note that subsequent callback registrations may also request to be moved to the start.
 			You should never rely on the registered callable being the first in order.

--- a/source/bdDetect.py
+++ b/source/bdDetect.py
@@ -180,10 +180,14 @@ Registered handlers should yield a tuple containing a driver name as str and Dev
 Handlers are called with these keyword arguments:
 
 :param usb: Whether the handler is expected to yield USB devices.
+:type usb: bool
 :param bluetooth: Whether the handler is expected to yield Bluetooth devices.
+:type bluetooth: bool
 :param ble: Whether the handler is expected to yield BLE devices.
+:type ble: bool
 :param limitToDevices: Drivers to which detection should be limited.
 	``None`` if no driver filtering should occur.
+:type limitToDevices: list[str] | None
 """
 
 
@@ -234,10 +238,10 @@ def _bleDeviceToMatch(device: BLEDevice) -> DeviceMatch:
 	:return: The device match describing the given device.
 	"""
 	return DeviceMatch(
-		ProtocolType.BLE,
-		device.name or device.address,
-		device.address,
-		{
+		type=ProtocolType.BLE,
+		id=device.name or device.address,
+		port=device.address,
+		deviceInfo={
 			"name": device.name or "",
 			"address": device.address,
 			"provider": CommunicationType.BLE,
@@ -472,7 +476,7 @@ class _Detector:
 		self._detectBluetooth = True
 		self._detectBle = True
 		self._limitToDevices: list[str] | None = None
-		# The scanner is None outside a running NVDA, such as in unit tests.
+		# Unit tests reach detection without initialising hwIo, leaving no scanner.
 		if hwIo.ble.scanner is not None:
 			hwIo.ble.scanner.deviceDiscovered.register(self._onBleDeviceDiscovered)
 
@@ -649,7 +653,7 @@ class _Detector:
 			if braille.handler.setDisplayByName(preferredDevice[0], detected=preferredDevice[1]):
 				if _isDebug():
 					log.debug("Switched to preferred device: %r", preferredDevice[0])
-				# Connected, so the radio is no longer needed.
+				# Connected, so the scanner is no longer needed.
 				_stopBleScanner()
 				return
 			elif _isDebug():
@@ -672,7 +676,7 @@ class _Detector:
 			if braille.handler.setDisplayByName(driver, detected=match):
 				if _isDebug():
 					log.debug("Switched to driver %r, match %r", driver, match)
-				# Connected, so the radio is no longer needed.
+				# Connected, so the scanner is no longer needed.
 				_stopBleScanner()
 				return
 			elif _isDebug():
@@ -762,6 +766,11 @@ class _Detector:
 		Immediately attempts to connect when a new BLE device matching
 		a registered driver is discovered, providing much faster connection
 		than waiting for periodic app-switch polling.
+
+		Bleak reports advertisements on the asyncio event loop thread, so this runs
+		there rather than on the main thread. Every BLE operation shares that thread,
+		which is why the work is handed to the detector's executor rather than done
+		here.
 
 		:param device: The BLE device that was discovered
 		:param advertisementData: Advertisement data from the device

--- a/source/bdDetect.py
+++ b/source/bdDetect.py
@@ -57,10 +57,10 @@ class ProtocolType(StrEnum):
 	"""HID devices"""
 	SERIAL = "serial"
 	"""Serial devices (COM ports)"""
-	CUSTOM = "custom"
-	"""Devices with a manufacturer specific protocol"""
 	BLE = "ble"
 	"""Bluetooth Low Energy devices using BLE commands and notifications"""
+	CUSTOM = "custom"
+	"""Devices with a manufacturer specific protocol"""
 
 
 class CommunicationType(StrEnum):

--- a/source/bdDetect.py
+++ b/source/bdDetect.py
@@ -1,7 +1,7 @@
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-# Copyright (C) 2013-2025 NV Access Limited, Babbage B.V., Leonard de Ruijter, Christian Comaschi
+# Copyright (C) 2013-2025 NV Access Limited, Babbage B.V., Leonard de Ruijter, Christian Comaschi, Dot Incorporated, Bram Duvigneau
 
 """Support for braille display detection.
 This allows devices to be automatically detected and used when they become available,
@@ -16,6 +16,7 @@ from dataclasses import dataclass, field
 from functools import partial
 import itertools
 import threading
+import time
 from concurrent.futures import ThreadPoolExecutor, Future
 from enum import StrEnum
 from typing import (
@@ -24,6 +25,10 @@ from typing import (
 )
 from collections import OrderedDict
 from collections.abc import Callable, Generator, Iterable, Iterator
+from bleak.backends.device import BLEDevice
+from bleak.backends.scanner import AdvertisementData
+import hwIo
+import hwIo.ble
 import hwPortUtils
 import NVDAState
 import braille
@@ -54,6 +59,8 @@ class ProtocolType(StrEnum):
 	"""Serial devices (COM ports)"""
 	CUSTOM = "custom"
 	"""Devices with a manufacturer specific protocol"""
+	BLE = "ble"
+	"""Bluetooth Low Energy devices using BLE commands and notifications"""
 
 
 class CommunicationType(StrEnum):
@@ -61,6 +68,8 @@ class CommunicationType(StrEnum):
 	"""Bluetooth devices"""
 	USB = "usb"
 	"""USB devices"""
+	BLE = "ble"
+	"""Bluetooth Low Energy devices"""
 
 
 class _DeviceTypeMeta(type):
@@ -171,8 +180,10 @@ Registered handlers should yield a tuple containing a driver name as str and Dev
 Handlers are called with these keyword arguments:
 @param usb: Whether the handler is expected to yield USB devices.
 @type usb: bool
-@param bluetooth: Whether the handler is expected to yield USB devices.
+@param bluetooth: Whether the handler is expected to yield Bluetooth devices.
 @type bluetooth: bool
+@param ble: Whether the handler is expected to yield BLE devices.
+@type ble: bool
 @param limitToDevices: Drivers to which detection should be limited.
 	``None`` if no driver filtering should occur.
 @type limitToDevices: Optional[List[str]]
@@ -181,6 +192,20 @@ Handlers are called with these keyword arguments:
 
 def _isDebug() -> bool:
 	return config.conf["debugLog"]["bdDetect"]
+
+
+def _stopBleScanner() -> None:
+	"""Stop the shared BLE scanner if BLE is initialized and a scan is running.
+
+	The scanner is created by ``hwIo.ble.initialize()`` at startup and is ``None``
+	in contexts where BLE is unavailable (e.g. unit tests), in which case there is
+	nothing to stop.
+	"""
+	scanner = hwIo.ble.scanner
+	if scanner is not None and scanner.isScanning:
+		if _isDebug():
+			log.debug("Stopping BLE scanner")
+		scanner.stop()
 
 
 def getDriversForConnectedUsbDevices(
@@ -408,12 +433,18 @@ class _Detector:
 		self._stopEvent = threading.Event()
 		self._detectUsb = True
 		self._detectBluetooth = True
+		self._detectBle = True
 		self._limitToDevices: list[str] | None = None
+		# Register for real-time BLE device discovery notifications.
+		# The scanner is None when BLE is unavailable (e.g. unit tests); skip registration then.
+		if hwIo.ble.scanner is not None:
+			hwIo.ble.scanner.deviceDiscovered.register(self._onBleDeviceDiscovered)
 
 	def _queueBgScan(
 		self,
 		usb: bool = False,
 		bluetooth: bool = False,
+		ble: bool = False,
 		limitToDevices: list[str] | None = None,
 		preferredDevice: DriverAndDeviceMatch | None = None,
 	):
@@ -422,6 +453,7 @@ class _Detector:
 		To explicitely cancel a scan in progress, use L{rescan}.
 		:param usb: Whether USB devices should be detected for this and subsequent scans.
 		:param bluetooth: Whether Bluetooth devices should be detected for this and subsequent scans.
+		:param ble: Whether BLE devices should be detected for this and subsequent scans.
 		:param limitToDevices: Drivers to which detection should be limited for this and subsequent scans.
 			``None`` if default driver filtering according to config should occur.
 		:param preferredDevice: An optional preferred device to use for detection before scanning.
@@ -429,15 +461,17 @@ class _Detector:
 		"""
 		if _isDebug():
 			log.debug(
-				"Queuing background scan: usb=%r, bluetooth=%r, limitToDevices=%r, preferredDevice=%r",
+				"Queuing background scan: usb=%r, bluetooth=%r, ble=%r, limitToDevices=%r, preferredDevice=%r",
 				usb,
 				bluetooth,
+				ble,
 				limitToDevices,
 				preferredDevice,
 			)
 
 		self._detectUsb = usb
 		self._detectBluetooth = bluetooth
+		self._detectBle = ble
 		if limitToDevices is None and config.conf["braille"]["auto"]["excludedDisplays"]:
 			limitToDevices = list(getBrailleDisplayDriversEnabledForDetection())
 			if limitToDevices and _isDebug():
@@ -457,6 +491,7 @@ class _Detector:
 			self._bgScan,
 			usb,
 			bluetooth,
+			ble,
 			limitToDevices,
 			preferredDevice,
 		)
@@ -472,6 +507,8 @@ class _Detector:
 			if _isDebug():
 				log.debug("Cancelling queued future for next background scan")
 			self._queuedFuture.cancel()
+		# Stop the BLE scanner if it's running
+		_stopBleScanner()
 
 	@staticmethod
 	def _bgScanUsb(
@@ -509,10 +546,23 @@ class _Detector:
 		if btDevsCache is not btDevs:
 			deviceInfoFetcher.btDevsCache = btDevsCache
 
+	@staticmethod
+	def _bgScanBle(
+		ble: bool = True,
+		limitToDevices: list[str] | None = None,
+	):
+		"""Handler for L{scanForDevices} that yields BLE devices.
+		See the L{scanForDevices} documentation for information about the parameters.
+		"""
+		if not ble:
+			return
+		yield from getDriversForBleDevices(limitToDevices)
+
 	def _bgScan(
 		self,
 		usb: bool,
 		bluetooth: bool,
+		ble: bool,
 		limitToDevices: list[str] | None,
 		preferredDevice: DriverAndDeviceMatch | None,
 	):
@@ -520,6 +570,7 @@ class _Detector:
 		this function should be run on a background thread.
 		:param usb: Whether USB devices should be detected for this particular scan.
 		:param bluetooth: Whether Bluetooth devices should be detected for this particular scan.
+		:param ble: Whether BLE devices should be detected for this particular scan.
 		:param limitToDevices: Drivers to which detection should be limited for this scan.
 			``None`` if no driver filtering should occur.
 		:param preferredDevice: An optional preferred device to use for detection before scanning.
@@ -527,21 +578,32 @@ class _Detector:
 		"""
 		if _isDebug():
 			log.debug(
-				"Starting background scan: usb=%r, bluetooth=%r, limitToDevices=%r, preferredDevice=%r",
+				"Starting background scan: usb=%r, bluetooth=%r, ble=%r, limitToDevices=%r, preferredDevice=%r",
 				usb,
 				bluetooth,
+				ble,
 				limitToDevices,
 				preferredDevice,
 			)
 		# Clear the stop event before a scan is started.
 		# Since a scan can take some time to complete, another thread can set the stop event to cancel it.
 		self._stopEvent.clear()
+
+		# Start BLE scanner if needed for this scan
+		if ble and hwIo.ble.scanner is not None and not hwIo.ble.scanner.isScanning:
+			if _isDebug():
+				log.debug("Starting BLE scanner for background scan")
+			hwIo.ble.scanner.start()
+			# Give the scanner some time to get initial results
+			time.sleep(0.2)
 		if preferredDevice:
 			if _isDebug():
 				log.debug("Trying preferred device first: %r", preferredDevice)
 			if braille.handler.setDisplayByName(preferredDevice[0], detected=preferredDevice[1]):
 				if _isDebug():
 					log.debug("Switched to preferred device: %r", preferredDevice[0])
+				# Device connected - stop BLE scanner to save resources
+				_stopBleScanner()
 				return
 			elif _isDebug():
 				log.debug("Failed to switch to preferred device, continuing scan: %r", preferredDevice)
@@ -552,6 +614,7 @@ class _Detector:
 		iterator = scanForDevices.iter(
 			usb=usb,
 			bluetooth=bluetooth,
+			ble=ble,
 			limitToDevices=limitToDevices,
 		)
 		for driver, match in iterator:
@@ -562,6 +625,8 @@ class _Detector:
 			if braille.handler.setDisplayByName(driver, detected=match):
 				if _isDebug():
 					log.debug("Switched to driver %r, match %r", driver, match)
+				# Device connected - stop BLE scanner to save resources
+				_stopBleScanner()
 				return
 			elif _isDebug():
 				log.debug("Failed to switch to driver %r, match %r. Continuing", driver, match)
@@ -572,12 +637,14 @@ class _Detector:
 		self,
 		usb: bool = True,
 		bluetooth: bool = True,
+		ble: bool = True,
 		limitToDevices: list[str] | None = None,
 		preferredDevice: DriverAndDeviceMatch | None = None,
 	):
 		"""Stop a current scan when in progress, and start scanning from scratch.
 		:param usb: Whether USB devices should be detected for this and subsequent scans.
 		:param bluetooth: Whether Bluetooth devices should be detected for this and subsequent scans.
+		:param ble: Whether BLE devices should be detected for this and subsequent scans.
 		:param limitToDevices: Drivers to which detection should be limited for this and subsequent scans.
 			``None`` if default driver filtering according to config should occur.
 		:param preferredDevice: An optional preferred device to use for detection before scanning.
@@ -589,13 +656,18 @@ class _Detector:
 		self._queueBgScan(
 			usb=usb,
 			bluetooth=bluetooth,
+			ble=ble,
 			limitToDevices=limitToDevices,
 			preferredDevice=preferredDevice,
 		)
 
 	def handleWindowMessage(self, msg=None, wParam=None):
 		if msg == winUser.WM_DEVICECHANGE and wParam == DBT_DEVNODES_CHANGED:
-			self.rescan(bluetooth=self._detectBluetooth, limitToDevices=self._limitToDevices)
+			self.rescan(
+				bluetooth=self._detectBluetooth,
+				ble=self._detectBle,
+				limitToDevices=self._limitToDevices,
+			)
 
 	def pollBluetoothDevices(self):
 		"""Poll bluetooth devices that might be in range.
@@ -605,11 +677,92 @@ class _Detector:
 			return
 		if not deviceInfoFetcher.btDevsCache:
 			return
-		self._queueBgScan(bluetooth=self._detectBluetooth, limitToDevices=self._limitToDevices)
+		self._queueBgScan(
+			bluetooth=self._detectBluetooth,
+			ble=self._detectBle,
+			limitToDevices=self._limitToDevices,
+		)
+
+	def _getBleDeviceMatch(self, device: BLEDevice) -> DriverAndDeviceMatch | None:
+		"""Check if BLE device matches any registered driver.
+
+		:param device: The BLE device to check
+		:return: Tuple of (driver_name, DeviceMatch) if match found, None otherwise
+		"""
+		# Create DeviceMatch for this device
+		match = DeviceMatch(
+			ProtocolType.BLE,
+			device.name or device.address,
+			device.address,
+			{
+				"name": device.name or "",
+				"address": device.address,
+				"provider": CommunicationType.BLE,
+			},
+		)
+
+		# Check against registered drivers (respect limitToDevices filter)
+		driversToCheck = (
+			((driver, devs) for driver, devs in _driverDevices.items() if driver in self._limitToDevices)
+			if self._limitToDevices
+			else _driverDevices.items()
+		)
+
+		for driver, devs in driversToCheck:
+			matchFunc = devs.get(CommunicationType.BLE)
+			if callable(matchFunc) and matchFunc(match):
+				return (driver, match)
+
+		return None
+
+	def _onBleDeviceDiscovered(
+		self,
+		device: BLEDevice,
+		advertisementData: AdvertisementData,
+		isNew: bool,
+	) -> None:
+		"""Handler for real-time BLE device discoveries.
+
+		Immediately attempts to connect when a new BLE device matching
+		a registered driver is discovered, providing much faster connection
+		than waiting for periodic app-switch polling.
+
+		:param device: The BLE device that was discovered
+		:param advertisementData: Advertisement data from the device
+		:param isNew: True if this is the first time seeing this device
+		"""
+		# Only react to newly discovered devices
+		if not isNew:
+			return
+
+		# Check if BLE detection is enabled
+		if not self._detectBle:
+			return
+
+		# Find matching driver for this device
+		match = self._getBleDeviceMatch(device)
+		if not match:
+			return
+
+		# Queue scan with this device as preferred
+		driver, deviceMatch = match
+		if _isDebug():
+			log.debug(
+				f"New BLE device {device.name or device.address} matches driver {driver}, "
+				f"queueing connection attempt",
+			)
+
+		self._queueBgScan(
+			ble=True,
+			limitToDevices=self._limitToDevices,
+			preferredDevice=(driver, deviceMatch),
+		)
 
 	def terminate(self):
 		appModuleHandler.post_appSwitch.unregister(self.pollBluetoothDevices)
 		messageWindow.pre_handleWindowMessage.unregister(self.handleWindowMessage)
+		if hwIo.ble.scanner is not None:
+			hwIo.ble.scanner.deviceDiscovered.unregister(self._onBleDeviceDiscovered)
 		self._stopBgScan()
 		# Clear the cache of bluetooth devices so new devices can be picked up with a new instance.
 		deviceInfoFetcher.btDevsCache = None
@@ -657,6 +810,86 @@ def getConnectedUsbDevicesForDriver(driver: str) -> Iterator[DeviceMatch]:
 		yield match
 
 
+def getDriversForBleDevices(
+	limitToDevices: list[str] | None = None,
+) -> Iterator[DriverAndDeviceMatch]:
+	"""Get any matching drivers for BLE devices.
+	:param limitToDevices: Drivers to which detection should be limited.
+		``None`` if no driver filtering should occur.
+	:return: Generator of pairs of drivers and device information.
+	"""
+	if limitToDevices and _isDebug():
+		log.debug("Limiting BLE device detection to drivers: %r", limitToDevices)
+
+	# Check if any drivers support BLE before starting the scanner
+	driversToCheck = (
+		((driver, devs) for driver, devs in _driverDevices.items() if driver in limitToDevices)
+		if limitToDevices
+		else _driverDevices.items()
+	)
+	hasBleDrivers = any(callable(devs.get(CommunicationType.BLE)) for _, devs in driversToCheck)
+	if not hasBleDrivers:
+		if _isDebug():
+			log.debug("No drivers with BLE support registered, skipping BLE scan")
+		return
+
+	# Use the module-level singleton scanner
+	scanner = hwIo.ble.scanner
+	if scanner is None:
+		# BLE not initialized (e.g. unit tests); no BLE devices to report.
+		return
+	if not scanner.isScanning:
+		if _isDebug():
+			log.debugWarning("BLE scanner not running, results may be incomplete")
+
+	scanResults = scanner.results()
+	for device in scanResults:
+		# Create DeviceMatch for each BLE device
+		# id: Display name for UI (device name if available, otherwise address)
+		# port: BLE address for unique identification and connection
+		# deviceInfo: All information as strings for backwards compatibility
+		match = DeviceMatch(
+			ProtocolType.BLE,
+			device.name or device.address,
+			device.address,
+			{
+				"name": device.name or "",
+				"address": device.address,
+				"provider": CommunicationType.BLE,
+			},
+		)
+
+		for driver, devs in _driverDevices.items():
+			if limitToDevices and driver not in limitToDevices:
+				if _isDebug():
+					log.debug("Skipping excluded driver %r for BLE device match: %r", driver, match)
+				continue
+
+			matchFunc = devs[CommunicationType.BLE]
+			if not callable(matchFunc):
+				if _isDebug():
+					log.debugWarning(
+						"Skipping non-callable matchFunc %r for BLE device match: %r",
+						matchFunc,
+						match,
+					)
+				continue
+
+			if matchFunc(match):
+				if _isDebug():
+					log.debug("Found BLE device match: %r for driver %r", match, driver)
+				yield (driver, match)
+
+
+def getBleDevicesForDriver(driver: str) -> Iterator[DeviceMatch]:
+	"""Get any BLE devices associated with a particular driver.
+	:param driver: The name of the driver.
+	:return: Generator of device information for matching BLE devices.
+	"""
+	for _driverName, match in getDriversForBleDevices(limitToDevices=[driver]):
+		yield match
+
+
 def getPossibleBluetoothDevicesForDriver(driver: str) -> Iterator[DeviceMatch]:
 	"""Get any possible Bluetooth devices associated with a particular driver.
 	@param driver: The name of the driver.
@@ -697,6 +930,7 @@ def driverHasPossibleDevices(driver: str) -> bool:
 			itertools.chain(
 				getConnectedUsbDevicesForDriver(driver),
 				getPossibleBluetoothDevicesForDriver(driver),
+				getBleDevicesForDriver(driver),
 			),
 			None,
 		),
@@ -750,6 +984,7 @@ def initialize():
 
 	scanForDevices.register(_Detector._bgScanUsb)
 	scanForDevices.register(_Detector._bgScanBluetooth)
+	scanForDevices.register(_Detector._bgScanBle)
 
 	# Add devices
 	for display in getSupportedBrailleDisplayDrivers():
@@ -762,8 +997,11 @@ def initialize():
 def terminate():
 	global deviceInfoFetcher
 	_driverDevices.clear()
+	scanForDevices.unregister(_Detector._bgScanBle)
 	scanForDevices.unregister(_Detector._bgScanBluetooth)
 	scanForDevices.unregister(_Detector._bgScanUsb)
+	# Stop BLE scanner if running
+	_stopBleScanner()
 	deviceInfoFetcher = None
 
 
@@ -862,6 +1100,15 @@ class DriverRegistrar:
 		devs = self._getDriverDict()
 		devs[CommunicationType.BLUETOOTH] = matchFunc
 
+	def addBleDevices(self, matchFunc: MatchFuncT):
+		"""Associate BLE devices with the driver on this instance.
+		@param matchFunc: A function which determines whether a given BLE device matches.
+			It takes a L{DeviceMatch} as its only argument
+			and returns a C{bool} indicating whether it matched.
+		"""
+		devs = self._getDriverDict()
+		devs[CommunicationType.BLE] = matchFunc
+
 	def addDeviceScanner(
 		self,
 		scanFunc: Callable[..., Iterable[DriverAndDeviceMatch]],
@@ -873,8 +1120,10 @@ class DriverRegistrar:
 			The callable is called with these keyword arguments:
 			@param usb: Whether the handler is expected to yield USB devices.
 			@type usb: bool
-			@param bluetooth: Whether the handler is expected to yield USB devices.
+			@param bluetooth: Whether the handler is expected to yield Bluetooth devices.
 			@type bluetooth: bool
+			@param ble: Whether the handler is expected to yield BLE devices.
+			@type ble: bool
 			@param limitToDevices: Drivers to which detection should be limited.
 				``None`` if no driver filtering should occur.
 			@type limitToDevices: Optional[List[str]]

--- a/source/bdDetect.py
+++ b/source/bdDetect.py
@@ -208,6 +208,42 @@ def _stopBleScanner() -> None:
 		scanner.stop()
 
 
+def _hasBleDrivers(limitToDevices: list[str] | None = None) -> bool:
+	"""Determine whether any driver in scope has registered BLE devices.
+
+	:param limitToDevices: Drivers to which detection should be limited.
+		``None`` if no driver filtering should occur.
+	:return: ``True`` if at least one driver in scope can match BLE devices.
+	"""
+	return any(
+		callable(devs.get(CommunicationType.BLE))
+		for driver, devs in _driverDevices.items()
+		if not limitToDevices or driver in limitToDevices
+	)
+
+
+def _bleDeviceToMatch(device: BLEDevice) -> DeviceMatch:
+	"""Convert a discovered BLE device into a :class:`DeviceMatch`.
+
+	The ``id`` is the display name used in the UI (the device name if available,
+	otherwise its address), while ``port`` is the address, which uniquely
+	identifies the device and is used to connect to it.
+
+	:param device: The BLE device to convert.
+	:return: The device match describing the given device.
+	"""
+	return DeviceMatch(
+		ProtocolType.BLE,
+		device.name or device.address,
+		device.address,
+		{
+			"name": device.name or "",
+			"address": device.address,
+			"provider": CommunicationType.BLE,
+		},
+	)
+
+
 def getDriversForConnectedUsbDevices(
 	limitToDevices: list[str] | None = None,
 ) -> Iterator[DriverAndDeviceMatch]:
@@ -589,8 +625,15 @@ class _Detector:
 		# Since a scan can take some time to complete, another thread can set the stop event to cancel it.
 		self._stopEvent.clear()
 
-		# Start BLE scanner if needed for this scan
-		if ble and hwIo.ble.scanner is not None and not hwIo.ble.scanner.isScanning:
+		# Start BLE scanner if needed for this scan.
+		# Scanning uses the Bluetooth radio continuously, so only do so
+		# when a driver in scope can actually match a BLE device.
+		if (
+			ble
+			and _hasBleDrivers(limitToDevices)
+			and hwIo.ble.scanner is not None
+			and not hwIo.ble.scanner.isScanning
+		):
 			if _isDebug():
 				log.debug("Starting BLE scanner for background scan")
 			hwIo.ble.scanner.start()
@@ -689,17 +732,7 @@ class _Detector:
 		:param device: The BLE device to check
 		:return: Tuple of (driver_name, DeviceMatch) if match found, None otherwise
 		"""
-		# Create DeviceMatch for this device
-		match = DeviceMatch(
-			ProtocolType.BLE,
-			device.name or device.address,
-			device.address,
-			{
-				"name": device.name or "",
-				"address": device.address,
-				"provider": CommunicationType.BLE,
-			},
-		)
+		match = _bleDeviceToMatch(device)
 
 		# Check against registered drivers (respect limitToDevices filter)
 		driversToCheck = (
@@ -752,8 +785,13 @@ class _Detector:
 				f"queueing connection attempt",
 			)
 
+		# Preserve the USB and Bluetooth detection state,
+		# as _queueBgScan stores its arguments as the state for subsequent scans.
+		# Omitting them here would permanently disable USB and Bluetooth detection.
 		self._queueBgScan(
-			ble=True,
+			usb=self._detectUsb,
+			bluetooth=self._detectBluetooth,
+			ble=self._detectBle,
 			limitToDevices=self._limitToDevices,
 			preferredDevice=(driver, deviceMatch),
 		)
@@ -821,14 +859,8 @@ def getDriversForBleDevices(
 	if limitToDevices and _isDebug():
 		log.debug("Limiting BLE device detection to drivers: %r", limitToDevices)
 
-	# Check if any drivers support BLE before starting the scanner
-	driversToCheck = (
-		((driver, devs) for driver, devs in _driverDevices.items() if driver in limitToDevices)
-		if limitToDevices
-		else _driverDevices.items()
-	)
-	hasBleDrivers = any(callable(devs.get(CommunicationType.BLE)) for _, devs in driversToCheck)
-	if not hasBleDrivers:
+	# Check if any drivers support BLE before inspecting the scan results
+	if not _hasBleDrivers(limitToDevices):
 		if _isDebug():
 			log.debug("No drivers with BLE support registered, skipping BLE scan")
 		return
@@ -844,20 +876,7 @@ def getDriversForBleDevices(
 
 	scanResults = scanner.results()
 	for device in scanResults:
-		# Create DeviceMatch for each BLE device
-		# id: Display name for UI (device name if available, otherwise address)
-		# port: BLE address for unique identification and connection
-		# deviceInfo: All information as strings for backwards compatibility
-		match = DeviceMatch(
-			ProtocolType.BLE,
-			device.name or device.address,
-			device.address,
-			{
-				"name": device.name or "",
-				"address": device.address,
-				"provider": CommunicationType.BLE,
-			},
-		)
+		match = _bleDeviceToMatch(device)
 
 		for driver, devs in _driverDevices.items():
 			if limitToDevices and driver not in limitToDevices:
@@ -865,14 +884,10 @@ def getDriversForBleDevices(
 					log.debug("Skipping excluded driver %r for BLE device match: %r", driver, match)
 				continue
 
-			matchFunc = devs[CommunicationType.BLE]
+			# Drivers without BLE support have no entry here.
+			# Note that _driverDevices maps to a defaultdict, so subscripting would add empty entries.
+			matchFunc = devs.get(CommunicationType.BLE)
 			if not callable(matchFunc):
-				if _isDebug():
-					log.debugWarning(
-						"Skipping non-callable matchFunc %r for BLE device match: %r",
-						matchFunc,
-						match,
-					)
 				continue
 
 			if matchFunc(match):

--- a/source/bdDetect.py
+++ b/source/bdDetect.py
@@ -648,12 +648,7 @@ class _Detector:
 
 		# Scanning occupies the Bluetooth radio continuously,
 		# so only do so when a driver in scope can actually match a BLE device.
-		if (
-			ble
-			and _hasBleDrivers(limitToDevices)
-			and hwIo.ble.scanner is not None
-			and not hwIo.ble.scanner.isScanning
-		):
+		if ble and _hasBleDrivers(limitToDevices) and not hwIo.ble.scanner.isScanning:
 			if _isDebug():
 				log.debug("Starting BLE scanner for background scan")
 			try:
@@ -891,9 +886,6 @@ def getDriversForBleDevices(
 		return
 
 	scanner = hwIo.ble.scanner
-	if scanner is None:
-		# BLE is not initialized outside a running NVDA, such as in unit tests.
-		return
 	if not scanner.isScanning:
 		if _isDebug():
 			log.debugWarning("BLE scanner not running, results may be incomplete")

--- a/source/braille/brailleHandler.py
+++ b/source/braille/brailleHandler.py
@@ -463,13 +463,13 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 			if not isFallback:
 				if not detected:
 					config.conf["braille"]["display"] = newDisplayClass.name
-				elif (
-					"bluetoothName" in detected.deviceInfo
-					or detected.deviceInfo.get("provider") == "bluetooth"
+				elif "bluetoothName" in detected.deviceInfo or detected.deviceInfo.get("provider") in (
+					"bluetooth",
+					"ble",
 				):
 					# As USB devices have priority over Bluetooth, keep a detector running to switch to USB when connected.
 					# Note that the detector should always be running in this situation, so we can trigger a rescan.
-					self._detector.rescan(bluetooth=False, limitToDevices=[newDisplayClass.name])
+					self._detector.rescan(bluetooth=False, ble=False, limitToDevices=[newDisplayClass.name])
 				else:
 					self._disableDetection()
 			return True
@@ -1044,6 +1044,7 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 		self,
 		usb: bool = True,
 		bluetooth: bool = True,
+		ble: bool = True,
 		limitToDevices: Optional[List[str]] = None,
 		preferredDevice: bdDetect.DriverAndDeviceMatch | None = None,
 	):
@@ -1053,6 +1054,7 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 		In that case, it is triggered by L{setDisplayByname}.
 		:param usb: Whether to scan for USB devices
 		:param bluetooth: Whether to scan for Bluetooth devices.
+		:param ble: Whether to scan for Bluetooth Low Energy devices.
 		:param limitToDevices: An optional list of driver names a scan should be limited to.
 			This is used when a Bluetooth device is detected, in order to switch to USB
 			when an USB device for the same driver is found.
@@ -1065,6 +1067,7 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 			self._detector.rescan(
 				usb=usb,
 				bluetooth=bluetooth,
+				ble=ble,
 				limitToDevices=limitToDevices,
 				preferredDevice=preferredDevice,
 			)
@@ -1074,6 +1077,7 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 		self._detector._queueBgScan(
 			usb=usb,
 			bluetooth=bluetooth,
+			ble=ble,
 			limitToDevices=limitToDevices,
 			preferredDevice=preferredDevice,
 		)

--- a/source/braille/brailleHandler.py
+++ b/source/braille/brailleHandler.py
@@ -470,13 +470,13 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 			if not isFallback:
 				if not detected:
 					config.conf["braille"]["display"] = newDisplayClass.name
-				elif (
-					"bluetoothName" in detected.deviceInfo
-					or detected.deviceInfo.get("provider") == "bluetooth"
+				elif "bluetoothName" in detected.deviceInfo or detected.deviceInfo.get("provider") in (
+					"bluetooth",
+					"ble",
 				):
 					# As USB devices have priority over Bluetooth, keep a detector running to switch to USB when connected.
 					# Note that the detector should always be running in this situation, so we can trigger a rescan.
-					self._detector.rescan(bluetooth=False, limitToDevices=[newDisplayClass.name])
+					self._detector.rescan(bluetooth=False, ble=False, limitToDevices=[newDisplayClass.name])
 				else:
 					self._disableDetection()
 			return True
@@ -1051,6 +1051,7 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 		self,
 		usb: bool = True,
 		bluetooth: bool = True,
+		ble: bool = True,
 		limitToDevices: Optional[List[str]] = None,
 		preferredDevice: bdDetect.DriverAndDeviceMatch | None = None,
 	):
@@ -1060,6 +1061,7 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 		In that case, it is triggered by L{setDisplayByname}.
 		:param usb: Whether to scan for USB devices
 		:param bluetooth: Whether to scan for Bluetooth devices.
+		:param ble: Whether to scan for Bluetooth Low Energy devices.
 		:param limitToDevices: An optional list of driver names a scan should be limited to.
 			This is used when a Bluetooth device is detected, in order to switch to USB
 			when an USB device for the same driver is found.
@@ -1072,6 +1074,7 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 			self._detector.rescan(
 				usb=usb,
 				bluetooth=bluetooth,
+				ble=ble,
 				limitToDevices=limitToDevices,
 				preferredDevice=preferredDevice,
 			)
@@ -1081,6 +1084,7 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 		self._detector._queueBgScan(
 			usb=usb,
 			bluetooth=bluetooth,
+			ble=ble,
 			limitToDevices=limitToDevices,
 			preferredDevice=preferredDevice,
 		)

--- a/source/braille/display/driver.py
+++ b/source/braille/display/driver.py
@@ -248,6 +248,23 @@ class BrailleDisplayDriver(driverHandler.Driver):
 				ports.update((USB_PORT,))
 			if bluetooth:
 				ports.update((BLUETOOTH_PORT,))
+		# Add individual BLE devices
+		try:
+			bleDevices = list(bdDetect.getBleDevicesForDriver(cls.name))
+			if bleDevices:
+				# Ensure "auto" option is present if we have BLE devices
+				if AUTOMATIC_PORT[0] not in ports:
+					ports.update((AUTOMATIC_PORT,))
+				# Add each BLE device as a selectable port
+				for match in bleDevices:
+					# Format: "ble:DeviceName@Address" for unique identification
+					portKey = f"{match.type}:{match.id}@{match.port}"
+					# Translators: Name of a Bluetooth Low Energy braille display port
+					portName = _("Bluetooth: {deviceName}").format(deviceName=match.id)
+					ports[portKey] = portName
+		except Exception:
+			# If BLE scanning fails, continue without BLE devices
+			pass
 		try:
 			ports.update(cls.getManualPorts())
 		except NotImplementedError:
@@ -298,6 +315,37 @@ class BrailleDisplayDriver(driverHandler.Driver):
 		if isinstance(port, bdDetect.DeviceMatch):
 			yield port
 		elif isinstance(port, str):
+			# Check if this is a specific BLE device port (format: "ble:DeviceName@Address")
+			if port.startswith("ble:"):
+				portContent = port[4:]  # Remove "ble:" prefix
+
+				# Require name@address format
+				if "@" not in portContent:
+					log.error(
+						f"Invalid BLE port format: {port}. Expected format: ble:DeviceName@Address",
+					)
+					return
+
+				deviceName, address = portContent.rsplit("@", 1)
+
+				# Try to find device in current scan results first (preferred)
+				for match in bdDetect.getBleDevicesForDriver(cls.name):
+					if match.id == deviceName or match.port == address:
+						yield match
+						return
+
+				# Fallback: If device not in scan, create DeviceMatch from config
+				log.debug(
+					f"BLE device {deviceName} not in scan results, "
+					f"attempting connection by address {address}",
+				)
+				yield bdDetect.DeviceMatch(
+					bdDetect.ProtocolType.BLE,
+					deviceName,  # id
+					address,  # port
+					{"name": deviceName, "address": address},
+				)
+				return
 			isUsb = port in (AUTOMATIC_PORT[0], USB_PORT[0])
 			isBluetooth = port in (AUTOMATIC_PORT[0], BLUETOOTH_PORT[0])
 			if not isUsb and not isBluetooth:

--- a/source/braille/display/driver.py
+++ b/source/braille/display/driver.py
@@ -301,10 +301,16 @@ class BrailleDisplayDriver(driverHandler.Driver):
 			return
 		deviceName, address = portContent.rsplit("@", 1)
 		# Prefer a device from the scan results, as connecting to it avoids implicit discovery.
-		for match in bdDetect.getBleDevicesForDriver(cls.name):
-			if match.id == deviceName or match.port == address:
-				yield match
-				return
+		scannedMatches = list(bdDetect.getBleDevicesForDriver(cls.name))
+		# The address identifies the device uniquely, so match on it first.
+		# Only fall back to the name if no device with this address is advertising,
+		# as devices using a resolvable private address change it over time.
+		for match in itertools.chain(
+			(match for match in scannedMatches if match.port == address),
+			(match for match in scannedMatches if match.id == deviceName),
+		):
+			yield match
+			return
 		# The device is not advertising at the moment,
 		# so fall back to the address recorded in the configuration.
 		log.debug(
@@ -318,20 +324,20 @@ class BrailleDisplayDriver(driverHandler.Driver):
 		)
 
 	@classmethod
-	def _getAutoPorts(cls, usb=True, bluetooth=True) -> Iterable[bdDetect.DeviceMatch]:
-		"""Returns possible ports to connect to using L{bdDetect} automatic detection data.
-		@param usb: Whether to search for USB devices.
-		@type usb: bool
-		@param bluetooth: Whether to search for bluetooth devices.
-		@type bluetooth: bool
-		@return: The device match for each port.
-		@rtype: iterable of L{DeviceMatch}
+	def _getAutoPorts(cls, usb=True, bluetooth=True, ble=False) -> Iterable[bdDetect.DeviceMatch]:
+		"""Returns possible ports to connect to using :mod:`bdDetect` automatic detection data.
+		:param usb: Whether to search for USB devices.
+		:param bluetooth: Whether to search for bluetooth devices.
+		:param ble: Whether to search for Bluetooth Low Energy devices.
+		:return: The device match for each port.
 		"""
 		iters = []
 		if usb:
 			iters.append(bdDetect.getConnectedUsbDevicesForDriver(cls.name))
 		if bluetooth:
 			iters.append(bdDetect.getPossibleBluetoothDevicesForDriver(cls.name))
+		if ble:
+			iters.append(bdDetect.getBleDevicesForDriver(cls.name))
 
 		try:
 			for match in itertools.chain(*iters):
@@ -366,6 +372,9 @@ class BrailleDisplayDriver(driverHandler.Driver):
 				return
 			isUsb = port in (AUTOMATIC_PORT[0], USB_PORT[0])
 			isBluetooth = port in (AUTOMATIC_PORT[0], BLUETOOTH_PORT[0])
+			# The automatic port is offered whenever BLE devices are known,
+			# so it must be able to yield them as well.
+			isBle = port == AUTOMATIC_PORT[0]
 			if not isUsb and not isBluetooth:
 				# Assume we are connecting to a com port, since these are the only manual ports supported.
 				try:
@@ -380,7 +389,7 @@ class BrailleDisplayDriver(driverHandler.Driver):
 						portInfo,
 					)
 			else:
-				for match in cls._getAutoPorts(usb=isUsb, bluetooth=isBluetooth):
+				for match in cls._getAutoPorts(usb=isUsb, bluetooth=isBluetooth, ble=isBle):
 					yield match
 
 	#: Global input gesture map for this display driver.

--- a/source/braille/display/driver.py
+++ b/source/braille/display/driver.py
@@ -267,7 +267,7 @@ class BrailleDisplayDriver(driverHandler.Driver):
 
 	@classmethod
 	def _getBlePorts(cls) -> typing.Iterator[typing.Tuple[str, str]]:
-		"""Get the BLE devices currently known to L{bdDetect} as selectable ports.
+		"""Get the BLE devices currently known to :mod:`bdDetect` as selectable ports.
 
 		:return: An iterator of ``(port, description)`` pairs,
 			where ``port`` is of the form ``ble:DeviceName@Address``.
@@ -290,7 +290,7 @@ class BrailleDisplayDriver(driverHandler.Driver):
 		"""Resolve a manually selected BLE port to the device to connect to.
 
 		:param port: A port of the form ``ble:DeviceName@Address``,
-			as returned by L{_getBlePorts}.
+			as returned by :meth:`_getBlePorts`.
 		:return: An iterator yielding at most one device match.
 		"""
 		portContent = port.removeprefix(cls._BLE_PORT_PREFIX)
@@ -300,19 +300,17 @@ class BrailleDisplayDriver(driverHandler.Driver):
 			)
 			return
 		deviceName, address = portContent.rsplit("@", 1)
-		# Prefer a device from the scan results, as connecting to it avoids implicit discovery.
+		# A device from the scan results can be connected to without implicit discovery.
 		scannedMatches = list(bdDetect.getBleDevicesForDriver(cls.name))
-		# The address identifies the device uniquely, so match on it first.
-		# Only fall back to the name if no device with this address is advertising,
-		# as devices using a resolvable private address change it over time.
+		# The address identifies a device uniquely, so it wins over the name.
+		# The name still has to be tried, as a resolvable private address changes over time.
 		for match in itertools.chain(
 			(match for match in scannedMatches if match.port == address),
 			(match for match in scannedMatches if match.id == deviceName),
 		):
 			yield match
 			return
-		# The device is not advertising at the moment,
-		# so fall back to the address recorded in the configuration.
+		# Not advertising, so fall back to the address recorded in the configuration.
 		log.debug(
 			f"BLE device {deviceName} not in scan results, attempting connection by address {address}",
 		)

--- a/source/braille/display/driver.py
+++ b/source/braille/display/driver.py
@@ -217,6 +217,10 @@ class BrailleDisplayDriver(driverHandler.Driver):
 	#: Kept for backwards compatibility
 	AUTOMATIC_PORT = AUTOMATIC_PORT
 
+	#: Prefix of the ports identifying an individual, manually selected BLE device.
+	#: The remainder of such a port is ``DeviceName@Address``.
+	_BLE_PORT_PREFIX = "ble:"
+
 	@classmethod
 	def getPossiblePorts(cls) -> typing.OrderedDict[str, str]:
 		"""Returns possible hardware ports for this driver.
@@ -248,28 +252,70 @@ class BrailleDisplayDriver(driverHandler.Driver):
 				ports.update((USB_PORT,))
 			if bluetooth:
 				ports.update((BLUETOOTH_PORT,))
-		# Add individual BLE devices
-		try:
-			bleDevices = list(bdDetect.getBleDevicesForDriver(cls.name))
-			if bleDevices:
-				# Ensure "auto" option is present if we have BLE devices
-				if AUTOMATIC_PORT[0] not in ports:
-					ports.update((AUTOMATIC_PORT,))
-				# Add each BLE device as a selectable port
-				for match in bleDevices:
-					# Format: "ble:DeviceName@Address" for unique identification
-					portKey = f"{match.type}:{match.id}@{match.port}"
-					# Translators: Name of a Bluetooth Low Energy braille display port
-					portName = _("Bluetooth: {deviceName}").format(deviceName=match.id)
-					ports[portKey] = portName
-		except Exception:
-			# If BLE scanning fails, continue without BLE devices
-			pass
+		blePorts = list(cls._getBlePorts())
+		if blePorts:
+			# BLE devices are not covered by the usb/bluetooth flags above,
+			# so the automatic option may still be missing at this point.
+			if AUTOMATIC_PORT[0] not in ports:
+				ports.update((AUTOMATIC_PORT,))
+			ports.update(blePorts)
 		try:
 			ports.update(cls.getManualPorts())
 		except NotImplementedError:
 			pass
 		return ports
+
+	@classmethod
+	def _getBlePorts(cls) -> typing.Iterator[typing.Tuple[str, str]]:
+		"""Get the BLE devices currently known to L{bdDetect} as selectable ports.
+
+		:return: An iterator of ``(port, description)`` pairs,
+			where ``port`` is of the form ``ble:DeviceName@Address``.
+		"""
+		try:
+			bleDevices = list(bdDetect.getBleDevicesForDriver(cls.name))
+		except Exception:
+			# Failing to enumerate BLE devices must not prevent the other ports from being offered.
+			log.error(f"Could not enumerate BLE devices for driver {cls.name}", exc_info=True)
+			return
+		for match in bleDevices:
+			# The address is part of the port to tell apart several devices sharing a name.
+			port = f"{cls._BLE_PORT_PREFIX}{match.id}@{match.port}"
+			# Translators: Name of a Bluetooth Low Energy braille display port
+			description = _("Bluetooth: {deviceName}").format(deviceName=match.id)
+			yield port, description
+
+	@classmethod
+	def _getBleTryPorts(cls, port: str) -> typing.Iterator[bdDetect.DeviceMatch]:
+		"""Resolve a manually selected BLE port to the device to connect to.
+
+		:param port: A port of the form ``ble:DeviceName@Address``,
+			as returned by L{_getBlePorts}.
+		:return: An iterator yielding at most one device match.
+		"""
+		portContent = port.removeprefix(cls._BLE_PORT_PREFIX)
+		if "@" not in portContent:
+			log.error(
+				f"Invalid BLE port format: {port}. Expected format: {cls._BLE_PORT_PREFIX}DeviceName@Address",
+			)
+			return
+		deviceName, address = portContent.rsplit("@", 1)
+		# Prefer a device from the scan results, as connecting to it avoids implicit discovery.
+		for match in bdDetect.getBleDevicesForDriver(cls.name):
+			if match.id == deviceName or match.port == address:
+				yield match
+				return
+		# The device is not advertising at the moment,
+		# so fall back to the address recorded in the configuration.
+		log.debug(
+			f"BLE device {deviceName} not in scan results, attempting connection by address {address}",
+		)
+		yield bdDetect.DeviceMatch(
+			bdDetect.ProtocolType.BLE,
+			deviceName,
+			address,
+			{"name": deviceName, "address": address},
+		)
 
 	@classmethod
 	def _getAutoPorts(cls, usb=True, bluetooth=True) -> Iterable[bdDetect.DeviceMatch]:
@@ -315,36 +361,8 @@ class BrailleDisplayDriver(driverHandler.Driver):
 		if isinstance(port, bdDetect.DeviceMatch):
 			yield port
 		elif isinstance(port, str):
-			# Check if this is a specific BLE device port (format: "ble:DeviceName@Address")
-			if port.startswith("ble:"):
-				portContent = port[4:]  # Remove "ble:" prefix
-
-				# Require name@address format
-				if "@" not in portContent:
-					log.error(
-						f"Invalid BLE port format: {port}. Expected format: ble:DeviceName@Address",
-					)
-					return
-
-				deviceName, address = portContent.rsplit("@", 1)
-
-				# Try to find device in current scan results first (preferred)
-				for match in bdDetect.getBleDevicesForDriver(cls.name):
-					if match.id == deviceName or match.port == address:
-						yield match
-						return
-
-				# Fallback: If device not in scan, create DeviceMatch from config
-				log.debug(
-					f"BLE device {deviceName} not in scan results, "
-					f"attempting connection by address {address}",
-				)
-				yield bdDetect.DeviceMatch(
-					bdDetect.ProtocolType.BLE,
-					deviceName,  # id
-					address,  # port
-					{"name": deviceName, "address": address},
-				)
+			if port.startswith(cls._BLE_PORT_PREFIX):
+				yield from cls._getBleTryPorts(port)
 				return
 			isUsb = port in (AUTOMATIC_PORT[0], USB_PORT[0])
 			isBluetooth = port in (AUTOMATIC_PORT[0], BLUETOOTH_PORT[0])

--- a/source/brailleDisplayDrivers/dotPad/defs.py
+++ b/source/brailleDisplayDrivers/dotPad/defs.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2024 NV Access Limited
+# Copyright (C) 2024-2026 NV Access Limited, Dot Incorporated, Bram Duvigneau
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -130,3 +130,4 @@ class DP_KeyGroup(enum.IntEnum):
 
 
 DP_CHECKSUM_BASE = 0xA5
+DP_MAX_PACKET_SIZE = 512

--- a/source/brailleDisplayDrivers/dotPad/defs.py
+++ b/source/brailleDisplayDrivers/dotPad/defs.py
@@ -145,3 +145,8 @@ A 4-byte header (2 sync bytes + 2-byte length) plus the 5-byte minimum body:
 destination + 2-byte command + sequence number + checksum. A declared length
 below this signals a desync or false header.
 """
+
+# BLE service and characteristic UUIDs
+BLE_SERVICE_UUID = "49535343-fe7d-4ae5-8fa9-9fafd205e455"
+BLE_READ_CHARACTERISTIC_UUID = "49535343-1e4d-4bd9-ba61-23c647249616"
+BLE_WRITE_CHARACTERISTIC_UUID = "49535343-8841-43f4-a8d4-ecbe34729bb3"

--- a/source/brailleDisplayDrivers/dotPad/defs.py
+++ b/source/brailleDisplayDrivers/dotPad/defs.py
@@ -130,6 +130,18 @@ class DP_KeyGroup(enum.IntEnum):
 
 
 DP_CHECKSUM_BASE = 0xA5
-# Largest plausible total packet size (sync bytes + length header + body). Real DotPad
-# packets are far smaller; a declared length beyond this signals a desync or false header.
+
 DP_MAX_PACKET_SIZE = 512
+"""Largest plausible total packet size (sync bytes + length header + body).
+
+Real DotPad packets are far smaller; a declared length beyond this signals a
+desync or false header.
+"""
+
+DP_MIN_PACKET_SIZE = 4 + 5
+"""Smallest valid total packet size.
+
+A 4-byte header (2 sync bytes + 2-byte length) plus the 5-byte minimum body:
+destination + 2-byte command + sequence number + checksum. A declared length
+below this signals a desync or false header.
+"""

--- a/source/brailleDisplayDrivers/dotPad/defs.py
+++ b/source/brailleDisplayDrivers/dotPad/defs.py
@@ -130,4 +130,6 @@ class DP_KeyGroup(enum.IntEnum):
 
 
 DP_CHECKSUM_BASE = 0xA5
+# Largest plausible total frame size (sync bytes + length header + body). Real DotPad
+# frames are far smaller; a declared length beyond this signals a desync or false header.
 DP_MAX_PACKET_SIZE = 512

--- a/source/brailleDisplayDrivers/dotPad/defs.py
+++ b/source/brailleDisplayDrivers/dotPad/defs.py
@@ -130,6 +130,6 @@ class DP_KeyGroup(enum.IntEnum):
 
 
 DP_CHECKSUM_BASE = 0xA5
-# Largest plausible total frame size (sync bytes + length header + body). Real DotPad
-# frames are far smaller; a declared length beyond this signals a desync or false header.
+# Largest plausible total packet size (sync bytes + length header + body). Real DotPad
+# packets are far smaller; a declared length beyond this signals a desync or false header.
 DP_MAX_PACKET_SIZE = 512

--- a/source/brailleDisplayDrivers/dotPad/defs.py
+++ b/source/brailleDisplayDrivers/dotPad/defs.py
@@ -1,7 +1,7 @@
 # A part of NonVisual Desktop Access (NVDA)
 # Copyright (C) 2024-2026 NV Access Limited, Dot Incorporated, Bram Duvigneau
-# This file is covered by the GNU General Public License.
-# See the file COPYING for more details.
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
 
 
 import enum

--- a/source/brailleDisplayDrivers/dotPad/defs.py
+++ b/source/brailleDisplayDrivers/dotPad/defs.py
@@ -146,7 +146,11 @@ destination + 2-byte command + sequence number + checksum. A declared length
 below this signals a desync or false header.
 """
 
-# BLE service and characteristic UUIDs
 BLE_SERVICE_UUID = "49535343-fe7d-4ae5-8fa9-9fafd205e455"
+"""UUID of the BLE service carrying the DotPad protocol."""
+
 BLE_READ_CHARACTERISTIC_UUID = "49535343-1e4d-4bd9-ba61-23c647249616"
+"""UUID of the characteristic the display sends notifications on."""
+
 BLE_WRITE_CHARACTERISTIC_UUID = "49535343-8841-43f4-a8d4-ecbe34729bb3"
+"""UUID of the characteristic that accepts DotPad commands."""

--- a/source/brailleDisplayDrivers/dotPad/driver.py
+++ b/source/brailleDisplayDrivers/dotPad/driver.py
@@ -1,7 +1,7 @@
 # A part of NonVisual Desktop Access (NVDA)
 # Copyright (C) 2024-2026 NV Access Limited, Dot Incorporated, Bram Duvigneau
-# This file is covered by the GNU General Public License.
-# See the file COPYING for more details.
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
 
 
 import struct

--- a/source/brailleDisplayDrivers/dotPad/driver.py
+++ b/source/brailleDisplayDrivers/dotPad/driver.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2024-2025 NV Access Limited, Dot Incorporated, Bram Duvigneau
+# Copyright (C) 2024-2026 NV Access Limited, Dot Incorporated, Bram Duvigneau
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -24,6 +24,7 @@ from .defs import (
 	DP_Command,
 	DP_DisplayResponse,
 	DP_Features,
+	DP_MAX_PACKET_SIZE,
 	DP_PacketSeqFlag,
 	DP_PacketSyncByte,
 	DP_PerkinsKey,
@@ -158,20 +159,61 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 			return response.data
 		return b""
 
-	def _onReceive(self, header1: bytes):
-		if ord(header1) != DP_PacketSyncByte.SYNC1:
-			raise RuntimeError(f"Bad {header1=}")
-		header2 = self._dev.read(1)
-		if ord(header2) != DP_PacketSyncByte.SYNC2:
-			raise RuntimeError(f"bad {header2=}")
-		length = struct.unpack(">H", self._dev.read(2))[0]
-		packetBody = self._dev.read(length)
-		dest, cmdHigh, cmdLow, seqNum, *data, checksum = packetBody
+	def _onReceive(self, data: bytes) -> None:
+		"""Handle received data from either Serial (1 byte) or BLE (full packets).
+
+		Buffers incoming data and extracts complete packets as they arrive.
+		Works with both byte-at-a-time delivery (Serial) and packet-based
+		delivery (BLE).
+
+		:param data: Received data (1 byte for Serial, variable length for BLE).
+		"""
+		self._receiveBuffer.extend(data)
+
+		if len(self._receiveBuffer) > DP_MAX_PACKET_SIZE:
+			log.warning(
+				f"Receive buffer exceeded {DP_MAX_PACKET_SIZE} bytes, discarding data and resyncing",
+			)
+			self._receiveBuffer.clear()
+			return
+
+		while len(self._receiveBuffer) >= 4:
+			if self._receiveBuffer[0] != DP_PacketSyncByte.SYNC1:
+				log.debug(f"Bad first sync byte: 0x{self._receiveBuffer[0]:02x}, discarding")
+				self._receiveBuffer.pop(0)
+				continue
+
+			if self._receiveBuffer[1] != DP_PacketSyncByte.SYNC2:
+				log.debug(f"Bad second sync byte: 0x{self._receiveBuffer[1]:02x}, discarding")
+				self._receiveBuffer.pop(0)
+				continue
+
+			packetLength = struct.unpack(">H", bytes(self._receiveBuffer[2:4]))[0]
+			totalLength = 4 + packetLength
+
+			if len(self._receiveBuffer) < totalLength:
+				break
+
+			packet = bytes(self._receiveBuffer[:totalLength])
+			self._receiveBuffer = self._receiveBuffer[totalLength:]
+
+			try:
+				self._processPacket(packet[4:])
+			except (RuntimeError, ValueError, struct.error):
+				log.error("Error processing packet", exc_info=True)
+
+	def _processPacket(self, packetBody: bytes) -> None:
+		"""Process a complete packet body (after sync bytes and length header).
+
+		:param packetBody: The packet body containing dest, command, sequence,
+			data, and checksum.
+		"""
+		dest, cmdFirstByte, cmdSecondByte, seqNum, *data, checksum = packetBody
 		data = bytes(data)
 		if checksum != functools.reduce(operator.xor, packetBody[:-1], DP_CHECKSUM_BASE):
 			raise RuntimeError("bad checksum")
-		cmd = DP_Command(struct.unpack(">H", bytes([cmdHigh, cmdLow]))[0])
-		log.debug(f"Received responce  {cmd.name}, {dest=}, {seqNum=}, data={bytes(data)}")
+		cmd = DP_Command(struct.unpack(">H", bytes([cmdFirstByte, cmdSecondByte]))[0])
+		log.debug(f"Received response {cmd.name}, {dest=}, {seqNum=}, data={bytes(data)}")
 		if cmd.name.startswith("RSP_"):
 			self._recordCommandResponse(cmd, data, dest, seqNum)
 		elif cmd.name.startswith("NTF_"):
@@ -265,6 +307,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 				self._keysPressed.clear()
 
 	def __init__(self, port: str = "auto"):
+		self._receiveBuffer: bytearray = bytearray()
 		if port == "auto":
 			# Try autodetection
 			for portType, portId, port, portInfo in self._getTryPorts(port):

--- a/source/brailleDisplayDrivers/dotPad/driver.py
+++ b/source/brailleDisplayDrivers/dotPad/driver.py
@@ -14,6 +14,7 @@ import inputCore
 import braille
 import winBindings.kernel32
 import hwIo
+import hwIo.ble
 import bdDetect
 from logHandler import log
 from autoSettingsUtils.driverSetting import DriverSetting
@@ -32,6 +33,9 @@ from .defs import (
 	DP_BoardInformation,
 	DP_CHECKSUM_BASE,
 	DP_KeyGroup,
+	BLE_SERVICE_UUID,
+	BLE_READ_CHARACTERISTIC_UUID,
+	BLE_WRITE_CHARACTERISTIC_UUID,
 )
 
 
@@ -100,6 +104,19 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 		return braille.getSerialPorts()
 
 	@classmethod
+	def check(cls) -> bool:
+		"""DotPad is always available on Windows 10/11.
+
+		This allows DotPad to appear in the braille display list even when
+		no devices are currently detected, enabling users to manually select
+		BLE devices after the GUI triggers a scan.
+
+		BLE is always supported on Windows 10/11. Even without BLE hardware,
+		the scanner will run without errors and simply return no results.
+		"""
+		return True
+
+	@classmethod
 	def registerAutomaticDetection(cls, driverRegistrar: bdDetect.DriverRegistrar):
 		driverRegistrar.addUsbDevices(
 			bdDetect.ProtocolType.SERIAL,
@@ -107,6 +124,16 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 				"VID_0403&PID_6010",  # FTDI Dual RS232 as used in DotPad320A
 			},
 		)
+		driverRegistrar.addBleDevices(cls._isBleDotPad)
+
+	@staticmethod
+	def _isBleDotPad(match: bdDetect.DeviceMatch) -> bool:
+		"""Check if a BLE device is a DotPad display.
+
+		:param match: DeviceMatch object containing BLE device information.
+		:return: True if device ID (name or address) starts with "DotPad".
+		"""
+		return match.id.startswith("DotPad")
 
 	supportedSettings = [
 		DriverSetting(
@@ -311,17 +338,13 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 
 	def __init__(self, port: str = "auto"):
 		self._receiveBuffer: bytearray = bytearray()
-		if port == "auto":
-			# Try autodetection
-			for portType, portId, port, portInfo in self._getTryPorts(port):
-				if self._tryConnect(port):
-					break
-			else:
-				raise RuntimeError("No DotPad device found")
+		# _getTryPorts handles all port types: "auto", "ble:DeviceName@Address", COM ports, etc.
+		# It yields DeviceMatch objects with type, id, port, and deviceInfo fields.
+		for match in self._getTryPorts(port):
+			if self._tryConnect(match.port, match.type, match.deviceInfo):
+				break
 		else:
-			# Direct port connection
-			if not self._tryConnect(port):
-				raise RuntimeError(f"Could not connect to DotPad on port {port}")
+			raise RuntimeError("No DotPad device found")
 
 		super().__init__()
 
@@ -333,34 +356,53 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 		for group in DP_KeyGroup:
 			self._keyGroupsReleased[group] = True
 
-	def _tryConnect(self, port: str) -> bool:
+	def _tryConnect(self, port: str, portType: str, portInfo: dict) -> bool:
 		"""Try to connect to a DotPad device on the given port.
 
-		Attempts to open a serial connection to the specified port and verifies that
-		the connected device is a DotPad. Updates internal state with device model,
-		board information, and braille destination if successful.
+		Attempts to open a serial or BLE connection and verifies that the connected
+		device is a DotPad. Updates internal state with device model, board
+		information, and braille destination if successful.
 
 		Side effects:
-			- Sets self._dev to the opened serial device on success.
+			- Sets self._dev to the opened device on success.
 			- Sets self.model and self._boardInformation based on the connected device.
 			- Sets self._brailleDestination depending on device features.
 			- Closes self._dev and resets related attributes on failure.
 
-		:param port: The port to connect to.
+		:param port: The port to connect to (COM port or BLE address).
+		:param portType: The protocol type (from bdDetect.ProtocolType).
+		:param portInfo: Additional port information dictionary.
 		:return: True if connection successful, False otherwise.
 		"""
 		# Start each probe with a clean buffer so stray bytes from a previously
 		# probed (non-DotPad) port can't corrupt this device's first response.
 		self._receiveBuffer.clear()
 		try:
-			self._dev = hwIo.Serial(
-				port=port,
-				baudrate=self.SERIAL_BAUD_RATE,
-				parity=self.SERIAL_PARITY,
-				timeout=self.timeout,
-				writeTimeout=self.timeout,
-				onReceive=self._onReceive,
-			)
+			if portType == bdDetect.ProtocolType.BLE:
+				address = portInfo.get("address") or port
+				# Prefer a BLEDevice from the scanner; this avoids implicit discovery.
+				device = hwIo.ble.findDeviceByAddress(address)
+				if device is None:
+					# Fallback: connect by address string (triggers implicit discovery in Bleak).
+					log.debug(f"BLE device {address} not in scan results, using address for connection")
+					device = address
+				self._dev = hwIo.ble.Ble(
+					device=device,
+					writeServiceUuid=BLE_SERVICE_UUID,
+					writeCharacteristicUuid=BLE_WRITE_CHARACTERISTIC_UUID,
+					readServiceUuid=BLE_SERVICE_UUID,
+					readCharacteristicUuid=BLE_READ_CHARACTERISTIC_UUID,
+					onReceive=self._onReceive,
+				)
+			else:
+				self._dev = hwIo.Serial(
+					port=port,
+					baudrate=self.SERIAL_BAUD_RATE,
+					parity=self.SERIAL_PARITY,
+					timeout=self.timeout,
+					writeTimeout=self.timeout,
+					onReceive=self._onReceive,
+				)
 			# Verify this is actually a DotPad device
 			self.model = self._requestDeviceName()
 			self._boardInformation = self._requestBoardInformation()
@@ -373,6 +415,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 			return True
 		except Exception:
 			# Clean up on failure
+			log.debugWarning("Failed to connect", exc_info=True)
 			try:
 				self._dev.close()
 			except Exception:

--- a/source/brailleDisplayDrivers/dotPad/driver.py
+++ b/source/brailleDisplayDrivers/dotPad/driver.py
@@ -25,6 +25,7 @@ from .defs import (
 	DP_DisplayResponse,
 	DP_Features,
 	DP_MAX_PACKET_SIZE,
+	DP_MIN_PACKET_SIZE,
 	DP_PacketSeqFlag,
 	DP_PacketSyncByte,
 	DP_PerkinsKey,
@@ -184,10 +185,11 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 			packetLength = struct.unpack(">H", bytes(self._receiveBuffer[2:4]))[0]
 			totalLength = 4 + packetLength
 
-			# Real DotPad packets are small. A declared length beyond the plausible
-			# maximum means we locked onto a false header (line noise or desync), so
-			# discard one byte and resync rather than stalling on a huge bogus length.
-			if totalLength > DP_MAX_PACKET_SIZE:
+			# Real DotPad packets fall within a narrow size range. A declared length
+			# outside the plausible bounds means we locked onto a false header (line
+			# noise or desync): discard one byte and resync rather than stalling on a
+			# huge bogus length or trying to unpack a runt packet.
+			if not DP_MIN_PACKET_SIZE <= totalLength <= DP_MAX_PACKET_SIZE:
 				log.debug(f"Implausible length {packetLength}, resyncing")
 				self._receiveBuffer.pop(0)
 				continue
@@ -201,7 +203,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 			try:
 				self._processPacket(packet[4:])
 			except (RuntimeError, ValueError, struct.error):
-				log.error("Error processing packet", exc_info=True)
+				log.exception("Error processing packet")
 
 	def _processPacket(self, packetBody: bytes) -> None:
 		"""Process a complete packet body (after sync bytes and length header).

--- a/source/brailleDisplayDrivers/dotPad/driver.py
+++ b/source/brailleDisplayDrivers/dotPad/driver.py
@@ -184,7 +184,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 			packetLength = struct.unpack(">H", bytes(self._receiveBuffer[2:4]))[0]
 			totalLength = 4 + packetLength
 
-			# Real DotPad frames are small. A declared length beyond the plausible
+			# Real DotPad packets are small. A declared length beyond the plausible
 			# maximum means we locked onto a false header (line noise or desync), so
 			# discard one byte and resync rather than stalling on a huge bogus length.
 			if totalLength > DP_MAX_PACKET_SIZE:

--- a/source/brailleDisplayDrivers/dotPad/driver.py
+++ b/source/brailleDisplayDrivers/dotPad/driver.py
@@ -170,13 +170,6 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 		"""
 		self._receiveBuffer.extend(data)
 
-		if len(self._receiveBuffer) > DP_MAX_PACKET_SIZE:
-			log.warning(
-				f"Receive buffer exceeded {DP_MAX_PACKET_SIZE} bytes, discarding data and resyncing",
-			)
-			self._receiveBuffer.clear()
-			return
-
 		while len(self._receiveBuffer) >= 4:
 			if self._receiveBuffer[0] != DP_PacketSyncByte.SYNC1:
 				log.debug(f"Bad first sync byte: 0x{self._receiveBuffer[0]:02x}, discarding")
@@ -190,6 +183,14 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 
 			packetLength = struct.unpack(">H", bytes(self._receiveBuffer[2:4]))[0]
 			totalLength = 4 + packetLength
+
+			# Real DotPad frames are small. A declared length beyond the plausible
+			# maximum means we locked onto a false header (line noise or desync), so
+			# discard one byte and resync rather than stalling on a huge bogus length.
+			if totalLength > DP_MAX_PACKET_SIZE:
+				log.debug(f"Implausible length {packetLength}, resyncing")
+				self._receiveBuffer.pop(0)
+				continue
 
 			if len(self._receiveBuffer) < totalLength:
 				break
@@ -346,6 +347,9 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 		:param port: The port to connect to.
 		:return: True if connection successful, False otherwise.
 		"""
+		# Start each probe with a clean buffer so stray bytes from a previously
+		# probed (non-DotPad) port can't corrupt this device's first response.
+		self._receiveBuffer.clear()
 		try:
 			self._dev = hwIo.Serial(
 				port=port,

--- a/source/brailleDisplayDrivers/dotPad/driver.py
+++ b/source/brailleDisplayDrivers/dotPad/driver.py
@@ -16,7 +16,6 @@ import braille.display
 import braille.display.driver
 import braille.display.gesture
 import winBindings.kernel32
-import hwIo
 import hwIo.ble
 import bdDetect
 from logHandler import log

--- a/source/brailleDisplayDrivers/dotPad/driver.py
+++ b/source/brailleDisplayDrivers/dotPad/driver.py
@@ -381,7 +381,9 @@ class BrailleDisplayDriver(braille.display.driver.BrailleDisplayDriver):
 			if portType == bdDetect.ProtocolType.BLE:
 				address = portInfo.get("address") or port
 				# A device from the scanner can be connected to without implicit discovery.
-				device = hwIo.ble.findDeviceByAddress(address)
+				# The lookup must not block: a display picked in the settings dialog is
+				# connected on the main thread.
+				device = hwIo.ble.getDiscoveredDevice(address)
 				if device is None:
 					log.debug(f"BLE device {address} not in scan results, using address for connection")
 					device = address

--- a/source/brailleDisplayDrivers/dotPad/driver.py
+++ b/source/brailleDisplayDrivers/dotPad/driver.py
@@ -107,15 +107,20 @@ class BrailleDisplayDriver(braille.display.driver.BrailleDisplayDriver):
 
 	@classmethod
 	def check(cls) -> bool:
-		"""Always report DotPad as available.
+		"""Determine whether a Dot Pad could be connected.
 
 		A BLE device is only known once a scan has run, and the braille display
-		selection dialog is what starts one. The driver therefore has to be offered
-		while no device is known, so that the user can reach that dialog at all.
-		That includes machines with no usable Bluetooth hardware, where the scan is
-		refused and the port list simply stays empty.
+		selection dialog is what starts one, so the driver cannot wait for a device
+		to be detected before offering itself. Reporting on the Bluetooth hardware
+		instead keeps it off machines that could never reach a device, without
+		hiding it on those that simply have nothing switched on yet.
+
+		:return: ``True`` if this machine has usable Bluetooth, or a Dot Pad is
+			otherwise reachable.
 		"""
-		return True
+		# Asking about the hardware is cheaper than enumerating ports, and on a machine
+		# with Bluetooth it settles the question on its own.
+		return hwIo.ble.isAvailable() or super().check()
 
 	@classmethod
 	def registerAutomaticDetection(cls, driverRegistrar: bdDetect.DriverRegistrar):

--- a/source/brailleDisplayDrivers/dotPad/driver.py
+++ b/source/brailleDisplayDrivers/dotPad/driver.py
@@ -113,8 +113,8 @@ class BrailleDisplayDriver(braille.display.driver.BrailleDisplayDriver):
 		A BLE device is only known once a scan has run, and the braille display
 		selection dialog is what starts one. The driver therefore has to be offered
 		while no device is known, so that the user can reach that dialog at all.
-		Machines without BLE hardware are no exception: the scanner runs there too
-		and simply returns no results.
+		That includes machines with no usable Bluetooth hardware, where the scan is
+		refused and the port list simply stays empty.
 		"""
 		return True
 

--- a/source/brailleDisplayDrivers/dotPad/driver.py
+++ b/source/brailleDisplayDrivers/dotPad/driver.py
@@ -347,7 +347,7 @@ class BrailleDisplayDriver(braille.display.driver.BrailleDisplayDriver):
 			if self._tryConnect(match.port, match.type, match.deviceInfo):
 				break
 		else:
-			raise RuntimeError("No DotPad device found")
+			raise RuntimeError(f"No DotPad device found for port {port!r}")
 
 		super().__init__()
 

--- a/source/brailleDisplayDrivers/dotPad/driver.py
+++ b/source/brailleDisplayDrivers/dotPad/driver.py
@@ -17,6 +17,7 @@ import braille.display.driver
 import braille.display.gesture
 import winBindings.kernel32
 import hwIo
+import hwIo.ble
 import bdDetect
 from logHandler import log
 from autoSettingsUtils.driverSetting import DriverSetting
@@ -35,6 +36,9 @@ from .defs import (
 	DP_BoardInformation,
 	DP_CHECKSUM_BASE,
 	DP_KeyGroup,
+	BLE_SERVICE_UUID,
+	BLE_READ_CHARACTERISTIC_UUID,
+	BLE_WRITE_CHARACTERISTIC_UUID,
 )
 
 
@@ -103,6 +107,19 @@ class BrailleDisplayDriver(braille.display.driver.BrailleDisplayDriver):
 		return braille.display.getSerialPorts()
 
 	@classmethod
+	def check(cls) -> bool:
+		"""DotPad is always available on Windows 10/11.
+
+		This allows DotPad to appear in the braille display list even when
+		no devices are currently detected, enabling users to manually select
+		BLE devices after the GUI triggers a scan.
+
+		BLE is always supported on Windows 10/11. Even without BLE hardware,
+		the scanner will run without errors and simply return no results.
+		"""
+		return True
+
+	@classmethod
 	def registerAutomaticDetection(cls, driverRegistrar: bdDetect.DriverRegistrar):
 		driverRegistrar.addUsbDevices(
 			bdDetect.ProtocolType.SERIAL,
@@ -110,6 +127,16 @@ class BrailleDisplayDriver(braille.display.driver.BrailleDisplayDriver):
 				"VID_0403&PID_6010",  # FTDI Dual RS232 as used in DotPad320A
 			},
 		)
+		driverRegistrar.addBleDevices(cls._isBleDotPad)
+
+	@staticmethod
+	def _isBleDotPad(match: bdDetect.DeviceMatch) -> bool:
+		"""Check if a BLE device is a DotPad display.
+
+		:param match: DeviceMatch object containing BLE device information.
+		:return: True if device ID (name or address) starts with "DotPad".
+		"""
+		return match.id.startswith("DotPad")
 
 	supportedSettings = [
 		DriverSetting(
@@ -314,17 +341,13 @@ class BrailleDisplayDriver(braille.display.driver.BrailleDisplayDriver):
 
 	def __init__(self, port: str = "auto"):
 		self._receiveBuffer: bytearray = bytearray()
-		if port == "auto":
-			# Try autodetection
-			for portType, portId, port, portInfo in self._getTryPorts(port):
-				if self._tryConnect(port):
-					break
-			else:
-				raise RuntimeError("No DotPad device found")
+		# _getTryPorts handles all port types: "auto", "ble:DeviceName@Address", COM ports, etc.
+		# It yields DeviceMatch objects with type, id, port, and deviceInfo fields.
+		for match in self._getTryPorts(port):
+			if self._tryConnect(match.port, match.type, match.deviceInfo):
+				break
 		else:
-			# Direct port connection
-			if not self._tryConnect(port):
-				raise RuntimeError(f"Could not connect to DotPad on port {port}")
+			raise RuntimeError("No DotPad device found")
 
 		super().__init__()
 
@@ -336,34 +359,53 @@ class BrailleDisplayDriver(braille.display.driver.BrailleDisplayDriver):
 		for group in DP_KeyGroup:
 			self._keyGroupsReleased[group] = True
 
-	def _tryConnect(self, port: str) -> bool:
+	def _tryConnect(self, port: str, portType: str, portInfo: dict) -> bool:
 		"""Try to connect to a DotPad device on the given port.
 
-		Attempts to open a serial connection to the specified port and verifies that
-		the connected device is a DotPad. Updates internal state with device model,
-		board information, and braille destination if successful.
+		Attempts to open a serial or BLE connection and verifies that the connected
+		device is a DotPad. Updates internal state with device model, board
+		information, and braille destination if successful.
 
 		Side effects:
-			- Sets self._dev to the opened serial device on success.
+			- Sets self._dev to the opened device on success.
 			- Sets self.model and self._boardInformation based on the connected device.
 			- Sets self._brailleDestination depending on device features.
 			- Closes self._dev and resets related attributes on failure.
 
-		:param port: The port to connect to.
+		:param port: The port to connect to (COM port or BLE address).
+		:param portType: The protocol type (from bdDetect.ProtocolType).
+		:param portInfo: Additional port information dictionary.
 		:return: True if connection successful, False otherwise.
 		"""
 		# Start each probe with a clean buffer so stray bytes from a previously
 		# probed (non-DotPad) port can't corrupt this device's first response.
 		self._receiveBuffer.clear()
 		try:
-			self._dev = hwIo.Serial(
-				port=port,
-				baudrate=self.SERIAL_BAUD_RATE,
-				parity=self.SERIAL_PARITY,
-				timeout=self.timeout,
-				writeTimeout=self.timeout,
-				onReceive=self._onReceive,
-			)
+			if portType == bdDetect.ProtocolType.BLE:
+				address = portInfo.get("address") or port
+				# Prefer a BLEDevice from the scanner; this avoids implicit discovery.
+				device = hwIo.ble.findDeviceByAddress(address)
+				if device is None:
+					# Fallback: connect by address string (triggers implicit discovery in Bleak).
+					log.debug(f"BLE device {address} not in scan results, using address for connection")
+					device = address
+				self._dev = hwIo.ble.Ble(
+					device=device,
+					writeServiceUuid=BLE_SERVICE_UUID,
+					writeCharacteristicUuid=BLE_WRITE_CHARACTERISTIC_UUID,
+					readServiceUuid=BLE_SERVICE_UUID,
+					readCharacteristicUuid=BLE_READ_CHARACTERISTIC_UUID,
+					onReceive=self._onReceive,
+				)
+			else:
+				self._dev = hwIo.Serial(
+					port=port,
+					baudrate=self.SERIAL_BAUD_RATE,
+					parity=self.SERIAL_PARITY,
+					timeout=self.timeout,
+					writeTimeout=self.timeout,
+					onReceive=self._onReceive,
+				)
 			# Verify this is actually a DotPad device
 			self.model = self._requestDeviceName()
 			self._boardInformation = self._requestBoardInformation()
@@ -376,6 +418,7 @@ class BrailleDisplayDriver(braille.display.driver.BrailleDisplayDriver):
 			return True
 		except Exception:
 			# Clean up on failure
+			log.debugWarning("Failed to connect", exc_info=True)
 			try:
 				self._dev.close()
 			except Exception:

--- a/source/brailleDisplayDrivers/dotPad/driver.py
+++ b/source/brailleDisplayDrivers/dotPad/driver.py
@@ -108,14 +108,13 @@ class BrailleDisplayDriver(braille.display.driver.BrailleDisplayDriver):
 
 	@classmethod
 	def check(cls) -> bool:
-		"""DotPad is always available on Windows 10/11.
+		"""Always report DotPad as available.
 
-		This allows DotPad to appear in the braille display list even when
-		no devices are currently detected, enabling users to manually select
-		BLE devices after the GUI triggers a scan.
-
-		BLE is always supported on Windows 10/11. Even without BLE hardware,
-		the scanner will run without errors and simply return no results.
+		A BLE device is only known once a scan has run, and the braille display
+		selection dialog is what starts one. The driver therefore has to be offered
+		while no device is known, so that the user can reach that dialog at all.
+		Machines without BLE hardware are no exception: the scanner runs there too
+		and simply returns no results.
 		"""
 		return True
 
@@ -341,8 +340,6 @@ class BrailleDisplayDriver(braille.display.driver.BrailleDisplayDriver):
 
 	def __init__(self, port: str = "auto"):
 		self._receiveBuffer: bytearray = bytearray()
-		# _getTryPorts handles all port types: "auto", "ble:DeviceName@Address", COM ports, etc.
-		# It yields DeviceMatch objects with type, id, port, and deviceInfo fields.
 		for match in self._getTryPorts(port):
 			if self._tryConnect(match.port, match.type, match.deviceInfo):
 				break
@@ -383,10 +380,9 @@ class BrailleDisplayDriver(braille.display.driver.BrailleDisplayDriver):
 		try:
 			if portType == bdDetect.ProtocolType.BLE:
 				address = portInfo.get("address") or port
-				# Prefer a BLEDevice from the scanner; this avoids implicit discovery.
+				# A device from the scanner can be connected to without implicit discovery.
 				device = hwIo.ble.findDeviceByAddress(address)
 				if device is None:
-					# Fallback: connect by address string (triggers implicit discovery in Bleak).
 					log.debug(f"BLE device {address} not in scan results, using address for connection")
 					device = address
 				self._dev = hwIo.ble.Ble(

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -5062,6 +5062,16 @@ class BrailleDisplaySelectionDialog(SettingsDialog):
 		self.updateStateDependentControls()
 
 	def postInit(self):
+		# Start BLE scanner if not already running to populate device list
+		import hwIo.ble
+
+		if not hwIo.ble.scanner.isScanning:
+			try:
+				hwIo.ble.scanner.start()  # Starts in background mode
+				log.debug("Started BLE scanner for braille display selection")
+			except Exception:
+				log.error("Failed to start BLE scanner", exc_info=True)
+
 		# Finally, ensure that focus is on the list of displays.
 		self.displayList.SetFocus()
 
@@ -5125,10 +5135,20 @@ class BrailleDisplaySelectionDialog(SettingsDialog):
 				# Display name not in config or port not valid
 				selection = 0
 			self.portsList.SetSelection(selection)
-		# If no port selection is possible or only automatic selection is available, disable the port selection control
-		enable = len(self.possiblePorts) > 0 and not (
-			len(self.possiblePorts) == 1 and self.possiblePorts[0][0] == "auto"
-		)
+			enable = True
+		else:
+			# No ports available - show helpful message
+			# Translators: Message shown when no devices are available for a braille display
+			noDevicesMessage = _("(No devices found - switch to another display and back to refresh)")
+			self.portsList.SetItems([noDevicesMessage])
+			self.portsList.SetSelection(0)
+			enable = False
+
+		# Special case: If only "auto" port exists, disable manual selection
+		# (This means devices are detected but no manual selection is needed)
+		if len(self.possiblePorts) == 1 and self.possiblePorts[0][0] == "auto":
+			enable = False
+
 		self.portsList.Enable(enable)
 
 		self.autoDetectList.Enable(isAutoDisplaySelected)
@@ -5174,7 +5194,25 @@ class BrailleDisplaySelectionDialog(SettingsDialog):
 			# Hack: we need to update the display in our parent window before closing.
 			# Otherwise, NVDA will report the old display even though the new display is reflected visually.
 			self.Parent.updateCurrentDisplay()
+		self._stopBleScanner()
 		super(BrailleDisplaySelectionDialog, self).onOk(evt)
+
+	def onCancel(self, evt):
+		"""Stop BLE scanner when dialog is cancelled if background detection is not active."""
+		self._stopBleScanner()
+		super().onCancel(evt)
+
+	def _stopBleScanner(self):
+		"""Stop BLE scanner if it's running and background detection is not active."""
+		import hwIo.ble
+
+		# Only stop if we're not in automatic detection mode
+		if hwIo.ble.scanner.isScanning and config.conf["braille"]["display"] != braille.AUTO_DISPLAY_NAME:
+			try:
+				hwIo.ble.scanner.stop()
+				log.debug("Stopped BLE scanner after braille display selection dialog closed")
+			except Exception:
+				log.error("Failed to stop BLE scanner", exc_info=True)
 
 
 class BrailleSettingsSubPanel(AutoSettingsMixin, SettingsPanel):

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -5153,6 +5153,16 @@ class BrailleDisplaySelectionDialog(SettingsDialog):
 		self.updateStateDependentControls()
 
 	def postInit(self):
+		# Start BLE scanner if not already running to populate device list
+		import hwIo.ble
+
+		if not hwIo.ble.scanner.isScanning:
+			try:
+				hwIo.ble.scanner.start()  # Starts in background mode
+				log.debug("Started BLE scanner for braille display selection")
+			except Exception:
+				log.error("Failed to start BLE scanner", exc_info=True)
+
 		# Finally, ensure that focus is on the list of displays.
 		self.displayList.SetFocus()
 
@@ -5216,10 +5226,20 @@ class BrailleDisplaySelectionDialog(SettingsDialog):
 				# Display name not in config or port not valid
 				selection = 0
 			self.portsList.SetSelection(selection)
-		# If no port selection is possible or only automatic selection is available, disable the port selection control
-		enable = len(self.possiblePorts) > 0 and not (
-			len(self.possiblePorts) == 1 and self.possiblePorts[0][0] == "auto"
-		)
+			enable = True
+		else:
+			# No ports available - show helpful message
+			# Translators: Message shown when no devices are available for a braille display
+			noDevicesMessage = _("(No devices found - switch to another display and back to refresh)")
+			self.portsList.SetItems([noDevicesMessage])
+			self.portsList.SetSelection(0)
+			enable = False
+
+		# Special case: If only "auto" port exists, disable manual selection
+		# (This means devices are detected but no manual selection is needed)
+		if len(self.possiblePorts) == 1 and self.possiblePorts[0][0] == "auto":
+			enable = False
+
 		self.portsList.Enable(enable)
 
 		self.autoDetectList.Enable(isAutoDisplaySelected)
@@ -5265,7 +5285,25 @@ class BrailleDisplaySelectionDialog(SettingsDialog):
 			# Hack: we need to update the display in our parent window before closing.
 			# Otherwise, NVDA will report the old display even though the new display is reflected visually.
 			self.Parent.updateCurrentDisplay()
+		self._stopBleScanner()
 		super(BrailleDisplaySelectionDialog, self).onOk(evt)
+
+	def onCancel(self, evt):
+		"""Stop BLE scanner when dialog is cancelled if background detection is not active."""
+		self._stopBleScanner()
+		super().onCancel(evt)
+
+	def _stopBleScanner(self):
+		"""Stop BLE scanner if it's running and background detection is not active."""
+		import hwIo.ble
+
+		# Only stop if we're not in automatic detection mode
+		if hwIo.ble.scanner.isScanning and config.conf["braille"]["display"] != braille.AUTO_DISPLAY_NAME:
+			try:
+				hwIo.ble.scanner.stop()
+				log.debug("Stopped BLE scanner after braille display selection dialog closed")
+			except Exception:
+				log.error("Failed to stop BLE scanner", exc_info=True)
 
 
 class BrailleSettingsSubPanel(AutoSettingsMixin, SettingsPanel):

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -6,7 +6,8 @@
 # Łukasz Golonka, Aaron Cannon, Adriani90, André-Abush Clause, Dawid Pieper,
 # Takuya Nishimoto, jakubl7545, Tony Malykh, Rob Meredith,
 # Burman's Computer and Education Ltd, hwf1324, Cary-rowen, Christopher Proß, Tianze
-# Neil Soiffer, Ryan McCleary, Wang Chong, Kefas Lungu.
+# Neil Soiffer, Ryan McCleary, Wang Chong, Kefas Lungu, Dot Incorporated,
+# Bram Duvigneau.
 # This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
 # For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
 
@@ -37,6 +38,7 @@ import characterProcessing
 import config
 import core
 import globalVars
+import hwIo.ble
 import installer
 import keyboardHandler
 import languageHandler
@@ -5134,6 +5136,7 @@ class BrailleDisplaySelectionDialog(SettingsDialog):
 		# so start scanning before the list is built for the first time.
 		self._startBleScanner()
 		self._portRefreshTimer: wx.CallLater | None = None
+		"""Timer that polls for BLE devices discovered after the port list was built."""
 		sHelper = guiHelper.BoxSizerHelper(self, sizer=settingsSizer)
 
 		# Translators: The label for a setting in braille settings to choose a braille display.
@@ -5168,11 +5171,9 @@ class BrailleDisplaySelectionDialog(SettingsDialog):
 
 	def _startBleScanner(self):
 		"""Start the shared BLE scanner, so that BLE devices can be offered as ports."""
-		import hwIo.ble
-
 		if not hwIo.ble.scanner.isScanning:
 			try:
-				hwIo.ble.scanner.start()  # Starts in background mode
+				hwIo.ble.scanner.start()
 				log.debug("Started BLE scanner for braille display selection")
 			except Exception:
 				log.error("Failed to start BLE scanner", exc_info=True)
@@ -5198,8 +5199,8 @@ class BrailleDisplaySelectionDialog(SettingsDialog):
 		if not newPorts:
 			return
 		if not self.possiblePorts:
-			# There is no selection to preserve, so build the list as if the dialog just opened.
-			# This also offers the automatic port, which is available as soon as any device is.
+			# With no selection to preserve, a full rebuild is safe,
+			# and it also offers the automatic port.
 			self.updateStateDependentControls()
 		else:
 			self.possiblePorts.extend(newPorts)
@@ -5290,15 +5291,13 @@ class BrailleDisplaySelectionDialog(SettingsDialog):
 			self.portsList.SetItems([])
 			enable = False
 		else:
-			# No ports available - show helpful message
 			# Translators: Message shown when no devices are available for a braille display
 			noDevicesMessage = _("(No devices found)")
 			self.portsList.SetItems([noDevicesMessage])
 			self.portsList.SetSelection(0)
 			enable = False
 
-		# Special case: If only "auto" port exists, disable manual selection
-		# (This means devices are detected but no manual selection is needed)
+		# With only the automatic port there is nothing to choose between.
 		if len(self.possiblePorts) == 1 and self.possiblePorts[0][0] == "auto":
 			enable = False
 
@@ -5352,16 +5351,12 @@ class BrailleDisplaySelectionDialog(SettingsDialog):
 		super(BrailleDisplaySelectionDialog, self).onOk(evt)
 
 	def onCancel(self, evt):
-		"""Stop BLE scanner when dialog is cancelled if background detection is not active."""
 		self._stopPortRefresh()
 		self._stopBleScanner()
 		super().onCancel(evt)
 
 	def _stopBleScanner(self):
-		"""Stop BLE scanner if it's running and background detection is not active."""
-		import hwIo.ble
-
-		# Only stop if we're not in automatic detection mode
+		"""Stop the shared BLE scanner, unless automatic detection owns it."""
 		if hwIo.ble.scanner.isScanning and config.conf["braille"]["display"] != braille.AUTO_DISPLAY_NAME:
 			try:
 				hwIo.ble.scanner.stop()

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -5128,8 +5128,8 @@ class BrailleDisplaySelectionDialog(SettingsDialog):
 	displayNames = []
 	possiblePorts = []
 
-	#: Interval in milliseconds at which the port list is checked for newly discovered BLE devices.
 	_BLE_REFRESH_INTERVAL = 1000
+	"""Interval in milliseconds at which the port list is checked for newly discovered BLE devices."""
 
 	def makeSettings(self, settingsSizer):
 		# BLE devices only appear in the port list once the scanner has discovered them,

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -5285,22 +5285,13 @@ class BrailleDisplaySelectionDialog(SettingsDialog):
 				# Display name not in config or port not valid
 				selection = 0
 			self.portsList.SetSelection(selection)
-			enable = True
-		elif isAutoDisplaySelected:
-			# Ports are irrelevant when displays are detected automatically.
-			self.portsList.SetItems([])
-			enable = False
 		else:
-			# Translators: Message shown when no devices are available for a braille display
-			noDevicesMessage = _("(No devices found)")
-			self.portsList.SetItems([noDevicesMessage])
-			self.portsList.SetSelection(0)
-			enable = False
-
-		# With only the automatic port there is nothing to choose between.
-		if len(self.possiblePorts) == 1 and self.possiblePorts[0][0] == "auto":
-			enable = False
-
+			# Ports from the previously selected display would otherwise stay on screen.
+			self.portsList.SetItems([])
+		# If no port selection is possible or only automatic selection is available, disable the port selection control
+		enable = len(self.possiblePorts) > 0 and not (
+			len(self.possiblePorts) == 1 and self.possiblePorts[0][0] == "auto"
+		)
 		self.portsList.Enable(enable)
 
 		self.autoDetectList.Enable(isAutoDisplaySelected)

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -5357,7 +5357,10 @@ class BrailleDisplaySelectionDialog(SettingsDialog):
 
 	def _stopBleScanner(self):
 		"""Stop the shared BLE scanner, unless automatic detection owns it."""
-		if hwIo.ble.scanner.isScanning and config.conf["braille"]["display"] != braille.AUTO_DISPLAY_NAME:
+		if (
+			hwIo.ble.scanner.isScanning
+			and config.conf["braille"]["display"] != braille.constants.AUTO_DISPLAY_NAME
+		):
 			try:
 				hwIo.ble.scanner.stop()
 				log.debug("Stopped BLE scanner after braille display selection dialog closed")

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -5227,6 +5227,10 @@ class BrailleDisplaySelectionDialog(SettingsDialog):
 				selection = 0
 			self.portsList.SetSelection(selection)
 			enable = True
+		elif isAutoDisplaySelected:
+			# Ports are irrelevant when displays are detected automatically.
+			self.portsList.SetItems([])
+			enable = False
 		else:
 			# No ports available - show helpful message
 			# Translators: Message shown when no devices are available for a braille display

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -5126,7 +5126,14 @@ class BrailleDisplaySelectionDialog(SettingsDialog):
 	displayNames = []
 	possiblePorts = []
 
+	#: Interval in milliseconds at which the port list is checked for newly discovered BLE devices.
+	_BLE_REFRESH_INTERVAL = 1000
+
 	def makeSettings(self, settingsSizer):
+		# BLE devices only appear in the port list once the scanner has discovered them,
+		# so start scanning before the list is built for the first time.
+		self._startBleScanner()
+		self._portRefreshTimer: wx.CallLater | None = None
 		sHelper = guiHelper.BoxSizerHelper(self, sizer=settingsSizer)
 
 		# Translators: The label for a setting in braille settings to choose a braille display.
@@ -5153,7 +5160,14 @@ class BrailleDisplaySelectionDialog(SettingsDialog):
 		self.updateStateDependentControls()
 
 	def postInit(self):
-		# Start BLE scanner if not already running to populate device list
+		# Discovering a BLE device takes a moment, so the port list built in makeSettings
+		# is usually still incomplete. Keep looking while the dialog is open.
+		self._portRefreshTimer = wx.CallLater(self._BLE_REFRESH_INTERVAL, self._refreshBlePorts)
+		# Finally, ensure that focus is on the list of displays.
+		self.displayList.SetFocus()
+
+	def _startBleScanner(self):
+		"""Start the shared BLE scanner, so that BLE devices can be offered as ports."""
 		import hwIo.ble
 
 		if not hwIo.ble.scanner.isScanning:
@@ -5163,8 +5177,52 @@ class BrailleDisplaySelectionDialog(SettingsDialog):
 			except Exception:
 				log.error("Failed to start BLE scanner", exc_info=True)
 
-		# Finally, ensure that focus is on the list of displays.
-		self.displayList.SetFocus()
+	def _refreshBlePorts(self):
+		"""Offer the BLE devices discovered since the port list was built.
+
+		New devices are appended to the list rather than the list being rebuilt,
+		so that neither the existing entries nor the selection move under the user.
+		This means a port that disappears while the dialog is open stays listed,
+		which matches the rest of the list being a snapshot taken when it opened.
+		"""
+		self._portRefreshTimer = wx.CallLater(self._BLE_REFRESH_INTERVAL, self._refreshBlePorts)
+		displayName = self.displayNames[self.displayList.GetSelection()]
+		if displayName == braille.constants.AUTO_DISPLAY_NAME:
+			# Ports are irrelevant when displays are detected automatically.
+			return
+		displayCls = braille.display._getDisplayDriver(displayName)
+		knownPorts = {port for port, description in self.possiblePorts}
+		newPorts = [
+			(port, description) for port, description in displayCls._getBlePorts() if port not in knownPorts
+		]
+		if not newPorts:
+			return
+		if not self.possiblePorts:
+			# There is no selection to preserve, so build the list as if the dialog just opened.
+			# This also offers the automatic port, which is available as soon as any device is.
+			self.updateStateDependentControls()
+		else:
+			self.possiblePorts.extend(newPorts)
+			# Appending leaves the existing entries, and therefore the selection, in place.
+			selection = self.portsList.GetSelection()
+			self.portsList.SetItems([description for port, description in self.possiblePorts])
+			self.portsList.SetSelection(selection)
+			self.portsList.Enable(True)
+		ui.message(
+			ngettext(
+				# Translators: Reported when a braille display is discovered over Bluetooth
+				# while the braille display selection dialog is open.
+				"{count} new Bluetooth device found",
+				"{count} new Bluetooth devices found",
+				len(newPorts),
+			).format(count=len(newPorts)),
+		)
+
+	def _stopPortRefresh(self):
+		"""Stop looking for newly discovered BLE devices."""
+		if self._portRefreshTimer is not None:
+			self._portRefreshTimer.Stop()
+			self._portRefreshTimer = None
 
 	@staticmethod
 	def getCurrentAutoDisplayDescription():
@@ -5234,7 +5292,7 @@ class BrailleDisplaySelectionDialog(SettingsDialog):
 		else:
 			# No ports available - show helpful message
 			# Translators: Message shown when no devices are available for a braille display
-			noDevicesMessage = _("(No devices found - switch to another display and back to refresh)")
+			noDevicesMessage = _("(No devices found)")
 			self.portsList.SetItems([noDevicesMessage])
 			self.portsList.SetSelection(0)
 			enable = False
@@ -5289,11 +5347,13 @@ class BrailleDisplaySelectionDialog(SettingsDialog):
 			# Hack: we need to update the display in our parent window before closing.
 			# Otherwise, NVDA will report the old display even though the new display is reflected visually.
 			self.Parent.updateCurrentDisplay()
+		self._stopPortRefresh()
 		self._stopBleScanner()
 		super(BrailleDisplaySelectionDialog, self).onOk(evt)
 
 	def onCancel(self, evt):
 		"""Stop BLE scanner when dialog is cancelled if background detection is not active."""
+		self._stopPortRefresh()
 		self._stopBleScanner()
 		super().onCancel(evt)
 

--- a/source/hwIo/ble/__init__.py
+++ b/source/hwIo/ble/__init__.py
@@ -62,10 +62,7 @@ def getDiscoveredDevice(address: str) -> BLEDevice | None:
 	"""
 	if scanner is None:
 		return None
-	for device in scanner.results():
-		if device.address == address:
-			return device
-	return None
+	return next((device for device in scanner.results() if device.address == address), None)
 
 
 @requiresBackgroundThread

--- a/source/hwIo/ble/__init__.py
+++ b/source/hwIo/ble/__init__.py
@@ -15,13 +15,18 @@ Bluetooth Classic devices should be paired through Windows' Bluetooth settings a
 import time
 from bleak.exc import BleakError
 from bleak.backends.device import BLEDevice
+from winrt.windows.devices.bluetooth import BluetoothAdapter
+from winrt.windows.devices.radios import RadioState
+
+import _asyncioEventLoop
+from _asyncioEventLoop.utils import runCoroutineSync
 from logHandler import log
 
 from ._scanner import Scanner
 from ._io import Ble
 from ..base import requiresBackgroundThread
 
-__all__ = ["Scanner", "Ble", "scanner", "getDiscoveredDevice", "findDeviceByAddress"]
+__all__ = ["Scanner", "Ble", "scanner", "isAvailable", "getDiscoveredDevice", "findDeviceByAddress"]
 
 #: Module-level singleton scanner shared by all BLE consumers.
 #: Using a single scanner avoids contention over the Windows BLE stack and
@@ -49,6 +54,39 @@ def terminate() -> None:
 				# NVDA is shutting down, so there is nothing left to salvage.
 				log.debugWarning("Failed to stop BLE scanner", exc_info=True)
 		scanner = None
+
+
+AVAILABILITY_TIMEOUT_SECONDS: int = 5
+"""How long to wait for Windows to report on the Bluetooth hardware."""
+
+
+async def _isBluetoothUsable() -> bool:
+	"""Ask Windows whether this machine has Bluetooth hardware able to act as a central."""
+	adapter = await BluetoothAdapter.get_default_async()
+	if adapter is None or not adapter.is_central_role_supported:
+		return False
+	radio = await adapter.get_radio_async()
+	return radio.state == RadioState.ON
+
+
+def isAvailable() -> bool:
+	"""Determine whether this machine can reach BLE devices.
+
+	Answering takes a few milliseconds, as it asks the Bluetooth stack rather than
+	reading a cached value, so the answer also reflects the radio being switched off.
+
+	:return: ``False`` only when Windows reports there is no usable Bluetooth hardware.
+		Anything that prevents asking reports ``True``: hiding a driver on a machine
+		that may well support it is worse than offering one that cannot connect.
+	"""
+	if not _asyncioEventLoop.isRunning():
+		# There is nothing to ask on, such as in unit tests.
+		return True
+	try:
+		return runCoroutineSync(_isBluetoothUsable(), AVAILABILITY_TIMEOUT_SECONDS)
+	except (BleakError, OSError, TimeoutError, RuntimeError):
+		log.debugWarning("Could not determine whether Bluetooth is available", exc_info=True)
+		return True
 
 
 def getDiscoveredDevice(address: str) -> BLEDevice | None:

--- a/source/hwIo/ble/__init__.py
+++ b/source/hwIo/ble/__init__.py
@@ -43,7 +43,11 @@ def terminate() -> None:
 	global scanner
 	if scanner is not None:
 		if scanner.isScanning:
-			scanner.stop()
+			try:
+				scanner.stop()
+			except (BleakError, OSError):
+				# NVDA is shutting down, so there is nothing left to salvage.
+				log.debugWarning("Failed to stop BLE scanner", exc_info=True)
 		scanner = None
 
 

--- a/source/hwIo/ble/__init__.py
+++ b/source/hwIo/ble/__init__.py
@@ -21,7 +21,7 @@ from ._scanner import Scanner
 from ._io import Ble
 from ..base import requiresBackgroundThread
 
-__all__ = ["Scanner", "Ble", "scanner", "findDeviceByAddress"]
+__all__ = ["Scanner", "Ble", "scanner", "getDiscoveredDevice", "findDeviceByAddress"]
 
 #: Module-level singleton scanner shared by all BLE consumers.
 #: Using a single scanner avoids contention over the Windows BLE stack and
@@ -47,6 +47,23 @@ def terminate() -> None:
 		scanner = None
 
 
+def getDiscoveredDevice(address: str) -> BLEDevice | None:
+	"""Get an already discovered BLE device by its address.
+
+	Unlike :func:`findDeviceByAddress` this never starts a scan and never blocks,
+	so it is safe to call on the main thread.
+
+	:param address: The BLE device address (MAC address)
+	:return: The BLE device object if the scanner has seen it, None otherwise
+	"""
+	if scanner is None:
+		return None
+	for device in scanner.results():
+		if device.address == address:
+			return device
+	return None
+
+
 @requiresBackgroundThread
 def findDeviceByAddress(address: str, timeout: float = 5.0, pollInterval: float = 0.1) -> BLEDevice | None:
 	"""Find a BLE device by its address.
@@ -62,11 +79,10 @@ def findDeviceByAddress(address: str, timeout: float = 5.0, pollInterval: float 
 		raise RuntimeError("hwIo.ble.initialize() must be called before using findDeviceByAddress")
 	log.debug(f"Searching for BLE device with address {address}")
 
-	# Check if device already discovered
-	for device in scanner.results():
-		if device.address == address:
-			log.debug(f"Found BLE device {address} in existing results")
-			return device
+	device = getDiscoveredDevice(address)
+	if device is not None:
+		log.debug(f"Found BLE device {address} in existing results")
+		return device
 
 	# Not found - start scanning if not already running
 	if not scanner.isScanning:
@@ -80,12 +96,10 @@ def findDeviceByAddress(address: str, timeout: float = 5.0, pollInterval: float 
 	while time.time() - startTime < timeout:
 		time.sleep(pollInterval)
 
-		# Check if device appeared
-		for device in scanner.results():
-			if device.address == address:
-				elapsed = time.time() - startTime
-				log.debug(f"Found BLE device {address} after {elapsed:.2f}s")
-				return device
+		device = getDiscoveredDevice(address)
+		if device is not None:
+			log.debug(f"Found BLE device {address} after {time.time() - startTime:.2f}s")
+			return device
 
 	# Timeout - device not found
 	log.debug(f"BLE device {address} not found after {timeout}s timeout")

--- a/source/hwIo/ble/_io.py
+++ b/source/hwIo/ble/_io.py
@@ -21,6 +21,18 @@ from bleak.backends.characteristic import BleakGATTCharacteristic
 from bleak.backends.winrt.client import WinRTClientArgs
 
 CONNECT_TIMEOUT_SECONDS: int = 2
+"""How long to wait for the connection to be established and its services discovered."""
+
+LINK_TIMEOUT_SECONDS: int = 10
+"""How long to wait for the connection attempt itself, including any implicit discovery.
+
+A device that is switched off or out of range would otherwise hold the calling thread
+for as long as the Bluetooth stack keeps trying. That thread is NVDA's main thread when
+a configured display is connected during startup or from the braille settings dialog,
+so the wait has to be bounded. Ten seconds matches Bleak's own discovery timeout, so
+this does not cut short an attempt that would have succeeded.
+"""
+
 WINRT_CLIENT_ARGS = WinRTClientArgs(use_cached_services=True)
 
 
@@ -148,8 +160,14 @@ class Ble(IoBase):
 			daemon=True,
 		)
 		self._readerThread.start()
-		runCoroutineSync(self._initAndConnect())
-		self.waitForConnection(CONNECT_TIMEOUT_SECONDS)
+		try:
+			runCoroutineSync(self._initAndConnect(), LINK_TIMEOUT_SECONDS)
+			self.waitForConnection(CONNECT_TIMEOUT_SECONDS)
+		except Exception:
+			# The reader thread outlives a failed constructor, as nothing owns this
+			# instance to close it.
+			self._stopReaderEvent.set()
+			raise
 
 	async def _initAndConnect(self) -> None:
 		await self._client.connect()

--- a/source/hwIo/ble/_scanner.py
+++ b/source/hwIo/ble/_scanner.py
@@ -7,13 +7,21 @@ import time
 from threading import Event
 from typing import Callable
 
-from _asyncioEventLoop.utils import runCoroutine
+from _asyncioEventLoop.utils import runCoroutineSync
 import extensionPoints
 from logHandler import log
 
 import bleak
 from bleak.backends.device import BLEDevice
 from bleak.backends.scanner import AdvertisementData
+
+SCAN_CONTROL_TIMEOUT_SECONDS: int = 10
+"""How long to wait for a scan to start or stop.
+
+Both reach the Bluetooth stack, which can be slow to answer when the adapter is
+busy, so the wait is bounded while staying generous enough not to give up on a
+stack that is merely slow.
+"""
 
 
 class Scanner:
@@ -54,21 +62,31 @@ class Scanner:
 
 		:param duration: If 0 (default), scan continues in background until stop() is called.
 			If > 0, scan for specified duration in seconds then stop automatically.
+		:raises bleak.exc.BleakError: If scanning could not be started, for example because
+			the machine has no Bluetooth adapter or its radio is switched off.
 		"""
 		log.debug("Scanning for devices")
 		# Clear device cache only on first start to allow multiple callers to share results
 		if not self._isScanning.is_set():
 			self._discoveredDevices.clear()
+		# Waiting for the result lets a refused start reach the caller. Bleak refuses
+		# when the machine has no Bluetooth adapter or its radio is off, and a scan that
+		# never started must not be recorded as running: that would suppress every later
+		# attempt and leave callers waiting for results that cannot arrive.
+		runCoroutineSync(self._scanner.start(), SCAN_CONTROL_TIMEOUT_SECONDS)
 		self._isScanning.set()
-		runCoroutine(self._scanner.start())
 		if duration > 0:
 			time.sleep(duration)
-			runCoroutine(self._scanner.stop())
-			self._isScanning.clear()
+			self.stop()
 
 	def stop(self):
-		"""Stop scanning"""
-		runCoroutine(self._scanner.stop())
+		"""Stop scanning.
+
+		:raises bleak.exc.BleakError: If the scan could not be stopped.
+		"""
+		# Waiting means the watcher has really stopped before this returns. Starting a
+		# new scan while the old one is still running is refused by Bleak.
+		runCoroutineSync(self._scanner.stop(), SCAN_CONTROL_TIMEOUT_SECONDS)
 		self._isScanning.clear()
 
 	def results(self, filterFunc: Callable[[BLEDevice], bool] | None = None) -> list[BLEDevice]:

--- a/tests/unit/brailleDisplayDrivers/__init__.py
+++ b/tests/unit/brailleDisplayDrivers/__init__.py
@@ -1,4 +1,4 @@
 # A part of NonVisual Desktop Access (NVDA)
 # Copyright (C) 2026 NV Access Limited, Dot Incorporated, Bram Duvigneau
-# This file is covered by the GNU General Public License.
-# See the file COPYING for more details.
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt

--- a/tests/unit/brailleDisplayDrivers/__init__.py
+++ b/tests/unit/brailleDisplayDrivers/__init__.py
@@ -1,0 +1,4 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2026 NV Access Limited, Dot Incorporated, Bram Duvigneau
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.

--- a/tests/unit/brailleDisplayDrivers/test_dotPad.py
+++ b/tests/unit/brailleDisplayDrivers/test_dotPad.py
@@ -81,6 +81,8 @@ class TestDotPadBufferedReceive(unittest.TestCase):
 		self.driver._onReceive(packet)
 
 		self.assertEqual(len(self.processedPackets), 1)
+		# The packet body passed on is the frame with the 4-byte sync/length header stripped.
+		self.assertEqual(self.processedPackets[0], packet[4:])
 		self.assertEqual(len(self.driver._receiveBuffer), 0)
 
 	def test_byteAtATime(self) -> None:
@@ -131,13 +133,23 @@ class TestDotPadBufferedReceive(unittest.TestCase):
 		self.assertEqual(len(self.processedPackets), 1)
 		self.assertEqual(len(self.driver._receiveBuffer), 0)
 
-	def test_bufferOverflow_cleared(self) -> None:
-		"""Test that buffer overflow triggers a clear and doesn't crash."""
-		oversizedData = b"\xaa" * (DP_MAX_PACKET_SIZE + 1)
+	def test_implausibleLength_resynchronize(self) -> None:
+		"""Test that a header declaring an oversized length is treated as a false header.
 
-		self.driver._onReceive(oversizedData)
+		Valid sync bytes followed by a length beyond DP_MAX_PACKET_SIZE indicate a
+		desync rather than a real packet, so the driver should discard a byte, resync,
+		and still process a valid packet that follows.
+		"""
+		bogusHeader = bytes([DP_PacketSyncByte.SYNC1, DP_PacketSyncByte.SYNC2]) + struct.pack(
+			">H",
+			DP_MAX_PACKET_SIZE,
+		)
+		goodPacket = self._createPacket(dest=0, cmd=DP_Command.RSP_DEVICE_NAME, seqNum=1, data=b"OK")
 
-		self.assertEqual(len(self.processedPackets), 0)
+		self.driver._onReceive(bogusHeader + goodPacket)
+
+		self.assertEqual(len(self.processedPackets), 1)
+		self.assertEqual(self.processedPackets[0], goodPacket[4:])
 		self.assertEqual(len(self.driver._receiveBuffer), 0)
 
 	def test_incompletePacketInBuffer(self) -> None:

--- a/tests/unit/brailleDisplayDrivers/test_dotPad.py
+++ b/tests/unit/brailleDisplayDrivers/test_dotPad.py
@@ -81,7 +81,7 @@ class TestDotPadBufferedReceive(unittest.TestCase):
 		self.driver._onReceive(packet)
 
 		self.assertEqual(len(self.processedPackets), 1)
-		# The packet body passed on is the frame with the 4-byte sync/length header stripped.
+		# The body passed on is the packet with the 4-byte sync/length header stripped.
 		self.assertEqual(self.processedPackets[0], packet[4:])
 		self.assertEqual(len(self.driver._receiveBuffer), 0)
 

--- a/tests/unit/brailleDisplayDrivers/test_dotPad.py
+++ b/tests/unit/brailleDisplayDrivers/test_dotPad.py
@@ -15,11 +15,13 @@ import struct
 import unittest
 from unittest.mock import MagicMock
 
+import bdDetect
 from brailleDisplayDrivers.dotPad.driver import BrailleDisplayDriver
 from brailleDisplayDrivers.dotPad.defs import (
 	DP_CHECKSUM_BASE,
 	DP_Command,
 	DP_MAX_PACKET_SIZE,
+	DP_MIN_PACKET_SIZE,
 	DP_PacketSyncByte,
 )
 
@@ -136,13 +138,36 @@ class TestDotPadBufferedReceive(unittest.TestCase):
 	def test_implausibleLength_resynchronize(self) -> None:
 		"""Test that a header declaring an oversized length is treated as a false header.
 
-		Valid sync bytes followed by a length beyond DP_MAX_PACKET_SIZE indicate a
-		desync rather than a real packet, so the driver should discard a byte, resync,
-		and still process a valid packet that follows.
+		Valid sync bytes followed by a length that pushes the total packet size beyond
+		DP_MAX_PACKET_SIZE indicate a desync rather than a real packet, so the driver
+		should discard a byte, resync, and still process a valid packet that follows.
 		"""
+		# A body length that makes totalLength (4-byte header + body) exceed DP_MAX_PACKET_SIZE.
+		oversizedBodyLength = DP_MAX_PACKET_SIZE
 		bogusHeader = bytes([DP_PacketSyncByte.SYNC1, DP_PacketSyncByte.SYNC2]) + struct.pack(
 			">H",
-			DP_MAX_PACKET_SIZE,
+			oversizedBodyLength,
+		)
+		goodPacket = self._createPacket(dest=0, cmd=DP_Command.RSP_DEVICE_NAME, seqNum=1, data=b"OK")
+
+		self.driver._onReceive(bogusHeader + goodPacket)
+
+		self.assertEqual(len(self.processedPackets), 1)
+		self.assertEqual(self.processedPackets[0], goodPacket[4:])
+		self.assertEqual(len(self.driver._receiveBuffer), 0)
+
+	def test_tooSmallLength_resynchronize(self) -> None:
+		"""Test that a header declaring a runt length is treated as a false header.
+
+		Valid sync bytes followed by a length too small to form the minimum packet
+		body indicate a desync rather than a real packet, so the driver should discard
+		a byte, resync, and still process a valid packet that follows.
+		"""
+		# A body length that makes totalLength (4-byte header + body) fall below DP_MIN_PACKET_SIZE.
+		runtBodyLength = DP_MIN_PACKET_SIZE - 4 - 1
+		bogusHeader = bytes([DP_PacketSyncByte.SYNC1, DP_PacketSyncByte.SYNC2]) + struct.pack(
+			">H",
+			runtBodyLength,
 		)
 		goodPacket = self._createPacket(dest=0, cmd=DP_Command.RSP_DEVICE_NAME, seqNum=1, data=b"OK")
 
@@ -205,8 +230,6 @@ class TestDotPadBle(unittest.TestCase):
 
 	def test_addBleDevices_registration(self) -> None:
 		"""addBleDevices registers _isBleDotPad as the BLE match function."""
-		import bdDetect
-
 		registrar = bdDetect.DriverRegistrar(BrailleDisplayDriver.name)
 		BrailleDisplayDriver.registerAutomaticDetection(registrar)
 		matchFunc = registrar._getDriverDict().get(bdDetect.CommunicationType.BLE)

--- a/tests/unit/brailleDisplayDrivers/test_dotPad.py
+++ b/tests/unit/brailleDisplayDrivers/test_dotPad.py
@@ -1,7 +1,7 @@
 # A part of NonVisual Desktop Access (NVDA)
 # Copyright (C) 2026 NV Access Limited, Dot Incorporated, Bram Duvigneau
-# This file is covered by the GNU General Public License.
-# See the file COPYING for more details.
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
 
 """Unit tests for the DotPad braille display driver.
 

--- a/tests/unit/brailleDisplayDrivers/test_dotPad.py
+++ b/tests/unit/brailleDisplayDrivers/test_dotPad.py
@@ -1,0 +1,210 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2026 NV Access Limited, Dot Incorporated, Bram Duvigneau
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+
+"""Unit tests for the DotPad braille display driver.
+
+Tests cover the buffered-receive logic that handles both byte-at-a-time
+delivery (Serial) and packet-based delivery (BLE).
+"""
+
+import functools
+import operator
+import struct
+import unittest
+from unittest.mock import MagicMock
+
+from brailleDisplayDrivers.dotPad.driver import BrailleDisplayDriver
+from brailleDisplayDrivers.dotPad.defs import (
+	DP_CHECKSUM_BASE,
+	DP_Command,
+	DP_MAX_PACKET_SIZE,
+	DP_PacketSyncByte,
+)
+
+
+class TestDotPadBufferedReceive(unittest.TestCase):
+	"""Tests for the DotPad buffered receive logic in _onReceive."""
+
+	def setUp(self) -> None:
+		self.driver = MagicMock(spec=BrailleDisplayDriver)
+		self.driver._receiveBuffer = bytearray()
+		self.driver._lastResponse = {}
+
+		self.processedPackets: list[bytes] = []
+
+		def mockProcessPacket(packetBody: bytes) -> None:
+			self.processedPackets.append(bytes(packetBody))
+
+		self.driver._processPacket = mockProcessPacket
+		self.driver._onReceive = BrailleDisplayDriver._onReceive.__get__(self.driver, type(self.driver))
+
+	def _createPacket(
+		self,
+		dest: int = 0,
+		cmd: int = DP_Command.RSP_DEVICE_NAME,
+		seqNum: int = 0,
+		data: bytes = b"",
+	) -> bytes:
+		"""Create a valid DotPad packet.
+
+		:param dest: Destination address.
+		:param cmd: Command code.
+		:param seqNum: Sequence number.
+		:param data: Packet data payload.
+		:return: Complete packet as bytes.
+		"""
+		packetBody = bytearray([dest])
+		packetBody.extend(struct.pack(">H", cmd))
+		packetBody.append(seqNum)
+		packetBody.extend(data)
+
+		checksum = functools.reduce(operator.xor, packetBody, DP_CHECKSUM_BASE)
+		packetBody.append(checksum)
+
+		packet = bytearray(
+			[
+				DP_PacketSyncByte.SYNC1,
+				DP_PacketSyncByte.SYNC2,
+			],
+		)
+		packet.extend(struct.pack(">H", len(packetBody)))
+		packet.extend(packetBody)
+
+		return bytes(packet)
+
+	def test_completePacketAtOnce(self) -> None:
+		"""Test receiving a complete packet in a single call (BLE behavior)."""
+		packet = self._createPacket(dest=0, cmd=DP_Command.RSP_DEVICE_NAME, seqNum=1, data=b"test")
+
+		self.driver._onReceive(packet)
+
+		self.assertEqual(len(self.processedPackets), 1)
+		self.assertEqual(len(self.driver._receiveBuffer), 0)
+
+	def test_byteAtATime(self) -> None:
+		"""Test receiving a packet one byte at a time (Serial behavior)."""
+		packet = self._createPacket(dest=0, cmd=DP_Command.RSP_DEVICE_NAME, seqNum=1, data=b"AB")
+
+		for byte in packet:
+			self.driver._onReceive(bytes([byte]))
+
+		self.assertEqual(len(self.processedPackets), 1)
+		self.assertEqual(len(self.driver._receiveBuffer), 0)
+
+	def test_partialPacket(self) -> None:
+		"""Test receiving a packet in multiple chunks."""
+		packet = self._createPacket(dest=0, cmd=DP_Command.RSP_DEVICE_NAME, seqNum=1, data=b"test data")
+
+		chunk1 = packet[: len(packet) // 2]
+		chunk2 = packet[len(packet) // 2 :]
+
+		self.driver._onReceive(chunk1)
+		self.assertEqual(len(self.processedPackets), 0)
+		self.assertGreater(len(self.driver._receiveBuffer), 0)
+
+		self.driver._onReceive(chunk2)
+		self.assertEqual(len(self.processedPackets), 1)
+		self.assertEqual(len(self.driver._receiveBuffer), 0)
+
+	def test_multiplePacketsAtOnce(self) -> None:
+		"""Test receiving multiple complete packets in a single call."""
+		packet1 = self._createPacket(dest=0, cmd=DP_Command.RSP_DEVICE_NAME, seqNum=1, data=b"A")
+		packet2 = self._createPacket(dest=0, cmd=DP_Command.REQ_DEVICE_NAME, seqNum=2, data=b"B")
+		packet3 = self._createPacket(dest=0, cmd=DP_Command.REQ_BOARD_INFORMATION, seqNum=3, data=b"C")
+
+		allPackets = packet1 + packet2 + packet3
+
+		self.driver._onReceive(allPackets)
+
+		self.assertEqual(len(self.processedPackets), 3)
+		self.assertEqual(len(self.driver._receiveBuffer), 0)
+
+	def test_badSyncByte_resynchronize(self) -> None:
+		"""Test that bad sync bytes are discarded and driver resynchronizes."""
+		badData = b"\x00\x11\x22"
+		goodPacket = self._createPacket(dest=0, cmd=DP_Command.RSP_DEVICE_NAME, seqNum=1, data=b"OK")
+
+		self.driver._onReceive(badData + goodPacket)
+
+		self.assertEqual(len(self.processedPackets), 1)
+		self.assertEqual(len(self.driver._receiveBuffer), 0)
+
+	def test_bufferOverflow_cleared(self) -> None:
+		"""Test that buffer overflow triggers a clear and doesn't crash."""
+		oversizedData = b"\xaa" * (DP_MAX_PACKET_SIZE + 1)
+
+		self.driver._onReceive(oversizedData)
+
+		self.assertEqual(len(self.processedPackets), 0)
+		self.assertEqual(len(self.driver._receiveBuffer), 0)
+
+	def test_incompletePacketInBuffer(self) -> None:
+		"""Test that an incomplete packet stays in the buffer."""
+		packet = self._createPacket(dest=0, cmd=DP_Command.RSP_DEVICE_NAME, seqNum=1, data=b"test data")
+		partialPacket = packet[:6]
+
+		self.driver._onReceive(partialPacket)
+
+		self.assertEqual(len(self.processedPackets), 0)
+		self.assertEqual(len(self.driver._receiveBuffer), 6)
+
+	def test_emptyData(self) -> None:
+		"""Test that empty data doesn't crash or produce spurious packets."""
+		self.driver._onReceive(b"")
+
+		self.assertEqual(len(self.processedPackets), 0)
+		self.assertEqual(len(self.driver._receiveBuffer), 0)
+
+	def test_partialHeaderOnly(self) -> None:
+		"""Test that a partial header stays buffered without processing."""
+		partialHeader = bytes([DP_PacketSyncByte.SYNC1, DP_PacketSyncByte.SYNC2, 0x00])
+
+		self.driver._onReceive(partialHeader)
+
+		self.assertEqual(len(self.processedPackets), 0)
+		self.assertEqual(len(self.driver._receiveBuffer), 3)
+
+
+@unittest.skip("Requires BLE support from PR C (#19122)")
+class TestDotPadBle(unittest.TestCase):
+	"""Skipped tests for BLE-specific DotPad functionality.
+
+	These tests document the expected BLE behavior and will be unskipped
+	when the BLE driver integration lands in PR C.
+	"""
+
+	def test_isBleDotPad_matching(self) -> None:
+		"""_isBleDotPad returns True for a device ID starting with 'DotPad'."""
+		device = MagicMock()
+		device.name = "DotPad320"
+		self.assertTrue(BrailleDisplayDriver._isBleDotPad(device))
+
+	def test_isBleDotPad_nonMatching(self) -> None:
+		"""_isBleDotPad returns False for an unrelated device."""
+		device = MagicMock()
+		device.name = "SomeOtherDevice"
+		self.assertFalse(BrailleDisplayDriver._isBleDotPad(device))
+
+	def test_check_returnsTrue(self) -> None:
+		"""check() returns True so DotPad always appears in the display list."""
+		self.assertTrue(BrailleDisplayDriver.check())
+
+	def test_addBleDevices_registration(self) -> None:
+		"""addBleDevices registers _isBleDotPad as the BLE match function."""
+		import bdDetect
+
+		registrar = bdDetect.DriverRegistrar(BrailleDisplayDriver.name)
+		BrailleDisplayDriver.registerAutomaticDetection(registrar)
+		matchFunc = registrar._getDriverDict().get(bdDetect.CommunicationType.BLE)
+		self.assertIsNotNone(matchFunc)
+		self.assertTrue(callable(matchFunc))
+
+	def test_tryConnect_bleDevice(self) -> None:
+		"""_tryConnect with a BLE device creates a hwIo.ble.Ble instance.
+
+		Requires hwIo.ble (PR A, #19838) and the _tryConnect BLE branch
+		(PR C). Will mock findDeviceByAddress, hwIo.ble.Ble,
+		_requestDeviceName, and _requestBoardInformation.
+		"""

--- a/tests/unit/brailleDisplayDrivers/test_dotPad.py
+++ b/tests/unit/brailleDisplayDrivers/test_dotPad.py
@@ -13,13 +13,14 @@ import functools
 import operator
 import struct
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import bdDetect
 from brailleDisplayDrivers.dotPad.driver import BrailleDisplayDriver
 from brailleDisplayDrivers.dotPad.defs import (
 	DP_CHECKSUM_BASE,
 	DP_Command,
+	DP_Features,
 	DP_MAX_PACKET_SIZE,
 	DP_MIN_PACKET_SIZE,
 	DP_PacketSyncByte,
@@ -204,42 +205,69 @@ class TestDotPadBufferedReceive(unittest.TestCase):
 		self.assertEqual(len(self.driver._receiveBuffer), 3)
 
 
-@unittest.skip("Requires BLE support from PR C (#19122)")
 class TestDotPadBle(unittest.TestCase):
-	"""Skipped tests for BLE-specific DotPad functionality.
+	"""Tests for BLE-specific DotPad functionality."""
 
-	These tests document the expected BLE behavior and will be unskipped
-	when the BLE driver integration lands in PR C.
-	"""
+	def tearDown(self) -> None:
+		# registerAutomaticDetection writes into the global registry; keep tests isolated.
+		bdDetect._driverDevices.clear()
+
+	@staticmethod
+	def _bleMatch(deviceId: str) -> bdDetect.DeviceMatch:
+		"""Build a BLE DeviceMatch with the given id (device name or address)."""
+		return bdDetect.DeviceMatch(
+			bdDetect.ProtocolType.BLE,
+			deviceId,
+			"AA:BB:CC:DD:EE:FF",
+			{"name": deviceId, "address": "AA:BB:CC:DD:EE:FF"},
+		)
 
 	def test_isBleDotPad_matching(self) -> None:
-		"""_isBleDotPad returns True for a device ID starting with 'DotPad'."""
-		device = MagicMock()
-		device.name = "DotPad320"
-		self.assertTrue(BrailleDisplayDriver._isBleDotPad(device))
+		"""_isBleDotPad returns True for a device id starting with 'DotPad'."""
+		self.assertTrue(BrailleDisplayDriver._isBleDotPad(self._bleMatch("DotPad320")))
 
 	def test_isBleDotPad_nonMatching(self) -> None:
 		"""_isBleDotPad returns False for an unrelated device."""
-		device = MagicMock()
-		device.name = "SomeOtherDevice"
-		self.assertFalse(BrailleDisplayDriver._isBleDotPad(device))
+		self.assertFalse(BrailleDisplayDriver._isBleDotPad(self._bleMatch("SomeOtherDevice")))
 
 	def test_check_returnsTrue(self) -> None:
 		"""check() returns True so DotPad always appears in the display list."""
 		self.assertTrue(BrailleDisplayDriver.check())
 
 	def test_addBleDevices_registration(self) -> None:
-		"""addBleDevices registers _isBleDotPad as the BLE match function."""
+		"""registerAutomaticDetection registers _isBleDotPad as the BLE match function."""
 		registrar = bdDetect.DriverRegistrar(BrailleDisplayDriver.name)
 		BrailleDisplayDriver.registerAutomaticDetection(registrar)
 		matchFunc = registrar._getDriverDict().get(bdDetect.CommunicationType.BLE)
-		self.assertIsNotNone(matchFunc)
-		self.assertTrue(callable(matchFunc))
+		self.assertEqual(matchFunc, BrailleDisplayDriver._isBleDotPad)
 
 	def test_tryConnect_bleDevice(self) -> None:
-		"""_tryConnect with a BLE device creates a hwIo.ble.Ble instance.
+		"""_tryConnect with a BLE port opens an hwIo.ble.Ble device and succeeds."""
+		driver = MagicMock(spec=BrailleDisplayDriver)
+		driver._receiveBuffer = bytearray()
+		driver._tryConnect = BrailleDisplayDriver._tryConnect.__get__(driver, type(driver))
+		# Device verification: report a text-capable DotPad board.
+		boardInfo = MagicMock()
+		boardInfo.features = DP_Features.HAS_TEXT_DISPLAY
+		driver._requestDeviceName = MagicMock(return_value="DotPad320")
+		driver._requestBoardInformation = MagicMock(return_value=boardInfo)
 
-		Requires hwIo.ble (PR A, #19838) and the _tryConnect BLE branch
-		(PR C). Will mock findDeviceByAddress, hwIo.ble.Ble,
-		_requestDeviceName, and _requestBoardInformation.
-		"""
+		address = "AA:BB:CC:DD:EE:FF"
+		bleDevice = object()
+		with (
+			patch("hwIo.ble.findDeviceByAddress", return_value=bleDevice) as mockFind,
+			patch("hwIo.ble.Ble") as mockBle,
+		):
+			result = driver._tryConnect(
+				port=address,
+				portType=bdDetect.ProtocolType.BLE,
+				portInfo={"address": address},
+			)
+
+		self.assertTrue(result)
+		mockFind.assert_called_once_with(address)
+		# The scanner-provided BLEDevice is passed through to the Ble transport.
+		mockBle.assert_called_once()
+		self.assertEqual(mockBle.call_args.kwargs["device"], bleDevice)
+		self.assertEqual(mockBle.call_args.kwargs["onReceive"], driver._onReceive)
+		self.assertIs(driver._dev, mockBle.return_value)

--- a/tests/unit/brailleDisplayDrivers/test_dotPad.py
+++ b/tests/unit/brailleDisplayDrivers/test_dotPad.py
@@ -241,8 +241,10 @@ class TestDotPadBle(unittest.TestCase):
 		matchFunc = registrar._getDriverDict().get(bdDetect.CommunicationType.BLE)
 		self.assertEqual(matchFunc, BrailleDisplayDriver._isBleDotPad)
 
-	def test_tryConnect_bleDevice(self) -> None:
-		"""_tryConnect with a BLE port opens an hwIo.ble.Ble device and succeeds."""
+	_ADDRESS = "AA:BB:CC:DD:EE:FF"
+
+	def _bleDriver(self) -> MagicMock:
+		"""Build a driver stub whose _tryConnect is the real implementation."""
 		driver = MagicMock(spec=BrailleDisplayDriver)
 		driver._receiveBuffer = bytearray()
 		driver._tryConnect = BrailleDisplayDriver._tryConnect.__get__(driver, type(driver))
@@ -251,23 +253,47 @@ class TestDotPadBle(unittest.TestCase):
 		boardInfo.features = DP_Features.HAS_TEXT_DISPLAY
 		driver._requestDeviceName = MagicMock(return_value="DotPad320")
 		driver._requestBoardInformation = MagicMock(return_value=boardInfo)
+		return driver
 
-		address = "AA:BB:CC:DD:EE:FF"
-		bleDevice = object()
-		with (
-			patch("hwIo.ble.findDeviceByAddress", return_value=bleDevice) as mockFind,
-			patch("hwIo.ble.Ble") as mockBle,
-		):
+	def _scannerWith(self, *devices: object):
+		"""Make the shared scanner report the given already-discovered devices."""
+		scanner = MagicMock()
+		scanner.results.return_value = list(devices)
+		return patch("hwIo.ble.scanner", scanner)
+
+	def test_tryConnect_bleDevice(self) -> None:
+		"""_tryConnect with a BLE port opens an hwIo.ble.Ble device and succeeds.
+
+		This runs on the main thread, as it does when the user picks a port in the
+		braille display selection dialog, so it also covers the device lookup being
+		safe to call there.
+		"""
+		driver = self._bleDriver()
+		bleDevice = MagicMock()
+		bleDevice.address = self._ADDRESS
+		with self._scannerWith(bleDevice), patch("hwIo.ble.Ble") as mockBle:
 			result = driver._tryConnect(
-				port=address,
+				port=self._ADDRESS,
 				portType=bdDetect.ProtocolType.BLE,
-				portInfo={"address": address},
+				portInfo={"address": self._ADDRESS},
 			)
 
 		self.assertTrue(result)
-		mockFind.assert_called_once_with(address)
-		# The scanner-provided BLEDevice is passed through to the Ble transport.
 		mockBle.assert_called_once()
+		# The scanner-provided device is passed through to the Ble transport.
 		self.assertEqual(mockBle.call_args.kwargs["device"], bleDevice)
 		self.assertEqual(mockBle.call_args.kwargs["onReceive"], driver._onReceive)
 		self.assertIs(driver._dev, mockBle.return_value)
+
+	def test_tryConnect_bleDeviceNotDiscovered(self) -> None:
+		"""_tryConnect falls back to the address when the scanner does not know the device."""
+		driver = self._bleDriver()
+		with self._scannerWith(), patch("hwIo.ble.Ble") as mockBle:
+			result = driver._tryConnect(
+				port=self._ADDRESS,
+				portType=bdDetect.ProtocolType.BLE,
+				portInfo={"address": self._ADDRESS},
+			)
+
+		self.assertTrue(result)
+		self.assertEqual(mockBle.call_args.kwargs["device"], self._ADDRESS)

--- a/tests/unit/brailleDisplayDrivers/test_dotPad.py
+++ b/tests/unit/brailleDisplayDrivers/test_dotPad.py
@@ -230,9 +230,27 @@ class TestDotPadBle(unittest.TestCase):
 		"""_isBleDotPad returns False for an unrelated device."""
 		self.assertFalse(BrailleDisplayDriver._isBleDotPad(self._bleMatch("SomeOtherDevice")))
 
-	def test_check_returnsTrue(self) -> None:
-		"""check() returns True so DotPad always appears in the display list."""
-		self.assertTrue(BrailleDisplayDriver.check())
+	def test_check_bluetoothAvailable(self) -> None:
+		"""Usable Bluetooth is enough on its own, as a device may be switched on later."""
+		with patch("hwIo.ble.isAvailable", return_value=True):
+			self.assertTrue(BrailleDisplayDriver.check())
+
+	def test_check_noBluetoothButDeviceReachable(self) -> None:
+		"""Without Bluetooth the driver still stands on its other connections."""
+		with (
+			patch("hwIo.ble.isAvailable", return_value=False),
+			patch("bdDetect.driverHasPossibleDevices", return_value=True),
+		):
+			self.assertTrue(BrailleDisplayDriver.check())
+
+	def test_check_nothingReachable(self) -> None:
+		"""With no Bluetooth and nothing connected there is nothing to offer."""
+		with (
+			patch("hwIo.ble.isAvailable", return_value=False),
+			patch("bdDetect.driverHasPossibleDevices", return_value=False),
+			patch.object(BrailleDisplayDriver, "getManualPorts", classmethod(lambda cls: iter(()))),
+		):
+			self.assertFalse(BrailleDisplayDriver.check())
 
 	def test_addBleDevices_registration(self) -> None:
 		"""registerAutomaticDetection registers _isBleDotPad as the BLE match function."""

--- a/tests/unit/test_bdDetect.py
+++ b/tests/unit/test_bdDetect.py
@@ -1,7 +1,7 @@
 # A part of NonVisual Desktop Access (NVDA)
-# This file is covered by the GNU General Public License.
-# See the file COPYING for more details.
-# Copyright (C) 2023-25 NV Access Limited, Babbage B.V., Leonard de Ruijter
+# Copyright (C) 2023-2026 NV Access Limited, Babbage B.V., Leonard de Ruijter, Dot Incorporated, Bram Duvigneau
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
 
 """Unit tests for the bdDetect module."""
 
@@ -9,6 +9,7 @@ import unittest
 import bdDetect
 from .extensionPointTestHelpers import chainTester
 import braille
+from brailleDisplayDrivers import dotPad
 from utils.blockUntilConditionMet import blockUntilConditionMet
 
 
@@ -101,9 +102,7 @@ class TestDriverRegistration(unittest.TestCase):
 		self.assertEqual(registrar._getDriverDict().get(bdDetect.CommunicationType.BLUETOOTH), matchFunc)
 
 	def test_addBleDevices(self):
-		"""Test adding a BLE match function."""
-		from brailleDisplayDrivers import dotPad
-
+		"""addBleDevices stores the match function under the BLE communication type."""
 		registrar = bdDetect.DriverRegistrar(dotPad.BrailleDisplayDriver.name)
 
 		def matchFunc(match: bdDetect.DeviceMatch) -> bool:
@@ -111,43 +110,29 @@ class TestDriverRegistration(unittest.TestCase):
 
 		registrar.addBleDevices(matchFunc)
 
-		# Verify the match function was stored
-		stored_match_func = registrar._getDriverDict().get(bdDetect.CommunicationType.BLE)
-		self.assertEqual(stored_match_func, matchFunc)
-
-		# Verify it's callable
-		self.assertTrue(callable(stored_match_func))
+		storedMatchFunc = registrar._getDriverDict().get(bdDetect.CommunicationType.BLE)
+		self.assertEqual(storedMatchFunc, matchFunc)
+		self.assertTrue(callable(storedMatchFunc))
 
 	def test_bleDeviceMatching(self):
-		"""Test that BLE device matching works correctly."""
-		from brailleDisplayDrivers import dotPad
-
+		"""The registered DotPad match function accepts DotPad devices and rejects others."""
 		registrar = bdDetect.DriverRegistrar(dotPad.BrailleDisplayDriver.name)
-
-		# Register the dotPad BLE match function
 		registrar.addBleDevices(dotPad.BrailleDisplayDriver._isBleDotPad)
 
-		# Create a matching DeviceMatch (DotPad device)
-		matching_device = bdDetect.DeviceMatch(
+		matchingDevice = bdDetect.DeviceMatch(
 			type=bdDetect.ProtocolType.BLE,
 			id="DotPad320",
 			port="AA:BB:CC:DD:EE:FF",
 			deviceInfo={"name": "DotPad320", "address": "AA:BB:CC:DD:EE:FF"},
 		)
 
-		# Create a non-matching DeviceMatch
-		non_matching_device = bdDetect.DeviceMatch(
+		nonMatchingDevice = bdDetect.DeviceMatch(
 			type=bdDetect.ProtocolType.BLE,
 			id="SomeOtherDevice",
 			port="11:22:33:44:55:66",
 			deviceInfo={"name": "SomeOtherDevice", "address": "11:22:33:44:55:66"},
 		)
 
-		# Get the match function
-		match_func = registrar._getDriverDict().get(bdDetect.CommunicationType.BLE)
-
-		# Test matching device
-		self.assertTrue(match_func(matching_device))
-
-		# Test non-matching device
-		self.assertFalse(match_func(non_matching_device))
+		matchFunc = registrar._getDriverDict().get(bdDetect.CommunicationType.BLE)
+		self.assertTrue(matchFunc(matchingDevice))
+		self.assertFalse(matchFunc(nonMatchingDevice))

--- a/tests/unit/test_bdDetect.py
+++ b/tests/unit/test_bdDetect.py
@@ -6,7 +6,7 @@
 """Unit tests for the bdDetect module."""
 
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 import bdDetect
 from .extensionPointTestHelpers import chainTester
 import braille
@@ -217,3 +217,56 @@ class TestBleDeviceDiscovery(unittest.TestCase):
 		detector._onBleDeviceDiscovered(self._device("DotPad320"), MagicMock(), True)
 
 		detector._queueBgScan.assert_not_called()
+
+
+class TestBleDriverMatching(unittest.TestCase):
+	"""Tests for matching discovered BLE devices against the registered drivers."""
+
+	def tearDown(self) -> None:
+		# Registration writes into the global registry; keep tests isolated.
+		bdDetect._driverDevices.clear()
+
+	def _registerDriver(self, driver: str, prefix: str) -> None:
+		"""Register a driver claiming any device whose name starts with the given prefix."""
+		registrar = bdDetect.DriverRegistrar(driver)
+		registrar.addBleDevices(lambda match, prefix=prefix: match.id.startswith(prefix))
+
+	def _scannerWith(self, *names: str):
+		"""Make the shared scanner report devices with the given names."""
+		devices = []
+		for i, name in enumerate(names):
+			device = MagicMock()
+			device.name = name
+			device.address = f"AA:BB:CC:DD:EE:{i:02X}"
+			devices.append(device)
+		scanner = MagicMock()
+		scanner.isScanning = True
+		scanner.results.return_value = devices
+		return patch("hwIo.ble.scanner", scanner)
+
+	def test_devicesAreOfferedInDiscoveryOrder(self):
+		"""The device discovered first is offered first, whichever driver claims it.
+
+		Driver registration order is import order, so ordering by driver would let that
+		decide which display is connected when several are in range.
+		"""
+		self._registerDriver("driverA", "Alpha")
+		self._registerDriver("driverB", "Beta")
+		with self._scannerWith("Beta1", "Alpha1"):
+			result = list(bdDetect.getDriversForBleDevices())
+		self.assertEqual([driver for driver, match in result], ["driverB", "driverA"])
+		self.assertEqual([match.id for driver, match in result], ["Beta1", "Alpha1"])
+
+	def test_limitToDevicesExcludesDrivers(self):
+		"""A driver outside the limit never sees the devices."""
+		self._registerDriver("driverA", "Alpha")
+		self._registerDriver("driverB", "Beta")
+		with self._scannerWith("Beta1", "Alpha1"):
+			result = list(bdDetect.getDriversForBleDevices(limitToDevices=["driverA"]))
+		self.assertEqual([(driver, match.id) for driver, match in result], [("driverA", "Alpha1")])
+
+	def test_noBleDriversYieldsNothing(self):
+		"""Without a driver that can match BLE devices the scan results are not inspected."""
+		with self._scannerWith("Alpha1") as scanner:
+			self.assertEqual(list(bdDetect.getDriversForBleDevices()), [])
+		scanner.results.assert_not_called()

--- a/tests/unit/test_bdDetect.py
+++ b/tests/unit/test_bdDetect.py
@@ -6,6 +6,7 @@
 """Unit tests for the bdDetect module."""
 
 import unittest
+from unittest.mock import MagicMock
 import bdDetect
 from .extensionPointTestHelpers import chainTester
 import braille
@@ -136,3 +137,83 @@ class TestDriverRegistration(unittest.TestCase):
 		matchFunc = registrar._getDriverDict().get(bdDetect.CommunicationType.BLE)
 		self.assertTrue(matchFunc(matchingDevice))
 		self.assertFalse(matchFunc(nonMatchingDevice))
+
+
+class TestBleDeviceDiscovery(unittest.TestCase):
+	"""Tests for the detector reacting to BLE devices as they advertise.
+
+	A background scan starts the scanner and moves on without waiting, so a device
+	that is not already known reaches the detector only through this handler.
+	"""
+
+	_ADDRESS = "AA:BB:CC:DD:EE:FF"
+
+	def _detector(self) -> MagicMock:
+		"""Build a detector stub whose _onBleDeviceDiscovered is the real implementation."""
+		detector = MagicMock(spec=bdDetect._Detector)
+		detector._detectUsb = True
+		detector._detectBluetooth = True
+		detector._detectBle = True
+		detector._limitToDevices = None
+		detector._onBleDeviceDiscovered = bdDetect._Detector._onBleDeviceDiscovered.__get__(
+			detector,
+			type(detector),
+		)
+		return detector
+
+	def _device(self, name: str) -> MagicMock:
+		"""Build a stand-in for a discovered BLE device."""
+		device = MagicMock()
+		device.name = name
+		device.address = self._ADDRESS
+		return device
+
+	def test_matchingDeviceQueuesScan(self):
+		"""A newly discovered matching device is queued as the preferred device."""
+		detector = self._detector()
+		match = bdDetect.DeviceMatch(
+			bdDetect.ProtocolType.BLE,
+			"DotPad320",
+			self._ADDRESS,
+			{"name": "DotPad320", "address": self._ADDRESS},
+		)
+		detector._getBleDeviceMatch = MagicMock(return_value=("dotPad", match))
+
+		detector._onBleDeviceDiscovered(self._device("DotPad320"), MagicMock(), True)
+
+		detector._queueBgScan.assert_called_once_with(
+			usb=True,
+			bluetooth=True,
+			ble=True,
+			limitToDevices=None,
+			preferredDevice=("dotPad", match),
+		)
+
+	def test_nonMatchingDeviceIsIgnored(self):
+		"""A device no driver claims does not trigger a scan."""
+		detector = self._detector()
+		detector._getBleDeviceMatch = MagicMock(return_value=None)
+
+		detector._onBleDeviceDiscovered(self._device("SomeOtherDevice"), MagicMock(), True)
+
+		detector._queueBgScan.assert_not_called()
+
+	def test_readvertisementIsIgnored(self):
+		"""Only the first sighting queues a scan, so repeat advertisements stay cheap."""
+		detector = self._detector()
+		detector._getBleDeviceMatch = MagicMock()
+
+		detector._onBleDeviceDiscovered(self._device("DotPad320"), MagicMock(), False)
+
+		detector._getBleDeviceMatch.assert_not_called()
+		detector._queueBgScan.assert_not_called()
+
+	def test_bleDetectionDisabled(self):
+		"""No scan is queued while BLE detection is off."""
+		detector = self._detector()
+		detector._detectBle = False
+		detector._getBleDeviceMatch = MagicMock()
+
+		detector._onBleDeviceDiscovered(self._device("DotPad320"), MagicMock(), True)
+
+		detector._queueBgScan.assert_not_called()

--- a/tests/unit/test_braille/test_brailleDisplayDrivers.py
+++ b/tests/unit/test_braille/test_brailleDisplayDrivers.py
@@ -1,7 +1,7 @@
 # A part of NonVisual Desktop Access (NVDA)
-# This file is covered by the GNU General Public License.
-# See the file COPYING for more details.
-# Copyright (C) 2017-2025 NV Access Limited, Leonard de Ruijter
+# Copyright (C) 2017-2026 NV Access Limited, Leonard de Ruijter, Dot Incorporated, Bram Duvigneau
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
 
 """Unit tests for braille display drivers."""
 
@@ -349,7 +349,7 @@ class _FakeBleDriver(braille.display.BrailleDisplayDriver):
 
 
 def _bleMatch(deviceName: str, address: str) -> bdDetect.DeviceMatch:
-	"""Build a BLE device match as L{bdDetect.getBleDevicesForDriver} would yield it."""
+	"""Build a BLE device match as :func:`bdDetect.getBleDevicesForDriver` would yield it."""
 	return bdDetect.DeviceMatch(
 		bdDetect.ProtocolType.BLE,
 		deviceName,
@@ -359,12 +359,12 @@ def _bleMatch(deviceName: str, address: str) -> bdDetect.DeviceMatch:
 
 
 class TestBleDisplayPorts(unittest.TestCase):
-	"""Tests for the BLE ports offered and resolved by L{braille.display.BrailleDisplayDriver}."""
+	"""Tests for the BLE ports offered and resolved by :class:`braille.display.BrailleDisplayDriver`."""
 
 	_ADDRESS = "AA:BB:CC:DD:EE:FF"
 
 	def _patchBleDevices(self, *devices: bdDetect.DeviceMatch):
-		"""Make L{bdDetect.getBleDevicesForDriver} report the given devices."""
+		"""Make :func:`bdDetect.getBleDevicesForDriver` report the given devices."""
 		return patch("bdDetect.getBleDevicesForDriver", return_value=iter(devices))
 
 	def test_getBlePorts_formatsPortAndDescription(self):

--- a/tests/unit/test_braille/test_brailleDisplayDrivers.py
+++ b/tests/unit/test_braille/test_brailleDisplayDrivers.py
@@ -384,6 +384,30 @@ class TestBleDisplayPorts(unittest.TestCase):
 		with patch("bdDetect.getBleDevicesForDriver", side_effect=RuntimeError("scan failed")):
 			self.assertEqual(list(_FakeBleDriver._getBlePorts()), [])
 
+	def test_getPossiblePorts_bleDevicesBringTheAutomaticPort(self):
+		"""A discovered BLE device never leaves the automatic port on its own.
+
+		The braille display selection dialog disables the port control when the
+		automatic port is the only entry, so a BLE device that arrives while the
+		dialog is open has to bring a second entry with it to be selectable.
+		"""
+		with (
+			patch("bdDetect.getConnectedUsbDevicesForDriver", side_effect=LookupError),
+			patch("bdDetect.getPossibleBluetoothDevicesForDriver", side_effect=LookupError),
+			self._patchBleDevices(_bleMatch("DotPad320", self._ADDRESS)),
+		):
+			ports = list(_FakeBleDriver.getPossiblePorts())
+		self.assertEqual(ports, ["auto", f"ble:DotPad320@{self._ADDRESS}"])
+
+	def test_getPossiblePorts_noDevicesGivesNoPorts(self):
+		"""With nothing discovered there is nothing to offer."""
+		with (
+			patch("bdDetect.getConnectedUsbDevicesForDriver", side_effect=LookupError),
+			patch("bdDetect.getPossibleBluetoothDevicesForDriver", side_effect=LookupError),
+			self._patchBleDevices(),
+		):
+			self.assertEqual(list(_FakeBleDriver.getPossiblePorts()), [])
+
 	def test_getBleTryPorts_deviceInScanResults(self):
 		"""A port matching a scanned device resolves to that device match."""
 		match = _bleMatch("DotPad320", self._ADDRESS)

--- a/tests/unit/test_braille/test_brailleDisplayDrivers.py
+++ b/tests/unit/test_braille/test_brailleDisplayDrivers.py
@@ -7,6 +7,8 @@
 
 from brailleDisplayDrivers import seikantk
 import unittest
+from unittest.mock import patch
+import bdDetect
 import braille
 import braille.display
 import braille.display.gesture
@@ -337,3 +339,92 @@ class TestBRLTTY(unittest.TestCase):
 			import brlapi  # noqa: F401
 		except Exception:
 			self.fail("Couldn't import the brlapi module")
+
+
+class _FakeBleDriver(braille.display.BrailleDisplayDriver):
+	"""A driver that only exists to exercise the BLE port helpers."""
+
+	name = "fakeBleDisplay"
+	description = "Fake BLE display"
+
+
+def _bleMatch(deviceName: str, address: str) -> bdDetect.DeviceMatch:
+	"""Build a BLE device match as L{bdDetect.getBleDevicesForDriver} would yield it."""
+	return bdDetect.DeviceMatch(
+		bdDetect.ProtocolType.BLE,
+		deviceName,
+		address,
+		{"name": deviceName, "address": address, "provider": bdDetect.CommunicationType.BLE},
+	)
+
+
+class TestBleDisplayPorts(unittest.TestCase):
+	"""Tests for the BLE ports offered and resolved by L{braille.display.BrailleDisplayDriver}."""
+
+	_ADDRESS = "AA:BB:CC:DD:EE:FF"
+
+	def _patchBleDevices(self, *devices: bdDetect.DeviceMatch):
+		"""Make L{bdDetect.getBleDevicesForDriver} report the given devices."""
+		return patch("bdDetect.getBleDevicesForDriver", return_value=iter(devices))
+
+	def test_getBlePorts_formatsPortAndDescription(self):
+		with self._patchBleDevices(_bleMatch("DotPad320", self._ADDRESS)):
+			ports = list(_FakeBleDriver._getBlePorts())
+		self.assertEqual(len(ports), 1)
+		port, description = ports[0]
+		self.assertEqual(port, f"ble:DotPad320@{self._ADDRESS}")
+		self.assertIn("DotPad320", description)
+
+	def test_getBlePorts_noDevices(self):
+		with self._patchBleDevices():
+			self.assertEqual(list(_FakeBleDriver._getBlePorts()), [])
+
+	def test_getBlePorts_enumerationFailureIsContained(self):
+		"""A failing scan yields no ports rather than propagating."""
+		with patch("bdDetect.getBleDevicesForDriver", side_effect=RuntimeError("scan failed")):
+			self.assertEqual(list(_FakeBleDriver._getBlePorts()), [])
+
+	def test_getBleTryPorts_deviceInScanResults(self):
+		"""A port matching a scanned device resolves to that device match."""
+		match = _bleMatch("DotPad320", self._ADDRESS)
+		with self._patchBleDevices(_bleMatch("SomethingElse", "11:22:33:44:55:66"), match):
+			result = list(_FakeBleDriver._getBleTryPorts(f"ble:DotPad320@{self._ADDRESS}"))
+		self.assertEqual(result, [match])
+
+	def test_getBleTryPorts_matchesOnAddressWhenNameChanged(self):
+		"""A renamed device is still found by its address."""
+		match = _bleMatch("DotPad320 renamed", self._ADDRESS)
+		with self._patchBleDevices(match):
+			result = list(_FakeBleDriver._getBleTryPorts(f"ble:DotPad320@{self._ADDRESS}"))
+		self.assertEqual(result, [match])
+
+	def test_getBleTryPorts_fallsBackToConfiguredAddress(self):
+		"""A device that is not advertising is still offered for connection by address."""
+		with self._patchBleDevices():
+			result = list(_FakeBleDriver._getBleTryPorts(f"ble:DotPad320@{self._ADDRESS}"))
+		self.assertEqual(len(result), 1)
+		match = result[0]
+		self.assertEqual(match.type, bdDetect.ProtocolType.BLE)
+		self.assertEqual(match.id, "DotPad320")
+		self.assertEqual(match.port, self._ADDRESS)
+		self.assertEqual(match.deviceInfo["address"], self._ADDRESS)
+
+	def test_getBleTryPorts_addressContainingSeparator(self):
+		"""The port is split on the last separator, so a name containing one is preserved."""
+		with self._patchBleDevices():
+			result = list(_FakeBleDriver._getBleTryPorts(f"ble:Dot@Pad@{self._ADDRESS}"))
+		self.assertEqual(len(result), 1)
+		self.assertEqual(result[0].id, "Dot@Pad")
+		self.assertEqual(result[0].port, self._ADDRESS)
+
+	def test_getBleTryPorts_malformedPortYieldsNothing(self):
+		"""A port without an address is rejected rather than half-parsed."""
+		with self._patchBleDevices(_bleMatch("DotPad320", self._ADDRESS)):
+			self.assertEqual(list(_FakeBleDriver._getBleTryPorts("ble:DotPad320")), [])
+
+	def test_getTryPorts_routesBlePortToHelper(self):
+		"""A BLE port reaches _getBleTryPorts rather than the serial port handling."""
+		match = _bleMatch("DotPad320", self._ADDRESS)
+		with self._patchBleDevices(match):
+			result = list(_FakeBleDriver._getTryPorts(f"ble:DotPad320@{self._ADDRESS}"))
+		self.assertEqual(result, [match])

--- a/tests/unit/test_braille/test_brailleDisplayDrivers.py
+++ b/tests/unit/test_braille/test_brailleDisplayDrivers.py
@@ -422,6 +422,35 @@ class TestBleDisplayPorts(unittest.TestCase):
 		with self._patchBleDevices(_bleMatch("DotPad320", self._ADDRESS)):
 			self.assertEqual(list(_FakeBleDriver._getBleTryPorts("ble:DotPad320")), [])
 
+	def test_getBleTryPorts_addressWinsOverName(self):
+		"""The address disambiguates two devices sharing a name, whatever the scan order."""
+		byName = _bleMatch("DotPad320", "11:22:33:44:55:66")
+		byAddress = _bleMatch("DotPad320", self._ADDRESS)
+		with self._patchBleDevices(byName, byAddress):
+			result = list(_FakeBleDriver._getBleTryPorts(f"ble:DotPad320@{self._ADDRESS}"))
+		self.assertEqual(result, [byAddress])
+
+	def test_getTryPorts_automaticPortYieldsBleDevices(self):
+		"""The automatic port tries BLE devices, as it is offered when only those are known."""
+		match = _bleMatch("DotPad320", self._ADDRESS)
+		with (
+			patch("bdDetect.getConnectedUsbDevicesForDriver", return_value=iter(())),
+			patch("bdDetect.getPossibleBluetoothDevicesForDriver", return_value=iter(())),
+			self._patchBleDevices(match),
+		):
+			result = list(_FakeBleDriver._getTryPorts("auto"))
+		self.assertEqual(result, [match])
+
+	def test_getTryPorts_usbPortDoesNotYieldBleDevices(self):
+		"""Explicitly asking for USB must not fall back to BLE devices."""
+		with (
+			patch("bdDetect.getConnectedUsbDevicesForDriver", return_value=iter(())),
+			patch("bdDetect.getBleDevicesForDriver") as mockBle,
+		):
+			result = list(_FakeBleDriver._getTryPorts("usb"))
+		self.assertEqual(result, [])
+		mockBle.assert_not_called()
+
 	def test_getTryPorts_routesBlePortToHelper(self):
 		"""A BLE port reaches _getBleTryPorts rather than the serial port handling."""
 		match = _bleMatch("DotPad320", self._ADDRESS)

--- a/tests/unit/test_hwIo_ble.py
+++ b/tests/unit/test_hwIo_ble.py
@@ -14,7 +14,7 @@ from unittest.mock import MagicMock, patch
 from bleak.backends.device import BLEDevice
 from bleak.backends.scanner import AdvertisementData
 from hwIo.ble._scanner import Scanner
-from hwIo.ble._io import Ble
+from hwIo.ble._io import Ble, LINK_TIMEOUT_SECONDS
 from hwIo.ble import findDeviceByAddress, getDiscoveredDevice
 
 
@@ -274,6 +274,58 @@ class TestBle(unittest.TestCase):
 
 		self.mockRunCoroutineSync.assert_called()
 		self.assertTrue(ble.isConnected())
+
+	def _bleKwargs(self, **overrides) -> dict:
+		"""Build the constructor arguments for a Ble instance."""
+		mockDevice = MagicMock(spec=BLEDevice)
+		mockDevice.address = "AA:BB:CC:DD:EE:FF"
+		mockDevice.name = "TestDevice"
+		kwargs = dict(
+			device=mockDevice,
+			writeServiceUuid="service-uuid",
+			writeCharacteristicUuid="write-char-uuid",
+			readServiceUuid="service-uuid",
+			readCharacteristicUuid="read-char-uuid",
+			onReceive=lambda data: None,
+			ioThread=MagicMock(),
+		)
+		kwargs.update(overrides)
+		return kwargs
+
+	def test_connectIsBounded(self):
+		"""The connection attempt is given a timeout, so a missing device cannot block forever."""
+		self._makeBle(**self._bleKwargs())
+		timeouts = [call.args[1] for call in self.mockRunCoroutineSync.call_args_list if len(call.args) > 1]
+		self.assertIn(LINK_TIMEOUT_SECONDS, timeouts)
+
+	def _makeConnectTimeOut(self) -> None:
+		"""Make the next connection attempt time out.
+
+		The coroutine is still closed, as the setUp fake does, so that Python does not
+		warn that it was never awaited.
+		"""
+
+		def timeOut(coro: object, timeout: float | None = None) -> None:
+			if hasattr(coro, "close"):
+				coro.close()
+			raise TimeoutError("timed out")
+
+		self.mockRunCoroutineSync.side_effect = timeOut
+
+	def test_connectTimeoutPropagates(self):
+		"""A connection attempt that times out fails the constructor."""
+		self._makeConnectTimeOut()
+		with self.assertRaises(TimeoutError):
+			self.Ble(**self._bleKwargs())
+
+	def test_connectTimeoutStopsReaderThread(self):
+		"""A failed constructor leaves no reader thread behind, as nothing owns the instance."""
+		self._makeConnectTimeOut()
+		with patch("hwIo.ble._io.Thread") as mockThread:
+			with self.assertRaises(TimeoutError):
+				self.Ble(**self._bleKwargs())
+		stopEvent = mockThread.call_args.kwargs["args"][2]
+		self.assertTrue(stopEvent.is_set())
 
 	def test_writeData(self):
 		"""Test writing data to BLE characteristic."""

--- a/tests/unit/test_hwIo_ble.py
+++ b/tests/unit/test_hwIo_ble.py
@@ -8,15 +8,26 @@
 These tests cover the BLE scanner, BLE I/O, and device discovery functionality.
 """
 
+import asyncio
 import unittest
 from unittest.mock import MagicMock, patch
 
 from bleak.backends.device import BLEDevice
+from winrt.windows.devices.radios import RadioState
 from bleak.backends.scanner import AdvertisementData
 from bleak.exc import BleakBluetoothNotAvailableError, BleakBluetoothNotAvailableReason
 from hwIo.ble._scanner import Scanner, SCAN_CONTROL_TIMEOUT_SECONDS
 from hwIo.ble._io import Ble, LINK_TIMEOUT_SECONDS
-from hwIo.ble import findDeviceByAddress, getDiscoveredDevice
+from hwIo.ble import findDeviceByAddress, getDiscoveredDevice, isAvailable
+
+
+def _runCoroutineHere(coro, timeout=None):
+	"""Run a coroutine to completion here, standing in for the asyncio event loop."""
+	loop = asyncio.new_event_loop()
+	try:
+		return loop.run_until_complete(coro)
+	finally:
+		loop.close()
 
 
 class TestScanner(unittest.TestCase):
@@ -478,6 +489,75 @@ class TestBle(unittest.TestCase):
 
 		self.assertGreater(self.mockRunCoroutineSync.call_count, 1)
 		self.assertIsNone(ble._onReceive)
+
+
+class TestIsAvailable(unittest.TestCase):
+	"""Tests for hwIo.ble.isAvailable"""
+
+	def _bluetooth(self, adapter: object):
+		"""Make Windows report the given Bluetooth adapter, and run the query here."""
+
+		async def getDefault():
+			return adapter
+
+		adapterClass = MagicMock()
+		adapterClass.get_default_async = getDefault
+		return (
+			patch("_asyncioEventLoop.isRunning", return_value=True),
+			patch("hwIo.ble.BluetoothAdapter", adapterClass),
+			patch("hwIo.ble.runCoroutineSync", new=_runCoroutineHere),
+		)
+
+	def _adapter(self, radioState: object, centralRole: bool = True) -> MagicMock:
+		"""Build an adapter reporting the given radio state and central role support."""
+		radio = MagicMock()
+		radio.state = radioState
+
+		async def getRadio():
+			return radio
+
+		adapter = MagicMock()
+		adapter.is_central_role_supported = centralRole
+		adapter.get_radio_async = getRadio
+		return adapter
+
+	def _availableWith(self, adapter: object) -> bool:
+		loopPatch, adapterPatch, runPatch = self._bluetooth(adapter)
+		with loopPatch, adapterPatch, runPatch:
+			return isAvailable()
+
+	def test_noEventLoop(self):
+		"""Without an event loop to ask on, availability is assumed.
+
+		Hiding a driver on a machine that may well support BLE is worse than
+		offering one that cannot connect.
+		"""
+		with patch("_asyncioEventLoop.isRunning", return_value=False):
+			self.assertTrue(isAvailable())
+
+	def test_noAdapter(self):
+		"""A machine without a Bluetooth adapter cannot reach BLE devices."""
+		self.assertFalse(self._availableWith(None))
+
+	def test_radioOff(self):
+		"""A switched off radio cannot reach BLE devices."""
+		self.assertFalse(self._availableWith(self._adapter(RadioState.OFF)))
+
+	def test_radioOn(self):
+		"""A powered adapter able to act as a central can reach BLE devices."""
+		self.assertTrue(self._availableWith(self._adapter(RadioState.ON)))
+
+	def test_noCentralRole(self):
+		"""An adapter that cannot act as a central is of no use for BLE."""
+		self.assertFalse(self._availableWith(self._adapter(RadioState.ON, centralRole=False)))
+
+	def test_failureToAsk(self):
+		"""A question that cannot be answered does not hide the driver."""
+		with (
+			patch("_asyncioEventLoop.isRunning", return_value=True),
+			patch("hwIo.ble.runCoroutineSync", side_effect=TimeoutError("timed out")),
+		):
+			self.assertTrue(isAvailable())
 
 
 class TestGetDiscoveredDevice(unittest.TestCase):

--- a/tests/unit/test_hwIo_ble.py
+++ b/tests/unit/test_hwIo_ble.py
@@ -13,7 +13,8 @@ from unittest.mock import MagicMock, patch
 
 from bleak.backends.device import BLEDevice
 from bleak.backends.scanner import AdvertisementData
-from hwIo.ble._scanner import Scanner
+from bleak.exc import BleakBluetoothNotAvailableError, BleakBluetoothNotAvailableReason
+from hwIo.ble._scanner import Scanner, SCAN_CONTROL_TIMEOUT_SECONDS
 from hwIo.ble._io import Ble, LINK_TIMEOUT_SECONDS
 from hwIo.ble import findDeviceByAddress, getDiscoveredDevice
 
@@ -27,18 +28,14 @@ class TestScanner(unittest.TestCase):
 		self.bleakScannerPatcher = patch("hwIo.ble._scanner.bleak.BleakScanner")
 		self.mockBleakScannerClass = self.bleakScannerPatcher.start()
 
-		mockFuture = MagicMock()
-		mockFuture.result.return_value = None
-		mockFuture.exception.return_value = None
-
-		def fakeRunCoroutine(coro: object) -> MagicMock:
+		def fakeRunCoroutineSync(coro: object, timeout: float | None = None) -> None:
 			if hasattr(coro, "close"):
 				coro.close()
-			return mockFuture
+			return None
 
 		self.runCoroutinePatcher = patch(
-			"hwIo.ble._scanner.runCoroutine",
-			side_effect=fakeRunCoroutine,
+			"hwIo.ble._scanner.runCoroutineSync",
+			side_effect=fakeRunCoroutineSync,
 		)
 		self.mockRunCoroutine = self.runCoroutinePatcher.start()
 
@@ -66,6 +63,51 @@ class TestScanner(unittest.TestCase):
 
 		self.mockScannerInstance.start.assert_called_once()
 		self.assertTrue(scanner.isScanning)
+
+	def _makeStartFail(self, error: Exception) -> None:
+		"""Make the next call into Bleak fail with the given error."""
+
+		def fail(coro: object, timeout: float | None = None) -> None:
+			if hasattr(coro, "close"):
+				coro.close()
+			raise error
+
+		self.mockRunCoroutine.side_effect = fail
+
+	def test_startRefusedIsReported(self):
+		"""A start Bleak refuses reaches the caller rather than being swallowed."""
+		scanner = self.Scanner()
+		self._makeStartFail(
+			BleakBluetoothNotAvailableError(
+				"No Bluetooth adapter found",
+				BleakBluetoothNotAvailableReason.NO_BLUETOOTH,
+			),
+		)
+		with self.assertRaises(BleakBluetoothNotAvailableError):
+			scanner.start()
+
+	def test_startRefusedLeavesScannerIdle(self):
+		"""A scan that never started is not recorded as running.
+
+		Otherwise every later attempt is skipped as redundant, and callers wait for
+		results that cannot arrive.
+		"""
+		scanner = self.Scanner()
+		self._makeStartFail(
+			BleakBluetoothNotAvailableError(
+				"Bluetooth radio is not powered on",
+				BleakBluetoothNotAvailableReason.POWERED_OFF,
+			),
+		)
+		with self.assertRaises(BleakBluetoothNotAvailableError):
+			scanner.start()
+		self.assertFalse(scanner.isScanning)
+
+	def test_startIsBounded(self):
+		"""Talking to the Bluetooth stack is given a timeout."""
+		scanner = self.Scanner()
+		scanner.start()
+		self.assertEqual(self.mockRunCoroutine.call_args.args[1], SCAN_CONTROL_TIMEOUT_SECONDS)
 
 	def test_stopScanning(self):
 		"""Test that stopping scan calls Bleak scanner and clears isScanning flag."""
@@ -305,10 +347,16 @@ class TestBle(unittest.TestCase):
 		warn that it was never awaited.
 		"""
 
+		failed: list[bool] = []
+
 		def timeOut(coro: object, timeout: float | None = None) -> None:
 			if hasattr(coro, "close"):
 				coro.close()
-			raise TimeoutError("timed out")
+			# Only the connection attempt fails; the clean-up that follows must still work.
+			if not failed:
+				failed.append(True)
+				raise TimeoutError("timed out")
+			return None
 
 		self.mockRunCoroutineSync.side_effect = timeOut
 

--- a/tests/unit/test_hwIo_ble.py
+++ b/tests/unit/test_hwIo_ble.py
@@ -15,7 +15,7 @@ from bleak.backends.device import BLEDevice
 from bleak.backends.scanner import AdvertisementData
 from hwIo.ble._scanner import Scanner
 from hwIo.ble._io import Ble
-from hwIo.ble import findDeviceByAddress
+from hwIo.ble import findDeviceByAddress, getDiscoveredDevice
 
 
 class TestScanner(unittest.TestCase):
@@ -378,6 +378,41 @@ class TestBle(unittest.TestCase):
 
 		self.assertGreater(self.mockRunCoroutineSync.call_count, 1)
 		self.assertIsNone(ble._onReceive)
+
+
+class TestGetDiscoveredDevice(unittest.TestCase):
+	"""Tests for hwIo.ble.getDiscoveredDevice
+
+	Unlike findDeviceByAddress this must be callable on the main thread,
+	which is where a braille display chosen in the settings dialog is connected.
+	These tests therefore deliberately do not patch out the main-thread check.
+	"""
+
+	def _fakeDevice(self, address: str) -> MagicMock:
+		device = MagicMock(spec=BLEDevice)
+		device.address = address
+		return device
+
+	def test_deviceInResults(self):
+		"""The device with the requested address is returned."""
+		wanted = self._fakeDevice("AA:BB:CC:DD:EE:FF")
+		other = self._fakeDevice("11:22:33:44:55:66")
+		with patch("hwIo.ble.scanner") as mockScanner:
+			mockScanner.results.return_value = [other, wanted]
+			self.assertIs(getDiscoveredDevice("AA:BB:CC:DD:EE:FF"), wanted)
+			mockScanner.start.assert_not_called()
+
+	def test_deviceNotInResults(self):
+		"""None is returned without starting a scan."""
+		with patch("hwIo.ble.scanner") as mockScanner:
+			mockScanner.results.return_value = [self._fakeDevice("11:22:33:44:55:66")]
+			self.assertIsNone(getDiscoveredDevice("AA:BB:CC:DD:EE:FF"))
+			mockScanner.start.assert_not_called()
+
+	def test_noScanner(self):
+		"""None is returned when BLE was never initialized."""
+		with patch("hwIo.ble.scanner", None):
+			self.assertIsNone(getDiscoveredDevice("AA:BB:CC:DD:EE:FF"))
 
 
 class TestFindDeviceByAddress(unittest.TestCase):

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -324,6 +324,10 @@ This can be enabled using the "Report when objects support multiple selection" s
 * Automatically reading the entire result after a successful recognition is now possible via a new option in the Windows OCR settings. (#19150, @Cary-rowen)
 * Performance improvements on ARM64 systems, such as with Qualcomm processors. (#18570, @leonarddeR)
 * A new unassigned global command has been added to toggle the "Play audio coordinates when mouse moves" option. (#19026, @rlawnsrl123)
+* Dot Pad displays can now be connected via Bluetooth Low Energy (BLE) in addition to USB. (#19122, @bramd)
+  * When automatic detection is enabled, Dot Pad devices will be discovered and connected automatically when in range.
+  * No Bluetooth pairing in Windows settings is required.
+  * Bluetooth Low Energy support requires Windows 10 version 1703 (Creators Update) or later.
 
 ### Changes
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -498,6 +498,10 @@ This can be enabled using the "Report when objects support multiple selection" s
 * Automatically reading the entire result after a successful recognition is now possible via a new option in the Windows OCR settings. (#19150, @Cary-rowen)
 * Performance improvements on ARM64 systems, such as with Qualcomm processors. (#18570, @leonarddeR)
 * A new unassigned global command has been added to toggle the "Play audio coordinates when mouse moves" option. (#19026, @rlawnsrl123)
+* Dot Pad displays can now be connected via Bluetooth Low Energy (BLE) in addition to USB. (#19122, @bramd)
+  * When automatic detection is enabled, Dot Pad devices will be discovered and connected automatically when in range.
+  * No Bluetooth pairing in Windows settings is required.
+  * Bluetooth Low Energy support requires Windows 10 version 1703 (Creators Update) or later.
 
 ### Changes
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -501,7 +501,6 @@ This can be enabled using the "Report when objects support multiple selection" s
 * Dot Pad displays can now be connected via Bluetooth Low Energy (BLE) in addition to USB. (#19122, @bramd)
   * When automatic detection is enabled, Dot Pad devices will be discovered and connected automatically when in range.
   * No Bluetooth pairing in Windows settings is required.
-  * Bluetooth Low Energy support requires Windows 10 version 1703 (Creators Update) or later.
 
 ### Changes
 

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -5032,6 +5032,7 @@ The following displays support this automatic detection functionality.
 * Nattiq nBraille displays
 * Seika Notetaker: MiniSeika (16, 24 cells), V6, and V6Pro (40 cells)
 * Tivomatic Caiku Albatross 46/80 displays
+* Dot Pad displays (USB and Bluetooth)
 * NLS eReader Zoomax
 * Any Display that supports the Standard HID Braille protocol
 
@@ -6285,11 +6286,28 @@ The Dot Pad has left and right panning keys and four function keys (f1 through f
 Multiple buttons can be pressed simultaneously to create combination gestures (e.g., `f1+panLeft`), which can be assigned via the Input Gestures dialog.
 Apart from panning, no other commands are assigned by default.
 
-The Dot Pad driver supports automatic detection of USB-connected devices.
+#### Connecting to Dot Pad {#dotPadConnecting}
+
+The Dot Pad can be connected via USB or Bluetooth Low Energy (BLE).
+
+The Dot Pad driver supports automatic detection via both USB and Bluetooth.
 However, automatic detection is disabled by default due to the device using generic USB identifiers that could conflict with other devices.
 To enable automatic detection, go to NVDA's Braille settings and check "Dot Pad" in the automatic detection list.
-When automatic detection is enabled and a compatible device is detected, NVDA will automatically connect to it.
-You can also manually select a specific USB or Bluetooth virtual serial port if needed.
+
+When automatic detection is enabled:
+
+* USB connections are detected immediately when plugged in
+* Bluetooth connections are discovered and connected automatically when the device is powered on and in range
+* No Bluetooth pairing in Windows settings is required for Bluetooth Low Energy connections
+* NVDA will automatically connect to the first compatible device found
+* Bluetooth devices will appear in the connection list with the prefix "Bluetooth:" followed by the device name (e.g., "Bluetooth: DotPad A320")
+
+Note: Bluetooth Low Energy support requires Windows 10 version 1703 (Creators Update) or later.
+
+You can also manually select a specific connection:
+
+* A USB port (e.g., COM3)
+* A Bluetooth device (e.g., "Bluetooth: DotPad A320")
 
 Please note that due to hardware limitations, the Dot Pad will not refresh all dots correctly while your hand is on the device.
 Make sure to lift your hand entirely off the device when navigating with NVDA, and only start reading again once it has fully updated.

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -5206,6 +5206,7 @@ The following displays support this automatic detection functionality.
 * Nattiq nBraille displays
 * Seika Notetaker: MiniSeika (16, 24 cells), V6, and V6Pro (40 cells)
 * Tivomatic Caiku Albatross 46/80 displays
+* Dot Pad displays (USB and Bluetooth)
 * NLS eReader Zoomax
 * Any Display that supports the Standard HID Braille protocol
 
@@ -6464,11 +6465,28 @@ The Dot Pad has left and right panning keys and four function keys (f1 through f
 Multiple buttons can be pressed simultaneously to create combination gestures (e.g., `f1+panLeft`), which can be assigned via the Input Gestures dialog.
 Apart from panning, no other commands are assigned by default.
 
-The Dot Pad driver supports automatic detection of USB-connected devices.
+#### Connecting to Dot Pad {#dotPadConnecting}
+
+The Dot Pad can be connected via USB or Bluetooth Low Energy (BLE).
+
+The Dot Pad driver supports automatic detection via both USB and Bluetooth.
 However, automatic detection is disabled by default due to the device using generic USB identifiers that could conflict with other devices.
 To enable automatic detection, go to NVDA's Braille settings and check "Dot Pad" in the automatic detection list.
-When automatic detection is enabled and a compatible device is detected, NVDA will automatically connect to it.
-You can also manually select a specific USB or Bluetooth virtual serial port if needed.
+
+When automatic detection is enabled:
+
+* USB connections are detected immediately when plugged in
+* Bluetooth connections are discovered and connected automatically when the device is powered on and in range
+* No Bluetooth pairing in Windows settings is required for Bluetooth Low Energy connections
+* NVDA will automatically connect to the first compatible device found
+* Bluetooth devices will appear in the connection list with the prefix "Bluetooth:" followed by the device name (e.g., "Bluetooth: DotPad A320")
+
+Note: Bluetooth Low Energy support requires Windows 10 version 1703 (Creators Update) or later.
+
+You can also manually select a specific connection:
+
+* A USB port (e.g., COM3)
+* A Bluetooth device (e.g., "Bluetooth: DotPad A320")
 
 Please note that due to hardware limitations, the Dot Pad will not refresh all dots correctly while your hand is on the device.
 Make sure to lift your hand entirely off the device when navigating with NVDA, and only start reading again once it has fully updated.

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -6465,28 +6465,14 @@ The Dot Pad has left and right panning keys and four function keys (f1 through f
 Multiple buttons can be pressed simultaneously to create combination gestures (e.g., `f1+panLeft`), which can be assigned via the Input Gestures dialog.
 Apart from panning, no other commands are assigned by default.
 
-#### Connecting to Dot Pad {#dotPadConnecting}
-
-The Dot Pad can be connected via USB or Bluetooth Low Energy (BLE).
-
-The Dot Pad driver supports automatic detection via both USB and Bluetooth.
+The Dot Pad driver supports automatic detection of devices connected over USB or Bluetooth.
 However, automatic detection is disabled by default due to the device using generic USB identifiers that could conflict with other devices.
 To enable automatic detection, go to NVDA's Braille settings and check "Dot Pad" in the automatic detection list.
+When automatic detection is enabled and a compatible device is detected, NVDA will automatically connect to it.
+Connecting over Bluetooth does not require pairing the device in Windows' Bluetooth settings first.
 
-When automatic detection is enabled:
-
-* USB connections are detected immediately when plugged in
-* Bluetooth connections are discovered and connected automatically when the device is powered on and in range
-* No Bluetooth pairing in Windows settings is required for Bluetooth Low Energy connections
-* NVDA will automatically connect to the first compatible device found
-* Bluetooth devices will appear in the connection list with the prefix "Bluetooth:" followed by the device name (e.g., "Bluetooth: DotPad A320")
-
-Note: Bluetooth Low Energy support requires Windows 10 version 1703 (Creators Update) or later.
-
-You can also manually select a specific connection:
-
-* A USB port (e.g., COM3)
-* A Bluetooth device (e.g., "Bluetooth: DotPad A320")
+You can also select a specific Bluetooth device as the port for this display.
+The port list is updated as devices are discovered while the braille display selection dialog is open.
 
 Please note that due to hardware limitations, the Dot Pad will not refresh all dots correctly while your hand is on the device.
 Make sure to lift your hand entirely off the device when navigating with NVDA, and only start reading again once it has fully updated.


### PR DESCRIPTION
DotPad braille displays support both USB serial and Bluetooth Low Energy (BLE) connections. NVDA previously only supported USB.

This is the last part of a series. The BLE stack itself is already in master:

- #19816 added the private `_asyncioEventLoop` module.
- #19838 added `hwIo.ble` (the `Scanner` singleton and the `Ble` transport) with unit tests.
- #19942 added the DotPad buffered-receive handling, along with the BLE tests as skipped skeletons.

This PR is the integration layer that connects those to the braille display system, and unskips those tests.

### Link to issue number:

Fixes #18584

### Summary of the issue:

DotPad braille displays support both USB serial and Bluetooth Low Energy (BLE) connections. NVDA previously only supported USB connections.

### Description of user facing changes:

- DotPad displays can be detected and connected automatically over BLE, alongside USB.
- A specific BLE device can be selected as the port in the braille display selection dialog.
- Scanning starts when that dialog opens, and the port list gains devices as they are discovered, reporting each newly found device.
- No pairing in Windows' Bluetooth settings is needed, as BLE devices are connected directly.

### Description of developer facing changes:

- `bdDetect` gained a `ble` scan flag, threaded through `rescan`, `_queueBgScan` and `_bgScan`, plus `DriverRegistrar.addBleDevices` for drivers to register a BLE match function, and `getBleDevicesForDriver` / `getDriversForBleDevices` to query matches. The scanner is only started when a driver in scope has registered BLE devices, so the Bluetooth radio is left alone otherwise.
- Discovery is event driven: `_Detector` subscribes to the scanner's `deviceDiscovered` extension point and queues a connection attempt as soon as a matching device advertises, rather than waiting for the next poll.
- `BrailleDisplayDriver` offers each discovered BLE device as a port of the form `ble:DeviceName@Address`, and resolves such a port back to a device, preferring the address over the name so that devices sharing a name can be told apart.
- `hwIo.ble.getDiscoveredDevice` was added: a non blocking lookup of what the scanner has already seen, safe to call on the main thread. `findDeviceByAddress`, which may scan and therefore may not, is now built on it.
- The BLE connection attempt is bounded by `LINK_TIMEOUT_SECONDS`, so a display that is switched off cannot hold the calling thread.

### Description of development approach:

`bdDetect` treats BLE as a communication type of its own rather than folding it into Bluetooth, so it can be scanned for and disabled independently. With BLE on Windows the application drives discovery, so nothing is known about a device until a scan has run. The braille display selection dialog therefore starts the shared scanner, and refreshes its port list while it is open so that devices found after it opened still appear.

The DotPad driver matches on a device name starting with `DotPad` and connects with `hwIo.ble.Ble`. A port is stored as `ble:Name@Address`: the address is what a connection needs when no scan result is available, while the name keeps the entry recognisable, and matching prefers the address so that a rotating resolvable private address does not confuse two devices with the same name.

### Testing strategy:

Unit tests cover the bdDetect BLE registration and matching, the port formatting and resolution on the display driver, the DotPad BLE connection path, and the `hwIo.ble` lookup and connection timeout.

Tested against DotPad 320A hardware:

1. Automatic detection over BLE and over USB.
2. Switching to USB while already connected over BLE.
3. Selecting a specific BLE device, saving it, and restarting NVDA, which reconnects from the saved port.
4. Selecting a display that is switched off, which now fails with an error rather than blocking.

### Known issues with pull request:

BLE requires no pairing, so automatic detection will connect to any DotPad it discovers. DotPad is excluded from automatic detection by default and a specific device can be configured, so this seems acceptable. Restricting it further would mean keeping a list of devices allowed to be detected, and a way to manage it.

Two things found while testing are deliberately left out of scope:

- `BrailleDisplayDriver.getManualPorts` offers every serial port on the machine, so displays from other vendors appear as DotPad ports. Filtering by the DotPad USB ID interacts with `check()`, which currently reports DotPad as always available so that the display can be selected before any scan has run. The two need deciding together.
- When a configured port is no longer present, the selection dialog silently selects another one and overwrites the configuration on OK. That affects every driver, not just this one.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [ ] Security precautions taken.
