### PR TITLE
Replace scons checkPot with standalone runcheckpot.bat

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -140,8 +140,8 @@ repos:
       types_or: [c, c++]
     - id: checkPot
       name: translation string check
-      entry: cmd.exe /c "scons checkPot --all-cores"
-      language: system
+      entry: ./runcheckpot.bat --all-cores
+      language: script
       pass_filenames: false
       types: [python]
       files: ^source/.*$

--- a/ci/scripts/tests/translationCheck.ps1
+++ b/ci/scripts/tests/translationCheck.ps1
@@ -1,7 +1,7 @@
 if ($env:RUNNER_DEBUG) {
-	cmd.exe /c "scons checkPot -j1 2> testOutput\translationCheckResults.log"
+	cmd.exe /c "runcheckpot.bat -j1 2> testOutput\translationCheckResults.log"
 } else {
-	cmd.exe /c "scons checkPot --all-cores 2> testOutput\translationCheckResults.log"
+	cmd.exe /c "runcheckpot.bat --all-cores 2> testOutput\translationCheckResults.log"
 }
 Write-Output "Translation check output:"
 Get-Content testOutput\translationCheckResults.log

--- a/projectDocs/dev/buildingNVDA.md
+++ b/projectDocs/dev/buildingNVDA.md
@@ -29,7 +29,7 @@ However note that building across cores can cause errors, and output will be scr
 
 ```cmd
 scons source --all-cores
-scons checkPot -j 1
+scons source -j 1
 ```
 
 If you are experiencing errors building NVDA with threading enabled, please force a serial build with the `-j 1` parameter.

--- a/projectDocs/dev/contributing.md
+++ b/projectDocs/dev/contributing.md
@@ -43,7 +43,7 @@ Then give people time to offer feedback.
 	* If possible for your PR, please consider creating a set of unit or system tests to test your changes.
 	* The lint check ensures your changes comply with our code style expectations.
 	Use `runlint.bat`.
