### PR TITLE
Update SCons to 4.10.1, introducing VS2026 support

### DIFF
--- a/projectDocs/dev/createDevEnvironment.md
+++ b/projectDocs/dev/createDevEnvironment.md
@@ -58,19 +58,19 @@ Install the python version listed in [.python-versions](../../.python-versions)
 
 #### Microsoft Visual Studio
 
-* Microsoft Visual Studio 2022
+* Microsoft Visual Studio 2022 or 2026
   * To replicate the production build environment, use the [version of Visual Studio 2022 that GitHub Actions is using](https://github.com/actions/runner-images/tree/main/images/windows).
   * If you don't use the Visual Studio IDE itself, you can download the [build tools](https://aka.ms/vs/17/release/vs_BuildTools.exe).
-  * If you do intend to use the Visual Studio IDE (not required for NVDA development), you can download [the community version](https://visualstudio.microsoft.com/vs/community/).
+  * If you do intend to use the Visual Studio IDE (not required for NVDA development), you can download [the community version](https://aka.ms/vs/17/release/vs_Community.exe).
     * The Professional and Enterprise versions are also supported.
-    * Preview versions are *not* supported.
+    * Preview or insiders versions are *not* supported.
 * When installing Visual Studio, additional components must be included:
   * You can automatically fetch these using [NVDAs .vsconfig](../../.vsconfig) using the [import feature of the VS installer](https://learn.microsoft.com/en-us/visualstudio/install/import-export-installation-configurations?view=vs-2022#import-a-configuration).
   * In the list on the Workloads tab, in the Desktop grouping:
     * Desktop development with C++.
       * Once selected, ensure "C++ Clang tools for Windows" is included under the optional grouping.
   * On the Individual components tab, ensure the following items are selected:
-    * Windows 11 SDK (10.0.26100.0)
+    * Windows 11 SDK (10.0.26100.x)
     * MSVC v143 - VS 2022 C++ ARM64/ARM64EC build tools
     * MSVC v143 - VS 2022 C++ x64/x86 build tools
     * C++ ATL for v143 build tools (x86 & x64)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -314,7 +314,7 @@ members = [
 dev = [
 	"nvda-misc-deps",
 	# NVDA's build system is SCons
-	"SCons==4.10.0",
+	"SCons==4.10.1",
 	# Packaging NVDA
 	"py2exe==0.14.0.0",
 	"setuptools~=72.0",

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -333,7 +333,7 @@ Please refer to [the developer guide](https://download.nvaccess.org/documentatio
   * Updated py2exe to 0.14.0.0. (#18611)
   * Updated markdown to 3.8.2. (#18638)
   * Updated detours to `9764cebcb1a75940e68fa83d6730ffaf0f669401`. (#18447, @LeonarddeR)
-  * Updated SCons to 4.10.1. (#19016, @LeonarddeR)
+  * Updated SCons to 4.10.1. (#19016, #19226, @LeonarddeR)
     * This introduces support to build NVDA with Visual Studio 2026.
 * For `IAccessible` objects, the `flowsFrom` and `flowsTo` properties will now raise a `NotImplementedError` for MSAA (non-IA2) objects. (#18416, @LeonarddeR)
 * The `nvda_dmp` utility has been removed. (#18480, @codeofdusk)

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -333,7 +333,8 @@ Please refer to [the developer guide](https://download.nvaccess.org/documentatio
   * Updated py2exe to 0.14.0.0. (#18611)
   * Updated markdown to 3.8.2. (#18638)
   * Updated detours to `9764cebcb1a75940e68fa83d6730ffaf0f669401`. (#18447, @LeonarddeR)
-  * Updated SCons to 4.10.0. (#19016, @LeonarddeR)
+  * Updated SCons to 4.10.1. (#19016, @LeonarddeR)
+    * This introduces support to build NVDA with Visual Studio 2026.
 * For `IAccessible` objects, the `flowsFrom` and `flowsTo` properties will now raise a `NotImplementedError` for MSAA (non-IA2) objects. (#18416, @LeonarddeR)
 * The `nvda_dmp` utility has been removed. (#18480, @codeofdusk)
 * `comInterfaces_sconscript` has been updated to make the generated files in `comInterfaces` work better with IDEs. (#17608, @gexgd0419)

--- a/uv.lock
+++ b/uv.lock
@@ -613,7 +613,7 @@ dev = [
     { name = "nvda-mathcat", editable = "include/nvda-mathcat" },
     { name = "nvda-misc-deps", editable = "miscDeps" },
     { name = "py2exe", specifier = "==0.14.0.0" },
-    { name = "scons", specifier = "==4.10.0" },
+    { name = "scons", specifier = "==4.10.1" },
     { name = "setuptools", specifier = "~=72.0" },
 ]
 dev-docs = [
@@ -1049,11 +1049,11 @@ wheels = [
 
 [[package]]
 name = "scons"
-version = "4.10.0"
+version = "4.10.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/91/ff/2c0bab6e1fcd837c52afd99a37e0cc16f2e1c970d313c3d4bc10b5c047f2/scons-4.10.0.tar.gz", hash = "sha256:61e2fc42e0e2c750105d61f26cc1dfebcae9f4103d3dc0e9aeb373016b0d208c", size = 3257277, upload-time = "2025-10-02T17:40:18.575Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/c9/2f430bb39e4eccba32ce8008df4a3206df651276422204e177a09e12b30b/scons-4.10.1.tar.gz", hash = "sha256:99c0e94a42a2c1182fa6859b0be697953db07ba936ecc9817ae0d218ced20b15", size = 3258403, upload-time = "2025-11-16T22:43:39.258Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/11/36/25bcc902d714fd0c36cc67642c88126e7a139b2e4b89686450f5aa676052/scons-4.10.0-py3-none-any.whl", hash = "sha256:df6f86828035a5c03abce64d4cf2f9c5cbd0051b58af498016bc58bfc05559b0", size = 4135796, upload-time = "2025-10-02T17:40:14.997Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/bf/931fb9fbb87234c32b8b1b1c15fba23472a10777c12043336675633809a7/scons-4.10.1-py3-none-any.whl", hash = "sha256:bd9d1c52f908d874eba92a8c0c0a8dcf2ed9f3b88ab956d0fce1da479c4e7126", size = 4136069, upload-time = "2025-11-16T22:43:35.933Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
SCons was updated recently. This is a necessary step to build NVDA with Visual Studio 2026, which is fully supported.

### Description of user facing changes:
None

### Description of developer facing changes:
Support for building with VS2026 is now there, however note that VS2022 is still the standard.

### Description of development approach:
Updated SCons

### Testing strategy:
Tested a from scratch build with Visual Studio 2026 community.

### Known issues with pull request:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
