### PR TITLE
Fix version comparisons when installing/updating/downgrading

### DIFF
--- a/source/fileUtils.py
+++ b/source/fileUtils.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2017-2025 NV Access Limited, Bram Duvigneau, Łukasz Golonka
+# Copyright (C) 2017-2026 NV Access Limited, Bram Duvigneau, Łukasz Golonka
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -70,10 +70,16 @@ def _suspendWow64RedirectionForFileInfoRetrieval(func):
 
 
 @_suspendWow64RedirectionForFileInfoRetrieval
-def getFileVersionInfo(name, *attributes):
-	"""Gets the specified file version info attributes from the provided file."""
-	if not isinstance(name, str):
-		raise TypeError("name must be an unicode string")
+def getFileVersionInfo(name: str, *attributes: list[str]) -> dict[str, str | None]:
+	"""
+	Gets the specified file version info attributes from the provided file.
+	:param name: The path to the file to get version info from.
+	:param attributes: The list of attributes to get. E.g. "FileVersion", "ProductVersion"
+	:return: A dictionary mapping the provided attributes to their values.
+	If an attribute is not found or invalid, its value will be None.
+
+	:raises RuntimeError: If the file does not exist, has no version information, or has no codepage.
+	"""
 	if not os.path.exists(name):
 		raise RuntimeError("The file %s does not exist" % name)
 	fileVersionInfo = {}

--- a/source/fileUtils.py
+++ b/source/fileUtils.py
@@ -70,7 +70,7 @@ def _suspendWow64RedirectionForFileInfoRetrieval(func):
 
 
 @_suspendWow64RedirectionForFileInfoRetrieval
