### PR TITLE
Fix Firefox browse mode not announcing aria-label when label element contains only hidden content

### DIFF
--- a/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.cpp
+++ b/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.cpp
@@ -287,6 +287,15 @@ OptionalLabelInfo GeckoVBufBackend_t::getLabelInfo(IAccessible2* pacc2) {
 	CComVariant state;
 	HRESULT res = firstAccTarget->get_accState(child, &state);
 	bool isVisible = res == S_OK && !(state.lVal & STATE_SYSTEM_INVISIBLE);
+	// If the label element is visible, also verify it has actual accessible text content.
+	// A label containing only aria-hidden elements would be visible but have no accessible text,
+	// meaning it cannot be the source of the accessible name (e.g. aria-label was used instead).
+	if (isVisible) {
+		wstring labelText;
+		if (!getTextFromIAccessible(labelText, firstAccTarget)) {
+			isVisible = false;
+		}
+	}
 	auto ID = getIAccessible2UniqueID(firstAccTarget);
 	return LabelInfo { isVisible, ID } ;
 }

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -15,6 +15,7 @@
 
 ### Bug Fixes
 
+* In Firefox browse mode, the accessible name of form controls (such as checkboxes and radio buttons) is now correctly announced when the control has an `aria-label` and an associated `<label>` element that contains only `aria-hidden` content. (#XXXX, @bramd)
 * Fixed excessive resource usage and highlight flickering when using Visual Highlight. (#17434, @hwf1324)
 
 ### Changes for Developers


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
<!-- Use Closes/Fixes/Resolves #xxx to link this PR to the issue it is responding to. -->
None

### Summary of the issue:

When a form control (such as a checkbox or radio button) has both:
1. An `aria-label` attribute providing the accessible name
2. A `<label for="...">` element whose content is entirely `aria-hidden`

NVDA's browse mode in Firefox fails to announce the accessible name. The name is correctly announced in focus mode.

Example HTML that reproduces the issue:
```html
<input type="checkbox" id="testinput" aria-label="TestArea">
<label for="testinput"><span aria-hidden="true">Test</span></label>
```

In Firefox browse mode, navigating to this checkbox announces only "check box not checked" with no name, even though the accessible name is "TestArea" from `aria-label`.

The root cause is in `getLabelInfo()` which determines if a control's label is "visible" by checking `IA2_RELATION_LABELLED_BY` targets. It only checked if the label element had `STATE_SYSTEM_INVISIBLE`, but a label element can be visible while containing only `aria-hidden` content, meaning it contributes no accessible text to the virtual buffer. This caused NVDA to incorrectly assume the user would read the label content in browse mode, so it didn't force the `aria-label` name to be announced.

It could be argued that exposing the labelled by association even if the name is set using aria-label is a bug in Firefox, since the label element is no longer contributing to the accessible name of the element and that it should be fixed there. I'm willing to open a Firefox bug for this if preferred.

### Description of user facing changes:

Form controls with `aria-label` will now correctly have their accessible name announced in browse mode, even when an associated `<label for>` element exists but contains only hidden content.

### Description of developer facing changes:

None

### Description of development approach:

The fix is in `getLabelInfo()` in `nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.cpp`. This function determines if a control's label is "visible" by checking `IA2_RELATION_LABELLED_BY` targets.

Previously, it only checked if the label element had `STATE_SYSTEM_INVISIBLE`. However, a label element can be visible while containing only `aria-hidden` content, meaning it contributes no accessible text to the virtual buffer.

The fix adds a check using `getTextFromIAccessible()` to verify the label element actually has accessible text content. If not, the label is treated as not visible, which causes `alwaysReportName` to be set, ensuring the `aria-label` name is announced.

### Testing strategy:

Tested the provided HTML test snippet and confirmed the name was read in browse mode in Firefox.

### Known issues with pull request:

None, but there is a risk of this breaking other edge cases that are hard to test.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
