### PR TITLE
Re-enable audio ducking for proxied x86 speech synths

### DIFF
--- a/source/_bridge/components/proxies/synthDriver.py
+++ b/source/_bridge/components/proxies/synthDriver.py
@@ -8,7 +8,6 @@ import json
 import weakref
 import typing
 from collections import OrderedDict
-import audioDucking
 from logHandler import log
 from _bridge.base import Proxy
 from autoSettingsUtils.driverSetting import DriverSetting, NumericDriverSetting, BooleanDriverSetting
@@ -39,17 +38,9 @@ if typing.TYPE_CHECKING:
 class SynthDriverProxy(Proxy, SynthDriver):
 	"""Wraps a remote SynthDriverService, providing the same interface as a local SynthDriver."""
 
-	_audioDuckingSuspender: audioDucking._AudioDuckingSuspender | None = None
-
 	def __init__(self, service: SynthDriverService):
 		log.debug(f"Creating SynthDriverProxy instance for remote synth driver '{self.name}'")
 		super().__init__(service)
-		if audioDucking.isAudioDuckingSupported():
-			# Proxied synthDrivers cannot currently support audio ducking because they produce audio directly
-			# in their own process, and NVDA cannot correctly duck this external audio. Therefore, we create
-			# an _AudioDuckingSuspender to ensure that audio ducking is suspended while any proxied synth
-			# driver exists.
-			self._audioDuckingSuspender = audioDucking._AudioDuckingSuspender()
 		selfRef = weakref.ref(self)
 		for notification in self.supportedNotifications:
 			if notification is synthIndexReached:


### PR DESCRIPTION
### Link to issue number:
Follow-up to #19665

### Summary of the issue:

#19665 prevents audio ducking when using a proxied SAPI4 or SAPI 5 speech synth, as it does not work correctly on betas due to the synth outputting sound out of process. However, as alpha builds broker the audio from from the 32-bit host process and output it in process, audio ducking works correctly.

### Description of user facing changes:

Audio ducking again works on alpha builds when using a SAPI 4 or 32-bit SAPI 5 synth.

### Description of developer facing changes:

None

### Description of development approach:

Reverted the changes to `source/_bridge/components/proxies/synthDriver.py` introduced in nvaccess/nvda@b0228fe9aa.

### Testing strategy:

Built a self-signed launcher and installed NVDA. Switched to SAPI 4, played some music, and tested that all 3 ducking modes work as expected.

### Known issues with pull request:

None known

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