-def getFileVersionInfo(name: str, *attributes: list[str]) -> dict[str, str | None]:
+def getFileVersionInfo(name: str, *attributes: str) -> dict[str, str | None]:
 	"""
 	Gets the specified file version info attributes from the provided file.
 	:param name: The path to the file to get version info from.

--- a/source/gui/installerGui.py
+++ b/source/gui/installerGui.py
@@ -406,11 +406,14 @@ class InstallingOverNewerVersionDialog(
 
 	@property
 	def _warningText(self) -> str:
-		if self._installState == ComparisonState.DOWNGRADE:
-			return self._DOWNGRADE_WARNING
-		if self._installState == ComparisonState.UNKNOWN:
-			return self._UNKNOWN_WARNING
-		raise ValueError("Invalid install state for warning dialog")
+		installState = installer._comparePreviousInstall()
+		match installState:
+			case ComparisonState.DOWNGRADE:
+				return self._DOWNGRADE_WARNING
+			case ComparisonState.UNKNOWN:
+				return self._UNKNOWN_WARNING
+			case _:
+				raise ValueError("Invalid install state for warning dialog")
 
 
 def showInstallGui():

--- a/source/gui/installerGui.py
+++ b/source/gui/installerGui.py
@@ -446,7 +446,7 @@ def _warnAndConfirmForNonEmptyDirectory(portableDirectory: str) -> bool:
 		# The directory is empty, so we can proceed.
 		return True
 	if _nvdaExistsInDir(portableDirectory):
-		return wx.YES == gui.messageBox(
+		if wx.NO == gui.messageBox(
 			_(
 				# Translators: The message displayed when the user has specified a destination directory
 				# that already has a portable copy in the Create Portable NVDA dialog.
@@ -457,7 +457,17 @@ def _warnAndConfirmForNonEmptyDirectory(portableDirectory: str) -> bool:
 			# that already has a portable copy in the Create Portable NVDA dialog.
 			_("Portable Copy Exists"),
 			wx.YES_NO | wx.ICON_QUESTION,
-		)
+		):
+			# The user does not want to update the existing portable copy, so we cancel.
+			return False
+		installState = installer._comparePreviousCopy(portableDirectory)
+		if installState in (ComparisonState.DOWNGRADE, ComparisonState.UNKNOWN):
+			d = InstallingOverNewerVersionDialog()
+			with d:
+				if d.ShowModal() == wx.ID_CANCEL:
+					gui.mainFrame.postPopup()
+					return False
+		return True
 	return wx.YES == gui.messageBox(
 		_(
 			# Translators: The message displayed when the user has specified a destination directory

--- a/source/gui/installerGui.py
+++ b/source/gui/installerGui.py
@@ -350,6 +350,26 @@ class InstallingOverNewerVersionDialog(
 ):
 	helpId = "InstallingNVDA"
 
+	_DOWNGRADE_WARNING = _(
+		# Translators: A warning presented when the user attempts to downgrade NVDA
+		# to an older version.
+		"You are attempting to install an earlier version of NVDA "
+		"than the version currently installed. "
+		"If you really wish to revert to an earlier version, "
+		"you should first cancel this installation "
+		"and completely uninstall NVDA before installing the earlier version.",
+	)
+
+	_UNKNOWN_WARNING = _(
+		# Translators: A warning presented when the installer is unable to determine
+		# the state of the current NVDA installation.
+		"NVDA has detected that you have NVDA already installed, "
+		"but it is unable to determine the version. "
+		"If you are attempting to install an earlier version of NVDA "
+		"you should first cancel this installation "
+		"and completely uninstall NVDA before installing the earlier version.",
+	)
+
 	def __init__(self):
 		# Translators: The title of a warning dialog.
 		super().__init__(gui.mainFrame, title=_("Warning"))
@@ -358,15 +378,7 @@ class InstallingOverNewerVersionDialog(
 		contentSizer = guiHelper.BoxSizerHelper(self, orientation=wx.VERTICAL)
 		text = wx.StaticText(
 			self,
-			label=_(
-				# Translators: A warning presented when the user attempts to downgrade NVDA
-				# to an older version.
-				"You are attempting to install an earlier version of NVDA "
-				"than the version currently installed. "
-				"If you really wish to revert to an earlier version, "
-				"you should first cancel this installation "
-				"and completely uninstall NVDA before installing the earlier version.",
-			),
+			label=self._warningText,
 		)
 		text.Wrap(self.scaleSize(600))
 		contentSizer.addItem(text)
@@ -391,6 +403,14 @@ class InstallingOverNewerVersionDialog(
 		self.SetSizer(mainSizer)
 		mainSizer.Fit(self)
 		self.CentreOnScreen()
+
+	@property
+	def _warningText(self) -> str:
+		if self._installState == ComparisonState.DOWNGRADE:
+			return self._DOWNGRADE_WARNING
+		if self._installState == ComparisonState.UNKNOWN:
+			return self._UNKNOWN_WARNING
+		raise ValueError("Invalid install state for warning dialog")
 
 
 def showInstallGui():

--- a/source/gui/installerGui.py
+++ b/source/gui/installerGui.py
@@ -424,7 +424,7 @@ class PortableCopyOverNewerVersionDialog(InstallingOverNewerVersionDialog):
 		# to an older version.
 		"You are attempting to replace a portable copy with an earlier version of NVDA. "
 		"Downgrading NVDA is not recommended. "
-		"Instead you should cancel this and create a new portable copy. "
+		"Instead you should cancel this and create a new portable copy. ",
 	)
 
 	_UNKNOWN_WARNING = _(
@@ -432,8 +432,9 @@ class PortableCopyOverNewerVersionDialog(InstallingOverNewerVersionDialog):
 		# the state of the current NVDA installation.
 		"NVDA is unable to determine the version of the portable copy. "
 		"If you are attempting to downgrade to an earlier version of NVDA "
-		"you should cancel this installation and create a new portable copy. "
+		"you should cancel this installation and create a new portable copy. ",
 	)
+
 
 def showInstallGui():
 	gui.mainFrame.prePopup()

--- a/source/gui/installerGui.py
+++ b/source/gui/installerGui.py
@@ -416,6 +416,25 @@ class InstallingOverNewerVersionDialog(
 				raise ValueError("Invalid install state for warning dialog")
 
 
+class PortableCopyOverNewerVersionDialog(InstallingOverNewerVersionDialog):
+	helpId = "CreatingAPortableCopy"
+
+	_DOWNGRADE_WARNING = _(
+		# Translators: A warning presented when the user attempts to downgrade NVDA
+		# to an older version.
+		"You are attempting to replace a portable copy with an earlier version of NVDA. "
+		"Downgrading NVDA is not recommended. "
+		"Instead you should cancel this and create a new portable copy. "
+	)
+
+	_UNKNOWN_WARNING = _(
+		# Translators: A warning presented when the installer is unable to determine
+		# the state of the current NVDA installation.
+		"NVDA is unable to determine the version of the portable copy. "
+		"If you are attempting to downgrade to an earlier version of NVDA "
+		"you should cancel this installation and create a new portable copy. "
+	)
+
 def showInstallGui():
 	gui.mainFrame.prePopup()
 	installState = installer._comparePreviousInstall()
@@ -462,7 +481,7 @@ def _warnAndConfirmForNonEmptyDirectory(portableDirectory: str) -> bool:
 			return False
 		installState = installer._comparePreviousCopy(portableDirectory)
 		if installState in (ComparisonState.DOWNGRADE, ComparisonState.UNKNOWN):
-			d = InstallingOverNewerVersionDialog()
+			d = PortableCopyOverNewerVersionDialog()
 			with d:
 				if d.ShowModal() == wx.ID_CANCEL:
 					gui.mainFrame.postPopup()

--- a/source/gui/installerGui.py
+++ b/source/gui/installerGui.py
@@ -181,7 +181,7 @@ def doSilentInstall(
 	copyPortableConfig=False,
 	startAfterInstall=True,
 ):
-	freshInstall = installer.comparePreviousInstall() is ComparisonState.FRESH_INSTALL
+	freshInstall = installer._comparePreviousInstall() is ComparisonState.FRESH_INSTALL
 	startOnLogon = globalVars.appArgs.enableStartOnLogon
 	if startOnLogon is None:
 		startOnLogon = config.getStartOnLogonScreen() if not freshInstall else False
@@ -395,7 +395,7 @@ class InstallingOverNewerVersionDialog(
 
 def showInstallGui():
 	gui.mainFrame.prePopup()
-	installState = installer.comparePreviousInstall()
+	installState = installer._comparePreviousInstall()
 	if installState in (ComparisonState.DOWNGRADE, ComparisonState.UNKNOWN):
 		d = InstallingOverNewerVersionDialog()
 		with d:

--- a/source/gui/installerGui.py
+++ b/source/gui/installerGui.py
@@ -370,9 +370,10 @@ class InstallingOverNewerVersionDialog(
 		"and completely uninstall NVDA before installing the earlier version.",
 	)
 
-	def __init__(self):
+	def __init__(self, installState: ComparisonState = ComparisonState.DOWNGRADE):
 		# Translators: The title of a warning dialog.
 		super().__init__(gui.mainFrame, title=_("Warning"))
+		self.installState = installState
 
 		mainSizer = wx.BoxSizer(wx.VERTICAL)
 		contentSizer = guiHelper.BoxSizerHelper(self, orientation=wx.VERTICAL)
@@ -406,14 +407,13 @@ class InstallingOverNewerVersionDialog(
 
 	@property
 	def _warningText(self) -> str:
-		installState = installer._comparePreviousInstall()
-		match installState:
+		match self.installState:
 			case ComparisonState.DOWNGRADE:
 				return self._DOWNGRADE_WARNING
 			case ComparisonState.UNKNOWN:
 				return self._UNKNOWN_WARNING
 			case _:
-				raise ValueError("Invalid install state for warning dialog")
+				raise ValueError(f"Invalid install state for warning dialog {self.installState}")
 
 
 class PortableCopyOverNewerVersionDialog(InstallingOverNewerVersionDialog):
@@ -440,7 +440,7 @@ def showInstallGui():
 	gui.mainFrame.prePopup()
 	installState = installer._comparePreviousInstall()
 	if installState in (ComparisonState.DOWNGRADE, ComparisonState.UNKNOWN):
-		d = InstallingOverNewerVersionDialog()
+		d = InstallingOverNewerVersionDialog(installState)
 		with d:
 			if d.ShowModal() == wx.ID_CANCEL:
 				gui.mainFrame.postPopup()
@@ -482,7 +482,7 @@ def _warnAndConfirmForNonEmptyDirectory(portableDirectory: str) -> bool:
 			return False
 		installState = installer._comparePreviousCopy(portableDirectory)
 		if installState in (ComparisonState.DOWNGRADE, ComparisonState.UNKNOWN):
-			d = PortableCopyOverNewerVersionDialog()
+			d = PortableCopyOverNewerVersionDialog(installState)
 			with d:
 				if d.ShowModal() == wx.ID_CANCEL:
 					gui.mainFrame.postPopup()

--- a/source/gui/installerGui.py
+++ b/source/gui/installerGui.py
@@ -56,12 +56,12 @@ def _canPortableConfigBeCopied() -> bool:
 
 
 def doInstall(
-	createDesktopShortcut=True,
-	startOnLogon=True,
-	isUpdate=False,
-	copyPortableConfig=False,
-	silent=False,
-	startAfterInstall=True,
+	createDesktopShortcut: bool = True,
+	startOnLogon: bool = False,
+	isUpdate: bool = False,
+	copyPortableConfig: bool = False,
+	silent: bool = False,
+	startAfterInstall: bool = True,
 ):
 	progressDialog = gui.IndeterminateProgressDialog(
 		gui.mainFrame,

--- a/source/gui/installerGui.py
+++ b/source/gui/installerGui.py
@@ -1,7 +1,7 @@
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-# Copyright (C) 2011-2025 NV Access Limited, Babbage B.v., Cyrille Bougot, Julien Cochuyt, Accessolutions,
+# Copyright (C) 2011-2026 NV Access Limited, Babbage B.v., Cyrille Bougot, Julien Cochuyt, Accessolutions,
 # Bill Dengler, Joseph Lee, Takuya Nishimoto
 
 import os
@@ -16,6 +16,7 @@ import core
 from winBindings import shell32
 import globalVars
 import installer
+from installer import ComparisonState
 from logHandler import log
 import gui
 from gui import guiHelper
@@ -180,14 +181,14 @@ def doSilentInstall(
 	copyPortableConfig=False,
 	startAfterInstall=True,
 ):
-	prevInstall = installer.comparePreviousInstall() is not None
+	freshInstall = installer.comparePreviousInstall() is ComparisonState.FRESH_INSTALL
 	startOnLogon = globalVars.appArgs.enableStartOnLogon
 	if startOnLogon is None:
-		startOnLogon = config.getStartOnLogonScreen() if prevInstall else True
+		startOnLogon = config.getStartOnLogonScreen() if not freshInstall else False
 	doInstall(
-		createDesktopShortcut=installer.isDesktopShortcutInstalled() if prevInstall else True,
+		createDesktopShortcut=installer.isDesktopShortcutInstalled() if not freshInstall else True,
 		startOnLogon=startOnLogon,
-		isUpdate=prevInstall,
+		isUpdate=not freshInstall,
 		copyPortableConfig=copyPortableConfig,
 		silent=True,
 		startAfterInstall=startAfterInstall,
@@ -262,7 +263,7 @@ class InstallerDialog(
 		if globalVars.appArgs.enableStartOnLogon is not None:
 			self.startOnLogonCheckbox.Value = globalVars.appArgs.enableStartOnLogon
 		else:
-			self.startOnLogonCheckbox.Value = config.getStartOnLogonScreen() if self.isUpdate else True
+			self.startOnLogonCheckbox.Value = config.getStartOnLogonScreen() if self.isUpdate else False
 
 		shortcutIsPrevInstalled = installer.isDesktopShortcutInstalled()
 		if self.isUpdate and shortcutIsPrevInstalled:
@@ -394,15 +395,15 @@ class InstallingOverNewerVersionDialog(
 
 def showInstallGui():
 	gui.mainFrame.prePopup()
-	previous = installer.comparePreviousInstall()
-	if previous is not None and previous > 0:
+	installState = installer.comparePreviousInstall()
+	if installState in (ComparisonState.SAME, ComparisonState.OLDER, ComparisonState.UNKNOWN):
 		# The existing installation is newer, which means this will be a downgrade.
 		d = InstallingOverNewerVersionDialog()
 		with d:
 			if d.ShowModal() == wx.ID_CANCEL:
 				gui.mainFrame.postPopup()
 				return
-	InstallerDialog(gui.mainFrame, previous is not None).Show()
+	InstallerDialog(gui.mainFrame, installState is not ComparisonState.FRESH_INSTALL).Show()
 	gui.mainFrame.postPopup()
 
 

--- a/source/gui/installerGui.py
+++ b/source/gui/installerGui.py
@@ -363,9 +363,9 @@ class InstallingOverNewerVersionDialog(
 	_UNKNOWN_WARNING = _(
 		# Translators: A warning presented when the installer is unable to determine
 		# the state of the current NVDA installation.
-		"NVDA has detected that you have NVDA already installed, "
-		"but it is unable to determine the version. "
-		"If you are attempting to install an earlier version of NVDA "
+		"An existing NVDA installation has been detected, "
+		"but its version cannot be determined. "
+		"If you are attempting to install an earlier version of NVDA, "
 		"you should first cancel this installation "
 		"and completely uninstall NVDA before installing the earlier version.",
 	)
@@ -422,17 +422,18 @@ class PortableCopyOverNewerVersionDialog(InstallingOverNewerVersionDialog):
 	_DOWNGRADE_WARNING = _(
 		# Translators: A warning presented when the user attempts to downgrade NVDA
 		# to an older version.
-		"You are attempting to replace a portable copy with an earlier version of NVDA. "
+		"You are attempting to replace an existing portable copy of NVDA with an earlier version. "
 		"Downgrading NVDA is not recommended. "
-		"Instead you should cancel this and create a new portable copy. ",
+		"You should cancel this operation and create a new portable copy instead. ",
 	)
 
 	_UNKNOWN_WARNING = _(
 		# Translators: A warning presented when the installer is unable to determine
 		# the state of the current NVDA installation.
-		"NVDA is unable to determine the version of the portable copy. "
-		"If you are attempting to downgrade to an earlier version of NVDA "
-		"you should cancel this installation and create a new portable copy. ",
+		"An existing copy of NVDA has been detected in the chosen directory, "
+		"but its version cannot be determined. "
+		"If you are attempting to downgrade to an earlier version of NVDA, "
+		"you should cancel this operation and create a new portable copy. ",
 	)
 
 

--- a/source/gui/installerGui.py
+++ b/source/gui/installerGui.py
@@ -396,8 +396,7 @@ class InstallingOverNewerVersionDialog(
 def showInstallGui():
 	gui.mainFrame.prePopup()
 	installState = installer.comparePreviousInstall()
-	if installState in (ComparisonState.SAME, ComparisonState.OLDER, ComparisonState.UNKNOWN):
-		# The existing installation is newer, which means this will be a downgrade.
+	if installState in (ComparisonState.REINSTALL, ComparisonState.DOWNGRADE, ComparisonState.UNKNOWN):
 		d = InstallingOverNewerVersionDialog()
 		with d:
 			if d.ShowModal() == wx.ID_CANCEL:

--- a/source/gui/installerGui.py
+++ b/source/gui/installerGui.py
@@ -396,7 +396,7 @@ class InstallingOverNewerVersionDialog(
 def showInstallGui():
 	gui.mainFrame.prePopup()
 	installState = installer.comparePreviousInstall()
-	if installState in (ComparisonState.REINSTALL, ComparisonState.DOWNGRADE, ComparisonState.UNKNOWN):
+	if installState in (ComparisonState.DOWNGRADE, ComparisonState.UNKNOWN):
 		d = InstallingOverNewerVersionDialog()
 		with d:
 			if d.ShowModal() == wx.ID_CANCEL:

--- a/source/installer.py
+++ b/source/installer.py
@@ -30,7 +30,7 @@ import winKernel
 import NVDAState
 from NVDAState import WritePaths
 from utils.tempFile import _createEmptyTempFileForDeletingFile
-from utils._deprecate import handleDeprecations, MovedSymbol
+from utils._deprecate import handleDeprecations, MovedSymbol, RemovedSymbol
 
 _wsh = None
 

--- a/source/installer.py
+++ b/source/installer.py
@@ -19,7 +19,7 @@ import globalVars
 import languageHandler
 import config
 from config.registry import NVDA_ADDON_PROG_ID, RegistryKey, _deleteKeyAndSubkeys
-from fileUtils
+import fileUtils
 import versionInfo
 import buildVersion
 from logHandler import log

--- a/source/installer.py
+++ b/source/installer.py
@@ -19,6 +19,7 @@ import globalVars
 import languageHandler
 import config
 from config.registry import NVDA_ADDON_PROG_ID, RegistryKey, _deleteKeyAndSubkeys
+from fileUtils
 import versionInfo
 import buildVersion
 from logHandler import log

--- a/source/installer.py
+++ b/source/installer.py
@@ -147,8 +147,8 @@ def _comparePreviousCopy(previousCopyPath: str) -> ComparisonState:
 		- ComparisonState.UPGRADE if the previous installation is older than the current one
 		- ComparisonState.UNKNOWN if there was an error determining the version of either the current or previous installation
 	"""
