### PR TITLE
Bugfix for displayed gesture identifier containing numlock modifier

### DIFF
--- a/source/keyboardHandler.py
+++ b/source/keyboardHandler.py
@@ -759,6 +759,7 @@ class KeyboardInputGesture(inputCore.InputGesture):
 		keys = set(keys.split("+"))
 		names = []
 		main = None
+		numlock = None
 		try:
 			# If present, the NVDA key should appear first.
 			keys.remove("nvda")
@@ -775,9 +776,15 @@ class KeyboardInputGesture(inputCore.InputGesture):
 			label = localizedKeyLabels.get(key, key)
 			if vk in cls.NORMAL_MODIFIER_KEYS:
 				names.append(label)
+			elif vk == winUser.VK_NUMLOCK:
+				# Numlock can be both modifier or main key so handle it separately and add it at the end after modifiers
+				# but before main key
+				numlock = label
 			else:
 				# The main key must be last, so handle that outside the loop.
 				main = label
+		if numlock is not None:
+			names.append(numlock)
 		if main is not None:
 			# If there is no main key, this gesture identifier only contains modifiers.
 			names.append(main)

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -67,7 +67,7 @@ We recommend using Windows 11, or if that is not possible, the latest Windows 10
 * Incorrect information is no longer displayed in braille when navigating the list of messages in Outlook Classic. (#18993, @nvdaes)
 * NVDA now detects and stops repeated crash loops to prevent system lockups when startup failures occur. (#19133, @derekriemer)
 * The browse mode cursor highlighter now appears on content recognition results, such as when using Windows OCR. (#19168, @hwf1324)
-* In the input gesture dialog, gestures including an operator while numlock is on will now appear correctly.
+* In the input gesture dialog, gestures including an operator while numlock is on will now be correctly displayed. (#19214, @CyrilleB79)
 
 ### Changes for Developers
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -66,6 +66,7 @@ We recommend using Windows 11, or if that is not possible, the latest Windows 10
 * Certain settings will no-longer erroneously be saved to disk when running NVDA from the launcher. (#18171)
 * Incorrect information is no longer displayed in braille when navigating the list of messages in Outlook Classic. (#18993, @nvdaes)
 * NVDA now detects and stops repeated crash loops to prevent system lockups when startup failures occur. (#19133, @derekriemer)
+* In the input gesture dialog, gestures including an operator while numlock is on will now appear correctly.
 
 ### Changes for Developers
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -67,7 +67,7 @@ We recommend using Windows 11, or if that is not possible, the latest Windows 10
 * Incorrect information is no longer displayed in braille when navigating the list of messages in Outlook Classic. (#18993, @nvdaes)
 * NVDA now detects and stops repeated crash loops to prevent system lockups when startup failures occur. (#19133, @derekriemer)
 * The browse mode cursor highlighter now appears on content recognition results, such as when using Windows OCR. (#19168, @hwf1324)
-* In the input gesture dialog, gestures including an operator while numlock is on will now be correctly displayed. (#19214, @CyrilleB79)
+* In the Input Gestures dialog, gestures including an operator while `numLock` is on will now be correctly displayed. (#19214, @CyrilleB79)
 
 ### Changes for Developers
 


### PR DESCRIPTION
### Link to issue number:
Fixes #19214
### Summary of the issue:

When gestures include numpad operators (numpad plus, numpad minus, numpad multiply and numpad divide) and are defined with numlock on, they do not appear correctly in input gesture dialog, e.g. "num lock" instead of "num lock+numpad plus")

### Description of user facing changes:
Gestures including numpad operators with num lock on are now correctly displayed in the input gesture dialog.

### Description of developer facing changes:
N/A

### Description of development approach:
In kayboard gestures identifiers, numlock can be considered a modifier or a main key name, depending on the situation:
* considered a modifier when combined with numpad operators, i.e. when numlock is on (but not currently physically pressed) and a numpad operator is presseed
* considered a main key name in all other other cases, i.e. when physically pressed (alone or with other modifiers such as control or shift)

In `KeyboardInputGesture.getDisplayTextForIdentifier` sort key name with normal modifiers, then numlock and then main key name.

### Testing strategy:
Manual test in input gestures dialog with:
* gestures without numlock, e.g. `numpadPlus`
* gestures with numlock as a modifier (i.e. numlock on + numpad operator), e.g. `numlock+numpadPlus`
* gestures with numlock handled as a main key name, e.g. `shift+numlock`

### Known issues with pull request:
While testing, I fell on the issue described in https://github.com/nvaccess/nvda/issues/4226#issuecomment-155321490, i.e. pressing `control+numlock` actually triggers `control+pause`.

### Code Review Checklist:


- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
