### PR TITLE
when upgrading config from schema 20 to 21, gracefully handle when a key or value does not exist E.g. for a config profile.

### DIFF
--- a/source/config/profileUpgradeSteps.py
+++ b/source/config/profileUpgradeSteps.py
@@ -639,20 +639,26 @@ def upgradeConfigFrom_19_to_20(profile: ConfigObj):
 
 def upgradeConfigFrom_20_to_21(profile: ConfigObj):
 	"""Redirect old sapi4 and sapi5 config to 32 bit versions."""
-	synth = profile["speech"]["synth"]
+	speechConf = profile.get("speech")
+	if not speechConf:
+		log.debug("Profile does not have a speech key")
+		return
+	synth = speechConf.get("synth")
 	if synth == "sapi4":
 		synth = "sapi4_32"
 		log.debug("Switching configured synthesizer from sapi4 to sapi4_32")
+		speechConf["synth"] = synth
 	elif synth == "sapi5":
 		synth = "sapi5_32"
 		log.debug("Switching configured synthesizer from sapi5 to sapi5_32")
-	profile["speech"]["synth"] = synth
-	sapi4Conf = profile["speech"].get("sapi4")
+		speechConf["synth"] = synth
+	sapi4Conf = speechConf.get("sapi4")
 	if sapi4Conf:
-		profile["speech"]["sapi4_32"] = sapi4Conf
-		del profile["speech"]["sapi4"]
-	sapi5Conf = profile["speech"].get("sapi5")
+		speechConf["sapi4_32"] = sapi4Conf
+		del speechConf["sapi4"]
+		log.debug("Moved old sapi4 configuration values to sapi4_32")
+	sapi5Conf = speechConf.get("sapi5")
 	if sapi5Conf:
-		profile["speech"]["sapi5_32"] = sapi5Conf
-		del profile["speech"]["sapi5"]
+		speechConf["sapi5_32"] = sapi5Conf
+		del speechConf["sapi5"]
 		log.debug("Moved old sapi5 configuration values to sapi5_32")

--- a/source/config/profileUpgradeSteps.py
+++ b/source/config/profileUpgradeSteps.py
@@ -641,7 +641,7 @@ def upgradeConfigFrom_20_to_21(profile: ConfigObj):
 	"""Redirect old sapi4 and sapi5 config to 32 bit versions."""
 	speechConf = profile.get("speech")
 	if not speechConf:
-		log.debug("Profile does not have a speech key")
+		log.debug("Profile's speech section is empty or does not exist. No action taken.")
 		return
 	synth = speechConf.get("synth")
 	if synth == "sapi4":


### PR DESCRIPTION
### Link to issue number:
<!-- Use Closes/Fixes/Resolves #xxx to link this PR to the issue it is responding to. -->

Addresses an issue introduced by pr #19432

### Summary of the issue:
With the merging of pr #19432 which adds SAPI 32 bit support, An error is produced when switching to config profiles that do not have particular synth keys already set. 
```
ERROR - config.ProfileTrigger.enter (16:08:50.860) - MainThread (12728):
Error entering trigger app:notepad, profile Text Editing
Traceback (most recent call last):
  File "config\__init__.pyc", line 1381, in enter
  File "config\__init__.pyc", line 865, in _triggerProfileEnter
  File "config\__init__.pyc", line 643, in _getProfile
  File "config\__init__.pyc", line 586, in _loadConfig
  File "config\__init__.pyc", line 582, in _loadConfig
  File "config\profileUpgrader.pyc", line 26, in upgrade
  File "config\profileUpgrader.pyc", line 42, in _doConfigUpgrade
  File "config\profileUpgradeSteps.pyc", line 642, in upgradeConfigFrom_20_to_21
  File "configobj\__init__.pyc", line 496, in __getitem__
KeyError: 'synth'
```
 
### Description of user facing changes:
No error is produced and profiles load correctly.

### Description of developer facing changes:

### Description of development approach:
* `config.profileUpgradeSteps.upgradeConfigFrom_20_to_21`: Fetch existing keys with `get` rather than key lookup. 
 
### Testing strategy:
* Starting with a main config schema of 20 that contained `synth = sapi4`, and both sapi4 and sapi5 sections in speech, ensured that the synth value was changed to sapi4_32, and that the sapi4 section was renamed to sapi4_32, and that the sapi5  section was renamed to sapi5_32 when running NvDA, and that NVDA successfully used the sapi4_32 synth.
* Started with a config profile for notepad at schema 20, which had no speech keys or values. Creted just with a change to braille config. Running NvDA, switching to notepad, ensured that the error reported above is gone, and that the profile loaded okay.

### Known issues with pull request:
None known.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
