### PR TITLE
Remove useless log

### DIFF
--- a/source/mathPres/MathCAT/localization.py
+++ b/source/mathPres/MathCAT/localization.py
@@ -266,7 +266,6 @@ def getLanguages() -> tuple[list[str], list[str]]:
 			# add to the list the text for this language variant together with the code
 			regionalCode: str = language + "-" + subDir.upper()
 			langDesc = getLanguageDescription(regionalCode)
-			log.info(f"regionalCode: {regionalCode}, langDesc: {langDesc}")
 			if langDesc is not None:
 				languageOptions.append(f"{langDesc} ({regionalCode})")
 			else:


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
A message with variable values was logged at info level when populating the Math language list with languages with regional codes (en_GB, zh_CN). This seems an oversight after debugging.

### Description of user facing changes:
This message will no kibger appear in the log.

### Description of developer facing changes:
N/A
### Description of development approach:
Removed the code line.
### Testing strategy:
Open the math settings and check that this log message is no longer logged.
### Known issues with pull request:
None
### Code Review Checklist:


- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
