### PR TITLE
Don't play spelling error reporting sounds when typing if speech mode is on-demand or off

### DIFF
--- a/source/NVDAObjects/behaviors.py
+++ b/source/NVDAObjects/behaviors.py
@@ -294,7 +294,8 @@ class EditableTextBase(editableText.EditableText, NVDAObject):
 			else:
 				# No error.
 				return
-			nvwave.playWaveFile(os.path.join(globalVars.appDir, "waves", "textError.wav"))
+			if speech.getState().speechMode not in [speech.SpeechMode.off, speech.SpeechMode.onDemand]:
+				nvwave.playWaveFile(os.path.join(globalVars.appDir, "waves", "textError.wav"))
 
 		core.callLater(50, _delayedDetection)
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -120,6 +120,7 @@ It currently includes Screen Curtain's settings (previously in the "Vision" cate
 * The browse mode cursor highlighter now appears on content recognition results, such as when using Windows OCR. (#19168, @hwf1324)
 * In the Input Gestures dialog, gestures including an operator while Num Lock is on will now be correctly displayed. (#19214, @CyrilleB79)
 * In Chromium browsers, if a document contains links with a malformed URL, reading the document will be possible again. (#19125, @nvdaes)
+* Spelling error reporting sounds while typing are no longer being emitted when speech mode is on-demand or off. (#19323 , @CyrilleB79)
 
 ### Changes for Developers
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -120,7 +120,7 @@ It currently includes Screen Curtain's settings (previously in the "Vision" cate
 * The browse mode cursor highlighter now appears on content recognition results, such as when using Windows OCR. (#19168, @hwf1324)
 * In the Input Gestures dialog, gestures including an operator while Num Lock is on will now be correctly displayed. (#19214, @CyrilleB79)
 * In Chromium browsers, if a document contains links with a malformed URL, reading the document will be possible again. (#19125, @nvdaes)
-* Spelling error reporting sounds while typing are no longer being emitted when speech mode is on-demand or off. (#19323 , @CyrilleB79)
+* NVDA no longer plays a sound for spelling errors while typing if speech mode is set to on-demand or off. (#19323, @CyrilleB79)
 
 ### Changes for Developers
 


### PR DESCRIPTION
### Link to issue number:
Fixes #19323

### Summary of the issue:
Sounds reporting errors while typing were emitted even when speech mode was off or on-demand.

### Description of user facing changes:
Spelling error sounds while typing are no longer emitted when speech mode are on-demand or off.
### Description of developer facing changes:
N/A
### Description of development approach:
Check the config to play the error wave file only only if we ar not in off or on-demand mode, i.e. only if we ar in "talk" or "beeps" mode.

### Testing strategy:
Manual test in the 4 speech modes.

### Known issues with pull request:
None
### Code Review Checklist:


- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
