### PR TITLE
Support pitch change for capitals and rate boost (SAPI5 only) for 32 bit SAPI synths

### DIFF
--- a/source/_bridge/components/proxies/synthDriver.py
+++ b/source/_bridge/components/proxies/synthDriver.py
@@ -149,35 +149,35 @@ class SynthDriverProxy(Proxy, SynthDriver):
 					{
 						"type": "str",
 						"value": item,
-					}
+					},
 				)
 			elif isinstance(item, IndexCommand):
 				data.append(
 					{
 						"type": "IndexCommand",
 						"index": item.index,
-					}
+					},
 				)
 			elif isinstance(item, CharacterModeCommand):
 				data.append(
 					{
 						"type": "CharacterModeCommand",
 						"state": item.state,
-					}
+					},
 				)
 			elif isinstance(item, LangChangeCommand):
 				data.append(
 					{
 						"type": "LangChangeCommand",
 						"lang": item.lang,
-					}
+					},
 				)
 			elif isinstance(item, BreakCommand):
 				data.append(
 					{
 						"type": "BreakCommand",
 						"time": item.time,
-					}
+					},
 				)
 			elif isinstance(item, PhonemeCommand):
 				data.append(
@@ -185,7 +185,7 @@ class SynthDriverProxy(Proxy, SynthDriver):
 						"type": "PhonemeCommand",
 						"ipa": item.ipa,
 						"text": item.text,
-					}
+					},
 				)
 			elif isinstance(item, (PitchCommand, RateCommand, VolumeCommand)):
 				data.append(
@@ -193,7 +193,7 @@ class SynthDriverProxy(Proxy, SynthDriver):
 						"type": item.__class__.__name__,
 						"offset": item._offset,
 						"multiplier": item._multiplier,
-					}
+					},
 				)
 			else:
 				log.debugWarning(f"Unsupported speech sequence item type: {type(item)}")

--- a/source/_bridge/components/proxies/synthDriver.py
+++ b/source/_bridge/components/proxies/synthDriver.py
@@ -240,3 +240,9 @@ class SynthDriverProxy(Proxy, SynthDriver):
 
 	def _set_variant(self, value):
 		self._remoteService.setParam("variant", value)
+
+	def _get_rateBoost(self):
+		return self._remoteService.getParam("rateBoost")
+
+	def _set_rateBoost(self, value):
+		self._remoteService.setParam("rateBoost", value)

