### PR TITLE
Excel legacy now reports Has note

### DIFF
--- a/source/NVDAObjects/window/excel.py
+++ b/source/NVDAObjects/window/excel.py
@@ -1462,7 +1462,7 @@ _nvCellStatesToStates: dict[NvCellState, controlTypes.State] = {
 	NvCellState.HASPOPUP: controlTypes.State.HASPOPUP,
 	NvCellState.PROTECTED: controlTypes.State.PROTECTED,
 	NvCellState.HASFORMULA: controlTypes.State.HASFORMULA,
-	NvCellState.HASCOMMENT: controlTypes.State.HASCOMMENT,
+	NvCellState.HASCOMMENT: controlTypes.State.HASNOTE,
 	NvCellState.CROPPED: controlTypes.State.CROPPED,
 	NvCellState.OVERFLOWING: controlTypes.State.OVERFLOWING,
 	NvCellState.UNLOCKED: controlTypes.State.UNLOCKED,


### PR DESCRIPTION
### Link to issue number:
Fixes #18709
Follow-up of #11311

### Summary of the issue:
In Excel (legacy), when entering a cell with a note, Excel reports "Has comment". This is confusing since there are new threaded comment types in newer Excel versions.

It was listed as a known issue of #11311.

It's worth noting that with Excel UIA, NVDA already reports "Has note" in this case.

### Description of user facing changes:
When moving the focus on a cell with a note, Excel now reports "Has note". It is consistent with NVDA's interface and User Guide which mention note everywhere else.

### Description of developer facing changes:
N/A
### Description of development approach:
Use the new `HASNOTE` state introduced since then instead of the `HASCOMMENT` state, as done for UIA.

### Testing strategy:
Manual check that "has note" is reported with cells having a note on:

- [x] Excel 2021 LTSC, without collaborative threaded comments
- [x] Excel 365, with collaborative threaded comment feature (should be unrelated anyway)

### Known issues with pull request:
Excel reports "has note" on older versions where notes were called comments.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
