### PR TITLE
Fix checkPot for plural

### DIFF
--- a/tests/checkPot.py
+++ b/tests/checkPot.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2017-2023 NV Access Limited, Ethan Holliger, Dinesh Kaushal, Leonard de Ruijter,
+# Copyright (C) 2017-2025 NV Access Limited, Ethan Holliger, Dinesh Kaushal, Leonard de Ruijter,
 # Joseph Lee, Julien Cochuyt, Łukasz Golonka, Cyrille Bougot
 # This file may be used under the terms of the GNU General Public License, version 2 or later.
 # For more details see: https://www.gnu.org/licenses/gpl-2.0.html
@@ -136,8 +136,8 @@ def checkPot(fileName):
 					# 	"keys are passed to the application"
 					msgid = ""
 					for line in pot:
-						if line.startswith("msgstr "):
-							# This begins the translated message, so msgid has ended.
+						if line.startswith("msgstr ") or line.startswith("msgid_plural"):
+							# This begins the translated or plural message, so msgid has ended.
 							break
 						msgid += getStringFromLine(line)
 				else:


### PR DESCRIPTION
### Link to issue number:
Fixes issue found while working on #19059

### Summary of the issue:
In #19059, commit 95957114b21bd2a1532864da3694e5fe759761c0, an error is raised during check Pot:

```
scons: *** [tests\checkPot] IndexError : list index out of range
Traceback (most recent call last):
  File "D:\a\nvda\nvda\.venv\Lib\site-packages\SCons\Action.py", line 1434, in execute
    result = self.execfunction(target=target, source=rsources, env=env)
  File "D:\a\nvda\nvda\tests\sconscript", line 21, in checkPotAction
    return checkPot.checkPot(source[0].abspath)
           ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
  File "D:\a\nvda\nvda\tests\checkPot.py", line 142, in checkPot
    msgid += getStringFromLine(line)
             ~~~~~~~~~~~~~~~~~^^^^^^
  File "D:\a\nvda\nvda\tests\checkPot.py", line 201, in getStringFromLine
    quoted = line.split(" ", 1)[1]
             ~~~~~~~~~~~~~~~~~~^^^
IndexError: list index out of range
Error: Process completed with exit code 1.
```

The test should pass or fail but no error should be raised.

The error occurs if a `msgid` command containing a multi-line string is followed by a `msgid_plural` command. This had probably never happened before the string introduced in #19059.

### Description of user facing changes:
The Python script to check Pot does not raise an error before completing.
### Description of developer facing changes:
N/A

### Description of development approach:
Take into account the presence of `msgid_plural`  token. Taken into account that a multi-line string in the `msgid` command can end:
* either with a `msgstr` command
* or a `msgid_plural` command

### Testing strategy:
Tested in #19059
### Known issues with pull request:
None
### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
