### PR TITLE
Allow config profile triggers when Add-on Store is open

### DIFF
--- a/source/gui/addonStoreGui/controls/storeDialog.py
+++ b/source/gui/addonStoreGui/controls/storeDialog.py
@@ -40,6 +40,7 @@ class AddonStoreDialog(SettingsDialog):
 	# more adapted like "AddonStore" so that old external links pointing to the add-ons manager paragraph now
 	# point to the Add-on Store one.
 	helpId = "AddonsManager"
+	shouldSuspendConfigProfileTriggers = False
 
 	def __init__(self, parent: wx.Window, storeVM: AddonStoreVM, openToTab: _StatusFilterKey | None = None):
 		self._storeVM = storeVM

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -29,6 +29,7 @@ Consult the speech dictionaries section in the User Guide for more details. (#19
 * In Microsoft Word with UIA enabled, page changes are now correctly announced when navigating table rows that span multiple pages. (#19386, @akj)
 * Fixed excessive resource usage and highlight flickering when using Visual Highlight. (#17434, @hwf1324)
 * The `NVDA+k` command now correctly reports the destination of links containing formatted text, such as bold or italics. (#19428, @Cary-rowen)
+* Configuration profile triggers now activate when the Add-on Store is open. (#19583, @bramd)
 
 ### Changes for Developers
 


### PR DESCRIPTION
### Link to issue number:

Closes #15165

### Summary of the issue:

Configuration profile triggers for "Current application" do not activate when the Add-on Store dialog is open, even though the Add-on Store is an NVDA window. This is because `AddonStoreDialog` inherits from `SettingsDialog`, which has `shouldSuspendConfigProfileTriggers = True` to prevent feedback loops while editing settings.

### Description of user facing changes:

Configuration profile triggers now activate when the Add-on Store is open. Users who create a config profile triggered by the NVDA application (e.g., to enable table headers in the Add-on Store) will now have their profile correctly activated.

### Description of developer facing changes:

Added `shouldSuspendConfigProfileTriggers = False` to `AddonStoreDialog` to override the inherited value from `SettingsDialog`.

### Description of development approach:

The `SettingsDialog` base class sets `shouldSuspendConfigProfileTriggers = True` because changing settings while a profile trigger is active could cause confusion. However, the Add-on Store doesn't modify NVDA settings, so there's no reason to suspend triggers. The fix simply overrides this attribute to `False`.

### Testing strategy:

* Unit tests pass (1031 tests)
* Manual testing:
  * Create a config profile with "Current application" trigger for NVDA
  * Open the Add-on Store - profile should activate
  * Close the Add-on Store - profile should deactivate
  * Open NVDA Settings dialog - profile should NOT activate (SettingsDialog still suspends triggers correctly)

### Known issues with pull request:

None

### Code Review Checklist:

* [x] Documentation:
  * [x] Change log entry
  * [ ] User Documentation - Not required
  * [ ] Developer / Technical Documentation - Not required
  * [ ] Context sensitive help for GUI changes - Not applicable
* [x] Testing:
  * [ ] Unit tests - Difficult to unit test GUI dialog behavior
  * [ ] System (end to end) tests - Manual testing covers scenarios
  * [x] Manual testing
* [x] UX of all users considered:
  * [x] Speech - No impact
  * [x] Braille - No impact
  * [x] Low Vision - No impact
  * [ ] Different web browsers - Not applicable
  * [x] Localization in other languages / culture than English - No translatable strings changed
* [x] API is compatible with existing add-ons.
* [x] Security precautions taken.
