### PR TITLE
Fix bugs when attempting to install add-ons requiring a newer NVDA release

### DIFF
--- a/source/gui/addonGui.py
+++ b/source/gui/addonGui.py
@@ -1,7 +1,7 @@
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-# Copyright (C) 2012-2024 NV Access Limited, Beqa Gozalishvili, Joseph Lee,
+# Copyright (C) 2012-2026 NV Access Limited, Beqa Gozalishvili, Joseph Lee,
 # Babbage B.V., Ethan Holliger, Arnold Loubriat, Thomas Stivers
 
 import weakref
@@ -17,7 +17,6 @@ from logHandler import log
 import addonHandler
 from . import guiHelper
 from . import nvdaControls
-from .message import displayDialogAsModal
 from .dpiScalingHelper import DpiScalingHelperMixinWithoutInit
 import gui.contextHelp
 import ui
@@ -112,12 +111,6 @@ class ErrorAddonInstallDialog(nvdaControls.MessageDialog):
 		)
 		okButton.SetDefault()
 		okButton.Bind(wx.EVT_BUTTON, lambda evt: self.EndModal(wx.OK))
-		displayDialogAsModal(
-			IncompatibleAddonsDialog(
-				parent=self,
-				# the defaults from the addon GUI are fine. We are testing against the running version.
-			),
-		)
 
 
 def installAddon(parentWindow: wx.Window, addonPath: str) -> bool:  # noqa: C901

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -110,6 +110,7 @@ It currently includes Screen Curtain's settings (previously in the "Vision" cate
 * When reporting the location of the caret in classic versions of Notepad and other Win32 edit controls, text position is now more accurate. (#18767, @LeonarddeR)
 * NVDA no longer fails to read the contents of wx Web View controls. (#17273, @LeonarddeR)
 * When NVDA is configured to update add-ons automatically in the background, add-ons can be properly updated. (#18965, @nvdaes)
+* Attempting to install an add-on that requires a newer version of NVDA from File Explorer no longer fails silently or shows the incompatible add-ons dialog. (#19260, #19261)
 * Fixed a case where braille output would fail with an error. (#19025, @LeonarddeR)
 * Battery time announcements now skip redundant "0 hours" and "0 minutes" and use proper singular/plural forms. (#9003, @hdzrvcc0X74)
 * When a synthesizer has a fallback language for the current dialect, the language of the text being read will no longer be reported as unsupported. (#18876, @nvdaes)


### PR DESCRIPTION
### Link to issue number:
Fixes #19260
Fixes #19261

### Summary of the issue:
When attempting to install an add-on which requires a newer version of NVDA via File Explorer:
* If no incompatible add-ons are installed, the installation fails silently.
* If disabled incompatible add-ons are installed, the incompatible add-ons dialog is erroneously shown, followed by the error dialog.

### Description of user facing changes:
Attempting to install such an add-on from File Explorer shows the correct error dialog and does not show the incompatible add-ons dialog.

### Description of developer facing changes:
None.

### Description of development approach:
Removed code that created and showed a `IncompatibleAddonsDialog` from `ErrorAddonInstallDialog._addButtons`. As best as I can tell, this code should not have been here. Presumably in a past rewrite its removal was missed and this issue has simply only now been discovered.

### Testing strategy:
Built a launcher and installed.
Attempted to install an add-on which specified a minimum NVDA version of 2027.1:
* With no other add-ons installed;
* With an incompatible add-on installed and disabled; and
* With an incompatible add-on installed and force-enabled. 

### Known issues with pull request:
None.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
