### PR TITLE
fix: catch exceptions when clearing addon store download directory on init

### DIFF
--- a/source/addonStore/network.py
+++ b/source/addonStore/network.py
@@ -111,10 +111,16 @@ class AddonFileDownloader:
 
 		if NVDAState.shouldWriteToDisk():
 			# empty temporary downloads
-			if os.path.exists(WritePaths.addonStoreDownloadDir):
-				shutil.rmtree(WritePaths.addonStoreDownloadDir)
-			# ensure downloads dir exist
-			pathlib.Path(WritePaths.addonStoreDownloadDir).mkdir(parents=True, exist_ok=True)
+			try:
+				if os.path.exists(WritePaths.addonStoreDownloadDir):
+					shutil.rmtree(WritePaths.addonStoreDownloadDir)
+				# ensure downloads dir exist
+				pathlib.Path(WritePaths.addonStoreDownloadDir).mkdir(parents=True, exist_ok=True)
+			except Exception:
+				log.exception(
+					f"Failed to initialise add-on store download directory {WritePaths.addonStoreDownloadDir!r}."
+					" The add-on store may not function correctly."
+				)
 
 	def download(
 		self,

--- a/source/addonStore/network.py
+++ b/source/addonStore/network.py
@@ -119,7 +119,7 @@ class AddonFileDownloader:
 			except Exception:
 				log.exception(
 					f"Failed to initialise add-on store download directory {WritePaths.addonStoreDownloadDir!r}."
-					" The add-on store may not function correctly."
+					" The add-on store may not function correctly.",
 				)
 
 	def download(


### PR DESCRIPTION
Fixes #19202

## Summary

When the `_dl` (addon store download) directory exists but has broken permissions (e.g. caused by a cloud backup tool like Google Drive locking the folder), `shutil.rmtree` raises a `PermissionError` that propagates uncaught through module initialisation. Because this happens at import time, NVDA crashes immediately with a `CRITICAL - core failure`, then the watchdog restarts it — creating a crash loop with no recovery path.

The fix wraps the `rmtree` + `mkdir` block in a `try/except` that logs the error with `log.exception` and continues. The add-on store may not be fully functional without a clean download directory, but NVDA itself will start successfully and the user can investigate.

## Changes

- `source/addonStore/network.py`: wrap the download directory cleanup and creation in a try/except inside `AddonFileDownloader.__init__`

## Test plan

- [ ] Simulate a permission error on the `_dl` directory (`%appdata%\nvda\addonStore\_dl`) and confirm NVDA starts without crashing
- [ ] Confirm the error is logged via `log.exception` in the NVDA log
- [ ] Confirm normal add-on store behaviour is unaffected when permissions are fine