-	previousCopyPath = previousCopyPath and os.path.isdir(previousCopyPath)
-	if not previousCopyPath:
+	previousCopyPathExists = previousCopyPath and os.path.isdir(previousCopyPath)
+	if not previousCopyPathExists:
 		return ComparisonState.FRESH_INSTALL
 
 	oldSlavePath = os.path.join(previousCopyPath, "nvda_slave.exe")

--- a/source/installer.py
+++ b/source/installer.py
@@ -49,7 +49,7 @@ __getattr__ = handleDeprecations(
 	),
 	RemovedSymbol(
 		"comparePreviousInstall",
-		"_legacyComparePreviousInstall",
+		_legacyComparePreviousInstall,
 	),
 )
 

--- a/source/installer.py
+++ b/source/installer.py
@@ -140,19 +140,15 @@ def comparePreviousInstall() -> ComparisonState:
 		newVersion = fileUtils.getFileVersionInfo("nvda_slave.exe", "FileVersion")
 	except (OSError, RuntimeError):
 		# This should never happen.
-		log.error("Unable to get file version of nvda_slave.exe in current process.")
+		log.exception("Unable to get file version of nvda_slave.exe in current process.")
 		return ComparisonState.UNKNOWN
-	else:
+
+	try:
+		oldVersion = oldVersion["FileVersion"].split(".")
 		newVersion = newVersion["FileVersion"].split(".")
-
-	if oldVersion is None:
-		log.debug("Previous installation does not have version information.")
+	except (KeyError, AttributeError):
+		log.exception("Error parsing version information.")
 		return ComparisonState.UNKNOWN
-	if newVersion is None:
-		log.error("Current version does not have version information.")
-		return ComparisonState.UNKNOWN
-
-	oldVersion = oldVersion["FileVersion"].split(".")
 
 	if oldVersion > newVersion:
 		return ComparisonState.OLDER

--- a/source/installer.py
+++ b/source/installer.py
@@ -6,7 +6,7 @@
 from collections.abc import Iterable
 import comtypes.client
 import ctypes
-from enum import Enum
+from enum import auto, Enum
 import pathlib
 import winreg
 import time
@@ -96,11 +96,30 @@ def createShortcut(
 
 
 class ComparisonState(Enum):
-	FRESH_INSTALL = None
-	DOWNGRADE = -1
-	REINSTALL = 0
-	UPGRADE = 1
-	UNKNOWN = None
+	FRESH_INSTALL = auto()
+	DOWNGRADE = auto()
+	REINSTALL = auto()
+	UPGRADE = auto()
+	UNKNOWN = auto()
+
+	@property
+	def legacyValue(self):
+		match self:
+			case ComparisonState.FRESH_INSTALL:
+				return None
+			case ComparisonState.DOWNGRADE:
+				return -1
+			case ComparisonState.REINSTALL:
+				return 0
+			case ComparisonState.UPGRADE:
+				return 1
+			case ComparisonState.UNKNOWN:
+				return None
+
+
+def _legacyComparePreviousInstall() -> int | None:
+	"""Legacy wrapper"""
+	return comparePreviousInstall().legacyValue
 
 
 def comparePreviousInstall() -> ComparisonState:

--- a/source/installer.py
+++ b/source/installer.py
@@ -123,6 +123,21 @@ class ComparisonState(Enum):
 
 
 def _comparePreviousInstall() -> ComparisonState:
+	pathX86 = WritePaths._installDirX86
+	pathX86Exists = pathX86 and os.path.isdir(pathX86)
+	pathX64 = WritePaths.installDir
+	pathExists = pathX64 and os.path.isdir(pathX64)
+
+	installPath = None
+	if pathExists:
+		installPath = pathX64
+	elif pathX86Exists:
+		installPath = pathX86
+
+	return _comparePreviousCopy(installPath)
+
+
+def _comparePreviousCopy(previousCopyPath: str) -> ComparisonState:
 	"""
 	Compares the version of the currently running NVDA with the version of a previous installation of NVDA on this system, if any.
 	:return:
@@ -132,28 +147,16 @@ def _comparePreviousInstall() -> ComparisonState:
 		- ComparisonState.UPGRADE if the previous installation is older than the current one
 		- ComparisonState.UNKNOWN if there was an error determining the version of either the current or previous installation
 	"""
-	pathX86 = WritePaths._installDirX86
-	pathX86Exists = pathX86 and os.path.isdir(pathX86)
-	path = WritePaths.installDir
-	pathExists = path and os.path.isdir(path)
-
-	if not (pathExists or pathX86Exists):
+	previousCopyPath = previousCopyPath and os.path.isdir(previousCopyPath)
+	if not previousCopyPath:
 		return ComparisonState.FRESH_INSTALL
 
-	if pathExists:
-		oldSlavePath = os.path.join(path, "nvda_slave.exe")
-		try:
-			oldVersion = fileUtils.getFileVersionInfo(oldSlavePath, "FileVersion")
-		except (OSError, RuntimeError):
-			log.debug("Unable to get file version of nvda_slave.exe in previous installation.")
-			return ComparisonState.UNKNOWN
-	elif pathX86Exists:
-		oldSlavePath = os.path.join(pathX86, "nvda_slave.exe")
-		try:
-			oldVersion = fileUtils.getFileVersionInfo(oldSlavePath, "FileVersion")
-		except (OSError, RuntimeError):
-			log.debug("Unable to get file version of nvda_slave.exe in previous installation (x86).")
-			return ComparisonState.UNKNOWN
+	oldSlavePath = os.path.join(previousCopyPath, "nvda_slave.exe")
+	try:
+		oldVersion = fileUtils.getFileVersionInfo(oldSlavePath, "FileVersion")
+	except (OSError, RuntimeError):
+		log.debug("Unable to get file version of nvda_slave.exe in previous copy.")
+		return ComparisonState.UNKNOWN
 
 	try:
 		newVersion = fileUtils.getFileVersionInfo("nvda_slave.exe", "FileVersion")

--- a/source/installer.py
+++ b/source/installer.py
@@ -47,6 +47,10 @@ __getattr__ = handleDeprecations(
 		"WritePaths",
 		"defaultInstallDir",
 	),
+	RemovedSymbol(
+		"comparePreviousInstall",
+		"_legacyComparePreviousInstall",
+	),
 )
 
 
