### PR TITLE
Correctly version and sign the 32 bit synthDriverHost runtime executable and don't include unnecessary pdb lib and exp files

### DIFF
--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -119,7 +119,7 @@ jobs:
         UV_PYTHON: ""          # clear setup-uv override
         VIRTUAL_ENV: ""        # avoid inheriting outer venv
       run: |
-        uv run --no-active --directory runtime-builders/synthDriverHost32 python setup-runtime.py --dest-dir ../../source/lib/x86/synthDriverHost-runtime
+        uv run --no-active --directory runtime-builders/synthDriverHost32 python setup-runtime.py --dest-dir ../../source/lib/x86/synthDriverHost-runtime --version "$env:version" --publisher "$env:scons_publisher"
     - name: Prepare for tests
       run: ci/scripts/tests/beforeTests.ps1
     - name: Cache scons build

--- a/runtime-builders/synthDriverHost32/setup-runtime.py
+++ b/runtime-builders/synthDriverHost32/setup-runtime.py
@@ -13,6 +13,8 @@ import argparse
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--dest-dir", default="dist")
+parser.add_argument("--version")
+parser.add_argument("--publisher")
 args = parser.parse_args()
 
 nvdaSourceDir = os.path.join("..", "..", "source")
@@ -30,6 +32,12 @@ from buildVersion import (  # noqa: E402
 	publisher,
 	version,
 )
+
+if args.version is not None:
+	version = args.version
+if args.publisher is not None:
+	publisher = args.publisher
+
 
 gettext.install("nvda")
 

--- a/sconstruct
+++ b/sconstruct
@@ -416,7 +416,7 @@ def NVDADistGenerator(target, source, env, for_signature):
 	action.append(buildCmd)
 
 	if certFile or apiSigningToken:
