### PR TITLE
Fix occasional freeze in 32 bit sapi synths when cancelling speech

### DIFF
--- a/source/_bridge/components/services/synthDriver.py
+++ b/source/_bridge/components/services/synthDriver.py
@@ -64,7 +64,8 @@ class SynthDriverService(Service):
 		def localCallback_synthIndexReached(synth: SynthDriver, index: int):
 			log.debug(f"synthIndexReached localCallback called with index {index}")
 			if synth is self._synth:
-				callback(index)
+				log.debug("Calling async callback")
+				rpyc.async_(callback)(index)
 
 		self._synthIndexReachedCallback = localCallback_synthIndexReached
 		synthIndexReached.register(localCallback_synthIndexReached)
@@ -74,7 +75,8 @@ class SynthDriverService(Service):
 		def localCallback_synthDoneSpeaking(synth: SynthDriver):
 			log.debug(f"synthDoneSpeaking localCallback called with synth {synth}")
 			if synth is self._synth:
-				callback()
+				log.debug("Calling async callback")
+				rpyc.async_(callback)()
 
 		self._synthDoneSpeakingCallback = localCallback_synthDoneSpeaking
 		synthDoneSpeaking.register(localCallback_synthDoneSpeaking)


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
<!-- Use Closes/Fixes/Resolves #xxx to link this PR to the issue it is responding to. -->
Fixes #19594

### Summary of the issue:
With the introduction of 32 bit sapi support in pr #19432, an occasional freeze may be seen when using 32 bit sapi synths. Specifically when cancelling speech at the same time a speech utterance was finishing.
NVDA would freeze in its call to synth.cancel and the synthDriver process would freeze when calling the synthIndexReached or synthDoneSpeaking callbacks.
This seems to be related to RPYC issue #345, where  if a remote call is being made on one thread, but another thread is also moving a remote call and or somehow serving or polling the connection, the second thread may accidentally read and eat the return of the call in the first thread, thus causing the call on the first thread to time out.
 

### Description of user facing changes:

### Description of developer facing changes:

### Description of development approach:
* the synthDriver process now makes all synthIndexReached and synthDoneSpeaking notification calls back to NvDA asynchronicely, rather than blocking. This ensures that the synth driver process is now no longer waiting on the connection for these returns, greatly reducing the chance of a freeze, as now all blocking calls should only be coming in from NVDA, not going out.


### Testing strategy:
* General smoke testing of sapi4.
* Artificial testing by adding a time.sleep to the synth notificaiton callback on the NVDA side, to make the bug more likely, and ensure that with the fix the bug is still gone.

### Known issues with pull request:
None known.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
