### PR TITLE
Pass 0 instead of None to VBuf_getControlFieldNodeWithIdentifier

### DIFF
--- a/source/virtualBuffers/__init__.py
+++ b/source/virtualBuffers/__init__.py
@@ -909,8 +909,8 @@ class VirtualBuffer(browseMode.BrowseModeDocumentTreeInterceptor):
 		try:
 			NVDAHelper.localLib.VBuf_getControlFieldNodeWithIdentifier(
 				self.VBufHandle,
-				docHandle,
-				objId,
+				docHandle if docHandle is not None else 0,
+				objId if objId is not None else 0,
 				ctypes.byref(node),
 			)
 		except WindowsError:


### PR DESCRIPTION
### Link to issue number:

Closes ##19258
fixes #18879

### Summary of the issue:

There is a type incompatibility between some return values from `virtualBuffers.VirtualBuffer.getIdentifierFromNVDAObject` (which seemingly returns `None` some of the time), and `NVDAHelper.localLib.VBuf_getControlFieldNodeWithIdentifier`, which expects its 2nd and 3rd arguments to be integers.

### Description of user facing changes:

This seems to be intermittent and only to produce excessive log output.

### Description of developer facing changes:

None

### Description of development approach:

When passing `docHandle` and `objId` to `VBuf_getControlFieldNodeWithIdentifier`, pass `0` instead of `None`. Note that before the 64-bit transition, this FFI binding had no typing information, so ctypes would have converted `None` to `0` silently.

### Testing strategy:

Automated tests. User testing.

### Known issues with pull request:

None

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
