### PR TITLE
fix VS code tests

### DIFF
--- a/tests/system/libraries/VSCodeLib.py
+++ b/tests/system/libraries/VSCodeLib.py
@@ -88,6 +88,8 @@ class VSCodeLib:
 							"workbench.tips.enabled": False,
 							"update.mode": "none",
 							"telemetry.telemetryLevel": "off",
+							# Hide the AI side bar by default to reduce noise for tests not interacting with it.
+							"workbench.secondarySideBar.defaultVisibility": "hidden",
 						},
 						cam,
 						ensure_ascii=False,

--- a/tests/system/robot/vscodeTests.py
+++ b/tests/system/robot/vscodeTests.py
@@ -127,7 +127,7 @@ def file_editor_operations():
 	spy.emulateKeyPress("h")
 	spy.emulateKeyPress("e")
 	speech = _NvdaLib.getSpeechAfterKey("l")
-	_builtIn.should_contain(speech, "1 of 1")
+	_builtIn.should_contain(speech, "1")
 	spy.emulateKeyPress("escape")
 	# open replace bar
 	speech = _NvdaLib.getSpeechAfterKey("control+h")


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
None

### Summary of the issue:
VS code tests are failing due to 2 changes in VS code:

- AI sidebar taking focus
- "1" spoken for search results instead of "1 of 1"

### Description of user facing changes:
None

### Description of developer facing changes:
None

### Description of development approach:

- hide AI sidebar
- fix string for test

### Testing strategy:
CI
### Known issues with pull request:
we may want to adjust to the default AI panel focus behaviour - the issue is the behaviour is inconsistent between win-2022 and win-2025
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
