### PR TITLE
Fix settings dialog title for 2 base-only panels

### DIFF
--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -6126,6 +6126,8 @@ class NVDASettingsDialog(MultiCategorySettingsDialog):
 			or isinstance(self.currentCategory, GeneralSettingsPanel)
 			or isinstance(self.currentCategory, AddonStorePanel)
 			or isinstance(self.currentCategory, RemoteSettingsPanel)
+			or isinstance(self.currentCategory, LocalCaptionerSettingsPanel)
+			or isinstance(self.currentCategory, MathSettingsPanel)
 			or isinstance(self.currentCategory, PrivacyAndSecuritySettingsPanel)
 		):
 			# Translators: The profile name for normal configuration


### PR DESCRIPTION
### Link to issue number:
Discussed in https://github.com/nvaccess/nvda/issues/19301#issuecomment-3616726134
### Summary of the issue:
The settings dialog indicate the current profile when "AI image description" and "Math" categories are selected. Though, their config is only global, i.e. not profile dependant.

### Description of user facing changes:
When categories "AI Image Description" and "Math" are selected, the settings dialog will indicate "normal configuration", no matter the current active profile since their config is only global. I.e. same as categories "General", "Add-on Store", "Remote Access" or "Privacy and security".
### Description of developer facing changes:
None
### Description of development approach:
Check for instance of the 2 newly added panels in 
`NVDASettingsDialog._doOnCategoryChange`

### Testing strategy:
Manual test
### Known issues with pull request:
Some may want these feature to be profile dependant. This may be discussed in new issues or PR; for now these features have been developed without profile support and this PR just makes the GUI consistent with it.

### Code Review Checklist:


- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
