### PR TITLE
Don't copy universal C Runtime as it will never be used on Windows 10/11

### DIFF
--- a/sconstruct
+++ b/sconstruct
@@ -413,32 +413,6 @@ def NVDADistGenerator(target, source, env, for_signature):
 
 	action.append(buildCmd)
 
-	# #10031: Apps written in Python 3 require Universal CRT to be installed. We cannot assume users have it on their systems.
-	# Therefore , copy required libraries from Windows 10 SDK.
-	try:
-		with winreg.OpenKey(
-			winreg.HKEY_LOCAL_MACHINE,
-			r"SOFTWARE\Microsoft\Microsoft SDKs\Windows\v10.0",
-			access=winreg.KEY_READ | winreg.KEY_WOW64_32KEY,
-		) as SDKKey:
-			sdk_installationFolder = winreg.QueryValueEx(SDKKey, "InstallationFolder")[0]
-			sdk_productVersion = winreg.QueryValueEx(SDKKey, "ProductVersion")[0]
-	except WindowsError:
-		raise RuntimeError("Windows 10 SDK not found")
-	# The Universal CRT should be in an SDK version-specific directory
-	# But usually has a '.0' appended after the productVersion found in the registry.
-	# E.g. 10.0.1941 might e actually 10.0.1941.0.
-	# Thus try both.
-	CRTDir = os.path.join(sdk_installationFolder, "Redist", sdk_productVersion + ".0", "ucrt", "DLLs", "x86")
-	if not os.path.isdir(CRTDir):
-		CRTDir = os.path.join(sdk_installationFolder, "Redist", sdk_productVersion, "ucrt", "DLLs", "x86")
-		if not os.path.isdir(CRTDir):
-			raise RuntimeError(f"Could not locate CRT dlls in SDK at {CRTDir}")
-	with os.scandir(CRTDir) as dir:
-		for file in dir:
-			if file.name.endswith(".dll") and file.is_file():
-				action.append(Copy(target[0], file.path))
-
 	if certFile or apiSigningToken:
 		for prog in "nvda_noUIAccess.exe", "nvda_uiAccess.exe", "nvda_slave.exe", "l10nUtil.exe":
 			action.append(

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -163,6 +163,7 @@ On ARM64 machines with Windows 11, these ARM64EC libraries are loaded instead of
 * NVDA is now licensed under "GPL-2 or later".
 * In `braille.py`, the `FormattingMarker` class has a new `shouldBeUsed` method, to determine if the formatting marker key should be reported (#7608, @nvdaes)
 * Added `api.fakeNVDAObjectClasses` set and `api.isFakeNVDAObject` function to identify fake NVDAObject instances. (#19168, @hwf1324)
+* NVDA no longer includes the Microsoft Universal C Runtime. (#19508)
 
 #### API Breaking Changes
 


### PR DESCRIPTION
### Link to issue number:
Resolves #19508

### Summary of the issue:
The Microsoft Universal C Runtime DLLs included with NVDA are x86 DLLs. Notwithstanding this, they aren't used on Windows 10 and 11, as, per [the docs](https://learn.microsoft.com/en-us/cpp/windows/universal-crt-deployment), "On Windows 10 and Windows 11, the Universal CRT in the system directory is always used, even if an application includes an application-local copy of the Universal CRT".

### Description of user facing changes:
Launcher and installed size are slightly reduced.

### Description of developer facing changes:
The Universal CRT is no longer included with NVDA.

### Description of development approach:
Removed the SCons code responsible for copying the UCRT DLLs.

### Testing strategy:
Built from source. Installed in a clean Windows 11 VM. Tested using Windows OCR.

### Known issues with pull request:
If there are cases where a machine doesn't have a copy of the UCRT, NVDA will no longer run. However, based on the above linked documentation, it wouldn't run in this case anyway.

### Code Review Checklist:

- [ ] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