-	* Run `scons checkPot` to ensure translatable strings have comments for the translators
+	* Run `runcheckpot.bat` to ensure translatable strings have comments for the translators
 	* Run `runlicensecheck.bat` to check that you don't introduce any new python dependencies with incompatible licenses.
 1. [Create a change log entry](#change-log-entry)
 1. Create a Pull Request (PR)

--- a/projectDocs/testing/automated.md
+++ b/projectDocs/testing/automated.md
@@ -33,7 +33,7 @@ You can run pre-commit hooks manually with [`pre commit run`](https://pre-commit
 To run the translatable string checks (which check that all translatable strings have translator comments), run:
 
 ```cmd
-scons checkPot
+runcheckpot.bat
 ```
 
 ## Linting your changes

--- a/runcheckpot.bat
+++ b/runcheckpot.bat
@@ -1,0 +1,13 @@
+@echo off
+rem runcheckpot [scons args]
+rem Checks that all translatable strings have translator comments.
+rem First generates the pot file using scons, then validates it.
+rem Any arguments are forwarded to the scons pot command.
+set hereOrig=%~dp0
+set here=%hereOrig%
+if #%hereOrig:~-1%# == #\# set here=%hereOrig:~0,-1%
+
+call scons pot %*
+if ERRORLEVEL 1 exit /b %ERRORLEVEL%
+call uv run --directory "%here%" python tests/checkPot.py "%here%\output\nvda.pot"
+if ERRORLEVEL 1 exit /b %ERRORLEVEL%

--- a/sconstruct
+++ b/sconstruct
@@ -688,18 +688,6 @@ env.Alias("appx", [installed_appx_storeSubmission, installed_appx_sideLoadable])
 
 env.Default(dist)
 
-import tests.checkPot
-
-
-def checkPotAction(target, source, env):
-	return tests.checkPot.checkPot(source[0].abspath)
-
-
-checkPotTarget = env.Command("checkPot", pot, checkPotAction)
-env.Depends(checkPotTarget, pot)
-env.AlwaysBuild(checkPotTarget)
-env.Alias("checkPot", checkPotTarget)
-
 
 # Generate a list of Python modules from compiled '.pyc' files in library.zip
 env.Tool("listModules")

--- a/tests/checkPot.py
+++ b/tests/checkPot.py
@@ -206,4 +206,4 @@ def getStringFromLine(line):
 if __name__ == "__main__":
 	fileName = sys.argv[1]
 	results = checkPot(fileName)
-	sys.exit(int(bool(results)))
+	sys.exit(results)

--- a/tests/checkPot.py
+++ b/tests/checkPot.py
@@ -205,4 +205,6 @@ def getStringFromLine(line):
 
 if __name__ == "__main__":
 	fileName = sys.argv[1]
-	sys.exit(checkPot(fileName))
+	results = checkPot(fileName)
+	print(results)
+	sys.exit(int(bool(results)))

--- a/tests/checkPot.py
+++ b/tests/checkPot.py
@@ -206,5 +206,4 @@ def getStringFromLine(line):
 if __name__ == "__main__":
 	fileName = sys.argv[1]
 	results = checkPot(fileName)
-	print(results)
 	sys.exit(int(bool(results)))

--- a/tests/checkPot.py
+++ b/tests/checkPot.py
@@ -204,6 +204,5 @@ def getStringFromLine(line):
 
 
 if __name__ == "__main__":
-	# Support command line usage for quick testing.
 	fileName = sys.argv[1]
-	print(checkPot(fileName))
+	sys.exit(checkPot(fileName))

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -44,7 +44,8 @@ Please refer to [the developer guide](https://download.nvaccess.org/documentatio
 * Subclasses of `browseMode.BrowseModeDocumentTreeInterceptor` that support screen layout being on and off should override the `_toggleScreenLayout` method, rather than implementing `script_toggleScreenLayout` directly. (#19487)
 * The `scons tests` build target has been removed, as it was misleadingly named.
 It only ran the translation string comment check, which is equivalent to `scons checkPot`.
-Use the individual test commands instead: `scons checkPot`, `rununittests.bat`, `runsystemtests.bat`, `runlint.bat`. (#19606, @bramd)
+The `scons checkPot` target has also been replaced with `runcheckpot.bat`.
+Use the individual test commands instead: `runcheckpot.bat`, `rununittests.bat`, `runsystemtests.bat`, `runlint.bat`. (#19606, #19676, @bramd)
 * Updated Python 3.13.11 to 3.13.12 (#19572, @dpy013)
 
 #### Deprecations


### PR DESCRIPTION
Remove the checkPot target from sconstruct and provide a standalone
runcheckpot.bat script that calls scons pot then validates the output
with tests/checkPot.py. This follows up on PR #19606 review feedback
to stop using SCons for checkPot entirely.

Also fixes tests/checkPot.py __main__ to call sys.exit() with the
error count so exit codes propagate correctly when run standalone.

<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
<!-- Use Closes/Fixes/Resolves #xxx to link this PR to the issue it is responding to. -->
N/A

### Summary of the issue:

scons checkPot is more a utility and not really part of the build. Having a separate `runcheckpot.bat` is consistent with other utilities like `rununittests` or `runlint`. This has been suggested in a comment on PR #19606. Since that PR was already merged, this change is done in this new PR.

### Description of user facing changes:

None

### Description of developer facing changes:

The scons checkPot command has been replaced with runcheckpot.bat. This script generates the pot file via scons pot, then runs tests/checkPot.py directly on the output. Any arguments (e.g. --all-cores, -j 1) are forwarded to the scons pot invocation. Since we need an up-to-date pot file to run checks and generating that file is part of the SCons build, we still have the overhead of calling SCons when running `runcheckpot.bat`.

### Description of development approach:

- Created runcheckpot.bat following the naming and structure conventions of existing bat files (rununittests.bat, runlicensecheck.bat, etc.).                                                                                                        
- Removed the checkPot target, action, and alias from sconstruct (the pot target is unchanged).                                                                                                                                                      
- Updated the pre-commit hook from language: system (invoking cmd.exe /c "scons checkPot") to language: script (invoking ./runcheckpot.bat), matching how other bat-based hooks are configured.                                                      
- Updated ci/scripts/tests/translationCheck.ps1 to call runcheckpot.bat.                                                                                                                                                                             
- Fixed tests/checkPot.py `__main__` block to call sys.exit() with the error count. Previously it only printed the count, which meant standalone invocation always exited 0 regardless of errors. This was not a problem when SCons used the return    
value directly, but is critical now that the script is invoked via bat file.                                                                                                                                                                         
- Updated developer documentationchangelog entry.                                                                                                                                   

### Testing strategy:
- Verify runcheckpot.bat --all-cores generates pot and runs validation successfully.
- Verify scons checkPot no longer exists as a target.
- Verify scons pot still works independently.
- Verify exit code propagation: python tests/checkPot.py with a bad/missing pot file returns non-zero.
- Verify pre-commit hook: uv run pre-commit run checkPot --all-files.

### Known issues with pull request:

None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
