### PR TITLE
Temporarily suspend audio ducking when a 32 bit synthDriver is in use

### DIFF
--- a/source/_bridge/components/proxies/synthDriver.py
+++ b/source/_bridge/components/proxies/synthDriver.py
@@ -8,6 +8,7 @@ import json
 import weakref
 import typing
 from collections import OrderedDict
+import audioDucking
 from logHandler import log
 from _bridge.base import Proxy
 from autoSettingsUtils.driverSetting import DriverSetting, NumericDriverSetting, BooleanDriverSetting
@@ -38,9 +39,14 @@ if typing.TYPE_CHECKING:
 class SynthDriverProxy(Proxy, SynthDriver):
 	"""Wraps a remote SynthDriverService, providing the same interface as a local SynthDriver."""
 
+	_audioDuckingSuspender: audioDucking._AudioDuckingSuspender | None = None
+
 	def __init__(self, service: SynthDriverService):
 		log.debug(f"Creating SynthDriverProxy instance for remote synth driver '{self.name}'")
 		super().__init__(service)
+		if audioDucking.isAudioDuckingSupported():
+			# Proxied synthDrivers cannot currently support audio ducking, so we create an _AudioDuckingSuspender to ensure that audio ducking is suspended while any proxied synth driver exists.
+			self._audioDuckingSuspender = audioDucking._AudioDuckingSuspender()
 		selfRef = weakref.ref(self)
 		for notification in self.supportedNotifications:
 			if notification is synthIndexReached:

--- a/source/_bridge/components/proxies/synthDriver.py
+++ b/source/_bridge/components/proxies/synthDriver.py
@@ -45,7 +45,10 @@ class SynthDriverProxy(Proxy, SynthDriver):
 		log.debug(f"Creating SynthDriverProxy instance for remote synth driver '{self.name}'")
 		super().__init__(service)
 		if audioDucking.isAudioDuckingSupported():
-			# Proxied synthDrivers cannot currently support audio ducking, so we create an _AudioDuckingSuspender to ensure that audio ducking is suspended while any proxied synth driver exists.
+			# Proxied synthDrivers cannot currently support audio ducking because they produce audio directly
+			# in their own process, and NVDA cannot correctly duck this external audio. Therefore, we create
+			# an _AudioDuckingSuspender to ensure that audio ducking is suspended while any proxied synth
+			# driver exists.
 			self._audioDuckingSuspender = audioDucking._AudioDuckingSuspender()
 		selfRef = weakref.ref(self)
 		for notification in self.supportedNotifications:

--- a/source/audioDucking.py
+++ b/source/audioDucking.py
@@ -282,7 +282,7 @@ class _AudioDuckingSuspender:
 			raise RuntimeError("audio ducking not supported")
 		global _audioDuckingSuspenderRefCount
 		with _audioDuckingSuspenderlock:
-			if _audioDuckingSuspenderRefCount== 0:
+			if _audioDuckingSuspenderRefCount == 0:
 				setAudioDuckingMode(AudioDuckingMode.NONE)
 			_audioDuckingSuspenderRefCount += 1
 			if _isDebug():
@@ -293,7 +293,9 @@ class _AudioDuckingSuspender:
 		with _audioDuckingSuspenderlock:
 			_audioDuckingSuspenderRefCount -= 1
 			if _isDebug():
-				log.debug(f"audio ducking suspender ref count decreased, count={_audioDuckingSuspenderRefCount}")
+				log.debug(
+					f"audio ducking suspender ref count decreased, count={_audioDuckingSuspenderRefCount}"
+				)
 			if _audioDuckingSuspenderRefCount == 0:
 				setAudioDuckingMode(config.conf["audio"]["audioDuckingMode"])
 

--- a/source/audioDucking.py
+++ b/source/audioDucking.py
@@ -272,7 +272,7 @@ _audioDuckingSuspenderRefCount: int = 0
 _audioDuckingSuspenderLock = threading.Lock()
 
 
-class _AudioDuckingSuspender:
+class _AudioDuckingSuspender: # pyright: ignore[reportUnusedClass]
 	"""Create one of these objects to temporarily suspend audio ducking.
 	If this object is deleted and no other _AudioDuckingSuspender objects exist, audio ducking will be re-enabled.
 	"""

--- a/source/audioDucking.py
+++ b/source/audioDucking.py
@@ -294,7 +294,7 @@ class _AudioDuckingSuspender:
 			_audioDuckingSuspenderRefCount -= 1
 			if _isDebug():
 				log.debug(
-					f"Audio ducking suspender ref count decreased, count={_audioDuckingSuspenderRefCount}"
+					f"Audio ducking suspender ref count decreased, count={_audioDuckingSuspenderRefCount}",
 				)
 			if _audioDuckingSuspenderRefCount == 0:
 				try:
@@ -303,8 +303,10 @@ class _AudioDuckingSuspender:
 					# Avoid raising from __del__; just log the error in debug builds.
 					if _isDebug():
 						log.exception(
-							"Failed to restore audio ducking mode during _AudioDuckingSuspender cleanup"
+							"Failed to restore audio ducking mode during _AudioDuckingSuspender cleanup",
 						)
