### PR TITLE
UIA: do not ignore supposedly obvious state information

### DIFF
--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -605,10 +605,6 @@ class UIATextInfo(textInfos.TextInfo):
 		field["_endOfNode"] = endOfNode
 		field["role"] = obj.role
 		states = obj.states
-		# The user doesn't care about certain states, as they are obvious.
-		states.discard(controlTypes.State.EDITABLE)
-		states.discard(controlTypes.State.MULTILINE)
-		states.discard(controlTypes.State.FOCUSED)
 		field["states"] = states
 		field["nameIsContent"] = nameIsContent = (
 			obj.UIAElement.cachedControlType in self.UIAControlTypesWhereNameIsContent


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
<!-- Use Closes/Fixes/Resolves #xxx to link this PR to the issue it is responding to. -->

### Summary of the issue:

As it currently stands, NVDA explicitly chooses to ignore state information that is actually quite significant. Contrary to the comment above it, this information is (not) obvious. For example, if a UIA control explicitly denotes that it is a multi-line edit field, but it is a `UIA_EditControlTypeId` and not `UIA_DocumentControlTypeId`, NVDA will not report that the field is a multi-line edit control. This yields some extremely confusing behavior (which to the end-user looks like an application accessibility bug) because NVDA will confusingly say "edit <content of field>" instead of it's usual "edit  multi line <content of field>", which makes the user believe that the  field is a single-line edit instead of functioning as a multi-line edit. That, in turn, will cause even more confusion when the user enters text, or navigates the field, expecting the mechanics of a single-line edit to apply when they do not in this instance.

### Description of user facing changes:

NVDA will now properly report UIA ARIA property state information which was previously explicitly ignored.

### Description of developer facing changes:

NVDA will no longer discard state information because it is supposedly obvious.

### Description of development approach:

I removed the discarding of state data on (what was) lines 608-612 of `__init__.py`. This bug was discovered in the [DVUI project](https://github.com/david-vanderson/dvui/pull/677) as we are working on improving it's accessibility.

### Testing strategy:

### Known issues with pull request:

I do not currently know of any, especially considering the fact that this is a miner PR.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [ ] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
