### PR TITLE
Fix updating windows root certificates in update check

### DIFF
--- a/source/updateCheck.py
+++ b/source/updateCheck.py
@@ -1,7 +1,7 @@
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-# Copyright (C) 2012-2025 NV Access Limited, Zahari Yurukov,
+# Copyright (C) 2012-2026 NV Access Limited, Zahari Yurukov,
 # Babbage B.V., Joseph Lee, Christopher Proß
 
 """Update checking functionality.
@@ -1101,7 +1101,7 @@ def _updateWindowsRootCertificates():
 	# Convert to a form usable by Windows.
 	certCont = crypt32.CertCreateCertificateContext(
 		0x00000001,  # X509_ASN_ENCODING
-		cert,
+		ctypes.cast(cert, ctypes.POINTER(ctypes.c_byte)),
 		len(cert),
 	)
 	# Ask Windows to build a certificate chain, thus triggering a root certificate update.


### PR DESCRIPTION
### Link to issue number:

Fixes #19443

### Summary of the issue:

NVDA fails to check for updates on corporate networks which make use of HTTPS interception.

### Description of user facing changes:

NVDA should again be able to check for updates on these networks.

### Description of developer facing changes:

None

### Description of development approach:

`winBindings.crypt32.CertCreateCertificateContext` expects its 2nd argument to be a byte pointer. Passing a Python `bytes` object directly to ctypes treats it as a char pointer to the address of the first byte in memory. Since this is memory compatible, cast the `bytes` to a byte pointer.

### Testing strategy:

* [x] Commented out the block preventing `updateCheck` from being imported when running from source. Attempted to run `_updateWindowsRootCertificates` directly.
  * On an alpha, got the expected exception.
  * With this patch, no exception was raised.
* [x] Set up [mitmproxy](https://www.mitmproxy.org/) to act as a stand-in for enterprise HTTPS interception, and checked for updates. Note that I did *not* install its CA, as doing so bypasses the call to `_updateWindowsRootCertificates`.
  * NVDA alpha-54296,aa95ea8e: Error as described in the issue, ultimately boiling down to a ctypes error:
    <details><summary>Alpha log</summary>

    ```
    DEBUG - updateCheck.checkForUpdate (07:02:08.918) - updateCheck.UpdateChecker.check (14044):
    Fetching update data from https://api.nvaccess.org/nvdaUpdateCheck?autoCheck=False&allowUsageStats=True&version=alpha-54296%2Caa95ea8e&versionType=snapshot%3Aalpha&osVersion=10.0.26220+workstation&x64=True&osArchitecture=AMD64
    DEBUG - updateCheck._updateWindowsRootCertificates (07:02:08.961) - updateCheck.UpdateChecker.check (14044):
    Updating Windows root certificates
    DEBUGWARNING - Python warning (07:02:09.041) - updateCheck.UpdateChecker.check (14044):
    urllib3\connectionpool.pyc:1097: InsecureRequestWarning: Unverified HTTPS request is being made to host '127.0.0.1'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#tls-warnings
    DEBUGWARNING - updateCheck.UpdateChecker._bg (07:02:09.278) - updateCheck.UpdateChecker.check (14044):
    Error checking for update
    Traceback (most recent call last):
      File "urllib\request.pyc", line 1319, in do_open
      File "http\client.pyc", line 1358, in request
      File "http\client.pyc", line 1404, in _send_request
      File "http\client.pyc", line 1353, in endheaders
      File "http\client.pyc", line 1113, in _send_output
      File "http\client.pyc", line 1057, in send
      File "http\client.pyc", line 1499, in connect
      File "ssl.pyc", line 455, in wrap_socket
      File "ssl.pyc", line 1076, in _create
      File "ssl.pyc", line 1372, in do_handshake
    ssl.SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1032)

    During handling of the above exception, another exception occurred:

    Traceback (most recent call last):
      File "updateCheck.pyc", line 244, in checkForUpdate
      File "urllib\request.pyc", line 189, in urlopen
      File "urllib\request.pyc", line 489, in open
      File "urllib\request.pyc", line 506, in _open
      File "urllib\request.pyc", line 466, in _call_chain
      File "urllib\request.pyc", line 1367, in https_open
      File "urllib\request.pyc", line 1322, in do_open
    urllib.error.URLError: <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1032)>

    During handling of the above exception, another exception occurred:

    Traceback (most recent call last):
      File "updateCheck.pyc", line 389, in _bg
      File "updateCheck.pyc", line 252, in checkForUpdate
      File "updateCheck.pyc", line 1102, in _updateWindowsRootCertificates
    ctypes.ArgumentError: argument 2: TypeError: expected LP_c_byte instance instead of bytes
    ```

    </details>
  * NVDA 2025.3.2 and [try-i19443-54246,566d6fea](https://download.nvaccess.org/snapshots/try/try-i19443/nvda_snapshot_try-i19443-54246,566d6fea.exe): I get the same `certificate verify failed: unable to get local issuer certificate (_ssl.c:1006)` exception. Given this is the same between these two versions and update check seems to work correctly on networks using HTTPS interception in 2025.3.2, I think this is an issue with my setup.
    
    <details><summary>Stable and try log</summary>

    ```
    DEBUG - updateCheck.checkForUpdate (07:09:48.362) - updateCheck.UpdateChecker.check (26764):
    Fetching update data from https://api.nvaccess.org/nvdaUpdateCheck?autoCheck=False&allowUsageStats=False&version=2025.3.2&versionType=stable&osVersion=10.0.26220+workstation&x64=True&osArchitecture=AMD64
    DEBUG - updateCheck._updateWindowsRootCertificates (07:09:48.462) - updateCheck.UpdateChecker.check (26764):
    Updating Windows root certificates
    DEBUGWARNING - Python warning (07:09:48.542) - updateCheck.UpdateChecker.check (26764):
    urllib3\connectionpool.pyc:1097: InsecureRequestWarning: Unverified HTTPS request is being made to host '127.0.0.1'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#tls-warnings
    DEBUG - updateCheck.checkForUpdate (07:09:48.772) - updateCheck.UpdateChecker.check (26764):
    Retrying update check from https://api.nvaccess.org/nvdaUpdateCheck?autoCheck=False&allowUsageStats=False&version=2025.3.2&versionType=stable&osVersion=10.0.26220+workstation&x64=True&osArchitecture=AMD64
    DEBUGWARNING - updateCheck.UpdateChecker._bg (07:09:48.853) - updateCheck.UpdateChecker.check (26764):
    Error checking for update
    Traceback (most recent call last):
      File "urllib\request.pyc", line 1348, in do_open
      File "http\client.pyc", line 1303, in request
      File "http\client.pyc", line 1349, in _send_request
      File "http\client.pyc", line 1298, in endheaders
      File "http\client.pyc", line 1058, in _send_output
      File "http\client.pyc", line 996, in send
      File "http\client.pyc", line 1475, in connect
      File "ssl.pyc", line 517, in wrap_socket
      File "ssl.pyc", line 1104, in _create
      File "ssl.pyc", line 1382, in do_handshake
    ssl.SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1006)

    During handling of the above exception, another exception occurred:

    Traceback (most recent call last):
      File "updateCheck.pyc", line 236, in checkForUpdate
      File "urllib\request.pyc", line 216, in urlopen
      File "urllib\request.pyc", line 519, in open
      File "urllib\request.pyc", line 536, in _open
      File "urllib\request.pyc", line 496, in _call_chain
      File "urllib\request.pyc", line 1391, in https_open
      File "urllib\request.pyc", line 1351, in do_open
    urllib.error.URLError: <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1006)>

    During handling of the above exception, another exception occurred:

    Traceback (most recent call last):
      File "urllib\request.pyc", line 1348, in do_open
      File "http\client.pyc", line 1303, in request
      File "http\client.pyc", line 1349, in _send_request
      File "http\client.pyc", line 1298, in endheaders
      File "http\client.pyc", line 1058, in _send_output
      File "http\client.pyc", line 996, in send
      File "http\client.pyc", line 1475, in connect
      File "ssl.pyc", line 517, in wrap_socket
      File "ssl.pyc", line 1104, in _create
      File "ssl.pyc", line 1382, in do_handshake
    ssl.SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1006)

    During handling of the above exception, another exception occurred:

    Traceback (most recent call last):
      File "updateCheck.pyc", line 381, in _bg
      File "updateCheck.pyc", line 247, in checkForUpdate
      File "urllib\request.pyc", line 216, in urlopen
      File "urllib\request.pyc", line 519, in open
      File "urllib\request.pyc", line 536, in _open
      File "urllib\request.pyc", line 496, in _call_chain
      File "urllib\request.pyc", line 1391, in https_open
      File "urllib\request.pyc", line 1351, in do_open
    urllib.error.URLError: <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1006)>
    ```

    </details>
* [ ] User testing.

### Known issues with pull request:

None known

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
