### PR TITLE
Improve language handling for MathCAT braille

### DIFF
--- a/source/mathPres/MathCAT/preferences.py
+++ b/source/mathPres/MathCAT/preferences.py
@@ -243,18 +243,28 @@ def getAutoBrailleCode(
 	if languageCode is None:
 		languageCode = languageHandler.getLanguage()
 
+	# de, nb, and nn should probably use Marburg when implemented upstream
 	languagesToBrailleCodes: dict[str, str] = {
+		"af": "UEB",
+		"an": "CMU",
+		"ca": "CMU",
+		"da": "LaTeX",
+		"de": "LaTeX",
 		"en": "UEB",
 		"es": "CMU",
-		"es_CO": "CMU",
-		"fi": "ASCIIMath-finnish",
-		"pt_BR": "CMU",
-		"pt_PT": "CMU",
+		"fi": "ASCIIMath-fi",
+		"ga": "UEB",
+		"gl": "CMU",
+		"mn": "UEB",
+		"nb": "LaTeX",
+		"nn": "LaTeX",
+		"pt": "CMU",
+		"ro": "UEB",
 		"sv": "Swedish",
 		"vi": "Vietnam",
 	}
 
-	res = languagesToBrailleCodes.get(languageCode)
+	res = languagesToBrailleCodes.get(languageCode.split("_")[0])
 	if res and res in availableCodes:
 		return res
 	return "ASCIIMath"


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Split from #19227. Follow-up of #19368.

### Summary of the issue:
* The automatic Braille entry for Finnish was incorrect.
* Several languages could have more reasonable Braille defaults.

### Description of how this pull request fixes the issue:
Simplify (key on base language only, not region codes), fix "fi", and expand Braille auto language table.

### Testing strategy:
Braille mapping still functional.

### Known issues with pull request:
None known

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
