### PR TITLE
Set the default MathCAT Braille code to AsciiMATH

### DIFF
--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -470,7 +470,7 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 		copyAs = string(default="MathML")
 
 	[[braille]]
-		# Any supported braille code (currently Nemeth, UEB)
+		# Any supported braille code
 		brailleCode = string(default="ASCIIMath")
 		# Highlight with dots 7 & 8 the current nav node -- values are Off, FirstChar, EndPoints, All
 		brailleNavHighlight = string(default="EndPoints")

--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -471,7 +471,7 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 
 	[[braille]]
 		# Any supported braille code (currently Nemeth, UEB)
-		brailleCode = string(default="Nemeth")
+		brailleCode = string(default="ASCIIMath")
 		# Highlight with dots 7 & 8 the current nav node -- values are Off, FirstChar, EndPoints, All
 		brailleNavHighlight = string(default="EndPoints")
 		# true/false


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Split from #19227.

### Summary of the issue:
"Nemeth" is unsuitable as a default Braille output code, because:

* Although Unified English Braille is the standard globally for English texts, mathematics codes in the English-speaking world have evolved very differently in different places. A vocal minority of North American Braille users prefer the Nemeth code alongside UEB due to its compactness compared to other systems (especially important on refreshable Braille displays with limited real estate) and/or for traditional or philosophical reasons. Other users find the Nemeth number representation system and modal nature confusing and prefer a system that represents symbols used in mathematical contexts in the same manner as they are represented in other contexts.
* For non-English languages (for instance, various mainland European languages), Nemeth symbols conflict with numbers or other punctuation symbols, making the reading experience potentially misleading.
* Nemeth notation is relatively unknown outside Canada and the US, and is likely to be especially unknown in developing countries.

### Description of how this pull request fixes the issue:
This PR changes the default MathCAT Braille code to ASCIIMath.

ASCIIMath uses the punctuation set selected by the user’s existing output table. This has several advantages:

* It improves clarity for users, since output is based on the symbols typically used by their language’s Braille table.
* It makes logs easier to read for developers and users who do not know Braille, since literal ASCII text for each mathematical expression (rather than a specialized Braille encoding) is sent to LibLouis.
* It is more approachable for users who have not yet learned a specialized mathematics code.
* It avoids making a potentially controversial default choice that is unlikely to suit all users.

Nemeth, UEB, and other specialized codes remain available as options, and will likely be selected by many users, but which specialized code each user selects will depend highly on their background and preferences.

### Testing strategy:
Tested that output appears as expected.

### Known issues with pull request:
We could, for some languages, possibly set a smarter default (for instance, CMU is uncontroversial in the Spanish blind community), but that could be done (or not done) at a future time. ASCIIMath is never completely wrong, even if it is not always the optimal choice.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [n/a] Documentation: (out-of-scope, see #19227)
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
