### PR TITLE
Move markdown lint disabling instruction below 2026.2 change log

### DIFF
--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -16,6 +16,9 @@ Please refer to [the developer guide](https://download.nvaccess.org/documentatio
 
 #### Deprecations
 
+<!-- Beyond this point, Markdown should not be linted, as we don't modify old change log sections. -->
+<!-- markdownlint-disable -->
+
 ## 2026.1
 
 This release includes built-in support for reading math content with MathCAT.
@@ -339,9 +342,6 @@ Use `INPUT_TYPE.MOUSE`, `INPUT_TYPE.KEYBOARD`, `KEYEVENTF.KEYUP` and `KEYEVENTF.
 Access to these symbols via `updateCheck` is deprecated. (#18956)
 * `textInfos.OffsetsTextInfo.allowMoveToOffsetPastEnd` is deprecated.
 Use the `OffsetsTextInfo.allowMoveToUnitOffsetPastEnd` method instead. (#19152, @LeonarddeR)
-
-<!-- Beyond this point, Markdown should not be linted, as we don't modify old change log sections. -->
-<!-- markdownlint-disable -->
 
 ## 2025.3.2
 


### PR DESCRIPTION
### Link to issue number:
Fix-up of #19354

### Summary of the issue:
In the PR to start 2026.2 dev cycle, the new 2026.2 section has been created, but the markdown disable instruction has remained below 2026.1 section.

### Description of user facing changes:
None
### Description of developer facing changes:
Moved the instruction to disable markdown linting below 2026.2 section.

### Description of development approach:
N/A

### Testing strategy:
Not tested. A careful review should be enough.

### Known issues with pull request:
None
### Additional remark
It seems that internally at NV Access, you have a task list that you copy / paste in the initial description of each PR starting a new dev cycle. It would be the opportunity to update also this task list to mention that the linter command should be moved below the newly created section.

### Code Review Checklist:


- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
