### PR TITLE
Set the MathCAT output code automatically by NVDA language

### DIFF
--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -469,8 +469,8 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 		copyAs = string(default="MathML")
 
 	[[braille]]
-		# Any supported braille code (currently Nemeth, UEB)
-		brailleCode = string(default="Nemeth")
+		# Any supported Braille code (such as UEB) or "Auto"
+		brailleCode = string(default="Auto")
 		# Highlight with dots 7 & 8 the current nav node -- values are Off, FirstChar, EndPoints, All
 		brailleNavHighlight = string(default="EndPoints")
 		# true/false

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -2948,14 +2948,27 @@ class MathSettingsPanel(SettingsPanel):
 
 		# Translators: label for combobox to specify which braille code to use
 		brailleMathCodeText = pgettext("math", "Braille math code for refreshable displays")
-		brailleMathCodeOptions: list[str] = preferences.getBrailleCodes()
+		availableBrailleCodes: list[str] = preferences.getBrailleCodes()
+		autoBrailleCode = preferences.getAutoBrailleCode(availableBrailleCodes)
+		# Translators: An option in Math settings to select a braille code automatically,
+		# according to NVDA's language.
+		autoDisplay = pgettext("math", "Automatic ({name})").format(name=autoBrailleCode)
+		self._brailleCodeIds: list[str] = ["Auto"]
+		brailleMathCodeOptions: list[str] = [autoDisplay]
+		self._brailleCodeIds.extend(availableBrailleCodes)
+		brailleMathCodeOptions.extend(availableBrailleCodes)
 		self.brailleMathCodeList = navGroup.addLabeledControl(
 			brailleMathCodeText,
 			wx.Choice,
 			choices=brailleMathCodeOptions,
 		)
 		self.bindHelpEvent("MathBrailleCode", self.brailleMathCodeList)
-		self.brailleMathCodeList.SetStringSelection(config.conf["math"]["braille"]["brailleCode"])
+		currentBrailleCode = config.conf["math"]["braille"]["brailleCode"]
+		try:
+			selectionIndex = self._brailleCodeIds.index(currentBrailleCode)
+		except ValueError:
+			selectionIndex = 0
+		self.brailleMathCodeList.SetSelection(selectionIndex)
 
 		# Translators: label for combobox to specify how braille dots should be modified when navigating/selecting subexprs
 		brailleHighlightsText = pgettext("math", "Highlight the current navigation node with dots 7 and 8")
@@ -3043,7 +3056,8 @@ class MathSettingsPanel(SettingsPanel):
 			BrailleNavHighlightOption,
 			self.brailleHighlightsList.GetSelection(),
 		)
-		mathConf["braille"]["brailleCode"] = self.brailleMathCodeList.GetStringSelection()
+		selectedBrailleIndex = self.brailleMathCodeList.GetSelection()
+		mathConf["braille"]["brailleCode"] = self._brailleCodeIds[selectedBrailleIndex]
 		mcPrefs: MathCATUserPreferences = MathCATUserPreferences.fromNVDAConfig()
 		mcPrefs.save()
 

--- a/source/mathPres/MathCAT/MathCAT.py
+++ b/source/mathPres/MathCAT/MathCAT.py
@@ -42,6 +42,7 @@ from textUtils import WCHAR_ENCODING
 
 import mathPres
 from .localization import getLanguageToUse
+from .preferences import setEffectiveBrailleCode
 from .speech import convertSSMLTextForNVDA
 
 
@@ -332,6 +333,7 @@ class MathCAT(mathPres.MathPresentationProvider):
 			log.info(f"MathCAT {libmathcat.GetVersion()} installed. Using rules dir: {rulesDir}")
 			libmathcat.SetRulesDir(rulesDir)
 			libmathcat.SetPreference("TTS", "SSML")
+			setEffectiveBrailleCode()
 		except Exception:
 			log.exception()
 			# Translators: this message directs users to look in the log file

