### PR TITLE
replace the default model with Mozilla's distilvit

### DIFF
--- a/source/_localCaptioner/modelDownloader.py
+++ b/source/_localCaptioner/modelDownloader.py
@@ -660,7 +660,7 @@ class ModelDownloader:
 	def downloadModelsMultithreaded(
 		self,
 		modelsDir: str = WritePaths.modelsDir,
-		modelName: str = "Xenova/vit-gpt2-image-captioning",
+		modelName: str = "Mozilla/distilvit",
 		filesToDownload: list[str] | None = None,
 		resolvePath: str = "/resolve/main",
 		progressCallback: ProgressCallback | None = None,

--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -531,7 +531,7 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 
 [automatedImageDescriptions]
 	enable = boolean(default=false)
-	defaultModel = string(default="Xenova/vit-gpt2-image-captioning")
+	defaultModel = string(default="Mozilla/distilvit")
 
 [screenCurtain]
 	enabled = boolean(default=false)

--- a/source/gui/_localCaptioner/messageDialogs.py
+++ b/source/gui/_localCaptioner/messageDialogs.py
@@ -110,7 +110,7 @@ class ImageDescDownloader:
 			message=pgettext(
 				"imageDesc",
 				# Translators: label of dialog when downloading image captioning
-				"Image captioning not installed. Would you like to install (235 MB)?",
+				"Image captioning not installed. Would you like to install (178 MB)?",
 			),
 			dialogType=DialogType.WARNING,
 			buttons=confirmationButtons,


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
<!-- Use Closes/Fixes/Resolves #xxx to link this PR to the issue it is responding to. -->

### Summary of the issue:

### Description of user facing changes:
replace the default model with Mozilla's distilvit
### Description of developer facing changes:
None
### Description of development approach:
None
### Testing strategy:
Manual
### Known issues with pull request:
More lightweight, but description sometimes seems vaguer
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
