### PR TITLE
Fix #19261: prevent duplicate IncompatibleAddonsDialog

### DIFF
--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -99,7 +99,7 @@ jobs:
     # This information is static for the current Github Actions runner image.
     # Therefore, cache this information with a key scoped to the current image version, ensuring that subsequent workflow runs will be much faster.
     - name: SCons MSVC Cache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ${{ env.SCONS_CACHE_MSVC_CONFIG }}
         key: ${{ env.SCONS_CACHE_KEY }}
@@ -109,7 +109,7 @@ jobs:
     - name: Prepare for tests
       run: ci/scripts/tests/beforeTests.ps1
     - name: Cache scons build
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v5
       with:
         path: .
         key: ${{ github.ref }}-${{ github.run_id }}-${{ matrix.pythonVersion }}-${{ matrix.arch }}
@@ -127,7 +127,7 @@ jobs:
     needs: [matrix, buildNVDA]
     steps:
     - name: Checkout cached build
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         path: .
         key: ${{ github.ref }}-${{ github.run_id }}-${{ env.defaultPythonVersion }}-${{ env.defaultArch }}
@@ -179,7 +179,7 @@ jobs:
     needs: [matrix, buildNVDA]
     steps:
     - name: Checkout cached build
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         path: .
         key: ${{ github.ref }}-${{ github.run_id }}-${{ env.defaultPythonVersion }}-${{ env.defaultArch }}
@@ -208,7 +208,7 @@ jobs:
     needs: [matrix, buildNVDA]
     steps:
     - name: Checkout cached build
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         path: .
         key: ${{ github.ref }}-${{ github.run_id }}-${{ env.defaultPythonVersion }}-${{ env.defaultArch }}
@@ -236,7 +236,7 @@ jobs:
       uv-arch: ${{ matrix.arch == 'x64' && 'x86_64' || 'x86' }}
     steps:
     - name: Checkout cached build
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         path: .
         key: ${{ github.ref }}-${{ github.run_id }}-${{ matrix.pythonVersion }}-${{ matrix.arch }}
@@ -279,7 +279,7 @@ jobs:
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/beta' && vars.CROWDIN_PROJECT_ID }}
     steps:
     - name: Checkout cached build
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         path: .
         key: ${{ github.ref }}-${{ github.run_id }}-${{ env.defaultPythonVersion }}-${{ env.defaultArch }}
@@ -321,7 +321,7 @@ jobs:
       launcherSha256: ${{ steps.addJobSummary.outputs.SHA256 }}
     steps:
     - name: Checkout cached build
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         path: .
         key: ${{ github.ref }}-${{ github.run_id }}-${{ matrix.pythonVersion }}-${{ matrix.arch }}
@@ -421,7 +421,7 @@ jobs:
       uv-arch: ${{ matrix.arch == 'x64' && 'x86_64' || 'x86' }}
     steps:
     - name: Checkout cached build
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         path: .
         key: ${{ github.ref }}-${{ github.run_id }}-${{ matrix.pythonVersion }}-${{ matrix.arch }}
@@ -486,7 +486,7 @@ jobs:
       symbolsArtifactId: ${{ steps.defaultArtifact.outputs.artifactId }}
     steps:
     - name: Checkout cached build
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         path: .
         key: ${{ github.ref }}-${{ github.run_id }}-${{ matrix.pythonVersion }}-${{ matrix.arch }}
@@ -531,7 +531,7 @@ jobs:
     if: ${{ github.event_name == 'push' && vars.feature_uploadSymbolsToMozilla }}
     steps:
     - name: Checkout cached build
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         path: .
         key: ${{ github.ref }}-${{ github.run_id }}-${{ env.defaultPythonVersion }}-${{ env.defaultArch }}

--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -195,7 +195,7 @@ jobs:
       run: ci/scripts/tests/translationCheck.ps1
     - name: Upload artifact
       if: ${{ success() || failure() }}
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v6
       with:
         name: makePot results
         path: |
@@ -259,7 +259,7 @@ jobs:
       run: sed -i 's|file="..\\|file="|g' testOutput/unit/unitTests.xml
     - name: Upload artifact
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v6
       with:
         name: Unit tests results (${{ matrix.pythonVersion }}, ${{ matrix.arch }})
         path: testOutput/unit/unitTests.xml
