### PR TITLE
Fix an error message in speech manager

### DIFF
--- a/source/speech/manager.py
+++ b/source/speech/manager.py
@@ -495,7 +495,7 @@ class SpeechManager(object):
 		utteranceIndex = self._getUtteranceIndex(utterance)
 		if utteranceIndex is None:
 			raise IndexError(
-				f"no utterance index({utteranceIndex}, cant save cancellable commands",
+				f"no utterance index({utterance}), can't save cancellable commands",
 			)
 		cancellableItems = list(
 			item for item in reversed(utterance) if isinstance(item, _CancellableSpeechCommand)


### PR DESCRIPTION
Small logging fix (found while debugging an add-on)

### Link to issue number:
None

### Summary of the issue:
In speech manager code, there is an error logging unuseful information, i.e. always `None`.:
`IndexError: no utterance index(None, cant save cancellable commands`

### Description of user facing changes:
Log the more usefule value of `utterance` instead of `utteranceIndex` which is always `None` in this case.

### Description of developer facing changes:
N/A
### Description of development approach:
Log the more usefule value of `utterance` instead of `utteranceIndex` which is always `None` in this case.
### Testing strategy:
In Python console, enter the following call (with a malformed speech sequence):
`speech.speak(['Hello world', None])`

### Known issues with pull request:
None
### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
