### PR TITLE
Update Liblouis to 3.37.0

### DIFF
--- a/projectDocs/dev/createDevEnvironment.md
+++ b/projectDocs/dev/createDevEnvironment.md
@@ -88,7 +88,7 @@ If you aren't sure, run `git submodule update` after every git pull, merge or ch
 * [eSpeak NG](https://github.com/espeak-ng/espeak-ng), commit `b0b605c8a80f76c4c19e18033c6780c3cc4afc5b`
 * [Sonic](https://github.com/waywardgeek/sonic), commit `d2cdb40fbdc82b464be364a50b34e8dd82b6c80a`
 * [IAccessible2](https://wiki.linuxfoundation.org/accessibility/iaccessible2/start), commit `c9ae003d9c85eb707716928de97e055f5b77189c`
-* [liblouis](http://www.liblouis.io/), version 3.36.0
+* [liblouis](http://www.liblouis.io/), version 3.37.0
 * [Unicode Common Locale Data Repository (CLDR)](http://cldr.unicode.org/), version 48.0
 * [Adobe Acrobat accessibility interface, version XI](https://download.macromedia.com/pub/developer/acrobat/AcrobatAccess.zip)
 * [Microsoft Detours](https://github.com/microsoft/Detours), commit `9764cebcb1a75940e68fa83d6730ffaf0f669401`

--- a/source/brailleTables/__tables.py
+++ b/source/brailleTables/__tables.py
@@ -198,6 +198,9 @@ addTable("es-g1.ctb", _("Spanish grade 1"))
 addTable("es-g2.ctb", _("Spanish grade 2"), contracted=True)
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
+addTable("et-6dot.utb", _("Estonian 6 dot"), input=False)
+# Translators: The name of a braille table displayed in the
+# braille settings dialog.
 addTable("et-g0.utb", _("Estonian grade 0"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
@@ -307,7 +310,7 @@ addTable(
 	"it-it-comp6.utb",
 	# Translators: The name of a braille table displayed in the
 	# braille settings dialog.
-	_("Italian 6 dot computer braille"),
+	_("Italian 6 dot"),
 	inputForLangs={"it"},
 	outputForLangs={"it"},
 )

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -26,6 +26,8 @@ The triple-press keyboard shortcut (`NVDA+ctrl+r`) is not affected, as it is int
 
 ### Changes
 
+* Updated Liblouis Braille translator to [3.37.0](https://github.com/liblouis/liblouis/releases/tag/v3.37.0). (#19758, @codeofdusk)
+  * Added new Italian and Estonian 6 dot tables.
 * It is now possible to open the log viewer with `NVDA+f1`, even when the log level is set to "disabled". (#19318, @CyrilleB79)
 * Improved search algorithm for filtering add-ons in the Add-on Store. (#19309)
 * NVDA can now be configured to not play error sounds, even in test versions. (#13021, @CyrilleB79)


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
None

### Summary of the issue:
Liblouis 3.37.0 was released.

### Description of how this pull request fixes the issue:
Update LibLouis.

### Testing strategy:
Alpha testing.

### Known issues with pull request:
None known

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
