### PR TITLE
Fixed a deprecation message and associated docstrings

### DIFF
--- a/source/gui/nvdaControls.py
+++ b/source/gui/nvdaControls.py
@@ -288,7 +288,7 @@ class MessageDialog(gui.message.MessageDialog):
 	"""Provides a more flexible message dialog.
 
 	.. warning:: This class is deprecated.
-		Use :class:`gui.messageDialog.MessageDialog` instead.
+		Use :class:`gui.message.MessageDialog` instead.
 		This class is an adapter around that class, and will be removed in 2026.1.
 
 	Consider overriding _addButtons, to set your own buttons and behaviour.
@@ -315,7 +315,7 @@ class MessageDialog(gui.message.MessageDialog):
 
 	def __new__(cls, *args, **kwargs):
 		warnings.warn(
-			"gui.nvdaControls.MessageDialog is deprecated. Use gui.messageDialog.MessageDialog instead.",
+			"gui.nvdaControls.MessageDialog is deprecated. Use gui.message.MessageDialog instead.",
 			DeprecationWarning,
 		)
 		return super().__new__(cls, *args, **kwargs)

--- a/source/gui/nvdaControls.py
+++ b/source/gui/nvdaControls.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2016-2025 NV Access Limited, Derek Riemer, Cyrille Bougot, Luke Davis, Leonard de Ruijter
+# Copyright (C) 2016-2026 NV Access Limited, Derek Riemer, Cyrille Bougot, Luke Davis, Leonard de Ruijter
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 

--- a/tests/unit/test_messageDialog.py
+++ b/tests/unit/test_messageDialog.py
@@ -1,7 +1,7 @@
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-# Copyright (C) 2024 NV Access Limited
+# Copyright (C) 2024-2026 NV Access Limited
 
 """Unit tests for the message dialog API."""
 

--- a/tests/unit/test_messageDialog.py
+++ b/tests/unit/test_messageDialog.py
@@ -34,7 +34,7 @@ def dummyCallback2(*a):
 
 
 def getDialogState(dialog: MessageDialog):
-	"""Capture internal state of a :class:`gui.messageDialog.MessageDialog` for later analysis.
+	"""Capture internal state of a :class:`gui.message.MessageDialog` for later analysis.
 
 	Currently this only captures state relevant to adding buttons.
 	Further tests wishing to use this dialog should be sure to add any state potentially modified by the functions under test.


### PR DESCRIPTION
Opened against beta since:
* 2026.1 beta cycle is the most privileged time for add-on authors to have a look at deprecation messages.
* This PR is low risk: only log message string and docstrings are modified.

### Link to issue number:
None 

### Summary of the issue:
A deprecation message recommended to use `gui.messageDialog.MessageDialog` but the `gui.message` module does not exist.


### Description of user facing changes:
The deprecation message will now mention `gui.message.MessageDialog`.

### Description of developer facing changes:
Fixed both the deprecation message and docstrings mentioning the non-existing `gui.messageDialog` module.

### Description of development approach:
String replacement. See diff

### Testing strategy:
Manual test of the deprecation message.
### Known issues with pull request:
None
### Code Review Checklist:


- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