@@ -103,7 +107,9 @@ class ComparisonState(Enum):
 	UNKNOWN = auto()
 
 	@property
-	def legacyValue(self):
+	def _legacyValue(self) -> int | None:
+		"""Legacy value for comparison state.
+		"""
 		match self:
 			case ComparisonState.FRESH_INSTALL:
 				return None
@@ -118,11 +124,11 @@ class ComparisonState(Enum):
 
 
 def _legacyComparePreviousInstall() -> int | None:
-	"""Legacy wrapper"""
-	return comparePreviousInstall().legacyValue
+	"""Legacy wrapper for _comparePreviousInstall"""
+	return _comparePreviousInstall()._legacyValue
 
 
-def comparePreviousInstall() -> ComparisonState:
+def _comparePreviousInstall() -> ComparisonState:
 	"""
 	Compares the version of the currently running NVDA with the version of a previous installation of NVDA on this system, if any.
 	:return:

--- a/source/installer.py
+++ b/source/installer.py
@@ -97,9 +97,9 @@ def createShortcut(
 
 class ComparisonState(Enum):
 	FRESH_INSTALL = None
-	OLDER = -1
-	SAME = 0
-	NEWER = 1
+	DOWNGRADE = -1
+	REINSTALL = 0
+	UPGRADE = 1
 	UNKNOWN = None
 
 
@@ -108,9 +108,9 @@ def comparePreviousInstall() -> ComparisonState:
 	Compares the version of the currently running NVDA with the version of a previous installation of NVDA on this system, if any.
 	:return:
 		- ComparisonState.FRESH_INSTALL if no previous installation is found
-		- ComparisonState.OLDER if the previous installation is newer than the current one
-		- ComparisonState.SAME if they are the same version
-		- ComparisonState.NEWER if the previous installation is older than the current one
+		- ComparisonState.DOWNGRADE if the previous installation is newer than the current one
+		- ComparisonState.REINSTALL if they are the same version
+		- ComparisonState.UPGRADE if the previous installation is older than the current one
 		- ComparisonState.UNKNOWN if there was an error determining the version of either the current or previous installation
 	"""
 	pathX86 = WritePaths._installDirX86
@@ -144,18 +144,18 @@ def comparePreviousInstall() -> ComparisonState:
 		return ComparisonState.UNKNOWN
 
 	try:
-		oldVersion = oldVersion["FileVersion"].split(".")
-		newVersion = newVersion["FileVersion"].split(".")
+		oldVersion = [int(x) for x in oldVersion["FileVersion"].split(".")]
+		newVersion = [int(x) for x in newVersion["FileVersion"].split(".")]
 	except (KeyError, AttributeError):
 		log.exception("Error parsing version information.")
 		return ComparisonState.UNKNOWN
 
 	if oldVersion > newVersion:
-		return ComparisonState.OLDER
+		return ComparisonState.DOWNGRADE
 	elif oldVersion < newVersion:
-		return ComparisonState.NEWER
+		return ComparisonState.UPGRADE
 	else:
-		return ComparisonState.SAME
+		return ComparisonState.REINSTALL
 
 
 def getDocFilePath(fileName: str, installDir: str):

--- a/source/installer.py
+++ b/source/installer.py
@@ -108,11 +108,11 @@ class ComparisonState(Enum):
 			case ComparisonState.FRESH_INSTALL:
 				return None
 			case ComparisonState.DOWNGRADE:
-				return -1
+				return 1
 			case ComparisonState.REINSTALL:
 				return 0
 			case ComparisonState.UPGRADE:
-				return 1
+				return -1
 			case ComparisonState.UNKNOWN:
 				return None
 

--- a/source/installer.py
+++ b/source/installer.py
@@ -49,7 +49,7 @@ __getattr__ = handleDeprecations(
 	),
 	RemovedSymbol(
 		"comparePreviousInstall",
-		_legacyComparePreviousInstall,
+		lambda: _comparePreviousInstall()._legacyValue,
 	),
 )
 
@@ -120,11 +120,6 @@ class ComparisonState(Enum):
 				return -1
 			case ComparisonState.UNKNOWN:
 				return None
-
-
-def _legacyComparePreviousInstall() -> int | None:
-	"""Legacy wrapper for _comparePreviousInstall"""
-	return _comparePreviousInstall()._legacyValue
 
 
 def _comparePreviousInstall() -> ComparisonState:

--- a/source/installer.py
+++ b/source/installer.py
@@ -108,8 +108,7 @@ class ComparisonState(Enum):
 
 	@property
 	def _legacyValue(self) -> int | None:
-		"""Legacy value for comparison state.
-		"""
+		"""Legacy value for comparison state."""
 		match self:
 			case ComparisonState.FRESH_INSTALL:
 				return None

--- a/source/installer.py
+++ b/source/installer.py
@@ -165,7 +165,7 @@ def comparePreviousInstall() -> ComparisonState:
 	try:
 		oldVersion = [int(x) for x in oldVersion["FileVersion"].split(".")]
 		newVersion = [int(x) for x in newVersion["FileVersion"].split(".")]
-	except (KeyError, AttributeError):
+	except (KeyError, AttributeError, ValueError, TypeError):
 		log.exception("Error parsing version information.")
 		return ComparisonState.UNKNOWN
 

--- a/source/installer.py
+++ b/source/installer.py
@@ -126,10 +126,10 @@ def _comparePreviousInstall() -> ComparisonState:
 	pathX86 = WritePaths._installDirX86
 	pathX86Exists = pathX86 and os.path.isdir(pathX86)
 	pathX64 = WritePaths.installDir
-	pathExists = pathX64 and os.path.isdir(pathX64)
+	pathX64Exists = pathX64 and os.path.isdir(pathX64)
 
 	installPath = None
-	if pathExists:
+	if pathX64Exists:
 		installPath = pathX64
 	elif pathX86Exists:
 		installPath = pathX86
@@ -137,7 +137,7 @@ def _comparePreviousInstall() -> ComparisonState:
 	return _comparePreviousCopy(installPath)
 
 
