### PR TITLE
Fix toggle screen layout command in input gestures dialog

### DIFF
--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -2633,6 +2633,15 @@ class BrowseModeDocumentTreeInterceptor(
 		"kb:,": "movePastEndOfContainer",
 	}
 
+	def _toggleScreenLayout(self) -> None:
+		"""Toggles whether the document is presented as it appears visually, or with interactive controls on their own lines.
+
+		Subclasses that support toggling this option should implement this method.
+
+		:raises NotImplementedError: If toggling this option is not supported by this document.
+		"""
+		raise NotImplementedError
+
 	@script(
 		description=_(
 			# Translators: the description for the toggleScreenLayout script.
@@ -2641,8 +2650,11 @@ class BrowseModeDocumentTreeInterceptor(
 		gesture="kb:NVDA+v",
 	)
 	def script_toggleScreenLayout(self, gesture):
-		# Translators: The message reported for not supported toggling of screen layout
-		ui.message(_("Not supported in this document."))
+		try:
+			self._toggleScreenLayout()
+		except NotImplementedError:
+			# Translators: The message reported for not supported toggling of screen layout
+			ui.message(_("Not supported in this document."))
 
 	def updateAppSelection(self):
 		"""Update the native selection in the application to match the browse mode selection in NVDA."""

--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -2649,7 +2649,7 @@ class BrowseModeDocumentTreeInterceptor(
 		),
 		gesture="kb:NVDA+v",
 	)
-	def script_toggleScreenLayout(self, gesture):
+	def script_toggleScreenLayout(self, gesture: inputCore.InputGesture) -> None:
 		try:
 			self._toggleScreenLayout()
 		except NotImplementedError:

--- a/source/virtualBuffers/__init__.py
+++ b/source/virtualBuffers/__init__.py
@@ -15,7 +15,6 @@ import wx
 import NVDAHelper
 import XMLFormatting
 import scriptHandler
-from scriptHandler import script
 import api
 import controlTypes
 import textInfos.offsets
@@ -688,18 +687,11 @@ class VirtualBuffer(browseMode.BrowseModeDocumentTreeInterceptor):
 	# Translators: the description for the refreshBuffer script on virtualBuffers.
 	script_refreshBuffer.__doc__ = _("Refreshes the document content")
 
-	@script(
-		description=_(
-			# Translators: the description for the toggleScreenLayout script on virtualBuffers.
-			"Toggles on and off if the screen layout is preserved while rendering the document content",
-		),
-		gesture="kb:NVDA+v",
-	)
-	def script_toggleScreenLayout(self, gesture):
-		config.conf["virtualBuffers"]["useScreenLayout"] = not config.conf["virtualBuffers"][
-			"useScreenLayout"
-		]
-		if config.conf["virtualBuffers"]["useScreenLayout"]:
+	def _toggleScreenLayout(self):
+		newUseScreenLayout = config.conf["virtualBuffers"]["useScreenLayout"] = not config.conf[
+			"virtualBuffers"
+		]["useScreenLayout"]
+		if newUseScreenLayout:
 			# Translators: Presented when use screen layout option is toggled.
 			ui.message(_("Use screen layout on"))
 		else:

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -23,6 +23,7 @@
 ### Bug Fixes
 
 * In Firefox browse mode, the accessible name of form controls (such as checkboxes and radio buttons) is now correctly announced when the control has an `aria-label` and an associated `<label>` element that contains only `aria-hidden` content. (#19409, @bramd)
+* The "Toggles on and off if the screen layout is preserved while rendering the document content" item in the "Browse mode" category of the Input Gestures dialog now behaves correctly. (#18378)
 * In Microsoft Word with UIA enabled, page changes are now correctly announced when navigating table rows that span multiple pages. (#19386, @akj)
 * Fixed excessive resource usage and highlight flickering when using Visual Highlight. (#17434, @hwf1324)
 
@@ -31,6 +32,8 @@
 * NVDA libraries built by the build system are now linked with the [/SETCOMPAT](https://learn.microsoft.com/en-us/cpp/build/reference/cetcompat) flag, improving protection against certain malware attacks. (#19435, @LeonarddeR)
 
 Please refer to [the developer guide](https://download.nvaccess.org/documentation/developerGuide.html#API) for information on NVDA's API deprecation and removal process.
+
+* Subclasses of `browseMode.BrowseModeDocumentTreeInterceptor` that support screen layout being on and off should override the `_toggleScreenLayout` method, rather than implementing `script_toggleScreenLayout` directly. (#19487)
 
 #### Deprecations
 


### PR DESCRIPTION
### Link to issue number:
Fixes #18378

### Summary of the issue:
The script to toggle screen layout in browse mode documents does not show the correct gestures:
* If it is only bound to `NVDA+v` (the default), no gestures are shown.
* If it is bound to multiple gestures, only a subset of these are shown.

### Description of user facing changes:
The command shows all bound gestures in the input gestures dialog.

### Description of developer facing changes:
Developers are now advised to implement the `_toggleScreenLayout` method on classes that inherit from `browseMode.BrowseModeDocumentTreeInterceptor`, rather than implementing `script_toggleScreenLayout`. The old approach will still work, it will just cause this issue to resurface for their document.

### Description of development approach:
Refactored `browseMode.BrowseModeDocumentTreeInterceptor.script_toggleScreenLayout` to call a helper method, `_toggleScreenLayout`. If the helper method raises `NotImplementedError`, the unsupported message is presented to the user. The base implementation simply raises `NotImplementedError`.
Changed `virtualBuffers.VirtualBuffer` to implement `_toggleScreenLayout` rather than `script_toggleScreenLayout`.

### Testing strategy:
Ran from source. In Firefox, toggled Screen Layout and verified that the correct message was output and that it corresponded with the new screen layout state.
In word, switched to browse mode and attempted to toggle screen layout, and observed that the unsupported message was heard.

### Known issues with pull request:
None

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
