### PR TITLE
Apply MathCAT settings with libmathcat.SetPreference when changed

### DIFF
--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -3041,7 +3041,7 @@ class MathSettingsPanel(SettingsPanel):
 				* math.pow(
 					PauseFactor.LOG_BASE.value,
 					pauseFactorSliderValue,
-				)
+				),
 			)
 		)  # avoid log(0)
 		if pauseFactor > 1000:

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -2717,6 +2717,24 @@ class MathSettingsPanel(SettingsPanel):
 			# If the selection is invalid, return the first option's value
 			return list(enumClass)[0].value
 
+	def _getPauseFactorSliderValue(
+		self,
+		pauseFactor: int,
+	) -> int:
+		"""Convert a pause factor value to the slider scale used in the UI."""
+		if pauseFactor <= 0:
+			return 0
+		import math
+		from mathPres.MathCAT.preferences import PauseFactor
+
+		sliderValue: int = round(
+			math.log(
+				pauseFactor / PauseFactor.SCALE.value,
+				PauseFactor.LOG_BASE.value,
+			),
+		)
+		return max(0, min(14, sliderValue))
+
 	def makeSettings(self, settingsSizer: wx.BoxSizer) -> None:
 		from mathPres.MathCAT import localization, preferences
 		from mathPres.MathCAT.preferences import (
@@ -2828,7 +2846,9 @@ class MathSettingsPanel(SettingsPanel):
 			maxValue=14,
 		)
 		self.bindHelpEvent("MathSpeechPauseFactor", self.pauseFactorSlider)
-		self.pauseFactorSlider.SetValue(config.conf["math"]["speech"]["pauseFactor"])
+		pauseFactorValue: int = config.conf["math"]["speech"]["pauseFactor"]
+		sliderValue: int = self._getPauseFactorSliderValue(pauseFactorValue)
+		self.pauseFactorSlider.SetValue(sliderValue)
 
 		# Translators: label for check box controlling a beep sound when math speech starts/ends
 		speechSoundText = pgettext("math", "Beep at the beginning and end of math")
@@ -3012,12 +3032,20 @@ class MathSettingsPanel(SettingsPanel):
 			self.speechAmountList.GetSelection(),
 		)
 		mathConf["speech"]["mathRate"] = self.relativeSpeedSlider.GetValue()
-		pfSlider: int = self.pauseFactorSlider.GetValue()
+		pauseFactorSliderValue: int = self.pauseFactorSlider.GetValue()
 		pauseFactor: int = (
 			0
-			if pfSlider == 0
-			else round(PauseFactor.SCALE.value * math.pow(PauseFactor.LOG_BASE.value, pfSlider))
+			if pauseFactorSliderValue == 0
+			else round(
+				PauseFactor.SCALE.value
+				* math.pow(
+					PauseFactor.LOG_BASE.value,
+					pauseFactorSliderValue,
+				)
+			)
 		)  # avoid log(0)
+		if pauseFactor > 1000:
+			pauseFactor = 1000
 		mathConf["speech"]["pauseFactor"] = pauseFactor
 		if self.speechSoundCheckBox.GetValue():
 			mathConf["speech"]["speechSound"] = "Beep"

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -12,6 +12,7 @@
 
 import copy
 import logging
+import math
 import os
 import re
 import typing
@@ -2724,7 +2725,6 @@ class MathSettingsPanel(SettingsPanel):
 		"""Convert a pause factor value to the slider scale used in the UI."""
 		if pauseFactor <= 0:
 			return 0