-def _comparePreviousCopy(previousCopyPath: str) -> ComparisonState:
+def _comparePreviousCopy(previousCopyPath: str | None) -> ComparisonState:
 	"""
 	Compares the version of the currently running NVDA with the version of a previous installation of NVDA on this system, if any.
 	:return:

--- a/source/installer.py
+++ b/source/installer.py
@@ -1,11 +1,12 @@
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-# Copyright (C) 2011-2025 NV Access Limited, Joseph Lee, Babbage B.V., Łukasz Golonka, Cyrille Bougot
+# Copyright (C) 2011-2026 NV Access Limited, Joseph Lee, Babbage B.V., Łukasz Golonka, Cyrille Bougot
 
 from collections.abc import Iterable
 import comtypes.client
 import ctypes
+from enum import Enum
 import pathlib
 import winreg
 import time
@@ -93,37 +94,71 @@ def createShortcut(
 		short.Save()
 
 
-def comparePreviousInstall() -> int | None:
-	"""Returns 1 if the existing installation is newer than this running version,
-	0 if it is the same, -1 if it is older,
-	None if there is no existing installation.
+class ComparisonState(Enum):
+	FRESH_INSTALL = None
+	OLDER = -1
+	SAME = 0
+	NEWER = 1
+	UNKNOWN = None
+
+
+def comparePreviousInstall() -> ComparisonState:
+	"""
+	Compares the version of the currently running NVDA with the version of a previous installation of NVDA on this system, if any.
+	:return:
+		- ComparisonState.FRESH_INSTALL if no previous installation is found
+		- ComparisonState.OLDER if the previous installation is newer than the current one
+		- ComparisonState.SAME if they are the same version
+		- ComparisonState.NEWER if the previous installation is older than the current one
+		- ComparisonState.UNKNOWN if there was an error determining the version of either the current or previous installation
 	"""
 	pathX86 = WritePaths._installDirX86
 	pathX86Exists = pathX86 and os.path.isdir(pathX86)
 	path = WritePaths.installDir
 	pathExists = path and os.path.isdir(path)
-	oldTime = None
+
 	if not (pathExists or pathX86Exists):
-		return None
+		return ComparisonState.FRESH_INSTALL
+
 	if pathExists:
+		oldSlavePath = os.path.join(path, "nvda_slave.exe")
 		try:
-			oldTime = os.path.getmtime(os.path.join(path, "nvda_slave.exe"))
-		except OSError:
-			log.debug("Unable to get modification time of nvda_slave.exe in previous installation.")
-			return None
+			oldVersion = fileUtils.getFileVersionInfo(oldSlavePath, "FileVersion")
+		except (OSError, RuntimeError):
+			log.debug("Unable to get file version of nvda_slave.exe in previous installation.")
+			return ComparisonState.UNKNOWN
 	elif pathX86Exists:
+		oldSlavePath = os.path.join(pathX86, "nvda_slave.exe")
 		try:
-			oldTime = os.path.getmtime(os.path.join(pathX86, "nvda_slave.exe"))
-		except OSError:
-			log.debug("Unable to get modification time of nvda_slave.exe in previous installation (x86).")
-			return None
+			oldVersion = fileUtils.getFileVersionInfo(oldSlavePath, "FileVersion")
+		except (OSError, RuntimeError):
+			log.debug("Unable to get file version of nvda_slave.exe in previous installation (x86).")
+			return ComparisonState.UNKNOWN
+
 	try:
-		newTime = os.path.getmtime("nvda_slave.exe")
-	except OSError:
+		newVersion = fileUtils.getFileVersionInfo("nvda_slave.exe", "FileVersion")
+	except (OSError, RuntimeError):
 		# This should never happen.
-		log.error("Unable to get modification time of nvda_slave.exe in current process.")
-		return None
-	return (oldTime > newTime) - (oldTime < newTime)
+		log.error("Unable to get file version of nvda_slave.exe in current process.")
+		return ComparisonState.UNKNOWN
+	else:
+		newVersion = newVersion["FileVersion"].split(".")
+
+	if oldVersion is None:
+		log.debug("Previous installation does not have version information.")
+		return ComparisonState.UNKNOWN
+	if newVersion is None:
+		log.error("Current version does not have version information.")
+		return ComparisonState.UNKNOWN
+
+	oldVersion = oldVersion["FileVersion"].split(".")
+
+	if oldVersion > newVersion:
+		return ComparisonState.OLDER
+	elif oldVersion < newVersion:
+		return ComparisonState.NEWER
+	else:
+		return ComparisonState.SAME
 
 
 def getDocFilePath(fileName: str, installDir: str):

--- a/tests/unit/test_installer.py
+++ b/tests/unit/test_installer.py
@@ -141,3 +141,247 @@ class testFollowerWarning(unittest.TestCase):
 					_remoteClient=patchedRemoteClient if remoteEnabled else None,
 				):
 					self.assertEqual(installerGui._shouldWarnBeforeUpdate(), expectedReturn)