@@ -285,7 +285,7 @@ jobs:
         key: ${{ github.ref }}-${{ github.run_id }}-${{ env.defaultPythonVersion }}-${{ env.defaultArch }}
         fail-on-cache-miss: true
     - name: Get makePot results
-      uses: actions/download-artifact@v6
+      uses: actions/download-artifact@v7
       with:
         name: makePot results
         path: output
@@ -354,14 +354,14 @@ jobs:
         scons %sconsLauncherOutTargets% %sconsArgs% %sconsCores%
     - name: Upload launcher
       id: uploadLauncher
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v6
       with:
         name: NVDA launcher (${{ matrix.pythonVersion }}, ${{ matrix.arch }})
         path: |
           output/nvda*.exe
           output/nvda*controllerClient.zip
     - name: Upload documentation artifacts
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v6
       id: uploadBuildArtifacts
       with:
         name: Documentation files and packaging metadata (${{ matrix.pythonVersion }}, ${{ matrix.arch }})
@@ -437,7 +437,7 @@ jobs:
         python-version: cpython-${{ matrix.pythonVersion }}-windows-${{ env.uv-arch }}-none
     - name: Get NVDA launcher
       id: getLauncher
-      uses: actions/download-artifact@v6
+      uses: actions/download-artifact@v7
       with:
         name: NVDA launcher (${{ matrix.pythonVersion }}, ${{ matrix.arch }})
         path: output
@@ -455,7 +455,7 @@ jobs:
         INCLUDE_SYSTEM_TEST_TAGS: ${{ matrix.testSuite }}
     - name: Upload system tests results
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v6
       with:
         name: "System tests results (${{ matrix.testSuite }}) (${{ matrix.runner }}, ${{ matrix.pythonVersion }}, ${{ matrix.arch }})"
         path: |
@@ -500,7 +500,7 @@ jobs:
       run: ci/scripts/buildSymbolStore.ps1
     - name: Upload symbols artifact
       id: uploadArtifact
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v6
       with:
         name: Symbols (${{ matrix.pythonVersion }}, ${{ matrix.arch }})
         path: output/symbols.zip
@@ -600,7 +600,7 @@ jobs:
       name: snapshot
     steps:
     - name: Get NVDA launcher
-      uses: actions/download-artifact@v6
+      uses: actions/download-artifact@v7
       with:
         name: NVDA launcher (${{ env.defaultPythonVersion }}, ${{ env.defaultArch }})
         path: output
@@ -654,7 +654,7 @@ jobs:
         echo RELEASE_NAME=$GITHUB_REF_NAME | sed 's/release-//g' >> $GITHUB_OUTPUT
         echo NORMALIZED_TAG_NAME=$GITHUB_REF_NAME | sed 's/\./-/g' | sed 's/release-//g' >> $GITHUB_OUTPUT
     - name: Get NVDA launcher
-      uses: actions/download-artifact@v6
+      uses: actions/download-artifact@v7
       with:
         name: NVDA launcher (${{ env.defaultPythonVersion }}, ${{ env.defaultArch }})
         path: output

--- a/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.cpp
+++ b/nvdaHelper/vbufBackends/gecko_ia2/gecko_ia2.cpp
@@ -287,6 +287,15 @@ OptionalLabelInfo GeckoVBufBackend_t::getLabelInfo(IAccessible2* pacc2) {
 	CComVariant state;
 	HRESULT res = firstAccTarget->get_accState(child, &state);
 	bool isVisible = res == S_OK && !(state.lVal & STATE_SYSTEM_INVISIBLE);
+	// If the label element is visible, also verify it has actual accessible text content.
+	// A label containing only aria-hidden elements would be visible but have no accessible text,
+	// meaning it cannot be the source of the accessible name (e.g. aria-label was used instead).
+	if (isVisible) {
+		wstring labelText;
+		if (!getTextFromIAccessible(labelText, firstAccTarget)) {
+			isVisible = false;
+		}
+	}
 	auto ID = getIAccessible2UniqueID(firstAccTarget);
 	return LabelInfo { isVisible, ID } ;
 }

--- a/source/NVDAObjects/UIA/wordDocument.py
+++ b/source/NVDAObjects/UIA/wordDocument.py
@@ -484,7 +484,7 @@ class WordDocumentTextInfo(UIATextInfo):
 			page = fields[0].field["page-number"]
 		except KeyError:
 			page = None