-		for prog in "nvda_noUIAccess.exe", "nvda_uiAccess.exe", "nvda_slave.exe", "l10nUtil.exe", rf"lib\{version}\x86\synthDriverHost-runtime\nvda_synthDriverHost.exe":
+		for prog in "nvda_noUIAccess.exe", "nvda_uiAccess.exe", "nvda_slave.exe", "l10nUtil.exe", os.path.join("lib", version, "x86", "synthDriverHost-runtime", "nvda_synthDriverHost.exe"):
 			if not os.path.isfile(os.path.join(target[0].path, prog)):
 				continue
 			action.append(

--- a/sconstruct
+++ b/sconstruct
@@ -701,15 +701,12 @@ synthDriverHost32Runtime = env.Command(
 	target="#runtime-builders/synthDriverHost32/dist",
 	source="#runtime-builders/synthDriverHost32/setup-runtime.py",
 	chdir=Dir("#runtime-builders/synthDriverHost32"),
-	ENV=os.environ | {
-		"VIRTUAL_ENV": "",
-		"UV_PYTHON": "",
-	},
 	action=[
 		  f"uv run -v --no-active --directory .  python setup-runtime.py --dest-dir dist --version {version} --publisher {publisher}",
 		r"rmdir /s /q ..\..\source\lib\x86\synthDriverHost-runtime || exit 0",
 		r"xcopy /e /i /y dist ..\..\source\lib\x86\synthDriverHost-runtime",
 	],
+	ENV=os.environ,
 )
 env.AlwaysBuild(synthDriverHost32Runtime)
 env.Alias("synthDriverHost32Runtime", synthDriverHost32Runtime)

--- a/sconstruct
+++ b/sconstruct
@@ -701,12 +701,15 @@ synthDriverHost32Runtime = env.Command(
 	target="#runtime-builders/synthDriverHost32/dist",
 	source="#runtime-builders/synthDriverHost32/setup-runtime.py",
 	chdir=Dir("#runtime-builders/synthDriverHost32"),
+	ENV=os.environ | {
+		"VIRTUAL_ENV": "",
+		"UV_PYTHON": "",
+	},
 	action=[
-		  "uv run -v python setup-runtime.py ",
+		  f"uv run -v --no-active --directory .  python setup-runtime.py --dest-dir dist --version {version} --publisher {publisher}",
 		r"rmdir /s /q ..\..\source\lib\x86\synthDriverHost-runtime || exit 0",
 		r"xcopy /e /i /y dist ..\..\source\lib\x86\synthDriverHost-runtime",
 	],
-	ENV=os.environ,
 )
 env.AlwaysBuild(synthDriverHost32Runtime)
 env.Alias("synthDriverHost32Runtime", synthDriverHost32Runtime)

--- a/sconstruct
+++ b/sconstruct
@@ -416,7 +416,9 @@ def NVDADistGenerator(target, source, env, for_signature):
 	action.append(buildCmd)
 
 	if certFile or apiSigningToken:
-		for prog in "nvda_noUIAccess.exe", "nvda_uiAccess.exe", "nvda_slave.exe", "l10nUtil.exe":
+		for prog in "nvda_noUIAccess.exe", "nvda_uiAccess.exe", "nvda_slave.exe", "l10nUtil.exe", rf"lib\{version}\x86\synthDriverHost-runtime\nvda_synthDriverHost.exe":
+			if not os.path.isfile(os.path.join(target[0].path, prog)):
+				continue
 			action.append(
 				lambda target, source, env, progByVal=prog: env["signExec"](
 					[target[0].File(progByVal)], source, env

--- a/source/setup.py
+++ b/source/setup.py
@@ -287,10 +287,9 @@ freeze(
 			else []
 		)
 		+ (
-			getRecursiveDataFiles(
-				"_synthDrivers32",
-				"_synthDrivers32",
-			)
+			[
+				("_synthDrivers32", glob("_synthDrivers32\\*.py") + glob("_synthDrivers32\\*.dll")),
+			]
 			if os.path.isdir("lib/x86/synthDriverHost-runtime")
 			else []
 		)

--- a/source/setup.py
+++ b/source/setup.py
@@ -288,7 +288,7 @@ freeze(
 		)
 		+ (
 			[
-				("_synthDrivers32", glob("_synthDrivers32\\*.py") + glob("_synthDrivers32\\*.dll")),
+				("_synthDrivers32", glob("_synthDrivers32/*.py") + glob("_synthDrivers32/*.dll")),
 			]
 			if os.path.isdir("lib/x86/synthDriverHost-runtime")
 			else []


### PR DESCRIPTION
- **setup.py: when copying the _synthDrivers32 directory, only copy py an dll files, not lib, exp or pdb files as they are not required.**
- **When creating dist, also sign nvda_synthDriverHost.exe if it exists.**
- **synthDriverHost32 runtime setup-runtime.py Py2exe script: accept version and publisher commandline arguments so that these can be set dynamically. The github action and sconstruct now pass version and publisher to py2exe when compiling the 32 bit synthDriverHost runtime.**

<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
<!-- Use Closes/Fixes/Resolves #xxx to link this PR to the issue it is responding to. -->
Fixes #19654
Fixes #19653

### Summary of the issue:
The 32 bit synthDriverhost runtime introduced in PR #19432:
* Does not contain correct version information in its executable,
* Is not signed, and
* includes some extra lib exp and pdb files which are not necessary and just take up space.

### Description of user facing changes:

### Description of developer facing changes:

### Description of development approach:
* synthDriverHost's setup-runtime.py py2exe script now takes version and publisher as commandline arguments, so that these can be set on the executable dynamically.
* The github workflow and sconstruct pass the correct version and publisher to the setup-runtime.py py2exe script.
* When building the main dist target with scons, sign nvda_synthDriverHost.exe if it exists.
* When building the main NvDA distribution with py2exe, only copy py and dll files in the _synthDrivers32 directory, which now ignores lib exp and pdb files.
 
### Testing strategy:
* [x] Compiled with scons synthDriverHost32Runtime and scons dist, providing a signing certificate and custom version and publisher.
  * Confirmed that nvda_synthDriverHost.exe was signed and contained correct version information.
  * Confirmed the dist\_synthDrivers32 directory only contained no lib exp or pdb files.
  * Confirmed that NVDA runs, and sapi4 and sapi5 (32 bit) could be used.
* [ ] Run the above tests on a CI build from this pr.


### Known issues with pull request:
None known.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
