### PR TITLE
Fix regression: restore ability to move braille to next paragraph in LibreOffice Writer

### DIFF
--- a/source/NVDAObjects/window/edit.py
+++ b/source/NVDAObjects/window/edit.py
@@ -466,7 +466,7 @@ class EditTextInfo(textInfos.offsets.OffsetsTextInfo):
 
 	def _getStoryText(self):
 		if controlTypes.State.PROTECTED in self.obj.states:
-			return "*" * self._getStoryLength()
+			return "*" * (self._getStoryLength() - 1)
 		return self.obj.windowText
 
 	def _getStoryLength(self):
@@ -501,12 +501,18 @@ class EditTextInfo(textInfos.offsets.OffsetsTextInfo):
 				)
 			finally:
 				winKernel.virtualFreeEx(processHandle, internalInfo, 0, winKernel.MEM_RELEASE)
-			return textLen
+			# Py3 review: investigation with Python 2 NVDA revealed that
+			# adding 1 to this creates an off by one error.
+			# Tested using Wordpad, enforcing EditTextInfo as the textInfo implementation.
+			return textLen + 1
 		else:
 			# ForWM_GETTEXTLENGTH documentation, see
 			# https://docs.microsoft.com/en-us/windows/desktop/winmsg/wm-gettextlength
 			# It determines the length, in characters, of the text associated with a window.
-			return watchdog.cancellableSendMessage(self.obj.windowHandle, winUser.WM_GETTEXTLENGTH, 0, 0)
+			# Py3 review: investigation with Python 2 NVDA revealed that
+			# adding 1 to this created an off by one error.
+			# Tested using Notepad
+			return watchdog.cancellableSendMessage(self.obj.windowHandle, winUser.WM_GETTEXTLENGTH, 0, 0) + 1
 
 	def _getLineCount(self):
 		return self.obj.windowTextLineCount

--- a/source/braille.py
+++ b/source/braille.py
@@ -1709,6 +1709,8 @@ class TextInfoRegion(Region):
 					dest = dest.obj.makeTextInfo(textInfos.POSITION_FIRST)
 			else:  # no page turn support
 				shouldCollapseToEnd = True
+				# This will allow to move to next paragraph In LibreOffice _Writer,
+				# And consistently move to the last position in different applications.
 				dest.expand(textInfos.UNIT_LINE)
 		dest.collapse(shouldCollapseToEnd)
 		self._setCursor(dest)

--- a/source/braille.py
+++ b/source/braille.py
@@ -1709,6 +1709,7 @@ class TextInfoRegion(Region):
 					dest = dest.obj.makeTextInfo(textInfos.POSITION_FIRST)
 			else:  # no page turn support
 				shouldCollapseToEnd = True
+				dest.expand(textInfos.UNIT_LINE)
 		dest.collapse(shouldCollapseToEnd)
 		self._setCursor(dest)
 		_speakOnNavigatingByUnit(dest, self._getReadingUnit())

--- a/source/textInfos/offsets.py
+++ b/source/textInfos/offsets.py
@@ -358,7 +358,7 @@ class OffsetsTextInfo(textInfos.TextInfo):
 			ctypes.byref(relEnd),
 		):
 			relStart = relStart.value
-			relEnd = relEnd.value
+			relEnd = min(lineLength, relEnd.value)
 			if self.encoding != textUtils.WCHAR_ENCODING:
 				# We need to convert the uniscribe based offsets to str offsets.
 				relStart, relEnd = offsetConverter.encodedToStrOffsets(relStart, relEnd)

--- a/source/textInfos/offsets.py
+++ b/source/textInfos/offsets.py
@@ -663,7 +663,7 @@ class OffsetsTextInfo(textInfos.TextInfo):
 		count = 0
 		lowLimit = 0
 		highLimit = self._getStoryLength()
-		if self.allowMoveToOffsetPastEnd:
+		if self.allowMoveToOffsetPastEnd and unit == textInfos.UNIT_CHARACTER:
 			# #2096: There is often an uncounted character at the end of the text
 			# where the caret is placed to append text.
 			highLimit += 1

--- a/tests/system/robot/chromeTests.py
+++ b/tests/system/robot/chromeTests.py
@@ -927,7 +927,7 @@ def test_pr11606():
 	actualSpeech = _chrome.getSpeechAfterKey("end")
 	_asserts.strings_match(
 		actualSpeech,
-		"blank",
+		"link",
 	)
 	# Read the current line.
 	# Before pr #11606 the next line ("C D")  would have been read.

