### PR TITLE
Fix skim reading issue

### DIFF
--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -40,6 +40,7 @@ from .commands import (
 	SuppressUnicodeNormalizationCommand,
 	CharacterModeCommand,
 	WaveFileCommand,
+	CallbackCommand,
 )
 from .shortcutKeys import getKeyboardShortcutsSpeech
 
@@ -149,9 +150,10 @@ def _setLastSpeechString(
 	priority: Spri,
 ):
 	# Check if the speech sequence contains text to speak
-	if [item for item in speechSequence if isinstance(item, str)]:
+	if any(isinstance(item, str) for item in speechSequence):
 		global _lastSpeech
-		_lastSpeech = speechSequence, symbolLevel
+		log.debug(f"{speechSequence=}")
+		_lastSpeech = [item for item in speechSequence if not isinstance(item, CallbackCommand)], symbolLevel
 
 
 def initialize():

--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -152,7 +152,6 @@ def _setLastSpeechString(
 	# Check if the speech sequence contains text to speak
 	if any(isinstance(item, str) for item in speechSequence):
 		global _lastSpeech
-		log.debug(f"{speechSequence=}")
 		_lastSpeech = [item for item in speechSequence if not isinstance(item, CallbackCommand)], symbolLevel
 
 

--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -154,7 +154,7 @@ def _setLastSpeechString(
 	if any(isinstance(item, str) for item in speechSequence):
 		global _lastSpeech
 		_lastSpeech = (
-i			[item for item in speechSequence if not isinstance(item, (CallbackCommand, _CancellableSpeechCommand))],
+			[item for item in speechSequence if not isinstance(item, (CallbackCommand, _CancellableSpeechCommand))],
 			symbolLevel,
 		)
 

--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -41,6 +41,7 @@ from .commands import (
 	CharacterModeCommand,
 	WaveFileCommand,
 	CallbackCommand,
+	_CancellableSpeechCommand,
 )
 from .shortcutKeys import getKeyboardShortcutsSpeech
 
@@ -152,7 +153,10 @@ def _setLastSpeechString(
 	# Check if the speech sequence contains text to speak
 	if any(isinstance(item, str) for item in speechSequence):
 		global _lastSpeech
-		_lastSpeech = [item for item in speechSequence if not isinstance(item, CallbackCommand)], symbolLevel
+		_lastSpeech = (
+i			[item for item in speechSequence if not isinstance(item, (CallbackCommand, _CancellableSpeechCommand))],
+			symbolLevel,
+		)
 
 
 def initialize():

--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -154,7 +154,11 @@ def _setLastSpeechString(
 	if any(isinstance(item, str) for item in speechSequence):
 		global _lastSpeech
 		_lastSpeech = (
-			[item for item in speechSequence if not isinstance(item, (CallbackCommand, _CancellableSpeechCommand))],
+			[
+				item
+				for item in speechSequence
+				if not isinstance(item, (CallbackCommand, _CancellableSpeechCommand))
+			],
 			symbolLevel,
 		)
 


### PR DESCRIPTION
### Link to issue number:
Fixes #19395
Fix-up of #19173.

### Summary of the issue:
Sometimes, e.g. in Notepad, skim reading process was not correctly interrupted when pressing `control` key: say all was restarting when another key was pressed.

### Description of user facing changes:
Skim reading process is now correctly interrupted when `control` is pressed.

### Description of developer facing changes:
N/A
### Description of development approach:
When the speech sequence is stored, it is first filtered.
`CallbackCommand`s are filtered out of the sequence since callback functions such as say all ones should not be called again when repeating the last speech (this was the cause of say all restarting).

Not all `BaseCallbackCommand`s are filtered since other `BaseCallbackCommand` such as `BeepCommand` (for indentation reporting) or `WaveFileCommand`s (for spelling error reporting) still need to be reported.

I have not included `IndexCommand`s in the filtering since in any case, they only seem to appear downstream, in the speech manager part.

Regarding `CancellableSpeechCommand`s, I have included them, since I've seen that they are also filtered out from remote speech. Though, I do not exactly know how cancellable speech works, so please double check. Thanks.

### Testing strategy:
Manual test of speech repetition in browse mode as well as in Notepad and tests with skim reading as described in #19395.
Also tested that indentation beeps or spelling errors sounds while reading are still played when repeating the last speech.

### Known issues with pull request:
None

### Code Review Checklist:


- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
