### PR TITLE
Rename COM Registration Fixing Tool to Accessibility registration repair tool

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/01-bug_report.yaml
@@ -219,17 +219,17 @@ body:
     validations:
       required: true
     attributes:
-      label: Does the issue still occur after you run the COM Registration Fixing Tool in NVDA's tools menu?
+      label: Does the issue still occur after you run the System accessibility repair tool (COM Registration Fixing Tool in older versions) in NVDA's tools menu?
       description: |
         COM DLL files, which the IAccessible COM interface depends on, can get unregistered after installing and uninstalling different programs on a computer.
         The consequence is that NVDA in certain cases does not work properly.
         Specifically, it reports "unknown" when trying to navigate websites or fails to switch between focus and browse mode, it causes performance issues, focus instability and other odd problems.
-        The COM registry fixing tool has been introduced in order to re-register those DLL files.
+        The System accessibility repair tool has been introduced in order to re-register those DLL files.
         In any case, re-registering those DLL files does not have any negative impact on a computer's functionality.
         Note that when installing NVDA, this tool is run automatically.
         Thus, it is recommended to run the fixing tool whenever focus problems, performance problems on websites or navigation problems in focus or browse mode on different interfaces are encountered.
       options: [
-        "I have run the COM Registration Fixing Tool and the issue still occurs",
-        "I have run the COM Registration Fixing Tool and the issue no longer occurs",
-        "I have not run the COM Registration Fixing Tool",
+        "I have run the System accessibility repair tool and the issue still occurs",
+        "I have run the System accessibility repair tool and the issue no longer occurs",
+        "I have not run the System accessibility repair tool",
       ]

--- a/.github/ISSUE_TEMPLATE/01-bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/01-bug_report.yaml
@@ -219,17 +219,17 @@ body:
     validations:
       required: true
     attributes:
-      label: Does the issue still occur after you run the System accessibility repair tool (COM Registration Fixing Tool in older versions) in NVDA's tools menu?
+      label: Does the issue still occur after you run the System Accessibility Repair Tool (COM Registration Fixing Tool in older versions) in NVDA's tools menu?
       description: |
         COM DLL files, which the IAccessible COM interface depends on, can get unregistered after installing and uninstalling different programs on a computer.
         The consequence is that NVDA in certain cases does not work properly.
         Specifically, it reports "unknown" when trying to navigate websites or fails to switch between focus and browse mode, it causes performance issues, focus instability and other odd problems.
-        The System accessibility repair tool has been introduced in order to re-register those DLL files.
+        The System Accessibility Repair Tool has been introduced in order to re-register those DLL files.
         In any case, re-registering those DLL files does not have any negative impact on a computer's functionality.
         Note that when installing NVDA, this tool is run automatically.
         Thus, it is recommended to run the fixing tool whenever focus problems, performance problems on websites or navigation problems in focus or browse mode on different interfaces are encountered.
       options: [
-        "I have run the System accessibility repair tool and the issue still occurs",
-        "I have run the System accessibility repair tool and the issue no longer occurs",
-        "I have not run the System accessibility repair tool",
+        "I have run the System Accessibility Repair Tool and the issue still occurs",
+        "I have run the System Accessibility Repair Tool and the issue no longer occurs",
+        "I have not run the System Accessibility Repair Tool",
       ]

--- a/.github/ISSUE_TEMPLATE/11-bug_report.md
+++ b/.github/ISSUE_TEMPLATE/11-bug_report.md
@@ -33,4 +33,4 @@ type: Bug
 
 #### If NVDA add-ons are disabled, is your problem still occurring?
 
-#### Does the issue still occur after you run the COM Registration Fixing Tool in NVDA's tools menu?
+#### Does the issue still occur after you run the System accessibility repair tool in NVDA's tools menu?

--- a/.github/ISSUE_TEMPLATE/11-bug_report.md
+++ b/.github/ISSUE_TEMPLATE/11-bug_report.md
@@ -33,4 +33,4 @@ type: Bug
 
 #### If NVDA add-ons are disabled, is your problem still occurring?
 
-#### Does the issue still occur after you run the System accessibility repair tool in NVDA's tools menu?
+#### Does the issue still occur after you run the System Accessibility Repair Tool in NVDA's tools menu?

--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -553,8 +553,8 @@ class MainFrame(wx.Frame):
 		installerGui.showInstallGui()
 
 	_CRFT_INTRO_MESSAGE: str = _(
-		# Translators: Explain the System accessibility repair tool to users before running
-		"Welcome to the System accessibility repair tool.\n\n"
+		# Translators: Explain the System Accessibility Repair Tool to users before running
+		"Welcome to the System Accessibility Repair Tool.\n\n"
 		"Installing and uninstalling programs, as well as other events, can damage accessibility entries in the "
 		"Windows registry. This can cause previously accessible elements to be presented incorrectly, "
 		'or can cause "unknown" or "pane" to be spoken or brailled in some applications or Windows components, '
@@ -564,7 +564,7 @@ class MainFrame(wx.Frame):
 		"Press Continue to run the tool now.",
 	)
 	"""
-	Contains the intro dialog contents for the System accessibility repair tool.
+	Contains the intro dialog contents for the System Accessibility Repair Tool.
 	Used by `gui.MainFrame.onRunCOMRegistrationFixesCommand`.
 	"""
 
