### PR TITLE
Word with UIA: Retrieve Page Numbers from Custom Attributes API (#19394)

### DIFF
--- a/source/NVDAObjects/UIA/wordDocument.py
+++ b/source/NVDAObjects/UIA/wordDocument.py
@@ -484,7 +484,7 @@ class WordDocumentTextInfo(UIATextInfo):
 			page = fields[0].field["page-number"]
 		except KeyError:
 			page = None
-		if page is not None:
+		if page is not None and not UIARemote.isSupported():
 			for field in fields:
 				if isinstance(field, textInfos.FieldCommand) and isinstance(
 					field.field,
@@ -537,6 +537,13 @@ class WordDocumentTextInfo(UIATextInfo):
 				if isinstance(lineNumber, int):
 					formatField.field["line-number"] = lineNumber
 			if formatConfig["reportPage"]:
+				pageNumber = UIARemote.msWord_getCustomAttributeValue(
+					docElement,
+					textRange,
+					UIACustomAttributeID.PAGE_NUMBER,
+				)
+				if isinstance(pageNumber, int):
+					formatField.field["page-number"] = pageNumber
 				sectionNumber = UIARemote.msWord_getCustomAttributeValue(
 					docElement,
 					textRange,

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -15,6 +15,7 @@
 
 ### Bug Fixes
 
+* In Microsoft Word with UIA enabled, page changes are now correctly announced when navigating table rows that span multiple pages. (#19386, @akj)
 * Fixed excessive resource usage and highlight flickering when using Visual Highlight. (#17434, @hwf1324)
 
 ### Changes for Developers


### PR DESCRIPTION

### Link to issue number:
Fixes #19386 

### Summary of the issue:
When using UIA to access Microsoft Word documents, page change announcements do not occur when navigating between table rows that span different pages. Page changes are only announced after exiting the table. This does not occur in IAccessible mode ("only where necessary" setting), where page changes are announced correctly within tables.                                                                           

### Description of user facing changes:
When navigating table rows in Word documents using UIA, NVDA will now correctly announce page changes (e.g., "page 2") when moving between rows on different pages.

### Description of developer facing changes:

### Description of development approach:
The `WordDocumentTextInfo._getFormatFieldAtRange` method now retrieves page numbers via Word's custom attribute API (`UIACustomAttributeID.PAGE_NUMBER`), similar to how line numbers and section numbers are already retrieved. The fallback mechanism in `getTextWithFields` has been updated to only propagate page numbers from control elements when UIARemote is not supported, preserving the more accurate custom attribute values.               

### Testing strategy:
Manual testing with UIA enabled and disabled.

### Known issues with pull request:
None known.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