+
+
+class Test_comparePreviousInstall(unittest.TestCase):
+	def test_freshInstall_whenNoInstallDirsExist(self):
+		with (
+			patch(
+				"installer.WritePaths.installDir",
+				"C:\\Program Files\\NVDA",
+			),
+			patch(
+				"installer.WritePaths._installDirX86",
+				"C:\\Program Files (x86)\\NVDA",
+			),
+			patch("installer.os.path.isdir", return_value=False),
+			patch("installer.fileUtils.getFileVersionInfo") as getVersionMock,
+		):
+			result = installer.comparePreviousInstall()
+			self.assertEqual(result, installer.ComparisonState.FRESH_INSTALL)
+			getVersionMock.assert_not_called()
+
+	def test_unknown_whenOldVersionLookupFails_inInstallDir(self):
+		installDir = "C:\\Program Files\\NVDA"
+		oldSlavePath = str(pathlib.Path(installDir) / "nvda_slave.exe")
+
+		def _isdir(path: str) -> bool:
+			return path == installDir
+
+		def _getVersion(path: str, field: str):
+			if path == oldSlavePath:
+				raise OSError("locked")
+			self.fail("Current version lookup should not occur when old version lookup fails.")
+
+		with (
+			patch("installer.WritePaths.installDir", installDir),
+			patch(
+				"installer.WritePaths._installDirX86",
+				"C:\\Program Files (x86)\\NVDA",
+			),
+			patch("installer.os.path.isdir", side_effect=_isdir),
+			patch(
+				"installer.fileUtils.getFileVersionInfo",
+				side_effect=_getVersion,
+			),
+		):
+			self.assertEqual(installer.comparePreviousInstall(), installer.ComparisonState.UNKNOWN)
+
+	def test_unknown_whenOldVersionLookupFails_inX86InstallDir(self):
+		installDir = "C:\\Program Files\\NVDA"
+		installDirX86 = "C:\\Program Files (x86)\\NVDA"
+		oldSlavePathX86 = str(pathlib.Path(installDirX86) / "nvda_slave.exe")
+
+		def _isdir(path: str) -> bool:
+			return path == installDirX86
+
+		def _getVersion(path: str, field: str):
+			if path == oldSlavePathX86:
+				raise RuntimeError("bad version metadata")
+			self.fail("Current version lookup should not occur when old version lookup fails.")
+
+		with (
+			patch("installer.WritePaths.installDir", installDir),
+			patch(
+				"installer.WritePaths._installDirX86",
+				installDirX86,
+			),
+			patch("installer.os.path.isdir", side_effect=_isdir),
+			patch(
+				"installer.fileUtils.getFileVersionInfo",
+				side_effect=_getVersion,
+			),
+		):
+			self.assertEqual(installer.comparePreviousInstall(), installer.ComparisonState.UNKNOWN)
+
+	def test_unknown_whenCurrentVersionLookupFails(self):
+		installDir = "C:\\Program Files\\NVDA"
+		oldSlavePath = str(pathlib.Path(installDir) / "nvda_slave.exe")
+
+		def _isdir(path: str) -> bool:
+			return path == installDir
+
+		def _getVersion(path: str, field: str):
+			if path == oldSlavePath:
+				return {"FileVersion": "2025.1.0"}
+			if path == "nvda_slave.exe":
+				raise OSError("missing current executable version")
+			self.fail(f"Unexpected path: {path}")
+
+		with (
+			patch("installer.WritePaths.installDir", installDir),
+			patch(
+				"installer.WritePaths._installDirX86",
+				None,
+			),
+			patch("installer.os.path.isdir", side_effect=_isdir),
+			patch(
+				"installer.fileUtils.getFileVersionInfo",
+				side_effect=_getVersion,
+			),
+		):
+			self.assertEqual(installer.comparePreviousInstall(), installer.ComparisonState.UNKNOWN)
+
+	def test_unknown_whenVersionParsingFails(self):
+		installDir = "C:\\Program Files\\NVDA"
+		oldSlavePath = str(pathlib.Path(installDir) / "nvda_slave.exe")
+
+		def _isdir(path: str) -> bool:
+			return path == installDir
+
+		def _getVersion(path: str, field: str):
+			if path == oldSlavePath:
+				return {"FileVersion": None}
+			if path == "nvda_slave.exe":
+				return {"FileVersion": "2025.1.0"}
+			self.fail(f"Unexpected path: {path}")
+
+		with (
+			patch("installer.WritePaths.installDir", installDir),
+			patch(
+				"installer.WritePaths._installDirX86",
+				None,
+			),
+			patch("installer.os.path.isdir", side_effect=_isdir),
+			patch(
+				"installer.fileUtils.getFileVersionInfo",
+				side_effect=_getVersion,
+			),
+		):
+			self.assertEqual(installer.comparePreviousInstall(), installer.ComparisonState.UNKNOWN)
+
+	def test_downgrade_whenPreviousInstallIsNewer(self):
+		installDir = "C:\\Program Files\\NVDA"
+		oldSlavePath = str(pathlib.Path(installDir) / "nvda_slave.exe")
+
+		def _isdir(path: str) -> bool:
+			return path == installDir
+
+		def _getVersion(path: str, field: str):
+			if path == oldSlavePath:
+				return {"FileVersion": "2026.1.0"}
+			if path == "nvda_slave.exe":
+				return {"FileVersion": "2025.1.0"}
+			self.fail(f"Unexpected path: {path}")
+
+		with (
+			patch("installer.WritePaths.installDir", installDir),
+			patch(
+				"installer.WritePaths._installDirX86",
+				None,
+			),
+			patch("installer.os.path.isdir", side_effect=_isdir),
+			patch(
+				"installer.fileUtils.getFileVersionInfo",
+				side_effect=_getVersion,
+			),
+		):
+			self.assertEqual(installer.comparePreviousInstall(), installer.ComparisonState.DOWNGRADE)
+
+	def test_upgrade_whenPreviousInstallIsOlder(self):
+		installDir = "C:\\Program Files\\NVDA"
+		oldSlavePath = str(pathlib.Path(installDir) / "nvda_slave.exe")
+
+		def _isdir(path: str) -> bool:
+			return path == installDir
+
+		def _getVersion(path: str, field: str):
+			if path == oldSlavePath:
+				return {"FileVersion": "2024.4.0"}
+			if path == "nvda_slave.exe":
+				return {"FileVersion": "2025.1.0"}
+			self.fail(f"Unexpected path: {path}")
+
+		with (
+			patch("installer.WritePaths.installDir", installDir),
+			patch(
+				"installer.WritePaths._installDirX86",
+				None,
+			),
+			patch("installer.os.path.isdir", side_effect=_isdir),
+			patch(
+				"installer.fileUtils.getFileVersionInfo",
+				side_effect=_getVersion,
+			),
+		):
+			self.assertEqual(installer.comparePreviousInstall(), installer.ComparisonState.UPGRADE)
+
+	def test_reinstall_whenVersionsAreEqual(self):
+		installDir = "C:\\Program Files\\NVDA"
+		oldSlavePath = str(pathlib.Path(installDir) / "nvda_slave.exe")
+
+		def _isdir(path: str) -> bool:
+			return path == installDir
+
+		def _getVersion(path: str, field: str):
+			if path == oldSlavePath:
+				return {"FileVersion": "2025.1.0"}
+			if path == "nvda_slave.exe":
+				return {"FileVersion": "2025.1.0"}
+			self.fail(f"Unexpected path: {path}")
+
+		with (
+			patch("installer.WritePaths.installDir", installDir),
+			patch(
+				"installer.WritePaths._installDirX86",
+				None,
+			),
+			patch("installer.os.path.isdir", side_effect=_isdir),
+			patch(
+				"installer.fileUtils.getFileVersionInfo",
+				side_effect=_getVersion,
+			),
+		):
+			self.assertEqual(installer.comparePreviousInstall(), installer.ComparisonState.REINSTALL)
+
+	def test_prefersPrimaryInstallDir_whenBothPrimaryAndX86Exist(self):
+		installDir = "C:\\Program Files\\NVDA"
+		installDirX86 = "C:\\Program Files (x86)\\NVDA"
+		oldSlavePath = str(pathlib.Path(installDir) / "nvda_slave.exe")
+		oldSlavePathX86 = str(pathlib.Path(installDirX86) / "nvda_slave.exe")
+
+		def _isdir(path: str) -> bool:
+			return path in (installDir, installDirX86)
+
+		def _getVersion(path: str, field: str):
+			if path == oldSlavePath:
+				return {"FileVersion": "2024.4.0"}
+			if path == oldSlavePathX86:
+				self.fail("x86 install path should not be used when primary install dir exists.")
+			if path == "nvda_slave.exe":
+				return {"FileVersion": "2025.1.0"}
+			self.fail(f"Unexpected path: {path}")
+
+		with (
+			patch("installer.WritePaths.installDir", installDir),
+			patch(
+				"installer.WritePaths._installDirX86",
+				installDirX86,
+			),
+			patch("installer.os.path.isdir", side_effect=_isdir),
+			patch(
+				"installer.fileUtils.getFileVersionInfo",
+				side_effect=_getVersion,
+			),
+		):
+			self.assertEqual(installer.comparePreviousInstall(), installer.ComparisonState.UPGRADE)

--- a/tests/unit/test_installer.py
+++ b/tests/unit/test_installer.py
@@ -9,7 +9,7 @@ import pathlib
 import tempfile
 from typing import NamedTuple
 import unittest
-from unittest.mock import patch
+from unittest.mock import patch, PropertyMock
 
 from parameterized import parameterized
 
