### PR TITLE
Add a third value for the 'Play a sound for logged errors:' option

### DIFF
--- a/source/config/configFlags.py
+++ b/source/config/configFlags.py
@@ -436,3 +436,28 @@ class LoggingLevel(DisplayStringIntEnum):
 			# Translators: One of the log levels of NVDA (the debug mode shows debug messages as NVDA runs).
 			self.DEBUG: _("debug"),
 		}
+
+
+@unique
+class PlayErrorSound(DisplayStringIntEnum):
+	"""Enumeration containing the possible config values to play a sound when an error is logged, depending on
+	NVDA version type.
+
+	Use PlayErrorSound.MEMBER.value to compare with the config;
+	use PlayErrorSound.MEMBER.displayString in the UI for a translatable description of this member.
+	"""
+
+	ONLY_IN_TEST_VERSIONS = 0
+	ALWAYS = 1
+	NEVER = 2
+
+	@property
+	def _displayStringLabels(self):
+		return {
+			# Translators: Label for a value in the Play a sound for logged errors combobox, in the Advanced settings.
+			PlayErrorSound.ONLY_IN_TEST_VERSIONS: pgettext("advanced.playErrorSound", "Only in NVDA test versions"),
+			# Translators: Label for a value in the Play a sound for logged errors combobox, in the Advanced settings.
+			PlayErrorSound.ALWAYS: pgettext("advanced.playErrorSound", "Always"),
+			# Translators: Label for a value in the Play a sound for logged errors combobox, in the Advanced settings.
+			PlayErrorSound.NEVER: pgettext("advanced.playErrorSound", "Never"),
+		}

