### PR TITLE
Show dialog to enable image desc once if it is not enabled in settings panel

### DIFF
--- a/source/_localCaptioner/imageDescriber.py
+++ b/source/_localCaptioner/imageDescriber.py
@@ -114,8 +114,9 @@ class ImageDescriber:
 		imageData = _screenshotNavigator()
 
 		if not self.isModelLoaded:
-			# Translators: Message when image description is not enabled
-			ui.message(pgettext("imageDesc", "image description is not enabled"))
+			from gui._localCaptioner.messageDialogs import openEnableOnceDialog
+			# Ask to enable image desc only in this session, No configuration modifications
+			wx.CallAfter(openEnableOnceDialog)
 			return
 
 		self.captionThread = threading.Thread(

--- a/source/_localCaptioner/imageDescriber.py
+++ b/source/_localCaptioner/imageDescriber.py
@@ -115,6 +115,7 @@ class ImageDescriber:
 
 		if not self.isModelLoaded:
 			from gui._localCaptioner.messageDialogs import openEnableOnceDialog
+
 			# Ask to enable image desc only in this session, No configuration modifications
 			wx.CallAfter(openEnableOnceDialog)
 			return

--- a/source/gui/_localCaptioner/messageDialogs.py
+++ b/source/gui/_localCaptioner/messageDialogs.py
@@ -191,4 +191,3 @@ def openEnableOnceDialog() -> None:
 		# load image desc in this session
 		if not _localCaptioner.isModelLoaded():
 			_localCaptioner.toggleImageCaptioning()
-

--- a/source/gui/_localCaptioner/messageDialogs.py
+++ b/source/gui/_localCaptioner/messageDialogs.py
@@ -177,7 +177,7 @@ def openEnableOnceDialog() -> None:
 	dialog = MessageDialog(
 		parent=None,
 		# Translators: title of dialog when enable image desc
-		title=pgettext("imageDesc", "Enable image description right now?"),
+		title=pgettext("imageDesc", "Enable AI image descriptions"),
 		message=pgettext(
 			"imageDesc",
 			# Translators: label of dialog when enable image desc

--- a/source/gui/_localCaptioner/messageDialogs.py
+++ b/source/gui/_localCaptioner/messageDialogs.py
@@ -166,3 +166,29 @@ class ImageDescDownloader:
 		self._progressDialog.Destroy()
 		self._progressDialog = None
 		ImageDescDownloader.isOpening = False
+
+
+def openEnableOnceDialog() -> None:
+	confirmationButtons = (
+		DefaultButton.YES.value._replace(defaultFocus=True, fallbackAction=False),
+		DefaultButton.NO.value._replace(defaultFocus=False, fallbackAction=True),
+	)
+
+	dialog = MessageDialog(
+		parent=None,
+		# Translators: title of dialog when enable image desc
+		title=pgettext("imageDesc", "Enable image description right now?"),
+		message=pgettext(
+			"imageDesc",
+			# Translators: label of dialog when enable image desc
+			"AI image description is not enabled, would you like to enable it right now?",
+		),
+		dialogType=DialogType.STANDARD,
+		buttons=confirmationButtons,
+	)
+
+	if dialog.ShowModal() == ReturnCode.YES:
+		# load image desc in this session
+		if not _localCaptioner.isModelLoaded():
+			_localCaptioner.toggleImageCaptioning()
+


### PR DESCRIPTION

<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
<!-- Use Closes/Fixes/Resolves #xxx to link this PR to the issue it is responding to. -->
Resolves #19097
### Summary of the issue:
Users need to open settings panel to enable image description
### Description of user facing changes:
If image description is not enabled in settings pannel, it will show a dialog to enable it in current session when press the keyboard shortcut  
### Description of developer facing changes:
Nonne
### Description of development approach:
None
### Testing strategy:
Disable image description in settings panel, then press the keyboard shortcut to enable it in a dialog.
### Known issues with pull request:
After enabling it requires another key press for recognition, but I think this is acceptable
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
