### PR TITLE
fix git attributes eol syntax

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,8 +4,7 @@
 # https://mail.gnome.org/archives/kupfer-list/2010-June/msg00002.html
 *.po filter=cleanpo
 
-eol=lf
-*	text=auto
+* text=auto eol=lf
 
 # Files which should not be renormalized
 *.dic   -text


### PR DESCRIPTION
This pull request makes a minor update to the `.gitattributes` file, clarifying the line ending and text attribute settings for all files. 