### PR TITLE
scons dist now signs the synthDriverHost32 runtime executable if it exists.

### DIFF
--- a/sconstruct
+++ b/sconstruct
@@ -416,11 +416,12 @@ def NVDADistGenerator(target, source, env, for_signature):
 	action.append(buildCmd)
 
 	if certFile or apiSigningToken:
-		for prog in "nvda_noUIAccess.exe", "nvda_uiAccess.exe", "nvda_slave.exe", "l10nUtil.exe":
+		for prog in "nvda_noUIAccess.exe", "nvda_uiAccess.exe", "nvda_slave.exe", "l10nUtil.exe", os.path.join("lib", version, "x86", "synthDriverHost-runtime", "nvda_synthDriverHost.exe"):
+			path = os.path.join(target[0].abspath, prog)
 			action.append(
-				lambda target, source, env, progByVal=prog: env["signExec"](
-					[target[0].File(progByVal)], source, env
-				)
+				lambda target, source, env, pathByVal=path: env["signExec"](
+					[File(pathByVal)], source, env
+				) if os.path.isfile(pathByVal) else None
 			)
 
 	action.extend((Delete(buildVersionFn), Delete(importlib.util.cache_from_source(buildVersionFn))))

--- a/sconstruct
+++ b/sconstruct
@@ -416,7 +416,14 @@ def NVDADistGenerator(target, source, env, for_signature):
 	action.append(buildCmd)
 
 	if certFile or apiSigningToken:
-		for prog in "nvda_noUIAccess.exe", "nvda_uiAccess.exe", "nvda_slave.exe", "l10nUtil.exe", os.path.join("lib", version, "x86", "synthDriverHost-runtime", "nvda_synthDriverHost.exe"):
+		executablesToSign = (
+			"nvda_noUIAccess.exe",
+			"nvda_uiAccess.exe",
+			"nvda_slave.exe",
+			"l10nUtil.exe",
+			os.path.join("lib", version, "x86", "synthDriverHost-runtime", "nvda_synthDriverHost.exe"),
+		)
+		for prog in executablesToSign:
 			path = os.path.join(target[0].abspath, prog)
 			action.append(
 				lambda target, source, env, pathByVal=path: env["signExec"](


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
<!-- Use Closes/Fixes/Resolves #xxx to link this PR to the issue it is responding to. -->

### Summary of the issue:
The 32 bit synthDriverhost runtime executable introduced in PR #19432 is not signed.
 
### Description of user facing changes:

### Description of developer facing changes:

### Description of development approach:
When building the main dist target with scons, also sign nvda_synthDriverHost.exe if it exists.
This is an improvement over the previous try in pr #19683, where now the path is passed into the lambda by value so that it does not change  in the for loop after being captured.
 

### Testing strategy:
* [x] Compiled with scons synthDriverHost32Runtime and scons dist, providing a signing certificate
  *Confirmed that nvda_synthDriverHost.exe was signed.
* [x] Run the above tests on a try build from this pr.

### Known issues with pull request:
None known.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
