### PR TITLE
Fix translatable string in copy add-ons feature

### DIFF
--- a/source/gui/addonStoreGui/controls/messageDialogs.py
+++ b/source/gui/addonStoreGui/controls/messageDialogs.py
@@ -788,7 +788,7 @@ class _CopyAddonsDialog(
 				npgettext(
 					"addonStore",
 					# Translators: A message to warn the user when attempting to copy add-ons for use on secure screens
-					"You have selected to copy 1 add-on to NVDA's system-wide configuration. "
+					"You have selected to copy {num} add-on to NVDA's system-wide configuration. "
 					"Using this add-on during sign-in and on secure screens is a serious security risk.",
 					"You have selected to copy {num} add-ons to NVDA's system-wide configuration. "
 					"Using these add-ons during sign-in and on secure screens is a serious security risk.",


### PR DESCRIPTION
### Link to issue number:

Fixes #19510

### Summary of the issue:
Translators are unable to correctly translate the warning message shown to users when copying add-on(s) to the system configuration.

### Description of user facing changes:
None

### Description of developer facing changes:
None

### Description of development approach:
Correct the singular string to use `{num}` instead of `1`. This is necessary because our pofile validation checks that the number and type of substitutions in translated strings matches those in English.

### Testing strategy:
Tested that the correct message is still shown in English by forcing the dialog to be shown..

### Known issues with pull request:
None

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
