### PR TITLE
Fix starting NVDA with `--no-logging` flag

### DIFF
--- a/source/utils/_crashHandler.py
+++ b/source/utils/_crashHandler.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2025 NV Access Limited, Derek Riemer
+# Copyright (C) 2025 NV Access Limited, Derek Riemer, Cyrille Bougot
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -112,7 +112,7 @@ def _writeCrashStats(path: str, events: list[CrashEvent]) -> None:
 def loadRecentCrashTimestamps(now: float) -> list[float]:
 	path = CRASH_STATS.crashStatsPath
 	# Check existence explicitly rather than catching exceptions, as this check is far faster than catching an expected exception.
-	if not os.path.exists(path):
+	if path is None or not os.path.exists(path):
 		return []
 	try:
 		with open(path, "r", encoding="utf-8") as f:


### PR DESCRIPTION
### Link to issue number:
Closes #19333

Fix-up of #19175.

### Summary of the issue:
NVDA was crashing at startup when using --no-logging command line flag.

### Description of user facing changes:
NVDA can start again when using the `--nologging` flag.

### Description of developer facing changes:
N/A
### Description of development approach:
When loading the crash list file, also test if its path is `None` since this is the case when using `--no-logging` flag.

### Testing strategy:
Manual tests: Started NVDA with `--no-logging`, with `-l 100` or normally.

### Known issues with pull request:
None
### Code Review Checklist:


- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