--- a/source/mathPres/MathCAT/preferences.py
+++ b/source/mathPres/MathCAT/preferences.py
@@ -244,6 +244,7 @@ def getAutoBrailleCode(
 		languageCode = languageHandler.getLanguage()
 
 	languagesToBrailleCodes: dict[str, str] = {
+		"en": "UEB",
 		"es": "CMU",
 		"es_CO": "CMU",
 		"fi": "ASCIIMath-finnish",

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -57,7 +57,7 @@ Windows 10 on ARM is also no longer supported.
   * VirusTotal scan results are now available in the details for an add-on.
   An action has been added to view the full scan results on the VirusTotal website. (#18974)
   * A new action has been added to see the latest changes for the current version of an add-on. (#14041, @josephsl, @nvdaes)
-* Added built-in support for reading math content by integrating MathCAT. (#18323, @RyanMcCleary)
+* Added built-in support for reading math content by integrating MathCAT. (#18323, #19368, @RyanMcCleary, @codeofdusk)
 * NVDA can now use on-device AI to generate image descriptions. (#18475, @tianzeshi-study)
   * This feature is experimental, and should not be used in situations where inaccurate descriptions could cause harm.
   * To use this feature, NVDA will need to download image description data.

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -3378,12 +3378,13 @@ Specify how math will be copied to the clipboard.
 
 ###### Braille math code for refreshable displays {#MathBrailleCode}
 
-The braille math code to use.
+The Braille math code to use.
+When this option is set to "Automatic", NVDA tries to infer a reasonable choice based on the current NVDA language.
 
 | . {.hideHeaderRow} | . |
 |---|---|
-| Options | ASCIIMath, ASCIIMath-Finnish, CMU, LaTeX, Nemeth, Swedish, UEB, Vietnam |
-| Default | Nemeth |
+| Options | Automatic, ASCIIMath, ASCIIMath-Finnish, CMU, LaTeX, Nemeth, Swedish, UEB, Vietnam |
+| Default | Automatic |
 
 ###### Highlight the current navigation node with dots 7 and 8 {#MathBrailleHighlights}
 

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -3378,7 +3378,7 @@ Specify how math will be copied to the clipboard.
 
 ###### Braille math code for refreshable displays {#MathBrailleCode}
 
-The Braille math code to use.
+The braille math code to use.
 When this option is set to "Automatic", NVDA tries to infer a reasonable choice based on the current NVDA language.
 
 | . {.hideHeaderRow} | . |

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -3378,8 +3378,8 @@ Specify how math will be copied to the clipboard.
 
 ###### Braille math code for refreshable displays {#MathBrailleCode}
 
-The braille math code to use.
-When this option is set to "Automatic", NVDA tries to infer a reasonable choice based on the current NVDA language.
+The Braille math code to use.
+When this option is set to "Automatic", NVDA selects a default math braille code based on the current NVDA language.
 
 | . {.hideHeaderRow} | . |
 |---|---|

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -3378,7 +3378,7 @@ Specify how math will be copied to the clipboard.
 
 ###### Braille math code for refreshable displays {#MathBrailleCode}
 
-The Braille math code to use.
+The braille math code to use.
 When this option is set to "Automatic", NVDA selects a default math braille code based on the current NVDA language.
 
 | . {.hideHeaderRow} | . |


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Closes #19233.

### Summary of the issue:
`nemeth` is unsuitable as a default MathCAT output code for NVDA's global user base (see #19233 for details).

### Description of how this pull request fixes the issue:
Adds a new "automatic" Braille code config option and switched to it by default. This option:

* Checks if there's a reasonable default code to use for the current NVDA language (es -> CMU, sv -> Swedish, vi -> Vietnamese);
* Otherwise, falls back to `ASCIIMath`.

### Testing strategy:
Changed NVDA language to Spanish and verified that CMU became the effective code when the Braille code option was set to `auto`.

### Known issues with pull request:
None known

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
