### PR TITLE
Allow the mathematics settings panel to load for NVDA languages without defined speech styles

### DIFF
--- a/source/mathPres/MathCAT/localization.py
+++ b/source/mathPres/MathCAT/localization.py
@@ -344,14 +344,14 @@ def getSpeechStyles(languageCode: str) -> list[str]:
 		allStyleFiles = list(set(allStyleFiles))  # make them unique
 		if len(allStyleFiles) == 0:
 			# look in the .zip file for the style files -- this will have regional variants, but also have that dir
+			zipFilePath: str = os.path.join(dir, mainLang, f"{mainLang}.zip")
 			try:
-				zipFilePath: str = dir + mainLang + "\\" + mainLang + ".zip"
-				zipFile: ZipFile = ZipFile(zipFilePath, "r")  # file might not exist
-				allStyleFiles = [
-					name.split("/")[-1] for name in zipFile.namelist() if name.endswith("_Rules.yaml")
-				]
+				with ZipFile(zipFilePath, "r") as zipFile:
+					allStyleFiles = [
+						name.split("/")[-1] for name in zipFile.namelist() if name.endswith("_Rules.yaml")
+					]
 			except Exception as e:
-				log.debugWarning(f"MathCAT: didn't find zip file {zipFile}. Error: {e}")
+				log.debugWarning(f"MathCAT: didn't find zip file {zipFilePath}. Error: {e}")
 		allStyleFiles.sort()
 		return allStyleFiles
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Split from #19227.

### Summary of the issue:
On languages without defined speech styles, such as `nl`, the mathematics settings panel does not load.

### Description of how this pull request fixes the issue:
Relocate ZIP file path calculation logic.

### Testing strategy:
Verified that the mathematics settings panel opens when the nVDA language and voice are set to Dutch.

### Known issues with pull request:
None known

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [n/a] Documentation: (out-of-scope, see #19227)
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
