### PR TITLE
Notify user when connecting as follower fails

### DIFF
--- a/source/_remoteClient/client.py
+++ b/source/_remoteClient/client.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2015-2025 NV Access Limited, Christopher Toth, Tyler Spivey, Babbage B.V., David Sexton and others.
+# Copyright (C) 2015-2026 NV Access Limited, Christopher Toth, Tyler Spivey, Babbage B.V., David Sexton and others.
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -283,6 +283,8 @@ class RemoteClient:
 
 	def disconnectAsFollower(self):
 		"""Close follower session and clean up related resources."""
+		if self.followerTransport:
+			self.followerTransport.transportConnectionFailed.unregister(self.onConnectAsFollowerFailed)
 		self.followerSession.close()
 		self.followerSession = None
 		self.followerTransport = None
@@ -297,6 +299,21 @@ class RemoteClient:
 		if self.leaderTransport.successfulConnects == 0:
 			log.error(f"Failed to connect to {self.leaderTransport.address}")
 			self.disconnectAsLeader()
+			# Translators: Title of the connection error dialog.
+			gui.messageBox(
+				parent=gui.mainFrame,
+				# Translators: Title of the connection error dialog.
+				caption=_("Error Connecting"),
+				# Translators: Message shown when unable to connect to the remote computer.
+				message=_("Unable to connect to the remote computer"),
+				style=wx.OK | wx.ICON_WARNING,
+			)
+
+	@alwaysCallAfter
+	def onConnectAsFollowerFailed(self):
+		if self.followerTransport and self.followerTransport.successfulConnects == 0:
+			log.error(f"Failed to connect to {self.followerTransport.address}")
+			self.disconnectAsFollower()
 			# Translators: Title of the connection error dialog.
 			gui.messageBox(
 				parent=gui.mainFrame,
@@ -422,6 +439,7 @@ class RemoteClient:
 			self.onFollowerCertificateFailed,
 		)
 		transport.transportConnected.register(self.onConnectedAsFollower)
+		transport.transportConnectionFailed.register(self.onConnectAsFollowerFailed)
 		transport.transportDisconnected.register(self.onDisconnectedAsFollower)
 		transport.reconnectorThread.start()
 		if self.menu:
@@ -773,3 +791,4 @@ class RemoteClient:
 			stack_info=True,
 		)
 		return 0
+        

--- a/source/_remoteClient/client.py
+++ b/source/_remoteClient/client.py
@@ -318,9 +318,9 @@ class RemoteClient:
 			gui.messageBox(
 				parent=gui.mainFrame,
 				# Translators: Title of the connection error dialog.
-				caption=_("Error Connecting"),
+				caption=pgettext("remote", "Error Connecting"),
 				# Translators: Message shown when unable to connect to the remote computer.
-				message=_("Unable to connect to the remote computer"),
+				message=pgettext("remote", "Unable to connect to the remote computer"),
 				style=wx.OK | wx.ICON_WARNING,
 			)
 

--- a/source/_remoteClient/client.py
+++ b/source/_remoteClient/client.py
@@ -791,4 +791,3 @@ class RemoteClient:
 			stack_info=True,
 		)
 		return 0
-        

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -114,6 +114,7 @@ It currently includes Screen Curtain's settings (previously in the "Vision" cate
 * In the Input Gestures dialog, gestures including an operator while Num Lock is on will now be correctly displayed. (#19214, @CyrilleB79)
 * In Chromium browsers, if a document contains links with a malformed URL, reading the document will be possible again. (#19125, @nvdaes)
 * NVDA no longer plays a sound for spelling errors while typing if speech mode is set to on-demand or off. (#19323, @CyrilleB79)
+* Fixed missing user notification when connecting as the controlled computer fails. (#19103, @hdzrvcc0X74)
 
 ### Changes for Developers
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -114,7 +114,7 @@ It currently includes Screen Curtain's settings (previously in the "Vision" cate
 * In the Input Gestures dialog, gestures including an operator while Num Lock is on will now be correctly displayed. (#19214, @CyrilleB79)
 * In Chromium browsers, if a document contains links with a malformed URL, reading the document will be possible again. (#19125, @nvdaes)
 * NVDA no longer plays a sound for spelling errors while typing if speech mode is set to on-demand or off. (#19323, @CyrilleB79)
-* Fixed missing user notification when connecting as the controlled computer fails. (#19103, @hdzrvcc0X74)
+* Improved user notifications for Remote Access when connecting as the controlled computer fails. (#19103, @hdzrvcc0X74)
 
 ### Changes for Developers
 


### PR DESCRIPTION
### Link to issue number:
Replaces #19454 
Replaces #19467 
Fixes #19103 

### Summary of the issue:

Users are not notified when connecting as the controlled computer (follower) fails. Only the leader connection errors are shown to users.  

### Description of user facing changes:

Users will now see an error message when connection as the controlled computer fails, just like when connecting as the controlling computer.  

### Description of developer facing changes:

None.

### Description of development approach:

Made follower connection error handling consistent with leader connection by adding the missing event handler and user notification.  

* Added onConnectAsFollowerFailed method in client.py to handle follower connection failures;
* Registered transportConnectionFailed event handler for follower transport;
* Added cleanup for event handlers in disconnectAsFollower method.

### Testing strategy:

Tested manually.

### Known issues with pull request:

None known.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
