### PR TITLE
Output type check results to stdout and GitHub step summary

### DIFF
--- a/ci/scripts/tests/typeCheck.ps1
+++ b/ci/scripts/tests/typeCheck.ps1
@@ -1,6 +1,6 @@
 # Stop Pyright warning us that we're not running the latest version
 $env:PYRIGHT_PYTHON_IGNORE_WARNINGS="1"
-$pyrightOutput = (uv run pyright) -Join "`n"
+(uv run pyright) -Join "`n" | Tee-Object -Variable pyrightOutput
 if ($LastExitCode -ne 0) {
 	Write-Output @"
 FAIL: Static type analysis. Pyright exited with exit code $LastExitCode.


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
Currently, failing type checks in CI only output errors and warning to the [workflow summary](https://github.com/nvaccess/nvda/actions/runs/20938000634/attempts/1#summary-60166146854), rather than the [job run details](https://github.com/nvaccess/nvda/actions/runs/20938000634/job/60166146854?pr=19432#step:5:26).

### Description of user facing changes:
None

### Description of developer facing changes:
Type checking failures in CI output details to both locations, making them easier to find.

### Description of development approach:
Tee the output of running pyright rather than saving it directly to a variable.

### Testing strategy:
Ran `ci/scripts/test/typeCheck.ps1` locally on a branch with pyright violations.

### Known issues with pull request:
None known.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- x ] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
