### PR TITLE
Improve error message when absolute path is not used

### DIFF
--- a/source/gui/installerGui.py
+++ b/source/gui/installerGui.py
@@ -640,7 +640,7 @@ class PortableCreaterDialog(
 					# Translators: The message displayed when the user has not specified an absolute destination directory
 					# in the Create Portable NVDA dialog.
 					"Please specify the absolute path where the portable copy should be created. "
-					"It may include system variables (%temp%, %homepath%, etc.). ",
+					"It may include system variables (%temp%, %homepath%, etc.). "
 					"Current path: {path}. ",
 				).format(path=expandedPortableDirectory),
 				# Translators: The message title displayed when the user has not specified an absolute

--- a/source/gui/installerGui.py
+++ b/source/gui/installerGui.py
@@ -640,8 +640,9 @@ class PortableCreaterDialog(
 					# Translators: The message displayed when the user has not specified an absolute destination directory
 					# in the Create Portable NVDA dialog.
 					"Please specify the absolute path where the portable copy should be created. "
-					"It may include system variables (%temp%, %homepath%, etc.).",
-				),
+					"It may include system variables (%temp%, %homepath%, etc.). ",
+					"Current path: {path}. ",
+				).format(path=expandedPortableDirectory),
 				# Translators: The message title displayed when the user has not specified an absolute
 				# destination directory in the Create Portable NVDA dialog.
 				_("Error"),

--- a/source/gui/installerGui.py
+++ b/source/gui/installerGui.py
@@ -640,7 +640,7 @@ class PortableCreaterDialog(
 					# Translators: The message displayed when the user has not specified an absolute destination directory
 					# in the Create Portable NVDA dialog.
 					"Please specify the absolute path where the portable copy should be created. "
-					"It may include system variables (%temp%, %homepath%, etc.). "
+					"It may include system variables (e.g. %temp%, %homepath%) and must start with a drive letter (e.g. C:\\). "
 					"Current path: {path}. ",
 				).format(path=expandedPortableDirectory),
 				# Translators: The message title displayed when the user has not specified an absolute


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Closes #19656 

### Summary of the issue:
Python 3.13 improved absolute path detection to make it more accurate.
`%homepath%` expands to `Users\username` not `C:\Users\username`, so it is not an absolute path.
However before Python 3.13, it was treated as an absolute path.
The dialog to warn the user about absolute paths doesn't include the expanded path, so users unaware of what `%homepath%` does won't understand why it's not being treated as an absolute path.

### Description of user facing changes:
Include the expanded path in the warning dialog.
This ensures users understand why their path may be invalid.

### Description of developer facing changes:
None

### Description of development approach:

Add path to dialog

### Testing strategy:

Test creating a portable copy with `%homepath%`

### Known issues with pull request:
none
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
