### PR TITLE
Use translated strings for driver settings in 32 bit sapi synthDrivers

### DIFF
--- a/source/_bridge/clients/synthDriverHost32/launcher.py
+++ b/source/_bridge/clients/synthDriverHost32/launcher.py
@@ -9,7 +9,6 @@ import rpyc
 from rpyc.core.stream import PipeStream
 import NVDAState
 from logHandler import log
-import languageHandler
 from _bridge.base import Connection, Service
 from _bridge.components.services.synthDriver import SynthDriverService
 from winBindings.jobapi2 import JOB_OBJECT_LIMIT
@@ -32,10 +31,11 @@ class NVDAService(Service):
 
 	@Service.exposed
 	def getAppArg(self, key):
-		""" Get an NVDA commandline argument value. """
-		if key.startswith('_'):
+		"""Get an NVDA commandline argument value."""
+		if key.startswith("_"):
 			raise RuntimeError(f"Cannot fetch key {key}")
 		import globalVars
+
 		return getattr(globalVars.appArgs, key)
 
 	@Service.exposed

--- a/source/_bridge/clients/synthDriverHost32/launcher.py
+++ b/source/_bridge/clients/synthDriverHost32/launcher.py
@@ -5,6 +5,7 @@
 
 import os
 import subprocess
+from typing import Any
 import rpyc
 from rpyc.core.stream import PipeStream
 import NVDAState
@@ -30,7 +31,7 @@ class NVDAService(Service):
 		return globalVars.appDir
 
 	@Service.exposed
-	def getAppArg(self, key):
+	def getAppArg(self, key: str) -> Any:
 		"""Get an NVDA commandline argument value."""
 		if key.startswith("_"):
 			raise RuntimeError(f"Cannot fetch key {key}")

--- a/source/_bridge/clients/synthDriverHost32/launcher.py
+++ b/source/_bridge/clients/synthDriverHost32/launcher.py
@@ -31,9 +31,12 @@ class NVDAService(Service):
 		return globalVars.appDir
 
 	@Service.exposed
-	def getLanguage(self) -> str:
-		"""Get the current NVDA language."""
-		return languageHandler.getLanguage()
+	def getAppArg(self, key):
+		""" Get an NVDA commandline argument value. """
+		if key.startswith('_'):
+			raise RuntimeError(f"Cannot fetch key {key}")
+		import globalVars
+		return getattr(globalVars.appArgs, key)
 
 	@Service.exposed
 	def isRunningAsSource(self) -> bool:

--- a/source/_bridge/runtimes/synthDriverHost/globalVars.py
+++ b/source/_bridge/runtimes/synthDriverHost/globalVars.py
@@ -13,3 +13,5 @@ appArgs = types.SimpleNamespace()
 appArgs.launcher = False
 appArgs.secure = False
 appArgs.configPath = "."
+appArgs.language =None
+

--- a/source/_bridge/runtimes/synthDriverHost/globalVars.py
+++ b/source/_bridge/runtimes/synthDriverHost/globalVars.py
@@ -13,5 +13,4 @@ appArgs = types.SimpleNamespace()
 appArgs.launcher = False
 appArgs.secure = False
 appArgs.configPath = "."
-appArgs.language =None
-
+appArgs.language = None

--- a/source/_bridge/runtimes/synthDriverHost/synthDriverHost.py
+++ b/source/_bridge/runtimes/synthDriverHost/synthDriverHost.py
@@ -69,7 +69,7 @@ class HostService(Service):
 		import globalVars
 
 		globalVars.appDir = remoteService.getAppDir()
-		globalVars.appArgs.language = remoteService.getAppArg('language')
+		globalVars.appArgs.language = remoteService.getAppArg("language")
 
 		log.debug("Synchronizing configuration values")
 		configNeeded = [
@@ -87,10 +87,11 @@ class HostService(Service):
 
 		log.debug("Initializing languageHandler")
 		import languageHandler
+
 		if languageHandler.isLanguageForced():
 			lang = globalVars.appArgs.language
 		else:
-			lang = config.conf['general']['language']
+			lang = config.conf["general"]["language"]
 		languageHandler.setLanguage(lang)
 
 		log.debug("Initializing nvwave")

--- a/source/_bridge/runtimes/synthDriverHost/synthDriverHost.py
+++ b/source/_bridge/runtimes/synthDriverHost/synthDriverHost.py
@@ -69,13 +69,11 @@ class HostService(Service):
 		import globalVars
 
 		globalVars.appDir = remoteService.getAppDir()
-		log.debug("Injecting languageHandler.getLanguage")
-		import languageHandler
-
-		languageHandler.getLanguage = remoteService.getLanguage
+		globalVars.appArgs.language = remoteService.getAppArg('language')
 
 		log.debug("Synchronizing configuration values")
 		configNeeded = [
+			("general", ["language"]),
 			("audio", ["outputDevice", "audioAwakeTime", "whiteNoiseVolume"]),
 			("speech", ["useWASAPIForSAPI4", "trimLeadingSilence"]),
 			("debugLog", ["synthDriver"]),
@@ -86,6 +84,14 @@ class HostService(Service):
 			config.conf[section] = {}
 			for key in keys:
 				config.conf[section][key] = remoteService.getConfigValue(section, key)
+
+		log.debug("Initializing languageHandler")
+		import languageHandler
+		if languageHandler.isLanguageForced():
+			lang = globalVars.appArgs.language
+		else:
+			lang = config.conf['general']['language']
+		languageHandler.setLanguage(lang)
 
 		log.debug("Initializing nvwave")
 		import nvwave


### PR DESCRIPTION
### Link to issue number:
Closes #19557

### Summary of the issue:
When using 32 bit sapi synthDrivers introduced with pr #19432, particular strings, such as the display name of driver settings, when moving through the synth settings ring, are not translated into the current NVDA language.
 
### Description of user facing changes:
The translations are now used, if available.

### Description of developer facing changes:

### Description of development approach:
* Expose a getAppArg method on the NvDA service, which the synthDriverHost runtime can use to fetch a particular NvDA commandline argument value.
* synthDriverHost runtime: Sync the language key from the general section of NVDA's configuration to the synthDriverHost's local copy of the configuration.
* synthDriverHost: appropriately set  its local copy of globalVars.appArgs.language to NVDA's value, using the NVDA Service's getAppArg method.
* SynthDriverHost: set the language based on the language in the config / the overridden commandline argument value, using the same logic that NvDA uses in core.
 
### Testing strategy:
* Set NvDA's language to German. Select the sapi4 synthesizer. Move left and right through the synth settings ring, ensuring that parameters such as rate and pitched are correctly announced with their German translated names.
* Do the above steps but instead of setting the configured language, override on the commandline with `--lang de`.

### Known issues with pull request:
None known.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
