### PR TITLE
Revert "Correctly version and sign the 32 bit synthDriverHost runtime executable and don't include unnecessary pdb lib and exp files"

### DIFF
--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -119,7 +119,7 @@ jobs:
         UV_PYTHON: ""          # clear setup-uv override
         VIRTUAL_ENV: ""        # avoid inheriting outer venv
       run: |
-        uv run --no-active --directory runtime-builders/synthDriverHost32 python setup-runtime.py --dest-dir ../../source/lib/x86/synthDriverHost-runtime --version "$env:version" --publisher "$env:scons_publisher"
+        uv run --no-active --directory runtime-builders/synthDriverHost32 python setup-runtime.py --dest-dir ../../source/lib/x86/synthDriverHost-runtime
     - name: Prepare for tests
       run: ci/scripts/tests/beforeTests.ps1
     - name: Cache scons build

--- a/runtime-builders/synthDriverHost32/setup-runtime.py
+++ b/runtime-builders/synthDriverHost32/setup-runtime.py
@@ -13,8 +13,6 @@ import argparse
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--dest-dir", default="dist")
-parser.add_argument("--version")
-parser.add_argument("--publisher")
 args = parser.parse_args()
 
 nvdaSourceDir = os.path.join("..", "..", "source")
@@ -32,12 +30,6 @@ from buildVersion import (  # noqa: E402
 	publisher,
 	version,
 )
-
-if args.version is not None:
-	version = args.version
-if args.publisher is not None:
-	publisher = args.publisher
-
 
 gettext.install("nvda")
 

--- a/sconstruct
+++ b/sconstruct
@@ -416,9 +416,7 @@ def NVDADistGenerator(target, source, env, for_signature):
 	action.append(buildCmd)
 
 	if certFile or apiSigningToken:
-		for prog in "nvda_noUIAccess.exe", "nvda_uiAccess.exe", "nvda_slave.exe", "l10nUtil.exe", os.path.join("lib", version, "x86", "synthDriverHost-runtime", "nvda_synthDriverHost.exe"):
-			if not os.path.isfile(os.path.join(target[0].path, prog)):
-				continue
+		for prog in "nvda_noUIAccess.exe", "nvda_uiAccess.exe", "nvda_slave.exe", "l10nUtil.exe":
 			action.append(
 				lambda target, source, env, progByVal=prog: env["signExec"](
 					[target[0].File(progByVal)], source, env
@@ -702,7 +700,7 @@ synthDriverHost32Runtime = env.Command(
 	source="#runtime-builders/synthDriverHost32/setup-runtime.py",
 	chdir=Dir("#runtime-builders/synthDriverHost32"),
 	action=[
-		  f"uv run -v --no-active --directory .  python setup-runtime.py --dest-dir dist --version {version} --publisher {publisher}",
+		  "uv run -v python setup-runtime.py ",
 		r"rmdir /s /q ..\..\source\lib\x86\synthDriverHost-runtime || exit 0",
 		r"xcopy /e /i /y dist ..\..\source\lib\x86\synthDriverHost-runtime",
 	],

--- a/source/setup.py
+++ b/source/setup.py
@@ -287,9 +287,10 @@ freeze(
 			else []
 		)
 		+ (
-			[
-				("_synthDrivers32", glob("_synthDrivers32/*.py") + glob("_synthDrivers32/*.dll")),
-			]
+			getRecursiveDataFiles(
+				"_synthDrivers32",
+				"_synthDrivers32",
+			)
 			if os.path.isdir("lib/x86/synthDriverHost-runtime")
 			else []
 		)


### PR DESCRIPTION

### Reverts PR
Reverts nvaccess/nvda#19683

### Issues fixed
N/A

### Issues reopened
<!-- Issues that will be re-opened by reverting, i.e. the issues that were fixed via the PR getting reverted  -->
Reopens https://github.com/nvaccess/nvda/issues/19654
Reopens https://github.com/nvaccess/nvda/issues/19653

### Reason for revert
This PR is causing system tests to hang indefinitely for signed builds. NVDA fails to start after being installed.

Compare these two commit builds

- https://github.com/nvaccess/nvda/actions/runs/22465329705
- https://github.com/nvaccess/nvda/actions/runs/22465348278

### Can this PR be reimplemented? If so, what is required for the next attempt
Create `try-` builds from the PR which pass 