### PR TITLE
Filter out markdown linter comments from translations

### DIFF
--- a/source/markdownTranslate.py
+++ b/source/markdownTranslate.py
@@ -92,7 +92,7 @@ def getRawGithubURLForPath(filePath: str) -> str:
 def preprocessMarkdownLines(mdLines):
 	for mdLine in mdLines:
 		# #18982: Remove markdown lint comments completely - not needed for intermediate markdown or final html.
-		mdLine = re_inlineMarkdownLintComment.sub(r'\1\2', mdLine)
+		mdLine = re_inlineMarkdownLintComment.sub(r"\1\2", mdLine)
 		yield mdLine
 
 
@@ -273,7 +273,7 @@ def generateXliff(
 		for lineNo, (mdLine, skelLine) in enumerate(
 			zip_longest(
 				preprocessMarkdownLines(mdFile.readlines()),
-				skelContent.splitlines(keepends=True)
+				skelContent.splitlines(keepends=True),
 			),
 			start=1,
 		):
@@ -503,7 +503,7 @@ def ensureMarkdownFilesMatch(path1: str, path2: str, allowBadAnchors: bool = Fal
 				preprocessMarkdownLines(file1.readlines()),
 				preprocessMarkdownLines(file2.readlines()),
 			),
-			start=1
+			start=1,
 		):
 			line1 = line1.rstrip()
 			line2 = line2.rstrip()

--- a/source/markdownTranslate.py
+++ b/source/markdownTranslate.py
@@ -4,6 +4,7 @@
 # See the file COPYING for more details.
 
 from typing import Generator
+from collections.abc import Iterable
 import tempfile
 import os
 import contextlib
@@ -89,7 +90,12 @@ def getRawGithubURLForPath(filePath: str) -> str:
 	return f"{RAW_GITHUB_REPO_URL}/{commitID}/{relativePath}"
 
 
-def preprocessMarkdownLines(mdLines):
+def preprocessMarkdownLines(mdLines: Iterable[str]) -> Iterable[str]:
+	"""
+	Preprocess markdown lines such as removing inline markdown lint comments.\
+	:param mdLines: The markdown lines to preprocess
+	:returns: The preprocessed markdown lines
+	"""
 	for mdLine in mdLines:
 		# #18982: Remove markdown lint comments completely - not needed for intermediate markdown or final html.
 		mdLine = re_inlineMarkdownLintComment.sub(r"\1\2", mdLine)

--- a/user_docs/en/userGuide.xliff
+++ b/user_docs/en/userGuide.xliff
@@ -5978,7 +5978,6 @@ $(ID:531ae3d4-1e18-4f7b-b17e-f8d05be6d922)
 |$(ID:d7cd7445-af1b-4bc0-b413-651d84ad1396)|
 |$(ID:bea70d39-8192-4ce1-b4cc-16f53ebdf6a7)|
 |$(ID:3c1b5da6-8d27-4b52-9674-0663cbf771b3)|
-$(ID:ab362c58-1f2e-4bbc-99aa-85bd37b39689)
 |$(ID:c55692e2-bb7f-40e7-84ea-b070001d3590)|
 |$(ID:175551f5-2a78-40a6-9464-43f3fa70e95b)|
 |$(ID:d6dc4878-b294-496f-a3d8-ec8585a1fa12)|
@@ -41845,14 +41844,6 @@ $(ID:061d7d61-cfab-44b3-a92c-4e65cf63213b)
 </notes>
 <segment>
 <source>None |`--install-silent` |Silently installs NVDA (does not start the newly installed copy)</source>
-</segment>
-</unit>
-<unit id="ab362c58-1f2e-4bbc-99aa-85bd37b39689">
-<notes>
-<note appliesTo="source">line: 5978</note>
-</notes>
-<segment>
-<source>|None |`--enable-start-on-logon=True|False` |When installing, enable NVDA's [Use NVDA during Windows sign-in](#StartAtWindowsLogon)| &lt;!-- markdownlint-disable-line MD055 MD056 --&gt;</source>
 </segment>
 </unit>
 <unit id="c55692e2-bb7f-40e7-84ea-b070001d3590">