-		if page is not None:
+		if page is not None and not UIARemote.isSupported():
 			for field in fields:
 				if isinstance(field, textInfos.FieldCommand) and isinstance(
 					field.field,
@@ -537,6 +537,13 @@ class WordDocumentTextInfo(UIATextInfo):
 				if isinstance(lineNumber, int):
 					formatField.field["line-number"] = lineNumber
 			if formatConfig["reportPage"]:
+				pageNumber = UIARemote.msWord_getCustomAttributeValue(
+					docElement,
+					textRange,
+					UIACustomAttributeID.PAGE_NUMBER,
+				)
+				if isinstance(pageNumber, int):
+					formatField.field["page-number"] = pageNumber
 				sectionNumber = UIARemote.msWord_getCustomAttributeValue(
 					docElement,
 					textRange,

--- a/source/UIAHandler/browseMode.py
+++ b/source/UIAHandler/browseMode.py
@@ -686,7 +686,12 @@ class UIABrowseModeDocument(UIADocumentWithTableNavigation, browseMode.BrowseMod
 				UIAHandler.UIA_ProgressBarControlTypeId,
 			)
 			return UIAControlQuicknavIterator(nodeType, self, pos, condition, direction)
-
+		elif nodeType == "slider":
+			condition = UIAHandler.handler.clientObject.createPropertyCondition(
+				UIAHandler.UIA_ControlTypePropertyId,
+				UIAHandler.UIA_SliderControlTypeId,
+			)
+			return UIAControlQuicknavIterator(nodeType, self, pos, condition, direction)
 		elif nodeType == "nonTextContainer":
 			condition = createUIAMultiPropertyCondition(
 				{

--- a/source/autoSettingsUtils/autoSettings.py
+++ b/source/autoSettingsUtils/autoSettings.py
@@ -2,21 +2,24 @@
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-# Copyright (C) 2019 NV Access Limited
+# Copyright (C) 2019-2025 NV Access Limited
 
 """autoSettings for add-ons"""
 
 from abc import abstractmethod
+from collections.abc import Iterable
 from copy import deepcopy
-from typing import Dict, Type, Any, Iterable
+from typing import Any
 
 import config
-from autoSettingsUtils.utils import paramToPercent, percentToParam, UnsupportedConfigParameterError
 from baseObject import AutoPropertyObject
 from logHandler import log
+
+from autoSettingsUtils.utils import UnsupportedConfigParameterError, paramToPercent, percentToParam
+
 from .driverSetting import DriverSetting
 
-SupportedSettingType: Type = Iterable[DriverSetting]
+type SupportedSettingType = Iterable[DriverSetting]
 
 
 class AutoSettings(AutoPropertyObject):
@@ -126,7 +129,7 @@ class AutoSettings(AutoPropertyObject):
 	def _getConfigSpecForSettings(
 		cls,
 		settings: SupportedSettingType,
-	) -> Dict:
+	) -> dict[str, str]:
 		section = cls._getConfigSection()
 		spec = deepcopy(config.confspec[section]["__many__"])
 		for setting in settings:

--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -1076,6 +1076,18 @@ qn(
 	prevError=_("no previous error"),
 )
 qn(
+	"slider",
+	key=None,
+	# Translators: Input help message for a quick navigation command in browse mode.
+	nextDoc=_("moves to the next slider"),
+	# Translators: Message presented when the browse mode element is not found.
+	nextError=_("no next slider"),
+	# Translators: Input help message for a quick navigation command in browse mode.
+	prevDoc=_("moves to the previous slider"),
+	# Translators: Message presented when the browse mode element is not found.
+	prevError=_("no previous slider"),
+)
+qn(
 	"article",
 	key=None,
 	# Translators: Input help message for a quick navigation command in browse mode.

--- a/source/buildVersion.py
+++ b/source/buildVersion.py
@@ -64,7 +64,7 @@ def formatVersionForGUI(year, major, minor):
 # Version information for NVDA
 name = "NVDA"
 version_year = 2026
-version_major = 1
+version_major = 2
 version_minor = 0
 version_build = 0  # Should not be set manually. Set in 'sconscript'.
 version = _formatDevVersionString()

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -5133,6 +5133,30 @@ class GlobalCommands(ScriptableObject):
 	def script_toggleImageCaptioning(self, gesture: "inputCore.InputGesture"):
 		_localCaptioner._localCaptioner.toggleImageCaptioning(gesture)
 
+	@script(
+		description=_(
+			# Translators: Description for the repeat last speech script
+			"Repeat the last spoken information. Pressing twice shows it in a browsable message. ",
+		),
+		gesture="kb:NVDA+x",
+		category=SCRCAT_SPEECH,
+		speakOnDemand=True,
+	)
+	def script_repeatLastSpokenInformation(self, gesture: "inputCore.InputGesture") -> None:
+		lastSpeech = speech.speech._lastSpeech
+		if lastSpeech is None:
+			return
+		lastSpeechSeq, symbolLevel = lastSpeech
+		repeats = scriptHandler.getLastScriptRepeatCount()
+		lastSpeechText = "  ".join(i for i in lastSpeechSeq if isinstance(i, str))
+		if repeats == 0:
+			speech.speak(lastSpeechSeq, symbolLevel=symbolLevel)
+			braille.handler.message(lastSpeechText)
+		elif repeats == 1:
+			# Translators: title for report last spoken information dialog.
+			title = _("Last spoken information")
+			ui.browseableMessage(lastSpeechText, title, copyButton=True, closeButton=True)
+
 
 #: The single global commands instance.
 #: @type: L{GlobalCommands}

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -34,7 +34,7 @@ from speech import (
 )
 from NVDAObjects import NVDAObject, NVDAObjectTextInfo
 import globalVars
-from logHandler import log
+from logHandler import log, Logger
 import gui
 import systemUtils
 import wx
@@ -3160,6 +3160,11 @@ class GlobalCommands(ScriptableObject):
 	)
 	@gui.blockAction.when(gui.blockAction.Context.SECURE_MODE)
 	def script_navigatorObject_devInfo(self, gesture):
+		if log.getEffectiveLevel() == Logger.OFF:
+			from gui import logViewer
+
+			logViewer.activate()
+			return
 		obj = api.getNavigatorObject()
 		if hasattr(obj, "devInfo"):
 			log.info(

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -570,6 +570,24 @@ class GlobalCommands(ScriptableObject):
 		ui.message("%s %s" % (previousSettingName, previousSettingValue))
 
 	@script(
+		# Translators: Input help mode message for toggling keyboard layout.
+		description=_("Toggles between desktop and laptop keyboard layout"),
+		category=SCRCAT_INPUT,
+	)
+	def script_toggleKeyboardLayout(self, gesture: "inputCore.InputGesture") -> None:
+		val = config.conf["keyboard"]["keyboardLayout"]
+		if val == "desktop":
+			newVal = "laptop"
+		else:
+			newVal = "desktop"
+		config.conf["keyboard"]["keyboardLayout"] = newVal
+		ui.message(
+			# Translators: Reported when the user toggles keyboard layout.
+			# {layout} will be replaced with the new keyboard layout, i.e. desktop or laptop
+			_("{layout} layout").format(layout=keyboardHandler.KeyboardInputGesture.LAYOUTS[newVal]),
+		)
+
+	@script(
 		# Translators: Input help mode message for cycling the reporting of typed characters.
 		description=_("Cycles through options for when to speak typed characters."),
 		category=SCRCAT_SPEECH,

--- a/source/gui/addonGui.py
+++ b/source/gui/addonGui.py
@@ -17,7 +17,6 @@ from logHandler import log
 import addonHandler
 from . import guiHelper
 from . import nvdaControls
-from .message import displayDialogAsModal
 from .dpiScalingHelper import DpiScalingHelperMixinWithoutInit
 import gui.contextHelp
 import ui

--- a/source/gui/addonGui.py
+++ b/source/gui/addonGui.py
@@ -112,14 +112,6 @@ class ErrorAddonInstallDialog(nvdaControls.MessageDialog):
 		)
 		okButton.SetDefault()
 		okButton.Bind(wx.EVT_BUTTON, lambda evt: self.EndModal(wx.OK))
-		if IncompatibleAddonsDialog._instance() is None:
-			displayDialogAsModal(
-				IncompatibleAddonsDialog(
-					parent=self,
-				),
-			)
-		else:
-			log.debug("IncompatibleAddonsDialog already open; skipping duplicate dialog")
 
 
 def installAddon(parentWindow: wx.Window, addonPath: str) -> bool:  # noqa: C901

--- a/source/gui/addonGui.py
+++ b/source/gui/addonGui.py
@@ -112,12 +112,14 @@ class ErrorAddonInstallDialog(nvdaControls.MessageDialog):
 		)
 		okButton.SetDefault()
 		okButton.Bind(wx.EVT_BUTTON, lambda evt: self.EndModal(wx.OK))
-		displayDialogAsModal(
-			IncompatibleAddonsDialog(
-				parent=self,
-				# the defaults from the addon GUI are fine. We are testing against the running version.
-			),
-		)
+		if IncompatibleAddonsDialog._instance() is None:
+			displayDialogAsModal(
+				IncompatibleAddonsDialog(
+					parent=self,
+				),
+			)
+		else:
+			log.debug("IncompatibleAddonsDialog already open; skipping duplicate dialog")
 
 
 def installAddon(parentWindow: wx.Window, addonPath: str) -> bool:  # noqa: C901

--- a/source/gui/addonStoreGui/controls/messageDialogs.py
+++ b/source/gui/addonStoreGui/controls/messageDialogs.py
@@ -251,6 +251,14 @@ def _showAddonRequiresNVDAUpdateDialog(
 			showAddonInfoFunction=lambda: _showAddonInfo(addon),
 		),
 	)
+	
+	from gui.addonGui import IncompatibleAddonsDialog
+
+	if IncompatibleAddonsDialog._instance() is not None:
+		log.debug(
+			"IncompatibleAddonsDialog already open while showing "
+			"Add-on requires newer NVDA version dialog"
+		)
 
 
 def _showConfirmAddonInstallDialog(

--- a/source/gui/addonStoreGui/controls/messageDialogs.py
+++ b/source/gui/addonStoreGui/controls/messageDialogs.py
@@ -251,13 +251,12 @@ def _showAddonRequiresNVDAUpdateDialog(
 			showAddonInfoFunction=lambda: _showAddonInfo(addon),
 		),
 	)
-	
+
 	from gui.addonGui import IncompatibleAddonsDialog
 
 	if IncompatibleAddonsDialog._instance() is not None:
 		log.debug(
-			"IncompatibleAddonsDialog already open while showing "
-			"Add-on requires newer NVDA version dialog"
+			"IncompatibleAddonsDialog already open while showing Add-on requires newer NVDA version dialog",
 		)
 
 

--- a/source/mouseHandler.py
+++ b/source/mouseHandler.py
@@ -179,14 +179,14 @@ def getMouseRestrictedToScreens(x, y, displays):
 	return (int(floor(newXY.x)), int(floor(newXY.y)))
 
 
-def getMinMaxPoints(screenRect):
+def getMinMaxPoints(screenRect: wx.Rect) -> tuple[wx.Point, wx.Point]:
 	screenMin = screenRect.GetTopLeft()
 	screenDim = wx.Point(screenRect.GetWidth(), screenRect.GetHeight())
 	screenMax = screenMin + screenDim
 	return (screenMin, screenMax)
 
 
-def getTotalWidthAndHeightAndMinimumPosition(displays):
+def getTotalWidthAndHeightAndMinimumPosition(displays: list[wx.Rect]) -> tuple[int, int, wx.Point]:
 	"""Calculate the total screen width and height.
 
 	Depending on screen layouts the rectangles may overlap on the vertical or

--- a/source/speech/__init__.py
+++ b/source/speech/__init__.py
@@ -2,7 +2,7 @@
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 # Copyright (C) 2006-2025 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Babbage B.V., Bill Dengler,
-# Julien Cochuyt, Leonard de Ruijter
+# Julien Cochuyt, Leonard de Ruijter, Cyrille Bougot
 
 from .speech import (
 	_extendSpeechSequence_addMathForTextInfo,
@@ -14,6 +14,7 @@ from .speech import (
 	_getSpeakMessageSpeech,
 	_manager,
 	_objectSpeech_calculateAllowedProps,
+	_setLastSpeechString,
 	_suppressSpeakTypedCharacters,
 	BLANK_CHUNK_CHARS,
 	cancelSpeech,
@@ -63,7 +64,7 @@ from .speech import (
 	spellTextInfo,
 	splitTextIndentation,
 )
-from .extensions import speechCanceled, post_speechPaused, pre_speechQueued, filter_speechSequence
+from .extensions import speechCanceled, post_speechPaused, pre_speechQueued, filter_speechSequence, pre_speech
 from .languageHandling import getSpeechSequenceWithLangs
 from .priorities import Spri
 
@@ -167,8 +168,10 @@ def initialize():
 		SpeakTextInfoState,
 	)
 	filter_speechSequence.register(getSpeechSequenceWithLangs)
+	pre_speech.register(_setLastSpeechString)
 
 
 def terminate():
 	synthDriverHandler.setSynth(None)
 	filter_speechSequence.unregister(getSpeechSequenceWithLangs)
+	pre_speech.unregister(_setLastSpeechString)

--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -87,6 +87,8 @@ if typing.TYPE_CHECKING:
 _speechState: Optional["SpeechState"] = None
 _curWordChars: List[str] = []
 IDEOGRAPHIC_COMMA: Final[str] = "\u3001"
+_lastSpeech: tuple[SpeechSequence, characterProcessing.SymbolLevel | None] | None = None
+"""Last spoken text and the symbol level with which it was spoken."""
 
 
 class SpeechMode(DisplayStringIntEnum):
@@ -139,6 +141,17 @@ def getState():
 
 def setSpeechMode(newMode: SpeechMode):
 	_speechState.speechMode = newMode
+
+
+def _setLastSpeechString(
+	speechSequence: SpeechSequence,
+	symbolLevel: characterProcessing.SymbolLevel | None,
+	priority: Spri,
+):
+	# Check if the speech sequence contains text to speak
+	if [item for item in speechSequence if isinstance(item, str)]:
+		global _lastSpeech
+		_lastSpeech = speechSequence, symbolLevel
 
 
 def initialize():

--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -40,6 +40,8 @@ from .commands import (
 	SuppressUnicodeNormalizationCommand,
 	CharacterModeCommand,
 	WaveFileCommand,
+	CallbackCommand,
+	_CancellableSpeechCommand,
 )
 from .shortcutKeys import getKeyboardShortcutsSpeech
 
@@ -149,9 +151,16 @@ def _setLastSpeechString(
 	priority: Spri,
 ):
 	# Check if the speech sequence contains text to speak
-	if [item for item in speechSequence if isinstance(item, str)]:
+	if any(isinstance(item, str) for item in speechSequence):
 		global _lastSpeech
-		_lastSpeech = speechSequence, symbolLevel
+		_lastSpeech = (
+			[
+				item
+				for item in speechSequence
+				if not isinstance(item, (CallbackCommand, _CancellableSpeechCommand))
+			],
+			symbolLevel,
+		)
 
 
 def initialize():

--- a/source/virtualBuffers/MSHTML.py
+++ b/source/virtualBuffers/MSHTML.py
@@ -396,6 +396,11 @@ class MSHTML(VirtualBuffer):
 				"IAccessible::role": [oleacc.ROLE_SYSTEM_CHECKBUTTON],
 				"IAccessible::state_%s" % oleacc.STATE_SYSTEM_FOCUSABLE: [1],
 			}
+		elif nodeType == "slider":
+			attrs = [
+				{"IAccessible::role": [oleacc.ROLE_SYSTEM_SLIDER]},
+				{"HTMLAttrib::role": ["slider"]},
+			]
 		elif nodeType == "table":
 			attrs = {"IHTMLDOMNode::nodeName": ["TABLE"]}
 			if not config.conf["documentFormatting"]["includeLayoutTables"]:

--- a/source/virtualBuffers/gecko_ia2.py
+++ b/source/virtualBuffers/gecko_ia2.py
@@ -473,6 +473,11 @@ class Gecko_ia2(VirtualBuffer):
 				{"IAccessible::role": [oleacc.ROLE_SYSTEM_CHECKBUTTON]},
 				{"IAccessible2::attribute_xml-roles": [VBufStorage_findMatch_word("switch")]},
 			]
+		elif nodeType == "slider":
+			attrs = [
+				{"IAccessible::role": [oleacc.ROLE_SYSTEM_SLIDER]},
+				{"IAccessible2::attribute_xml-roles": [VBufStorage_findMatch_word("slider")]},
+			]
 		elif nodeType == "graphic":
 			attrs = {"IAccessible::role": [oleacc.ROLE_SYSTEM_GRAPHIC]}
 		elif nodeType == "blockQuote":

--- a/source/visionEnhancementProviders/NVDAHighlighter.py
+++ b/source/visionEnhancementProviders/NVDAHighlighter.py
@@ -582,7 +582,7 @@ class NVDAHighlighter(providerBase.VisionEnhancementProvider):
 		if rect is None:
 			try:
 				rect = getContextRect(context, obj=obj)
-			except (LookupError, RuntimeError, TypeError):
+			except (LookupError, ValueError, RuntimeError, TypeError):
 				rect = None
 		self.contextToRectMap[context] = rect
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -150,6 +150,7 @@ It currently includes Screen Curtain's settings (previously in the "Vision" cate
 * In the Input Gestures dialog, gestures including an operator while Num Lock is on will now be correctly displayed. (#19214, @CyrilleB79)
 * In Chromium browsers, if a document contains links with a malformed URL, reading the document will be possible again. (#19125, @nvdaes)
 * NVDA no longer plays a sound for spelling errors while typing if speech mode is set to on-demand or off. (#19323, @CyrilleB79)
+* Fixed a crash that could occur when installing an add-on requiring a newer NVDA version, caused by duplicate incompatibility dialogs. (#19261)
 
 ### Changes for Developers
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -8,6 +8,7 @@
 
 * A new command, assigned to `NVDA+x`, has been introduced to repeat the last information spoken by NVDA; pressing it twice shows it in a browseable message. (#625, @CyrilleB79)
 * Added an unassigned command to toggle keyboard layout. (#19211, @CyrilleB79)
+* Added an unassigned Quick Navigation Command for jumping to next/previous slider in browse mode. (#17005, @hdzrvcc0X74)
 
 ### Changes
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -1,5 +1,21 @@
 # What's New in NVDA
 
+## 2026.2
+
+### Important notes
+
+### New Features
+
+### Changes
+
+### Bug Fixes
+
+### Changes for Developers
+
+Please refer to [the developer guide](https://download.nvaccess.org/documentation/developerGuide.html#API) for information on NVDA's API deprecation and removal process.
+
+#### Deprecations
+
 ## 2026.1
 
 This release includes built-in support for reading math content with MathCAT.

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -7,6 +7,7 @@
 ### New Features
 
 * A new command, assigned to `NVDA+x`, has been introduced to repeat the last information spoken by NVDA; pressing it twice shows it in a browseable message. (#625, @CyrilleB79)
+* Added an unassigned command to toggle keyboard layout. (#19211, @CyrilleB79)
 
 ### Changes
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -6,6 +6,8 @@
 
 ### New Features
 
+* A new command, assigned to `NVDA+x`, has been introduced to repeat the last information spoken by NVDA; pressing it twice shows it in a browseable message. (#625, @CyrilleB79)
+
 ### Changes
 
 ### Bug Fixes

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -10,6 +10,8 @@
 
 ### Changes
 
+* It is now possible to open the log viewer with `NVDA+f1`, even when the log level is set to "disabled". (#19318, @CyrilleB79)
+
 ### Bug Fixes
 
 * Fixed excessive resource usage and highlight flickering when using Visual Highlight. (#17434, @hwf1324)

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -16,6 +16,7 @@
 
 ### Bug Fixes
 
+* In Firefox browse mode, the accessible name of form controls (such as checkboxes and radio buttons) is now correctly announced when the control has an `aria-label` and an associated `<label>` element that contains only `aria-hidden` content. (#19409, @bramd)
 * In Microsoft Word with UIA enabled, page changes are now correctly announced when navigating table rows that span multiple pages. (#19386, @akj)
 * Fixed excessive resource usage and highlight flickering when using Visual Highlight. (#17434, @hwf1324)
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -15,6 +15,7 @@
 
 ### Bug Fixes
 
+* In Microsoft Word with UIA enabled, page changes are now correctly announced when navigating table rows that span multiple pages. (#19386, @akj)
 * Fixed excessive resource usage and highlight flickering when using Visual Highlight. (#17434, @hwf1324)
 
 ### Changes for Developers

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -12,6 +12,8 @@
 
 ### Bug Fixes
 
+* Fixed excessive resource usage and highlight flickering when using Visual Highlight. (#17434, @hwf1324)
+
 ### Changes for Developers
 
 Please refer to [the developer guide](https://download.nvaccess.org/documentation/developerGuide.html#API) for information on NVDA's API deprecation and removal process.

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -23,6 +23,9 @@ Please refer to [the developer guide](https://download.nvaccess.org/documentatio
 
 #### Deprecations
 
+<!-- Beyond this point, Markdown should not be linted, as we don't modify old change log sections. -->
+<!-- markdownlint-disable -->
+
 ## 2026.1
 
 This release includes built-in support for reading math content with MathCAT.
@@ -347,9 +350,6 @@ Use `INPUT_TYPE.MOUSE`, `INPUT_TYPE.KEYBOARD`, `KEYEVENTF.KEYUP` and `KEYEVENTF.
 Access to these symbols via `updateCheck` is deprecated. (#18956)
 * `textInfos.OffsetsTextInfo.allowMoveToOffsetPastEnd` is deprecated.
 Use the `OffsetsTextInfo.allowMoveToUnitOffsetPastEnd` method instead. (#19152, @LeonarddeR)
-
-<!-- Beyond this point, Markdown should not be linted, as we don't modify old change log sections. -->
-<!-- markdownlint-disable -->
 
 ## 2025.3.2
 

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -245,6 +245,7 @@ The actual commands will not execute while in input help mode.
 |Read window |`NVDA+b` |`NVDA+b` |Reads the entire current window (useful for dialogs)|
 |Read status bar |`NVDA+end` |`NVDA+shift+end` |Reports the Status Bar if NVDA finds one. Pressing twice will spell the information. Pressing three times will copy it to the clipboard|
 |Read time |`NVDA+f12` |`NVDA+f12` |Pressing once reports the current time, pressing twice reports the date. The time and date are reported in the format specified in Windows settings for the system tray clock.|
+|Repeat last spoken information |`NVDA+x` |`NVDA+x` |Repeats the last information spoken by NVDA. Pressing twice shows it in a browseable window |
 |Report text formatting |`NVDA+f` |`NVDA+f` |Reports text formatting. Pressing twice shows the information in a window|
 |Report link destination |`NVDA+k` |`NVDA+k` |Pressing once speaks the destination URL of the link at the current caret or focus position. Pressing twice shows it in a window for more careful review|
 
@@ -650,6 +651,7 @@ When the menu comes up, You can use the arrow keys to navigate the menu, and the
 |Starts or restarts NVDA |Control+alt+n |Control+alt+n |none |Starts or restarts NVDA from the Desktop, if this Windows shortcut is enabled during NVDA's installation process. This is a Windows specific shortcut and therefore it cannot be reassigned in the input gestures dialog.|
 |Stop speech |Control |control |2-finger tap |Instantly stops speaking|
 |Pause Speech |shift |shift |none |Instantly pauses speech. Pressing it again will continue speaking where it left off (if pausing is supported by the current synthesizer)|
+|Repeat last spoken information |`NVDA+x` |`NVDA+x` |none |Repeats the last information spoken by NVDA. Pressing twice shows it in a browseable window |
 |NVDA Menu |NVDA+n |NVDA+n |2-finger double-tap |Pops up the NVDA menu to allow you to access preferences, tools, help, etc.|
 |Toggle Input Help Mode |NVDA+1 |NVDA+1 |none |Pressing any key in this mode will report the key, and the description of any NVDA command associated with it|
 |Quit NVDA |NVDA+q |NVDA+q |none |Exits NVDA|

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -1083,6 +1083,7 @@ Here is a list of available commands:
 * Menu item
 * Toggle button
 * Progress bar
+* Slider
 * Reference
 * Math formula
 * Vertically aligned paragraph


### PR DESCRIPTION
### Link to issue number:
Fixes #19261

### Summary of the issue:
Installing an add-on that requires a newer NVDA version could trigger duplicate incompatible add-on dialogs, leading to a crash.

### Description of user facing changes:
NVDA now prevents duplicate incompatible add-on dialogs from being shown when installing an add-on that requires a newer NVDA version, avoiding a potential crash during installation.

### Description of developer facing changes:
Incompatible add-on dialog handling was centralized to ensure only a single dialog instance is created across relevant code paths.

### Description of development approach:
The logic responsible for displaying the incompatible add-on dialog was refactored to avoid multiple invocations for the same add-on installation attempt.

### Testing strategy:
Manual testing by attempting to install an add-on that requires a newer NVDA version and verifying that only one dialog is shown and NVDA remains stable.

### Known issues with pull request:
None.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests (not applicable)
  - System (end to end) tests (not applicable)
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