@@ -146,13 +146,17 @@ class testFollowerWarning(unittest.TestCase):
 class Test_comparePreviousInstall(unittest.TestCase):
 	def test_freshInstall_whenNoInstallDirsExist(self):
 		with (
-			patch(
-				"installer.WritePaths.installDir",
-				"C:\\Program Files\\NVDA",
+			patch.object(
+				installer.WritePaths.__class__,
+				"installDir",
+				new_callable=PropertyMock,
+				return_value="C:\\Program Files\\NVDA",
 			),
-			patch(
-				"installer.WritePaths._installDirX86",
-				"C:\\Program Files (x86)\\NVDA",
+			patch.object(
+				installer.WritePaths.__class__,
+				"_installDirX86",
+				new_callable=PropertyMock,
+				return_value="C:\\Program Files (x86)\\NVDA",
 			),
 			patch("installer.os.path.isdir", return_value=False),
 			patch("installer.fileUtils.getFileVersionInfo") as getVersionMock,
@@ -174,10 +178,17 @@ class Test_comparePreviousInstall(unittest.TestCase):
 			self.fail("Current version lookup should not occur when old version lookup fails.")
 
 		with (
-			patch("installer.WritePaths.installDir", installDir),
-			patch(
-				"installer.WritePaths._installDirX86",
-				"C:\\Program Files (x86)\\NVDA",
+			patch.object(
+				installer.WritePaths.__class__,
+				"installDir",
+				new_callable=PropertyMock,
+				return_value=installDir,
+			),
+			patch.object(
+				installer.WritePaths.__class__,
+				"_installDirX86",
+				new_callable=PropertyMock,
+				return_value="C:\\Program Files (x86)\\NVDA",
 			),
 			patch("installer.os.path.isdir", side_effect=_isdir),
 			patch(
@@ -201,10 +212,17 @@ class Test_comparePreviousInstall(unittest.TestCase):
 			self.fail("Current version lookup should not occur when old version lookup fails.")
 
 		with (
-			patch("installer.WritePaths.installDir", installDir),
-			patch(
-				"installer.WritePaths._installDirX86",
-				installDirX86,
+			patch.object(
+				installer.WritePaths.__class__,
+				"installDir",
+				new_callable=PropertyMock,
+				return_value=installDir,
+			),
+			patch.object(
+				installer.WritePaths.__class__,
+				"_installDirX86",
+				new_callable=PropertyMock,
+				return_value=installDirX86,
 			),
 			patch("installer.os.path.isdir", side_effect=_isdir),
 			patch(
@@ -229,10 +247,17 @@ class Test_comparePreviousInstall(unittest.TestCase):
 			self.fail(f"Unexpected path: {path}")
 
 		with (
-			patch("installer.WritePaths.installDir", installDir),
-			patch(
-				"installer.WritePaths._installDirX86",
-				None,
+			patch.object(
+				installer.WritePaths.__class__,
+				"installDir",
+				new_callable=PropertyMock,
+				return_value=installDir,
+			),
+			patch.object(
+				installer.WritePaths.__class__,
+				"_installDirX86",
+				new_callable=PropertyMock,
+				return_value=None,
 			),
 			patch("installer.os.path.isdir", side_effect=_isdir),
 			patch(
@@ -257,10 +282,17 @@ class Test_comparePreviousInstall(unittest.TestCase):
 			self.fail(f"Unexpected path: {path}")
 
 		with (
-			patch("installer.WritePaths.installDir", installDir),
-			patch(
-				"installer.WritePaths._installDirX86",
-				None,
+			patch.object(
+				installer.WritePaths.__class__,
+				"installDir",
+				new_callable=PropertyMock,
+				return_value=installDir,
+			),
+			patch.object(
+				installer.WritePaths.__class__,
+				"_installDirX86",
+				new_callable=PropertyMock,
+				return_value=None,
 			),
 			patch("installer.os.path.isdir", side_effect=_isdir),
 			patch(
@@ -285,10 +317,17 @@ class Test_comparePreviousInstall(unittest.TestCase):
 			self.fail(f"Unexpected path: {path}")
 
 		with (
-			patch("installer.WritePaths.installDir", installDir),
-			patch(
-				"installer.WritePaths._installDirX86",
-				None,
+			patch.object(
+				installer.WritePaths.__class__,
+				"installDir",
+				new_callable=PropertyMock,
+				return_value=installDir,
+			),
+			patch.object(
+				installer.WritePaths.__class__,
+				"_installDirX86",
+				new_callable=PropertyMock,
+				return_value=None,
 			),
 			patch("installer.os.path.isdir", side_effect=_isdir),
 			patch(
@@ -313,10 +352,17 @@ class Test_comparePreviousInstall(unittest.TestCase):
 			self.fail(f"Unexpected path: {path}")
 
 		with (
-			patch("installer.WritePaths.installDir", installDir),
-			patch(
-				"installer.WritePaths._installDirX86",
-				None,
+			patch.object(
+				installer.WritePaths.__class__,
+				"installDir",
+				new_callable=PropertyMock,
+				return_value=installDir,
+			),
+			patch.object(
+				installer.WritePaths.__class__,
+				"_installDirX86",
+				new_callable=PropertyMock,
+				return_value=None,
 			),
 			patch("installer.os.path.isdir", side_effect=_isdir),
 			patch(
@@ -341,10 +387,17 @@ class Test_comparePreviousInstall(unittest.TestCase):
 			self.fail(f"Unexpected path: {path}")
 
 		with (
-			patch("installer.WritePaths.installDir", installDir),
-			patch(
-				"installer.WritePaths._installDirX86",
-				None,
+			patch.object(
+				installer.WritePaths.__class__,
+				"installDir",
+				new_callable=PropertyMock,
+				return_value=installDir,
+			),
+			patch.object(
+				installer.WritePaths.__class__,
+				"_installDirX86",
+				new_callable=PropertyMock,
+				return_value=None,
 			),
 			patch("installer.os.path.isdir", side_effect=_isdir),
 			patch(
@@ -373,10 +426,17 @@ class Test_comparePreviousInstall(unittest.TestCase):
 			self.fail(f"Unexpected path: {path}")
 
 		with (
-			patch("installer.WritePaths.installDir", installDir),
-			patch(
-				"installer.WritePaths._installDirX86",
-				installDirX86,
+			patch.object(
+				installer.WritePaths.__class__,
+				"installDir",
+				new_callable=PropertyMock,
+				return_value=installDir,
+			),
+			patch.object(
+				installer.WritePaths.__class__,
+				"_installDirX86",
+				new_callable=PropertyMock,
+				return_value=installDirX86,
 			),
 			patch("installer.os.path.isdir", side_effect=_isdir),
 			patch(

--- a/tests/unit/test_installer.py
+++ b/tests/unit/test_installer.py
@@ -161,7 +161,7 @@ class Test_comparePreviousInstall(unittest.TestCase):
 			patch("installer.os.path.isdir", return_value=False),
 			patch("installer.fileUtils.getFileVersionInfo") as getVersionMock,
 		):
-			result = installer.comparePreviousInstall()
+			result = installer._comparePreviousInstall()
 			self.assertEqual(result, installer.ComparisonState.FRESH_INSTALL)
 			getVersionMock.assert_not_called()
 
@@ -196,7 +196,7 @@ class Test_comparePreviousInstall(unittest.TestCase):
 				side_effect=_getVersion,
 			),
 		):
-			self.assertEqual(installer.comparePreviousInstall(), installer.ComparisonState.UNKNOWN)
+			self.assertEqual(installer._comparePreviousInstall(), installer.ComparisonState.UNKNOWN)
 
 	def test_unknown_whenOldVersionLookupFails_inX86InstallDir(self):
 		installDir = "C:\\Program Files\\NVDA"
@@ -230,7 +230,7 @@ class Test_comparePreviousInstall(unittest.TestCase):
 				side_effect=_getVersion,
 			),
 		):
-			self.assertEqual(installer.comparePreviousInstall(), installer.ComparisonState.UNKNOWN)
+			self.assertEqual(installer._comparePreviousInstall(), installer.ComparisonState.UNKNOWN)
 
 	def test_unknown_whenCurrentVersionLookupFails(self):
 		installDir = "C:\\Program Files\\NVDA"
@@ -265,7 +265,7 @@ class Test_comparePreviousInstall(unittest.TestCase):
 				side_effect=_getVersion,
 			),
 		):
-			self.assertEqual(installer.comparePreviousInstall(), installer.ComparisonState.UNKNOWN)
+			self.assertEqual(installer._comparePreviousInstall(), installer.ComparisonState.UNKNOWN)
 
 	def test_unknown_whenVersionParsingFails(self):
 		installDir = "C:\\Program Files\\NVDA"
@@ -300,7 +300,42 @@ class Test_comparePreviousInstall(unittest.TestCase):
 				side_effect=_getVersion,
 			),
 		):
-			self.assertEqual(installer.comparePreviousInstall(), installer.ComparisonState.UNKNOWN)
+			self.assertEqual(installer._comparePreviousInstall(), installer.ComparisonState.UNKNOWN)
+
+	def test_unknown_whenPreviousVersionContainsPrereleaseTag(self):
+		installDir = "C:\\Program Files\\NVDA"
+		oldSlavePath = str(pathlib.Path(installDir) / "nvda_slave.exe")
+
+		def _isdir(path: str) -> bool:
+			return path == installDir
+
+		def _getVersion(path: str, field: str):
+			if path == oldSlavePath:
+				return {"FileVersion": "2026.1.beta1"}
+			if path == "nvda_slave.exe":
+				return {"FileVersion": "2025.1.0"}
+			self.fail(f"Unexpected path: {path}")
+
+		with (
+			patch.object(
+				installer.WritePaths.__class__,
+				"installDir",
+				new_callable=PropertyMock,
+				return_value=installDir,
+			),
+			patch.object(
+				installer.WritePaths.__class__,
+				"_installDirX86",
+				new_callable=PropertyMock,
+				return_value=None,
+			),
+			patch("installer.os.path.isdir", side_effect=_isdir),
+			patch(
+				"installer.fileUtils.getFileVersionInfo",
+				side_effect=_getVersion,
+			),
+		):
+			self.assertEqual(installer._comparePreviousInstall(), installer.ComparisonState.UNKNOWN)
 
 	def test_downgrade_whenPreviousInstallIsNewer(self):
 		installDir = "C:\\Program Files\\NVDA"
@@ -335,7 +370,7 @@ class Test_comparePreviousInstall(unittest.TestCase):
 				side_effect=_getVersion,
 			),
 		):
-			self.assertEqual(installer.comparePreviousInstall(), installer.ComparisonState.DOWNGRADE)
+			self.assertEqual(installer._comparePreviousInstall(), installer.ComparisonState.DOWNGRADE)
 
 	def test_upgrade_whenPreviousInstallIsOlder(self):
 		installDir = "C:\\Program Files\\NVDA"
@@ -370,7 +405,7 @@ class Test_comparePreviousInstall(unittest.TestCase):
 				side_effect=_getVersion,
 			),
 		):
-			self.assertEqual(installer.comparePreviousInstall(), installer.ComparisonState.UPGRADE)
+			self.assertEqual(installer._comparePreviousInstall(), installer.ComparisonState.UPGRADE)
 
 	def test_reinstall_whenVersionsAreEqual(self):
 		installDir = "C:\\Program Files\\NVDA"
@@ -405,7 +440,7 @@ class Test_comparePreviousInstall(unittest.TestCase):
 				side_effect=_getVersion,
 			),
 		):
-			self.assertEqual(installer.comparePreviousInstall(), installer.ComparisonState.REINSTALL)
+			self.assertEqual(installer._comparePreviousInstall(), installer.ComparisonState.REINSTALL)
 
 	def test_prefersPrimaryInstallDir_whenBothPrimaryAndX86Exist(self):
 		installDir = "C:\\Program Files\\NVDA"
@@ -444,4 +479,4 @@ class Test_comparePreviousInstall(unittest.TestCase):
 				side_effect=_getVersion,
 			),
 		):
-			self.assertEqual(installer.comparePreviousInstall(), installer.ComparisonState.UPGRADE)
+			self.assertEqual(installer._comparePreviousInstall(), installer.ComparisonState.UPGRADE)

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -101,12 +101,16 @@ It currently includes Screen Curtain's settings (previously in the "Vision" cate
   * By default, NVDA doesn't copy any add-ons; you must select any you wish to include. (#12879)
 * Audio ducking is no longer supported for Microsoft Speech API version 4 or 32-bit Microsoft Speech API version 5 voices. (#19432)
 * The NVDA interface is now translated to Cambodian. (#19450)
+* NVDA will no longer enable "Use NVDA during sign-in" by default when installing for the first time. (#19631)
 
 ### Bug Fixes
 
 * Remote Access:
   * Improved user notifications when connecting as the controlled computer fails. (#19103, @hdzrvcc0X74)
   * NVDA will no longer open multiple disconnection confirmation dialogs if the action is triggered repeatedly. (#19442, @Cary-rowen)
+* NVDA installer:
+  * NVDA should now correctly identify downgrades and show the downgrade warning dialog appropriately. (#19631)
+  * NVDA will now retain the "Use NVDA during sign-in" setting and desktop shortcut more consistently. (#19631)
 * Fixed `<` not being escaped in MathML in PDF documents. (#18520, @NSoiffer)
 * When unicode normalization is enabled for speech, navigating by character will again correctly announce combining diacritic characters like acute ( &#x0301; ). (#18722, @LeonarddeR)
 * Fixed cases where NVDA was unable to retrieve information for an application, such as product name, version and architecture. (#18826, @LeonarddeR)
@@ -169,6 +173,7 @@ On ARM64 machines with Windows 11, these ARM64EC libraries are loaded instead of
 * Added `api.fakeNVDAObjectClasses` set and `api.isFakeNVDAObject` function to identify fake NVDAObject instances. (#19168, @hwf1324)
 * NVDA no longer includes the Microsoft Universal C Runtime. (#19508)
 * `synthDriverHandler.setSynth` and `synthDriverHandler.findAndSetNextSynth` now attempt to find fallback synthesizers starting from the start of `defaultSynthPriorityList`, rather than starting immediately after `name` or `currentSynthName`, respectively. (#19603)
+* `gui.installerGui.doInstall` parameter `startOnLogon` default value is now False not True. (#19631)
 
 #### API Breaking Changes
 
@@ -334,6 +339,7 @@ Use `INPUT_TYPE.MOUSE`, `INPUT_TYPE.KEYBOARD`, `KEYEVENTF.KEYUP` and `KEYEVENTF.
 Access to these symbols via `updateCheck` is deprecated. (#18956)
 * `textInfos.OffsetsTextInfo.allowMoveToOffsetPastEnd` is deprecated.
 Use the `OffsetsTextInfo.allowMoveToUnitOffsetPastEnd` method instead. (#19152, @LeonarddeR)
+* `installer.comparePreviousInstall` is deprecated with no planned replacement. (#19631)
 
 <!-- Beyond this point, Markdown should not be linted, as we don't modify old change log sections. -->
 <!-- markdownlint-disable -->

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -173,7 +173,7 @@ On ARM64 machines with Windows 11, these ARM64EC libraries are loaded instead of
 * Added `api.fakeNVDAObjectClasses` set and `api.isFakeNVDAObject` function to identify fake NVDAObject instances. (#19168, @hwf1324)
 * NVDA no longer includes the Microsoft Universal C Runtime. (#19508)
 * `synthDriverHandler.setSynth` and `synthDriverHandler.findAndSetNextSynth` now attempt to find fallback synthesizers starting from the start of `defaultSynthPriorityList`, rather than starting immediately after `name` or `currentSynthName`, respectively. (#19603)
-* `gui.installerGui.doInstall` parameter `startOnLogon` default value is now False not True. (#19631)
+* `gui.installerGui.doInstall` parameter `startOnLogon` default value is now `False`. (#19631)
 
 #### API Breaking Changes
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -109,7 +109,7 @@ It currently includes Screen Curtain's settings (previously in the "Vision" cate
   * Improved user notifications when connecting as the controlled computer fails. (#19103, @hdzrvcc0X74)
   * NVDA will no longer open multiple disconnection confirmation dialogs if the action is triggered repeatedly. (#19442, @Cary-rowen)
 * NVDA installer:
-  * NVDA should now correctly identify downgrades and show the downgrade warning dialog appropriately. (#19631)
+  * NVDA should now correctly identify downgrades and show the downgrade warning dialog appropriately, including for portable copies. (#19631, #18291)
   * NVDA will now retain the "Use NVDA during sign-in" setting and desktop shortcut more consistently. (#19631)
 * Fixed `<` not being escaped in MathML in PDF documents. (#18520, @NSoiffer)
 * When unicode normalization is enabled for speech, navigating by character will again correctly announce combining diacritic characters like acute ( &#x0301; ). (#18722, @LeonarddeR)


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
May fix #19600
Fixes #18291

### Summary of the issue:

- NVDA would identify a downgrade if the old installed copy files were created before/after the new installer. This should instead compare the versions of the NVDA files. By checking timestamps, an alpha build of 2026.2 created before 2026.1 was released would be identified as a downgrade incorrectly.
- NVDA would check "Use NVDA during sign-in" by default when performing a fresh install. This might be considered a security issue, and should be explicitly opt-in. 
- NVDA would always check "Use NVDA during sign-in" by default when not performing a fresh install, but downgrade/upgrade status could not be determined. i.e. we know that a previous copy exists, but we don't know the time difference of the files, so we don't check the registry. instead we should check the registry if we know a previous copy exists.
NVDA would do the same for creating the desktop shortcut.
- NVDA would not warn about downgrading a portable copy

### Description of user facing changes:

- NVDA will no longer check the "Use NVDA during sign-in" by default when performing a fresh install
- NVDA will now check the registry to see if "Use NVDA during sign-in" is set even if we are unsure if the previous install makes this an upgrade or downgrade.
- NVDA will now check to see if we should re-create the desktop shortcut, even if we are unsure if the previous install makes this an upgrade or downgrade.
- NVDA should now correctly identify downgrades and show the Downgrade warning dialog appropriately including for portable copies

### Description of developer facing changes:

- `installer._comparePreviousInstall` now returns a `ComparisonState` enum
- `gui.installerGui.doInstall` parameter `startOnLogon` default value is now False not True

### Description of development approach:
This pull request refactors the installer logic to improve version comparison and installation flow, primarily by introducing a new `ComparisonState` enum for clearer handling of installation states. 

* Introduced a `ComparisonState` enum in `installer.py` to represent installation comparison results more clearly (e.g., `FRESH_INSTALL`, `UPGRADE`, `REINSTALL`, `DOWNGRADE`, `UNKNOWN`), replacing the previous integer/None return values. The `comparePreviousInstall` function now returns this enum and uses file version information for comparison instead of file modification times.
* Updated `installerGui.py` to use the new `ComparisonState` enum throughout the installation logic, ensuring correct handling of fresh installs, upgrades, and downgrades, and improving the logic for desktop shortcut creation and "start on logon" options. [[1]](diffhunk://#diff-267bed251f0a5fbfde3025ae0fe34def5df794d66d88e3812c9a9e62565000abL183-R191) [[2]](diffhunk://#diff-267bed251f0a5fbfde3025ae0fe34def5df794d66d88e3812c9a9e62565000abL265-R266) [[3]](diffhunk://#diff-267bed251f0a5fbfde3025ae0fe34def5df794d66d88e3812c9a9e62565000abL397-R406) [[4]](diffhunk://#diff-267bed251f0a5fbfde3025ae0fe34def5df794d66d88e3812c9a9e62565000abR19)


### Testing strategy:

- [x] Test updating to this PR
- [x] Test downgrading to this PR
- [x] Test sidegrade (reinstall) with this PR
- [x] Test unknown upgrade/downgrade with this PR (modify file version)
- [x] Test silent install from CLI variations 
- [x] Test fresh install
- [x] Test upgrading/downgrading portable copies

### Known issues with pull request:

The backwards compatibility here might not be correct. Callers may need to call `.value` on the return of `comparePreviousInstall` to have the same behaviour. We may either need to make an API breaking change, a deprecation layer, or create a new function entirely and keep the old broken one.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
