### PR TITLE
Move Toggle Screen Curtain command to Misc category

### DIFF
--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -2,7 +2,7 @@
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-# Copyright (C) 2006-2025 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Rui Batista, Joseph Lee,
+# Copyright (C) 2006-2026 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Rui Batista, Joseph Lee,
 # Leonard de Ruijter, Derek Riemer, Babbage B.V., Davy Kager, Ethan Holliger, Łukasz Golonka, Accessolutions,
 # Julien Cochuyt, Jakub Lukowicz, Bill Dengler, Cyrille Bougot, Rob Meredith, Luke Davis,
 # Burman's Computer and Education Ltd, Cary-rowen.

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -4808,7 +4808,6 @@ class GlobalCommands(ScriptableObject):
 			"Pressed once, screen curtain is enabled until you restart NVDA. "
 			"Pressed twice, screen curtain is enabled until you disable it",
 		),
-		category=SCRCAT_VISION,
 		gesture="kb:NVDA+control+escape",
 	)
 	def script_toggleScreenCurtain(self, gesture: inputCore.InputGesture) -> None:


### PR DESCRIPTION

### Link to issue number:
Fix-up of #19177.
### Summary of the issue:
Since #19177, Screen curtain settings have been moved from Vision to "Privacy and Security" settings panel in the settings dialog. Though, in the input gestures dialog, its toggle command is still located in the Vision category. This is not consistent.

### Description of user facing changes:
In the input gestures dialog, the screen curtain toggle command is now located in the Misc category rather than in the Vision category.

### Description of developer facing changes:
N/A
### Description of development approach:
Removed the category of the script. A script with no category lands in the Misc category.
### Testing strategy:
Manual test of:
* look at input gesture dialog content
* input help for screen curtain
* tested that screen curtain still works.
### Known issues with pull request:
None
### Code Review Checklist:


- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
