### PR TITLE
Make synth fallback check all other synths, not just later ones

### DIFF
--- a/source/synthDriverHandler.py
+++ b/source/synthDriverHandler.py
@@ -485,7 +485,7 @@ def getSynthInstance(name: str, asDefault: bool = False):
 defaultSynthPriorityList = ["oneCore", "espeak", "silence"]
 
 
-def setSynth(name: str | None, isFallback: bool = False, *, leftToTry: list[str] | None = None) -> bool:
+def setSynth(name: str | None, isFallback: bool = False, *, _leftToTry: list[str] | None = None) -> bool:
 	"""Set the currently active speech synth by name.
 
 	If the chosen synth cannot be used, this function will attempt to fall back to another synth.
@@ -493,7 +493,7 @@ def setSynth(name: str | None, isFallback: bool = False, *, leftToTry: list[str]
 
 	:param name: The name of the synth driver to use.
 	:param isFallback: Whether this synth is a fallback, i.e. it isn't the synth that the user wants. Defaults to ``False``.
-	:param leftToTry: List of synth names to try falling back to, in reverse order of priority. Defaults to ``None``.
+	:param _leftToTry: List of synth names to try falling back to, in reverse order of priority. Defaults to ``None``.
 		If ``None``, the list will be calculated automatically.
 	:return: ``True`` if switching to the named synthesizer succeeds; ``False`` otherwise.
 	"""
