### PR TITLE
Add debouncer

### DIFF
--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -1547,6 +1547,7 @@ class ElementsListDialog(
 	@debounceLimiter(
 		cooldownTimeMs=FILTER_TIMER_DELAY_MS,
 		delayTimeMs=FILTER_TIMER_DELAY_MS,
+		runImmediateFirstCall=False,
 	)
 	def _scheduleFilter(self, filterText: str) -> None:
 		self.filter(filterText)

--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -242,7 +242,7 @@ class TextInfoQuickNavItem(QuickNavItem):
 		caret = self.document.makeTextInfo(textInfos.POSITION_CARET)
 		return self.textInfo.compareEndPoints(caret, "startToStart") > 0
 
-	def _getLabelForProperties(self, labelPropertyGetter: Callable[[str], Any | None]):
+	def _getLabelForProperties(self, labelPropertyGetter: Callable[[str], Any]):
 		"""
 		Fetches required properties for this L{TextInfoQuickNavItem} and constructs a label to be shown in an elements list.
 		This can be used by subclasses to implement the L{label} property.
@@ -499,8 +499,8 @@ class BrowseModeTreeInterceptor(treeInterceptorHandler.TreeInterceptor):
 	def _iterSimilarParagraph(
 		self,
 		kind: str,
-		paragraphFunction: Callable[[textInfos.TextInfo], Any | None],
-		desiredValue: Any | None,
+		paragraphFunction: Callable[[textInfos.TextInfo], Any],
+		desiredValue: Any,
 		direction: _Movement,
 		pos: textInfos.TextInfo,
 	) -> Generator[TextInfoQuickNavItem, None, None]:
@@ -2681,8 +2681,8 @@ class BrowseModeDocumentTreeInterceptor(
 	def _iterSimilarParagraph(
 		self,
 		kind: str,
-		paragraphFunction: Callable[[textInfos.TextInfo], Any | None],
-		desiredValue: Any | None,
+		paragraphFunction: Callable[[textInfos.TextInfo], Any],
+		desiredValue: Any,
 		direction: _Movement,
 		pos: textInfos.TextInfo,
 	) -> Generator[TextInfoQuickNavItem, None, None]:

--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -1545,7 +1545,7 @@ class ElementsListDialog(
 	FILTER_TIMER_DELAY_MS = 300
 
 	@debounceLimiter(
-		cooldownTimeMs=FILTER_TIMER_DELAY_MS,
+		cooldownTimeMs=100,
 		delayTimeMs=FILTER_TIMER_DELAY_MS,
 	)
 	def _scheduleFilter(self, filterText: str) -> None:

--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -1,16 +1,11 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2007-2025 NV Access Limited, Babbage B.V., James Teh, Leonard de Ruijter,
+# Copyright (C) 2007-2026 NV Access Limited, Babbage B.V., James Teh, Leonard de Ruijter,
 # Thomas Stivers, Accessolutions, Julien Cochuyt, Cyrille Bougot
 # This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
 # For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
 
-from typing import (
-	Any,
-	Callable,
-	Generator,
-	Union,
-)
-from collections.abc import Generator  # noqa: F811
+from typing import Any
+from collections.abc import Callable, Generator
 import os
 import itertools
 import collections
@@ -54,8 +49,8 @@ from NVDAObjects import NVDAObject
 import gui.contextHelp
 from abc import ABCMeta, abstractmethod
 import globalVars
+from utils.debounce import debounceLimiter
 from utils import urlUtils
-from typing import Optional
 
 
 def reportPassThrough(treeInterceptor, onlyIfChanged=True):
@@ -247,7 +242,7 @@ class TextInfoQuickNavItem(QuickNavItem):
 		caret = self.document.makeTextInfo(textInfos.POSITION_CARET)
 		return self.textInfo.compareEndPoints(caret, "startToStart") > 0
 
-	def _getLabelForProperties(self, labelPropertyGetter: Callable[[str], Optional[Any]]):
+	def _getLabelForProperties(self, labelPropertyGetter: Callable[[str], Any | None]):
 		"""
 		Fetches required properties for this L{TextInfoQuickNavItem} and constructs a label to be shown in an elements list.
 		This can be used by subclasses to implement the L{label} property.
@@ -269,7 +264,7 @@ class TextInfoQuickNavItem(QuickNavItem):
 			# Example output: main menu; navigation
 			labelParts = (name, landmark)
 		else:
-			role: Union[controlTypes.Role, int] = labelPropertyGetter("role")
+			role: controlTypes.Role | int = labelPropertyGetter("role")
 			role = controlTypes.Role(role)
 			roleText = role.displayString
 			# Translators: Reported label in the elements list for an element which which has no name and value
@@ -368,7 +363,7 @@ class BrowseModeTreeInterceptor(treeInterceptorHandler.TreeInterceptor):
 		},
 	)
 
-	def shouldPassThrough(self, obj, reason: Optional[OutputReason] = None):
+	def shouldPassThrough(self, obj, reason: OutputReason | None = None):
 		"""Determine whether pass through mode should be enabled (focus mode) or disabled (browse mode) for a given object.
 		@param obj: The object in question.
 		@type obj: L{NVDAObjects.NVDAObject}
@@ -504,8 +499,8 @@ class BrowseModeTreeInterceptor(treeInterceptorHandler.TreeInterceptor):
 	def _iterSimilarParagraph(
 		self,
 		kind: str,
-		paragraphFunction: Callable[[textInfos.TextInfo], Optional[Any]],
-		desiredValue: Optional[Any],
+		paragraphFunction: Callable[[textInfos.TextInfo], Any | None],
+		desiredValue: Any | None,
 		direction: _Movement,
 		pos: textInfos.TextInfo,
 	) -> Generator[TextInfoQuickNavItem, None, None]:
@@ -582,12 +577,12 @@ class BrowseModeTreeInterceptor(treeInterceptorHandler.TreeInterceptor):
 	def addQuickNav(
 		cls,
 		itemType: str,
-		key: Optional[str],
+		key: str | None,
 		nextDoc: str,
 		nextError: str,
 		prevDoc: str,
 		prevError: str,
-		readUnit: Optional[str] = None,
+		readUnit: str | None = None,
 	):
 		"""Adds a script for the given quick nav item.
 		@param itemType: The type of item, I.E. "heading" "Link" ...
