### PR TITLE
Update workflow to collect individual pofile check reports and email if any fail

### DIFF
--- a/.github/workflows/fetch-crowdin-translations.yml
+++ b/.github/workflows/fetch-crowdin-translations.yml
@@ -57,13 +57,6 @@ jobs:
         crowdinProjectID: ${{ vars.CROWDIN_PROJECT_ID }}
         crowdinAuthToken: ${{ secrets.CROWDIN_AUTH_TOKEN }}
 
-    - name: Install pre-commit
-      run: |
-        python -m pip install --upgrade pip
-        pip install pre-commit
-        pre-commit install
-
-    # Job will fail if pre-commit checks fail
     - name: Commit tracked files only
       id: commit
       shell: bash
@@ -71,7 +64,40 @@ jobs:
         git checkout -b ${{ env.branchName }}
         git config --local user.name "GitHub Actions"
         git config --local user.email ""
-        git add -u source/locale
+
+        # Check each modified tracked po file.
+        failures=
+        tempfile=$(mktemp)
+        # Take each \0-separated path from stdin
+        while IFS= read -r -d $'\0' path <&3; do
+          echo -n "Checking $path... "
+          if output=$(uv run source/l10nutil.py checkPo "$path"); then
+            # Add files that don't produce errors.
+            echo Ok
+            git add "$path"
+          else
+            # This file produced errors.
+            echo Failed
+            echo "$output" >&2
+            echo "$output" >> $tempfile
+            echo "----------" >> $tempfile
+            # Append the language code to $failures
+            # by stripping /LC_MESSAGES/nvda.po,
+            # and getting the basename (the trailing path component)
+            failures+="$(basename ${path%/LC_MESSAGES/nvda.po}) "
+          fi
+        # Substitute getting modified files into stdin
+        done 3< <(git ls-files --modified -z source/locale/**.po)
+        if [[ $failures ]]; then
+          # $failures is not empty
+          echo "has_failures=true" >> "$GITHUB_OUTPUT"
+          echo "invalid_pofile_locales=$failures" >> "$GITHUB_OUTPUT"
+          echo "invalid_pofile_reports<<EOF"$'\n'"$(cat $tempfile)"$'\n'EOF >> $GITHUB_OUTPUT
+        else
+          echo "has_failures=false" >> "$GITHUB_OUTPUT"
+        fi
+
+        # Add modified tracked xliff files.
         git add -u user_docs
 
         # Check if there are any changes to commit
@@ -105,3 +131,33 @@ jobs:
         --body "Merged translations from Crowdin"
       env:
         GITHUB_TOKEN: ${{ github.token }}
+
+    - name: Notify translators of errors
+      if: steps.commit.outputs.has_failures == 'true'
+      uses: dawidd6/action-send-mail@v4
+      with:
+        server_address: ${{ secrets.EMAIL_SERVER_ADDRESS }}
+        server_port: ${{ secrets.EMAIL_SERVER_PORT || 465 }}
+        username: ${{ secrets.EMAIL_USERNAME }}
+        password: ${{ secrets.EMAIL_PASSWORD }}
+        subject: "[${{ steps.commit.outputs.invalid_pofile_locales }}]: Errors in interface translations"
+        to: nvda-l10n@nvaccess.org
+        from: '"NVDA localisations" <nvda-l10n@nvaccess.org>'
+        convert_markdown: true
+        body: |
+          Errors have been found in the user interface translations for the following locales: ${{ steps.commit.outputs.invalid_pofile_locales }}.
+          Updated translations for these locales will not be included in NVDA untill these errors have been corrected.
+
+          For more information, review the guide on translating NVDA's interface: <https://github.com/nvaccess/nvda/blob/master/projectDocs/translating/crowdin.md#translating-nvdas-interface>.
+
+          ${{ steps.commit.outputs.invalid_pofile_reports }}
+
+        html_body: |
+          Errors have been found in the user interface translations for the following locales: ${{ steps.commit.outputs.invalid_pofile_locales }}.
+          Updated translations for these locales will not be included in NVDA untill these errors have been corrected.
+
+          For more information, [review the guide on translating NVDA's interface](https://github.com/nvaccess/nvda/blob/master/projectDocs/translating/crowdin.md#translating-nvdas-interface).
+
+          ```
+          ${{ steps.commit.outputs.invalid_pofile_reports }}
+          ```


### PR DESCRIPTION
### Link to issue number:

### Summary of the issue:

When automatically updating translations from crowdin, a failure in any individual pofile causes the entire job to fail.

### Description of user facing changes:

Translators will be emailed if there are errors in pofiles when this job runs.

### Description of developer facing changes:

The automatic crowdin update should succede even when there are invalid translations in locale(s); the affected files will not be committed.

### Description of development approach:

* Don't rely on pre-commit to perform these checks, as it isn't granular enough
* Query git for the tracked modified po files.
  * For each of these, run it through `l10nutil checkPo`.
    * If this succedes, stage the file.
    * If it fails, store the report and locale, and do not stage the file.
* If there were any failures, email the l10n list.

Much of the bash script was written and initially tested in bash on Windows.

### Testing strategy:

Tested running parts that can be run locally on my work machine.

TODO: set up requirements in my personal fork and test running the workflow.

### Known issues with pull request:

### Code Review Checklist:

- [ ] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [ ] Security precautions taken.