--- a/source/config/configFlags.py
+++ b/source/config/configFlags.py
@@ -455,7 +455,9 @@ class PlayErrorSound(DisplayStringIntEnum):
 	def _displayStringLabels(self):
 		return {
 			# Translators: Label for a value in the Play a sound for logged errors combobox, in the Advanced settings.
-			PlayErrorSound.ONLY_IN_TEST_VERSIONS: pgettext("advanced.playErrorSound", "Only in NVDA test versions"),
+			PlayErrorSound.ONLY_IN_TEST_VERSIONS: pgettext(
+				"advanced.playErrorSound", "Only in NVDA test versions"
+			),
 			# Translators: Label for a value in the Play a sound for logged errors combobox, in the Advanced settings.
 			PlayErrorSound.ALWAYS: pgettext("advanced.playErrorSound", "Always"),
 			# Translators: Label for a value in the Play a sound for logged errors combobox, in the Advanced settings.

--- a/source/config/configFlags.py
+++ b/source/config/configFlags.py
@@ -448,8 +448,8 @@ class PlayErrorSound(DisplayStringIntEnum):
 	"""
 
 	ONLY_IN_TEST_VERSIONS = 0
-	ALWAYS = 1
-	NEVER = 2
+	YES = 1
+	NO = 2
 
 	@property
 	def _displayStringLabels(self):
@@ -460,7 +460,7 @@ class PlayErrorSound(DisplayStringIntEnum):
 				"Only in NVDA test versions",
 			),
 			# Translators: Label for a value in the Play a sound for logged errors combobox, in the Advanced settings.
-			PlayErrorSound.ALWAYS: pgettext("advanced.playErrorSound", "Always"),
+			PlayErrorSound.YES: pgettext("advanced.playErrorSound", "Yes"),
 			# Translators: Label for a value in the Play a sound for logged errors combobox, in the Advanced settings.
-			PlayErrorSound.NEVER: pgettext("advanced.playErrorSound", "Never"),
+			PlayErrorSound.NO: pgettext("advanced.playErrorSound", "No"),
 		}

--- a/source/config/configFlags.py
+++ b/source/config/configFlags.py
@@ -454,9 +454,10 @@ class PlayErrorSound(DisplayStringIntEnum):
 	@property
 	def _displayStringLabels(self):
 		return {
-			# Translators: Label for a value in the Play a sound for logged errors combobox, in the Advanced settings.
 			PlayErrorSound.ONLY_IN_TEST_VERSIONS: pgettext(
-				"advanced.playErrorSound", "Only in NVDA test versions"
+				"advanced.playErrorSound",
+				# Translators: Label for a value in the Play a sound for logged errors combobox, in the Advanced settings.
+				"Only in NVDA test versions",
 			),
 			# Translators: Label for a value in the Play a sound for logged errors combobox, in the Advanced settings.
 			PlayErrorSound.ALWAYS: pgettext("advanced.playErrorSound", "Always"),

--- a/source/config/configFlags.py
+++ b/source/config/configFlags.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2022-2025 NV Access Limited, Cyrille Bougot, Cary-rowen
+# Copyright (C) 2022-2026 NV Access Limited, Cyrille Bougot, Cary-rowen
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 

--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2006-2025 NV Access Limited, Babbage B.V., Davy Kager, Bill Dengler, Julien Cochuyt,
+# Copyright (C) 2006-2026 NV Access Limited, Babbage B.V., Davy Kager, Bill Dengler, Julien Cochuyt,
 # Joseph Lee, Dawid Pieper, mltony, Bram Duvigneau, Cyrille Bougot, Rob Meredith,
 # Burman's Computer and Education Ltd., Leonard de Ruijter, Łukasz Golonka, Cary-rowen
 # This file is covered by the GNU General Public License.
@@ -347,8 +347,8 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 [featureFlag]
 	# 0:default, 1:yes, 2:no
 	cancelExpiredFocusSpeech = integer(0, 2, default=0)
-	# 0:Only in test versions, 1:yes
-	playErrorSound = integer(0, 1, default=0)
+	# 0: Only in test versions, 1: Always, 2: Never
+	playErrorSound = integer(0, 2, default=0)
 
 [addonStore]
 	automaticUpdates = option("notify", "update", "disabled", default="notify")

--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -347,7 +347,7 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 [featureFlag]
 	# 0:default, 1:yes, 2:no
 	cancelExpiredFocusSpeech = integer(0, 2, default=0)
-	# 0: Only in test versions, 1: Always, 2: Never
+	# 0: Only in test versions, 1: Yes, 2: No
 	playErrorSound = integer(0, 2, default=0)
 
 [addonStore]

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -66,6 +66,7 @@ from config.configFlags import (
 	NVDAKey,
 	OutputMode,
 	ParagraphStartMarker,
+	PlayErrorSound,
 	RemoteConnectionMode,
 	RemoteServerType,
 	ReportCellBorders,
@@ -4574,12 +4575,7 @@ class AdvancedPanelControls(
 
 		# Translators: Label for the Play a sound for logged errors combobox, in the Advanced settings panel.
 		label = _("Play a sound for logged e&rrors:")
-		playErrorSoundChoices = (
-			# Translators: Label for a value in the Play a sound for logged errors combobox, in the Advanced settings.
-			pgettext("advanced.playErrorSound", "Only in NVDA test versions"),
-			# Translators: Label for a value in the Play a sound for logged errors combobox, in the Advanced settings.
-			pgettext("advanced.playErrorSound", "Yes"),
-		)
+		playErrorSoundChoices =  [i.displayString for i in PlayErrorSound]
 		self.playErrorSoundCombo = debugLogGroup.addLabeledControl(
 			label,
 			wx.Choice,

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -4575,7 +4575,7 @@ class AdvancedPanelControls(
 
 		# Translators: Label for the Play a sound for logged errors combobox, in the Advanced settings panel.
 		label = _("Play a sound for logged e&rrors:")
-		playErrorSoundChoices =  [i.displayString for i in PlayErrorSound]
+		playErrorSoundChoices = [i.displayString for i in PlayErrorSound]
 		self.playErrorSoundCombo = debugLogGroup.addLabeledControl(
 			label,
 			wx.Choice,

--- a/source/logHandler.py
+++ b/source/logHandler.py
@@ -183,13 +183,18 @@ def getOnErrorSoundRequested() -> "extensionPoints.Action":
 def shouldPlayErrorSound() -> bool:
 	"""Indicates if an error sound should be played when an error is logged."""
 	import config
-
-	# Only play the error sound if this is a test version or if the config states it explicitly.
-	return (
-		buildVersion.isTestVersion
-		# Play error sound: 1 = Yes
-		or (config.conf is not None and config.conf["featureFlag"]["playErrorSound"] == 1)
+	from config.configFlags import PlayErrorSound
+	
+	playErrorSound = (
+		config.conf["featureFlag"]["playErrorSound"] if config.conf else PlayErrorSound.ONLY_IN_TEST_VERSIONS.value
 	)
+	
+	if playErrorSound == PlayErrorSound.ALWAYS.value:
+		return True
+	elif playErrorSound == PlayErrorSound.NEVER.value:
+		return False
+	else:
+		return buildVersion.isTestVersion
 
 
 # Function to strip the base path of our code from traceback text to improve readability.

--- a/source/logHandler.py
+++ b/source/logHandler.py
@@ -184,11 +184,13 @@ def shouldPlayErrorSound() -> bool:
 	"""Indicates if an error sound should be played when an error is logged."""
 	import config
 	from config.configFlags import PlayErrorSound
-	
+
 	playErrorSound = (
-		config.conf["featureFlag"]["playErrorSound"] if config.conf else PlayErrorSound.ONLY_IN_TEST_VERSIONS.value
+		config.conf["featureFlag"]["playErrorSound"]
+		if config.conf
+		else PlayErrorSound.ONLY_IN_TEST_VERSIONS.value
 	)
-	
+
 	if playErrorSound == PlayErrorSound.ALWAYS.value:
 		return True
 	elif playErrorSound == PlayErrorSound.NEVER.value:

--- a/source/logHandler.py
+++ b/source/logHandler.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2007-2025 NV Access Limited, Rui Batista, Joseph Lee, Leonard de Ruijter, Babbage B.V.,
+# Copyright (C) 2007-2026 NV Access Limited, Rui Batista, Joseph Lee, Leonard de Ruijter, Babbage B.V.,
 # Accessolutions, Julien Cochuyt, Cyrille Bougot, Łukasz Golonka
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.

--- a/source/logHandler.py
+++ b/source/logHandler.py
@@ -186,17 +186,17 @@ def shouldPlayErrorSound() -> bool:
 	from config.configFlags import PlayErrorSound
 
 	playErrorSound = (
-		config.conf["featureFlag"]["playErrorSound"]
+		PlayErrorSound(config.conf["featureFlag"]["playErrorSound"])
 		if config.conf
-		else PlayErrorSound.ONLY_IN_TEST_VERSIONS.value
+		else PlayErrorSound.ONLY_IN_TEST_VERSIONS
 	)
 
 	match playErrorSound:
-		case PlayErrorSound.ALWAYS.value:
+		case PlayErrorSound.YES:
 			return True
-		case PlayErrorSound.NEVER.value:
+		case PlayErrorSound.NO:
 			return False
-		case _:
+		case PlayErrorSound.ONLY_IN_TEST_VERSIONS:
 			return buildVersion.isTestVersion
 
 

--- a/source/logHandler.py
+++ b/source/logHandler.py
@@ -191,12 +191,13 @@ def shouldPlayErrorSound() -> bool:
 		else PlayErrorSound.ONLY_IN_TEST_VERSIONS.value
 	)
 
-	if playErrorSound == PlayErrorSound.ALWAYS.value:
-		return True
-	elif playErrorSound == PlayErrorSound.NEVER.value:
-		return False
-	else:
-		return buildVersion.isTestVersion
+	match playErrorSound:
+		case PlayErrorSound.ALWAYS.value:
+			return True
+		case PlayErrorSound.NEVER.value:
+			return False
+		case _:
+			return buildVersion.isTestVersion
 
 
 # Function to strip the base path of our code from traceback text to improve readability.

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -19,6 +19,7 @@
 ### Changes
 
 * It is now possible to open the log viewer with `NVDA+f1`, even when the log level is set to "disabled". (#19318, @CyrilleB79)
+* The "Play a sound for logged errors" option in Advanced settings now allow to choose among three possible values instead of two: "Only in test versions" (default), "Always" or "Never". (#13021, @CyrilleB79)
 
 ### Bug Fixes
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -19,7 +19,7 @@
 ### Changes
 
 * It is now possible to open the log viewer with `NVDA+f1`, even when the log level is set to "disabled". (#19318, @CyrilleB79)
-* The "Play a sound for logged errors" option in Advanced settings now allow to choose among three possible values instead of two: "Only in test versions" (default), "Always" or "Never". (#13021, @CyrilleB79)
+* NVDA can now be configured to not play error sounds, even in test versions. (#13021, @CyrilleB79)
 
 ### Bug Fixes
 

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -4020,7 +4020,8 @@ Only turn one of these on if specifically instructed to by an NVDA developer e.g
 
 This option allows you to specify if NVDA will play an error sound in case an error is logged.
 Choosing Only in test versions (default) makes NVDA play error sounds only if the current NVDA version is a test version (alpha, beta or run from source).
-Choosing Yes allows to enable error sounds whatever your current NVDA version is.
+Choosing Always allows to enable error sounds whatever your current NVDA version is.
+On the opposite, choosing Never disables error sounds whatever your current NVDA version is, i.e. even in test versions.
 
 ##### Regular expression for text paragraph quick navigation commands {#TextParagraphRegexEdit}
 

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -4021,7 +4021,7 @@ Only turn one of these on if specifically instructed to by an NVDA developer e.g
 This option allows you to specify if NVDA will play an error sound in case an error is logged.
 Choosing Only in test versions (default) makes NVDA play error sounds only if the current NVDA version is a test version (alpha, beta or run from source).
 Choosing Yes allows to enable error sounds whatever your current NVDA version is.
-choosing No disables error sounds whatever your current NVDA version is, i.e. even in test versions.
+Choosing No disables error sounds no matter what your current NVDA version is, i.e. even in test versions.
 
 ##### Regular expression for text paragraph quick navigation commands {#TextParagraphRegexEdit}
 

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -4020,8 +4020,8 @@ Only turn one of these on if specifically instructed to by an NVDA developer e.g
 
 This option allows you to specify if NVDA will play an error sound in case an error is logged.
 Choosing Only in test versions (default) makes NVDA play error sounds only if the current NVDA version is a test version (alpha, beta or run from source).
-Choosing Always allows to enable error sounds whatever your current NVDA version is.
-choosing Never disables error sounds whatever your current NVDA version is, i.e. even in test versions.
+Choosing Yes allows to enable error sounds whatever your current NVDA version is.
+choosing No disables error sounds whatever your current NVDA version is, i.e. even in test versions.
 
 ##### Regular expression for text paragraph quick navigation commands {#TextParagraphRegexEdit}
 

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -4021,7 +4021,7 @@ Only turn one of these on if specifically instructed to by an NVDA developer e.g
 This option allows you to specify if NVDA will play an error sound in case an error is logged.
 Choosing Only in test versions (default) makes NVDA play error sounds only if the current NVDA version is a test version (alpha, beta or run from source).
 Choosing Always allows to enable error sounds whatever your current NVDA version is.
-On the opposite, choosing Never disables error sounds whatever your current NVDA version is, i.e. even in test versions.
+choosing Never disables error sounds whatever your current NVDA version is, i.e. even in test versions.
 
 ##### Regular expression for text paragraph quick navigation commands {#TextParagraphRegexEdit}
 


### PR DESCRIPTION
### Link to issue number:
Fixes #13021

### Summary of the issue:
Some people want to be able to use NVDA test versions but want to disable the error sound.
### Description of user facing changes:
The "Play a sound for logged errors:" option now has 3 choices:
* "Only in NVDA test versions" (default), as before, i.e. error sounds are played only in test versions
* "Always", was "Yes" before: error sounds are always played, no matter the type of NVDA version (test or not)
* "Never", new value: error sounds are never played, no matter the type of NVDA version (test or not)

### Description of developer facing changes:
N/A

### Description of development approach:
* Added third value
* Created a config flag so that the code be more understandable and to match what was done for other values recently in NVDA.
* Simplified the way `shouldPlayErrorSound` is written to make the logic easier to follow.

### Testing strategy:

Log errors running the following line in Python console:
`from logHandler import log;import core;core.callLater(0, lambda: log.error("foo"))`

Tested error logging for the 3 config values:
* with a test version, running NVDA from source normally
* with a non-test version, spoofing the test running the following console command:
  `import buildVersion;buildVersion.isTestVersion = True`

### Known issues with pull request:
None
### Code Review Checklist:


- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
