### PR TITLE
Added an option to automatically read the entire result after a successful recognition

### DIFF
--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -328,6 +328,7 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 	language = string(default="")
 	autoRefresh = boolean(default=false)
 	autoRefreshInterval = integer(default=1500, min=100)
+	autoSayAllOnResult = boolean(default=false)
 
 [editableText]
 	caretMoveTimeoutMs = integer(min=0, max=2000, default=100)

--- a/source/contentRecog/__init__.py
+++ b/source/contentRecog/__init__.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2017-2023 NV Access Limited, James Teh, Leonard de Ruijter
+# Copyright (C) 2017-2023 NV Access Limited, James Teh, Leonard de Ruijter, Cary-rowen
 # This file is covered by the GNU General Public License.
 #  See the file COPYING for more details.
 
@@ -44,6 +44,12 @@ class ContentRecognizer(AutoPropertyObject):
 	"""
 	autoRefreshInterval: int = 1500
 	"""How often (in ms) to perform recognition."""
+	autoSayAllOnResult: bool = False
+	"""
+	Whether to automatically start reading the entire result after a successful recognition.
+	This is useful for users who want to hear the full content immediately
+	without needing to press additional keys.
+	"""
 
 	def getResizeFactor(self, width: int, height: int) -> Union[int, float]:
 		"""Return the factor by which an image must be resized

--- a/source/contentRecog/__init__.py
+++ b/source/contentRecog/__init__.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2017-2023 NV Access Limited, James Teh, Leonard de Ruijter, Cary-rowen
+# Copyright (C) 2017-2025 NV Access Limited, James Teh, Leonard de Ruijter, Cary-rowen
 # This file is covered by the GNU General Public License.
 #  See the file COPYING for more details.
 

--- a/source/contentRecog/recogUi.py
+++ b/source/contentRecog/recogUi.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2017-2025 NV Access Limited, James Teh, Leonard de Ruijter, Cyrille Bougot
+# Copyright (C) 2017-2025 NV Access Limited, James Teh, Leonard de Ruijter, Cyrille Bougot, Cary-rowen
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -22,6 +22,7 @@ import cursorManager
 import eventHandler
 import textInfos
 from logHandler import log
+from speech import sayAll
 import queueHandler
 import core
 from scriptHandler import script
