### PR TITLE
Revert "Fix off by one text length in EditTextInfo (#18767)"

### DIFF
--- a/source/NVDAObjects/window/edit.py
+++ b/source/NVDAObjects/window/edit.py
@@ -466,7 +466,7 @@ class EditTextInfo(textInfos.offsets.OffsetsTextInfo):
 
 	def _getStoryText(self):
 		if controlTypes.State.PROTECTED in self.obj.states:
-			return "*" * self._getStoryLength()
+			return "*" * (self._getStoryLength() - 1)
 		return self.obj.windowText
 
 	def _getStoryLength(self):
@@ -501,12 +501,18 @@ class EditTextInfo(textInfos.offsets.OffsetsTextInfo):
 				)
 			finally:
 				winKernel.virtualFreeEx(processHandle, internalInfo, 0, winKernel.MEM_RELEASE)
-			return textLen
+			# Py3 review: investigation with Python 2 NVDA revealed that
+			# adding 1 to this creates an off by one error.
+			# Tested using Wordpad, enforcing EditTextInfo as the textInfo implementation.
+			return textLen + 1
 		else:
 			# ForWM_GETTEXTLENGTH documentation, see
 			# https://docs.microsoft.com/en-us/windows/desktop/winmsg/wm-gettextlength
 			# It determines the length, in characters, of the text associated with a window.
-			return watchdog.cancellableSendMessage(self.obj.windowHandle, winUser.WM_GETTEXTLENGTH, 0, 0)
+			# Py3 review: investigation with Python 2 NVDA revealed that
+			# adding 1 to this created an off by one error.
+			# Tested using Notepad
+			return watchdog.cancellableSendMessage(self.obj.windowHandle, winUser.WM_GETTEXTLENGTH, 0, 0) + 1
 
 	def _getLineCount(self):
 		return self.obj.windowTextLineCount

--- a/source/textInfos/offsets.py
+++ b/source/textInfos/offsets.py
@@ -358,7 +358,7 @@ class OffsetsTextInfo(textInfos.TextInfo):
 			ctypes.byref(relEnd),
 		):
 			relStart = relStart.value
-			relEnd = relEnd.value
+			relEnd = min(lineLength, relEnd.value)
 			if self.encoding != textUtils.WCHAR_ENCODING:
 				# We need to convert the uniscribe based offsets to str offsets.
 				relStart, relEnd = offsetConverter.encodedToStrOffsets(relStart, relEnd)

--- a/tests/system/robot/symbolPronunciationTests.py
+++ b/tests/system/robot/symbolPronunciationTests.py
@@ -596,12 +596,23 @@ def test_symbolInSpeechUI():
 	"""Replace a translation string to include a character that is can be substituted,
 	check if the 'speech UI' translation string the character substituted.
 	"""
-	character = "t"  # Character doesn't matter, we just want to invoke "Right" speech UI.
-	_notepad.prepareNotepad(character)
+	_notepad.prepareNotepad(
+		(
+			"t"  # Character doesn't matter, we just want to invoke "Right" speech UI.
+		),
+	)
 	_setConfig(SymLevel.ALL)
 	spy = _NvdaLib.getSpyLib()
 	expected = "shouldn't sub tick symbol"
 	spy.override_translationString(EndSpeech.RIGHT.value, expected)
+
+	# get to the end char
+	actual = _pressKeyAndCollectSpeech(Move.REVIEW_CHAR.value, numberOfTimes=1)
+	_builtIn.should_be_equal(
+		actual,
+		["blank"],
+		msg="actual vs expected. Unexpected speech when moving to final character.",
+	)
 
 	actual = _pressKeyAndCollectSpeech(Move.REVIEW_CHAR.value, numberOfTimes=1)
 	_builtIn.should_be_equal(
@@ -611,7 +622,7 @@ def test_symbolInSpeechUI():
 		[
 			# todo: 'tick' is a bug
 			"shouldn tick t sub tick symbol"  # intentionally concatenate strings
-			f"\n{character}",
+			"\nblank",
 		],
 		msg="actual vs expected. NVDA speech UI substitutes symbols",
 	)
@@ -621,7 +632,7 @@ def test_symbolInSpeechUI():
 	actual = _pressKeyAndCollectSpeech(Move.REVIEW_CHAR.value, numberOfTimes=1)
 	_builtIn.should_be_equal(
 		actual,
-		[f"{expected}\n{character}"],
+		[f"{expected}\nblank"],
 		msg="actual vs expected. NVDA speech UI substitutes symbols",
 	)
 


### PR DESCRIPTION
This reverts commit a514710ebc4a5f116322700f53d548e8082fe310.

---
name: Revert PR
about: Revert an existing pull request

---

### Reverts PR
Reverts #18767

### Issues fixed
<!-- Issues that will be closed by reverting, i.e. the issues introduced via the PR getting reverted  -->
This doesn't fix issues, but we are reverting several pull request to let NVDA in a clean state to merge #19204 and fix #19152.
### Issues reopened
<!-- Issues that will be re-opened by reverting, i.e. the issues that were fixed via the PR getting reverted  -->
Reopens: None.

### Reason for revert
When reverting #18348, test are failing, and we need to make test pass to merge other PRs.
### Can this PR be reimplemented? If so, what is required for the next attempt
Perhaps introducing changes in NVDAObjects/window/edit.py, if needed.