--- a/tests/system/robot/symbolPronunciationTests.py
+++ b/tests/system/robot/symbolPronunciationTests.py
@@ -596,12 +596,23 @@ def test_symbolInSpeechUI():
 	"""Replace a translation string to include a character that is can be substituted,
 	check if the 'speech UI' translation string the character substituted.
 	"""
-	character = "t"  # Character doesn't matter, we just want to invoke "Right" speech UI.
-	_notepad.prepareNotepad(character)
+	_notepad.prepareNotepad(
+		(
+			"t"  # Character doesn't matter, we just want to invoke "Right" speech UI.
+		),
+	)
 	_setConfig(SymLevel.ALL)
 	spy = _NvdaLib.getSpyLib()
 	expected = "shouldn't sub tick symbol"
 	spy.override_translationString(EndSpeech.RIGHT.value, expected)
+
+	# get to the end char
+	actual = _pressKeyAndCollectSpeech(Move.REVIEW_CHAR.value, numberOfTimes=1)
+	_builtIn.should_be_equal(
+		actual,
+		["blank"],
+		msg="actual vs expected. Unexpected speech when moving to final character.",
+	)
 
 	actual = _pressKeyAndCollectSpeech(Move.REVIEW_CHAR.value, numberOfTimes=1)
 	_builtIn.should_be_equal(
@@ -611,7 +622,7 @@ def test_symbolInSpeechUI():
 		[
 			# todo: 'tick' is a bug
 			"shouldn tick t sub tick symbol"  # intentionally concatenate strings
-			f"\n{character}",
+			"\nblank",
 		],
 		msg="actual vs expected. NVDA speech UI substitutes symbols",
 	)
@@ -621,7 +632,7 @@ def test_symbolInSpeechUI():
 	actual = _pressKeyAndCollectSpeech(Move.REVIEW_CHAR.value, numberOfTimes=1)
 	_builtIn.should_be_equal(
 		actual,
-		[f"{expected}\n{character}"],
+		[f"{expected}\nblank"],
 		msg="actual vs expected. NVDA speech UI substitutes symbols",
 	)
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -50,6 +50,7 @@ We recommend using Windows 11, or if that is not possible, the latest Windows 10
     * Improvements to Portuguese 8-dot, Greek International, Biblical Hebrew, Norwegian 8-dot and Unified English Braille.
   * Updated BrlAPI for BRLTTY to version 0.8.7, and its corresponding python module to a Python 3.13 compatible build. (#18657, @LeonarddeR)
 * In browse mode in web browsers, NVDA no longer sometimes treats controls with 0 visual width or height as invisible. This technique is sometimes used to make content accessible to screen readers without it being visible visually. Such controls will now be accessible in browse mode where they weren't before. (#13897, @jcsteh)
+* In LibreOffice Writer documents, when scrolling forward a braille display, the cursor will be moved to the end of the document if no more text is encountered. (#19152, @nvdaes)
 
 ### Bug Fixes
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
<!-- Use Closes/Fixes/Resolves #xxx to link this PR to the issue it is responding to. -->
Fixes #19152
### Summary of the issue:
Braille cannot be moved to next paragraph, due to a regression introduced in #18348 
### Description of user facing changes:
Braille can be moved to the next paragraph again.
### Description of developer facing changes:
None.

### Description of development approach:
Restore changes introduced for the `move` method in `textInfos/offsets.py`.
In `nextLine` of braille.py, if the cursor is not moved, expand to line before collapsing.
Revert "Fix off by one text length in EditTextInfo (#18767) (otherwise system test fail.
### Testing strategy:
Tested locally with a Focus 40 braille display, in LibreOffice Writer and Notepad++:
- Checked that, when scrolling forward with braille, the cursor is moved to the end of the document from the last line, also in LibreOffice Writer (this is a documented change since this was not happening in NVDA 2025.3.1).
- Checked that the behavior is consistent regardless of the Read by paragraph option (when this is turned on or off).
- Checked that the review cursor can be moved across lines, i.e., performing the review previous and review next line commands.
- Tested proposal by @LeonarddeR mentioned in #issuecomment-3506121489
The only difference found between Leonards's proposal and this pull request is that, with this PR, the cursor can be moved to the end of the documment in LibreOffice Writer from the last line, which is consistent with the behavior of other applications.

- 
### Known issues with pull request:
None.
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
