### PR TITLE
UI Automation in Microsoft Word: Use move by sentence custom pattern when available instead of the legacy model

### DIFF
--- a/source/NVDAObjects/UIA/wordDocument.py
+++ b/source/NVDAObjects/UIA/wordDocument.py
@@ -719,7 +719,7 @@ class WordDocument(UIADocumentWithTableNavigation, WordDocumentNode, WordDocumen
 	# The following override of the EditableText._caretMoveBySentenceHelper private method
 	# First tries to use UI Automation remote operations to move by sentence when available,
 	# falling back to the MS Word object model otherwise.
-	def _caretMoveBySentenceHelper(self, gesture, direction):
+	def _caretMoveBySentenceHelper(self, gesture: inputCore.InputGesture, direction: int):
 		if isScriptWaiting():
 			return
 

--- a/source/NVDAObjects/UIA/wordDocument.py
+++ b/source/NVDAObjects/UIA/wordDocument.py
@@ -716,40 +716,65 @@ class WordDocument(UIADocumentWithTableNavigation, WordDocumentNode, WordDocumen
 			return
 		super(WordDocument, self).event_UIA_notification(**kwargs)
 
-	# The following overide of the EditableText._caretMoveBySentenceHelper private method
-	# Falls back to the MS Word object model if available.
-	# This override should be removed as soon as UI Automation in MS Word has the ability to move by sentence.
+	# The following override of the EditableText._caretMoveBySentenceHelper private method
+	# First tries to use UI Automation remote operations to move by sentence when available,
+	# falling back to the MS Word object model otherwise.
 	def _caretMoveBySentenceHelper(self, gesture, direction):
 		if isScriptWaiting():
 			return
-		if not self.WinwordSelectionObject:
-			# Legacy object model not available.
-			# Translators: a message when navigating by sentence is unavailable in MS Word
-			ui.message(_("Navigating by sentence not supported in this document"))
-			gesture.send()
-			return
-		# Using the legacy object model,
-		# Move the caret to the next sentence in the requested direction.
-		legacyInfo = LegacyWordDocumentTextInfo(self, textInfos.POSITION_CARET)
-		legacyInfo.move(textInfos.UNIT_SENTENCE, direction)
-		# Save the start of the sentence for future use
-		legacyStart = legacyInfo.copy()
-		# With the legacy object model,
-		# Move the caret to the end of the new sentence.
-		legacyInfo.move(textInfos.UNIT_SENTENCE, 1)
-		legacyInfo.updateCaret()
-		# Fetch the caret position (end of the next sentence) with UI automation.
-		endInfo = self.makeTextInfo(textInfos.POSITION_CARET)
-		# Move the caret back to the start of the next sentence,
-		# where it should be left for the user.
-		legacyStart.updateCaret()
-		# Fetch the new caret position (start of the next sentence) with UI Automation.
-		startInfo = self.makeTextInfo(textInfos.POSITION_CARET)
-		# Make a UI automation text range spanning the entire next sentence.
-		info = startInfo.copy()
-		info.end = endInfo.end
+
+		info = None
+
+		# Prefer UIA remote sentence navigation when available.
+		if UIARemote.isSupported():
+			try:
+				caretInfo = self.makeTextInfo(textInfos.POSITION_CARET)
+				sentenceRange = UIARemote.msWord_moveTextRangeBySentence(
+					self.UIAElement,
+					caretInfo._rangeObj,
+					direction,
+				)
+			except Exception:
+				log.debugWarning(
+					"Failed to fetch caret text range for remote sentence navigation",
+					exc_info=True,
+				)
+			else:
+				if sentenceRange is not None:
+					info = WordDocumentTextInfo(self, textInfos.POSITION_CARET, _rangeObj=sentenceRange)
+					info.updateCaret()
+
+		if info is None:
+			if not self.WinwordSelectionObject:
+				# Legacy object model not available.
+				# Translators: a message when navigating by sentence is unavailable in MS Word
+				ui.message(_("Navigating by sentence not supported in this document"))
+				gesture.send()
+				return
+			# Using the legacy object model,
+			# Move the caret to the next sentence in the requested direction.
+			legacyInfo = LegacyWordDocumentTextInfo(self, textInfos.POSITION_CARET)
+			legacyInfo.move(textInfos.UNIT_SENTENCE, direction)
+			# Save the start of the sentence for future use
+			legacyStart = legacyInfo.copy()
+			legacyInfo.move(textInfos.UNIT_SENTENCE, 1)
+			# Fetch the caret position (end of the next sentence) with UI automation.
+			endInfo = self.makeTextInfo(textInfos.POSITION_CARET)
+			# Move the caret back to the start of the next sentence,
+			# where it should be left for the user.
+			legacyStart.updateCaret()
+			# Fetch the new caret position (start of the next sentence) with UI Automation.
+			startInfo = self.makeTextInfo(textInfos.POSITION_CARET)
+			# Make a UI automation text range spanning the entire next sentence.
+			info = startInfo.copy()
+			info.end = endInfo.end
+
 		# Speak the sentence moved to
-		speech.speakTextInfo(info, unit=textInfos.UNIT_SENTENCE, reason=controlTypes.OutputReason.CARET)
+		speech.speakTextInfo(
+			info,
+			unit=textInfos.UNIT_SENTENCE,
+			reason=controlTypes.OutputReason.CARET,
+		)
 		# Forget the word currently being typed as the user has moved the caret somewhere else.
 		speech.clearTypedWordBuffer()
 		# Alert review and braille the caret has moved to its new position

--- a/source/NVDAObjects/UIA/wordDocument.py
+++ b/source/NVDAObjects/UIA/wordDocument.py
@@ -718,8 +718,8 @@ class WordDocument(UIADocumentWithTableNavigation, WordDocumentNode, WordDocumen
 
 	def _moveBySentenceWithObjectModel(self, direction) -> LegacyWordDocumentTextInfo:
 		"""
-			Using the legacy object model,
-			Move the caret to the next sentence in the requested direction.
+		Using the legacy object model,
+		Move the caret to the next sentence in the requested direction.
 		"""
 		legacyInfo = LegacyWordDocumentTextInfo(self, textInfos.POSITION_CARET)
 		legacyInfo.move(textInfos.UNIT_SENTENCE, direction)

--- a/source/NVDAObjects/UIA/wordDocument.py
+++ b/source/NVDAObjects/UIA/wordDocument.py
@@ -739,8 +739,7 @@ class WordDocument(UIADocumentWithTableNavigation, WordDocumentNode, WordDocumen
 					"Failed to fetch caret text range for remote sentence navigation",
 					exc_info=True,
 				)
-			else:
-				if sentenceRange is not None:
+			elif sentenceRange is not None:
 					info = WordDocumentTextInfo(self, textInfos.POSITION_CARET, _rangeObj=sentenceRange)
 					info.updateCaret()
 

--- a/source/NVDAObjects/UIA/wordDocument.py
+++ b/source/NVDAObjects/UIA/wordDocument.py
@@ -716,7 +716,7 @@ class WordDocument(UIADocumentWithTableNavigation, WordDocumentNode, WordDocumen
 			return
 		super(WordDocument, self).event_UIA_notification(**kwargs)
 
-	def _moveBySentenceWithObjectModel(self, direction) -> LegacyWordDocumentTextInfo:
+	def _moveBySentenceWithObjectModel(self, direction: int) -> LegacyWordDocumentTextInfo:
 		"""
 		Using the legacy object model,
 		Move the caret to the next sentence in the requested direction.

--- a/source/NVDAObjects/UIA/wordDocument.py
+++ b/source/NVDAObjects/UIA/wordDocument.py
@@ -739,7 +739,8 @@ class WordDocument(UIADocumentWithTableNavigation, WordDocumentNode, WordDocumen
 					"Failed to fetch caret text range for remote sentence navigation",
 					exc_info=True,
 				)
-			elif sentenceRange is not None:
+			else:
+				if sentenceRange is not None:
 					info = WordDocumentTextInfo(self, textInfos.POSITION_CARET, _rangeObj=sentenceRange)
 					info.updateCaret()
 

--- a/source/UIAHandler/remote.py
+++ b/source/UIAHandler/remote.py
@@ -5,7 +5,6 @@
 
 
 from typing import (
-	Optional,
 	Any,
 	Generator,
 	cast,

--- a/source/UIAHandler/remote.py
+++ b/source/UIAHandler/remote.py
@@ -86,7 +86,7 @@ def msWord_getCustomAttributeValue(
 	docElement: UIA.IUIAutomationElement,
 	textRange: UIA.IUIAutomationTextRange,
 	customAttribID: int,
-) -> Optional[Any]:
+) -> Any | None:
 	guid_msWord_getCustomAttributeValue = GUID("{081ACA91-32F2-46F0-9FB9-017038BC45F8}")
 	op = operation.Operation()
 

--- a/source/UIAHandler/remote.py
+++ b/source/UIAHandler/remote.py
@@ -16,6 +16,7 @@ import winVersion
 from logHandler import log
 from ._remoteOps import remoteAlgorithms
 from ._remoteOps.remoteTypes import (
+	RemoteElement,
 	RemoteExtensionTarget,
 	RemoteInt,
 )
@@ -56,12 +57,36 @@ def terminate():
 	_isSupported = False
 
 
+def _msWord_remote_getExtendedTextRangePattern(
+	ra: remoteAPI.RemoteAPI,
+	remoteDocElement: RemoteElement,
+) -> RemoteExtensionTarget:
+	guid_msWord_extendedTextRangePattern = GUID("{93514122-FF04-4B2C-A4AD-4AB04587C129}")
+	remoteResult = ra.newVariant()
+	extendedTextRangeIsSupported = remoteDocElement.isExtensionSupported(
+		guid_msWord_extendedTextRangePattern,
+	)
+	with ra.ifBlock(extendedTextRangeIsSupported.inverse()):
+		ra.logRuntimeMessage("docElement does not support extendedTextRangePattern")
+		ra.Return(None)
+	ra.logRuntimeMessage("docElement supports extendedTextRangePattern")
+	ra.logRuntimeMessage("doing callExtension for extendedTextRangePattern")
+	remoteDocElement.callExtension(
+		guid_msWord_extendedTextRangePattern,
+		remoteResult,
+	)
+	with ra.ifBlock(remoteResult.isNull()):
+		ra.logRuntimeMessage("extendedTextRangePattern is null")
+		ra.Return(None)
+	ra.logRuntimeMessage("got extendedTextRangePattern")
+	return remoteResult.asType(RemoteExtensionTarget)
+
+
 def msWord_getCustomAttributeValue(
 	docElement: UIA.IUIAutomationElement,
 	textRange: UIA.IUIAutomationTextRange,
 	customAttribID: int,
 ) -> Optional[Any]:
-	guid_msWord_extendedTextRangePattern = GUID("{93514122-FF04-4B2C-A4AD-4AB04587C129}")
 	guid_msWord_getCustomAttributeValue = GUID("{081ACA91-32F2-46F0-9FB9-017038BC45F8}")
 	op = operation.Operation()
 
@@ -70,24 +95,10 @@ def msWord_getCustomAttributeValue(
 		remoteDocElement = ra.newElement(docElement)
 		remoteTextRange = ra.newTextRange(textRange)
 		remoteCustomAttribValue = ra.newVariant()
-		extendedTextRangeIsSupported = remoteDocElement.isExtensionSupported(
-			guid_msWord_extendedTextRangePattern,
+		remoteExtendedTextRangePattern = _msWord_remote_getExtendedTextRangePattern(
+			ra,
+			remoteDocElement,
 		)
-		with ra.ifBlock(extendedTextRangeIsSupported.inverse()):
-			ra.logRuntimeMessage("docElement does not support extendedTextRangePattern")
-			ra.Return(None)
-		ra.logRuntimeMessage("docElement supports extendedTextRangePattern")
-		remoteResult = ra.newVariant()
-		ra.logRuntimeMessage("doing callExtension for extendedTextRangePattern")
-		remoteDocElement.callExtension(
-			guid_msWord_extendedTextRangePattern,
-			remoteResult,
-		)
-		with ra.ifBlock(remoteResult.isNull()):
-			ra.logRuntimeMessage("extendedTextRangePattern is null")
-			ra.Return(None)
-		ra.logRuntimeMessage("got extendedTextRangePattern")
-		remoteExtendedTextRangePattern = remoteResult.asType(RemoteExtensionTarget)
 		customAttributeValueIsSupported = remoteExtendedTextRangePattern.isExtensionSupported(
 			guid_msWord_getCustomAttributeValue,
 		)
@@ -110,6 +121,70 @@ def msWord_getCustomAttributeValue(
 		log.debugWarning("Custom attribute value not available")
 		return None
 	return customAttribValue
+
+
+def msWord_moveTextRangeBySentence(
+	docElement: UIA.IUIAutomationElement,
+	textRange: UIA.IUIAutomationTextRange,
+	unitCount: int,
+) -> Optional[UIA.IUIAutomationTextRange]:
+	"""
+	Move a UI Automation text range by sentence using the Word-specific UIA
+	extended text range pattern, if available.
+	Returns None if the operation fails or the extensions are not supported.
+	"""
+	if not isSupported():
+		return None
+
+	guid_msWord_moveBySentence = GUID("{F39655AC-133A-435B-A318-C197F0D3D203}")
+	guid_msWord_expandToEnclosingSentence = GUID("{98FE8B34-F317-459A-9627-21123EA95BEA}")
+	op = operation.Operation()
+
+	@op.buildFunction
+	def code(ra: remoteAPI.RemoteAPI):
+		remoteDocElement = ra.newElement(docElement)
+		remoteTextRange = ra.newTextRange(textRange)
+
+		remoteExtendedTextRangePattern = _msWord_remote_getExtendedTextRangePattern(
+			ra,
+			remoteDocElement,
+		)
+
+		moveBySentenceSupported = remoteExtendedTextRangePattern.isExtensionSupported(
+			guid_msWord_moveBySentence,
+		)
+		with ra.ifBlock(moveBySentenceSupported.inverse()):
+			ra.logRuntimeMessage("extendedTextRangePattern does not support MoveBySentence")
+			ra.Return(None)
+
+		moveCount = ra.newInt(unitCount)
+		actualMoved = ra.newInt(0)
+		ra.logRuntimeMessage("doing callExtension for MoveBySentence")
+		remoteExtendedTextRangePattern.callExtension(
+			guid_msWord_moveBySentence,
+			remoteTextRange,
+			moveCount,
+			actualMoved,
+		)
+
+		expandSupported = remoteExtendedTextRangePattern.isExtensionSupported(
+			guid_msWord_expandToEnclosingSentence,
+		)
+		with ra.ifBlock(expandSupported.inverse()):
+			ra.logRuntimeMessage(
+				"extendedTextRangePattern does not support ExpandToEnclosingSentence",
+			)
+			ra.Return(None)
+
+		ra.logRuntimeMessage("doing callExtension for ExpandToEnclosingSentence")
+		remoteExtendedTextRangePattern.callExtension(
+			guid_msWord_expandToEnclosingSentence,
+			remoteTextRange,
+		)
+
+		ra.Return(remoteTextRange)
+
+	return op.execute()
 
 
 def collectAllHeadingsInTextRange(

--- a/source/UIAHandler/remote.py
+++ b/source/UIAHandler/remote.py
@@ -127,7 +127,7 @@ def msWord_moveTextRangeBySentence(
 	docElement: UIA.IUIAutomationElement,
 	textRange: UIA.IUIAutomationTextRange,
 	unitCount: int,
-) -> Optional[UIA.IUIAutomationTextRange]:
+) -> UIA.IUIAutomationTextRange | None:
 	"""
 	Move a UI Automation text range by sentence using the Word-specific UIA
 	extended text range pattern, if available.
@@ -156,6 +156,14 @@ def msWord_moveTextRangeBySentence(
 		with ra.ifBlock(moveBySentenceSupported.inverse()):
 			ra.logRuntimeMessage("extendedTextRangePattern does not support MoveBySentence")
 			ra.Return(None)
+		expandSupported = remoteExtendedTextRangePattern.isExtensionSupported(
+			guid_msWord_expandToEnclosingSentence,
+		)
+		with ra.ifBlock(expandSupported.inverse()):
+			ra.logRuntimeMessage(
+				"extendedTextRangePattern does not support ExpandToEnclosingSentence",
+			)
+			ra.Return(None)
 
 		moveCount = ra.newInt(unitCount)
 		actualMoved = ra.newInt(0)
@@ -166,16 +174,6 @@ def msWord_moveTextRangeBySentence(
 			moveCount,
 			actualMoved,
 		)
-
-		expandSupported = remoteExtendedTextRangePattern.isExtensionSupported(
-			guid_msWord_expandToEnclosingSentence,
-		)
-		with ra.ifBlock(expandSupported.inverse()):
-			ra.logRuntimeMessage(
-				"extendedTextRangePattern does not support ExpandToEnclosingSentence",
-			)
-			ra.Return(None)
-
 		ra.logRuntimeMessage("doing callExtension for ExpandToEnclosingSentence")
 		remoteExtendedTextRangePattern.callExtension(
 			guid_msWord_expandToEnclosingSentence,

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -8,6 +8,8 @@
 
 ### Changes
 
+* In Microsoft Word with UI Automation on Windows 11, NVDA can navigate by sentence in environments where the legacy object model is unavailable. (#13517, @codeofdusk)
+
 ### Bug Fixes
 
 ### Changes for Developers

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -11,7 +11,6 @@
 
 ### Changes
 
-* In Microsoft Word with UI Automation on Windows 11, NVDA can navigate by sentence in environments where the legacy object model is unavailable. (#13517, @codeofdusk)
 * It is now possible to open the log viewer with `NVDA+f1`, even when the log level is set to "disabled". (#19318, @CyrilleB79)
 
 ### Bug Fixes


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Closes #13517.

### Summary of the issue:
NVDA exclusively uses Word's legacy object model for sentence navigation, even when UIA is enabled.

### Description of how this pull request fixes the issue:
Added support for the [UIA custom extension](https://docs.microsoft.com/en-gb/office/uia/word/wordcustompatterns) to move and expand by sentence in supported scenarios. The legacy implementation remains as a fallback on systems without remote ops support (Windows below 11/Cobalt platform) or older Office versions.

### Testing strategy:
Moved by sentence in a large document and verified functionality.

### Known issues with pull request:
None known

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