+
+
 def _isAudioDuckingSuspended() -> bool:
 	with _audioDuckingSuspenderlock:
 		return _audioDuckingSuspenderRefCount > 0

--- a/source/audioDucking.py
+++ b/source/audioDucking.py
@@ -281,7 +281,7 @@ class _AudioDuckingSuspender:
 		if not isAudioDuckingSupported():
 			raise RuntimeError("audio ducking not supported")
 		global _audioDuckingSuspenderRefCount
-		with _audioDuckingSuspenderlock:
+		with _audioDuckingSuspenderLock:
 			if _audioDuckingSuspenderRefCount == 0:
 				setAudioDuckingMode(AudioDuckingMode.NONE)
 			_audioDuckingSuspenderRefCount += 1
@@ -290,7 +290,7 @@ class _AudioDuckingSuspender:
 
 	def __del__(self):
 		global _audioDuckingSuspenderRefCount
-		with _audioDuckingSuspenderlock:
+		with _audioDuckingSuspenderLock:
 			_audioDuckingSuspenderRefCount -= 1
 			if _isDebug():
 				log.debug(
@@ -308,5 +308,5 @@ class _AudioDuckingSuspender:
 
 
 def _isAudioDuckingSuspended() -> bool:
-	with _audioDuckingSuspenderlock:
+	with _audioDuckingSuspenderLock:
 		return _audioDuckingSuspenderRefCount > 0

--- a/source/audioDucking.py
+++ b/source/audioDucking.py
@@ -272,7 +272,7 @@ _audioDuckingSuspenderRefCount: int = 0
 _audioDuckingSuspenderLock = threading.Lock()
 
 
-class _AudioDuckingSuspender: # pyright: ignore[reportUnusedClass]
+class _AudioDuckingSuspender:  # pyright: ignore[reportUnusedClass]
 	"""Create one of these objects to temporarily suspend audio ducking.
 	If this object is deleted and no other _AudioDuckingSuspender objects exist, audio ducking will be re-enabled.
 	"""

--- a/source/audioDucking.py
+++ b/source/audioDucking.py
@@ -269,7 +269,7 @@ class AudioDucker(object):
 
 
 _audioDuckingSuspenderRefCount: int = 0
-_audioDuckingSuspenderlock = threading.Lock()
+_audioDuckingSuspenderLock = threading.Lock()
 
 
 class _AudioDuckingSuspender:
@@ -294,12 +294,17 @@ class _AudioDuckingSuspender:
 			_audioDuckingSuspenderRefCount -= 1
 			if _isDebug():
 				log.debug(
-					f"audio ducking suspender ref count decreased, count={_audioDuckingSuspenderRefCount}"
+					f"Audio ducking suspender ref count decreased, count={_audioDuckingSuspenderRefCount}"
 				)
 			if _audioDuckingSuspenderRefCount == 0:
-				setAudioDuckingMode(config.conf["audio"]["audioDuckingMode"])
-
-
+				try:
+					setAudioDuckingMode(config.conf["audio"]["audioDuckingMode"])
+				except Exception:
+					# Avoid raising from __del__; just log the error in debug builds.
+					if _isDebug():
+						log.exception(
+							"Failed to restore audio ducking mode during _AudioDuckingSuspender cleanup"
+						)
 def _isAudioDuckingSuspended() -> bool:
 	with _audioDuckingSuspenderlock:
 		return _audioDuckingSuspenderRefCount > 0

--- a/source/audioDucking.py
+++ b/source/audioDucking.py
@@ -266,3 +266,38 @@ class AudioDucker(object):
 			_unensureDucked()
 			winBindings.kernel32.SetEvent(self._disabledEvent)
 			return True
+
+
+_audioDuckingSuspenderRefCount: int = 0
+_audioDuckingSuspenderlock = threading.Lock()
+
+
+class _AudioDuckingSuspender:
+	"""Create one of these objects to temporarily suspend audio ducking.
+	If this object is deleted and no other _AudioDuckingSuspender objects exist, audio ducking will be re-enabled.
+	"""
+
+	def __init__(self):
+		if not isAudioDuckingSupported():
+			raise RuntimeError("audio ducking not supported")
+		global _audioDuckingSuspenderRefCount
+		with _audioDuckingSuspenderlock:
+			if _audioDuckingSuspenderRefCount== 0:
+				setAudioDuckingMode(AudioDuckingMode.NONE)
+			_audioDuckingSuspenderRefCount += 1
+			if _isDebug():
+				log.debug(f"Audio ducking suspended, count={_audioDuckingSuspenderRefCount}")
+
+	def __del__(self):
+		global _audioDuckingSuspenderRefCount
+		with _audioDuckingSuspenderlock:
+			_audioDuckingSuspenderRefCount -= 1
+			if _isDebug():
+				log.debug(f"audio ducking suspender ref count decreased, count={_audioDuckingSuspenderRefCount}")
+			if _audioDuckingSuspenderRefCount == 0:
+				setAudioDuckingMode(config.conf["audio"]["audioDuckingMode"])
+
+
+def _isAudioDuckingSuspended() -> bool:
+	with _audioDuckingSuspenderlock:
+		return _audioDuckingSuspenderRefCount > 0

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -192,10 +192,7 @@ class GlobalCommands(ScriptableObject):
 		gesture="kb:NVDA+shift+d",
 	)
 	def script_cycleAudioDuckingMode(self, gesture):