--- a/source/_bridge/components/services/synthDriver.py
+++ b/source/_bridge/components/services/synthDriver.py
@@ -22,7 +22,6 @@ from speech.commands import (
 	CharacterModeCommand,
 	LangChangeCommand,
 	BreakCommand,
-	BaseProsodyCommand,
 	PitchCommand,
 	RateCommand,
 	VolumeCommand,
@@ -48,17 +47,17 @@ class SynthDriverService(Service):
 		self._synthIndexReachedCallback = None
 		self._synthDoneSpeakingCallback = None
 		# Ensure default pitch, rate, and volume settings exist in config
-		speechConf = config.conf['speech']
+		speechConf = config.conf["speech"]
 		if self._synth.name not in speechConf:
 			synthConf = speechConf[self._synth.name] = {}
 		else:
 			synthConf = speechConf[self.name]
-		if 'pitch' not in synthConf:
-			synthConf['pitch'] = self._synth.pitch
-		if 'rate' not in synthConf:
-			synthConf['rate'] = self._synth.rate
-		if 'volume' not in synthConf:
-			synthConf['volume'] = self._synth.volume
+		if "pitch" not in synthConf:
+			synthConf["pitch"] = self._synth.pitch
+		if "rate" not in synthConf:
+			synthConf["rate"] = self._synth.rate
+		if "volume" not in synthConf:
+			synthConf["volume"] = self._synth.volume
 
 	@Service.exposed
 	def registerSynthIndexReachedNotification(self, callback: Callable[[int], Any]):
@@ -98,14 +97,25 @@ class SynthDriverService(Service):
 	def getSupportedCommands(self) -> frozenset[str]:
 		commands: list[str] = []
 		for item in self._synth.supportedCommands:
-			if issubclass(item, (IndexCommand, CharacterModeCommand, LangChangeCommand, BreakCommand, PitchCommand, RateCommand, VolumeCommand, PhonemeCommand)):
+			if issubclass(
+				item,
+				(
+					IndexCommand,
+					CharacterModeCommand,
+					LangChangeCommand,
+					BreakCommand,
+					PitchCommand,
+					RateCommand,
+					VolumeCommand,
+					PhonemeCommand,
+				),
+			):
 				name = item.__name__
 			else:
 				log.debugWarning(f"Unknown command type in supportedCommands: {item}")
 				continue
 			commands.append(name)
 		return frozenset(commands)
-
 
 	@Service.exposed
 	def getSupportedNotifications(self) -> frozenset[str]:
@@ -137,19 +147,19 @@ class SynthDriverService(Service):
 				speechSequence.append(item["value"])
 			elif item["type"] == "IndexCommand":
 				speechSequence.append(
-					IndexCommand(index=item["index"])
+					IndexCommand(index=item["index"]),
 				)
 			elif item["type"] == "CharacterModeCommand":
 				speechSequence.append(
-					CharacterModeCommand(state=item["state"])
+					CharacterModeCommand(state=item["state"]),
 				)
 			elif item["type"] == "LangChangeCommand":
 				speechSequence.append(
-					LangChangeCommand(lang=item["lang"])
+					LangChangeCommand(lang=item["lang"]),
 				)
 			elif item["type"] == "BreakCommand":
 				speechSequence.append(
-					BreakCommand(time=item["time"])
+					BreakCommand(time=item["time"]),
 				)
 			elif item["type"] in (
 				"PitchCommand",
@@ -162,14 +172,14 @@ class SynthDriverService(Service):
 					cls(
 						offset=item["offset"],
 						multiplier=item["multiplier"],
-					)
+					),
 				)
 			elif item["type"] == "PhonemeCommand":
 				speechSequence.append(
 					PhonemeCommand(
 						ipa=item["ipa"],
 						text=item["text"],
-					)
+					),
 				)
 			else:
 				log.debugWarning(f"Unsupported speech sequence item type: {item['type']}")
@@ -197,7 +207,7 @@ class SynthDriverService(Service):
 		setattr(self._synth, param, val)
 		# Update local config
 		# So synthCommands can use current defaults.
-		synthConf = config.conf['speech'][self._synth.name]
+		synthConf = config.conf["speech"][self._synth.name]
 		synthConf[param] = val
 
 	def terminate(self):

--- a/source/_bridge/components/services/synthDriver.py
+++ b/source/_bridge/components/services/synthDriver.py
@@ -51,7 +51,7 @@ class SynthDriverService(Service):
 		if self._synth.name not in speechConf:
 			synthConf = speechConf[self._synth.name] = {}
 		else:
-			synthConf = speechConf[self.name]
+			synthConf = speechConf[self._synth.name]
 		if "pitch" not in synthConf:
 			synthConf["pitch"] = self._synth.pitch
 		if "rate" not in synthConf:

--- a/source/_bridge/runtimes/synthDriverHost/synthDriverHost.py
+++ b/source/_bridge/runtimes/synthDriverHost/synthDriverHost.py
@@ -9,6 +9,7 @@ import sys
 import importlib
 import rpyc
 from rpyc.core.stream import PipeStream
+import synthDriverHandler
 from _bridge.components.services.synthDriver import SynthDriverService
 
 
@@ -121,6 +122,7 @@ class HostService(Service):
 		log.debug(f"Loading synth driver '{name}'")
 		mod = importlib.import_module(f"synthDrivers.{name}")
 		synth = mod.SynthDriver()
+		synthDriverHandler._curSynth = synth  # Locally track as the active synth.
 		return SynthDriverService(synth)
 
 

