### PR TITLE
Move settings to Privacy and Security category

### DIFF
--- a/source/config/configFlags.py
+++ b/source/config/configFlags.py
@@ -13,6 +13,7 @@ the default value.
 
 from typing import TYPE_CHECKING
 from enum import unique, verify, CONTINUOUS
+from logHandler import Logger
 from utils.displayString import (
 	DisplayStringFlag,
 	DisplayStringIntEnum,
@@ -405,4 +406,33 @@ class RemoteServerType(DisplayStringFlag):
 			RemoteServerType.EXISTING: pgettext("remote", "Use existing"),
 			# Translators: Use NVDA as the Remote control server
 			RemoteServerType.LOCAL: pgettext("remote", "Host locally"),
+		}
+
+
+class LoggingLevel(DisplayStringIntEnum):
+	"""Enumeration containing the possible logging levels.
+
+	Use LoggingLevel.MEMBER.value to compare with the config;
+	use LoggingLevel.MEMBER.displayString in the UI for a translatable description of this member.
+	"""
+
+	OFF = Logger.OFF
+	INFO = Logger.INFO
+	DEBUGWARNING = Logger.DEBUGWARNING
+	IO = Logger.IO
+	DEBUG = Logger.DEBUG
+
+	@property
+	def _displayStringLabels(self) -> dict[int, str]:
+		return {
+			# Translators: One of the log levels of NVDA (the disabled mode turns off logging completely).
+			self.OFF: _("disabled"),
+			# Translators: One of the log levels of NVDA (the info mode shows info as NVDA runs).
+			self.INFO: _("info"),
+			# Translators: One of the log levels of NVDA (the debug warning shows debugging messages and warnings as NVDA runs).
+			self.DEBUGWARNING: _("debug warning"),
+			# Translators: One of the log levels of NVDA (the input/output shows keyboard commands and/or braille commands as well as speech and/or braille output of NVDA).
+			self.IO: _("input/output"),
+			# Translators: One of the log levels of NVDA (the debug mode shows debug messages as NVDA runs).
+			self.DEBUG: _("debug"),
 		}

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -801,18 +801,6 @@ class GeneralSettingsPanel(SettingsPanel):
 	# Translators: This is the label for the general settings panel.
 	title = _("General")
 	helpId = "GeneralSettings"
-	LOG_LEVELS = (
-		# Translators: One of the log levels of NVDA (the disabled mode turns off logging completely).
-		(log.OFF, _("disabled")),
-		# Translators: One of the log levels of NVDA (the info mode shows info as NVDA runs).
-		(log.INFO, _("info")),
-		# Translators: One of the log levels of NVDA (the debug warning shows debugging messages and warnings as NVDA runs).
-		(log.DEBUGWARNING, _("debug warning")),
-		# Translators: One of the log levels of NVDA (the input/output shows keyboard commands and/or braille commands as well as speech and/or braille output of NVDA).
-		(log.IO, _("input/output")),
-		# Translators: One of the log levels of NVDA (the debug mode shows debug messages as NVDA runs).
-		(log.DEBUG, _("debug")),
-	)
 
 	def makeSettings(self, settingsSizer):
 		settingsSizerHelper = guiHelper.BoxSizerHelper(self, sizer=settingsSizer)
@@ -870,27 +858,6 @@ class GeneralSettingsPanel(SettingsPanel):
 		self.bindHelpEvent("GeneralSettingsPlaySounds", self.playStartAndExitSoundsCheckBox)
 		self.playStartAndExitSoundsCheckBox.SetValue(config.conf["general"]["playStartAndExitSounds"])
 		settingsSizerHelper.addItem(self.playStartAndExitSoundsCheckBox)
-
-		# Translators: The label for a setting in general settings to select logging level of NVDA as it runs
-		# (available options and what they are logging are found under comments for the logging level messages
-		# themselves).
-		logLevelLabelText = _("L&ogging level:")
-		logLevelChoices = [name for level, name in self.LOG_LEVELS]
-		self.logLevelList = settingsSizerHelper.addLabeledControl(
-			logLevelLabelText,
-			wx.Choice,
-			choices=logLevelChoices,
-		)
-		self.bindHelpEvent("GeneralSettingsLogLevel", self.logLevelList)
-		curLevel = log.getEffectiveLevel()
-		if logHandler.isLogLevelForced():
-			self.logLevelList.Disable()
-		for index, (level, name) in enumerate(self.LOG_LEVELS):
-			if level == curLevel:
-				self.logLevelList.SetSelection(index)
-				break
-		else:
-			log.debugWarning("Could not set log level list to current log level")
 
 		# Translators: The label for a setting in general settings to allow NVDA to start after logging onto
 		# Windows (if checked, NVDA will start automatically after logging into Windows; if not, user must
