### PR TITLE
No longer allow moving to offset past end for NVDAObjectTextInfo

### DIFF
--- a/source/NVDAObjects/__init__.py
+++ b/source/NVDAObjects/__init__.py
@@ -73,7 +73,7 @@ class NVDAObjectTextInfo(textInfos.offsets.OffsetsTextInfo):
 		return [self.obj.location]
 
 	def allowMoveToUnitOffsetPastEnd(self, unit: str) -> bool:
-		"""Default NVDA Object TextInfo has no insertion point, so no need to move past the end of text."""
+		# Default NVDA Object TextInfo has no insertion point, so no need to move past the end of text.
 		return False
 
 

--- a/source/NVDAObjects/__init__.py
+++ b/source/NVDAObjects/__init__.py
@@ -1,9 +1,8 @@
-# -*- coding: UTF-8 -*-
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2006-2023 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Patrick Zajda, Babbage B.V.,
+# Copyright (C) 2006-2026 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Patrick Zajda, Babbage B.V.,
 # Davy Kager, Leonard de Ruijter, Cyrille Bougot
-# This file is covered by the GNU General Public License.
-# See the file COPYING for more details.
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
 
 """Module that contains the base NVDA object type with dynamic class creation support,
 as well as the associated TextInfo class."""

--- a/source/NVDAObjects/__init__.py
+++ b/source/NVDAObjects/__init__.py
@@ -73,6 +73,10 @@ class NVDAObjectTextInfo(textInfos.offsets.OffsetsTextInfo):
 			raise LookupError("Object is off screen, invisible or has no location")
 		return [self.obj.location]
 
+	def allowMoveToUnitOffsetPastEnd(self, unit: str) -> bool:
+		"""Default NVDA Object TextInfo has no insertion point, so no need to move past the end of text."""
+		return False
+
 
 class InvalidNVDAObject(RuntimeError):
 	"""Raised by NVDAObjects during construction to inform that this object is invalid.

--- a/tests/unit/test_compoundDocuments.py
+++ b/tests/unit/test_compoundDocuments.py
@@ -14,7 +14,7 @@ from .objectProvider import PlaceholderNVDAObject
 from .textProvider import BasicTextInfo, BasicTextProvider
 
 
-class BasicCompoundTextLeafTextInfo(BasicTextInfo, compoundDocuments.CompoundTextLeafTextInfo): ...
+class BasicCompoundTextLeafTextInfo(compoundDocuments.CompoundTextLeafTextInfo, BasicTextInfo): ...
 
 
 class BasicCompoundTextLeaf(BasicTextProvider):

--- a/tests/unit/test_compoundDocuments.py
+++ b/tests/unit/test_compoundDocuments.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2025 NV Access Limited, Leonard de Ruijter
+# Copyright (C) 2025-2026 NV Access Limited, Leonard de Ruijter
 # This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
 # For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
 


### PR DESCRIPTION
### Link to issue number:
fixes #18912 

### Summary of the issue:
#18744 fixed up issues with uniscribe. Since that change, NVDAObjectTextInfo properly allows moving offset past end, however NVDAObjectTextInfo is not supposed to do so as it has no insertion point anyway.

### Description of user facing changes:
NVDA no longer reports blank at the end of NVDA Objext text info text review, such as for list items.

### Description of developer facing changes:
Since `allowMoveToUnitOffsetPastEnd` is now implemented on NVDAObjectTextInfo, I had to swap two classes in the inheritance hiërarchie for a unit tests class.

### Description of development approach:
Handle NVDAObjectTextInfo as a text info without insertion point, similar to virtual buffers. In other words, don't allow moving offset past end, as there's no point to do so.

### Testing strategy:
Tested str from #18912 

### Known issues with pull request:
None known

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
