### PR TITLE
Fixup MathCAT settings

### DIFF
--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -2753,7 +2753,7 @@ class MathSettingsPanel(SettingsPanel):
 		sHelper.addItem(speechGroup)
 
 		# Translators: Select an impairment for MathCAT
-		impairmentText = pgettext("math", "Generate speech for:")
+		impairmentText = pgettext("math", "Impairment:")
 		self.impairmentList = speechGroup.addLabeledControl(
 			impairmentText,
 			wx.Choice,
@@ -2842,7 +2842,7 @@ class MathSettingsPanel(SettingsPanel):
 		self.pauseFactorSlider.SetValue(config.conf["math"]["speech"]["pauseFactor"])
 
 		# Translators: label for check box controlling a beep sound when math speech starts/ends
-		speechSoundText = pgettext("math", "Make a sound when starting/ending math speech")
+		speechSoundText = pgettext("math", "Beep at the beginning and end of math")
 		self.speechSoundCheckBox = speechGroup.addItem(wx.CheckBox(speechGroupBox, label=speechSoundText))
 		self.bindHelpEvent("MathSpeechSound", self.speechSoundCheckBox)
 		self.speechSoundCheckBox.SetValue(config.conf["math"]["speech"]["speechSound"] != "None")

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -2864,8 +2864,8 @@ class MathSettingsPanel(SettingsPanel):
 		navSpeechOptions: list[str] = [
 			# Translators: "Speak" the expression after moving to it
 			pgettext("math", "Speak"),
-			# Translators: "Describe" the expression after moving to it ("overview is a synonym")
-			pgettext("math", "Describe/overview"),
+			# Translators: "Describe" the expression after moving to it
+			pgettext("math", "Describe overview"),
 		]
 		self.navSpeechList = speechGroup.addLabeledControl(
 			navSpeechText,

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -2753,7 +2753,7 @@ class MathSettingsPanel(SettingsPanel):
 		sHelper.addItem(speechGroup)
 
 		# Translators: Select an impairment for MathCAT
-		impairmentText = pgettext("math", "Impairment")
+		impairmentText = pgettext("math", "Generate speech for:")
 		self.impairmentList = speechGroup.addLabeledControl(
 			impairmentText,
 			wx.Choice,
@@ -2765,7 +2765,7 @@ class MathSettingsPanel(SettingsPanel):
 		)
 
 		# Translators: MathCAT language option
-		languageText = pgettext("math", "Language")
+		languageText = pgettext("math", "Language:")
 		self.languageOptions, self.languageCodes = localization.getLanguages()
 		self.languageList = speechGroup.addLabeledControl(
 			languageText,
@@ -2792,7 +2792,7 @@ class MathSettingsPanel(SettingsPanel):
 		)
 
 		# Translators: Select a speech style.
-		speechStyleText = pgettext("math", "Speech style")
+		speechStyleText = pgettext("math", "Speech style:")
 		self.speechStyleOptions = getSpeechStyleChoicesWithTranslations(
 			config.conf["math"]["speech"]["language"],
 		)
@@ -2808,7 +2808,7 @@ class MathSettingsPanel(SettingsPanel):
 		self.speechStyleList.SetStringSelection(speechStyleDisplayString)
 
 		# Translators: MathCAT's verbosity setting
-		speechAmountText = pgettext("math", "Speech verbosity")
+		speechAmountText = pgettext("math", "Speech verbosity:")
 		self.speechAmountList = speechGroup.addLabeledControl(
 			speechAmountText,
 			wx.Choice,
@@ -2848,7 +2848,7 @@ class MathSettingsPanel(SettingsPanel):
 		self.speechSoundCheckBox.SetValue(config.conf["math"]["speech"]["speechSound"] != "None")
 
 		# Translators: label for combobox to specify how verbose/terse the speech should be
-		speechForChemicalText = pgettext("math", "Speech for chemical formulas")
+		speechForChemicalText = pgettext("math", "Chemical formulae:")
 		self.speechForChemicalList = speechGroup.addLabeledControl(
 			speechForChemicalText,
 			wx.Choice,
@@ -2859,27 +2859,8 @@ class MathSettingsPanel(SettingsPanel):
 			self._getEnumIndexFromConfigValue(ChemistryOption, config.conf["math"]["speech"]["chemistry"]),
 		)
 
-		# Translators: Text for the navigation group.
-		navGroupText = pgettext("math", "Navigation")
-		navGroupSizer = wx.StaticBoxSizer(wx.VERTICAL, self, label=navGroupText)
-		navGroupBox = navGroupSizer.GetStaticBox()
-		navGroup = guiHelper.BoxSizerHelper(self, sizer=navGroupSizer)
-		sHelper.addItem(navGroup)
-
-		# Translators: label for combobox to specify one of three modes use to navigate math expressions
-		navModeText = pgettext("math", "Navigation mode to use when beginning to navigate an equation")
-		self.navModeList = speechGroup.addLabeledControl(
-			navModeText,
-			wx.Choice,
-			choices=[option.displayString for option in NavModeOption],
-		)
-		self.bindHelpEvent("MathNavMode", self.navModeList)
-		self.navModeList.SetSelection(
-			self._getEnumIndexFromConfigValue(NavModeOption, config.conf["math"]["navigation"]["navMode"]),
-		)
-
 		# Translators: label for combobox to specify whether the expression is spoken or described (an overview)
-		navSpeechText = pgettext("math", "Navigation speech to use when beginning to navigate an equation")
+		navSpeechText = pgettext("math", "When entering an equation:")
 		navSpeechOptions: list[str] = [
 			# Translators: "Speak" the expression after moving to it
 			pgettext("math", "Speak"),
@@ -2897,21 +2878,43 @@ class MathSettingsPanel(SettingsPanel):
 		else:
 			self.navSpeechList.SetSelection(0)
 
-		# Translators: label for check box controlling a beep sound when math speech starts/ends
-		resetNavSpeechText = pgettext("math", "Make a sound when starting/ending math speech")
+		# Translators: Text for the navigation group.
+		navGroupText = pgettext("math", "Navigation")
+		navGroupSizer = wx.StaticBoxSizer(wx.VERTICAL, self, label=navGroupText)
+		navGroupBox = navGroupSizer.GetStaticBox()
+		navGroup = guiHelper.BoxSizerHelper(self, sizer=navGroupSizer)
+		sHelper.addItem(navGroup)
+
+		# Translators: label for combobox to specify one of three modes use to navigate math expressions
+		navModeText = pgettext("math", "Default navigation mode:")
+		self.navModeList = navGroup.addLabeledControl(
+			navModeText,
+			wx.Choice,
+			choices=[option.displayString for option in NavModeOption],
+		)
+		self.bindHelpEvent("MathNavMode", self.navModeList)
+		self.navModeList.SetSelection(
+			self._getEnumIndexFromConfigValue(NavModeOption, config.conf["math"]["navigation"]["navMode"]),
+		)
+
+		# Translators: label for check box that determines whether MathCAT
+		# reverts to the user-selected "default navigation mode" when
+		# navigating into a new equation, even if they selected a different
+		# one this session.
+		resetNavSpeechText = pgettext("math", "Reset to the default navigation mode for each new equation")
 		self.resetNavSpeechCheckBox = navGroup.addItem(wx.CheckBox(navGroupBox, label=resetNavSpeechText))
 		self.bindHelpEvent("MathNavReset", self.resetNavSpeechCheckBox)
 		self.resetNavSpeechCheckBox.SetValue(config.conf["math"]["navigation"]["resetOverview"])
 
 		# Translators: label for checkbox that controls whether arrow keys move out of fractions, etc.,
 		# or whether you have to manually back out of the fraction, etc.
-		navAutoZoomText = pgettext("math", "Automatic zoom out of 2D notations")
+		navAutoZoomText = pgettext("math", "Automatically zoom out of two-dimensional notation")
 		self.navAutoZoomCheckBox = navGroup.addItem(wx.CheckBox(navGroupBox, label=navAutoZoomText))
 		self.bindHelpEvent("MathNavAutoZoom", self.navAutoZoomCheckBox)
 		self.navAutoZoomCheckBox.SetValue(config.conf["math"]["navigation"]["autoZoomOut"])
 
 		# Translators: label for combobox down to specify whether you want a terse or verbose reading of navigation commands
-		navSpeechAmountText = pgettext("math", "Speech amount for navigation")
+		navSpeechAmountText = pgettext("math", "Navigation verbosity:")
 		self.navSpeechAmountList = navGroup.addLabeledControl(
 			navSpeechAmountText,
 			wx.Choice,
@@ -2929,7 +2932,7 @@ class MathSettingsPanel(SettingsPanel):
 		)
 
 		# Translators: label for combobox to specify how math will be copied to the clipboard
-		navCopyAsText = pgettext("math", "Copy math as")
+		navCopyAsText = pgettext("math", "Copy math as:")
 		self.navCopyAsList = navGroup.addLabeledControl(
 			navCopyAsText,
 			wx.Choice,
@@ -2947,7 +2950,7 @@ class MathSettingsPanel(SettingsPanel):
 		sHelper.addItem(brailleGroup)
 
 		# Translators: label for combobox to specify which braille code to use
-		brailleMathCodeText = pgettext("math", "Braille math code for refreshable displays")
+		brailleMathCodeText = pgettext("math", "Output code:")
 		availableBrailleCodes: list[str] = preferences.getBrailleCodes()
 		autoBrailleCode = preferences.getAutoBrailleCode(availableBrailleCodes)
 		# Translators: An option in Math settings to select a braille code automatically,
@@ -2957,7 +2960,7 @@ class MathSettingsPanel(SettingsPanel):
 		brailleMathCodeOptions: list[str] = [autoDisplay]
 		self._brailleCodeIds.extend(availableBrailleCodes)
 		brailleMathCodeOptions.extend(availableBrailleCodes)
-		self.brailleMathCodeList = navGroup.addLabeledControl(
+		self.brailleMathCodeList = brailleGroup.addLabeledControl(
 			brailleMathCodeText,
 			wx.Choice,
 			choices=brailleMathCodeOptions,
@@ -2971,8 +2974,8 @@ class MathSettingsPanel(SettingsPanel):
 		self.brailleMathCodeList.SetSelection(selectionIndex)
 
 		# Translators: label for combobox to specify how braille dots should be modified when navigating/selecting subexprs
-		brailleHighlightsText = pgettext("math", "Highlight the current navigation node with dots 7 and 8")
-		self.brailleHighlightsList = navGroup.addLabeledControl(
+		brailleHighlightsText = pgettext("math", "Highlight navigation focus with dots 7 and 8")
+		self.brailleHighlightsList = brailleGroup.addLabeledControl(
 			brailleHighlightsText,
 			wx.Choice,
 			choices=[option.displayString for option in BrailleNavHighlightOption],

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -3241,7 +3241,7 @@ If speech rules for the main language cannot be found, English ("en") is used.
 
 Different styles can be used to speak mathematical content:
 
-* ClearSpeak was developed by the Educational Testing Service for use on high-stakes examinations such as the SAT, a university entrance exam often administored in the United States.
+* ClearSpeak was developed by the Educational Testing Service for use on university-admission and other high-stakes tests in the United States.
 Refer to the [ClearSpeak specification details in this Word document](https://nsoiffer.github.io/MathCAT/ClearSpeakRulesAndPreferences.docx).
 * SimpleSpeak tries to minimize speech by speaking simple expressions such as $\frac{a}{b}$ quickly without bracketing words ("a over b").
 These are distinguished from more complex expressions such as $\frac{a}{b+1}$ which will always have bracketing words ("fraction a over b plus 1 end fraction").
@@ -3275,7 +3275,7 @@ For example, square roots are verbosely spoken as "the square root of x" and ter
 
 Changes the relative speech rate.
 The change is a percentage speed change from the standard speech engine's rate.
-In other words, `100` means the reading rates of text and mathematical content are the same, whereas `50` means that mathematical content is read at half the speed of other content.
+`100` means the reading rates of text and math content are the same, whereas `50` means that math content is read at half the speed of other content.
 
 | . {.hideHeaderRow} | . |
 |---|---|
@@ -3317,7 +3317,7 @@ Whether to speak the expression after moving to it or give an overview.
 
 | . {.hideHeaderRow} | . |
 |---|---|
-| Options | Speak, Overview |
+| Options | Speak, Describe overview |
 | Default | Speak |
 
 ##### Navigation Options {#MathNavigation}
@@ -3339,10 +3339,20 @@ This option selects whether NVDA resets to the default navigation mode when ente
 When this option is disabled, NVDA preserves the last selected navigation mode across equations in the same NVDA session.
 This option is enabled by default.
 
+| . {.hideHeaderRow} | . |
+|---|---|
+| Options | Checked, Unchecked |
+| Default | Checked |
+
 ###### Automatically zoom out of two-dimensional notation {#MathNavAutoZoom}
 
 Auto zoom out of 2D expressions like fractions (use `shift+arrow` to force zoom out if this is unchecked).
 This option is enabled by default.
+
+| . {.hideHeaderRow} | . |
+|---|---|
+| Options | Checked, Unchecked |
+| Default | Checked |
 
 ###### Navigation verbosity {#MathNavSpeechAmount}
 
@@ -3355,7 +3365,7 @@ This option specifies whether NVDA should read mathematical expressions in a ter
 
 ###### Copy math as {#MathNavCopyAs}
 
-This option selects the format of mathematical content copied to the clipboard.
+This option selects the format of math content copied to the clipboard.
 
 | . {.hideHeaderRow} | . |
 |---|---|

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -3295,7 +3295,12 @@ Changes the relative amount of pausing that MathCAT adds.
 ###### Beep at the beginning and end of math {#MathSpeechSound}
 
 This option determines whether NVDA beeps at the beginning and end of math content.
-This option is enabled by default.
+This option is disabled by default.
+
+| . {.hideHeaderRow} | . |
+|---|---|
+| Options | Checked, Unchecked |
+| Default | Unchecked |
 
 ###### Chemical formulae {#MathSpeechForChemical}
 

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -3294,7 +3294,7 @@ Changes the relative amount of pausing that MathCAT adds.
 
 ###### Make a sound when starting/ending math speech {#MathSpeechSound}
 
-This option determines whether NVDA beeps at the beginning and end of mathematical content.
+This option determines whether NVDA beeps at the beginning and end of math content.
 This option is enabled by default.
 
 ###### Chemical formulae {#MathSpeechForChemical}

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -3217,7 +3217,7 @@ This category allows you to adjust how NVDA reads mathematical content.
 
 ##### Speech Options {#MathCATSpeechOptions}
 
-###### Generate speech for {#MathSpeechImpairment}
+###### Impairment {#MathSpeechImpairment}
 
 This controls whether certain notations are disambiguated or not in speech.
 
@@ -3292,7 +3292,7 @@ Changes the relative amount of pausing that MathCAT adds.
 | Options | Number between 0 and 100 |
 | Default | 50 |
 
-###### Make a sound when starting/ending math speech {#MathSpeechSound}
+###### Beep at the beginning and end of math {#MathSpeechSound}
 
 This option determines whether NVDA beeps at the beginning and end of math content.
 This option is enabled by default.

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -1309,9 +1309,8 @@ Backspace will take you back to where you were, which is not always the same as 
 For example, if right arrow moved you out of a fraction, backspace will take you back to where you were in the denominator and left arrow will land on the entire fraction.
 
 You will likely find one mode of navigation the most natural for you most of the time.
-This can be set in the MathCAT settings.
-However, at any time during navigation, you can switch the navigation modes using `shift+up/down arrow`.
-This is useful because each mode of navigation has its strengths and weaknesses.
+The default mode can be set in the math settings panel.
+However, at any time during navigation, you can switch navigation modes using `shift+up/down arrow` to take advantage of the differing strengths of each navigation mode.
 
 ## Braille {#Braille}
 
@@ -3218,7 +3217,7 @@ This category allows you to adjust how NVDA reads mathematical content.
 
 ##### Speech Options {#MathCATSpeechOptions}
 
-###### Impairment {#MathSpeechImpairment}
+###### Generate speech for {#MathSpeechImpairment}
 
 This controls whether certain notations are disambiguated or not in speech.
 
@@ -3240,9 +3239,9 @@ If speech rules for the main language cannot be found, English ("en") is used.
 
 ###### Speech Style {MathSpeechStyle}
 
-Different speech styles are used to change how math is reported.
+Different styles can be used to speak mathematical content:
 
-* ClearSpeak was developed by the Educational Testing Service (ETS) for use on high-stakes tests such as national standardized testing.
+* ClearSpeak was developed by the Educational Testing Service for use on high-stakes examinations such as the SAT, a university entrance exam often administored in the United States.
 Refer to the [ClearSpeak specification details in this Word document](https://nsoiffer.github.io/MathCAT/ClearSpeakRulesAndPreferences.docx).
 * SimpleSpeak tries to minimize speech by speaking simple expressions such as $\frac{a}{b}$ quickly without bracketing words ("a over b").
 These are distinguished from more complex expressions such as $\frac{a}{b+1}$ which will always have bracketing words ("fraction a over b plus 1 end fraction").
@@ -3264,7 +3263,7 @@ Examples of each type of speech:
 
 ###### Speech verbosity {#MathSpeechVerbosity}
 
-Controls how much "extra" speech is used.
+This option controls how much "extra" speech is used.
 For example, square roots are verbosely spoken as "the square root of x" and tersely spoken as "square root x".
 
 | . {.hideHeaderRow} | . |
@@ -3276,7 +3275,7 @@ For example, square roots are verbosely spoken as "the square root of x" and ter
 
 Changes the relative speech rate.
 The change is a percentage speed change from the standard speech engine's rate.
-`100` means the math reading rate is the same as that of the text rate.
+In other words, `100` means the reading rates of text and mathematical content are the same, whereas `50` means that mathematical content is read at half the speed of other content.
 
 | . {.hideHeaderRow} | . |
 |---|---|
@@ -3295,16 +3294,12 @@ Changes the relative amount of pausing that MathCAT adds.
 
 ###### Make a sound when starting/ending math speech {#MathSpeechSound}
 
-A start and end beep occur before and after reading an expression.
+This option determines whether NVDA beeps at the beginning and end of mathematical content.
+This option is enabled by default.
 
-| . {.hideHeaderRow} | . |
-|---|---|
-| Options | None, Beep |
-| Default | None |
+###### Chemical formulae {#MathSpeechForChemical}
 
-###### Speech for chemical formulas {#MathSpeechForChemical}
-
-Controls how chemical formulae are read.
+This option controls how chemical formulae are read.
 Examples for $\mathrm{H}_2\mathrm{O}$:
 
 * SpellOut: "H 2 O" (verbosity controls whether "sub"/"super" is spoken)
@@ -3316,9 +3311,18 @@ Examples for $\mathrm{H}_2\mathrm{O}$:
 | Options | Spell Out, As Compound, Off |
 | Default | SpellOut |
 
+###### When entering an equation {#MathNavSpeech}
+
+Whether to speak the expression after moving to it or give an overview.
+
+| . {.hideHeaderRow} | . |
+|---|---|
+| Options | Speak, Overview |
+| Default | Speak |
+
 ##### Navigation Options {#MathNavigation}
 
-###### Navigation mode to use when beginning to navigate an equation {#MathNavMode}
+###### Default navigation mode {#MathNavMode}
 
 "Enhanced" mode understands math structure.
 "Simple" mode walks by character to find things like fractions, roots, and scripts.
@@ -3329,36 +3333,20 @@ Examples for $\mathrm{H}_2\mathrm{O}$:
 | Options | Enhanced, Character, Simple |
 | Default | Enhanced |
 
-###### Navigation speech to use when beginning to navigate an equation {#MathNavSpeech}
+###### Reset to the default navigation mode for each new equation {#MathNavReset}
 
-Whether to speak the expression after moving to it or give an overview.
+This option selects whether NVDA resets to the default navigation mode when entering a new equation.
+When this option is disabled, NVDA preserves the last selected navigation mode across equations in the same NVDA session.
+This option is enabled by default.
 
-| . {.hideHeaderRow} | . |
-|---|---|
-| Options | Speak, Overview |
-| Default | Speak |
-
-###### Make a sound when starting/ending math speech {#MathNavReset}
-
-Whether to play a beep sound when speech starts/ends.
-
-| . {.hideHeaderRow} | . |
-|---|---|
-| Options | Checked, Unchecked |
-| Default | Checked |
-
-###### Automatic zoom out of 2D notations {#MathNavAutoZoom}
+###### Automatically zoom out of two-dimensional notation {#MathNavAutoZoom}
 
 Auto zoom out of 2D expressions like fractions (use `shift+arrow` to force zoom out if this is unchecked).
+This option is enabled by default.
 
-| . {.hideHeaderRow} | . |
-|---|---|
-| Options | Checked, Unchecked |
-| Default | Checked |
+###### Navigation verbosity {#MathNavSpeechAmount}
 
-###### Speech amount for navigation {#MathNavSpeechAmount}
-
-Specify whether you want a terse or verbose reading of navigation commands.
+This option specifies whether NVDA should read mathematical expressions in a terse or verbose manner during navigation.
 
 | . {.hideHeaderRow} | . |
 |---|---|
@@ -3367,7 +3355,7 @@ Specify whether you want a terse or verbose reading of navigation commands.
 
 ###### Copy math as {#MathNavCopyAs}
 
-Specify how math will be copied to the clipboard.
+This option selects the format of mathematical content copied to the clipboard.
 
 | . {.hideHeaderRow} | . |
 |---|---|
@@ -3376,7 +3364,7 @@ Specify how math will be copied to the clipboard.
 
 ##### Braille Options {#MathBrailleOptions}
 
-###### Braille math code for refreshable displays {#MathBrailleCode}
+###### Output code {#MathBrailleCode}
 
 The braille math code to use.
 When this option is set to "Automatic", NVDA selects a default math braille code based on the current NVDA language.
@@ -3386,9 +3374,9 @@ When this option is set to "Automatic", NVDA selects a default math braille code
 | Options | Automatic, ASCIIMath, ASCIIMath-Finnish, CMU, LaTeX, Nemeth, Swedish, UEB, Vietnam |
 | Default | Automatic |
 
-###### Highlight the current navigation node with dots 7 and 8 {#MathBrailleHighlights}
+###### Highlight navigation focus with dots 7 and 8 {#MathBrailleHighlights}
 
-Highlight the currently selected navigation node with dots 7 and 8.
+This option determines whether NVDA indicates the currently selected subexpression with dots 7 and 8 during navigation.
 The options allow for either no highlighting, only highlighting of the first character, highlighting of the first and last character, or highlighting of the entire subexpression.
 
 | . {.hideHeaderRow} | . |


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Follow-up of #18323.

### Summary of the issue:
Some MathCAT options were unclear and hard to understand.

### Description of how this pull request fixes the issue:
Cleanup UI and documentation.

### Testing strategy:
Tested that settings changes appear as expected. Alpha testing.

### Known issues with pull request:
None known

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