@@ -1107,10 +1074,6 @@ class GeneralSettingsPanel(SettingsPanel):
 		config.conf["general"]["saveConfigurationOnExit"] = self.saveOnExitCheckBox.IsChecked()
 		config.conf["general"]["askToExit"] = self.askToExitCheckBox.IsChecked()
 		config.conf["general"]["playStartAndExitSounds"] = self.playStartAndExitSoundsCheckBox.IsChecked()
-		logLevel = self.LOG_LEVELS[self.logLevelList.GetSelection()][0]
-		if not logHandler.isLogLevelForced():
-			config.conf["general"]["loggingLevel"] = logging.getLevelName(logLevel)
-			logHandler.setLogLevelFromConfig()
 		if self.startAfterLogonCheckBox.IsEnabled():
 			config.setStartAfterLogon(self.startAfterLogonCheckBox.GetValue())
 		if self.startOnLogonScreenCheckBox.IsEnabled():
@@ -5966,6 +5929,19 @@ class PrivacyAndSecuritySettingsPanel(SettingsPanel):
 	title = _("Privacy and Security")
 	helpId = "PrivacyAndSecuritySettings"
 
+	LOG_LEVELS = (
+		# Translators: One of the log levels of NVDA (the disabled mode turns off logging completely).
+		(log.OFF, _("disabled")),
+		# Translators: One of the log levels of NVDA (the info mode shows info as NVDA runs).
+		(log.INFO, _("info")),
+		# Translators: One of the log levels of NVDA (the debug warning shows debugging messages and warnings as NVDA runs).
+		(log.DEBUGWARNING, _("debug warning")),
+		# Translators: One of the log levels of NVDA (the input/output shows keyboard commands and/or braille commands as well as speech and/or braille output of NVDA).
+		(log.IO, _("input/output")),
+		# Translators: One of the log levels of NVDA (the debug mode shows debug messages as NVDA runs).
+		(log.DEBUG, _("debug")),
+	)
+
 	def makeSettings(self, sizer: wx.BoxSizer):
 		sHelper = guiHelper.BoxSizerHelper(self, sizer=sizer)
 
@@ -6010,6 +5986,27 @@ class PrivacyAndSecuritySettingsPanel(SettingsPanel):
 		self._screenCurtainPlayToggleSoundsCheckbox.SetValue(self._screenCurtainConfig["playToggleSounds"])
 		self.bindHelpEvent("ScreenCurtainPlayToggleSounds", self._screenCurtainPlayToggleSoundsCheckbox)
 
+		# Translators: The label for a setting in general settings to select logging level of NVDA as it runs
+		# (available options and what they are logging are found under comments for the logging level messages
+		# themselves).
+		logLevelLabelText = _("L&ogging level:")
+		logLevelChoices = [name for level, name in self.LOG_LEVELS]
+		self.logLevelList = sHelper.addLabeledControl(
+			logLevelLabelText,
+			wx.Choice,
+			choices=logLevelChoices,
+		)
+		self.bindHelpEvent("GeneralSettingsLogLevel", self.logLevelList)
+		curLevel = log.getEffectiveLevel()
+		if logHandler.isLogLevelForced():
+			self.logLevelList.Disable()
+		for index, (level, name) in enumerate(self.LOG_LEVELS):
+			if level == curLevel:
+				self.logLevelList.SetSelection(index)
+				break
+		else:
+			log.debugWarning("Could not set log level list to current log level")
+
 	def onSave(self):
 		# We intentionally don't save whether the screen curtain is enabled here,
 		# so we don't unintentionally persist a temporary screen curtain to config.
@@ -6017,6 +6014,11 @@ class PrivacyAndSecuritySettingsPanel(SettingsPanel):
 		self._screenCurtainConfig["playToggleSounds"] = (
 			self._screenCurtainPlayToggleSoundsCheckbox.IsChecked()
 		)
