### PR TITLE
Fix: Directly enable image descriptions for the current session without showing extra dialogs

### DIFF
--- a/source/_localCaptioner/captioner/vitGpt2.py
+++ b/source/_localCaptioner/captioner/vitGpt2.py
@@ -87,9 +87,13 @@ class VitGpt2ImageCaptioner(ImageCaptioner):
 			self.encoderSession = ort.InferenceSession(encoderPath, sess_options=sessionOptions)
 			self.decoderSession = ort.InferenceSession(decoderPath, sess_options=sessionOptions)
 		except (
+			# Model  file incomplete
 			ort.capi.onnxruntime_pybind11_state.InvalidProtobuf,
 			ort.capi.onnxruntime_pybind11_state.NoSuchFile,
+			# Model file still downloading
+			ort.capi.onnxruntime_pybind11_state.Fail,
 		) as e:
+			log.debug("model file incomplete")
 			raise FileNotFoundError(
 				"model file incomplete"
 				f" Please check whether the file is complete or re-download. Original error: {e}",

--- a/source/_localCaptioner/captioner/vitGpt2.py
+++ b/source/_localCaptioner/captioner/vitGpt2.py
@@ -87,7 +87,7 @@ class VitGpt2ImageCaptioner(ImageCaptioner):
 			self.encoderSession = ort.InferenceSession(encoderPath, sess_options=sessionOptions)
 			self.decoderSession = ort.InferenceSession(decoderPath, sess_options=sessionOptions)
 		except (
-			# Model  file incomplete
+			# Model file incomplete
 			ort.capi.onnxruntime_pybind11_state.InvalidProtobuf,
 			ort.capi.onnxruntime_pybind11_state.NoSuchFile,
 			# Model file still downloading

--- a/source/_localCaptioner/imageDescriber.py
+++ b/source/_localCaptioner/imageDescriber.py
@@ -37,8 +37,8 @@ _beepLength = 100
 
 
 def _isNavigatorExpected() -> bool:
-	""" Check whether the current navigation object is of the expected type
-	
+	"""Check whether the current navigation object is of the expected type
+
 	:return: Whether it is an element of the expected type
 	"""
 	# Get the currently focused object on screen
@@ -144,8 +144,8 @@ class ImageDescriber:
 	def _prepareCaption(self) -> None:
 		"""Preparations for running image captions on the current navigator object."""
 		if not _isNavigatorExpected():
-			return 
-			
+			return
+
 		if not self.isModelLoaded:
 			# Directly load the model here (session only), it may take a while
 			self.loadModelInBackground()

--- a/source/_localCaptioner/imageDescriber.py
+++ b/source/_localCaptioner/imageDescriber.py
@@ -164,7 +164,7 @@ class ImageDescriber:
 		pollThread.start()
 
 		while pollThread.is_alive():
-			pollThread.join(0.1)
+			pollThread.join(timeout=0.1)
 			i += 1
 			if i % _beepInterval == 0:
 				beep(_beepHz, _beepLength)

--- a/source/_localCaptioner/imageDescriber.py
+++ b/source/_localCaptioner/imageDescriber.py
@@ -30,7 +30,7 @@ from .captioner import imageCaptionerFactory
 
 # Module-level configuration
 _localCaptioner = None
-_beepInterval = 2 # The unit is 0.1s 
+_beepInterval = 2  # The unit is 0.1s
 _beepHz = 300
 _beepLength = 100
 
@@ -143,11 +143,11 @@ class ImageDescriber:
 
 		:param imageData: The image data to caption.
 		"""
-		# Ensure model is loaded 
+		# Ensure model is loaded
 		i = 0
 		while self.loadModelThread is not None and self.loadModelThread.is_alive():
 			self.loadModelThread.join(0.1)
-			i+=1
+			i += 1
 			if i % _beepInterval == 0:
 				beep(_beepHz, _beepLength)
 
@@ -156,7 +156,6 @@ class ImageDescriber:
 			log.debug("Captioner not found.")
 			return
 
-		
 		pollThread = threading.Thread(
 			target=_messageCaption,
 			args=(self.captioner, imageData),
@@ -166,7 +165,7 @@ class ImageDescriber:
 
 		while pollThread.is_alive():
 			pollThread.join(0.1)
-			i+=1
+			i += 1
 			if i % _beepInterval == 0:
 				beep(_beepHz, _beepLength)
 

--- a/source/_localCaptioner/imageDescriber.py
+++ b/source/_localCaptioner/imageDescriber.py
@@ -188,7 +188,7 @@ class ImageDescriber:
 		encoderPath = f"{localModelDirPath}/onnx/encoder_model_quantized.onnx"
 		decoderPath = f"{localModelDirPath}/onnx/decoder_model_merged_quantized.onnx"
 		configPath = f"{localModelDirPath}/config.json"
-		
+
 		# Mark each time the model is loading
 		self.isModelDownloading = False
 
@@ -201,7 +201,7 @@ class ImageDescriber:
 		except FileNotFoundError:
 			self.isModelLoaded = False
 			# Should be set before prepareCaptioner checks
-			# If not, the user will hear an extra beep 
+			# If not, the user will hear an extra beep
 			# and incur the overhead of starting a thread one more time.
 			self.isModelDownloading = True
 			from gui._localCaptioner.messageDialogs import ImageDescDownloader

--- a/source/_localCaptioner/imageDescriber.py
+++ b/source/_localCaptioner/imageDescriber.py
@@ -118,9 +118,9 @@ class ImageDescriber:
 		self._prepareCaption()
 
 	def _prepareCaption(self) -> None:
-		"""Preparations for running image captions on the current Navigator object."""
+		"""Preparations for running image captions on the current navigator object."""
 		if not self.isModelLoaded:
-			# Directly load the model here(session only), it may take a while
+			# Directly load the model here (session only), it may take a while
 			self.loadModelInBackground()
 
 		imageData = _screenshotNavigator()

--- a/source/_localCaptioner/imageDescriber.py
+++ b/source/_localCaptioner/imageDescriber.py
@@ -138,7 +138,7 @@ class ImageDescriber:
 		log.debug("starting caption thread")
 		self.captionThread.start()
 
-	def _pollCaptionn(self, imageData: bytes) -> None:
+	def _pollCaption(self, imageData: bytes) -> None:
 		"""Poll to load the model and run caption to get the results.
 
 		:param imageData: The image data to caption.

--- a/source/_localCaptioner/imageDescriber.py
+++ b/source/_localCaptioner/imageDescriber.py
@@ -51,7 +51,7 @@ def _isNavigatorExpected() -> bool:
 		return False
 
 	if State.OFFSCREEN in obj.states:
-		# Translator: Message when image is off screen
+		# Translators: Message when image is off screen
 		ui.message(pgettext("imageDesc", "Image off screen"))
 		return False
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
<!-- Use Closes/Fixes/Resolves #xxx to link this PR to the issue it is responding to. -->
Fixes #19302
### Summary of the issue:
a dialog instance is opened everytime AI image description is running
### Description of user facing changes:
1. Noe extra dialog will be opened when calling AI image descriptions

2. use beeps to indicate recognition is in progress instead of the extra 'getting image description' message.

3. Enhanced error handling for cases where image recognition is triggered during the download process.
### Description of developer facing changes:
None
### Description of development approach:
None
### Testing strategy:
Disable AI image description in settings panel, directly press `NVDA+g`, user will hear beeps and then directly get the recognition result .
### Known issues with pull request:
Loading the model in the child thread will still cause lag
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
