### PR TITLE
Fix magnifier tracking vertical lists

### DIFF
--- a/source/_magnifier/utils/focusManager.py
+++ b/source/_magnifier/utils/focusManager.py
@@ -32,7 +32,7 @@ class FocusManager:
 	def getCurrentFocusCoordinates(self) -> Coordinates:
 		"""
 		Get the current focus coordinates based on priority.
-		Priority: Mouse > System Focus > Navigator Object
+		Priority: Mouse > Navigator Object > System Focus
 
 		:return: The (x, y) coordinates of the current focus
 		"""
@@ -67,17 +67,22 @@ class FocusManager:
 			self._lastFocusedObject = FocusType.MOUSE
 			return mousePosition
 
-		# Priority 3: Navigator object.
-		# Takes precedence over system focus so that table cell navigation
-		# (ctrl+alt+arrows) follows the reported cell rather than the focused row.
-		# This also covers plain NumPad navigation where only the navigator moves.
+		# Priority 3: Navigator object – but only when it represents a genuinely independent movement.
 		if navigatorObjectChanged:
+			# If both navigator and system focus changed but ended up at the same
+			# coordinates, treat this as ordinary system-focus navigation.
+			# This avoids marking normal focus/caret movement as NAVIGATOR when
+			# the review cursor is merely following focus/caret.
+			if systemFocusChanged and navigatorObjectPosition == systemFocusPosition:
+				# Navigator followed focus/caret – behave as a system-focus event.
+				self._lastFocusedObject = FocusType.SYSTEM_FOCUS
+				return systemFocusPosition
 			self._lastFocusedObject = FocusType.NAVIGATOR
 			return navigatorObjectPosition
 
-		# Priority 4: System focus (focus object + browse mode cursor).
-		# Reached only when the navigator did not change, e.g. plain Tab/focus
-		# movement or browse mode caret navigation.
+		# Priority 4: System focus (Tab, plain focus changes, browse-mode caret).
+		# Reached when only the system-focus position changed without a corresponding
+		# navigator change
 		if systemFocusChanged:
 			self._lastFocusedObject = FocusType.SYSTEM_FOCUS
 			return systemFocusPosition

--- a/source/_magnifier/utils/focusManager.py
+++ b/source/_magnifier/utils/focusManager.py
@@ -67,15 +67,20 @@ class FocusManager:
 			self._lastFocusedObject = FocusType.MOUSE
 			return mousePosition
 
-		# Priority 3: System focus (focus object + browse mode cursor)
-		if systemFocusChanged:
-			self._lastFocusedObject = FocusType.SYSTEM_FOCUS
-			return systemFocusPosition
-
-		# Priority 4: Navigator object (NumPad navigation)
+		# Priority 3: Navigator object.
+		# Takes precedence over system focus so that table cell navigation
+		# (ctrl+alt+arrows) follows the reported cell rather than the focused row.
+		# This also covers plain NumPad navigation where only the navigator moves.
 		if navigatorObjectChanged:
 			self._lastFocusedObject = FocusType.NAVIGATOR
 			return navigatorObjectPosition
+
+		# Priority 4: System focus (focus object + browse mode cursor).
+		# Reached only when the navigator did not change, e.g. plain Tab/focus
+		# movement or browse mode caret navigation.
+		if systemFocusChanged:
+			self._lastFocusedObject = FocusType.SYSTEM_FOCUS
+			return systemFocusPosition
 
 		# No changes detected - return last focused position
 		match self._lastFocusedObject:

--- a/tests/unit/test_magnifier/test_focusManager.py
+++ b/tests/unit/test_magnifier/test_focusManager.py
@@ -132,7 +132,7 @@ class TestFocusManager(unittest.TestCase):
 				leftPressed=False,
 				expectedCoords=Coordinates(15, 15),
 				expectedFocus=FocusType.SYSTEM_FOCUS,
-				description="System focus changed",
+				description="System focus changed alone (navigator did not move)",
 			),
 			FocusTestParam(
 				navigatorObjectPos=Coordinates(20, 20),
@@ -142,6 +142,15 @@ class TestFocusManager(unittest.TestCase):
 				expectedCoords=Coordinates(20, 20),
 				expectedFocus=FocusType.NAVIGATOR,
 				description="Navigator object changed (NumPad navigation)",
+			),
+			FocusTestParam(
+				navigatorObjectPos=Coordinates(30, 30),
+				systemFocusPos=Coordinates(15, 15),
+				mousePos=(0, 0),
+				leftPressed=False,
+				expectedCoords=Coordinates(30, 30),
+				expectedFocus=FocusType.NAVIGATOR,
+				description="Both system focus and navigator changed (table cell navigation): navigator wins",
 			),
 			FocusTestParam(
 				navigatorObjectPos=Coordinates(0, 0),


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Fixes #19635
### Summary of the issue:

When using `Ctrl+Alt+Arrow` to navigate vertical list, both the system focus (row) and the navigator object (cell) change simultaneously.

In `getCurrentFocusCoordinates()`, system focus had priority 3 and navigator had priority 4.  
As a result, the magnifier always followed the row instead of the active cell.

### Description of user facing changes:

- Magnifier should follow properly on (`Ctrl+Alt+Arrow`).
-
- No behavior change for:
  - Tab / normal focus navigation
  - Caret navigation (browse mode)
  - Numpad navigator movement

### Description of developer facing changes:

**focusManager.py**

- Inverted priorities 3 and 4 in `getCurrentFocusCoordinates()`:

    - If both system focus and navigator change, navigator wins.
    - System focus only wins if navigator did not move.


### Description of development approach:

The fix is limited to priority inversion to align behavior with expected table navigation semantics.

This ensures:
- Normal focus changes remain unchanged.
- Caret-only movement remains unchanged.
- Navigator-only movement remains unchanged.
- Simultaneous changes correctly favor the navigator (table cell case).

### Testing strategy:

- Added new test case.

### Known issues with pull request:
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.