--- a/source/_synthDrivers32/sapi4.py
+++ b/source/_synthDrivers32/sapi4.py
@@ -1183,6 +1183,8 @@ class SynthDriver(SynthDriver):
 	def _get_rate(self) -> int:
 		val = DWORD()
 		self._ttsAttrs.SpeedGet(byref(val))
+		# Sometimes the raw value can drift outside the min and max value.
+		val.value = max(min(val.value, self._maxRate), self._minRate)
 		return self._paramToPercent(val.value, self._minRate, self._maxRate)
 
 	def _set_rate(self, val: int):
@@ -1193,6 +1195,8 @@ class SynthDriver(SynthDriver):
 	def _get_pitch(self) -> int:
 		val = WORD()
 		self._ttsAttrs.PitchGet(byref(val))
+		# Sometimes the raw value can drift outside the min and max value.
+		val.value = max(min(val.value, self._maxPitch), self._minPitch)
 		return self._paramToPercent(val.value, self._minPitch, self._maxPitch)
 
 	def _set_pitch(self, val: int):
@@ -1203,7 +1207,10 @@ class SynthDriver(SynthDriver):
 	def _get_volume(self) -> int:
 		val = DWORD()
 		self._ttsAttrs.VolumeGet(byref(val))
-		return self._paramToPercent(val.value & 0xFFFF, self._minVolume, self._maxVolume)
+		# Sometimes the raw value can drift outside the min and max value.
+		val.value &=  0xFFFF
+		val.value = max(min(val.value, self._maxVolume), self._minVolume)
+		return self._paramToPercent(val.value, self._minVolume, self._maxVolume)
 
 	def _set_volume(self, val: int):
 		self._volume = val

--- a/source/_synthDrivers32/sapi4.py
+++ b/source/_synthDrivers32/sapi4.py
@@ -1208,7 +1208,7 @@ class SynthDriver(SynthDriver):
 		val = DWORD()
 		self._ttsAttrs.VolumeGet(byref(val))
 		# Sometimes the raw value can drift outside the min and max value.
-		val.value &=  0xFFFF
+		val.value &= 0xFFFF
 		val.value = max(min(val.value, self._maxVolume), self._minVolume)
 		return self._paramToPercent(val.value, self._minVolume, self._maxVolume)
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
<!-- Use Closes/Fixes/Resolves #xxx to link this PR to the issue it is responding to. -->
Fixes #19529


### Summary of the issue:
PR #19432 added back support for 32 bit sapi synths via  a 32 bit shim. However, in-stream synth parameter changes (E.g. pitch changes for capital letters) was not implemented, and therefore  pitch would never change  when speaking a capital letter.


### Description of user facing changes:

### Description of developer facing changes:

### Description of development approach:
* synthDriverHost: when creating a synth driver and returning it to NVDA, also locally track it as the active synth in the host by setting synthDriverHandler._curSynth. this allows synthDriverhandler.getsynth() to return the synth inside the 32 bit host. Needed to fetch the synth's name for config value lookup via synth commands.**
* Support all built-in synth commands (I.e. index, break, langChange, characterMode, pitch, rate, volume and phoneme) on 32 bit synthDrivers proxied to NvDA. This includes correctly expsing the supportedCommands property, and a much better serialization / deserialization in speak, which no longer uses Pickle, but instead json, fully supporting all the synth commands.  This lallows pitch changes for capital letters among other things.**
* sapi4 synthDriver: when fetching rate, pitch and volume values, ensure that the raw values are clipped to the min and max values before converting to percentage. Sometimes the raw value was outside the min max range and was producing values higher than 100%.
* Add missing rateBoost getter / setter on SynthDriver proxy. This allows rateBoost to fully function on 32 bit sapi5.

### Testing strategy:
* Switch to sapi4.
* Open notepad.
* Type `Hh`. (The first h being capitalized).
* Use left and right arrows to move to each character, having NVDA speak it. Ensure that the pitch is raised for the capital h and back to normal for the second h.

### Known issues with pull request:
None known.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
