### PR TITLE
Clarify error message of #19666

### DIFF
--- a/source/gui/installerGui.py
+++ b/source/gui/installerGui.py
@@ -640,7 +640,8 @@ class PortableCreaterDialog(
 					# Translators: The message displayed when the user has not specified an absolute destination directory
 					# in the Create Portable NVDA dialog.
 					"Please specify the absolute path where the portable copy should be created. "
-					"It may include system variables (e.g. %temp%, %homepath%) and must start with a drive letter (e.g. C:\\). "
+					"It must start with a drive letter (e.g. C:). "
+					"It may include system variables (e.g. %temp%, %homepath%) as placeholders for parts of the path.\n"
 					"Current path: {path}. ",
 				).format(path=expandedPortableDirectory),
 				# Translators: The message title displayed when the user has not specified an absolute


### PR DESCRIPTION
### Link to issue number:
Fix-up of #19666

Discussed in https://github.com/nvaccess/nvda/pull/19666#issuecomment-3949752457

### Summary of the issue:
The error message as written in #19666 could let think that a drive letter should be added in the portable path definition even when using `%temp%` which, though, already contains it.

### Description of user facing changes:
Rewrote the error message.
### Description of developer facing changes:
N/A
### Description of development approach:
N/A
### Testing strategy:
Check installer
### Known issues with pull request:
None
### Code Review Checklist:


- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
