### PR TITLE
Add undo dialog after factory defaults reset from NVDA menu

### DIFF
--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -3645,7 +3645,7 @@ class GlobalCommands(ScriptableObject):
 		if scriptCount == 0:
 			gui.mainFrame.onRevertToSavedConfigurationCommand(None)
 		elif scriptCount == 2:
-			gui.mainFrame.onRevertToDefaultConfigurationCommand(None)
+			gui.mainFrame._revertToDefaultConfigurationNoConfirm()
 
 	@script(
 		# Translators: Input help mode message for activate python console command.

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -3645,7 +3645,7 @@ class GlobalCommands(ScriptableObject):
 		if scriptCount == 0:
 			gui.mainFrame.onRevertToSavedConfigurationCommand(None)
 		elif scriptCount == 2:
-			gui.mainFrame._revertToDefaultConfigurationNoConfirm()
+			gui.mainFrame.onRevertToDefaultConfigurationCommand(None)
 
 	@script(
 		# Translators: Input help mode message for activate python console command.

--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -220,6 +220,7 @@ class MainFrame(wx.Frame):
 
 		confirmRevertToDefaultConfiguration()
 
+	@blockAction.when(blockAction.Context.MODAL_DIALOG_OPEN)
 	def onRevertToDefaultConfigurationCommand(self, evt):
 		"""Reset config to factory defaults without showing an undo dialog.
 		This is used for the keyboard shortcut triple-press recovery scenario.

--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -6,6 +6,7 @@
 
 from collections.abc import Callable
 import os
+import shutil
 import warnings
 import wx
 import wx.adv
@@ -27,7 +28,9 @@ from typing import Any
 import systemUtils
 from .message import (
 	Button,
+	DefaultButton,
 	Payload,
+	ReturnCode,
 	# messageBox is accessed through `gui.messageBox` as opposed to `gui.message.messageBox` throughout NVDA,
 	# be cautious when removing
 	messageBox,
@@ -211,7 +214,95 @@ class MainFrame(wx.Frame):
 		# Translators: Reported when last saved configuration has been applied by using revert to saved configuration option in NVDA menu.
 		queueHandler.queueFunction(queueHandler.eventQueue, ui.message, _("Configuration applied"))
 
+	@blockAction.when(blockAction.Context.MODAL_DIALOG_OPEN)
 	def onRevertToDefaultConfigurationCommand(self, evt):
+		"""Reset config to factory defaults, then show a dialog allowing the user to undo the reset.
+		This is used when triggered from the NVDA menu.
+		"""
+		configPath = NVDAState.WritePaths.nvdaConfigFile
+		backupPath = configPath + ".beforeReset.bak"
+		# Back up the current config file before resetting.
+		try:
+			if os.path.isfile(configPath):
+				shutil.copy2(configPath, backupPath)
+		except Exception:
+			log.error("Failed to back up configuration file before factory reset", exc_info=True)
+		queueHandler.queueFunction(queueHandler.eventQueue, core.resetConfiguration, factoryDefaults=True)
+		queueHandler.queueFunction(
+			queueHandler.eventQueue,
+			self._showFactoryResetUndoDialog,
+			backupPath,
+			configPath,
+		)
+
+	def _showFactoryResetUndoDialog(self, backupPath: str, configPath: str) -> None:
+		"""Show a dialog after factory reset allowing the user to undo the reset or keep it."""
+
+		def _showDialog():
+			# Translators: The title of the dialog shown after resetting configuration to factory defaults.
+			title = _("Factory Defaults Restored")
+			message = _(
+				# Translators: The message shown in the dialog after the configuration has been reset to factory defaults.
+				# The user can choose to keep the factory defaults or undo the reset.
+				"Your configuration has been reset to factory defaults.\n"
+				"Choose OK to keep factory defaults, or Undo to restore your previous configuration.",
+			)
+			undoButton = Button(
+				id=ReturnCode.CUSTOM_1,
+				# Translators: The label of the undo button in the factory defaults reset dialog.
+				# Pressing this button restores the previous configuration.
+				label=_("&Undo"),
+				fallbackAction=True,
+			)
+			dialog = MessageDialog(
+				None,
+				message,
+				title,
+				buttons=(
+					DefaultButton.OK,
+					undoButton,
+				),
+			)
+			result = displayDialogAsModal(dialog)
+			if result == ReturnCode.CUSTOM_1:
+				# User chose to undo the reset.
+				try:
+					if os.path.isfile(backupPath):
+						shutil.copy2(backupPath, configPath)
+						queueHandler.queueFunction(
+							queueHandler.eventQueue,
+							core.resetConfiguration,
+						)
+						queueHandler.queueFunction(
+							queueHandler.eventQueue,
+							ui.message,
+							# Translators: Reported when a factory reset has been undone
+							# and the previous configuration has been restored.
+							_("Factory reset undone. Previous configuration restored."),
+						)
+					else:
+						log.error("Backup configuration file not found for undo")
+				except Exception:
+					log.error("Failed to restore configuration from backup", exc_info=True)
+			else:
+				# User chose OK: save the factory defaults to disk.
+				try:
+					config.conf.save()
+				except Exception:
+					log.error("Failed to save factory default configuration to disk", exc_info=True)
+			# Clean up the backup file.
+			try:
+				if os.path.isfile(backupPath):
+					os.remove(backupPath)
+			except Exception:
+				log.debugWarning("Failed to remove configuration backup file", exc_info=True)
+
+		wx.CallAfter(_showDialog)
+
+	def _revertToDefaultConfigurationNoConfirm(self) -> None:
+		"""Reset config to factory defaults without showing an undo dialog.
+		This is used for the keyboard shortcut triple-press recovery scenario.
+		"""
 		queueHandler.queueFunction(queueHandler.eventQueue, core.resetConfiguration, factoryDefaults=True)
 		queueHandler.queueFunction(
 			queueHandler.eventQueue,

--- a/source/gui/configManagement.py
+++ b/source/gui/configManagement.py
@@ -1,20 +1,14 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2006-2026 NV Access Limited, Bram Duvigneau
+# Copyright (C) 2026 NV Access Limited, Bram Duvigneau
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
 """GUI functionality for managing NVDA configuration, including factory reset with undo support."""
 
-import os
-import shutil
-
-import config
 import core
-import NVDAState
 import queueHandler
 import ui
 import wx
-from logHandler import log
 
 from .message import (
 	Button,
@@ -28,9 +22,7 @@ from .message import (
 class FactoryResetUndoDialog(MessageDialog):
 	"""Dialog shown after a factory reset, allowing the user to undo the reset or keep it."""
 
-	def __init__(self, backupPath: str, configPath: str):
-		self._backupPath = backupPath
-		self._configPath = configPath
+	def __init__(self):
 		# Translators: The title of the dialog shown after resetting configuration to factory defaults.
 		title = _("Factory Defaults Restored")
 		message = _(
@@ -61,83 +53,37 @@ class FactoryResetUndoDialog(MessageDialog):
 		result = displayDialogAsModal(self)
 		if result == ReturnCode.CUSTOM_1:
 			self._handleUndo()
-		else:
-			self._handleKeepDefaults()
-		self._cleanupBackup()
 
 	def _handleUndo(self) -> None:
-		"""Restore the previous configuration from backup."""
-		if not os.path.isfile(self._backupPath):
-			log.error("Backup configuration file not found for undo")
-			return
-		try:
-			shutil.copy2(self._backupPath, self._configPath)
-		except OSError:
-			log.error("Failed to restore configuration from backup", exc_info=True)
-		else:
-			queueHandler.queueFunction(
-				queueHandler.eventQueue,
-				core.resetConfiguration,
-			)
-			queueHandler.queueFunction(
-				queueHandler.eventQueue,
-				ui.message,
-				# Translators: Reported when a factory reset has been undone
-				# and the previous configuration has been restored.
-				_("Factory reset undone. Previous configuration restored."),
-			)
-
-	def _handleKeepDefaults(self) -> None:
-		"""Save the factory defaults to disk."""
-		try:
-			config.conf.save()
-		except OSError:
-			log.error("Failed to save factory default configuration to disk", exc_info=True)
-
-	def _cleanupBackup(self) -> None:
-		"""Remove the backup file."""
-		try:
-			if os.path.isfile(self._backupPath):
-				os.remove(self._backupPath)
-		except OSError:
-			log.debugWarning("Failed to remove configuration backup file", exc_info=True)
-
-
-def confirmRevertToDefaultConfiguration() -> None:
-	"""Reset config to factory defaults, then show a dialog allowing the user to undo the reset.
-
-	If the configuration cannot be backed up (e.g. read-only media), the reset proceeds
-	without showing the undo dialog, as undo would not be possible.
-	This is used when triggered from the NVDA menu.
-	"""
-	configPath = NVDAState.WritePaths.nvdaConfigFile
-	backupPath = configPath + ".beforeReset.bak"
-	backupSucceeded = False
-	# Back up the current config file before resetting.
-	try:
-		if os.path.isfile(configPath):
-			shutil.copy2(configPath, backupPath)
-			backupSucceeded = True
-	except OSError:
-		log.error("Failed to back up configuration file before factory reset", exc_info=True)
-	queueHandler.queueFunction(queueHandler.eventQueue, core.resetConfiguration, factoryDefaults=True)
-	if backupSucceeded:
+		"""Restore the previous configuration by reloading from disk."""
 		queueHandler.queueFunction(
 			queueHandler.eventQueue,
-			_showFactoryResetUndoDialog,
-			backupPath,
-			configPath,
+			core.resetConfiguration,
 		)
-	else:
 		queueHandler.queueFunction(
 			queueHandler.eventQueue,
 			ui.message,
-			# Translators: Reported when configuration has been restored to defaults,
-			# by using restore configuration to factory defaults item in NVDA menu.
-			_("Configuration restored to factory defaults"),
+			# Translators: Reported when a factory reset has been undone
+			# and the previous configuration has been restored.
+			_("Factory reset undone. Previous configuration restored."),
 		)
 
 
-def _showFactoryResetUndoDialog(backupPath: str, configPath: str) -> None:
+def confirmRevertToDefaultConfiguration() -> None:
+	"""Reset config to factory defaults in memory, then show a dialog allowing the user to undo.
+
+	The on-disk configuration is not modified. If the user chooses to undo, the configuration
+	is reloaded from disk. If the user keeps the factory defaults, the in-memory defaults
+	will be saved to disk on normal NVDA shutdown.
+	This is used when triggered from the NVDA menu.
+	"""
+	queueHandler.queueFunction(queueHandler.eventQueue, core.resetConfiguration, factoryDefaults=True)
+	queueHandler.queueFunction(
+		queueHandler.eventQueue,
+		_showFactoryResetUndoDialog,
+	)
+
+
+def _showFactoryResetUndoDialog() -> None:
 	"""Create and show the factory reset undo dialog on the wx GUI thread."""
-	wx.CallAfter(FactoryResetUndoDialog(backupPath, configPath).showAndHandleResult)
+	wx.CallAfter(FactoryResetUndoDialog().showAndHandleResult)

--- a/source/gui/configManagement.py
+++ b/source/gui/configManagement.py
@@ -1,0 +1,130 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2006-2026 NV Access Limited, Bram Duvigneau
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+
+"""GUI functionality for managing NVDA configuration, including factory reset with undo support."""
+
+import os
+import shutil
+
+import config
+import core
+import NVDAState
+import queueHandler
+import ui
+import wx
+from logHandler import log
+
+from .message import (
+	Button,
+	DefaultButton,
+	displayDialogAsModal,
+	MessageDialog,
+	ReturnCode,
+)
+
+
+class FactoryResetUndoDialog(MessageDialog):
+	"""Dialog shown after a factory reset, allowing the user to undo the reset or keep it."""
+
+	def __init__(self, backupPath: str, configPath: str):
+		self._backupPath = backupPath
+		self._configPath = configPath
+		# Translators: The title of the dialog shown after resetting configuration to factory defaults.
+		title = _("Factory Defaults Restored")
+		message = _(
+			# Translators: The message shown in the dialog after the configuration has been reset to factory defaults.
+			# The user can choose to keep the factory defaults or undo the reset.
+			"Your configuration has been reset to factory defaults.\n"
+			"Choose OK to keep factory defaults, or Undo to restore your previous configuration.",
+		)
+		undoButton = Button(
+			id=ReturnCode.CUSTOM_1,
+			# Translators: The label of the undo button in the factory defaults reset dialog.
+			# Pressing this button restores the previous configuration.
+			label=_("&Undo"),
+			fallbackAction=True,
+		)
+		super().__init__(
+			None,
+			message,
+			title,
+			buttons=(
+				DefaultButton.OK,
+				undoButton,
+			),
+		)
+
+	def showAndHandleResult(self) -> None:
+		"""Show the dialog modally and handle the user's choice."""
+		result = displayDialogAsModal(self)
+		if result == ReturnCode.CUSTOM_1:
+			self._handleUndo()
+		else:
+			self._handleKeepDefaults()
+		self._cleanupBackup()
+
+	def _handleUndo(self) -> None:
+		"""Restore the previous configuration from backup."""
+		if not os.path.isfile(self._backupPath):
+			log.error("Backup configuration file not found for undo")
+			return
+		try:
+			shutil.copy2(self._backupPath, self._configPath)
+		except OSError:
+			log.error("Failed to restore configuration from backup", exc_info=True)
+		else:
+			queueHandler.queueFunction(
+				queueHandler.eventQueue,
+				core.resetConfiguration,
+			)
+			queueHandler.queueFunction(
+				queueHandler.eventQueue,
+				ui.message,
+				# Translators: Reported when a factory reset has been undone
+				# and the previous configuration has been restored.
+				_("Factory reset undone. Previous configuration restored."),
+			)
+
+	def _handleKeepDefaults(self) -> None:
+		"""Save the factory defaults to disk."""
+		try:
+			config.conf.save()
+		except OSError:
+			log.error("Failed to save factory default configuration to disk", exc_info=True)
+
+	def _cleanupBackup(self) -> None:
+		"""Remove the backup file."""
+		try:
+			if os.path.isfile(self._backupPath):
+				os.remove(self._backupPath)
+		except OSError:
+			log.debugWarning("Failed to remove configuration backup file", exc_info=True)
+
+
+def confirmRevertToDefaultConfiguration() -> None:
+	"""Reset config to factory defaults, then show a dialog allowing the user to undo the reset.
+
+	This is used when triggered from the NVDA menu.
+	"""
+	configPath = NVDAState.WritePaths.nvdaConfigFile
+	backupPath = configPath + ".beforeReset.bak"
+	# Back up the current config file before resetting.
+	try:
+		if os.path.isfile(configPath):
+			shutil.copy2(configPath, backupPath)
+	except OSError:
+		log.error("Failed to back up configuration file before factory reset", exc_info=True)
+	queueHandler.queueFunction(queueHandler.eventQueue, core.resetConfiguration, factoryDefaults=True)
+	queueHandler.queueFunction(
+		queueHandler.eventQueue,
+		_showFactoryResetUndoDialog,
+		backupPath,
+		configPath,
+	)
+
+
+def _showFactoryResetUndoDialog(backupPath: str, configPath: str) -> None:
+	"""Create and show the factory reset undo dialog on the wx GUI thread."""
+	wx.CallAfter(FactoryResetUndoDialog(backupPath, configPath).showAndHandleResult)

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -17,7 +17,8 @@
 * Added an unassigned Quick Navigation Command for jumping to next/previous slider in browse mode. (#17005, @hdzrvcc0X74)
 * New types have been added for Speech Dictionary entries, such as part of word and start of word.
 Consult the speech dictionaries section in the User Guide for more details. (#19506, @LeonarddeR)
-* When resetting the configuration to factory defaults from the NVDA menu, a dialog is now shown afterwards with an Undo button to restore the previous configuration. This prevents accidental loss of settings. The triple-press keyboard shortcut (`NVDA+ctrl+r`) is not affected, as it is intended for recovery scenarios. (#19575, @bramd)
+* When resetting the configuration to factory defaults from the NVDA menu, a dialog is now shown afterwards with an Undo button to restore the previous configuration.
+The triple-press keyboard shortcut (`NVDA+ctrl+r`) is not affected, as it is intended for recovery scenarios. (#19575, @bramd)
 
 ### Changes
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -17,6 +17,7 @@
 * Added an unassigned Quick Navigation Command for jumping to next/previous slider in browse mode. (#17005, @hdzrvcc0X74)
 * New types have been added for Speech Dictionary entries, such as part of word and start of word.
 Consult the speech dictionaries section in the User Guide for more details. (#19506, @LeonarddeR)
+* When resetting the configuration to factory defaults from the NVDA menu, a dialog is now shown afterwards with an Undo button to restore the previous configuration. This prevents accidental loss of settings. The triple-press keyboard shortcut (`NVDA+ctrl+r`) is not affected, as it is intended for recovery scenarios. (#19575, @bramd)
 
 ### Changes
 

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -4166,6 +4166,7 @@ To save the settings manually at any time, choose the Save configuration item in
 
 If you ever make a mistake with your settings and need to revert back to the saved settings, choose the "revert to saved configuration" item in the NVDA menu.
 You can also reset your settings to their original factory defaults by choosing Reset Configuration To Factory Defaults, which is also found in the NVDA menu.
+After resetting, a dialog will appear allowing you to undo the reset and restore your previous configuration.
 
 The following NVDA key commands are also useful:
 <!-- KC:beginInclude -->
@@ -4173,7 +4174,7 @@ The following NVDA key commands are also useful:
 | Name |Desktop key |Laptop key |Description|
 |---|---|---|---|
 |Save configuration |`NVDA+control+c` |`NVDA+control+c` |Saves your current configuration so that it is not lost when you exit NVDA|
-|Revert configuration |`NVDA+control+r` |`NVDA+control+r` |Pressing once resets your configuration to when you last saved it. Pressing three times will reset it back to factory defaults.|
+|Revert configuration |`NVDA+control+r` |`NVDA+control+r` |Pressing once resets your configuration to when you last saved it. Pressing three times will reset it back to factory defaults without showing the undo dialog.|
 
 <!-- KC:endInclude -->
 


### PR DESCRIPTION
### Link to issue number:

Closes #6648

### Summary of the issue:

When users accidentally press the F key in the NVDA menu, configuration is reset to factory defaults with no way to recover. Users may not be able to reconfigure NVDA themselves, and restoring settings can be time-consuming.

### Description of user facing changes:

When resetting configuration to factory defaults from the NVDA menu, a dialog is now shown after the reset with "OK" and "Undo" buttons:

* **OK** (focused by default): Keeps the factory defaults
* **Undo**: Restores the previous configuration
* **Escape**: Triggers Undo (restores previous configuration)

This prevents accidental loss of settings. The triple-press keyboard shortcut (`NVDA+ctrl+r`) is not affected and does not show the dialog, as it is intended for recovery scenarios.

### Description of developer facing changes:

* Added `source/gui/configManagement.py` with `FactoryResetUndoDialog` (subclass of `MessageDialog`) and `confirmRevertToDefaultConfiguration`
* Added `_confirmRevertToDefaultConfiguration` on `MainFrame` for the menu path, delegating to `configManagement`
* `onRevertToDefaultConfigurationCommand` remains the keyboard shortcut path (no dialog)
* Both menu and keyboard handlers are decorated with `@blockAction.when(blockAction.Context.MODAL_DIALOG_OPEN)`

### Description of development approach:

The factory reset (`core.resetConfiguration(factoryDefaults=True)`) only modifies configuration in memory — the on-disk config file is not changed. This means:

1. **Undo** simply calls `core.resetConfiguration()` to reload the saved config from disk
2. **Keep defaults** requires no immediate action; the in-memory defaults are saved to disk on normal NVDA shutdown

No file-based backup is needed. This approach was chosen based on community feedback in the issue discussion.

### Testing strategy:

* Unit tests pass
* Manual testing:
  * Factory reset from menu shows undo dialog
  * Undo restores previous configuration
  * OK keeps factory defaults
  * Triple-press keyboard shortcut works without dialog
  * Escape triggers Undo (restores previous configuration)

### Known issues with pull request:

None

### Code Review Checklist:

* [x] Documentation:
  * [x] Change log entry
  * [x] User Documentation
  * [ ] Developer / Technical Documentation - Not required
  * [ ] Context sensitive help for GUI changes - Not applicable (simple dialog)
* [x] Testing:
  * [ ] Unit tests - Dialog behavior is difficult to unit test; manual testing covers functionality
  * [ ] System (end to end) tests - Manual testing covers scenarios
  * [x] Manual testing
* [x] UX of all users considered:
  * [x] Speech - Dialog is announced, undo confirmation is spoken
  * [x] Braille - Standard dialog, works with braille, auto is the default display and hopefully gives the user braille output
  * [x] Low Vision - Standard Windows dialog
  * [ ] Different web browsers - Not applicable
  * [x] Localization in other languages / culture than English - All strings are translatable
* [x] API is compatible with existing add-ons.
* [x] Security precautions taken.