### PR TITLE
Revert "Fix OffsetTextInfo.collapse() and OffsetTextInfo.move() (#18348)"

### DIFF
--- a/source/NVDAObjects/window/scintilla.py
+++ b/source/NVDAObjects/window/scintilla.py
@@ -313,16 +313,6 @@ class ScintillaTextInfo(textInfos.offsets.OffsetsTextInfo):
 				tempOffset -= 1
 		return [start, end]
 
-	def collapse(self, end: bool = False):
-		"""Before collapsing to end, if no text is selected, TextInfo is expanded to line.
-		This fixes a bug where next braille line command didn't move the cursor to the last empty line
-		in Notepad++ documents.
-		https://github.com/nvaccess/nvda/issues/17430
-		"""
-		if end and self.obj.makeTextInfo(textInfos.POSITION_SELECTION).isCollapsed:
-			self.expand(textInfos.UNIT_LINE)
-		super().collapse(end=end)
-
 
 # The Scintilla NVDA object, inherists the generic MSAA NVDA object
 class Scintilla(EditableTextWithAutoSelectDetection, Window):

--- a/source/NVDAObjects/window/scintilla.py
+++ b/source/NVDAObjects/window/scintilla.py
@@ -313,6 +313,16 @@ class ScintillaTextInfo(textInfos.offsets.OffsetsTextInfo):
 				tempOffset -= 1
 		return [start, end]
 
+	def collapse(self, end: bool = False):
+		"""Before collapsing to end, if no text is selected, TextInfo is expanded to line.
+		This fixes a bug where next braille line command didn't move the cursor to the last empty line
+		in Notepad++ documents.
+		https://github.com/nvaccess/nvda/issues/17430
+		"""
+		if end and self.obj.makeTextInfo(textInfos.POSITION_SELECTION).isCollapsed:
+			self.expand(textInfos.UNIT_LINE)
+		super().collapse(end=end)
+
 
 # The Scintilla NVDA object, inherists the generic MSAA NVDA object
 class Scintilla(EditableTextWithAutoSelectDetection, Window):

--- a/source/textInfos/offsets.py
+++ b/source/textInfos/offsets.py
@@ -643,11 +643,7 @@ class OffsetsTextInfo(textInfos.TextInfo):
 		else:
 			raise NotImplementedError
 
-	allowMoveToOffsetPastEnd = True
-	"""
-	We can move 1 past story length to allow braille routing to end insertion point. (#2096)
-	Furthermore, review cursor is able to reach the last, empty line in some controls, like Scintilla. (#18348)
-	"""
+	allowMoveToOffsetPastEnd = True  #: move with unit_character can move 1 past story length to allow braille routing to end insertion point. (#2096)
 
 	def move(self, unit, direction, endPoint=None):
 		if direction == 0:
@@ -663,7 +659,7 @@ class OffsetsTextInfo(textInfos.TextInfo):
 		count = 0
 		lowLimit = 0
 		highLimit = self._getStoryLength()
-		if self.allowMoveToOffsetPastEnd:
+		if self.allowMoveToOffsetPastEnd and unit == textInfos.UNIT_CHARACTER:
 			# #2096: There is often an uncounted character at the end of the text
 			# where the caret is placed to append text.
 			highLimit += 1

--- a/tests/system/robot/chromeTests.py
+++ b/tests/system/robot/chromeTests.py
@@ -927,7 +927,7 @@ def test_pr11606():
 	actualSpeech = _chrome.getSpeechAfterKey("end")
 	_asserts.strings_match(
 		actualSpeech,
-		"blank",
+		"link",
 	)
 	# Read the current line.
 	# Before pr #11606 the next line ("C D")  would have been read.

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -95,8 +95,6 @@ Please open a GitHub issue if your add-on has an issue with updating to the new 
 * typing_extensions have been removed.
 These should be supported natively in Python 3.13. (#18689)
 * `copyrightYears` and `url` have been moved from `versionInfo` to `buildVersion`. (#18682)
-* Fixed behavior of `TextInfo.collapse()` - previously it was moving TextInfo to the next paragraph in some cases. (#18320, @mltony)
-* Fixed behavior of `OffsetTextInfo.move()` - previously it wouldn't move to the very end of the document unless moving by character. (#18348, @mltony)
 * `NVDAHelper.localLib` is now a module, not a `ctypes.CDLL`.
 Most API consumers should not be impacted by this change.
 Use `NVDAHelper.localLib.dll` for access to the `ctypes.CDLL` if necessary. (#18207)


### PR DESCRIPTION
This reverts commit 8742b3a613c29bf636374c6c6696c9a8553c7e87.

---
name: Revert PR
about: Revert an existing pull request

---

### Reverts PR
Partially reverts #18348
### Issues fixed
<!-- Issues that will be closed by reverting, i.e. the issues introduced via the PR getting reverted  -->
Fixes #19152

### Issues reopened
<!-- Issues that will be re-opened by reverting, i.e. the issues that were fixed via the PR getting reverted  -->
Reopens #18320

### Reason for revert
This causes a regression in LibreOffice Writer documents, where braille cannot be moved to the next paragraph by scrolling forward. (issue #19152).
### Can this PR be reimplemented? If so, what is required for the next attempt
@LeonarddeR proposed a solution in #19171 PR which would likely fix #17430 and #19152 properly.