### PR TITLE
Remote Access: prevent multiple disconnection confirmation dialogs

### DIFF
--- a/source/_remoteClient/client.py
+++ b/source/_remoteClient/client.py
@@ -222,6 +222,9 @@ class RemoteClient:
 	@alwaysCallAfter
 	def doDisconnect(self) -> None:
 		"""Seek confirmation from the user before disconnecting."""
+		if MessageDialog.blockingInstancesExist():
+			MessageDialog.focusBlockingInstances()
+			return
 		if (
 			self.followerSession is not None
 			and configuration.getRemoteConfig()["ui"]["confirmDisconnectAsFollower"]

--- a/source/_remoteClient/client.py
+++ b/source/_remoteClient/client.py
@@ -75,7 +75,7 @@ class RemoteClient:
 		self.localControlServer = None
 		self.sendingKeys = False
 		self._wasSendingKeysBeforeLock: bool = False
-		self._disconnectConfirmationDialog: Optional[MessageDialog] = None
+		self._disconnectConfirmationDialog: MessageDialog | None = None
 		try:
 			self.sdHandler = SecureDesktopHandler()
 		except RuntimeError:
@@ -257,6 +257,9 @@ class RemoteClient:
 					if dialog.ShowModal() != ReturnCode.YES:
 						log.info("Remote disconnection cancelled by user.")
 						return
+				except Exception:
+					log.error("Error showing disconnect confirmation dialog", exc_info=True)
+					return
 				finally:
 					self._disconnectConfirmationDialog = None
 		self.disconnect()

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -2,6 +2,7 @@
 
 ## 2026.1
 
+
 This release includes built-in support for reading math content with MathCAT.
 
 There have been several improvements to speech.
@@ -112,6 +113,7 @@ It currently includes Screen Curtain's settings (previously in the "Vision" cate
 * In the Input Gestures dialog, gestures including an operator while Num Lock is on will now be correctly displayed. (#19214, @CyrilleB79)
 * In Chromium browsers, if a document contains links with a malformed URL, reading the document will be possible again. (#19125, @nvdaes)
 * NVDA no longer plays a sound for spelling errors while typing if speech mode is set to on-demand or off. (#19323, @CyrilleB79)
+* NVDA Remote Access will no longer open multiple disconnection confirmation dialogs if the action is triggered repeatedly. (#19442, @Cary-rowen)
 
 ### Changes for Developers
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -2,7 +2,6 @@
 
 ## 2026.1
 
-
 This release includes built-in support for reading math content with MathCAT.
 
 There have been several improvements to speech.


### PR DESCRIPTION
### Link to issue number:
None.

### Summary of the issue:
In NVDA Remote Access, if a user is in "Follower" mode and the "Confirm disconnection when controlled" option is enabled, triggering the "Disconnect" action multiple times in rapid succession (e.g. by clicking the menu item repeatedly) results in multiple confirmation dialogs stacking on top of each other.

### Description of user facing changes:
When attempting to disconnect from a Remote Access session, if a confirmation dialog is already open, NVDA will now focus the existing dialog instead of opening a new one.

### Description of developer facing changes:
None.

### Description of development approach:
The `RemoteClient` now maintains a reference to the active disconnection confirmation dialog in `self._disconnectConfirmationDialog`.
In `doDisconnect`, if this reference is set, the existing dialog is brought to the foreground. Otherwise, a new dialog is created, stored in the reference, and cleared in a `finally` block after it closes. This prevents re-entrancy while targeting only the specific dialog instance.

### Testing strategy:
- Enabled "Confirm disconnection when controlled" in Remote Access settings.
- Triggered the "Disconnect" menu item repeatedly.
- Verified that only one dialog appeared and subsequent triggers focused the existing one.

### Known issues with pull request:
None.

### Code Review Checklist:

- [x] Documentation:
  - [x] Change log entry
  - [x] User Documentation
  - [x] Developer / Technical Documentation
  - [x] Context sensitive help for GUI changes
- [x] Testing:
  - [x] Unit tests
  - [x] System (end to end) tests
  - [x] Manual testing
- [x] UX of all users considered:
  - [x] Speech
  - [x] Braille
  - [x] Low Vision
  - [x] Different web browsers
  - [x] Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.