### PR TITLE
Fix copying add-ons to the system profile

### DIFF
--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -1010,7 +1010,7 @@ class GeneralSettingsPanel(SettingsPanel):
 		)
 		while True:
 			try:
-				systemUtils.ExecAndPump(config.setSystemConfigToCurrentConfig, _addonsToCopy=addonsToCopy)
+				systemUtils.ExecAndPump(config.setSystemConfigToCurrentConfig, addonsToCopy=addonsToCopy)
 				res = True
 				break
 			except installer.RetriableFailure:


### PR DESCRIPTION
### Link to issue number:

Follow-up to [#19446](https://github.com/nvaccess/nvda/pull/19446#issuecomment-3791320405)

### Summary of the issue:

#19446 introduced the ability to select which add-ons should be copied to the system profile (now described to users as "NVDA's system-wide configuration"). Early in the prototype phase, I underscore-prefixed the new `addonsToCopy` parameter to `setSystemConfigToCurrentConfig`. I removed the underscore late in the dev/testing process, so late that I didn't do enough testing to ensure that every instance was renamed.

### Description of user facing changes:

Copying configuration to the system profile works again.

### Description of developer facing changes:

None.

### Description of development approach:

Corrected the name of the parameter in `gui.settingsDialogs.GeneralSettingsPanel.onCopySettings`. Searched `source/` for any other instances of `_addonsToCopy` and found none.

### Testing strategy:

Created a dist. Installed from same. Copied settings to system settings, with and without add-ons installed and selected.

### Known issues with pull request:

None

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
