### PR TITLE
Improve Magnifier error messages

### DIFF
--- a/source/_magnifier/commands.py
+++ b/source/_magnifier/commands.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2025 NV Access Limited, Antoine Haffreingue
+# Copyright (C) 2025 NV Access Limited, Antoine Haffreingue, Cyrille Bougot
 # This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
 # For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
 
@@ -203,10 +203,10 @@ def magnifierIsActiveVerify(
 		return True
 	else:
 		ui.message(
-			"magnifier",
 			pgettext(
-				# Translators: Message announced that the magnifier is not active.
-				"Magnifier is not active when {action}",
+				"magnifier",
+				# Translators: Message announced when the magnifier is not active.
+				"Cannot {action} when Magnifier is not active.",
 			).format(action=action.displayString),
 		)
 		return False
@@ -230,8 +230,8 @@ def magnifierIsFullscreenVerify(
 		ui.message(
 			pgettext(
 				"magnifier",
-				# Translators: Message announced that the magnifier is not full-screen.
-				"Magnifier is not full-screen when {action}",
+				# Translators: Message announced when the magnifier is not full-screen.
+				"Cannot {action} when Magnifier is not full-screen/",
 			).format(action=action.displayString),
 		)
 		return False

--- a/source/_magnifier/commands.py
+++ b/source/_magnifier/commands.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2025 NV Access Limited, Antoine Haffreingue, Cyrille Bougot
+# Copyright (C) 2025-2026 NV Access Limited, Antoine Haffreingue, Cyrille Bougot
 # This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
 # For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
 

--- a/source/_magnifier/commands.py
+++ b/source/_magnifier/commands.py
@@ -231,7 +231,7 @@ def magnifierIsFullscreenVerify(
 			pgettext(
 				"magnifier",
 				# Translators: Message announced when the magnifier is not full-screen.
-				"Cannot {action} when Magnifier is not full-screen/",
+				"Cannot {action} when Magnifier is not full-screen.",
 			).format(action=action.displayString),
 		)
 		return False

--- a/source/_magnifier/utils/types.py
+++ b/source/_magnifier/utils/types.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2025 NV Access Limited, Antoine Haffreingue
+# Copyright (C) 2025 NV Access Limited, Antoine Haffreingue, Cyrille Bougot
 # This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
 # For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
 
@@ -40,15 +40,15 @@ class MagnifierAction(DisplayStringEnum):
 	def _displayStringLabels(self) -> dict["MagnifierAction", str]:
 		return {
 			# Translators: Action description for zooming in.
-			self.ZOOM_IN: pgettext("magnifier action", "trying to zoom in"),
+			self.ZOOM_IN: pgettext("magnifier action", "zoom in"),
 			# Translators: Action description for zooming out.
-			self.ZOOM_OUT: pgettext("magnifier action", "trying to zoom out"),
+			self.ZOOM_OUT: pgettext("magnifier action", "zoom out"),
 			# Translators: Action description for toggling color filters.
-			self.TOGGLE_FILTER: pgettext("magnifier action", "trying to toggle filters"),
+			self.TOGGLE_FILTER: pgettext("magnifier action", "toggle filters"),
 			# Translators: Action description for changing full-screen mode.
-			self.CHANGE_FULLSCREEN_MODE: pgettext("magnifier action", "trying to change full-screen mode"),
+			self.CHANGE_FULLSCREEN_MODE: pgettext("magnifier action", "change full-screen mode"),
 			# Translators: Action description for starting spotlight mode.
-			self.START_SPOTLIGHT: pgettext("magnifier action", "trying to start spotlight mode"),
+			self.START_SPOTLIGHT: pgettext("magnifier action", "start spotlight mode"),
 		}
 
 


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
When trying to execute Magnifier commands while Magnifier is not active, there is no error message and an error is logged because `pgettext` context argument has been put at a wrong position.

### Description of user facing changes:
* Executing Magnifier commands when Magnifier is not active now report a message as expected.
* The reported messages have been improved to be more similar to other NVDA messages when an action cannot be performed.

### Description of developer facing changes:
N/A
### Description of development approach:
* Fix `pgettext` call
* Reworded error messages
### Testing strategy:
Manuel tests of all Magnifier commands.

The full screen scheck has not been tested since for now, no other mode is available.

### Known issues with pull request:
N/A
### Code Review Checklist:


- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
