### PR TITLE
When update is not available, do not remove corresponding GUI controls but disable them

### DIFF
--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -900,62 +900,63 @@ class GeneralSettingsPanel(SettingsPanel):
 			self.copySettingsButton.Disable()
 		settingsSizerHelper.addItem(self.copySettingsButton)
 
-		if updateCheck:
-			item = self.autoCheckForUpdatesCheckBox = wx.CheckBox(
-				self,
-				# Translators: The label of a checkbox in general settings to toggle automatic checking for updated versions of NVDA.
-				# If not checked, user must check for updates manually.
-				label=_("Automatically check for &updates to NVDA"),
-			)
-			self.bindHelpEvent("GeneralSettingsCheckForUpdates", self.autoCheckForUpdatesCheckBox)
-			item.Value = config.conf["update"]["autoCheck"]
-			if globalVars.appArgs.secure:
-				item.Disable()
-			settingsSizerHelper.addItem(item)
+		item = self.autoCheckForUpdatesCheckBox = wx.CheckBox(
+			self,
+			# Translators: The label of a checkbox in general settings to toggle automatic checking for updated versions of NVDA.
+			# If not checked, user must check for updates manually.
+			label=_("Automatically check for &updates to NVDA"),
+		)
+		self.bindHelpEvent("GeneralSettingsCheckForUpdates", self.autoCheckForUpdatesCheckBox)
+		item.Value = config.conf["update"]["autoCheck"]
+		if not updateCheck:
+			item.Value = False
+			item.Disable()
+		settingsSizerHelper.addItem(item)
 
-			item = self.notifyForPendingUpdateCheckBox = wx.CheckBox(
-				self,
-				# Translators: The label of a checkbox in general settings to toggle startup notifications
-				# for a pending NVDA update.
-				label=_("Notify for &pending update on startup"),
-			)
-			self.bindHelpEvent("GeneralSettingsNotifyPendingUpdates", self.notifyForPendingUpdateCheckBox)
-			item.Value = config.conf["update"]["startupNotification"]
-			if globalVars.appArgs.secure:
-				item.Disable()
-			settingsSizerHelper.addItem(item)
+		item = self.notifyForPendingUpdateCheckBox = wx.CheckBox(
+			self,
+			# Translators: The label of a checkbox in general settings to toggle startup notifications
+			# for a pending NVDA update.
+			label=_("Notify for &pending update on startup"),
+		)
+		self.bindHelpEvent("GeneralSettingsNotifyPendingUpdates", self.notifyForPendingUpdateCheckBox)
+		item.Value = config.conf["update"]["startupNotification"]
+		if not updateCheck:
+			item.Value = False
+			item.Disable()
+		settingsSizerHelper.addItem(item)
 
-			# Translators: The label for the update mirror on the General Settings panel.
-			mirrorBoxSizer = wx.StaticBoxSizer(wx.HORIZONTAL, self, label=_("Update mirror"))
-			mirrorBox = mirrorBoxSizer.GetStaticBox()
-			mirrorBoxSizerHelper = guiHelper.BoxSizerHelper(self, sizer=mirrorBoxSizer)
-			settingsSizerHelper.addItem(mirrorBoxSizerHelper)
+		# Translators: The label for the update mirror on the General Settings panel.
+		mirrorBoxSizer = wx.StaticBoxSizer(wx.HORIZONTAL, self, label=_("Update mirror"))
+		mirrorBox = mirrorBoxSizer.GetStaticBox()
+		mirrorBoxSizerHelper = guiHelper.BoxSizerHelper(self, sizer=mirrorBoxSizer)
+		settingsSizerHelper.addItem(mirrorBoxSizerHelper)
 
