### PR TITLE
[POC/WIP] Fix radio button label not read with aria-labelledby in browse mode (#19472)

### DIFF
--- a/source/NVDAObjects/UIA/web.py
+++ b/source/NVDAObjects/UIA/web.py
@@ -256,6 +256,8 @@ class UIAWebTextInfo(UIATextInfo):
 					field["content"] = obj.name
 		elif hasAriaLabel or hasAriaLabelledby:
 			field["alwaysReportName"] = True
+			if hasAriaLabelledby and not field.get("content"):
+				field["content"] = obj.name
 		# Give lists an item count
 		if obj.role == controlTypes.Role.LIST:
 			child = UIAHandler.handler.clientObject.ControlViewWalker.GetFirstChildElement(obj.UIAElement)


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
<!-- Use Closes/Fixes/Resolves #xxx to link this PR to the issue it is responding to. -->

### Summary of the issue:

see #19472

### Description of user facing changes:

TODO: if the fix is successful, in browse mode, when browsing into a radio input in word by word navigation, screen reader should read the input name associated by aria-labelledby.




### Description of developer facing changes:

### Description of development approach:

### Testing strategy:

TODO: _pending_

Edge cases:
- to test when the combination is also wrapped inside a HTML Label Element
- to test when there exist for...id label
- repeat tests for checkbox and other text input

### Known issues with pull request:

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [ ] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [ ] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [ ] API is compatible with existing add-ons.
- [ ] Security precautions taken.