@@ -573,12 +573,12 @@ class MainFrame(wx.Frame):
 		blockAction.Context.MODAL_DIALOG_OPEN,
 	)
 	def onRunCOMRegistrationFixesCommand(self, evt: wx.CommandEvent) -> None:
-		"""Manages the interactive running of the System accessibility repair tool.
+		"""Manages the interactive running of the System Accessibility Repair Tool.
 		Shows a dialog to the user, giving an overview of what is going to happen.
 		If the user chooses to continue: runs the tool, and displays a completion dialog.
 		Cancels the run attempt if the user fails or declines the UAC prompt.
 		"""
-		# Translators: The title of various dialogs displayed when using the System accessibility repair tool
+		# Translators: The title of various dialogs displayed when using the System Accessibility Repair Tool
 		genericTitle: str = _("System Accessibility Repair")
 		introDialog = _ContinueCancelDialog(
 			self,
@@ -588,12 +588,12 @@ class MainFrame(wx.Frame):
 		)
 		response: int = introDialog.ShowModal()
 		if response != wx.OK:
-			log.debug("Run of System accessibility repair tool canceled before UAC.")
+			log.debug("Run of System Accessibility Repair Tool canceled before UAC.")
 			return
 		progressDialog = IndeterminateProgressDialog(
 			mainFrame,
 			genericTitle,
-			# Translators: The message displayed while NVDA is running the System accessibility repair tool
+			# Translators: The message displayed while NVDA is running the System Accessibility Repair Tool
 			_("Please wait while NVDA attempts to repair your system's accessibility registrations..."),
 		)
 		error: str | None = None
@@ -603,7 +603,7 @@ class MainFrame(wx.Frame):
 			# 1223 is "The operation was canceled by the user."
 			if e.winerror == 1223:
 				# Same as if the user selected "no" in the initial dialog.
-				log.debug("Run of System accessibility repair tool canceled during UAC.")
+				log.debug("Run of System Accessibility Repair Tool canceled during UAC.")
 				return
 			else:
 				log.error("Could not execute fixCOMRegistrations command", exc_info=True)
@@ -621,18 +621,18 @@ class MainFrame(wx.Frame):
 				messageBox(
 					_(
 						# Translators: message shown to the user on System accessibility repair fail
-						"The System accessibility repair tool was unsuccessful. This Windows "
+						"The System Accessibility Repair Tool was unsuccessful. This Windows "
 						"error may provide more information.\n{error}",
 					).format(error=error),
-					# Translators: The title of a System accessibility repair tool dialog, when the tool has failed
+					# Translators: The title of a System Accessibility Repair Tool dialog, when the tool has failed
 					_("System Accessibility Repair Failed"),
 					wx.OK,
 				)
 		# Display success dialog if there were no errors
 		messageBox(
 			_(
-				# Translators: Message shown when the System accessibility repair tool completes.
-				"The System accessibility repair tool has completed successfully.\n"
+				# Translators: Message shown when the System Accessibility Repair Tool completes.
+				"The System Accessibility Repair Tool has completed successfully.\n"
 				"It is highly recommended that you restart your computer now, to make sure the changes take full effect.",
 			),
 			genericTitle,
@@ -721,8 +721,8 @@ class SysTrayIcon(wx.adv.TaskBarIcon):
 				# Translators: The label for the menu item to install NVDA on the computer.
 				item = menu_tools.Append(wx.ID_ANY, _("&Install NVDA..."))
 				self.Bind(wx.EVT_MENU, frame.onInstallCommand, item)
-			# Translators: The label for the menu item to run the System accessibility repair tool
-			item = menu_tools.Append(wx.ID_ANY, _("Run System accessibility repair tool..."))
+			# Translators: The label for the menu item to run the System Accessibility Repair Tool
+			item = menu_tools.Append(wx.ID_ANY, _("Run System Accessibility Repair Tool..."))
 			self.Bind(wx.EVT_MENU, frame.onRunCOMRegistrationFixesCommand, item)
 		if not config.isAppX:
 			# Translators: The label for the menu item to reload plugins.

--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -553,8 +553,8 @@ class MainFrame(wx.Frame):
 		installerGui.showInstallGui()
 
 	_CRFT_INTRO_MESSAGE: str = _(
-		# Translators: Explain the COM Registration Fixing tool to users before running
-		"Welcome to the COM Registration Fixing tool.\n\n"
+		# Translators: Explain the System accessibility repair tool to users before running
+		"Welcome to the System accessibility repair tool.\n\n"
 		"Installing and uninstalling programs, as well as other events, can damage accessibility entries in the "
 		"Windows registry. This can cause previously accessible elements to be presented incorrectly, "
 		'or can cause "unknown" or "pane" to be spoken or brailled in some applications or Windows components, '
@@ -564,7 +564,7 @@ class MainFrame(wx.Frame):
 		"Press Continue to run the tool now.",
 	)
 	"""
