### PR TITLE
Do not mention Notes in Doc formatting settings

### DIFF
--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -2795,7 +2795,7 @@ class DocumentFormattingPanel(SettingsPanel):
 
 		# Translators: This is the label for a checkbox in the
 		# document formatting settings panel.
-		commentsText = _("No&tes and comments")
+		commentsText = _("Commen&ts")
 		self.commentsCheckBox = docInfoGroup.addItem(wx.CheckBox(docInfoBox, label=commentsText))
 		self.commentsCheckBox.SetValue(config.conf["documentFormatting"]["reportComments"])
 


### PR DESCRIPTION
### Link to issue number:
Fix-up of #11311

### Summary of the issue:

In #11311, it was taken into account that older Excel comments were known as "notes" in newer interfaces, so NVDA's GUI and documentation has been updatedt to be consistent with newer versions.

The "Comments" checkbox in the Document formatting settings panel has been updated to "Notes and comments" as part of this work.

However, this checkbox does not control Excel's comments/notes reporting; it only controls whether comments in text, e.g. in Word, are reported.

### Description of user facing changes:

This checkbox has been renamed back to "Comments"

### Description of developer facing changes:
N/A
### Description of development approach:
N/A
### Testing strategy:
Manual check
### Known issues with pull request:
One could argue that this checkbox should instead remain "Notes and comments" and should control Excel's Notes or comments.

That's not my approach. And allowing to control "has notes" cell's property while "has formula" cannot be controlled would not be consistent.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
