### PR TITLE
Fixed an error that occurred when enabling visual highlighter for elements with a height less than 0.

### DIFF
--- a/source/visionEnhancementProviders/NVDAHighlighter.py
+++ b/source/visionEnhancementProviders/NVDAHighlighter.py
@@ -582,7 +582,7 @@ class NVDAHighlighter(providerBase.VisionEnhancementProvider):
 		if rect is None:
 			try:
 				rect = getContextRect(context, obj=obj)
-			except (LookupError, RuntimeError, TypeError):
+			except (LookupError, ValueError, RuntimeError, TypeError):
 				rect = None
 		self.contextToRectMap[context] = rect
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -16,6 +16,7 @@
 ### Bug Fixes
 
 * Fixed excessive resource usage and highlight flickering when using Visual Highlight. (#17434, @hwf1324)
+* Fixed an error that occurred when enabling visual highlighter for elements with a height less than 0. (#19383, @hwf1324)
 
 ### Changes for Developers
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -16,7 +16,6 @@
 ### Bug Fixes
 
 * Fixed excessive resource usage and highlight flickering when using Visual Highlight. (#17434, @hwf1324)
-* Fixed an error that occurred when enabling visual highlighter for elements with a height less than 0. (#19383, @hwf1324)
 
 ### Changes for Developers
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
<!-- Use Closes/Fixes/Resolves #xxx to link this PR to the issue it is responding to. -->

Fixes: #19383

### Summary of the issue:

The highlighter gets an error getting a rectangle of objects with heights less than 0. This is because we are not handling the `ValueError` exception thrown by `locationHelper.RectLTRB`.

### Description of user facing changes:

The highlighter does not report an error when it encounters an object with a height less than 0.

### Description of developer facing changes:

### Description of development approach:

Handle `ValueError` exception when `NVDAHighlighter.updateContextRect` gets the context rectangle.

### Testing strategy:

Manual testing:

1. Open Visual Highlighter and check "Navigation object follows mouse cursor".
2. Press `Win+i` to open Settings and maximize it.
3. Move the mouse outside the top right corner of the screen.

### Known issues with pull request:

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