-	Contains the intro dialog contents for the COM Registration Fixing Tool.
+	Contains the intro dialog contents for the System accessibility repair tool.
 	Used by `gui.MainFrame.onRunCOMRegistrationFixesCommand`.
 	"""
 
@@ -573,13 +573,13 @@ class MainFrame(wx.Frame):
 		blockAction.Context.MODAL_DIALOG_OPEN,
 	)
 	def onRunCOMRegistrationFixesCommand(self, evt: wx.CommandEvent) -> None:
-		"""Manages the interactive running of the COM Registration Fixing Tool.
+		"""Manages the interactive running of the System accessibility repair tool.
 		Shows a dialog to the user, giving an overview of what is going to happen.
 		If the user chooses to continue: runs the tool, and displays a completion dialog.
 		Cancels the run attempt if the user fails or declines the UAC prompt.
 		"""
-		# Translators: The title of various dialogs displayed when using the COM Registration Fixing tool
-		genericTitle: str = _("Fix COM Registrations")
+		# Translators: The title of various dialogs displayed when using the System accessibility repair tool
+		genericTitle: str = _("System Accessibility Repair")
 		introDialog = _ContinueCancelDialog(
 			self,
 			genericTitle,
@@ -588,13 +588,13 @@ class MainFrame(wx.Frame):
 		)
 		response: int = introDialog.ShowModal()
 		if response != wx.OK:
-			log.debug("Run of COM Registration Fixing Tool canceled before UAC.")
+			log.debug("Run of System accessibility repair tool canceled before UAC.")
 			return
 		progressDialog = IndeterminateProgressDialog(
 			mainFrame,
 			genericTitle,
-			# Translators: The message displayed while NVDA is running the COM Registration fixing tool
-			_("Please wait while NVDA attempts to fix your system's COM registrations..."),
+			# Translators: The message displayed while NVDA is running the System accessibility repair tool
+			_("Please wait while NVDA attempts to repair your system's accessibility registrations..."),
 		)
 		error: str | None = None
 		try:
@@ -603,7 +603,7 @@ class MainFrame(wx.Frame):
 			# 1223 is "The operation was canceled by the user."
 			if e.winerror == 1223:
 				# Same as if the user selected "no" in the initial dialog.
-				log.debug("Run of COM Registration Fixing Tool canceled during UAC.")
+				log.debug("Run of System accessibility repair tool canceled during UAC.")
 				return
 			else:
 				log.error("Could not execute fixCOMRegistrations command", exc_info=True)