-		if (
-			not audioDucking.isAudioDuckingSupported()
-			or audioDucking._isAudioDuckingSuspended()
-		):
+		if not audioDucking.isAudioDuckingSupported() or audioDucking._isAudioDuckingSuspended():
 			# Translators: a message when audio ducking is not supported on this machine
 			ui.message(_("Audio ducking not supported"))
 			return

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -192,7 +192,10 @@ class GlobalCommands(ScriptableObject):
 		gesture="kb:NVDA+shift+d",
 	)
 	def script_cycleAudioDuckingMode(self, gesture):
-		if not audioDucking.isAudioDuckingSupported():
+		if (
+			not audioDucking.isAudioDuckingSupported()
+			or audioDucking._isAudioDuckingSuspended()
+		):
 			# Translators: a message when audio ducking is not supported on this machine
 			ui.message(_("Audio ducking not supported"))
 			return

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -3530,10 +3530,7 @@ class AudioPanel(SettingsPanel):
 		self.bindHelpEvent("SelectSynthesizerDuckingMode", self.duckingList)
 		index = config.conf["audio"]["audioDuckingMode"]
 		self.duckingList.SetSelection(index)
-		if (
-			not audioDucking.isAudioDuckingSupported()
-			or audioDucking._isAudioDuckingSuspended()
-		):
+		if not audioDucking.isAudioDuckingSupported() or audioDucking._isAudioDuckingSuspended():
 			self.duckingList.Disable()
 
 		# Translators: This is the label for a checkbox control in the

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -3530,7 +3530,10 @@ class AudioPanel(SettingsPanel):
 		self.bindHelpEvent("SelectSynthesizerDuckingMode", self.duckingList)
 		index = config.conf["audio"]["audioDuckingMode"]
 		self.duckingList.SetSelection(index)
-		if not audioDucking.isAudioDuckingSupported():
+		if (
+			not audioDucking.isAudioDuckingSupported()
+			or audioDucking._isAudioDuckingSuspended()
+		):
 			self.duckingList.Disable()
 
 		# Translators: This is the label for a checkbox control in the


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
<!-- Use Closes/Fixes/Resolves #xxx to link this PR to the issue it is responding to. -->
Partial fix for #19618

### Summary of the issue:
As 32 bit sapi synthDrivers introduced in pr #19432 produce audio directly in their own process, NVDA currently cannot correctly duck audio when they are in use. Specifically, if NVDA is set to always duck, the audio from these synths is ducked along with other external audio. And if set to duck for speech and sounds, their audio does not cause ducking, and any NvDA sound that does, ducks their audio.
The correct approach to fix this for the long-term is to broker all 32 bit audio through NVDA, rather than it being played directly by the external process. See pr #19577. But until then, we should at least consider tempoarily disabling audio ducking while one of these synthDrivers is in use, so that its audio is not inappropriately ducked.
 
### Description of user facing changes:

### Description of developer facing changes:

### Description of development approach:
* Added a new private `_AudioDuckingSuspender` class to `audioDucking` which when at least one instance exists, temporarily suspends audio ducking, and disallows changing the current audio ducking setting via the gesture or GUI setting. When all instances are deleted, then audio ducking is restored back to the state it was before  one or more instances were created.
* `_bridge`'s `SynthDriverProxy` class when instantiated now creates an instance of `_AudioDuckingsuspender` and holds it on the SynthDriverProxy instance, thus causing audio ducking to be temporarily disabled while this synthDriver is in use.
 
### Testing strategy:
With a copy of NVDA that supports audio ducking:
* Using eSpeak, set audio ducking via the gesture to always duck. Confirm that audio stays ducked.
* Choose the sapi 32 bit synth from the Select Synthesizer dialog. Confirm that audio is no longer ducked. 
* Try to cycle through audio ducking modes with `NVDA+shift+d`. Confirm that NvDA reports that audio ducking is not supported.
* Go to the audio pannel in the NvDA settings dialog. Confirm that the Audio ducking mode control is disabled.
* Choose eSpeak from the Selected synthesizer dialog. Confirm that audio is again ducked.
* Try to cycle through the audio ducking modes with the gesture. Confirm that this works.
* Confirm that the audio ducking mode in the Audio panel of the NvDA settings dialog is no longer disabled.

### Known issues with pull request:
* This is a temporary partial fix that just ensures that audio ducking is correctly disabled. The full fix is to broker audio and again fully support audio ducking. PR #19432.
* An alternative would be to grant the 32 bit synthDriver runtime process UIAccess and build audio ducking directly into it. However, adding a second process with UIAccess would greatly increase our possible attack surface, and is not moving in the direction of a secure add-on runtime.
 

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