+
+		logLevel = self.LOG_LEVELS[self.logLevelList.GetSelection()][0]
+		if not logHandler.isLogLevelForced():
+			config.conf["general"]["loggingLevel"] = logging.getLevelName(logLevel)
+			logHandler.setLogLevelFromConfig()
 
 	def _ocrActive(self) -> bool:
 		"""

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -5975,7 +5975,14 @@ class PrivacyAndSecuritySettingsPanel(SettingsPanel):
 		self._screenCurtainPlayToggleSoundsCheckbox.SetValue(self._screenCurtainConfig["playToggleSounds"])
 		self.bindHelpEvent("ScreenCurtainPlayToggleSounds", self._screenCurtainPlayToggleSoundsCheckbox)
 
-		self._logLevelCombo: wx.Choice = sHelper.addLabeledControl(
+		# Translators: name of a grouping in Privacy and Security settings
+		# which contains miscellaneous settings.
+		generalSizer = wx.StaticBoxSizer(wx.VERTICAL, self, label=_("General"))
+		generalBox = generalSizer.GetStaticBox()
+		generalGroup = guiHelper.BoxSizerHelper(self, sizer=generalSizer)
+		sHelper.addItem(generalGroup)
+
+		self._logLevelCombo: wx.Choice = generalGroup.addLabeledControl(
 			# Translators: The label for a setting in privacy and security settings to select NVDA's logging level
 			_("L&ogging level:"),
 			wx.Choice,
@@ -5993,9 +6000,9 @@ class PrivacyAndSecuritySettingsPanel(SettingsPanel):
 			log.debugWarning("Could not set log level list to current log level")
 
 		if updateCheck:
-			self._allowUsageStatsCheckBox: wx.CheckBox = sHelper.addItem(
+			self._allowUsageStatsCheckBox: wx.CheckBox = generalGroup.addItem(
 				# Translators: The label of a checkbox in privacy and security settings to toggle allowing of usage stats gathering
-				wx.CheckBox(self, label=_("Allow NV Access to gather NVDA usage statistics")),
+				wx.CheckBox(generalBox, label=_("Allow NV Access to gather NVDA usage statistics")),
 			)
 			self.bindHelpEvent("GeneralSettingsGatherUsageStats", self._allowUsageStatsCheckBox)
 			self._allowUsageStatsCheckBox.Value = config.conf["update"]["allowUsageStats"]

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -923,16 +923,6 @@ class GeneralSettingsPanel(SettingsPanel):
 			if globalVars.appArgs.secure:
 				item.Disable()
 			settingsSizerHelper.addItem(item)
-			item = self.allowUsageStatsCheckBox = wx.CheckBox(
-				self,
-				# Translators: The label of a checkbox in general settings to toggle allowing of usage stats gathering
-				label=_("Allow NV Access to gather NVDA usage statistics"),
-			)
-			self.bindHelpEvent("GeneralSettingsGatherUsageStats", self.allowUsageStatsCheckBox)
-			item.Value = config.conf["update"]["allowUsageStats"]
-			if globalVars.appArgs.secure:
-				item.Disable()
-			settingsSizerHelper.addItem(item)
 
 			# Translators: The label for the update mirror on the General Settings panel.
 			mirrorBoxSizer = wx.StaticBoxSizer(wx.HORIZONTAL, self, label=_("Update mirror"))
@@ -1088,7 +1078,6 @@ class GeneralSettingsPanel(SettingsPanel):
 				)
 		if updateCheck:
 			config.conf["update"]["autoCheck"] = self.autoCheckForUpdatesCheckBox.IsChecked()
-			config.conf["update"]["allowUsageStats"] = self.allowUsageStatsCheckBox.IsChecked()
 			config.conf["update"]["startupNotification"] = self.notifyForPendingUpdateCheckBox.IsChecked()
 			updateCheck.terminate()
 			updateCheck.initialize()
@@ -6003,6 +5992,18 @@ class PrivacyAndSecuritySettingsPanel(SettingsPanel):
 		else:
 			log.debugWarning("Could not set log level list to current log level")
 
+		if updateCheck:
+			item = self.allowUsageStatsCheckBox = wx.CheckBox(
+				self,
+				# Translators: The label of a checkbox in general settings to toggle allowing of usage stats gathering
+				label=_("Allow NV Access to gather NVDA usage statistics"),
+			)
+			self.bindHelpEvent("GeneralSettingsGatherUsageStats", self.allowUsageStatsCheckBox)
+			item.Value = config.conf["update"]["allowUsageStats"]
+			if globalVars.appArgs.secure:
+				item.Disable()
+			sHelper.addItem(item)
+
 	def onSave(self):
 		# We intentionally don't save whether the screen curtain is enabled here,
 		# so we don't unintentionally persist a temporary screen curtain to config.
@@ -6016,6 +6017,10 @@ class PrivacyAndSecuritySettingsPanel(SettingsPanel):
 				self._LOG_LEVELS[self._logLevelCombo.GetSelection()][0],
 			)
 			logHandler.setLogLevelFromConfig()
+
+		if updateCheck:
+			config.conf["update"]["allowUsageStats"] = self.allowUsageStatsCheckBox.IsChecked()
+			# updateCheck queries this value whenever checking for updates, so there's no need to restart it
 
 	def _ocrActive(self) -> bool:
 		"""

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -74,6 +74,7 @@ from config.configFlags import (
 	ShowMessages,
 	TetherTo,
 	TypingEcho,
+	LoggingLevel,
 )
 from logHandler import log
 from synthDriverHandler import SynthDriver, changeVoice, getSynth, getSynthList, setSynth
