### PR TITLE
Fix uploading of symbols to Mozilla.

### DIFF
--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -512,7 +512,7 @@ jobs:
   uploadSymbols:
     name: Upload symbols
     runs-on: ${{ needs.matrix.outputs.defaultRunner }}
-    needs: [matrix, createSymbols]
+    needs: [matrix, buildNvda]
     if: ${{ github.event_name == 'push' && vars.feature_uploadSymbolsToMozilla }}
     steps:
     - name: Checkout cached build
@@ -526,13 +526,13 @@ jobs:
       with:
         python-version: ${{ env.defaultPythonVersion }}
         architecture: ${{ env.defaultArch }}
+    - name: Download and extract dump_syms
+      shell: bash
+      run: |
+        curl -L -o dump_syms.zip https://github.com/mozilla/dump_syms/releases/download/v2.3.5/dump_syms-x86_64-pc-windows-msvc.zip
+        7z x dump_syms.zip dump_syms.exe
     - name: Install the latest version of uv
       uses: astral-sh/setup-uv@v6
-    - name: Get symbols
-      uses: actions/download-artifact@v4
-      with:
-        name: Symbols (${{ env.defaultPythonVersion }}, ${{ env.defaultArch }})
-        path: output
     - name: Upload symbols to Mozilla
       continue-on-error: true
       run: uv run --with requests --directory ${{ github.workspace }} ci\scripts\mozillaSyms.py

--- a/ci/scripts/mozillaSyms.py
+++ b/ci/scripts/mozillaSyms.py
@@ -13,10 +13,10 @@ import zipfile
 import requests
 
 SCRIPT_DIR = os.path.abspath(os.path.dirname(__file__))
-DUMP_SYMS = os.path.join(os.path.dirname(SCRIPT_DIR), "miscDeps", "tools", "dump_syms.exe")
-NVDA_SOURCE = os.path.join(os.path.dirname(SCRIPT_DIR), "source")
+REPO_ROOT = os.path.dirname(os.path.dirname(SCRIPT_DIR))
+DUMP_SYMS = os.path.join(REPO_ROOT, "dump_syms.exe")
+NVDA_SOURCE = os.path.join(REPO_ROOT, "source")
 NVDA_LIB = os.path.join(NVDA_SOURCE, "lib")
-NVDA_LIB64 = os.path.join(NVDA_SOURCE, "lib64")
 ZIP_FILE = os.path.join(SCRIPT_DIR, "mozillaSyms.zip")
 URL = "https://symbols.mozilla.org/upload/"
 
@@ -28,10 +28,10 @@ DLL_NAMES = [
 	"nvdaHelperRemote.dll",
 ]
 DLL_FILES = [
-	f
+	os.path.join(NVDA_LIB, arch, dll)
 	for dll in DLL_NAMES
-	# We need both the 32 bit and 64 bit symbols.
-	for f in (os.path.join(NVDA_LIB, dll), os.path.join(NVDA_LIB64, dll))
+	# We need symbols for all supported architectures.
+	for arch in ("x86", "x64", "arm64", "arm64ec")
 ]
 
 


### PR DESCRIPTION
### Link to issue number:
None.

### Summary of the issue:
NVDA builds are intended to upload debug symbols to Mozilla. This makes it easier to diagnose issues related to NVDA's in-process code in Firefox (both crash analysis and profiling), which helps both projects. Unfortunately, this broke years ago for various reasons.

### Description of user facing changes:
None.

### Description of developer facing changes:
Mozilla crash reports and profiles will show useful symbols for NVDA code.
I haven't included a change log entry for NVDA because this doesn't impact NVDA developers normally, only if they're working with Firefox.

### Description of development approach:
1. The version of dump_syms.exe in miscDeps from Google Breakpad is very outdated and probably no longer works. Mozilla completely rewrote this a few years ago. Download that from GitHub releases and use that instead.
2. mozillaSyms.py uses relative paths, but the script was moved in bd6b99ea, which broke these paths. Update the script accordingly.
3. The structure of NVDA's lib directory has changed significantly in the last few years. Furthermore, NVDA now supports more architectures (arm64, arm64ec). Update mozillaSyms.py accordingly.
4. Remove some unnecessary actions from the uploadSymbols CI job.

### Testing strategy:
Confirmed that [symbols were uploaded successfully in a try run](https://github.com/nvaccess/nvda/actions/runs/18735136393/job/53440453068).

### Known issues with pull request:
None.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