@@ -1314,7 +1309,6 @@ class ElementsListDialog(
 		filterText = _("Filter b&y:")
 		labeledCtrl = gui.guiHelper.LabeledControlHelper(self, filterText, wx.TextCtrl)
 		self.filterEdit = labeledCtrl.control
-		self.filterTimer: Optional[wx.CallLater] = None
 		self.filterEdit.Bind(wx.EVT_TEXT, self.onFilterEditTextChange)
 		contentsSizer.Add(labeledCtrl.sizer)
 		contentsSizer.AddSpacer(gui.guiHelper.SPACE_BETWEEN_VERTICAL_DIALOG_ITEMS)
@@ -1549,13 +1543,17 @@ class ElementsListDialog(
 			item = self.tree.GetNextSibling(item)
 
 	FILTER_TIMER_DELAY_MS = 300
+	FILTER_DELAY_MS = 300
+
+	@debounceLimiter(
+		cooldownTimeMs=FILTER_TIMER_DELAY_MS,
+		delayTimeMs=FILTER_DELAY_MS,
+	)
+	def _scheduleFilter(self, filterText: str) -> None:
+		self.filter(filterText)
 
 	def onFilterEditTextChange(self, evt: wx.CommandEvent) -> None:
-		filter = self.filterEdit.GetValue()
-		if self.filterTimer is None:
-			self.filterTimer = wx.CallLater(self.FILTER_TIMER_DELAY_MS, self.filter, filter)
-		else:
-			self.filterTimer.Start(self.FILTER_TIMER_DELAY_MS, filter)
+		self._scheduleFilter(self.filterEdit.GetValue())
 		evt.Skip()
 
 	def onAction(self, activate):
@@ -1613,7 +1611,7 @@ class BrowseModeDocumentTreeInterceptor(
 		self._lastProgrammaticScrollTime = None
 		# Cache the document constant identifier so it can be saved with the last caret position on termination.
 		# As the original property may not be available as the document will be already dead.
-		self._lastCachedDocumentConstantIdentifier: Optional[str] = self.documentConstantIdentifier
+		self._lastCachedDocumentConstantIdentifier: str | None = self.documentConstantIdentifier
 		self._lastFocusObj = None
 		self._objPendingFocusBeforeActivate = None
 		self._hadFirstGainFocus = False
@@ -2075,7 +2073,7 @@ class BrowseModeDocumentTreeInterceptor(
 
 	def _handleScrollTo(
 		self,
-		obj: Union[NVDAObject, textInfos.TextInfo],
+		obj: NVDAObject | textInfos.TextInfo,
 	) -> bool:
 		"""Handle scrolling the browseMode document to a given object in response to an event.
 		Subclasses should call this from an event which indicates that the document has scrolled.
@@ -2185,13 +2183,13 @@ class BrowseModeDocumentTreeInterceptor(
 			obj = container
 		return doResult(False)
 
-	documentConstantIdentifier: Optional[str]
+	documentConstantIdentifier: str | None
 	""" Typing information for auto-property: _get_documentConstantIdentifier"""
 
 	# Mark documentConstantIdentifier property for caching during the current core cycle
 	_cache_documentConstantIdentifier = True
 
-	def _get_documentConstantIdentifier(self) -> Optional[str]:
+	def _get_documentConstantIdentifier(self) -> str | None:
 		"""Get the constant identifier for this document.
 		This identifier should uniquely identify all instances (not just one instance) of a document for at least the current session of the hosting application.
 		Generally, the document URL should be used.
@@ -2683,8 +2681,8 @@ class BrowseModeDocumentTreeInterceptor(
 	def _iterSimilarParagraph(
 		self,
 		kind: str,
-		paragraphFunction: Callable[[textInfos.TextInfo], Optional[Any]],
-		desiredValue: Optional[Any],
+		paragraphFunction: Callable[[textInfos.TextInfo], Any | None],
+		desiredValue: Any | None,
 		direction: _Movement,
 		pos: textInfos.TextInfo,
 	) -> Generator[TextInfoQuickNavItem, None, None]:

--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -1543,11 +1543,10 @@ class ElementsListDialog(
 			item = self.tree.GetNextSibling(item)
 
 	FILTER_TIMER_DELAY_MS = 300
-	FILTER_DELAY_MS = 300
 
 	@debounceLimiter(
 		cooldownTimeMs=FILTER_TIMER_DELAY_MS,
-		delayTimeMs=FILTER_DELAY_MS,
+		delayTimeMs=FILTER_TIMER_DELAY_MS,
 	)
 	def _scheduleFilter(self, filterText: str) -> None:
 		self.filter(filterText)

--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -1545,7 +1545,6 @@ class ElementsListDialog(
 	FILTER_TIMER_DELAY_MS = 300
 
 	@debounceLimiter(
-		cooldownTimeMs=100,
 		delayTimeMs=FILTER_TIMER_DELAY_MS,
 	)
 	def _scheduleFilter(self, filterText: str) -> None:

--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -1545,6 +1545,7 @@ class ElementsListDialog(
 	FILTER_TIMER_DELAY_MS = 300
 
 	@debounceLimiter(
+		cooldownTimeMs=FILTER_TIMER_DELAY_MS,
 		delayTimeMs=FILTER_TIMER_DELAY_MS,
 	)
 	def _scheduleFilter(self, filterText: str) -> None:

--- a/source/utils/debounce.py
+++ b/source/utils/debounce.py
@@ -101,7 +101,7 @@ def _debounceThreadDecider(
 		case ThreadTarget.DAEMON:
 
 			def callJobOnThread(delayTimeMs: int, func: Callable[..., Any], *args, **kwargs):
-				log.debug(f"Executing delayed job on thread {threading.get_ident()}")
+				log.debug("Scheduling delayed job on daemon thread")
 				timer = threading.Timer(delayTimeMs / 1000, func, args=args, kwargs=kwargs)
 				timer.daemon = True
 				timer.name = f"DebounceTimer-{func.__name__}"

--- a/source/utils/debounce.py
+++ b/source/utils/debounce.py
@@ -52,10 +52,10 @@ def _scheduleDelayedCall(
 	delayTimeMs: int,
 	func: Callable[..., Any],
 ) -> None:
-	# Cancel any previously scheduled delayed call to ensure only the latest one executes.
-	if state.pendingHandle is not None:
-		state.pendingHandle.Stop()
-	state.pendingHandle = wx.CallLater(delayTimeMs, _executeDelayedCall, func, state)
+	if state.pendingHandle is None:
+		state.pendingHandle = wx.CallLater(delayTimeMs, _executeDelayedCall, func, state)
+	else:
+		state.pendingHandle.Start(delayTimeMs)
 	state.lastCallTimeMs = monotonic() * 1000
 
 

--- a/source/utils/debounce.py
+++ b/source/utils/debounce.py
@@ -38,7 +38,7 @@ class ThreadTarget(Enum):
 @dataclass
 class _DebounceState:
 	lastExecutionTimeMs: float | None = None
-	pendingHandle: wx.Timer | threading.Timer | None = None
+	pendingHandle: wx.CallLater | threading.Timer | None = None
 	pendingArgs: tuple[Any, ...] = ()
 	pendingKwargs: dict[str, Any] | None = None
 
@@ -78,7 +78,7 @@ def _scheduleDelayedCall(
 	if handle is not None:
 		match threadTarget:
 			case ThreadTarget.GUI:
-				assert isinstance(handle, wx.Timer)
+				assert isinstance(handle, wx.CallLater)
 				handle.Stop()
 			case ThreadTarget.DAEMON:
 				assert isinstance(handle, threading.Timer)

--- a/source/utils/debounce.py
+++ b/source/utils/debounce.py
@@ -1,0 +1,156 @@
+# A part of NonVisual Desktop Access (NVDA)
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+# Copyright (C) 2026 NV Access Limited.
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from enum import Enum, auto
+from functools import wraps
+import threading
+from time import monotonic
+from typing import Any, ParamSpec
+from weakref import WeakKeyDictionary
+
+from logHandler import log
+import wx
+
+
+P = ParamSpec("P")
+
+class ThreadTarget(Enum):
+	"""
+	When debouncing a task, specify the thread to run the task on.
+	"""
+
+	GUI = auto()
+	"""
+	Uses wx.CallLater to run the job on the GUI thread.
+	This is encouraged for tasks that interact with the GUI, such as dialogs.
+	"""
+
+	DAEMON = auto()
+	"""
+	Uses threading.Thread(daemon=True) to run the job in the background.
+	"""
+
+
+@dataclass
+class _DebounceState:
+	lastExecutionTimeMs: float | None = None
+	pendingHandle: wx.Timer | threading.Timer | None = None
+	pendingArgs: tuple[Any, ...] = ()
+	pendingKwargs: dict[str, Any] | None = None
+
+
+def _getStateForCall(
+	instanceStates: WeakKeyDictionary[object, _DebounceState],
+	globalState: _DebounceState,
+	args: tuple[Any, ...],
+) -> _DebounceState:
+	if not args:
+		return globalState
+	instanceCandidate = args[0]
+	try:
+		return instanceStates.setdefault(instanceCandidate, _DebounceState())
+	except TypeError:
+		return globalState
+
+
+def _executeDelayedCall(func: Callable[..., Any], state: _DebounceState) -> None:
+	args = state.pendingArgs
+	kwargs = state.pendingKwargs or {}
+	state.pendingArgs = ()
+	state.pendingKwargs = None
+	state.pendingHandle = None
+	state.lastExecutionTimeMs = monotonic() * 1000
+	func(*args, **kwargs)
+
+
+def _scheduleDelayedCall(
+	state: _DebounceState,
+	callLater: Callable[..., Any],
+	threadTarget: ThreadTarget,
+	delayTimeMs: int,
+	func: Callable[..., Any],
+) -> None:
+	handle = state.pendingHandle
+	if handle is not None:
+		match threadTarget:
+			case ThreadTarget.GUI:
+				assert isinstance(handle, wx.Timer)
+				handle.Stop()
+			case ThreadTarget.DAEMON:
+				assert isinstance(handle, threading.Timer)
+				handle.cancel()
+			case _:
+				raise ValueError(f"Invalid threadTarget value: {threadTarget}")
+	state.pendingHandle = callLater(delayTimeMs, _executeDelayedCall, func, state)
+
+
+def _debounceThreadDecider(
+	threadTarget: ThreadTarget,
+) -> Callable[..., Any]:
+	match threadTarget:
+		case ThreadTarget.GUI:
+			def callJobOnThread(delayTimeMs: int, func: Callable[..., Any], *args, **kwargs):
+				log.debug(f"Scheduling delayed job on GUI thread in {delayTimeMs}ms")
+				return wx.CallLater(delayTimeMs, func, *args, **kwargs)
+		case ThreadTarget.DAEMON:
+			def callJobOnThread(delayTimeMs: int, func: Callable[..., Any], *args, **kwargs):
+				log.debug(f"Executing delayed job on thread {threading.get_ident()}")
+				timer = threading.Timer(delayTimeMs / 1000, func, args=args, kwargs=kwargs)
+				timer.daemon = True
+				timer.name = f"DebounceTimer-{func.__name__}"
+				timer.start()
+				return timer
+		case _:
+			raise ValueError(f"Invalid threadTarget value: {threadTarget}")
+	return callJobOnThread
+
+
+def debounceLimiter(
+	cooldownTimeMs: int = 50,
+	delayTimeMs: int = 50,
+	threadTarget: ThreadTarget = ThreadTarget.GUI,
+) -> Callable[[Callable[P, Any]], Callable[P, None]]:
+	"""
+	:param cooldownTimeMs: Time in milliseconds during which subsequent calls are considered to be within the cooldown period.
+	:param delayTimeMs: Time in milliseconds to delay the execution of a call received during the
+	cooldown period.
+	:param threadTarget: The thread to run the task on.
+	:returns: A decorator that debounces calls to the decorated function.
+
+	Create a decorator that executes the first call immediately, then debounces
+	subsequent calls received within `cooldownTimeMs` by delaying execution by
+	`delayTimeMs`.
+	"""
+	if cooldownTimeMs < 0:
+		raise ValueError("cooldownTimeMs must be non-negative")
+	if delayTimeMs < 0:
+		raise ValueError("delayTimeMs must be non-negative")
+
+	def decorator(func: Callable[P, Any]) -> Callable[P, None]:
+		instanceStates: WeakKeyDictionary[object, _DebounceState] = WeakKeyDictionary()
+		globalState = _DebounceState()
+		callLater = _debounceThreadDecider(threadTarget)
+
+		@wraps(func)
+		def wrapper(*args: P.args, **kwargs: P.kwargs) -> None:
+			state = _getStateForCall(instanceStates, globalState, args)
+			nowMs = monotonic() * 1000
+			withinCooldown = (
+				state.lastExecutionTimeMs is not None and (nowMs - state.lastExecutionTimeMs) < cooldownTimeMs
+			)
+			if not withinCooldown and state.pendingHandle is None:
+				state.lastExecutionTimeMs = nowMs
+				func(*args, **kwargs)
+				return
+
+			state.pendingArgs = args
+			state.pendingKwargs = kwargs
+			_scheduleDelayedCall(state, callLater, threadTarget, delayTimeMs, func)
+
+		return wrapper
+
+	return decorator

--- a/source/utils/debounce.py
+++ b/source/utils/debounce.py
@@ -4,7 +4,7 @@
 # For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
 
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from functools import wraps
 from time import monotonic
 from typing import Any, ParamSpec
@@ -40,10 +40,10 @@ def _getStateForCall(
 
 def _executeDelayedCall(func: Callable[..., Any], state: _DebounceState) -> None:
 	args = state.pendingArgs
-	kwargs = state.pendingKwargs or {}
+	kwargs = state.pendingKwargs
 	func(*args, **kwargs)
 	state.pendingArgs = ()
-	state.pendingKwargs = None
+	state.pendingKwargs = {}
 	state.pendingHandle = None
 
 

--- a/source/utils/debounce.py
+++ b/source/utils/debounce.py
@@ -62,11 +62,14 @@ def _scheduleDelayedCall(
 def debounceLimiter(
 	cooldownTimeMs: int = 50,
 	delayTimeMs: int = 50,
+	runImmediateFirstCall: bool = True,
 ) -> Callable[[Callable[P, Any]], Callable[P, None]]:
 	"""
 	:param cooldownTimeMs: Time in milliseconds during which subsequent calls are considered to be within the cooldown period.
 	:param delayTimeMs: Time in milliseconds to delay the execution of a call received during the
 	cooldown period.
+	:param runImmediateFirstCall: Whether the first call in a burst should execute immediately.
+	If False, all calls are trailing-debounced by `delayTimeMs`.
 	:returns: A decorator that debounces calls to the decorated function.
 
 	Executes calls immediately when outside the cooldown period (when there is no
@@ -80,16 +83,16 @@ def debounceLimiter(
 
 	def decorator(func: Callable[P, Any]) -> Callable[P, None]:
 		instanceStates: WeakKeyDictionary[object, _DebounceState] = WeakKeyDictionary()
-		globalState = _DebounceState()
+		stateForDecorated = _DebounceState()
 
 		@wraps(func)
 		def wrapper(*args: P.args, **kwargs: P.kwargs) -> None:
-			state = _getStateForCall(instanceStates, globalState, args)
+			state = _getStateForCall(instanceStates, stateForDecorated, args)
 			nowMs = monotonic() * 1000
 			withinCooldown = (
 				state.lastCallTimeMs is not None and (nowMs - state.lastCallTimeMs) < cooldownTimeMs
 			)
-			if not withinCooldown and state.pendingHandle is None:
+			if runImmediateFirstCall and not withinCooldown and state.pendingHandle is None:
 				state.lastCallTimeMs = nowMs
 				func(*args, **kwargs)
 				return

--- a/source/utils/debounce.py
+++ b/source/utils/debounce.py
@@ -21,7 +21,7 @@ class _DebounceState:
 	lastCallTimeMs: float | None = None
 	pendingHandle: wx.CallLater | None = None
 	pendingArgs: tuple[Any, ...] = ()
-	pendingKwargs: dict[str, Any] | None = None
+	pendingKwargs: dict[str, Any] = field(default_factory=dict)
 
 
 def _getStateForCall(

--- a/source/utils/debounce.py
+++ b/source/utils/debounce.py
@@ -65,7 +65,6 @@ def debounceLimiter(
 	:param cooldownTimeMs: Time in milliseconds during which subsequent calls are considered to be within the cooldown period.
 	:param delayTimeMs: Time in milliseconds to delay the execution of a call received during the
 	cooldown period.
-	:param threadTarget: The thread to run the task on.
 	:returns: A decorator that debounces calls to the decorated function.
 
 	Executes calls immediately when outside the cooldown period (when there is no

--- a/source/utils/debounce.py
+++ b/source/utils/debounce.py
@@ -60,6 +60,7 @@ def _scheduleDelayedCall(
 
 
 def debounceLimiter(
+	*,
 	cooldownTimeMs: int = 50,
 	delayTimeMs: int = 50,
 	runImmediateFirstCall: bool = True,

--- a/source/utils/debounce.py
+++ b/source/utils/debounce.py
@@ -10,7 +10,6 @@ from time import monotonic
 from typing import Any, ParamSpec
 from weakref import WeakKeyDictionary
 
-from logHandler import log
 import wx
 
 

--- a/source/utils/debounce.py
+++ b/source/utils/debounce.py
@@ -124,9 +124,9 @@ def debounceLimiter(
 	:param threadTarget: The thread to run the task on.
 	:returns: A decorator that debounces calls to the decorated function.
 
-	Create a decorator that executes the first call immediately, then debounces
-	subsequent calls received within `cooldownTimeMs` by delaying execution by
-	`delayTimeMs`.
+	Executes calls immediately when outside the cooldown period (when there is no
+	pending delayed call), and debounces calls received within `cooldownTimeMs`
+	by delaying their execution by `delayTimeMs`.
 	"""
 	if cooldownTimeMs < 0:
 		raise ValueError("cooldownTimeMs must be non-negative")

--- a/source/utils/debounce.py
+++ b/source/utils/debounce.py
@@ -1,7 +1,7 @@
 # A part of NonVisual Desktop Access (NVDA)
-# This file is covered by the GNU General Public License.
-# See the file COPYING for more details.
-# Copyright (C) 2026 NV Access Limited.
+# Copyright (C) 2026 NV Access Limited
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
 
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -26,16 +26,16 @@ class _DebounceState:
 
 def _getStateForCall(
 	instanceStates: WeakKeyDictionary[object, _DebounceState],
-	globalState: _DebounceState,
+	defaultState: _DebounceState,
 	args: tuple[Any, ...],
 ) -> _DebounceState:
 	if not args:
-		return globalState
+		return defaultState
 	instanceCandidate = args[0]
 	try:
 		return instanceStates.setdefault(instanceCandidate, _DebounceState())
 	except TypeError:
-		return globalState
+		return defaultState
 
 
 def _executeDelayedCall(func: Callable[..., Any], state: _DebounceState) -> None:
@@ -65,16 +65,18 @@ def debounceLimiter(
 	runImmediateFirstCall: bool = True,
 ) -> Callable[[Callable[P, Any]], Callable[P, None]]:
 	"""
-	:param cooldownTimeMs: Time in milliseconds during which subsequent calls are considered to be within the cooldown period.
-	:param delayTimeMs: Time in milliseconds to delay the execution of a call received during the
-	cooldown period.
-	:param runImmediateFirstCall: Whether the first call in a burst should execute immediately.
-	If False, all calls are trailing-debounced by `delayTimeMs`.
-	:returns: A decorator that debounces calls to the decorated function.
+	Limit the rate at which expensive functions are called.
 
 	Executes calls immediately when outside the cooldown period (when there is no
-	pending delayed call), and debounces calls received within `cooldownTimeMs`
-	by delaying their execution by `delayTimeMs`.
+	pending delayed call), and debounces calls received within ``cooldownTimeMs``
+	by delaying their execution by ``delayTimeMs``.
+
+	:param cooldownTimeMs: Time in milliseconds during which subsequent calls are considered to be within the cooldown period.
+	:param delayTimeMs: Time in milliseconds to delay the execution of a call received during the cooldown period.
+	:param runImmediateFirstCall: Whether the first call in a burst should execute immediately.
+		If False, all calls are trailing-debounced by `delayTimeMs`.
+	:returns: A decorator that debounces calls to the decorated function.
+	:raises ValueError: If ``cooldownTimeMs`` or ``delayTimeMs`` is negative.
 	"""
 	if cooldownTimeMs < 0:
 		raise ValueError("cooldownTimeMs must be non-negative")

--- a/source/utils/debounce.py
+++ b/source/utils/debounce.py
@@ -5,9 +5,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from enum import Enum, auto
 from functools import wraps
-import threading
 from time import monotonic
 from typing import Any, ParamSpec
 from weakref import WeakKeyDictionary
@@ -19,27 +17,10 @@ import wx
 P = ParamSpec("P")
 
 
-class ThreadTarget(Enum):
-	"""
-	When debouncing a task, specify the thread to run the task on.
-	"""
-
-	GUI = auto()
-	"""
-	Uses wx.CallLater to run the job on the GUI thread.
-	This is encouraged for tasks that interact with the GUI, such as dialogs.
-	"""
-
-	DAEMON = auto()
-	"""
-	Uses threading.Thread(daemon=True) to run the job in the background.
-	"""
-
-
 @dataclass
 class _DebounceState:
 	lastExecutionTimeMs: float | None = None
-	pendingHandle: wx.CallLater | threading.Timer | None = None
+	pendingHandle: wx.CallLater | None = None
 	pendingArgs: tuple[Any, ...] = ()
 	pendingKwargs: dict[str, Any] | None = None
 
@@ -70,52 +51,15 @@ def _executeDelayedCall(func: Callable[..., Any], state: _DebounceState) -> None
 
 def _scheduleDelayedCall(
 	state: _DebounceState,
-	callLater: Callable[..., Any],
-	threadTarget: ThreadTarget,
 	delayTimeMs: int,
 	func: Callable[..., Any],
 ) -> None:
-	handle = state.pendingHandle
-	if handle is not None:
-		match threadTarget:
-			case ThreadTarget.GUI:
-				assert isinstance(handle, wx.CallLater)
-				handle.Stop()
-			case ThreadTarget.DAEMON:
-				assert isinstance(handle, threading.Timer)
-				handle.cancel()
-			case _:
-				raise ValueError(f"Invalid threadTarget value: {threadTarget}")
-	state.pendingHandle = callLater(delayTimeMs, _executeDelayedCall, func, state)
-
-
-def _debounceThreadDecider(
-	threadTarget: ThreadTarget,
-) -> Callable[..., Any]:
-	match threadTarget:
-		case ThreadTarget.GUI:
-
-			def callJobOnThread(delayTimeMs: int, func: Callable[..., Any], *args, **kwargs):
-				log.debug(f"Scheduling delayed job on GUI thread in {delayTimeMs}ms")
-				return wx.CallLater(delayTimeMs, func, *args, **kwargs)
-		case ThreadTarget.DAEMON:
-
-			def callJobOnThread(delayTimeMs: int, func: Callable[..., Any], *args, **kwargs):
-				log.debug("Scheduling delayed job on daemon thread")
-				timer = threading.Timer(delayTimeMs / 1000, func, args=args, kwargs=kwargs)
-				timer.daemon = True
-				timer.name = f"DebounceTimer-{func.__name__}"
-				timer.start()
-				return timer
-		case _:
-			raise ValueError(f"Invalid threadTarget value: {threadTarget}")
-	return callJobOnThread
+	state.pendingHandle = wx.CallLater(delayTimeMs, _executeDelayedCall, func, state)
 
 
 def debounceLimiter(
 	cooldownTimeMs: int = 50,
 	delayTimeMs: int = 50,
-	threadTarget: ThreadTarget = ThreadTarget.GUI,
 ) -> Callable[[Callable[P, Any]], Callable[P, None]]:
 	"""
 	:param cooldownTimeMs: Time in milliseconds during which subsequent calls are considered to be within the cooldown period.
@@ -136,7 +80,6 @@ def debounceLimiter(
 	def decorator(func: Callable[P, Any]) -> Callable[P, None]:
 		instanceStates: WeakKeyDictionary[object, _DebounceState] = WeakKeyDictionary()
 		globalState = _DebounceState()
-		callLater = _debounceThreadDecider(threadTarget)
 
 		@wraps(func)
 		def wrapper(*args: P.args, **kwargs: P.kwargs) -> None:
@@ -152,7 +95,7 @@ def debounceLimiter(
 
 			state.pendingArgs = args
 			state.pendingKwargs = kwargs
-			_scheduleDelayedCall(state, callLater, threadTarget, delayTimeMs, func)
+			_scheduleDelayedCall(state, delayTimeMs, func)
 
 		return wrapper
 

--- a/source/utils/debounce.py
+++ b/source/utils/debounce.py
@@ -53,6 +53,9 @@ def _scheduleDelayedCall(
 	delayTimeMs: int,
 	func: Callable[..., Any],
 ) -> None:
+	# Cancel any previously scheduled delayed call to ensure only the latest one executes.
+	if state.pendingHandle is not None:
+		state.pendingHandle.Stop()
 	state.pendingHandle = wx.CallLater(delayTimeMs, _executeDelayedCall, func, state)
 
 

--- a/source/utils/debounce.py
+++ b/source/utils/debounce.py
@@ -18,6 +18,7 @@ import wx
 
 P = ParamSpec("P")
 
+
 class ThreadTarget(Enum):
 	"""
 	When debouncing a task, specify the thread to run the task on.
@@ -93,10 +94,12 @@ def _debounceThreadDecider(
 ) -> Callable[..., Any]:
 	match threadTarget:
 		case ThreadTarget.GUI:
+
 			def callJobOnThread(delayTimeMs: int, func: Callable[..., Any], *args, **kwargs):
 				log.debug(f"Scheduling delayed job on GUI thread in {delayTimeMs}ms")
 				return wx.CallLater(delayTimeMs, func, *args, **kwargs)
 		case ThreadTarget.DAEMON:
+
 			def callJobOnThread(delayTimeMs: int, func: Callable[..., Any], *args, **kwargs):
 				log.debug(f"Executing delayed job on thread {threading.get_ident()}")
 				timer = threading.Timer(delayTimeMs / 1000, func, args=args, kwargs=kwargs)

--- a/source/utils/debounce.py
+++ b/source/utils/debounce.py
@@ -18,7 +18,7 @@ P = ParamSpec("P")
 
 @dataclass
 class _DebounceState:
-	lastExecutionTimeMs: float | None = None
+	lastCallTimeMs: float | None = None
 	pendingHandle: wx.CallLater | None = None
 	pendingArgs: tuple[Any, ...] = ()
 	pendingKwargs: dict[str, Any] | None = None
@@ -41,11 +41,10 @@ def _getStateForCall(
 def _executeDelayedCall(func: Callable[..., Any], state: _DebounceState) -> None:
 	args = state.pendingArgs
 	kwargs = state.pendingKwargs or {}
+	func(*args, **kwargs)
 	state.pendingArgs = ()
 	state.pendingKwargs = None
 	state.pendingHandle = None
-	state.lastExecutionTimeMs = monotonic() * 1000
-	func(*args, **kwargs)
 
 
 def _scheduleDelayedCall(
@@ -57,6 +56,7 @@ def _scheduleDelayedCall(
 	if state.pendingHandle is not None:
 		state.pendingHandle.Stop()
 	state.pendingHandle = wx.CallLater(delayTimeMs, _executeDelayedCall, func, state)
+	state.lastCallTimeMs = monotonic() * 1000
 
 
 def debounceLimiter(
@@ -87,10 +87,10 @@ def debounceLimiter(
 			state = _getStateForCall(instanceStates, globalState, args)
 			nowMs = monotonic() * 1000
 			withinCooldown = (
-				state.lastExecutionTimeMs is not None and (nowMs - state.lastExecutionTimeMs) < cooldownTimeMs
+				state.lastCallTimeMs is not None and (nowMs - state.lastCallTimeMs) < cooldownTimeMs
 			)
 			if not withinCooldown and state.pendingHandle is None:
-				state.lastExecutionTimeMs = nowMs
+				state.lastCallTimeMs = nowMs
 				func(*args, **kwargs)
 				return
 

--- a/tests/unit/test_util/test_debounce.py
+++ b/tests/unit/test_util/test_debounce.py
@@ -29,6 +29,10 @@ class _FakeCallLaterHandle:
 	def Stop(self) -> None:
 		self._stopped = True
 
+	def Start(self, delay: int) -> None:
+		self.delay = delay
+		self._stopped = False
+
 	def run(self) -> None:
 		if self._stopped or self._ran:
 			return
@@ -39,19 +43,10 @@ class _FakeCallLaterHandle:
 class _FakeCallLater:
 	def __init__(self):
 		self.handles = []
-		self._lastHandleByStateId = {}
 
 	def __call__(self, delay: int, callback, *args, **kwargs):
-		if args:
-			state = args[-1]
-			stateId = id(state)
-			previousHandle = self._lastHandleByStateId.get(stateId)
-			if previousHandle is not None:
-				previousHandle.Stop()
 		handle = _FakeCallLaterHandle(delay, callback, args, kwargs)
 		self.handles.append(handle)
-		if args:
-			self._lastHandleByStateId[id(args[-1])] = handle
 		return handle
 
 	def runPending(self) -> None:

--- a/tests/unit/test_util/test_debounce.py
+++ b/tests/unit/test_util/test_debounce.py
@@ -39,10 +39,19 @@ class _FakeCallLaterHandle:
 class _FakeCallLater:
 	def __init__(self):
 		self.handles = []
+		self._lastHandleByStateId = {}
 
 	def __call__(self, delay: int, callback, *args, **kwargs):
+		if args:
+			state = args[-1]
+			stateId = id(state)
+			previousHandle = self._lastHandleByStateId.get(stateId)
+			if previousHandle is not None:
+				previousHandle.Stop()
 		handle = _FakeCallLaterHandle(delay, callback, args, kwargs)
 		self.handles.append(handle)
+		if args:
+			self._lastHandleByStateId[id(args[-1])] = handle
 		return handle
 
 	def runPending(self) -> None:
@@ -60,13 +69,13 @@ class TestDebounceLimiter(unittest.TestCase):
 		self.clock = _FakeClock()
 		self.callLater = _FakeCallLater()
 		self.monotonicPatch = patch("utils.debounce.monotonic", new=self.clock.monotonic)
-		self.deciderPatch = patch("utils.debounce._debounceThreadDecider", return_value=self.callLater)
+		self.callLaterPatch = patch("utils.debounce.wx.CallLater", new=self.callLater)
 		self.monotonicPatch.start()
-		self.deciderPatch.start()
+		self.callLaterPatch.start()
 
 	def tearDown(self) -> None:
 		self.monotonicPatch.stop()
-		self.deciderPatch.stop()
+		self.callLaterPatch.stop()
 
 	def test_firstCallImmediate_thenDelayedWithinCooldown(self):
 		calls = []

--- a/tests/unit/test_util/test_debounce.py
+++ b/tests/unit/test_util/test_debounce.py
@@ -139,3 +139,18 @@ class TestDebounceLimiter(unittest.TestCase):
 
 		self.assertEqual(["target1-first"], target1.calls)
 		self.assertEqual(["target2-first"], target2.calls)
+
+	def test_canDisableImmediateFirstCall(self):
+		calls = []
+
+		@debounceLimiter(cooldownTimeMs=300, delayTimeMs=200, runImmediateFirstCall=False)
+		def limited(value):
+			calls.append(value)
+
+		self.clock.now = 0.0
+		limited("first")
+		self.assertEqual([], calls)
+
+		self.clock.now = 0.2
+		self.callLater.runPending()
+		self.assertEqual(["first"], calls)

--- a/tests/unit/test_util/test_debounce.py
+++ b/tests/unit/test_util/test_debounce.py
@@ -1,0 +1,137 @@
+# A part of NonVisual Desktop Access (NVDA)
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+# Copyright (C) 2026 NV Access Limited.
+
+import unittest
+from unittest.mock import patch
+
+from utils.debounce import debounceLimiter
+
+
+class _FakeClock:
+	def __init__(self):
+		self.now = 0.0
+
+	def monotonic(self) -> float:
+		return self.now
+
+
+class _FakeCallLaterHandle:
+	def __init__(self, delay: int, callback, args, kwargs):
+		self.delay = delay
+		self._callback = callback
+		self._args = args
+		self._kwargs = kwargs
+		self._stopped = False
+		self._ran = False
+
+	def Stop(self) -> None:
+		self._stopped = True
+
+	def run(self) -> None:
+		if self._stopped or self._ran:
+			return
+		self._ran = True
+		self._callback(*self._args, **self._kwargs)
+
+
+class _FakeCallLater:
+	def __init__(self):
+		self.handles = []
+
+	def __call__(self, delay: int, callback, *args, **kwargs):
+		handle = _FakeCallLaterHandle(delay, callback, args, kwargs)
+		self.handles.append(handle)
+		return handle
+
+	def runPending(self) -> None:
+		for handle in self.handles:
+			handle.run()
+
+
+class _Target:
+	def __init__(self):
+		self.calls = []
+
+
+class TestDebounceLimiter(unittest.TestCase):
+	def setUp(self) -> None:
+		self.clock = _FakeClock()
+		self.callLater = _FakeCallLater()
+		self.monotonicPatch = patch("utils.debounce.monotonic", new=self.clock.monotonic)
+		self.deciderPatch = patch("utils.debounce._debounceThreadDecider", return_value=self.callLater)
+		self.monotonicPatch.start()
+		self.deciderPatch.start()
+
+	def tearDown(self) -> None:
+		self.monotonicPatch.stop()
+		self.deciderPatch.stop()
+
+	def test_firstCallImmediate_thenDelayedWithinCooldown(self):
+		calls = []
+
+		@debounceLimiter(cooldownTimeMs=300, delayTimeMs=200)
+		def limited(value):
+			calls.append(value)
+
+		self.clock.now = 0.0
+		limited("first")
+		self.assertEqual(["first"], calls)
+
+		self.clock.now = 0.1
+		limited("second")
+		self.assertEqual(["first"], calls)
+
+		self.clock.now = 0.4
+		self.callLater.runPending()
+		self.assertEqual(["first", "second"], calls)
+
+	def test_subsequentCallsWithinCooldown_areCoalesced(self):
+		calls = []
+
+		@debounceLimiter(cooldownTimeMs=300, delayTimeMs=200)
+		def limited(value):
+			calls.append(value)
+
+		self.clock.now = 0.0
+		limited("first")
+		self.clock.now = 0.1
+		limited("second")
+		self.clock.now = 0.2
+		limited("third")
+
+		self.assertEqual(["first"], calls)
+		self.clock.now = 0.5
+		self.callLater.runPending()
+		self.assertEqual(["first", "third"], calls)
+
+	def test_callAfterCooldown_executesImmediately(self):
+		calls = []
+
+		@debounceLimiter(cooldownTimeMs=300, delayTimeMs=200)
+		def limited(value):
+			calls.append(value)
+
+		self.clock.now = 0.0
+		limited("first")
+		self.clock.now = 0.4
+		limited("second")
+
+		self.assertEqual(["first", "second"], calls)
+
+	def test_methodCalls_areLimitedPerInstance(self):
+		@debounceLimiter(cooldownTimeMs=300, delayTimeMs=200)
+		def limited(target: _Target, value: str):
+			target.calls.append(value)
+
+		target1 = _Target()
+		target2 = _Target()
+
+		self.clock.now = 0.0
+		limited(target1, "target1-first")
+		self.clock.now = 0.1
+		limited(target2, "target2-first")
+
+		self.assertEqual(["target1-first"], target1.calls)
+		self.assertEqual(["target2-first"], target2.calls)

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -259,6 +259,7 @@ Use `config.configFlags.LoggingLevel` instead. (#19296)
   Use `synthDrivers.sapi5_32` (name: "sapi5_32") for the 32-bit SAPI 5 driver.
 * `config.setSystemConfigToCurrentConfig` now takes a `Collection` of add-on IDs (as strings) to copy to the system configuration.
 Only add-ons with the given IDs will be copied. (#19446)
+* `browseMode.ElementsListDialog.filterTimer` has been removed. (#19702)
 
 #### Deprecations
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Inspired by #19686 

### Summary of the issue:

We regularly run into problems where the GUI being updated frequently causing issues.
We fix this using a ratelimiter/debouncer.
We do not have a generic debouncer in NVDA.


### Description of user facing changes:
none
### Description of developer facing changes:
Adds a generic debouncer to NVDA

### Description of development approach:
This pull request introduces a new debouncing utility for limiting the frequency of function calls, primarily to improve GUI responsiveness and reduce unnecessary processing in NVDA. The main changes include the addition of the `debounceLimiter` decorator, its integration into the `browseMode.py` file for filtering elements, and comprehensive unit tests to verify its behavior. The pull request also modernizes type annotations throughout `browseMode.py` for improved readability and consistency.

Debounce utility and integration:

* Added a new `debounceLimiter` decorator in `utils/debounce.py` to control the execution rate of functions, supporting both GUI and daemon threads.
* Integrated `debounceLimiter` into the filtering logic of the elements list dialog in `browseMode.py`, replacing manual timer handling for improved efficiency and code clarity. [[1]](diffhunk://#diff-c06396a3ec18ce65a0a2306d329917bbfba8470a762866091e180936d37fff04R52-L58) [[2]](diffhunk://#diff-c06396a3ec18ce65a0a2306d329917bbfba8470a762866091e180936d37fff04R1546-R1556)

### Testing

Introduced `tests/unit/test_util/test_debounce.py` with unit tests covering various debounce scenarios, including cooldown, delay, call coalescing, and per-instance limiting.

Manually tested filtering the elements list dialog
### Known issues with pull request:
None
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
