### PR TITLE
Correctly register .nvda-addon file association on installation

### DIFF
--- a/source/config/registry.py
+++ b/source/config/registry.py
@@ -35,7 +35,7 @@ class RegistryKey(str, Enum):
 	# TODO: remove winreg.KEY_WOW64_64KEY from usages when NVDA is 64-bit only.
 	EASE_OF_ACCESS_APP = rf"{EASE_OF_ACCESS}\ATs\{EASE_OF_ACCESS_APP_KEY_NAME}"
 	ADDON_PROG = rf"{_SOFTWARE}\Classes\{NVDA_ADDON_PROG_ID}"
-	ADDON_EXT = rf"{_SOFTWARE}\Classes\{ADDON_BUNDLE_EXTENSION}"
+	ADDON_EXT = rf"{_SOFTWARE}\Classes\.{ADDON_BUNDLE_EXTENSION}"
 	REMOTE_URL_HANDLER = rf"{_SOFTWARE}\Classes\nvdaremote"
 
 	# Sub keys


### PR DESCRIPTION
### Link to issue number:
Fixes #19411

### Summary of the issue:
When installing 64-bit versions of NVDA for the first time, the `.nvda-addon` file association is not registered.

### Description of user facing changes:
The file association is now registered, so users can activate NVDA add-on packages for installation from File Explorer.

### Description of developer facing changes:
None

### Description of development approach:
Corrected the value of `config.registry.RegistryKey.ADDON_EXT` to include the leading `.` in `.nvda-addon`.

### Testing strategy:
1. Created a self-signed build.
2. Installed it in a clean Windows 11 VM.
3. Copied an NVDA add-on package into the VM.
4. Activated the file from File Explorer and verified that NVDA asked me if I wanted to install the add-on.

### Known issues with pull request:
None.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
