### PR TITLE
appModules/whatsapp.root: initial support for WhatsApp WebView2 version (disable browse mode by default)

### DIFF
--- a/source/appModules/whatsapp_root.py
+++ b/source/appModules/whatsapp_root.py
@@ -1,0 +1,13 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2026 NV Access Limited, Joseph Lee
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+
+"""Support for WhatsApp WebView2 app.
+Notably, this app module disables browse mode for WhatsApp by defualt."""
+
+import appModuleHandler
+
+
+class AppModule(appModuleHandler.AppModule):
+	disableBrowseModeByDefault: bool = True

--- a/source/appModules/whatsapp_root.py
+++ b/source/appModules/whatsapp_root.py
@@ -4,7 +4,7 @@
 # See the file COPYING for more details.
 
 """Support for WhatsApp WebView2 app.
-Notably, this app module disables browse mode for WhatsApp by defualt."""
+Notably, this app module disables browse mode for WhatsApp by default."""
 
 import appModuleHandler
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -25,6 +25,7 @@ The triple-press keyboard shortcut (`NVDA+ctrl+r`) is not affected, as it is int
 * It is now possible to open the log viewer with `NVDA+f1`, even when the log level is set to "disabled". (#19318, @CyrilleB79)
 * Improved search algorithm for filtering add-ons in the Add-on Store. (#19309)
 * NVDA can now be configured to not play error sounds, even in test versions. (#13021, @CyrilleB79)
+* NVDA will start in focus mode by default when using WebView2 version of WhatsApp. (#19655, @josephsl)
 
 ### Bug Fixes
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -25,7 +25,7 @@ The triple-press keyboard shortcut (`NVDA+ctrl+r`) is not affected, as it is int
 * It is now possible to open the log viewer with `NVDA+f1`, even when the log level is set to "disabled". (#19318, @CyrilleB79)
 * Improved search algorithm for filtering add-ons in the Add-on Store. (#19309)
 * NVDA can now be configured to not play error sounds, even in test versions. (#13021, @CyrilleB79)
-* NVDA will start in focus mode by default when using WebView2 version of WhatsApp. (#19655, @josephsl)
+* NVDA will start in focus mode by default when using WhatsApp 2.2584.3.0 or newer. (#19655, @josephsl)
 
 ### Bug Fixes
 


### PR DESCRIPTION

### Link to issue number:
Closes #19655 

### Summary of the issue:
In late 2025, Meta released WebView2 version of WhatsApp, meaning NVDA will start in browse mode when the app is launched.

### Description of user facing changes:
NVDA will start in focus mode when using WhatsApp WebView2 version.

### Description of developer facing changes:
A new app module is introduced to disable browse mode in WhatsApp WebView2 version.

### Description of development approach:
Added a new app module for whatsapp.root.exe (whatsapp_root.py) that instructs NVDA to disable browse mode by default. This work borrows from Skype app module where browse mode is turned off by default as well. While the linked issue asks for more features, this pull request addresses the problem noted in the linked issue.

### Testing strategy:
Manual testing:

1. Install WhatsApp and create an account if not done so.
2. When WhatsApp is launched, observeobserve that NVDA says "browse mode" or plays browse mode sound when NVDA+Space is pressed, indicating that browse mode is disabled by default.

### Known issues with pull request:
This pull request will conflict with add-ons that include whatsapp_root.py. This means add-ons wishing to target NVDA 2026.2 or later should import the base app module.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

### Additional context:
The changelog entry is listed under 2026.2/changes as this PR addresses a change to WhatsApp and NVDA's behavior in this app. This can change if additional features are added to WhatsApp WebView2 app module throughout 2026.2 development cycle. Also, Meta may change WhatsApp in the future, including potentially abandoning WebView2 approach altogether and/or changin the webView2 interface presentation (after all, WebView is a glorified web browser inside a host application).

Thanks.