### PR TITLE
fix: guard oldTracker.pluralTimeout before comparison in makeMergedTrackerIfPossible

### DIFF
--- a/source/touchTracker.py
+++ b/source/touchTracker.py
@@ -355,6 +355,7 @@ class TrackerManager(object):
 		elif (
 			self.numUnknownTrackers == 0
 			and newTracker.pluralTimeout is not None
+			and oldTracker.pluralTimeout is not None
 			and newTracker.startTime >= oldTracker.endTime
 			and newTracker.startTime < oldTracker.pluralTimeout
 			and newTracker.action == oldTracker.action


### PR DESCRIPTION
Fixes #19620

## Summary

In `makeMergedTrackerIfPossible`, the pluralization branch checked `newTracker.pluralTimeout is not None` before using it, but did not apply the same guard to `oldTracker.pluralTimeout`. When `oldTracker` represented a non-tap action (e.g. a flick or hover), its `pluralTimeout` is `None`, causing:

```
TypeError: '<' not supported between instances of 'float' and 'NoneType'
```

at the line:
```python
and newTracker.startTime < oldTracker.pluralTimeout
```

## Fix

Add `and oldTracker.pluralTimeout is not None` to the condition, consistent with the existing guard on `newTracker.pluralTimeout`. When `oldTracker.pluralTimeout` is `None` the trackers cannot be pluralized anyway, so skipping the branch is correct.

## Test plan

- [ ] Reproduce the crash by enabling hardware keyboard suggestions and using touch input simultaneously, then confirm no `TypeError` is raised
- [ ] Verify normal touch gestures (tap, double-tap, flick) still work correctly