@@ -5986,17 +5987,22 @@ class PrivacyAndSecuritySettingsPanel(SettingsPanel):
 			# Translators: The label for a setting in privacy and security settings to select NVDA's logging level
 			_("L&ogging level:"),
 			wx.Choice,
-			choices=[name for level, name in self._LOG_LEVELS],
+			choices=[level.displayString for level in LoggingLevel],
 		)
 		self.bindHelpEvent("GeneralSettingsLogLevel", self._logLevelCombo)
 		if logHandler.isLogLevelForced():
 			self._logLevelCombo.Disable()
 		curLevel = log.getEffectiveLevel()
-		for index, (level, name) in enumerate(self._LOG_LEVELS):
-			if level == curLevel:
-				self._logLevelCombo.SetSelection(index)
-				break
-		else:
+		try:
+			self._logLevelCombo.SetSelection(
+				next(
+					filter(
+						lambda indexAndLevel: indexAndLevel[1] == curLevel,
+						enumerate(LoggingLevel.__members__.values()),
+					)
+				)[0]
+			)
+		except StopIteration:
 			log.debugWarning("Could not set log level list to current log level")
 
 		if updateCheck:
@@ -6017,7 +6023,7 @@ class PrivacyAndSecuritySettingsPanel(SettingsPanel):
 
 		if not logHandler.isLogLevelForced():
 			config.conf["general"]["loggingLevel"] = logging.getLevelName(
-				self._LOG_LEVELS[self._logLevelCombo.GetSelection()][0],
+				list(LoggingLevel)[self._logLevelCombo.GetSelection()]
 			)
 			logHandler.setLogLevelFromConfig()
 

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -5993,16 +5993,12 @@ class PrivacyAndSecuritySettingsPanel(SettingsPanel):
 			log.debugWarning("Could not set log level list to current log level")
 
 		if updateCheck:
