### PR TITLE
Made the Orbit Reader 40 support Orbit HID mode

### DIFF
--- a/source/brailleDisplayDrivers/baum.py
+++ b/source/brailleDisplayDrivers/baum.py
@@ -106,6 +106,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 				"VID_0904&PID_600A",  # Brailliant2 80
 				"VID_0904&PID_6201",  # Vario 340
 				"VID_0483&PID_A1D3",  # Orbit Reader 20
+				"VID_0483&PID_A366",  # Orbit Reader 40
 				"VID_0904&PID_6301",  # Vario 4
 			},
 		)
@@ -147,6 +148,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 					"Pronto!",
 					"VarioUltra",
 					"Orbit Reader 20",
+					"Orbit Reader 40",
 					"Vario 4",
 				)
 			),

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -29,6 +29,7 @@ The triple-press keyboard shortcut (`NVDA+ctrl+r`) is not affected, as it is int
 * It is now possible to open the log viewer with `NVDA+f1`, even when the log level is set to "disabled". (#19318, @CyrilleB79)
 * Improved search algorithm for filtering add-ons in the Add-on Store. (#19309)
 * NVDA can now be configured to not play error sounds, even in test versions. (#13021, @CyrilleB79)
+* NVDA now supports the Orbit Reader 40 in its proprietary HID mode. (#19756, @trypsynth)
 * NVDA will start in focus mode by default when using WhatsApp 2.2584.3.0 or newer. (#19655, @josephsl)
 
 ### Bug Fixes

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -5061,15 +5061,15 @@ These include:
 * Baum: SuperVario, PocketVario, VarioUltra, Pronto!, SuperVario2, Vario 340
 * HumanWare: Brailliant, BrailleConnect, Brailliant2
 * APH: Refreshabraille
-* Orbit: Orbit Reader 20
+* Orbit: Orbit Reader 20, Orbit Reader 40
 
 Some other displays manufactured by Baum may also work, though this has not been tested.
 
 If connecting via USB to displays which do not use HID, you must first install the USB drivers provided by the manufacturer.
 The VarioUltra and Pronto! use HID.
-The Refreshabraille and Orbit Reader 20 can use HID if configured appropriately.
+The Refreshabraille, Orbit Reader 20, and Orbit Reader 40 can use HID if configured appropriately.
 
-The USB serial mode of the Orbit Reader 20 is currently only supported in Windows 10 and later.
+The USB serial mode of the Orbit Reader 20 and 40 is currently only supported in Windows 10 and later.
 USB HID should generally be used instead.
 
 Following are the key assignments for these displays with NVDA.

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -5069,9 +5069,6 @@ If connecting via USB to displays which do not use HID, you must first install t
 The VarioUltra and Pronto! use HID.
 The Refreshabraille, Orbit Reader 20, and Orbit Reader 40 can use HID if configured appropriately.
 
-The USB serial mode of the Orbit Reader 20 and 40 is currently only supported in Windows 10 and later.
-USB HID should generally be used instead.
-
 Following are the key assignments for these displays with NVDA.
 Please see your display's documentation for descriptions of where these keys can be found.
 <!-- KC:beginInclude -->


### PR DESCRIPTION
### Link to issue number:
None known
### Summary of the issue:
Both Orbit Research braille displays have two modes: an Orbit proprietary HID mode which implements the HID Braille standard, and a mode that emulates another display (Refreshabraille 18 for the Orbit Reader 20, Vario for the Orbit Reader 40). Previously, NVDA could only talk to the Orbit Reader 20 in the specialized HID mode, not the 40.

### Description of user facing changes:
The Orbit Reader 40 is now supported with NVDA in both modes.

### Description of developer facing changes:
None, two lines added to baum.py.

### Description of development approach:
Added the hardware ID from a real Orbit Reader 40 in Orbit HID mode to the list in baum.py.

### Testing strategy:
Confirmed braille is seen from the Orbit Reader 40 in both modes with NVDA.

### Known issues with pull request:
None

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