@@ -45,6 +46,7 @@ class RecogResultNVDAObject(cursorManager.CursorManager, NVDAObjects.window.Wind
 
 	def __init__(self, result=None, obj=None):
 		self.parent = parent = api.getFocusObject()
+		self._shouldSayAllOnFirstFocus = False
 		self.result = result
 		if result:
 			self._selection = self.makeTextInfo(textInfos.POSITION_FIRST)
@@ -160,6 +162,8 @@ class RefreshableRecogResultNVDAObject(RecogResultNVDAObject, LiveText):
 		self._selection = self.makeTextInfo(textInfos.POSITION_FIRST)
 		# This method queues an event to the main thread.
 		self.setFocus()
+		if self.recognizer.autoSayAllOnResult:
+			self._shouldSayAllOnFirstFocus = True
 		if self.recognizer.allowAutoRefresh:
 			self._scheduleRecognize()
 
@@ -204,6 +208,9 @@ class RefreshableRecogResultNVDAObject(RecogResultNVDAObject, LiveText):
 
 	def event_gainFocus(self):
 		super().event_gainFocus()
+		if self._shouldSayAllOnFirstFocus:
+			self._shouldSayAllOnFirstFocus = False
+			sayAll.SayAllHandler.readText(sayAll.CURSOR.CARET)
 		if self.recognizer.allowAutoRefresh:
 			# Make LiveText watch for and report new text.
 			self.startMonitoring()

--- a/source/contentRecog/uwpOcr.py
+++ b/source/contentRecog/uwpOcr.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2017-2021 NV Access Limited
+# Copyright (C) 2017-2021 NV Access Limited, Cary-rowen
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -90,6 +90,10 @@ class UwpOcr(ContentRecognizer):
 	@classmethod
 	def _get_autoRefreshInterval(cls) -> int:
 		return config.conf["uwpOcr"]["autoRefreshInterval"]
+
+	@classmethod
+	def _get_autoSayAllOnResult(cls) -> bool:
+		return config.conf["uwpOcr"]["autoSayAllOnResult"]
 
 	def getResizeFactor(self, width, height):
 		# UWP OCR performs poorly with small images, so increase their size.

--- a/source/contentRecog/uwpOcr.py
+++ b/source/contentRecog/uwpOcr.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2017-2021 NV Access Limited, Cary-rowen
+# Copyright (C) 2017-2025 NV Access Limited, Cary-rowen
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -3763,10 +3763,19 @@ class UwpOcrPanel(SettingsPanel):
 		self.bindHelpEvent("Win10OcrSettingsAutoRefresh", self.autoRefreshCheckbox)
 		self.autoRefreshCheckbox.SetValue(config.conf["uwpOcr"]["autoRefresh"])
 
+		# Translators: The label for a setting in OCR settings to automatically say all on result.
+		autoSayAllText = _("Automatically say all on result")
+		self.autoSayAllOnResultCheckbox = sHelper.addItem(
+			wx.CheckBox(self, label=autoSayAllText),
+		)
+		self.bindHelpEvent("Win10OcrSettingsAutoSayAllOnResult", self.autoSayAllOnResultCheckbox)
+		self.autoSayAllOnResultCheckbox.SetValue(config.conf["uwpOcr"]["autoSayAllOnResult"])
+
 	def onSave(self):
 		lang = self.languageCodes[self.languageChoice.Selection]
 		config.conf["uwpOcr"]["language"] = lang
 		config.conf["uwpOcr"]["autoRefresh"] = self.autoRefreshCheckbox.IsChecked()
+		config.conf["uwpOcr"]["autoSayAllOnResult"] = self.autoSayAllOnResultCheckbox.IsChecked()
 
 
 class AdvancedPanelControls(

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -32,6 +32,7 @@ This can be enabled using the "Report when lists support multiple selection" set
 An action has been added to view the full scan results on the VirusTotal website. (#18974)
 * In the Add-on Store, a new action has been added to see the latest changes for the current version of add-ons. (#14041, @josephsl, @nvdaes)
 * In browse mode, the number of items in a list is now reported in braille. (#7455, @nvdaes)
+* Automatically reading the entire result after a successful recognition is now possible via a new option in the Windows OCR settings. (#xxxx, @Cary-rowen)
 
 ### Changes
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -32,7 +32,7 @@ This can be enabled using the "Report when lists support multiple selection" set
 An action has been added to view the full scan results on the VirusTotal website. (#18974)
 * In the Add-on Store, a new action has been added to see the latest changes for the current version of add-ons. (#14041, @josephsl, @nvdaes)
 * In browse mode, the number of items in a list is now reported in braille. (#7455, @nvdaes)
-* Automatically reading the entire result after a successful recognition is now possible via a new option in the Windows OCR settings. (#xxxx, @Cary-rowen)
+* Automatically reading the entire result after a successful recognition is now possible via a new option in the Windows OCR settings. (#19150, @Cary-rowen)
 
 ### Changes
 

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -3309,6 +3309,11 @@ This can be very useful when you want to monitor constantly changing content, su
 The refresh takes place every one and a half seconds.
 This option is disabled by default.
 
+##### Automatically say all on result {#Win10OcrSettingsAutoSayAllOnResult}
+
+This checkbox toggles the automatic reading of all recognized content after a recognition is complete.
+This option is disabled by default.
+
 #### Set Mirror Dialog {#SetURLDialog}
 
 This dialog allows you to specify the URL of a mirror to use when [updating NVDA](#GeneralSettingsCheckForUpdates) or [using the Add-on Store](#AddonsManager).


### PR DESCRIPTION
### Link to issue number:
Resolves #19144

### Summary of the issue:
After performing an OCR, users must manually initiate a "say all" command to hear the full recognition result. For users who frequently perform OCR on large blocks of text, this requires an extra step each time, slowing down their workflow.

### Description of user facing changes:
- Adds a new checkbox, "Automatically say all on result", to the Windows OCR settings panel (under Preferences -> Windows OCR).
- When enabled, NVDA will automatically start reading the full text of a successful OCR result.
- This feature is disabled by default.

### Description of developer facing changes:
- Adds a new configuration key `autoSayAllOnResult` (boolean, default `False`) under the `[uwpOcr]` section in `configSpec.py`.

### Description of development approach:
To ensure "say all" is triggered only after the recognition result document has focus, a flag (`_shouldSayAllOnFirstFocus`) is set when the result is first received in `_onFirstResult`. The actual `sayAll` command (`sayAll.SayAllHandler.readText(sayAll.CURSOR.CARET)`) is then called from the `event_gainFocus` handler of the `RefreshableRecogResultNVDAObject`.

### Testing strategy:
Manually tested by:
1. Enabling the "Automatically say all on result" option in the Windows OCR settings.
2. Performing OCR on a navigator object (`NVDA+r`). Verified that "say all" begins automatically.
3. Disabling the option and performing OCR again. Verified that "say all" does not start, and only the document title is announced.
4. Confirmed the setting persists after restarting NVDA.

### Known issues with pull request:
The options in Windows OCR do not appear to follow profile switching, which seems to be a general issue and not specific to this change.
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [X] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [X] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [X] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [ ] API is compatible with existing add-ons.
- [ ] Security precautions taken.