-			item = self.allowUsageStatsCheckBox = wx.CheckBox(
-				self,
-				# Translators: The label of a checkbox in general settings to toggle allowing of usage stats gathering
-				label=_("Allow NV Access to gather NVDA usage statistics"),
+			self._allowUsageStatsCheckBox = sHelper.addItem(
+				# Translators: The label of a checkbox in privacy and security settings to toggle allowing of usage stats gathering
+				wx.CheckBox(self, label=_("Allow NV Access to gather NVDA usage statistics")),
 			)
-			self.bindHelpEvent("GeneralSettingsGatherUsageStats", self.allowUsageStatsCheckBox)
-			item.Value = config.conf["update"]["allowUsageStats"]
-			if globalVars.appArgs.secure:
-				item.Disable()
-			sHelper.addItem(item)
+			self.bindHelpEvent("GeneralSettingsGatherUsageStats", self._allowUsageStatsCheckBox)
+			self._allowUsageStatsCheckBox.Value = config.conf["update"]["allowUsageStats"]
 
 	def onSave(self):
 		# We intentionally don't save whether the screen curtain is enabled here,
@@ -6019,7 +6015,7 @@ class PrivacyAndSecuritySettingsPanel(SettingsPanel):
 			logHandler.setLogLevelFromConfig()
 
 		if updateCheck:
-			config.conf["update"]["allowUsageStats"] = self.allowUsageStatsCheckBox.IsChecked()
+			config.conf["update"]["allowUsageStats"] = self._allowUsageStatsCheckBox.IsChecked()
 			# updateCheck queries this value whenever checking for updates, so there's no need to restart it
 
 	def _ocrActive(self) -> bool:

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -5929,7 +5929,7 @@ class PrivacyAndSecuritySettingsPanel(SettingsPanel):
 	title = _("Privacy and Security")
 	helpId = "PrivacyAndSecuritySettings"
 
-	LOG_LEVELS = (
+	_LOG_LEVELS: tuple[int, str] = (
 		# Translators: One of the log levels of NVDA (the disabled mode turns off logging completely).
 		(log.OFF, _("disabled")),
 		# Translators: One of the log levels of NVDA (the info mode shows info as NVDA runs).
@@ -5986,23 +5986,19 @@ class PrivacyAndSecuritySettingsPanel(SettingsPanel):
 		self._screenCurtainPlayToggleSoundsCheckbox.SetValue(self._screenCurtainConfig["playToggleSounds"])
 		self.bindHelpEvent("ScreenCurtainPlayToggleSounds", self._screenCurtainPlayToggleSoundsCheckbox)
 
-		# Translators: The label for a setting in general settings to select logging level of NVDA as it runs
-		# (available options and what they are logging are found under comments for the logging level messages
-		# themselves).
-		logLevelLabelText = _("L&ogging level:")
-		logLevelChoices = [name for level, name in self.LOG_LEVELS]
-		self.logLevelList = sHelper.addLabeledControl(
-			logLevelLabelText,
+		self._logLevelCombo = sHelper.addLabeledControl(
+			# Translators: The label for a setting in privacy and security settings to select NVDA's logging level
+			_("L&ogging level:"),
 			wx.Choice,
-			choices=logLevelChoices,
+			choices=[name for level, name in self._LOG_LEVELS],
 		)
-		self.bindHelpEvent("GeneralSettingsLogLevel", self.logLevelList)
-		curLevel = log.getEffectiveLevel()
+		self.bindHelpEvent("GeneralSettingsLogLevel", self._logLevelCombo)
 		if logHandler.isLogLevelForced():
-			self.logLevelList.Disable()
-		for index, (level, name) in enumerate(self.LOG_LEVELS):
+			self._logLevelCombo.Disable()
+		curLevel = log.getEffectiveLevel()
+		for index, (level, name) in enumerate(self._LOG_LEVELS):
 			if level == curLevel:
-				self.logLevelList.SetSelection(index)
+				self._logLevelCombo.SetSelection(index)
 				break
 		else:
 			log.debugWarning("Could not set log level list to current log level")
@@ -6015,9 +6011,10 @@ class PrivacyAndSecuritySettingsPanel(SettingsPanel):
 			self._screenCurtainPlayToggleSoundsCheckbox.IsChecked()
 		)
 
-		logLevel = self.LOG_LEVELS[self.logLevelList.GetSelection()][0]
 		if not logHandler.isLogLevelForced():
-			config.conf["general"]["loggingLevel"] = logging.getLevelName(logLevel)
+			config.conf["general"]["loggingLevel"] = logging.getLevelName(
+				self._LOG_LEVELS[self._logLevelCombo.GetSelection()][0],
+			)
 			logHandler.setLogLevelFromConfig()
 
 	def _ocrActive(self) -> bool:

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -5919,19 +5919,6 @@ class PrivacyAndSecuritySettingsPanel(SettingsPanel):
 	title = _("Privacy and Security")
 	helpId = "PrivacyAndSecuritySettings"
 
-	_LOG_LEVELS: tuple[int, str] = (
-		# Translators: One of the log levels of NVDA (the disabled mode turns off logging completely).
-		(log.OFF, _("disabled")),
-		# Translators: One of the log levels of NVDA (the info mode shows info as NVDA runs).
-		(log.INFO, _("info")),
-		# Translators: One of the log levels of NVDA (the debug warning shows debugging messages and warnings as NVDA runs).
-		(log.DEBUGWARNING, _("debug warning")),
-		# Translators: One of the log levels of NVDA (the input/output shows keyboard commands and/or braille commands as well as speech and/or braille output of NVDA).
-		(log.IO, _("input/output")),
-		# Translators: One of the log levels of NVDA (the debug mode shows debug messages as NVDA runs).
-		(log.DEBUG, _("debug")),
-	)
-
 	def makeSettings(self, sizer: wx.BoxSizer):
 		sHelper = guiHelper.BoxSizerHelper(self, sizer=sizer)
 
@@ -5999,8 +5986,8 @@ class PrivacyAndSecuritySettingsPanel(SettingsPanel):
 					filter(
 						lambda indexAndLevel: indexAndLevel[1] == curLevel,
 						enumerate(LoggingLevel.__members__.values()),
-					)
-				)[0]
+					),
+				)[0],
 			)
 		except StopIteration:
 			log.debugWarning("Could not set log level list to current log level")
