### PR TITLE
fix crowdin sync to beta by running pyright locally

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -159,3 +159,6 @@ repos:
     - id: pyright
       name: type check with pyright
       entry: uv run pyright
+      language: system
+      types_or: [python, pyw]
+      pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -161,4 +161,3 @@ repos:
       entry: uv run pyright
       language: system
       types: [python]
-      pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -160,5 +160,5 @@ repos:
       name: type check with pyright
       entry: uv run pyright
       language: system
-      types_or: [python, pyw]
+      types: [python]
       pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -109,13 +109,6 @@ repos:
     - id: ruff-format
       name: format with ruff
 
-- repo: https://github.com/RobertCraigie/pyright-python
-  rev: v1.1.407
-  hooks:
-  - id: pyright
-    name: Check types with pyright
-    additional_dependencies: [ "pyright[nodejs]==1.1.407" ]
-
 - repo: https://github.com/astral-sh/uv-pre-commit
   rev: 0.9.11
   hooks:
@@ -163,3 +156,6 @@ repos:
       entry: ./runlicensecheck.bat
       language: script
       pass_filenames: false
+    - id: pyright
+      name: type check with pyright
+      entry: uv run pyright


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
None

### Summary of the issue:
Fetching translations from Crowdin is failing because pre-commit is failing to install on the github actions image.
This is because pyright is failing to install.
We rely on pre-commit to ensure translated files don't introduce regressions.
https://github.com/nvaccess/nvda/actions/runs/19559152241

### Description of user facing changes:
none

### Description of developer facing changes:
run pyright with uv directly when using pre-commit. This might result in slightly different output to the official hook.

This has the following benefits:
- we don't need to manually sync versions
- it matches closer to what we run in GitHub CI (ci/scripts/tests/typeCheck.ps1), as pre-commit CI doesn't support pyright anyway

### Description of development approach:

See above

### Testing strategy:
We need to test this by getting this on beta's pre-commit yml file
### Known issues with pull request:
None
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