-			# Use an ExpandoTextCtrl because even when read-only it accepts focus from keyboard, which
-			# standard read-only TextCtrl does not. ExpandoTextCtrl is a TE_MULTILINE control, however
-			# by default it renders as a single line. Standard TextCtrl with TE_MULTILINE has two lines,
-			# and a vertical scroll bar. This is not neccessary for the single line of text we wish to
-			# display here.
-			# Note: To avoid code duplication, the value of this text box will be set in `onPanelActivated`.
-			self.mirrorURLTextBox = ExpandoTextCtrl(
-				mirrorBox,
-				size=(self.scaleSize(250), -1),
-				style=wx.TE_READONLY,
-			)
-			# Translators: This is the label for the button used to change the NVDA update mirror URL,
-			# it appears in the context of the update mirror group on the General page of NVDA's settings.
-			changeMirrorBtn = wx.Button(mirrorBox, label=_("Change..."))
-			mirrorBoxSizerHelper.addItem(
-				guiHelper.associateElements(
-					self.mirrorURLTextBox,
-					changeMirrorBtn,
-				),
-			)
-			self.bindHelpEvent("UpdateMirror", mirrorBox)
-			self.mirrorURLTextBox.Bind(wx.EVT_CHAR_HOOK, self._enterTriggersOnChangeMirrorURL)
-			changeMirrorBtn.Bind(wx.EVT_BUTTON, self.onChangeMirrorURL)
-			if globalVars.appArgs.secure:
-				mirrorBox.Disable()
+		# Use an ExpandoTextCtrl because even when read-only it accepts focus from keyboard, which
+		# standard read-only TextCtrl does not. ExpandoTextCtrl is a TE_MULTILINE control, however
+		# by default it renders as a single line. Standard TextCtrl with TE_MULTILINE has two lines,
+		# and a vertical scroll bar. This is not neccessary for the single line of text we wish to
+		# display here.
+		# Note: To avoid code duplication, the value of this text box will be set in `onPanelActivated`.
+		self.mirrorURLTextBox = ExpandoTextCtrl(
+			mirrorBox,
+			size=(self.scaleSize(250), -1),
+			style=wx.TE_READONLY,
+		)
+		# Translators: This is the label for the button used to change the NVDA update mirror URL,
+		# it appears in the context of the update mirror group on the General page of NVDA's settings.
+		changeMirrorBtn = wx.Button(mirrorBox, label=_("Change..."))
+		mirrorBoxSizerHelper.addItem(
+			guiHelper.associateElements(
+				self.mirrorURLTextBox,
+				changeMirrorBtn,
+			),
+		)
+		self.bindHelpEvent("UpdateMirror", mirrorBox)
+		self.mirrorURLTextBox.Bind(wx.EVT_CHAR_HOOK, self._enterTriggersOnChangeMirrorURL)
+		changeMirrorBtn.Bind(wx.EVT_BUTTON, self.onChangeMirrorURL)
+		if not updateCheck:
+			mirrorBox.Disable()
 
 		item = self.preventDisplayTurningOffCheckBox = wx.CheckBox(
 			self,
@@ -5992,13 +5993,15 @@ class PrivacyAndSecuritySettingsPanel(SettingsPanel):
 		except StopIteration:
 			log.debugWarning("Could not set log level list to current log level")
 
-		if updateCheck:
-			self._allowUsageStatsCheckBox: wx.CheckBox = generalGroup.addItem(
-				# Translators: The label of a checkbox in privacy and security settings to toggle allowing of usage stats gathering
-				wx.CheckBox(generalBox, label=_("Allow NV Access to gather NVDA usage statistics")),
-			)
-			self.bindHelpEvent("GeneralSettingsGatherUsageStats", self._allowUsageStatsCheckBox)
-			self._allowUsageStatsCheckBox.Value = config.conf["update"]["allowUsageStats"]
+		self._allowUsageStatsCheckBox: wx.CheckBox = generalGroup.addItem(
+			# Translators: The label of a checkbox in privacy and security settings to toggle allowing of usage stats gathering
+			wx.CheckBox(generalBox, label=_("Allow NV Access to gather NVDA usage statistics")),
+		)
+		self.bindHelpEvent("GeneralSettingsGatherUsageStats", self._allowUsageStatsCheckBox)
+		self._allowUsageStatsCheckBox.Value = config.conf["update"]["allowUsageStats"]
+		if not updateCheck:
+			self._allowUsageStatsCheckBox.Value = False
+			self._allowUsageStatsCheckBox.Disable()
 
 	def onSave(self):
 		# We intentionally don't save whether the screen curtain is enabled here,


### PR DESCRIPTION
### Link to issue number:
Closes #19320

### Summary of the issue:
Update check is not available when running from source or when running in secure mode. In these cases, related controls are just not created in the GUI.

### Description of user facing changes:
Update related controls are now created in the GUI but are disabled when there is no update check.

### Description of developer facing changes:
N/A
### Description of development approach:
* Created "Automatically check for updates to NVDA", "Notify for pending update on startup", "Allow NV Access to gather NVDA usage statistics" and the "Update mirror" group but disable them.
* When necessary, force also their value to denote that there is no update check / stats collection.
* No change log item for this minor modification

### Testing strategy:
Manual test:
* from source
* from source setting `updateCheck` to `True` to check that the controls are created.

### Known issues with pull request:
None
### Code Review Checklist:


- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
