### PR TITLE
restore screen curtain state on settings cancel

### DIFF
--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -5952,9 +5952,8 @@ class PrivacyAndSecuritySettingsPanel(SettingsPanel):
 				label=_("Make screen black (immediate effect)"),
 			),
 		)
-		self._screenCurtainEnabledCheckbox.SetValue(
-			screenCurtain.screenCurtain is not None and screenCurtain.screenCurtain.enabled,
-		)
+		self._wasScreenCurtainEnabledOnInit = screenCurtain.screenCurtain is not None and screenCurtain.screenCurtain.enabled
+		self._screenCurtainEnabledCheckbox.SetValue(self._wasScreenCurtainEnabledOnInit)
 		self._screenCurtainEnabledCheckbox.Bind(wx.EVT_CHECKBOX, self._ensureScreenCurtainEnableState)
 		self._screenCurtainEnabledCheckbox.Enable(screenCurtain.screenCurtain is not None)
 		self.bindHelpEvent("ScreenCurtainEnable", self._screenCurtainEnabledCheckbox)
@@ -6016,6 +6015,18 @@ class PrivacyAndSecuritySettingsPanel(SettingsPanel):
 		if not updateCheck:
 			self._allowUsageStatsCheckBox.Value = False
 			self._allowUsageStatsCheckBox.Disable()
+
+	def onCancel(self, evt: wx.CommandEvent):
+		# Restore the screen curtain enabled state to what it was when the dialog was opened, in case the user enabled or disabled it without saving.
+		if (
+			screenCurtain.screenCurtain is not None
+			and self._screenCurtainEnabledCheckbox.GetValue() != self._wasScreenCurtainEnabledOnInit
+		):
+			if screenCurtain.screenCurtain.enabled:
+				screenCurtain.screenCurtain.disable()
+			else:
+				screenCurtain.screenCurtain.enable()
+		super().onCancel(evt)
 
 	def onSave(self):
 		# We intentionally don't save whether the screen curtain is enabled here,

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -5952,7 +5952,9 @@ class PrivacyAndSecuritySettingsPanel(SettingsPanel):
 				label=_("Make screen black (immediate effect)"),
 			),
 		)
-		self._wasScreenCurtainEnabledOnInit = screenCurtain.screenCurtain is not None and screenCurtain.screenCurtain.enabled
+		self._wasScreenCurtainEnabledOnInit = (
+			screenCurtain.screenCurtain is not None and screenCurtain.screenCurtain.enabled
+		)
 		self._screenCurtainEnabledCheckbox.SetValue(self._wasScreenCurtainEnabledOnInit)
 		self._screenCurtainEnabledCheckbox.Bind(wx.EVT_CHECKBOX, self._ensureScreenCurtainEnableState)
 		self._screenCurtainEnabledCheckbox.Enable(screenCurtain.screenCurtain is not None)

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -6022,7 +6022,7 @@ class PrivacyAndSecuritySettingsPanel(SettingsPanel):
 		# Restore the screen curtain enabled state to what it was when the dialog was opened, in case the user enabled or disabled it without saving.
 		if (
 			screenCurtain.screenCurtain is not None
-			and self._screenCurtainEnabledCheckbox.GetValue() != self._wasScreenCurtainEnabledOnInit
+			and screenCurtain.screenCurtain.enabled != self._wasScreenCurtainEnabledOnInit
 		):
 			if self._wasScreenCurtainEnabledOnInit:
 				screenCurtain.screenCurtain.enable()

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -5952,12 +5952,11 @@ class PrivacyAndSecuritySettingsPanel(SettingsPanel):
 				label=_("Make screen black (immediate effect)"),
 			),
 		)
-		self._wasScreenCurtainEnabledOnInit = (
-			screenCurtain.screenCurtain is not None and screenCurtain.screenCurtain.enabled
-		)
+		isScreenCurtainAvailable = screenCurtain.screenCurtain is not None
+		self._wasScreenCurtainEnabledOnInit = isScreenCurtainAvailable and screenCurtain.screenCurtain.enabled
 		self._screenCurtainEnabledCheckbox.SetValue(self._wasScreenCurtainEnabledOnInit)
 		self._screenCurtainEnabledCheckbox.Bind(wx.EVT_CHECKBOX, self._ensureScreenCurtainEnableState)
-		self._screenCurtainEnabledCheckbox.Enable(screenCurtain.screenCurtain is not None)
+		self._screenCurtainEnabledCheckbox.Enable(isScreenCurtainAvailable)
 		self.bindHelpEvent("ScreenCurtainEnable", self._screenCurtainEnabledCheckbox)
 
 		self._screenCurtainWarnOnLoadCheckbox = screenCurtainGroup.addItem(

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -6018,17 +6018,17 @@ class PrivacyAndSecuritySettingsPanel(SettingsPanel):
 			self._allowUsageStatsCheckBox.Value = False
 			self._allowUsageStatsCheckBox.Disable()
 
-	def onCancel(self, evt: wx.CommandEvent):
+	def onDiscard(self):
 		# Restore the screen curtain enabled state to what it was when the dialog was opened, in case the user enabled or disabled it without saving.
 		if (
 			screenCurtain.screenCurtain is not None
 			and self._screenCurtainEnabledCheckbox.GetValue() != self._wasScreenCurtainEnabledOnInit
 		):
-			if screenCurtain.screenCurtain.enabled:
-				screenCurtain.screenCurtain.disable()
-			else:
+			if self._wasScreenCurtainEnabledOnInit:
 				screenCurtain.screenCurtain.enable()
-		super().onCancel(evt)
+			else:
+				screenCurtain.screenCurtain.disable()
+		super().onDiscard()
 
 	def onSave(self):
 		# We intentionally don't save whether the screen curtain is enabled here,

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -5953,8 +5953,13 @@ class PrivacyAndSecuritySettingsPanel(SettingsPanel):
 			),
 		)
 		isScreenCurtainAvailable = screenCurtain.screenCurtain is not None
