### PR TITLE
Fix up API symbols introduced in 2025.3 patch releases

### DIFF
--- a/source/gui/installerGui.py
+++ b/source/gui/installerGui.py
@@ -1,8 +1,8 @@
 # A part of NonVisual Desktop Access (NVDA)
-# This file is covered by the GNU General Public License.
-# See the file COPYING for more details.
-# Copyright (C) 2011-2025 NV Access Limited, Babbage B.v., Cyrille Bougot, Julien Cochuyt, Accessolutions,
+# Copyright (C) 2011-2026 NV Access Limited, Babbage B.v., Cyrille Bougot, Julien Cochuyt, Accessolutions,
 # Bill Dengler, Joseph Lee, Takuya Nishimoto
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
 
 import os
 import subprocess

--- a/source/gui/installerGui.py
+++ b/source/gui/installerGui.py
@@ -8,7 +8,7 @@ import os
 import subprocess
 import sys
 
-from utils.security import _isRunningElevated
+from utils.security import isRunningElevated
 import winUser
 import wx
 import config
@@ -123,7 +123,7 @@ def doInstall(
 		)
 		return
 
-	startAfterInstall = startAfterInstall and not _isRunningElevated()
+	startAfterInstall = startAfterInstall and not isRunningElevated()
 	if not silent:
 		msg = (
 			# Translators: The message displayed when NVDA has been successfully installed.
@@ -551,7 +551,7 @@ class PortableCreaterDialog(
 		startAfterCreateText = _("&Start the new portable copy after creation")
 		self.startAfterCreateCheckbox = sHelper.addItem(wx.CheckBox(self, label=startAfterCreateText))
 		self.startAfterCreateCheckbox.Value = False
-		self.startAfterCreateCheckbox.Enable(not _isRunningElevated())
+		self.startAfterCreateCheckbox.Enable(not isRunningElevated())
 
 		bHelper = sHelper.addDialogDismissButtons(guiHelper.ButtonHelper(wx.HORIZONTAL), separated=True)
 
@@ -675,7 +675,7 @@ def doCreatePortable(
 			# Translators: Title of a dialog shown when a portable copy of NVDA is created.
 			_("Success"),
 		)
-	startAfterCreate = startAfterCreate and not _isRunningElevated()
+	startAfterCreate = startAfterCreate and not isRunningElevated()
 	if silent or startAfterCreate:
 		newNVDA = None
 		if startAfterCreate:

--- a/source/systemUtils.py
+++ b/source/systemUtils.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2020-2025 NV Access Limited, Łukasz Golonka, Luke Davis, Leonard de Ruijter
+# Copyright (C) 2020-2026 NV Access Limited, Łukasz Golonka, Luke Davis, Leonard de Ruijter
 # This file may be used under the terms of the GNU General Public License, version 2 or later.
 # For more details see: https://www.gnu.org/licenses/gpl-2.0.html
 

--- a/source/systemUtils.py
+++ b/source/systemUtils.py
@@ -279,11 +279,19 @@ def resetThreadExecutionState() -> None:
 
 
 @contextmanager
-def getCurrentProcessToken() -> Generator[ctypes.wintypes.HANDLE, None, None]:
+def getCurrentProcessToken(desiredAccess: int) -> Generator[ctypes.wintypes.HANDLE, None, None]:
+	"""Context manager which provides access to the access token associated with the current process.
+
+	Handles closing the handle to the access token when the context manager is exited.
+
+	:param desiredAccess: Access mask specifying the requested types of access to the access token.
+	:raises OSError: If calling OpenProcessToken fails.
+	:yield: A handle that identifies the newly opened access token.
+	"""
 	currentProcessToken = ctypes.wintypes.HANDLE()
 	if not winBindings.advapi32.OpenProcessToken(
 		winBindings.kernel32.GetCurrentProcess(),
-		winBindings.advapi32.TokenAccessRight.QUERY,
+		desiredAccess,
 		byref(currentProcessToken),
 	):
 		raise OSError(None, FormatError(), None, GetLastError())

--- a/source/systemUtils.py
+++ b/source/systemUtils.py
@@ -5,13 +5,17 @@
 
 """System related functions."""
 
+from contextlib import contextmanager
 import ctypes
 import time
 import threading
 from collections.abc import (
 	Callable,
+	Generator,
 )
 from ctypes import (
+	FormatError,
+	GetLastError,
 	byref,
 	create_unicode_buffer,
 	sizeof,
@@ -272,3 +276,18 @@ def preventSystemIdle(preventDisplayTurningOff: bool | None = None, persistent: 
 def resetThreadExecutionState() -> None:
 	"""Reset the thread execution state to the default."""
 	winBindings.kernel32.SetThreadExecutionState(winKernel.ES_CONTINUOUS)
+
+
+@contextmanager
+def getCurrentProcessToken() -> Generator[ctypes.wintypes.HANDLE, None, None]:
+	currentProcessToken = ctypes.wintypes.HANDLE()
+	if not winBindings.advapi32.OpenProcessToken(
+		winBindings.kernel32.GetCurrentProcess(),
+		winBindings.advapi32.TokenAccessRight.QUERY,
+		byref(currentProcessToken),
+	):
+		raise OSError(None, FormatError(), None, GetLastError())
+	try:
+		yield currentProcessToken
+	finally:
+		winBindings.kernel32.CloseHandle(currentProcessToken)

--- a/source/utils/security.py
+++ b/source/utils/security.py
@@ -3,11 +3,8 @@
 # This file may be used under the terms of the GNU General Public License, version 2 or later.
 # For more details see: https://www.gnu.org/licenses/gpl-2.0.html
 
-from collections.abc import Generator
-from contextlib import contextmanager
-from ctypes import WINFUNCTYPE, FormatError, GetLastError, byref, c_int, sizeof, windll
-from ctypes.wintypes import BOOL, DWORD, HANDLE, LPVOID, PDWORD, PHANDLE
-from enum import IntEnum
+from ctypes import FormatError, GetLastError, byref, sizeof
+from ctypes.wintypes import DWORD
 import hashlib
 from typing import (
 	Any,
@@ -23,6 +20,7 @@ import extensionPoints
 from logHandler import log
 import systemUtils
 from winAPI.sessionTracking import isLockScreenModeActive
+from winBindings.advapi32 import TOKEN_ELEVATION_TYPE, TOKEN_INFORMATION_CLASS, GetTokenInformation
 import winUser
 
 if TYPE_CHECKING:
@@ -419,85 +417,7 @@ def isRunningOnSecureDesktop() -> bool:
 	return systemUtils._getDesktopName() == "Winlogon"
 
 
-class _TOKEN_INFORMATION_CLASS(IntEnum):
-	"""
-	Specifies the type of information being assigned to or retrieved from an access token.
-
-	.. seealso::
-		https://learn.microsoft.com/en-us/windows/win32/api/winnt/ne-winnt-token_information_class
-	"""
-
-	ELEVATION_TYPE = 18
-	"""The buffer receives a TOKEN_ELEVATION_TYPE value that specifies the elevation level of the token."""
-
-
-class _TOKEN_ELEVATION_TYPE(IntEnum):
-	"""
-	Indicates the elevation type of an access token.
-
-	.. seealso::
-		https://learn.microsoft.com/en-us/windows/win32/api/winnt/ne-winnt-token_elevation_type
-	"""
-
-	DEFAULT = 1
-	"""The token does not have a linked token."""
-
-	FULL = 2
-	"""The token is an elevated token."""
-
-	LIMITED = 3
-	"""The token is a limited token."""
-
-
-_GetTokenInformation = WINFUNCTYPE(
-	BOOL,
-	HANDLE,  # TokenHandle
-	c_int,  # TokenInformationClass
-	LPVOID,  # TokenInformation
-	DWORD,  # TokenInformationLength
-	PDWORD,  # ReturnLength
-)(("GetTokenInformation", windll.advapi32))
-"""Retrieves a specified type of information about an access token."""
-
-_OpenProcessToken = WINFUNCTYPE(
-	BOOL,
-	HANDLE,  # ProcessHandle
-	DWORD,  # DesiredAccess
-	PHANDLE,  # TokenHandle
-)(("OpenProcessToken", windll.advapi32))
-"""Opens the access token associated with a process."""
-
-_GetCurrentProcess = WINFUNCTYPE(HANDLE)(("GetCurrentProcess", windll.kernel32))
-"""Retrieves a pseudo handle for the current process."""
-
-_CloseHandle = WINFUNCTYPE(BOOL, HANDLE)(("CloseHandle", windll.kernel32))
-"""Closes an open object handle."""
-
-
-class _TokenAccessRight(IntEnum):
-	"""
-	The specific access rights for access tokens.
-
-	.. seealso::
-		https://learn.microsoft.com/en-us/windows/win32/secauthz/access-rights-for-access-token-objects
-	"""
-
-	QUERY = 8
-	"""TOKEN_QUERY: Required to query an access token."""
-
-
-@contextmanager
-def _getCurrentProcessToken() -> Generator[HANDLE, None, None]:
-	currentProcessToken = HANDLE()
-	if not _OpenProcessToken(_GetCurrentProcess(), _TokenAccessRight.QUERY, byref(currentProcessToken)):
-		raise OSError(None, FormatError(), None, GetLastError())
-	try:
-		yield currentProcessToken
-	finally:
-		_CloseHandle(currentProcessToken)
-
-
-def _isRunningElevated() -> bool:
+def isRunningElevated() -> bool:
 	"""
 	Determine whether NVDA is running as an elevated administrator.
 
@@ -513,14 +433,14 @@ def _isRunningElevated() -> bool:
 	"""
 	elevationType = DWORD()
 	actualSize = DWORD()
-	with _getCurrentProcessToken() as currentProcessToken:
-		if not _GetTokenInformation(
+	with systemUtils.getCurrentProcessToken() as currentProcessToken:
+		if not GetTokenInformation(
 			currentProcessToken,
-			_TOKEN_INFORMATION_CLASS.ELEVATION_TYPE,
+			TOKEN_INFORMATION_CLASS.ELEVATION_TYPE,
 			byref(elevationType),
 			sizeof(DWORD),
 			byref(actualSize),
 		):
 			raise OSError(None, FormatError(), None, GetLastError())
 
-	return elevationType.value == _TOKEN_ELEVATION_TYPE.FULL
+	return elevationType.value == TOKEN_ELEVATION_TYPE.FULL

--- a/source/utils/security.py
+++ b/source/utils/security.py
@@ -20,7 +20,12 @@ import extensionPoints
 from logHandler import log
 import systemUtils
 from winAPI.sessionTracking import isLockScreenModeActive
-from winBindings.advapi32 import TOKEN_ELEVATION_TYPE, TOKEN_INFORMATION_CLASS, GetTokenInformation
+from winBindings.advapi32 import (
+	TOKEN_ELEVATION_TYPE,
+	TOKEN_INFORMATION_CLASS,
+	GetTokenInformation,
+	TokenAccessRight,
+)
 import winUser
 
 if TYPE_CHECKING:
@@ -433,7 +438,7 @@ def isRunningElevated() -> bool:
 	"""
 	elevationType = DWORD()
 	actualSize = DWORD()
-	with systemUtils.getCurrentProcessToken() as currentProcessToken:
+	with systemUtils.getCurrentProcessToken(TokenAccessRight.QUERY) as currentProcessToken:
 		if not GetTokenInformation(
 			currentProcessToken,
 			TOKEN_INFORMATION_CLASS.ELEVATION_TYPE,

--- a/source/utils/security.py
+++ b/source/utils/security.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2022-2023 NV Access Limited, Cyrille Bougot
+# Copyright (C) 2022-2026 NV Access Limited, Cyrille Bougot
 # This file may be used under the terms of the GNU General Public License, version 2 or later.
 # For more details see: https://www.gnu.org/licenses/gpl-2.0.html
 

--- a/source/winBindings/advapi32.py
+++ b/source/winBindings/advapi32.py
@@ -25,6 +25,7 @@ from ctypes.wintypes import (
 	LPWSTR,
 	LPVOID,
 )
+from enum import IntEnum
 
 __all__ = (
 	"OpenProcessToken",
@@ -38,6 +39,18 @@ __all__ = (
 
 
 dll = windll.advapi32
+
+
+class TokenAccessRight(IntEnum):
+	"""
+	The specific access rights for access tokens.
+
+	.. seealso::
+		https://learn.microsoft.com/en-us/windows/win32/secauthz/access-rights-for-access-token-objects
+	"""
+
+	QUERY = 8
+	"""TOKEN_QUERY: Required to query an access token."""
 
 
 OpenProcessToken = WINFUNCTYPE(None)(("OpenProcessToken", dll))
@@ -200,6 +213,37 @@ CreateProcessAsUser.argtypes = (
 	POINTER(PROCESS_INFORMATION),  # lpProcessInformation
 )
 CreateProcessAsUser.restype = BOOL
+
+
+class TOKEN_INFORMATION_CLASS(IntEnum):
+	"""
+	Specifies the type of information being assigned to or retrieved from an access token.
+
+	.. seealso::
+		https://learn.microsoft.com/en-us/windows/win32/api/winnt/ne-winnt-token_information_class
+	"""
+
+	ELEVATION_TYPE = 18
+	"""The buffer receives a TOKEN_ELEVATION_TYPE value that specifies the elevation level of the token."""
+
+
+class TOKEN_ELEVATION_TYPE(IntEnum):
+	"""
+	Indicates the elevation type of an access token.
+
+	.. seealso::
+		https://learn.microsoft.com/en-us/windows/win32/api/winnt/ne-winnt-token_elevation_type
+	"""
+
+	DEFAULT = 1
+	"""The token does not have a linked token."""
+
+	FULL = 2
+	"""The token is an elevated token."""
+
+	LIMITED = 3
+	"""The token is a limited token."""
+
 
 GetTokenInformation = WINFUNCTYPE(None)(("GetTokenInformation", dll))
 """

--- a/source/winBindings/advapi32.py
+++ b/source/winBindings/advapi32.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2025 NV Access Limited
+# Copyright (C) 2025-2026 NV Access Limited
 # This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
 # For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
 


### PR DESCRIPTION
### Link to issue number:

Follow-up nvaccess/nvda@a8f4f802c3
Follow-up nvaccess/nvda@1a9a5e8003

### Summary of the issue:

The patches introduced in 2025.3.1 and 2025.3.3 introduced new Windows API bindings. As the project's approach to these bindings has changed a lot in the transition to 64-bit, and as patch releases avoid introducing changes to the API (including additions), these prototypes were marked internal.

### Description of user facing changes:

None.

### Description of developer facing changes:

The following symbols are now part of the public API: `systemUtils.getCurrentProcessToken`; `utils.security.isRunningElevated`; `winBindings.advapi32.TokenAccessRight`, `TOKEN_INFORMATION_CLASS`, and `TOKEN_ELEVATION_TYPE`; and `winBindings.kernel32.WAIT`, `PAGE`, `CreateFileMapping`, `FILE_MAP`, `MapViewOfFile`, `UnmapViewOfFile`, and `OpenFileMapping`.

### Description of development approach:

Used VS Code's refactoring tools to move the above listed function, enumerations and ctypes prototypes from `_remoteClient.secureDesktop` and `utils.security`, removing their underscore prefixes in the process.

Added the `desiredAccess` parameter to `systemUtils.getCurrentProcessToken` (previously `utils.security._getCurrentProcessToken`) and pass that to `OpenProcessToken`, rather than the previously hardcoded `TOKEN_QUERY` value.

### Testing strategy:

Unit and system tests.

### Known issues with pull request:

None known

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
