### PR TITLE
Add user warning that certain logging levels can log sensitive inform…

### DIFF
--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -6162,6 +6162,23 @@ class PrivacyAndSecuritySettingsPanel(SettingsPanel):
 			wx.Choice,
 			choices=[level.displayString for level in LoggingLevel],
 		)
+		# Translators: Warning shown when selecting logging levels that may expose sensitive information.
+		self._logLevelWarningText = generalGroup.addItem(
+			wx.StaticText(
+				generalBox,
+				label=_(
+					"Warning: Selecting \"Debug warning\", \"Input/output\", or \"Debug\" logging levels "
+					"may record sensitive information such as typed text, system information, or application data. "
+					"Only enable these levels if you understand the risks."
+				),
+			),
+		)
+
+		# Hide by default
+		self._logLevelWarningText.Hide()
+
+		# Bind change event
+		self._logLevelCombo.Bind(wx.EVT_CHOICE, self._onLogLevelChanged)
 		self.bindHelpEvent("GeneralSettingsLogLevel", self._logLevelCombo)
 		if logHandler.isLogLevelForced():
 			self._logLevelCombo.Disable()
@@ -6187,7 +6204,19 @@ class PrivacyAndSecuritySettingsPanel(SettingsPanel):
 		if not updateCheck:
 			self._allowUsageStatsCheckBox.Value = False
 			self._allowUsageStatsCheckBox.Disable()
+	def _onLogLevelChanged(self, evt):
+		selectedLevel = list(LoggingLevel)[self._logLevelCombo.GetSelection()]
 
+		if selectedLevel in (
+			LoggingLevel.DEBUGWARNING,
+			LoggingLevel.IO,
+			LoggingLevel.DEBUG,
+		):
+			self._logLevelWarningText.Show()
+		else:
+			self._logLevelWarningText.Hide()
+
+		self.Layout()
 	def onDiscard(self):
 		# Restore screen curtain state and setting to the most recently saved baseline,
 		# in case the user enabled or disabled it without saving.
@@ -6328,6 +6357,7 @@ class NVDASettingsDialog(MultiCategorySettingsDialog):
 		# Ensure that after the settings dialog is created the name is set correctly
 		super(NVDASettingsDialog, self).makeSettings(settingsSizer)
 		self._doOnCategoryChange()
+		self._onLogLevelChanged(None)
 		global NvdaSettingsDialogWindowHandle
 		NvdaSettingsDialogWindowHandle = self.GetHandle()
 


### PR DESCRIPTION


<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
<!-- Use Closes/Fixes/Resolves #xxx to link this PR to the issue it is responding to. -->
Fixes #19465 

### Summary of the issue:
Changing logging levels to "debug warning", "input/output", or "debug" allows the program to log sensitive information on the user's computer, such as passwords and personal information. No warning message currently exists to alert users of this consequence. 

### Description of user facing changes:
A warning message will pop up after users select logging levels above "info." The message states the following: "Warning: Selecting 'Debug warning', 'Input/output', or 'Debug' logging levels may record sensitive information such as typed text, system information, or application data. Only enable these levels if you understand the risks."

### Description of developer facing changes:

### Description of development approach:
Added an event handler in the PrivacyAndSecuritySettingsPanel class to display a warning message if the user selects certain logging levels. The box is hidden by default and only displays after the event handler checks the logging level selected.

### Testing strategy:

### Known issues with pull request:

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [ ] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [ ] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [ ] API is compatible with existing add-ons.
- [ ] Security precautions taken.
