### PR TITLE
Fix updating windows root certificates in update check

### DIFF
--- a/source/updateCheck.py
+++ b/source/updateCheck.py
@@ -1,7 +1,7 @@
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-# Copyright (C) 2012-2025 NV Access Limited, Zahari Yurukov,
+# Copyright (C) 2012-2026 NV Access Limited, Zahari Yurukov,
 # Babbage B.V., Joseph Lee, Christopher Proß
 
 """Update checking functionality.
@@ -1101,7 +1101,7 @@ def _updateWindowsRootCertificates():
 	# Convert to a form usable by Windows.
 	certCont = crypt32.CertCreateCertificateContext(
 		0x00000001,  # X509_ASN_ENCODING
-		cert,
+		ctypes.cast(cert, ctypes.POINTER(ctypes.c_byte)),
 		len(cert),
 	)
 	# Ask Windows to build a certificate chain, thus triggering a root certificate update.


### PR DESCRIPTION
### Link to issue number:

Fixes #19443

### Summary of the issue:

NVDA fails to check for updates on corporate networks.

### Description of user facing changes:

NVDA should again be able to check for updates on these networks.

### Description of developer facing changes:

None

### Description of development approach:

`winBindings.crypt32.CertCreateCertificateContext` expects its 2nd argument to be a byte pointer. Passing a Python `bytes` object directly to ctypes treats it as a char pointer to the address of the first byte in memory. Since this is memory compatible, cast the `bytes` to a byte pointer.

### Testing strategy:

* [x] Commented out the block preventing `updateCheck` from being imported when running from source. Attempted to run `_updateWindowsRootCertificates` directly.
* [ ] User testing.

### Known issues with pull request:

None known

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