@@ -620,19 +620,19 @@ class MainFrame(wx.Frame):
 			if error is not None:
 				messageBox(
 					_(
-						# Translators: message shown to the user on COM Registration Fix fail
-						"The COM Registration Fixing Tool was unsuccessful. This Windows "
+						# Translators: message shown to the user on System accessibility repair fail
+						"The System accessibility repair tool was unsuccessful. This Windows "
 						"error may provide more information.\n{error}",
 					).format(error=error),
-					# Translators: The title of a COM Registration Fixing Tool dialog, when the tool has failed
-					_("COM Registration Fixing Tool Failed"),
+					# Translators: The title of a System accessibility repair tool dialog, when the tool has failed
+					_("System Accessibility Repair Failed"),
 					wx.OK,
 				)
 		# Display success dialog if there were no errors
 		messageBox(
 			_(
-				# Translators: Message shown when the COM Registration Fixing tool completes.
-				"The COM Registration Fixing Tool has completed successfully.\n"
+				# Translators: Message shown when the System accessibility repair tool completes.
+				"The System accessibility repair tool has completed successfully.\n"
 				"It is highly recommended that you restart your computer now, to make sure the changes take full effect.",
 			),
 			genericTitle,
@@ -721,8 +721,8 @@ class SysTrayIcon(wx.adv.TaskBarIcon):
 				# Translators: The label for the menu item to install NVDA on the computer.
 				item = menu_tools.Append(wx.ID_ANY, _("&Install NVDA..."))
 				self.Bind(wx.EVT_MENU, frame.onInstallCommand, item)
-			# Translators: The label for the menu item to run the COM registration fix tool
-			item = menu_tools.Append(wx.ID_ANY, _("Run COM Registration Fixing tool..."))
+			# Translators: The label for the menu item to run the System accessibility repair tool
+			item = menu_tools.Append(wx.ID_ANY, _("Run System accessibility repair tool..."))
 			self.Bind(wx.EVT_MENU, frame.onRunCOMRegistrationFixesCommand, item)
 		if not config.isAppX:
 			# Translators: The label for the menu item to reload plugins.

--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -579,7 +579,7 @@ class MainFrame(wx.Frame):
 		Cancels the run attempt if the user fails or declines the UAC prompt.
 		"""
 		# Translators: The title of various dialogs displayed when using the System Accessibility Repair Tool
-		genericTitle: str = _("System Accessibility Repair")
+		genericTitle: str = _("System Accessibility Repair Tool")
 		introDialog = _ContinueCancelDialog(
 			self,
 			genericTitle,
@@ -620,7 +620,7 @@ class MainFrame(wx.Frame):
 			if error is not None:
 				messageBox(
 					_(
-						# Translators: message shown to the user on System accessibility repair fail
+						# Translators: message shown to the user on System Accessibility Repair fail
 						"The System Accessibility Repair Tool was unsuccessful. This Windows "
 						"error may provide more information.\n{error}",
 					).format(error=error),

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -44,6 +44,7 @@ The triple-press keyboard shortcut (`NVDA+ctrl+r`) is not affected, as it is int
 * Product version for File Explorer will reflect actual Windows version including correct build and revision numbers.
 This is more noticeable for Windows releases which are enablement packages on top of an earlier release such as Windows 11 2025 Update based on Windows 11 2024 Update. (#19802, @josephsl)
 * Math navigation commands now support input help, on-demand speech mode, and can be remapped. (#19871, @RyanMcCleary)
+* The "COM Registration Fixing Tool" has been renamed to "System Accessibility Repair Tool" for clarity. (#19622, @bramd)
 
 ### Bug Fixes
 

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -4812,11 +4812,11 @@ This will open a dialog which allows you to create a portable copy of NVDA out o
 
 Follow the directions in [Creating a portable copy](#CreatingAPortableCopy) for more information.
 
-### Run System accessibility repair tool... {#RunCOMRegistrationFixingTool}
+### Run System Accessibility Repair Tool... {#RunCOMRegistrationFixingTool}
 
 Sometimes, problems can develop with the Windows Registry, that result in NVDA behaving abnormally.
 This can be caused by, for example, installing or uninstalling certain programs (such as Adobe Reader or Math Player), as well as Windows updates and other events.
-The System accessibility repair tool attempts to fix these issues by repairing accessibility entries in the registry.
+The System Accessibility Repair Tool attempts to fix these issues by repairing accessibility entries in the registry.
 
 The types of problem this tool can fix include:
 

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -4812,11 +4812,11 @@ This will open a dialog which allows you to create a portable copy of NVDA out o
 
 Follow the directions in [Creating a portable copy](#CreatingAPortableCopy) for more information.
 
-### Run COM registration fixing tool... {#RunCOMRegistrationFixingTool}
+### Run System accessibility repair tool... {#RunCOMRegistrationFixingTool}
 
 Sometimes, problems can develop with the Windows Registry, that result in NVDA behaving abnormally.
 This can be caused by, for example, installing or uninstalling certain programs (such as Adobe Reader or Math Player), as well as Windows updates and other events.
-The COM Registration Fixing Tool attempts to fix these issues by repairing accessibility entries in the registry.
+The System accessibility repair tool attempts to fix these issues by repairing accessibility entries in the registry.
 
 The types of problem this tool can fix include:
 


### PR DESCRIPTION
### Link to issue number:

Closes #18666

### Summary of the issue:

The "COM Registration Fixing Tool" name uses technical jargon ("COM Registration") that is unclear to most users. Users encountering accessibility issues may not understand what this tool does or when to use it based on its current name.

### Description of user facing changes:

All user-facing references to "COM Registration Fixing Tool" have been renamed to "System accessibility repair tool":
- Tools menu item
- All dialog titles and messages (intro, progress, success, failure)
- User Guide documentation
- Change log entry
- Bug report issue templates

### Description of developer facing changes:

Internal identifiers (method names, file names, helpId anchors) are preserved to minimize risk and maintain backward compatibility with add-ons or scripts referencing these identifiers.

### Description of development approach:

Renamed all user-facing strings across the codebase while keeping internal code identifiers unchanged. Updated translatable strings, documentation, and issue templates. The dialog title was changed from "Fix COM Registrations" to "System Accessibility Repair" and the progress message was updated to be more descriptive.

### Testing strategy:

Manual testing: Built the launcher executable, ran NVDA from the launcher, and verified the renamed tool appears correctly in the Tools menu and that the repair tool dialogs display the updated strings when invoked.

### Known issues with pull request:

None.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.