### PR TITLE
Rename "_setPythonLocale" function in languageHandler.py

### DIFF
--- a/source/languageHandler.py
+++ b/source/languageHandler.py
@@ -382,7 +382,7 @@ def localeStringFromLocaleCode(localeCode: str) -> str:
 	return f"{langName}_{countryName}.{codePage}"
 
 
-def _setPythonLocale(localeString: str) -> bool:
+def _isPythonLocaleSet(localeString: str) -> bool:
 	"""Sets Python locale to a specified one.
 	Returns `True` if succesfull `False` if locale cannot be set or retrieved."""
 	try:
@@ -415,7 +415,7 @@ def setLocale(localeName: str) -> None:
 		log.debug(f"Win32 locale string from locale code is {localeString}")
 	except ValueError:
 		log.debugWarning(f"Locale {localeName} not supported by Windows")
-	if localeString and _setPythonLocale(localeString):
+	if localeString and _isPythonLocaleSet(localeString):
 		return
 	# The full form langName_country either cannot be retrieved from Windows
 	# or Python cannot be set to that locale.
@@ -427,11 +427,11 @@ def setLocale(localeName: str) -> None:
 			log.debug(f"Win32 locale string from locale code is {localeString}")
 		except ValueError:
 			log.debugWarning(f"Locale {localeName} not supported by Windows")
-	if localeString and _setPythonLocale(localeString):
+	if localeString and _isPythonLocaleSet(localeString):
 		return
 	# As a final fallback try setting locale just to the English name of the given language.
 	localeFromLang = englishLanguageNameFromNVDALocale(localeName)
-	if localeFromLang and _setPythonLocale(localeFromLang):
+	if localeFromLang and _isPythonLocaleSet(localeFromLang):
 		return
 	# Either Windows does not know the locale, or Python is unable to handle it.
 	# reset to default locale


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->


### Summary of the issue:
"_setPythonLocale" is a boolean function located in languageHandler.py which returns "True" if Python locale is set and "False" if not. The name currently does not relate to what the function actually does and, as a boolean function, its name should be in the form of a question. Its name is also very similar to the "setLocale" function within the same file and could cause confusion. 

### Description of user facing changes:
None.

### Description of developer facing changes:
None.

### Description of development approach:
Changed name of _setPythonLocale and all references within the program to "_isPythonLocaleSet".

### Testing strategy:
Manual testing

### Known issues with pull request:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [ ] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [ ] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [ ] API is compatible with existing add-ons.
- [ ] Security precautions taken.
