### PR TITLE
Documentation and minor code fix-ups to 32-bit SAPI support

### DIFF
--- a/source/nvwave.py
+++ b/source/nvwave.py
@@ -20,8 +20,6 @@ from ctypes import (
 	c_float,
 	string_at,
 )
-from logHandler import log
-
 from comtypes import HRESULT
 from comtypes.hresult import E_INVALIDARG
 import atexit
@@ -30,7 +28,7 @@ import time
 import garbageHandler
 import wave
 import config
-from logHandler import getOnErrorSoundRequested
+from logHandler import log, getOnErrorSoundRequested
 import os.path
 import extensionPoints
 import wasapi

--- a/source/synthDrivers/sapi5.py
+++ b/source/synthDrivers/sapi5.py
@@ -555,7 +555,7 @@ class SynthDriver(SynthDriver):
 
 	name = "sapi5"
 	# Translators: Description for a speech synthesizer.
-	description = "Microsoft Speech API version 5 (64 bit)"
+	description = _("Microsoft Speech API version 5 (64 bit)")
 
 	@classmethod
 	def check(cls):

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -246,8 +246,10 @@ Use `wx.lib.scrolledpanel.ScrolledPanel` directly instead. (#17751)
 * `gui.settingsDialogs.GeneralSettingsPanel.LOG_LEVELS` has been removed.
 Use `config.configFlags.LoggingLevel` instead. (#19296)
 * Changes to Microsoft Speech API version 4 and 5: (#19432)
-  * `synthDrivers.sapi4` (name: "sapi4") has been removed. Use `synthDrivers.sapi4_32` (name: "sapi4_32") instead.
-  * `synthDrivers.sapi5` (name: "sapi5") now refers to the 64-bit SAPI 5 synth driver. Use `synthDrivers.sapi5_32` (name: "sapi5_32") for the 32-bit SAPI 5 driver.
+  * `synthDrivers.sapi4` (name: "sapi4") has been removed.
+  Use `synthDrivers.sapi4_32` (name: "sapi4_32") instead.
+  * `synthDrivers.sapi5` (name: "sapi5") now refers to the 64-bit SAPI 5 synth driver.
+  Use `synthDrivers.sapi5_32` (name: "sapi5_32") for the 32-bit SAPI 5 driver.
 * `config.setSystemConfigToCurrentConfig` now takes a `Collection` of add-on IDs (as strings) to copy to the system configuration.
 Only add-ons with the given IDs will be copied. (#19446)
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -8,6 +8,7 @@ There have been several improvements to speech.
 Spelling errors can now be reported with a sound instead of speech when reading.
 You can now configure NVDA to automatically say all after successfully recognising content, such as with Windows OCR.
 NVDA no longer reports the language being read as unsupported when the synthesizer supports the language but not the specific dialect.
+NVDA now supports 64-bit SAPI 5 voices.
 
 Braille support has also been improved.
 It now continues to work when switching to a secure screen, like the sign-in screen or User Account Control dialog.
@@ -57,6 +58,7 @@ Windows 10 on ARM is also no longer supported.
   * A new action has been added to see the latest changes for the current version of an add-on. (#14041, @josephsl, @nvdaes)
 * It is now possible to select which add-ons to copy for use during sign-in and on secure screens. (#6305)
 * Added built-in support for reading math content by integrating MathCAT. (#18323, #19368, @RyanMcCleary, @codeofdusk)
+* NVDA now supports 64-bit Microsoft Speech API version 5 voices. (#19432)
 * Added references (e.g. to footnotes and endnotes) to the elements list in Microsoft Word.
 Also added unassigned Quick Navigation commands to jump to the next/previous reference. (#19300, @LeonarddeR)
 * In browse mode, the number of items in a list is now reported in braille. (#7455, @nvdaes)
@@ -97,6 +99,7 @@ It currently includes Screen Curtain's settings (previously in the "Vision" cate
 * When copying settings for use during sign-in and on secure screens:
   * NVDA no longer warns about or copies disabled add-ons. (#8274, #9020)
   * By default, NVDA doesn't copy any add-ons; you must select any you wish to include. (#12879)
+* Audio ducking is no longer supported for Microsoft Speech API version 4 or 32-bit Microsoft Speech API version 5 voices. (#19432)
 * The NVDA interface is now translated to Cambodian. (#19450)
 
 ### Bug Fixes

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -242,7 +242,9 @@ Use `wx.lib.scrolledpanel.ScrolledPanel` directly instead. (#17751)
 * The following symbols have been removed from `gui.settingsDialogs.GeneralSettingsPanel` without replacement: `logLevelList`, `allowUsageStatsCheckBox`. (#19296)
 * `gui.settingsDialogs.GeneralSettingsPanel.LOG_LEVELS` has been removed.
 Use `config.configFlags.LoggingLevel` instead. (#19296)
-* `NVDAHelper.localLib.wasapi*` functions have been moved to `wasapi.wassapi*`.
+* Changes to Microsoft Speech API version 4 and 5: (#19432)
+  * `synthDrivers.sapi4` (name: "sapi4") has been removed. Use `synthDrivers.sapi4_32` (name: "sapi4_32") instead.
+  * `synthDrivers.sapi5` (name: "sapi5") now refers to the 64-bit SAPI 5 synth driver. Use `synthDrivers.sapi5_32` (name: "sapi5_32") for the 32-bit SAPI 5 driver.
 * `config.setSystemConfigToCurrentConfig` now takes a `Collection` of add-on IDs (as strings) to copy to the system configuration.
 Only add-ons with the given IDs will be copied. (#19446)
 

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -2519,7 +2519,7 @@ This option allows you to choose if NVDA should lower the volume of other applic
 This option is only available if NVDA has been installed.
 It is not possible to support audio ducking for portable and temporary copies of NVDA.
 
-Audio ducking is not available when using [Microsoft Speech API version 4 (SAPI 4)](#SAPI4) or [Microsoft Speech API version 5 (SAPI 5)](#SAPI5) voices.
+Audio ducking is not available when using [Microsoft Speech API version 4 (SAPI 4)](#SAPI4) or 32 bit [Microsoft Speech API version 5 (SAPI 5)](#SAPI5) voices.
 
 ##### Volume of NVDA sounds follows voice volume {#SoundVolumeFollowsVoice}
 

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -2519,6 +2519,8 @@ This option allows you to choose if NVDA should lower the volume of other applic
 This option is only available if NVDA has been installed.
 It is not possible to support audio ducking for portable and temporary copies of NVDA.
 
+Audio ducking is not available when using [Microsoft Speech API version 4 (SAPI 4)](#SAPI4) or [Microsoft Speech API version 5 (SAPI 5)](#SAPI5) voices.
+
 ##### Volume of NVDA sounds follows voice volume {#SoundVolumeFollowsVoice}
 
 | . {.hideHeaderRow} |.|
@@ -3817,7 +3819,7 @@ If you find that some necessary silence periods are also missing (e.g. pause bet
 ##### Use WASAPI for SAPI 4 audio output {#UseWASAPIForSAPI4}
 
 This option enables Microsoft Speech API version 4 (SAPI 4) voices to output audio via the Windows Audio Session API (WASAPI).
-This can allow SAPI 4 voices to work with more features, such as audio ducking, leading silence trimming, and keeping audio device awake.
+This can allow SAPI 4 voices to work with more features, such as leading silence trimming and keeping audio device awake.
 However, some SAPI 4 voices might not work with the current WASAPI implementation.
 If you find that the SAPI 4 voice you are using stops working, you may disable this option.
 
@@ -4547,8 +4549,12 @@ When using this synthesizer with NVDA, the available voices (accessed from the [
 ### Microsoft Speech API version 5 (SAPI 5) {#SAPI5}
 
 SAPI 5 is a Microsoft standard for software speech synthesizers.
+NVDA supports both 32-bit and 64-bit SAPI5 voices.
+For the best performance and feature compatibility, 64-bit voices should be preferred.
 Many speech synthesizers that comply with this standard may be purchased or downloaded for free from various companies and websites, though your system will probably already come with at least one SAPI 5 voice preinstalled.
-When using this synthesizer with NVDA, the available voices (accessed from the [Speech category](#SpeechSettings) of the [NVDA Settings](#NVDASettings) dialog or by the [Synth Settings Ring](#SynthSettingsRing)) will contain all the voices from all the installed SAPI 5 engines found on your system.
+
+When using the 32-bit or 64-bit SAPI 5 synthesizer with NVDA, the available voices (accessed from the [Speech category](#SpeechSettings) of the [NVDA Settings](#NVDASettings) dialog or by the [Synth Settings Ring](#SynthSettingsRing)) will contain all the voices from all the installed 32-bit or 64-bit SAPI 5 engines found on your system, respectively.
+If you are unable to find a SAPI 5 voice that is installed on your system, try switching to the other SAPI 5 synthesizer using the [Select Synthesizer dialog](#SelectSynthesizer).
 
 ### Microsoft Speech Platform {#MicrosoftSpeechPlatform}
 


### PR DESCRIPTION
### Link to issue number:
Follow-up to #19432

### Summary of the issue:

* Addition of SAPI5x64 was not documented
* Removal of audio ducking support from SAPI4 and SAPI5x86 was not documented
* Documented API breaking changes were incorrect

### Description of user facing changes:

The documentation has been updated.

### Description of developer facing changes:

The documentation has been updated.

### Description of development approach:

Added documentation about audio ducking changes. Also documented that 32-bit and 64-bit SAPI5 are supported, recommending 64-bit SAPI5.

Reviewed changed (not added) files in nvaccess/nvda@f32e049e, noting changes to the API.

Also fixed up that we were importing from `logHandler` globally in two different places in `nvwave.py`, and that the name of the SAPI5 driver had a translator comment but was not wrapped in `gettext`.

### Testing strategy:

Built and reviewed user guide. Automated tests.

### Known issues with pull request:

None.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
