### PR TITLE
Remove change log item unrelated to NVDA itself

### DIFF
--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -52,7 +52,6 @@ Please refer to [the developer guide](https://download.nvaccess.org/documentatio
 It only ran the translation string comment check, which is equivalent to `scons checkPot`.
 Use the individual test commands instead: `scons checkPot`, `rununittests.bat`, `runsystemtests.bat`, `runlint.bat`. (#19606, @bramd)
 * Updated Python 3.13.11 to 3.13.12 (#19572, @dpy013)
-* Updated security issue SLA policy (#19699)
 
 #### Deprecations
 


### PR DESCRIPTION
### Link to issue number:
Fix-up of #19699

(see https://github.com/nvaccess/nvda/pull/19699#discussion_r2857361925)

### Summary of the issue:

#19699 modified ‎`security.md‎` file which defines what is displayed in GitHub repo's security section. This PR thus impacts GitHub NVDA repo but not NVDA itself, nor any released artifact, e.g. NVDA controller. Thus it should not be mentioned in NVDA's change log.

### Description of user facing changes:
Removed the item's change log.
### Description of developer facing changes:
N/A
### Description of development approach:
N/A
### Testing strategy:
Check generated change log
### Known issues with pull request:
None
### Code Review Checklist:


- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
