### PR TITLE
Link with cetCompat flag

### DIFF
--- a/nvdaHelper/archBuild_sconscript
+++ b/nvdaHelper/archBuild_sconscript
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2006-2025 NV Access Limited
+# Copyright (C) 2006-2026 NV Access Limited
 # This file may be used under the terms of the GNU General Public License, version 2 or later.
 # For more details see: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -167,6 +167,8 @@ if isArm64EC:
 	env.Append(CCFLAGS="/arm64EC")
 	env.Append(LINKFLAGS="/machine:arm64ec")
 	env.Append(ARFLAGS="/machine:arm64ec")
+elif TARGET_ARCH != "arm64":
+	env.Append(LINKFLAGS="/CETCOMPAT")
 
 if "debugCRT" in debug:
 	env.Append(CCFLAGS=["/MTd"])

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -28,6 +28,8 @@
 
 ### Changes for Developers
 
+* NVDA libraries built by the build system are now linked with the [/SETCOMPAT](https://learn.microsoft.com/en-us/cpp/build/reference/cetcompat) flag, improving protection against certain malware attacks. (#19435, @LeonarddeR)
+
 Please refer to [the developer guide](https://download.nvaccess.org/documentation/developerGuide.html#API) for information on NVDA's API deprecation and removal process.
 
 #### Deprecations


### PR DESCRIPTION
### Link to issue number:
Fixes #19435

### Summary of the issue:
NVDA on X86 and X64 is not linked with the [/CETCOMPAT](https://learn.microsoft.com/en-us/cpp/build/reference/cetcompat) flag. This flag should improve security.

### Description of user facing changes:
None

### Description of developer facing changes:
None

### Description of development approach:
Add the flag, but only on X64 and X86.

### Testing strategy:
System tests, ensured that the flag is set in binaries. See https://github.com/nvaccess/nvda/issues/19435#issuecomment-3768937294

### Known issues with pull request:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
