### PR TITLE
setup.py: when copying _synthDrivers32, only include .py and .dll files, excluding lib exp and pdb files which are not needed.

### DIFF
--- a/source/setup.py
+++ b/source/setup.py
@@ -287,10 +287,9 @@ freeze(
 			else []
 		)
 		+ (
-			getRecursiveDataFiles(
-				"_synthDrivers32",
-				"_synthDrivers32",
-			)
+			[
+				("_synthDrivers32", glob("_synthDrivers32/*.py") + glob("_synthDrivers32/*.dll")),
+			]
 			if os.path.isdir("lib/x86/synthDriverHost-runtime")
 			else []
 		)

--- a/source/setup.py
+++ b/source/setup.py
@@ -288,7 +288,11 @@ freeze(
 		)
 		+ (
 			[
-				("_synthDrivers32", glob("_synthDrivers32/*.py") + glob("_synthDrivers32/*.dll")),
+				(
+					"_synthDrivers32",
+					glob("_synthDrivers32/**/*.py", recursive=True)
+					+ glob("_synthDrivers32/**/*.dll", recursive=True),
+				),
 			]
 			if os.path.isdir("lib/x86/synthDriverHost-runtime")
 			else []


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
<!-- Use Closes/Fixes/Resolves #xxx to link this PR to the issue it is responding to. -->
Fixes #19653


### Summary of the issue:
The 32 bit synthDriverhost runtime introduced in PR #19432 includes some extra lib exp and pdb files which are not necessary and just take up space.

### Description of user facing changes:

### Description of developer facing changes:

### Description of development approach:
When building the main NvDA distribution with py2exe, only copy py and dll files in the _synthDrivers32 directory, which now ignores lib exp and pdb files.

### Testing strategy:
* [x] Build locally, ensuring that the unneeded lib exp and pdb files are not included in the _synthDrivers32 directory. Ensure NvDA runs and that the sapi4 and 32 bit sapi5 synthDrivers can be selected and used.
* [x] Create a try build, also ensuring all of the above.

### Known issues with pull request:
None known.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
