### PR TITLE
Save and restore speech rate in espeak

### DIFF
--- a/source/synthDrivers/espeak.py
+++ b/source/synthDrivers/espeak.py
@@ -379,7 +379,11 @@ class SynthDriver(SynthDriver):
 			textList.append("</prosody>")
 		text = "".join(textList)
 		_espeak.speak(text)
-		self._set_rate(self._rate)
+		# If self.rate is not the same as self._rate, that means
+		# the rate has been changed without calling _set_rate
+		# (this can happen due to a bug in eSpeak's handling of SSML).
+		if self.rate != self._rate:
+			self.rate = self._rate
 
 	def cancel(self):
 		_espeak.stop()

--- a/source/synthDrivers/espeak.py
+++ b/source/synthDrivers/espeak.py
@@ -379,6 +379,7 @@ class SynthDriver(SynthDriver):
 			textList.append("</prosody>")
 		text = "".join(textList)
 		_espeak.speak(text)
+		self._set_rate(self._rate)
 
 	def cancel(self):
 		_espeak.stop()
@@ -387,6 +388,7 @@ class SynthDriver(SynthDriver):
 		_espeak.pause(switch)
 
 	_rateBoost = False
+	_rate: int = 0
 	RATE_BOOST_MULTIPLIER = 3
 
 	def _get_rateBoost(self):
@@ -406,6 +408,7 @@ class SynthDriver(SynthDriver):
 		return self._paramToPercent(val, _espeak.minRate, _espeak.maxRate)
 
 	def _set_rate(self, rate):
+		self._rate = rate
 		val = self._percentToParam(rate, _espeak.minRate, _espeak.maxRate)
 		if self._rateBoost:
 			val = int(val * self.RATE_BOOST_MULTIPLIER)

--- a/source/synthDrivers/espeak.py
+++ b/source/synthDrivers/espeak.py
@@ -388,7 +388,7 @@ class SynthDriver(SynthDriver):
 		_espeak.pause(switch)
 
 	_rateBoost = False
-	_rate: int = 0
+	_rate: int
 	RATE_BOOST_MULTIPLIER = 3
 
 	def _get_rateBoost(self):


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:

Fixes #19660
Fixes #15221
### Summary of the issue:

When using eSpeak with the rate set to any value less than 100% in NVDA's math settings, the original speech rate was not being restored after reading math content. 

### Description of user facing changes:

After navigating away from math content while using eSpeak, the original (non-math) speech rate is restored.

### Description of developer facing changes:

A new attribute `_rate` was added to the `SynthDriver` class in `synthDrivers/espeak.py`. This value is updated whenever `_set_rate` is called (but not when eSpeak's rate is changed through SSML), so it will always reflect the original speech rate before applying the possibly slower math rate. In the `speak` method, a call to `_set_rate(_rate)` was added so that the original rate is restored. 

### Description of development approach:

### Testing strategy:

Tested manually by reading webpages containing MathML in Chrome.

### Known issues with pull request:

No known issues.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [ ] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [ ] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [ ] API is compatible with existing add-ons.
- [ ] Security precautions taken.
