### PR TITLE
Move mathCATDir to ReadPaths

### DIFF
--- a/source/NVDAState.py
+++ b/source/NVDAState.py
@@ -28,22 +28,6 @@ class _WritePaths:
 		return configPath
 
 	@property
-	def mathCATDir(self) -> str:
-		"""
-		Base directory for MathCAT assets (rules etc.).
-		"""
-		if isRunningAsSource():
-			base = os.path.dirname(globalVars.appDir)
-		else:
-			base = globalVars.appDir
-		return os.path.join(
-			base,
-			"include",
-			"nvda-mathcat",
-			"assets",
-		)
-
-	@property
 	def addonsDir(self) -> str:
 		return os.path.join(self.configDir, "addons")
 
@@ -268,6 +252,22 @@ class _ReadPaths:
 	@property
 	def nvdaHelperLocalWin10Dll(self) -> str:
 		return os.path.join(self.coreArchLibPath, "nvdaHelperLocalWin10.dll")
+
+	@property
+	def mathCATDir(self) -> str:
+		"""
+		Base directory for MathCAT assets (rules etc.).
+		"""
+		if isRunningAsSource():
+			base = os.path.dirname(globalVars.appDir)
+		else:
+			base = globalVars.appDir
+		return os.path.join(
+			base,
+			"include",
+			"nvda-mathcat",
+			"assets",
+		)
 
 	@property
 	def UIARemoteDll(self) -> str:

--- a/source/mathPres/MathCAT/MathCAT.py
+++ b/source/mathPres/MathCAT/MathCAT.py
@@ -26,7 +26,7 @@ from api import getClipData
 from keyboardHandler import KeyboardInputGesture
 from logHandler import log
 from scriptHandler import script
-from NVDAState import WritePaths
+from NVDAState import ReadPaths
 
 from speech.commands import (
 	BeepCommand,
@@ -326,7 +326,7 @@ class MathCAT(mathPres.MathPresentationProvider):
 		try:
 			# IMPORTANT -- SetRulesDir must be the first call to libmathcat besides GetVersion()
 			rulesDir: str = path.join(
-				WritePaths.mathCATDir,
+				ReadPaths.mathCATDir,
 				"Rules",
 			)
 			log.info(f"MathCAT {libmathcat.GetVersion()} installed. Using rules dir: {rulesDir}")

--- a/source/mathPres/MathCAT/localization.py
+++ b/source/mathPres/MathCAT/localization.py
@@ -12,7 +12,7 @@ import wx
 from languageHandler import getLanguageDescription
 from logHandler import log
 from speech import getCurrentLanguage
-from NVDAState import WritePaths
+from NVDAState import ReadPaths
 
 import libmathcat_py as libmathcat
 from . import rulesUtils
@@ -236,7 +236,7 @@ def pathToLanguagesFolder() -> str:
 	:return: Absolute path to the Languages folder as a string.
 	"""
 	return os.path.join(
-		WritePaths.mathCATDir,
+		ReadPaths.mathCATDir,
 		"Rules",
 		"Languages",
 	)

--- a/source/mathPres/MathCAT/preferences.py
+++ b/source/mathPres/MathCAT/preferences.py
@@ -9,7 +9,7 @@ import os
 import config
 import yaml
 from logHandler import log
-from NVDAState import WritePaths
+from NVDAState import ReadPaths
 from utils.displayString import DisplayStringStrEnum
 
 import libmathcat_py as libmathcat
@@ -207,7 +207,7 @@ def pathToBrailleFolder() -> str:
 	:return: Absolute path to the Braille folder as a string.
 	"""
 	return os.path.join(
-		WritePaths.mathCATDir,
+		ReadPaths.mathCATDir,
 		"Rules",
 		"Braille",
 	)


### PR DESCRIPTION
### Link to issue number:
Fixup #18323

### Summary of the issue:

`mathCATDir` is a property of `NVDAState.WritePaths`, even though it is not writable by non-elevated installed copies, and it doesn't seem like we even want to write to it.

### Description of user facing changes:

None

### Description of developer facing changes:

`mathCATDir` is now a property of `NVDAState.ReadDirs`.

### Description of development approach:

Moved `mathCATDir` to `NVDAState._ReadDirs`.
Searched for usages of `mathCATDir` in `source/` and updated them.

### Testing strategy:

Ran from source and interacted with MathML in Firefox.

### Known issues with pull request:

None

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
