### PR TITLE
Update to Python 3.13.12 on beta

### DIFF
--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -35,8 +35,8 @@ env:
   supportedRunners: '["windows-2022", "windows-2025"]'
   defaultArch: x64
   supportedArchitectures: '["x64"]'
-  defaultPythonVersion: '3.13.11'
-  supportedPythonVersions: '["3.13.11"]'
+  defaultPythonVersion: '3.13.12'
+  supportedPythonVersions: '["3.13.12"]'
 
 jobs:
   matrix:

--- a/.python-versions
+++ b/.python-versions
@@ -1,1 +1,1 @@
-cpython-3.13.11-windows-x86_64-none
+cpython-3.13.12-windows-x86_64-none

--- a/projectDocs/dev/createDevEnvironment.md
+++ b/projectDocs/dev/createDevEnvironment.md
@@ -49,7 +49,7 @@ The following dependencies need to be installed on your system:
 
 #### Python
 
-[Python](https://www.python.org/), version 3.13.11, 64-bit.
+[Python](https://www.python.org/), version 3.13.12, 64-bit.
 Install the python version listed in [.python-versions](../../.python-versions)
 
 #### uv

--- a/runtime-builders/synthDriverHost32/.python-version
+++ b/runtime-builders/synthDriverHost32/.python-version
@@ -1,1 +1,1 @@
-cpython-3.13.11-windows-x86-none
+cpython-3.13.12-windows-x86-none

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -180,7 +180,7 @@ On ARM64 machines with Windows 11, these ARM64EC libraries are loaded instead of
 These are breaking API changes.
 Please open a GitHub issue if your add-on has an issue with updating to the new API.
 
-* NVDA is now built with Python 3.13, 64-bit. (#18591)
+* NVDA is now built with Python 3.13.12, 64-bit. (#18591, #19111, #19351, #19572, @LeonarddeR, @dpy013)
 * typing_extensions have been removed.
 These should be supported natively in Python 3.13. (#18689)
 * `copyrightYears` and `url` have been moved from `versionInfo` to `buildVersion`. (#18682)


### PR DESCRIPTION
### Link to issue number:

### Summary of the issue:

Python does not like it when you have multiple patch versions on the same system. This was making it difficult to work on alpha and beta versions of NVDA at the same time.

### Description of user facing changes:

None.

### Description of developer facing changes:

Betas are now built with Python 3.13.12. Practically this should make no difference.

### Description of development approach:

Cherry-picked nvaccess/nvda@d0be47cec4 to beta and updated the change log.

### Testing strategy:

CI

### Known issues with pull request:

The 2026.2 change log will need to be updated.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
