### PR TITLE
add unassigned command to report the status of screen curtain

### DIFF
--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -4970,6 +4970,36 @@ class GlobalCommands(ScriptableObject):
 	@script(
 		description=_(
 			# Translators: Describes a command.
+			"Reports the state of the screen curtain.",
+		),
+		category=SCRCAT_VISION,
+	)
+	def script_reportScreenCurtainState(self, gesture: inputCore.InputGesture) -> None:
+		import screenCurtain
+
+		if screenCurtain.screenCurtain is None:
+			# Screen curtain has not been initialized.
+			# Translators: Reported when the screen curtain is not available.
+			ui.message(_("Screen curtain not available"), speechPriority=speech.priorities.Spri.NOW)
+			return
+
+		if screenCurtain.screenCurtain.enabled:
+			if not screenCurtain.screenCurtain.settings["enabled"]:
+				# Translators: Reported when the screen curtain is temporarily enabled.
+				ui.message(
+					_("Temporary Screen curtain, enabled until next restart"),
+					speechPriority=speech.priorities.Spri.NOW,
+				)
+			else:
+				# Translators: Reported when the screen curtain is enabled.
+				ui.message(_("Screen curtain enabled"), speechPriority=speech.priorities.Spri.NOW)
+		else:
+			# Translators: Reported when the screen curtain is disabled.
+			ui.message(_("Screen curtain disabled"), speechPriority=speech.priorities.Spri.NOW)
+
+	@script(
+		description=_(
+			# Translators: Describes a command.
 			"Toggles the magnifier on and off",
 		),
 		category=SCRCAT_VISION,

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -23,6 +23,7 @@
 Consult the speech dictionaries section in the User Guide for more details. (#19506, @LeonarddeR)
 * When resetting the configuration to factory defaults from the NVDA menu, a dialog is now shown afterwards with an Undo button to restore the previous configuration.
 The triple-press keyboard shortcut (`NVDA+ctrl+r`) is not affected, as it is intended for recovery scenarios. (#19575, @bramd)
+* Added an unassigned command to report the current status of the Screen Curtain
 
 ### Changes
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -23,7 +23,7 @@
 Consult the speech dictionaries section in the User Guide for more details. (#19506, @LeonarddeR)
 * When resetting the configuration to factory defaults from the NVDA menu, a dialog is now shown afterwards with an Undo button to restore the previous configuration.
 The triple-press keyboard shortcut (`NVDA+ctrl+r`) is not affected, as it is intended for recovery scenarios. (#19575, @bramd)
-* Added an unassigned command to report the current status of the Screen Curtain
+* Added an unassigned command to report the current status of the Screen Curtain. (#19759)
 
 ### Changes
 

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -1502,6 +1502,8 @@ You can enable Screen Curtain in the [Privacy and Security category](#PrivacyAnd
 
 <!-- KC:endInclude -->
 
+You can also assign a gesture for reporting the current status of the Screen curtain from [Input Gestures dialog](#InputGestures) in NVDA's Preferences menu, When this gesture is performed NVDA will tell you the current status of the Screen Curtain if it is activated or disabled.
+
 When Screen Curtain is enabled, features that rely on what is literally on screen will not function.
 For example, you cannot [use OCR](#Win10Ocr).
 Some screenshot utilities also may not work.

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -1499,10 +1499,9 @@ You can enable Screen Curtain in the [Privacy and Security category](#PrivacyAnd
 | Name |Key |Description|
 |---|---|---|
 |Toggles the state of the screen curtain |`NVDA+control+escape` |Enable to make the screen black or disable to show the contents of the screen. Pressed once, screen curtain is enabled until you restart NVDA. Pressed twice, screen curtain is enabled until you disable it.|
+|Reports the state of the screen curtain |`None` |allows you to here the current status of the screen curtain weather if it is disabled or enabled.|
 
 <!-- KC:endInclude -->
-
-You can also assign a gesture for reporting the current status of the Screen curtain from [Input Gestures dialog](#InputGestures) in NVDA's Preferences menu, When this gesture is performed NVDA will tell you the current status of the Screen Curtain if it is activated or disabled.
 
 When Screen Curtain is enabled, features that rely on what is literally on screen will not function.
 For example, you cannot [use OCR](#Win10Ocr).

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -1499,7 +1499,7 @@ You can enable Screen Curtain in the [Privacy and Security category](#PrivacyAnd
 | Name |Key |Description|
 |---|---|---|
 |Toggles the state of the screen curtain |`NVDA+control+escape` |Enable to make the screen black or disable to show the contents of the screen. Pressed once, screen curtain is enabled until you restart NVDA. Pressed twice, screen curtain is enabled until you disable it.|
-|Reports the state of the screen curtain |`None` |allows you to here the current status of the screen curtain weather if it is disabled or enabled.|
+| Reports the state of the screen curtain | `None` | Announces the current status of the screen curtain, whether it is disabled or enabled or in temporary mode. |
 
 <!-- KC:endInclude -->
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
<!-- Use Closes/Fixes/Resolves #xxx to link this PR to the issue it is responding to. -->
Resolves #19759

### Summary of the issue:
users needs a way to know what the current status of screen curtain is. Previously , Users had to check the NVDA settings or perform the shortcut NVDA+CTRL+ESC to know what is the current status of the screen curtain if it is activated or deactivated.
### Description of user facing changes:
Now, users can assign a new custom shortcut that when it is performed will allow the users to get a notification with the current status of the screen curtain .
### Description of developer facing changes:
None
### Description of development approach:
Added a new intrys with an if check in /source/globalCommands.py, and added new entrys in the changes and the user docs files
### Testing strategy:
tested locally
### Known issues with pull request:
None
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