-		self._wasScreenCurtainEnabledOnInit = isScreenCurtainAvailable and screenCurtain.screenCurtain.enabled
-		self._screenCurtainEnabledCheckbox.SetValue(self._wasScreenCurtainEnabledOnInit)
+		if isScreenCurtainAvailable:
+			self._cachedScreenCurtainConfigEnabled = screenCurtain.screenCurtain.settings["enabled"]
+			self._cachedScreenCurtainEnabled = screenCurtain.screenCurtain.enabled
+		else:
+			self._cachedScreenCurtainConfigEnabled = self._screenCurtainConfig["enabled"]
+			self._cachedScreenCurtainEnabled = False
+		self._screenCurtainEnabledCheckbox.SetValue(self._cachedScreenCurtainEnabled)
 		self._screenCurtainEnabledCheckbox.Bind(wx.EVT_CHECKBOX, self._ensureScreenCurtainEnableState)
 		self._screenCurtainEnabledCheckbox.Enable(isScreenCurtainAvailable)
 		self.bindHelpEvent("ScreenCurtainEnable", self._screenCurtainEnabledCheckbox)
@@ -6018,15 +6023,19 @@ class PrivacyAndSecuritySettingsPanel(SettingsPanel):
 			self._allowUsageStatsCheckBox.Disable()
 
 	def onDiscard(self):
-		# Restore the screen curtain enabled state to what it was when the dialog was opened, in case the user enabled or disabled it without saving.
-		if (
-			screenCurtain.screenCurtain is not None
-			and screenCurtain.screenCurtain.enabled != self._wasScreenCurtainEnabledOnInit
-		):
-			if self._wasScreenCurtainEnabledOnInit:
-				screenCurtain.screenCurtain.enable()
-			else:
-				screenCurtain.screenCurtain.disable()
+		# Restore screen curtain state and setting to the most recently saved baseline,
+		# in case the user enabled or disabled it without saving.
+		if screenCurtain.screenCurtain is not None:
+			if screenCurtain.screenCurtain.enabled != self._cachedScreenCurtainEnabled:
+				if self._cachedScreenCurtainEnabled:
+					screenCurtain.screenCurtain.enable(persist=self._cachedScreenCurtainConfigEnabled)
+				else:
+					screenCurtain.screenCurtain.disable(persist=not self._cachedScreenCurtainConfigEnabled)
+			if (
+				screenCurtain.screenCurtain.settings["enabled"]
+				!= self._cachedScreenCurtainConfigEnabled
+			):
+				screenCurtain.screenCurtain.settings["enabled"] = self._cachedScreenCurtainConfigEnabled
 		super().onDiscard()
 
 	def onSave(self):
@@ -6046,6 +6055,10 @@ class PrivacyAndSecuritySettingsPanel(SettingsPanel):
 		if updateCheck:
 			config.conf["update"]["allowUsageStats"] = self._allowUsageStatsCheckBox.IsChecked()
 			# updateCheck queries this value whenever checking for updates, so there's no need to restart it
+
+		if screenCurtain.screenCurtain is not None:
+			self._cachedScreenCurtainConfigEnabled = screenCurtain.screenCurtain.settings["enabled"]
+			self._cachedScreenCurtainEnabled = screenCurtain.screenCurtain.enabled
 
 	def _ocrActive(self) -> bool:
 		"""

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -6031,10 +6031,7 @@ class PrivacyAndSecuritySettingsPanel(SettingsPanel):
 					screenCurtain.screenCurtain.enable(persist=self._cachedScreenCurtainConfigEnabled)
 				else:
 					screenCurtain.screenCurtain.disable(persist=not self._cachedScreenCurtainConfigEnabled)
-			if (
-				screenCurtain.screenCurtain.settings["enabled"]
-				!= self._cachedScreenCurtainConfigEnabled
-			):
+			if screenCurtain.screenCurtain.settings["enabled"] != self._cachedScreenCurtainConfigEnabled:
 				screenCurtain.screenCurtain.settings["enabled"] = self._cachedScreenCurtainConfigEnabled
 		super().onDiscard()
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Fixes #19642

### Summary of the issue:
The state of screen curtain was not restored when cancelling from the settings dialog
### Description of user facing changes:
The state of screen curtain should be restored when cancelling from the settings dialog

### Description of developer facing changes:
none
### Description of development approach:
Store the state of screen curtain when the settings load.
Restore that state on cancellation.

### Testing strategy:
Test if the state of screen curtain is restored when cancelling from the settings dialog.

Tested a combination of applying, saving and escaping without applying. Ensured config and state of screen curtain was retained correct;y
### Known issues with pull request:

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
