### PR TITLE
Fix disabling then enabling touch support

### DIFF
--- a/source/touchHandler.py
+++ b/source/touchHandler.py
@@ -12,6 +12,7 @@ import threading
 from ctypes import (
 	byref,
 	Structure,
+	c_void_p,
 	sizeof,
 	cast,
 	c_int,
@@ -306,7 +307,8 @@ class TouchHandler(threading.Thread):
 		winBindings.oleacc.AccSetRunningUtilityState(self._touchWindow, ANRUS_TOUCH_MODIFICATION_ACTIVE, 0)
 		user32.UnregisterPointerInputTarget(self._touchWindow, PT_TOUCH)
 		user32.DestroyWindow(self._touchWindow)
-		user32.UnregisterClass(self._wca, self._appInstance)
+		# The class atom should be stored as the low word of the class name string pointer.
+		user32.UnregisterClass(cast(c_void_p(self._wca), LPCWSTR), self._appInstance)
 
 	def inputTouchWndProc(self, hwnd, msg, wParam, lParam):
 		if msg >= _WM_POINTER_FIRST and msg <= _WM_POINTER_LAST:


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
On 64-bit versions of NVDA, disabling touch support then reenabling it causes an error. This subsequently renders the settings dialog inoperable.

### Description of user facing changes:
Disabling and re-enabling touch support works correctly.

### Description of developer facing changes:
NOne

### Description of development approach:
Cast the window class attom to `LPCWSTR` before passing to `UnregisterClass`, as ctypes does not know that the integer atom is a valid value in this case.

### Testing strategy:
Built a self-signed launcher, installed it, then disabled and re-enabled touch support via the settings dialog.

### Known issues with pull request:
None

### Code Review Checklist:
- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
