### PR TITLE
MathCAT: Use CMU in Portuguese

### DIFF
--- a/source/mathPres/MathCAT/preferences.py
+++ b/source/mathPres/MathCAT/preferences.py
@@ -248,6 +248,8 @@ def getAutoBrailleCode(
 		"es": "CMU",
 		"es_CO": "CMU",
 		"fi": "ASCIIMath-finnish",
+		"pt_BR": "CMU",
+		"pt_PT": "CMU",
 		"sv": "Swedish",
 		"vi": "Vietnam",
 	}


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Follow-up of #19368.

### Summary of the issue:
Portuguese usually uses the código matemático unificado (per [the ONCE](https://www.once.es/dejanos-ayudarte/la-discapacidad-visual/revista-red-visual/numeros-publicados-red-visual/2023-redvisual-81/novedades-que-incluye-el-codigo-matematico-unificado-para-iberoamerica-del-consejo-iberoamericano-del-braille)):

> ...la actualización del código matemático unificado, realizada por la Comisión Técnica de Ciencias del Consejo **Iberoamericano** del Braille.

### Description of how this pull request fixes the issue:
Mapped pt_BR and pt_PT to CMU in the MathCAT auto table.

### Testing strategy:
Verified mapping.

### Known issues with pull request:
None known

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
