### PR TITLE
Fix Screen Curtain

### DIFF
--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -4911,8 +4911,7 @@ class GlobalCommands(ScriptableObject):
 						screenCurtain.screenCurtain.enable(persist=not tempEnable)
 				except Exception:
 					log.error("Screen curtain initialization error", exc_info=True)
-					# Translators: Reported when the screen curtain could not be enabled.
-					enableMessage = _("Could not enable screen curtain")
+					enableMessage = screenCurtain._screenCurtain.ERROR_ENABLING_MESSAGE
 				finally:
 					self._toggleScreenCurtainMessage = enableMessage
 					ui.message(enableMessage, speechPriority=speech.priorities.Spri.NOW)

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -6062,7 +6062,15 @@ class PrivacyAndSecuritySettingsPanel(SettingsPanel):
 			if not confirmed or self._ocrActive():
 				self._screenCurtainEnabledCheckbox.SetValue(False)
 			else:
-				screenCurtain.screenCurtain.enable()
+				try:
+					screenCurtain.screenCurtain.enable()
+				except Exception:
+					log.error("Error enabling Screen Curtain.", exc_info=True)
+					ui.message(
+						screenCurtain._screenCurtain.ERROR_ENABLING_MESSAGE,
+						speechPriority=speech.priorities.Spri.NOW,
+					)
+					self._screenCurtainEnabledCheckbox.SetValue(False)
 		elif not shouldBeEnabled and currentlyEnabled:
 			screenCurtain.screenCurtain.disable()
 

--- a/source/screenCurtain/_screenCurtain.py
+++ b/source/screenCurtain/_screenCurtain.py
@@ -33,6 +33,9 @@ UNAVAILABLE_WHEN_RECOGNISING_CONTENT_MESSAGE = pgettext(
 	"Cannot enable screen curtain while performing content recognition",
 )
 
+# Translators: Reported when the screen curtain could not be enabled.
+ERROR_ENABLING_MESSAGE = _("Could not enable screen curtain")
+
 
 class ScreenCurtainSettings(TypedDict):
 	"""Type information for the "screenCurtain" section of the config."""

--- a/source/screenCurtain/_screenCurtain.py
+++ b/source/screenCurtain/_screenCurtain.py
@@ -184,12 +184,9 @@ class ScreenCurtain:
 		for attempt in range(self._MAX_ENABLE_RETRIES):
 			exception: Exception | None = None
 			try:
-				if not magnification.MagInitialize():
-					raise RuntimeError("Failed to initialize magnification runtime")
-				if not magnification.MagSetFullscreenColorEffect(TRANSFORM_BLACK):
-					raise RuntimeError("Failed to set full screen color effect.")
-				if not magnification.MagShowSystemCursor(False):
-					raise RuntimeError("Failed to hide the system cursor")
+				magnification.MagInitialize()
+				magnification.MagSetFullscreenColorEffect(TRANSFORM_BLACK)
+				magnification.MagShowSystemCursor(False)
 				if not isScreenFullyBlack():
 					raise RuntimeError("Screen is not black.")
 				break
@@ -202,7 +199,7 @@ class ScreenCurtain:
 				exception = e
 		else:
 			log.debug(f"Failed to enable Screen Curtain after {self._MAX_ENABLE_RETRIES} attempts.")
-			raise exception
+			raise RuntimeError("Failed to enable screen curtain") from exception
 		log.debug("Screen Curtain enabled")
 		self._enabled = True
 		if persist:


### PR DESCRIPTION
### Link to issue number:

Fixes #19263
Closes #10545
Possible fix for #18693 and #18743

### Summary of the issue:

Since #19177, if Screen Curtain fails to initialise because `isScreenFullyBlack` returns `False`, NVDA crashes (#19263).

It would appear that from time to time, bitblitting from the desktop context to the capture context in `nvdaHelper/local/screenCurtain.cpp` failes due to one or both of the context handles being invalid.
I have no idea why this happens, but can only surmise that it's a timing issue, as we check the validity of the contexts upon creation, so something must be invalidating them in the meantime.

I strongly suspect that this is the underlying cause of Screen Curtain failing to be activated on the Windows login screen (#18743) and after login (#18693).

### Description of user facing changes:

NVDA no longer crashes if Screen Curtain fails to be enabled when initializing NVDA.

Screen curtain may be enabled more reliably at the login screen and immediately after login.

I have not included a change log entry, because #19263 was introduced as part of 2026.1 alphas, and I don't know if this PR fixes #18693 or #18743.

### Description of developer facing changes:

None

### Description of development approach:

* In `screenCurtain._screenCurtain.ScreenCurtain.enable`, add logic to automatically retry enabling the Screen Curtain a fixed number of times before admitting defeat.
If the issue really is a race condition or other timing issue, future retries should theoretically be uneffected by the issue, so it will succeed.
Currently the maximum number of attempts is hardcoded at 3.
* In `screenCurtain._screenCurtain.ScreenCurtain.__init__`, wrap `self.enable` in a try/except block.
* In `gui.settingsDialogs.PrivacyAndSecurityDialog._ensureScreenCurtainEnableState`, wrap `screenCurtain.screenCurtain.enable` in a try/except block, and notify the user when enabling the screen curtain has failed.

### Testing strategy:

Intentionally introduced errors into `screenCurtain._screenCurtain.ScreenCurtain.enable`, and ensure that the error handling works correctly.

Intentionally introduced errors that only happen a fixed number of times into `screenCurtain._screenCurtain.ScreenCurtain.enable`, and ensure that the retry logic works correctly.

### Known issues with pull request:

None

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
