### PR TITLE
Update NVDA license information in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,7 @@ The NVDA project is guided by a [product vision statement and set of principles]
 The vision and principles should be always considered when planning features and prioritizing work.
 NV Access also maintains a [development roadmap](https://www.nvaccess.org/post/nvda-roadmap/) of NVDA features and supporting infrastructure work.
 
-NVDA is available under a modified GNU General Public License version 2.
+NVDA is available under a modified GNU General Public License version 2 or later.
 Please refer to [our license](./copying.txt) for more information.
 
 ## Acknowledgements


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
#19003 follow up 

### Summary of the issue:

This pull request makes a minor update to the licensing information in the project documentation. The change clarifies that NVDA is available under a modified GNU General Public License version 2 or any later version.

Updated the license statement in `readme.md` to specify "version 2 or later" rather than just "version 2" for the GNU General Public License.
