### PR TITLE
Add-on Store: label update action as 'Enable and update' for disabled add-ons

### DIFF
--- a/source/gui/addonStoreGui/viewModels/action.py
+++ b/source/gui/addonStoreGui/viewModels/action.py
@@ -10,6 +10,7 @@ from typing import (
 	Iterable,
 	Optional,
 	TypeVar,
+	Union,
 	TYPE_CHECKING,
 )
 
@@ -29,23 +30,28 @@ ActionTargetT = TypeVar("ActionTargetT", Optional["AddonListItemVM"], Iterable["
 class _AddonAction(Generic[ActionTargetT], ABC):
 	def __init__(
 		self,
-		displayName: str,
+		displayName: Union[str, Callable[[], str]],
 		actionHandler: Callable[[ActionTargetT], None],
 		validCheck: Callable[[ActionTargetT], bool],
 		actionTarget: ActionTargetT,
 	):
 		"""
-		@param displayName: Translated string, to be displayed to the user. Should describe the action / behaviour.
+		@param displayName: Translated string, or callable returning one, to be displayed to the user.
+		Should describe the action / behaviour.
 		@param actionHandler: Call when the action is triggered.
 		@param validCheck: Is the action valid for the current target
 		@param actionTarget: The target this action will be applied to. L{updated} notifies of modification.
 		"""
-		self.displayName = displayName
+		self._displayName = displayName if callable(displayName) else lambda: displayName
 		self.actionHandler = actionHandler
 		self._validCheck = validCheck
 		self._actionTarget = actionTarget
 		self.updated = extensionPoints.Action()
 		"""Notify of changes to the action"""
+
+	@property
+	def displayName(self) -> str:
+		return self._displayName()
 
 	@abstractmethod
 	def _listItemChanged(self, addonListItemVM: "AddonListItemVM"): ...

--- a/source/gui/addonStoreGui/viewModels/store.py
+++ b/source/gui/addonStoreGui/viewModels/store.py
@@ -129,8 +129,13 @@ class AddonStoreVM:
 				actionTarget=selectedListItem,
 			),
 			AddonActionVM(
-				# Translators: Label for an action that updates the selected addon
-				displayName=pgettext("addonStore", "&Update"),
+				displayName=lambda: (
+					# Translators: Label for an action that enables and updates the selected disabled addon
+					pgettext("addonStore", "&Enable and update")
+					if selectedListItem is not None and selectedListItem.model.isDisabled
+					# Translators: Label for an action that updates the selected addon
+					else pgettext("addonStore", "&Update")
+				),
 				actionHandler=self.getAddon,
 				validCheck=lambda aVM: aVM.canUseUpdateAction(),
 				actionTarget=selectedListItem,

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -26,6 +26,7 @@ The triple-press keyboard shortcut (`NVDA+ctrl+r`) is not affected, as it is int
 
 ### Changes
 
+* In the Add-on Store, the "Update" action for disabled add-ons is now labelled "Enable and update" to clarify that the add-on will be enabled as part of the update process. (#17624)
 * It is now possible to open the log viewer with `NVDA+f1`, even when the log level is set to "disabled". (#19318, @CyrilleB79)
 * Improved search algorithm for filtering add-ons in the Add-on Store. (#19309)
 * NVDA can now be configured to not play error sounds, even in test versions. (#13021, @CyrilleB79)


### PR DESCRIPTION
### Summary

When a disabled add-on has an update available, triggering the update will also enable it (this is intended behaviour, as noted in #17624). However, the action was labelled simply "Update", giving no indication that the add-on would also be enabled.

This PR relabels the action to "Enable and update" when the target add-on is currently disabled, making the behaviour explicit to the user.

### Changes

- `_AddonAction.displayName` now accepts a `str | Callable[[], str]`, allowing the label to be computed dynamically at display time.
- The Update action in `store.py` uses a lambda to return "Enable and update" when the selected add-on is disabled, and "Update" otherwise.

### Testing

- Unit tests: 1050 passed, 0 failures (`rununittests.bat`)
- Lint: 0 errors (`runlint.bat`)
- Manual testing of the exact scenario (disabled add-on + update available) requires installing an older version of an add-on side-by-side with a store version; the logic relies on `model.isDisabled` which is the same property used throughout the codebase for this check.

### Checklist

- [x] Changes are limited to the issue scope
- [x] Unit tests pass
- [x] Lint passes
- [x] `changes.md` entry added (#17624)
- [x] "Allow edits from maintainers" is enabled