### PR TITLE
docs: document how to build the synthDriverHost32 runtime

### DIFF
--- a/projectDocs/dev/buildingNVDA.md
+++ b/projectDocs/dev/buildingNVDA.md
@@ -69,6 +69,25 @@ scons launcher
 
 The archive will be placed in the output directory.
 
+### Building the synthDriverHost32 runtime
+
+The 32-bit synth driver host (`synthDriverHost32`) is **not** built by scons.
+It has its own build script and Python environment managed by [uv](https://github.com/astral-sh/uv).
+
+Prerequisites:
+- [uv](https://github.com/astral-sh/uv) must be installed and available on your `PATH`.
+
+To build the runtime, run the following from the root of the repository:
+
+```cmd
+uv run --no-active --directory runtime-builders/synthDriverHost32 python setup-runtime.py --dest-dir source/lib/x86/synthDriverHost-runtime
+```
+
+The built runtime will be placed in `source/lib/x86/synthDriverHost-runtime/`.
+
+You only need to rebuild this when the `runtime-builders/synthDriverHost32` directory changes.
+For release builds, CI passes additional `--version` and `--publisher` arguments automatically.
+
 ### Building developer documentation
 
 Refer to [building developer documentation](./buildingDevDocumentation.md).

--- a/projectDocs/dev/buildingNVDA.md
+++ b/projectDocs/dev/buildingNVDA.md
@@ -75,7 +75,7 @@ The 32-bit synth driver host (`synthDriverHost32`) is **not** built by scons.
 It has its own build script and Python environment managed by [uv](https://github.com/astral-sh/uv).
 
 Prerequisites:
-- [uv](https://github.com/astral-sh/uv) must be installed and available on your `PATH`.
+* [uv](https://github.com/astral-sh/uv) must be installed and available on your `PATH`.
 
 To build the runtime, run the following from the root of the repository:
 


### PR DESCRIPTION
Fixes #19697

## Summary

The 32-bit synth driver host introduced in #19432 is built separately from the main scons build, but this wasn't documented anywhere. Developers had to inspect the CI workflow to discover the build command.

Adds a **Building the synthDriverHost32 runtime** section to `projectDocs/dev/buildingNVDA.md` covering:
- That it is not part of the scons build
- The `uv` prerequisite
- The exact command to run locally
- Where the output is placed
- When a rebuild is needed

## Test plan

- [ ] Verify the new section renders correctly in the docs
- [ ] Confirm the documented command matches what CI runs in `testAndPublish.yml`