@@ -539,25 +539,25 @@ def setSynth(name: str | None, isFallback: bool = False, *, leftToTry: list[str]
 		# There was no previous synth, so fall back to the first available default synthesizer
 		# that has not been tried yet.
 		log.info("Searching for next synthDriver")
-		findAndSetNextSynth(name, leftToTry=leftToTry)
+		findAndSetNextSynth(name, _leftToTry=_leftToTry)
 	return False
 
 
-def findAndSetNextSynth(currentSynthName: str, *, leftToTry: list[str] | None = None) -> bool:
+def findAndSetNextSynth(currentSynthName: str, *, _leftToTry: list[str] | None = None) -> bool:
 	"""Finds the first untried synth in ``defaultSynthPriorityList`` and switches to it.
 
 	:param currentSynthName: The name of the synth driver that was just tried.
-		Only used if ``leftToTry`` is ``None``.
-	:param leftToTry: A list of synth drivers that haven't been tried yet, in reverse order of priority. Defaults to ``None``.
+		Only used if ``_leftToTry`` is ``None``.
+	:param _leftToTry: A list of synth drivers that haven't been tried yet, in reverse order of priority. Defaults to ``None``.
 		If ``None``, the list of synths left to try will be calculated automatically.
 	:return: ``True`` if an attempt was made to switch to a synth driver; ``False`` if there are no more drivers in ``defaultSynthPriorityList `` to try.
 	"""
-	if leftToTry is None:
-		leftToTry = [synth for synth in reversed(defaultSynthPriorityList) if synth != currentSynthName]
-	if len(leftToTry) > 0:
-		newName = leftToTry.pop()
+	if _leftToTry is None:
+		_leftToTry = [synth for synth in reversed(defaultSynthPriorityList) if synth != currentSynthName]
+	if len(_leftToTry) > 0:
+		newName = _leftToTry.pop()
 		log.info(f"Falling back to next synthDriver {newName}")
-		setSynth(newName, isFallback=True, leftToTry=leftToTry)
+		setSynth(newName, isFallback=True, _leftToTry=_leftToTry)
 		return True
 	else:
 		return False

--- a/source/synthDriverHandler.py
+++ b/source/synthDriverHandler.py
@@ -1,8 +1,8 @@
 # A part of NonVisual Desktop Access (NVDA)
-# This file is covered by the GNU General Public License.
-# See the file COPYING for more details.
-# Copyright (C) 2006-2025 NV Access Limited, Peter Vágner, Aleksey Sadovoy,
+# Copyright (C) 2006-2026 NV Access Limited, Peter Vágner, Aleksey Sadovoy,
 # Joseph Lee, Arnold Loubriat, Leonard de Ruijter
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
 
 from collections import OrderedDict
 import pkgutil

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -117,6 +117,7 @@ It currently includes Screen Curtain's settings (previously in the "Vision" cate
 * Fixed a case where braille output would fail with an error. (#19025, @LeonarddeR)
 * Battery time announcements now skip redundant "0 hours" and "0 minutes" and use proper singular/plural forms. (#9003, @hdzrvcc0X74)
 * When a synthesizer has a fallback language for the current dialect, the language of the text being read will no longer be reported as unsupported. (#18876, @nvdaes)
+* If eSpeak NG fails to load, NVDA will now attempt to fall back to OneCore before resorting to no speech. (#19603)
 * Certain settings will no longer erroneously be saved to disk when running NVDA from the launcher. (#18171)
 * Incorrect information is no longer displayed in braille when navigating the list of messages in Outlook Classic. (#18993, @nvdaes)
 * NVDA now detects and stops repeated crash loops to prevent system lockups when startup failures occur. (#19133, @derekriemer)

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -117,7 +117,7 @@ It currently includes Screen Curtain's settings (previously in the "Vision" cate
 * Fixed a case where braille output would fail with an error. (#19025, @LeonarddeR)
 * Battery time announcements now skip redundant "0 hours" and "0 minutes" and use proper singular/plural forms. (#9003, @hdzrvcc0X74)
 * When a synthesizer has a fallback language for the current dialect, the language of the text being read will no longer be reported as unsupported. (#18876, @nvdaes)
-* If eSpeak NG fails to load, NVDA will now attempt to fall back to OneCore before resorting to no speech. (#19603)
+* If the speech synthesizer is set to eSpeak NG and it fails to load when NVDA starts, NVDA will now attempt to fall back to OneCore before resorting to no speech. (#19603)
 * Certain settings will no longer erroneously be saved to disk when running NVDA from the launcher. (#18171)
 * Incorrect information is no longer displayed in braille when navigating the list of messages in Outlook Classic. (#18993, @nvdaes)
 * NVDA now detects and stops repeated crash loops to prevent system lockups when startup failures occur. (#19133, @derekriemer)
@@ -168,6 +168,7 @@ On ARM64 machines with Windows 11, these ARM64EC libraries are loaded instead of
 * In `braille.py`, the `FormattingMarker` class has a new `shouldBeUsed` method, to determine if the formatting marker key should be reported (#7608, @nvdaes)
 * Added `api.fakeNVDAObjectClasses` set and `api.isFakeNVDAObject` function to identify fake NVDAObject instances. (#19168, @hwf1324)
 * NVDA no longer includes the Microsoft Universal C Runtime. (#19508)
+* `synthDriverHandler.setSynth` and `synthDriverHandler.findAndSetNextSynth` now attempt to find fallback synthesizers starting from the start of `defaultSynthPriorityList`, rather than starting immediately after `name` or `currentSynthName`, respectively. (#19603)
 
 #### API Breaking Changes
 


### PR DESCRIPTION
### Link to issue number:

None

### Summary of the issue:

If the default speech synthesizer is set to a synth that can't be loaded for some reason, and the only working synth(s) are before that synth in `synthDriverHandler.defaultSynthPriorityList`, NVDA will fall back to `silence`.

That is, as reported in #19582, if the default synth is eSpeak and it can't be loaded, NVDA doesn't produce speech at all.

### Description of user facing changes:

If eSpeak is set as the default synth and it can't be loaded, NVDA will first try to use OneCore before falling back to no speech.

### Description of developer facing changes:

`synthDriverHandler.setSynth` and `findAndSetNextSynth` now optionally take an internal-only keyword-only `_leftToTry` list of synth names (in reverse order of priority). The behaviour of `findAndSetNextSynth` has changed to find the first working synth in `defaultSynthPriorityList`, rather than only considering synths after `currentSynthName`. As a result, `setSynth` may fall back to a synth anywhere in `defaultSynthPriorityList`, and will preference synths earlier therein.

### Description of development approach:

Update `synthDriverHandler.setSynth` and `findNextSynth` to take an optional list of synth names. If `None`, it is calculated in `findAndSetNextSynth` from `currentSynthName` and `defaultSynthPriorityList`.

In `findAndSetNextSynth`, rather than finding the index of `currentSynthName` in `defaultSynthPriorityList` and attempting to use the next synth, pop a synth name from `leftToTry` and attempt to use that synth. as `findAndSetNextSynth` calls `setSynth` with the popped name and the remainder of `leftToTry`, and `setSynth` calls `findAndSetNextSynth` with what it received as `leftToTry`, this will consume `leftToTry` tail-first until either a working synth is found or `leftToTry` is exhausted.

If `findAndSetNextSynth` receives `None` as the value of `leftToTry`, it uses `defaultSynthPriorityList` in reverse order, excluding `currentSynthName`. Otherwise, `currentSynthName` is ignored. 

Since, if unspecified, `leftToTry` defaults to `defaultSynthPriorityList`, and `findAndSetNextSynth` consumes `leftToTry` in reverse, we try synths from `defaultSynthPriorityList` in order (axiomatically, `reverss(reverse(sequence)) = sequence`).

### Testing strategy:

Raised `RuntimeError` from `synthDrivers.espeak.SynthDriver.__init__` and/or `synthDriverHandler.OneCore.OneCoreSynthDriver.__init__`. Observed the following behaviour:

* Default synth OneCore:
  * OneCore raises: eSpeak NG is used at startup
  * oneCore does not raise: OneCore is used at startup
* Default synth eSpeak NG:
  * eSpeak NG raises: oneCore is used at startup
  * eSpeak NG does not raise: eSpeak NG is used at startup
* Default synth OneCore or eSpeak NG:
  * OneCore and eSpeak NG raise: No speech is used at startup
* Default synth SAPI 5:
  * eSpeak NG raises: when attempting to select eSpeak NG, SAPI 5 continues to be used and an error is shown.

### Known issues with pull request:

None known

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
