### PR TITLE
Fix NVDA reading the Unicode hyphen (U+2010) as hyphen (#19114)

### DIFF
--- a/source/locale/en/symbols.dic
+++ b/source/locale/en/symbols.dic
@@ -96,6 +96,7 @@ _	line	most
 ′	prime	some
 ″	double prime	some
 ‴	triple prime	some
+‐	hyphen	most	always
 
 # Other characters
 •	bullet	some


### PR DESCRIPTION

<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
<!-- Use Closes/Fixes/Resolves #xxx to link this PR to the issue it is responding to. -->
Resolves #19114
### Summary of the issue:
NVDA reads the Unicode hyphen (U+2010) differently from the standard ASCII hyphen-minus (U+002D). When U+2010 appears inside compound words like "open‑source", NVDA would read it explicitly as “open hyphen source” which is incorrect. 
### Description of user facing changes:
Compound words containing U+2010 are now read naturally without calling out “hyphen.” 
### Description of developer facing changes:
Added the following line to source/locale/en/symbols.dic under Standard punctuation/symbols: 
`hyphen  most  always`
This ensures U+2010 is preserved inside words but not spoken explicitly.
### Description of development approach:
U+2010 (Unicode hyphen) previously had level=0 and preserve=0, causing it to be read aloud as “hyphen” inside words. By adding an entry in source/locale/en/symbols.dic: This sets an appropriate level and preserve value so that U+2010 is preserved in compound words but not explicitly spoken.
### Testing strategy:
Manually tested examples:
- open‑source          -> "open source"          (U+2010)
- open-source          -> "open source"          (U+002D)
- utility‑first        -> "utility first"        (U+2010)
- GDPR‑compliant       -> "GDPR compliant"       (U+2010)
- out‑of‑the‑box       -> "out of the box"       (U+2010)
   
Confirms that NVDA is reading these compound words read correctly, with "hyphen" now not being spoken explicitly in the U+2010 case.
### Known issues with pull request:
Note that due to the small nature of this change, I decided not to include a change log entry.
Currently, this change only updates `source/locale/en/symbols.dic`. It is unclear whether U+2010 should also be added to other locales and may require further review.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