@@ -6023,7 +6010,7 @@ class PrivacyAndSecuritySettingsPanel(SettingsPanel):
 
 		if not logHandler.isLogLevelForced():
 			config.conf["general"]["loggingLevel"] = logging.getLevelName(
-				list(LoggingLevel)[self._logLevelCombo.GetSelection()]
+				list(LoggingLevel)[self._logLevelCombo.GetSelection()],
 			)
 			logHandler.setLogLevelFromConfig()
 

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -5975,7 +5975,7 @@ class PrivacyAndSecuritySettingsPanel(SettingsPanel):
 		self._screenCurtainPlayToggleSoundsCheckbox.SetValue(self._screenCurtainConfig["playToggleSounds"])
 		self.bindHelpEvent("ScreenCurtainPlayToggleSounds", self._screenCurtainPlayToggleSoundsCheckbox)
 
-		self._logLevelCombo = sHelper.addLabeledControl(
+		self._logLevelCombo: wx.Choice = sHelper.addLabeledControl(
 			# Translators: The label for a setting in privacy and security settings to select NVDA's logging level
 			_("L&ogging level:"),
 			wx.Choice,
@@ -5993,7 +5993,7 @@ class PrivacyAndSecuritySettingsPanel(SettingsPanel):
 			log.debugWarning("Could not set log level list to current log level")
 
 		if updateCheck:
-			self._allowUsageStatsCheckBox = sHelper.addItem(
+			self._allowUsageStatsCheckBox: wx.CheckBox = sHelper.addItem(
 				# Translators: The label of a checkbox in privacy and security settings to toggle allowing of usage stats gathering
 				wx.CheckBox(self, label=_("Allow NV Access to gather NVDA usage statistics")),
 			)

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -57,8 +57,8 @@ We recommend using Windows 11, or if that is not possible, the latest Windows 10
   * Updated eSpeak NG to [commit `b0b605c8`](https://github.com/espeak-ng/espeak-ng/commit/b0b605c8a80f76c4c19e18033c6780c3cc4afc5b). (#19293)
 * In browse mode in web browsers, NVDA no longer sometimes treats controls with 0 visual width or height as invisible. This technique is sometimes used to make content accessible to screen readers without it being visible visually. Such controls will now be accessible in browse mode where they weren't before. (#13897, @jcsteh)
 * The state of the Screen Curtain is no longer dependent on the configuration profile in use. (#10476)
-* Screen Curtain settings have been moved to the new Privacy and Security category of NVDA's settings. (#19177)
-* The "Logging level" and "Allow NV Access to gather NVDA usage statistics" settings have been moved to the new Privacy and Security category of NVDA's settings. (#19296)
+* A new "Privacy and Security" category has been added to NVDA's settings dialog.
+It currently includes Screen Curtain's settings (previously in the "Vision" category), and the "Logging level" and "Allow NV Access to gather NVDA usage statistics" settings (previously in the "General" category). (#19177, #19296)
 * Support for the MathPlayer software from Wiris has been removed. (#19239)
 * Support for Microsoft Speech API version 4 (SAPI 4) speech synthesizers has been removed. (#19290)
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -58,6 +58,7 @@ We recommend using Windows 11, or if that is not possible, the latest Windows 10
 * In browse mode in web browsers, NVDA no longer sometimes treats controls with 0 visual width or height as invisible. This technique is sometimes used to make content accessible to screen readers without it being visible visually. Such controls will now be accessible in browse mode where they weren't before. (#13897, @jcsteh)
 * The state of the Screen Curtain is no longer dependent on the configuration profile in use. (#10476)
 * Screen Curtain settings have been moved to the new Privacy and Security category of NVDA's settings. (#19177)
+* The "Logging level" and "Allow NV Access to gather NVDA usage statistics" settings have been moved to the new Privacy and Security category of NVDA's settings. (#19296)
 * Support for the MathPlayer software from Wiris has been removed. (#19239)
 * Support for Microsoft Speech API version 4 (SAPI 4) speech synthesizers has been removed. (#19290)
 
@@ -198,6 +199,7 @@ Use `wx.lib.scrolledpanel.ScrolledPanel` directly instead. (#17751)
   * The `synthDrivers.sapi4` module has been removed.
   * `gui.settingsDialogs.AdvancedPanelControls.useWASAPIForSAPI4Combo` has been removed.
   * `config.conf["speech"]["useWASAPIForSAPI4"]` is no longer part of NVDA's configuration schema.
+* The following symbols have been removed from `gui.settingsDialogs.GeneralSettingsPanel`: `LOG_LEVELS`, `logLevelList`, `allowUsageStatsCheckBox`. (#19296)
 
 #### Deprecations
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -199,7 +199,9 @@ Use `wx.lib.scrolledpanel.ScrolledPanel` directly instead. (#17751)
   * The `synthDrivers.sapi4` module has been removed.
   * `gui.settingsDialogs.AdvancedPanelControls.useWASAPIForSAPI4Combo` has been removed.
   * `config.conf["speech"]["useWASAPIForSAPI4"]` is no longer part of NVDA's configuration schema.
-* The following symbols have been removed from `gui.settingsDialogs.GeneralSettingsPanel`: `LOG_LEVELS`, `logLevelList`, `allowUsageStatsCheckBox`. (#19296)
+* The following symbols have been removed from `gui.settingsDialogs.GeneralSettingsPanel` without replacement: `logLevelList`, `allowUsageStatsCheckBox`. (#19296)
+* `gui.settingsDialogs.GeneralSettingsPanel.LOG_LEVELS` has been removed.
+Use `config.configFlags.LoggingLevel` instead. (#19296)
 
 #### Deprecations
 

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -527,9 +527,10 @@ The third lets you control if this Welcome dialog should appear each time NVDA s
 #### Data usage statistics dialog {#UsageStatsDialog}
 
 When starting NVDA for the first time, a dialog will appear which will ask you if you want to accept sending data to NV Access while using NVDA, in order to help improve NVDA in the future.
-You can read more info about the data gathered by NV Access in the general settings section, [Allow NV Access to gather NVDA usage statistics](#GeneralSettingsGatherUsageStats).
-Note: pressing on "yes" or "no" will save this setting and the dialog will never appear again unless you reinstall NVDA.
-However, you can enable or disable the data gathering process manually in NVDA's general settings panel. For changing this setting manually, you can check or uncheck the checkbox called [Allow the NVDA project to gather NVDA usage statistics](#GeneralSettingsGatherUsageStats).
+You can read more info about the data gathered by NV Access in the Privacy and Security Settings section, [Allow NV Access to gather NVDA usage statistics](#GeneralSettingsGatherUsageStats).
+
+Note: pressing "yes" or "no" will save this setting and the dialog will not appear again unless you reinstall NVDA or reset your configuration.
+You can enable or disable the data gathering process manually in the [Privacy and Security category](#PrivacyAndSecuritySettings) of the [NVDA Settings dialog](#NVDASettings).
 
 ### About NVDA keyboard commands {#AboutNVDAKeyboardCommands}
 
@@ -1888,21 +1889,6 @@ The following information is always sent:
 * Operating System version
 * Whether the Operating System is 64 or 32 bit
 
-##### Allow NV Access to gather NVDA usage statistics {#GeneralSettingsGatherUsageStats}
-
-If this is enabled, NV Access will use the information from update checks in order to track the number of NVDA users including particular demographics such as the operating system and country of origin.
-Note that although your IP address will be used to calculate your country during the update check, the IP address is never kept.
-Apart from the mandatory information required to check for updates, the following extra information is also currently sent:
-
-* A unique ID for the current NVDA user, this changes once a month
-* NVDA interface language
-* Whether this copy of NVDA is portable or installed
-* Name of the current speech synthesizer in use (including the name of the add-on the driver comes from)
-* Name of the current Braille display in use (including the name of the add-on the driver comes from)
-* The current output Braille table (if Braille is in use)
-
-This information greatly aides NV Access to prioritize future development of NVDA.
-
 ##### Notify for pending updates on startup {#GeneralSettingsNotifyPendingUpdates}
 
 If this is enabled, NVDA will inform you when there is a pending update on startup, offering you the possibility to install it.
@@ -2643,6 +2629,21 @@ The available logging levels are:
 If you are concerned about privacy, do not set the logging level to this option.
 * Debug: In addition to info, warning, and input/output messages, additional debug messages will be logged.
 Just like input/output, if you are concerned about privacy, you should not set the logging level to this option.
+
+##### Allow NV Access to gather NVDA usage statistics {#GeneralSettingsGatherUsageStats}
+
+If this is enabled, NV Access will use the information from update checks in order to track the number of NVDA users including particular demographics such as the operating system and country of origin.
+Note that although your IP address will be used to calculate your country during the update check, the IP address is never kept.
+Apart from the [mandatory information required to check for updates](#GeneralSettingsCheckForUpdates), the following extra information is also currently sent:
+
+* A unique ID for the current NVDA user, this changes once a month
+* NVDA interface language
+* Whether this copy of NVDA is portable or installed
+* Name of the current speech synthesizer in use (including the name of the add-on the driver comes from)
+* Name of the current Braille display in use (including the name of the add-on the driver comes from)
+* The current output Braille table (if Braille is in use)
+
+This information greatly aides NV Access to prioritize future development of NVDA.
 
 #### Vision {#VisionSettings}
 

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -1861,22 +1861,6 @@ When unchecked, NVDA will exit immediately.
 
 This option is a checkbox that, when checked, tells NVDA to play sounds when it starts or exits.
 
-##### Logging level {#GeneralSettingsLogLevel}
-
-This is a combo box that lets you choose how much NVDA will log as it's running.
-Generally users should not need to touch this as not too much is logged.
-However, if you wish to provide information in a bug report, or enable or disable logging altogether, then it may be a useful option.
-
-The available logging levels are:
-
-* Disabled: Apart from a brief startup message, NVDA will not log anything while it runs.
-* Info: NVDA will log basic information such as startup messages and information useful for developers.
-* Debug warning: Warning messages that are not caused by severe errors will be logged.
-* Input/output: Input from keyboard and braille displays, as well as speech and braille output will be logged.
-If you are concerned about privacy, do not set the logging level to this option.
-* Debug: In addition to info, warning, and input/output messages, additional debug messages will be logged.
-Just like input/output, if you are concerned about privacy, you should not set the logging level to this option.
-
 ##### Start NVDA after I sign in {#GeneralSettingsStartAfterLogOn}
 
 If this option is enabled, NVDA will start automatically as soon as you sign in to Windows.
@@ -2643,6 +2627,22 @@ This option controls whether a sound cue is played when [Screen Curtain](#Vision
 By default, sounds are played when Screen Curtain is toggled.
 If you do not wish to hear these sounds, you can uncheck this checkbox.
 Note that you will still be alerted in speech and/or braille when Screen Curtain is toggled with an input gesture.
+
+##### Logging level {#GeneralSettingsLogLevel}
+
+This is a combo box that lets you choose how much NVDA will log as it's running.
+Generally users should not need to touch this as not too much is logged.
+However, if you wish to provide information in a bug report, or enable or disable logging altogether, then it may be a useful option.
+
+The available logging levels are:
+
+* Disabled: Apart from a brief startup message, NVDA will not log anything while it runs.
+* Info: NVDA will log basic information such as startup messages and information useful for developers.
+* Debug warning: Warning messages that are not caused by severe errors will be logged.
+* Input/output: Input from keyboard and braille displays, as well as speech and braille output will be logged.
+If you are concerned about privacy, do not set the logging level to this option.
+* Debug: In addition to info, warning, and input/output messages, additional debug messages will be logged.
+Just like input/output, if you are concerned about privacy, you should not set the logging level to this option.
 
 #### Vision {#VisionSettings}
 


### PR DESCRIPTION
### Link to issue number:

Resolves #16272

### Summary of the issue:

NVDA has several settings that have a direct impact on users' privacy and security, but they are scattered throughout its settings dialog.

### Description of user facing changes:

Some of these settings have now been moved to the Privacy and Security category.

### Description of developer facing changes:

A few items have been removed from the public API.

### Description of development approach:

- Move the code for the logging level setting from `GeneralSettingsPanel` to `PrivacyAndSecuritySettingsPanel`, and slightly refactored it.
- Moved the code for the allow usage stats setting from `GeneralSettingsPanel` to `PrivacyAndSecurityPanel`, and refactored slightly.
- Searched the User Guide for references to logs/logging and stats/statistics, and updated as appropriate.

### Testing strategy:

Tried changing log levels and ensured that the changes were reflected in the log output and in the GUI.

Disabled the source check in `updateCheck`, and tried checking for an update with usage stats gathering on and off, and checked that the setting was reflected in the URL.

### Known issues with pull request:

Users may find it difficult to adjust to the change in location

NVDA's output when tabbing to the "Logging level" control is slightly misleading, as no indication is given that you are out of the "Screen curtain" grouping.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