-		import math
 		from mathPres.MathCAT.preferences import PauseFactor
 
 		sliderValue: int = round(

--- a/source/mathPres/MathCAT/MathCAT.py
+++ b/source/mathPres/MathCAT/MathCAT.py
@@ -42,7 +42,7 @@ from textUtils import WCHAR_ENCODING
 
 import mathPres
 from .localization import getLanguageToUse
-from .preferences import setEffectiveBrailleCode
+from .preferences import applyUserPreferences
 from .speech import convertSSMLTextForNVDA
 
 
@@ -333,7 +333,7 @@ class MathCAT(mathPres.MathPresentationProvider):
 			log.info(f"MathCAT {libmathcat.GetVersion()} installed. Using rules dir: {rulesDir}")
 			libmathcat.SetRulesDir(rulesDir)
 			libmathcat.SetPreference("TTS", "SSML")
-			setEffectiveBrailleCode()
+			applyUserPreferences()
 		except Exception:
 			log.exception()
 			# Translators: this message directs users to look in the log file

--- a/source/mathPres/MathCAT/preferences.py
+++ b/source/mathPres/MathCAT/preferences.py
@@ -310,7 +310,7 @@ def applyUserPreferences(prefs: PreferencesDict | None = None) -> None:
 				libmathcat.SetPreference(k, yaml_val)
 			except Exception as e:
 				log.exception(
-					f"MathCAT: failed to set {k} preference: {e}"
+					f"MathCAT: failed to set {k} preference: {e}",
 				)
 	setEffectiveBrailleCode()
 

--- a/source/mathPres/MathCAT/preferences.py
+++ b/source/mathPres/MathCAT/preferences.py
@@ -294,6 +294,28 @@ def toNVDAConfigKey(key: str) -> str:
 type PreferencesDict = dict[str, dict[str, int | str | bool]]
 
 
+def applyUserPreferences(prefs: PreferencesDict | None = None) -> None:
+	"""Apply user preferences to MathCAT's runtime preferences."""
+	if prefs is None:
+		prefs = MathCATUserPreferences.fromNVDAConfig()._prefs
+	for categoryPrefs in prefs.values():
+		for k, v in categoryPrefs.items():
+			if k == "BrailleCode":
+				continue
+			try:
+				if isinstance(v, bool):
+					yaml_val = "true" if v else "false"
+				else:
+					yaml_val = str(v)
+				libmathcat.SetPreference(k, yaml_val)
+			except Exception as e:
+				log.debugWarning(
+					f"MathCAT: failed to set {k} preference: {e}",
+					exc_info=True,
+				)
+	setEffectiveBrailleCode()
+
+
 def getSpeechStyleChoicesWithTranslations(languageCode: str) -> list[str]:
 	"""Get speech style choices with translations for known styles.
 
@@ -396,22 +418,8 @@ class MathCATUserPreferences:
 		return MathCATUserPreferences(prefs)
 
 	def save(self) -> None:
-		"""Writes the current user preferences to a file and updates special settings.
-
-		Sets the language preference through the native library, ensures the preferences
-		folder exists, and saves the preferences to disk.
-		"""
-		# Language is special because it is set elsewhere by SetPreference which overrides the user_prefs -- so set it here
-
-		try:
-			libmathcat.SetPreference("Language", self._prefs["Speech"]["Language"])
-		except Exception as e:
-			log.exception(
-				f'Error in trying to set MathCAT "Language" preference to "{self._prefs["Speech"]["Language"]}": {e}',
-			)
-
-		setEffectiveBrailleCode()
-
+		"""Writes the current user preferences to a file and updates runtime settings."""
+		applyUserPreferences(self._prefs)
 		with open(pathToUserPreferences(), "w", encoding="utf-8") as f:
 			# write values to the user preferences file, NOT the default
 			yaml.dump(self._prefs, stream=f, allow_unicode=True)

--- a/source/mathPres/MathCAT/preferences.py
+++ b/source/mathPres/MathCAT/preferences.py
@@ -309,9 +309,8 @@ def applyUserPreferences(prefs: PreferencesDict | None = None) -> None:
 					yaml_val = str(v)
 				libmathcat.SetPreference(k, yaml_val)
 			except Exception as e:
-				log.debugWarning(
-					f"MathCAT: failed to set {k} preference: {e}",
-					exc_info=True,
+				log.exception(
+					f"MathCAT: failed to set {k} preference: {e}"
 				)
 	setEffectiveBrailleCode()
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Closes #19597.

### Summary of the issue:
After #19373, NVDA math preferences were not honoured by MathCAT.

### Description of how this pull request fixes the issue:
Per https://github.com/nvaccess/nvda/pull/19373#issuecomment-3752918889, use `libmathcat.SetPreference` to apply settings changes when they are saved to the NVDA configuration.

### Testing strategy:
Confirmed that I could reproduce #19597 before this PR and not after. Verified that preferences persist across NVDA restarts.

### Known issues with pull request:
None known

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
