### PR TITLE
Add crash stats output to git ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ source/locale/*/cldr.dic
 nvdaHelper/docs/
 *.pfx
 *.egg-info
+source/nvda_crash_stats.txt


### PR DESCRIPTION
### Link to issue number:
Follow-up #19175

### Summary of the issue:

If NVDA crashes when running from source, git picks up `nvda_crash_stats.txt` as an untracked file.

### Description of user facing changes:

None

### Description of developer facing changes:

Git will ignore `nvda_crash_stats.txt`, meaning it's much less likely to be accidentally committed and doesn't clutter our git output.

### Description of development approach:

Added `source/nvda_crash_stats.txt` to `.gitignore`.

### Testing strategy:

Ran `git status`. Verified that `nvda_crash_stats` was no longer showing as an untracked file.

### Known issues with pull request:

None

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