--- a/user_docs/en/userGuide.xliff
+++ b/user_docs/en/userGuide.xliff
@@ -5978,6 +5978,7 @@ $(ID:531ae3d4-1e18-4f7b-b17e-f8d05be6d922)
 |$(ID:d7cd7445-af1b-4bc0-b413-651d84ad1396)|
 |$(ID:bea70d39-8192-4ce1-b4cc-16f53ebdf6a7)|
 |$(ID:3c1b5da6-8d27-4b52-9674-0663cbf771b3)|
+|$(ID:9d39ada4-103e-435e-91e9-2ab479318399)|
 |$(ID:c55692e2-bb7f-40e7-84ea-b070001d3590)|
 |$(ID:175551f5-2a78-40a6-9464-43f3fa70e95b)|
 |$(ID:d6dc4878-b294-496f-a3d8-ec8585a1fa12)|
@@ -41844,6 +41845,16 @@ $(ID:061d7d61-cfab-44b3-a92c-4e65cf63213b)
 </notes>
 <segment>
 <source>None |`--install-silent` |Silently installs NVDA (does not start the newly installed copy)</source>
+</segment>
+</unit>
+<unit id="9d39ada4-103e-435e-91e9-2ab479318399">
+<notes>
+<note appliesTo="source">line: 5978</note>
+<note appliesTo="source">prefix: |</note>
+<note appliesTo="source">suffix: |</note>
+</notes>
+<segment>
+<source>None |`--enable-start-on-logon=True|False` |When installing, enable NVDA's [Use NVDA during Windows sign-in](#StartAtWindowsLogon)</source>
 </segment>
 </unit>
 <unit id="c55692e2-bb7f-40e7-84ea-b070001d3590">


### PR DESCRIPTION
### Link to issue number:
<!-- Use Closes/Fixes/Resolves #xxx to link this PR to the issue it is responding to. -->
Fixes #18982

### Summary of the issue:
Markdown files for our documentation may sometimes contain special markdown linter comments, which are incorrectly being included in content to translate, and  in some cases breaking detection of markdown entities such as table rows.
For example in userguide.md we have:
```
|None |`--enable-start-on-logon=True|False` |When installing, enable NVDA's [Use NVDA during Windows sign-in](#StartAtWindowsLogon)| <!-- markdownlint-disable-line MD055 MD056 -->
```

This produces a translation unit such as:
```
<unit id="ab362c58-1f2e-4bbc-99aa-85bd37b39689">
<notes>
<note appliesTo="source">line: 5978</note>
</notes>
<segment>
<source>|None |`--enable-start-on-logon=True|False` |When installing, enable NVDA's [Use NVDA during Windows sign-in](#StartAtWindowsLogon)| &lt;!-- markdownlint-disable-line MD055 MD056 --&gt;</source>
</segment>
</unit>
```

* The source string incorrectly contains the markdown linter comment.
* The source string has not been correctly processed as a table row (the start and end vertical bars are still present)
* There is no prefix and suffix (containing the vertical bars) in the notes.

### Description of user facing changes:
None.

### Description of developer facing changes:
None.

### Description of development approach:
In markdownTranslate.py:
* add a regular expression to match these markdown comments.
* Add a preprocessMarkdownLines function, which runs this regex on all lines.
* All places that read in a markdown file now preprocess all lines with preprocessMarkdownLines, such as generateSkeleton, updateSkeleton, generateXliff, and ensureMarkdownFilesMatch.

English auto generated userguide xliff:
* manually remove the translation unit that incorrectly contains the markdown linter comment, and also remove its line from the skeleton. The next time that userGuide.md is changed, this translation unit will automatically be replaced with the correct content.

### Testing strategy:
* ran `markdownTranslate.py generateXliff -m userguide.md -o test_generated.xliff` and ensured that the translation unit  in test_generated.xliff for that table row no longer contains the markdown linter comment.
* ran `markdownTranslate.py updateXliff -x userguide.xliff -m userGuide.md -o test_updated.xliff`
  * again ensured that the translation unit for that table row no longer contained the markdown linter comment.
 * generated a unified diff of userguide.xliff and test_updated.xliff, and ensured that the only change was the addition of the corrected translation unit, and the replacement of the related line in the skeleton content with the new translation ID for that unit, now with the leading and trailing vertical bars previously missing.

 ### Known issues with pull request:
None known.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
