### PR TITLE
Ensure multiselectable is discarded for TableCell

### DIFF
--- a/source/controlTypes/processAndLabelStates.py
+++ b/source/controlTypes/processAndLabelStates.py
@@ -14,18 +14,18 @@ from .state import STATES_LINK_TYPE, STATES_SORTED, State
 
 def _processPositiveStates(
 	role: Role,
-	states: Set[State],
+	states: set[State],
 	reason: OutputReason,
-	positiveStates: Optional[Set[State]] = None,
-) -> Set[State]:
+	positiveStates: set[State] | None = None,
+) -> set[State]:
 	"""Processes the states for an object and returns the positive states to output for a specified reason.
 	For example, if C{State.CHECKED} is in the returned states, it means that the processed object is checked.
-	@param role: The role of the object to process states for (e.g. C{Role.CHECKBOX}).
-	@param states: The raw states for an object to process.
-	@param reason: The reason to process the states (e.g. C{OutputReason.FOCUS}).
-	@param positiveStates: Used for C{OutputReason.CHANGE}, specifies states changed from negative to
+	:param role: The role of the object to process states for (e.g. C{Role.CHECKBOX}).
+	:param states: The raw states for an object to process.
+	:param reason: The reason to process the states (e.g. C{OutputReason.FOCUS}).
+	:param positiveStates: Used for C{OutputReason.CHANGE}, specifies states changed from negative to
 	positive.
-	@return: The processed positive states.
+	:return: The processed positive states.
 	"""
 	positiveStates = positiveStates.copy() if positiveStates is not None else states.copy()
 	# The user never cares about certain states.
@@ -35,7 +35,14 @@ def _processPositiveStates(
 		positiveStates.discard(State.VISITED)
 		positiveStates.discard(State.INTERNAL_LINK)
 	positiveStates.discard(State.SELECTABLE)
-	if not config.conf["presentation"]["reportMultiSelect"]:
+	if not config.conf["presentation"]["reportMultiSelect"] or role in (
+		Role.LISTITEM,
+		Role.TREEVIEWITEM,
+		Role.MENUITEM,
+		Role.TABLEROW,
+		Role.TABLECELL,
+		Role.CHECKBOX,
+	):
 		positiveStates.discard(State.MULTISELECTABLE)
 	positiveStates.discard(State.FOCUSABLE)
 	positiveStates.discard(State.CHECKABLE)
@@ -75,7 +82,6 @@ def _processPositiveStates(
 			and State.SELECTABLE in states
 		):
 			positiveStates.discard(State.SELECTED)
-			positiveStates.discard(State.MULTISELECTABLE)
 	if role not in (Role.EDITABLETEXT, Role.CHECKBOX):
 		positiveStates.discard(State.READONLY)
 	if role == Role.CHECKBOX:

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -2492,7 +2492,7 @@ class ObjectPresentationPanel(SettingsPanel):
 
 		# Translators: This is the label for a checkbox in the
 		# object presentation settings panel.
-		reportMultiSelectText = _("Report when lists support &multiple selection")
+		reportMultiSelectText = _("Report when objects support &multiple selection")
 		self.reportMultiSelectCheckBox = sHelper.addItem(wx.CheckBox(self, label=reportMultiSelectText))
 		self.bindHelpEvent("ReportMultiSelect", self.reportMultiSelectCheckBox)
 		self.reportMultiSelectCheckBox.SetValue(

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -2911,9 +2911,9 @@ If reporting of object position information is turned on, this option allows NVD
 
 When on, NVDA will report position information for more controls such as menus and toolbars, however this information may be slightly inaccurate.
 
-##### Report when lists support multiple selection {#ReportMultiSelect}
+##### Report when objects support multiple selection {#ReportMultiSelect}
 
-When this option is enabled, NVDA will report when a list box supports selecting multiple items.
+When this option is enabled, NVDA will report when an object, such as a list box, supports selecting multiple items.
 As it is usually possible to infer multiple selection support from the context of a list box, this option is disabled by default.
 
 ##### Report Object descriptions {#ObjectPresentationReportDescriptions}


### PR DESCRIPTION
### Link to issue number:
Fixes #19242 

### Summary of the issue:
NVDA was reporting multieselectable for every table cell in Libre Office Calc.

### Description of user facing changes:
1. No longer redundant multiselectable reporting
2. Since the table in Libre Office has the multieselectable state, reword the option in settings to talk about object, not specifically lists.

### Description of developer facing changes:
None

### Description of development approach:
Simplified code for discarding into a single separate if branch that also includes table cells.

### Testing strategy:
Tested in Libre Office calc.

### Known issues with pull request:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
