### PR TITLE
Add on-device OCR engine (RapidOCR + ONNX Runtime + PP-OCRv5)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,9 @@ dependencies = [
 	"mdx-gh-links==0.4",
 	"l2m4m==1.0.4",
 	"pymdown-extensions==10.17.1",
+	# On-device OCR engine
+	"rapidocr>=3.3.0",
+	"onnxruntime>=1.17.0",
 ]
 
 [project.urls]

--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -341,6 +341,12 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 	autoRefreshInterval = integer(default=1500, min=100)
 	autoSayAllOnResult = boolean(default=false)
 
+[onDeviceOcr]
+	language = string(default="auto")
+	autoRefresh = boolean(default=false)
+	autoRefreshInterval = integer(default=1500, min=100)
+	autoSayAllOnResult = boolean(default=false)
+
 [editableText]
 	caretMoveTimeoutMs = integer(min=0, max=2000, default=100)
 

--- a/source/contentRecog/onDeviceOcr/__init__.py
+++ b/source/contentRecog/onDeviceOcr/__init__.py
@@ -1,0 +1,139 @@
+# A part of NonVisual Desktop Access (NVDA)
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+
+"""On-device OCR for NVDA using RapidOCR + ONNX Runtime.
+
+Provides offline text recognition from screen content using PaddleOCR models
+(PP-OCRv4/v5) via the RapidOCR library with ONNX Runtime inference.
+This recognizer runs entirely on-device with no cloud dependency.
+"""
+
+import ctypes
+import threading
+from typing import Union
+
+import config
+from logHandler import log
+from contentRecog import (
+	ContentRecognizer,
+	LinesWordsResult,
+	RecogImageInfo,
+	onRecognizeResultCallbackT,
+)
+from .engine import OcrEngineManager
+from .resultConverter import convert_rapidocr_result
+
+
+class OnDeviceOcr(ContentRecognizer):
+	"""On-device OCR content recognizer.
+
+	Subclasses ContentRecognizer to integrate with NVDA's content recognition
+	framework. Uses RapidOCR + ONNX Runtime for inference in a background thread.
+	"""
+
+	@classmethod
+	def _get_allowAutoRefresh(cls) -> bool:
+		return config.conf["onDeviceOcr"]["autoRefresh"]
+
+	@classmethod
+	def _get_autoRefreshInterval(cls) -> int:
+		return config.conf["onDeviceOcr"]["autoRefreshInterval"]
+
+	@classmethod
+	def _get_autoSayAllOnResult(cls) -> bool:
+		return config.conf["onDeviceOcr"]["autoSayAllOnResult"]
+
+	def __init__(self, language: str = None):
+		"""
+		@param language: The language code for recognition,
+			C{None} to use the user's configured language.
+		"""
+		if language:
+			self.language = language
+		else:
+			self.language = config.conf["onDeviceOcr"]["language"] or "auto"
+		self._onResult: onRecognizeResultCallbackT = None
+
+	def getResizeFactor(self, width: int, height: int) -> Union[int, float]:
+		"""Upscale small images for better OCR accuracy."""
+		if width < 100 or height < 100:
+			return 4
+		return 1
+
+	def recognize(
+		self,
+		pixels: ctypes.Array,
+		imageInfo: RecogImageInfo,
+		onResult: onRecognizeResultCallbackT,
+	):
+		"""Asynchronously recognize text from screen pixels.
+
+		Spawns a daemon thread for OCR inference. The onResult callback
+		will be called from the background thread with either a
+		LinesWordsResult or an Exception. The recogUi layer handles
+		marshalling the result back to the main thread.
+		"""
+		self._onResult = onResult
+
+		def _backgroundRecognize():
+			try:
+				import numpy as np
+
+				engine = OcrEngineManager.get_engine()
+				if not engine.is_initialized:
+					engine.initialize(language=self.language)
+
+				# --- Pixel format conversion ---
+				# screenBitmap.captureImage() returns (RGBQUAD * width * height).
+				# RGBQUAD memory layout: [Blue, Green, Red, Reserved] = 4 bytes/pixel.
+				# We need BGR numpy array for RapidOCR (OpenCV convention).
+				width = imageInfo.recogWidth
+				height = imageInfo.recogHeight
+				byte_count = width * height * 4
+
+				# from_buffer_copy creates an independent copy, safe after pixels
+				# buffer is invalidated. from_buffer would be faster but unsafe.
+				flat_buf = (ctypes.c_ubyte * byte_count).from_buffer_copy(pixels)
+				arr = np.frombuffer(flat_buf, dtype=np.uint8).reshape((height, width, 4))
+
+				# BGRA[:3] -> BGR. The memory is already in BGR order (Blue=0, Green=1,
+				# Red=2), which is exactly what RapidOCR/OpenCV expects.
+				# .copy() ensures contiguous memory for ONNX Runtime.
+				bgr_image = arr[:, :, :3].copy()
+
+				# --- Run OCR inference ---
+				raw_result = engine.recognize(bgr_image)
+
+				# --- Convert results to NVDA format ---
+				lines_data = convert_rapidocr_result(raw_result)
+
+				if self._onResult is None:
+					return  # Recognition was cancelled
+
+				if lines_data:
+					self._onResult(LinesWordsResult(lines_data, imageInfo))
+				else:
+					# No text detected - return empty result rather than error
+					self._onResult(
+						LinesWordsResult(
+							[[{"x": 0, "y": 0, "width": 1, "height": 1, "text": ""}]],
+							imageInfo,
+						)
+					)
+
+			except Exception as e:
+				log.error(f"On-device OCR recognition failed: {e}", exc_info=True)
+				if self._onResult is not None:
+					self._onResult(RuntimeError(f"On-device OCR failed: {e}"))
+
+		thread = threading.Thread(
+			target=_backgroundRecognize,
+			name="onDeviceOcr_recognize",
+			daemon=True,
+		)
+		thread.start()
+
+	def cancel(self):
+		"""Cancel the recognition in progress (if any)."""
+		self._onResult = None

--- a/source/contentRecog/onDeviceOcr/__init__.py
+++ b/source/contentRecog/onDeviceOcr/__init__.py
@@ -119,7 +119,7 @@ class OnDeviceOcr(ContentRecognizer):
 						LinesWordsResult(
 							[[{"x": 0, "y": 0, "width": 1, "height": 1, "text": ""}]],
 							imageInfo,
-						)
+						),
 					)
 
 			except Exception as e:

--- a/source/contentRecog/onDeviceOcr/engine.py
+++ b/source/contentRecog/onDeviceOcr/engine.py
@@ -1,0 +1,99 @@
+# A part of NonVisual Desktop Access (NVDA)
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+
+"""Abstract OCR engine interface and engine lifecycle manager.
+
+This module defines the contract for on-device OCR engines and provides
+a manager class that handles lazy initialization and cleanup.
+The abstraction allows swapping the underlying engine (e.g., from RapidOCR
+to another ONNX-based engine) without modifying the recognizer class.
+"""
+
+from abc import ABC, abstractmethod
+from typing import List, Optional
+
+from logHandler import log
+
+
+class OcrEngine(ABC):
+	"""Abstract base class for on-device OCR engines.
+
+	Implementations must handle their own model loading/unloading.
+	The recognize() method receives a BGR numpy array and returns
+	a list of (quad, text, confidence) tuples.
+	"""
+
+	@abstractmethod
+	def initialize(self, language: str = "auto") -> None:
+		"""Initialize or re-initialize the engine for the given language.
+
+		May download models on first call. Must be safe to call multiple times;
+		if already initialized with the same language, should be a no-op.
+
+		@param language: Language code (e.g., "auto", "ch", "en", "japan").
+		@raises RuntimeError: If initialization fails.
+		"""
+		...
+
+	@abstractmethod
+	def recognize(self, image) -> list:
+		"""Run OCR on an image.
+
+		@param image: numpy ndarray in BGR format, shape (H, W, 3), dtype uint8.
+		@return: List of (quad_coords, text, confidence) tuples.
+			quad_coords: [[x1,y1],[x2,y2],[x3,y3],[x4,y4]]
+			text: str
+			confidence: float 0.0-1.0
+		"""
+		...
+
+	@abstractmethod
+	def get_available_languages(self) -> List[str]:
+		"""Return list of supported language codes."""
+		...
+
+	@abstractmethod
+	def shutdown(self) -> None:
+		"""Release all resources (ONNX sessions, model memory)."""
+		...
+
+	@property
+	@abstractmethod
+	def is_initialized(self) -> bool:
+		"""Whether the engine has been initialized and is ready for recognition."""
+		...
+
+
+class OcrEngineManager:
+	"""Singleton manager for the on-device OCR engine.
+
+	Uses lazy initialization: the engine is created on first access,
+	not at NVDA startup, to avoid unnecessary startup delay and memory usage.
+	"""
+
+	_instance: Optional[OcrEngine] = None
+
+	@classmethod
+	def get_engine(cls) -> OcrEngine:
+		"""Get or create the OCR engine instance.
+
+		@return: The active OcrEngine instance.
+		"""
+		if cls._instance is None:
+			from .rapidOcrEngine import RapidOcrEngine
+
+			cls._instance = RapidOcrEngine()
+			log.debug("On-device OCR engine created (not yet initialized)")
+		return cls._instance
+
+	@classmethod
+	def shutdown(cls) -> None:
+		"""Shut down and release the engine instance."""
+		if cls._instance is not None:
+			try:
+				cls._instance.shutdown()
+			except Exception:
+				log.error("Error during OCR engine shutdown", exc_info=True)
+			cls._instance = None
+			log.debug("On-device OCR engine manager shut down")

--- a/source/contentRecog/onDeviceOcr/rapidOcrEngine.py
+++ b/source/contentRecog/onDeviceOcr/rapidOcrEngine.py
@@ -1,0 +1,114 @@
+# A part of NonVisual Desktop Access (NVDA)
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+
+"""RapidOCR engine implementation using ONNX Runtime for on-device OCR."""
+
+import threading
+from typing import List, Optional
+
+from logHandler import log
+from .engine import OcrEngine
+
+
+# Language codes supported by RapidOCR with PP-OCRv4/v5 models.
+# "auto" uses the default Chinese+English model.
+SUPPORTED_LANGUAGES = [
+	"auto",
+	"ch",
+	"en",
+	"japan",
+	"korean",
+	"french",
+	"german",
+	"arabic",
+	"latin",
+	"cyrillic",
+	"devanagari",
+]
+
+
+class RapidOcrEngine(OcrEngine):
+	"""On-device OCR engine backed by RapidOCR + ONNX Runtime.
+
+	Models are loaded lazily on first recognition call.
+	Thread-safe for sequential access (one inference at a time).
+	"""
+
+	def __init__(self):
+		self._engine = None
+		self._language: str = "auto"
+		self._initialized: bool = False
+		self._lock = threading.Lock()
+
+	def initialize(self, language: str = "auto") -> None:
+		with self._lock:
+			if self._initialized and self._language == language:
+				return  # Already initialized with same config
+			if self._initialized:
+				self._cleanup()
+
+			try:
+				from rapidocr import RapidOCR
+
+				self._engine = RapidOCR()
+				self._language = language
+				self._initialized = True
+				log.info(f"RapidOCR engine initialized (language={language})")
+			except ImportError:
+				log.error(
+					"RapidOCR is not installed. "
+					"Install with: pip install rapidocr onnxruntime",
+					exc_info=True,
+				)
+				raise RuntimeError("RapidOCR package not available")
+			except Exception:
+				log.error("Failed to initialize RapidOCR engine", exc_info=True)
+				raise
+
+	def recognize(self, image) -> list:
+		"""Run OCR inference on a BGR image.
+
+		@param image: numpy ndarray, shape (H, W, 3), dtype uint8, BGR format.
+		@return: List of (quad, text, confidence) tuples.
+		@raises RuntimeError: If engine is not initialized.
+		"""
+		with self._lock:
+			if not self._initialized or self._engine is None:
+				raise RuntimeError("OCR engine not initialized. Call initialize() first.")
+			result = self._engine(image)
+			# RapidOCR >= 3.x returns a RapidOCRResult object.
+			# Access .boxes, .txts, .scores or iterate.
+			# For compatibility, handle both old tuple format and new object format.
+			if result is None:
+				return []
+			# New API (>= 3.0): result has .boxes, .txts, .scores attributes
+			if hasattr(result, "boxes") and result.boxes is not None:
+				items = []
+				for box, txt, score in zip(result.boxes, result.txts, result.scores):
+					items.append((box.tolist() if hasattr(box, "tolist") else box, txt, float(score)))
+				return items
+			# Legacy API: result is (list_of_results, elapsed)
+			if isinstance(result, tuple) and len(result) == 2:
+				raw, _ = result
+				if raw is None:
+					return []
+				return raw
+			return []
+
+	def get_available_languages(self) -> List[str]:
+		return list(SUPPORTED_LANGUAGES)
+
+	def shutdown(self) -> None:
+		with self._lock:
+			self._cleanup()
+
+	def _cleanup(self):
+		"""Release engine resources. Must be called with self._lock held."""
+		self._engine = None
+		self._initialized = False
+		log.debug("RapidOCR engine resources released")
+
+	@property
+	def is_initialized(self) -> bool:
+		return self._initialized

--- a/source/contentRecog/onDeviceOcr/rapidOcrEngine.py
+++ b/source/contentRecog/onDeviceOcr/rapidOcrEngine.py
@@ -5,7 +5,7 @@
 """RapidOCR engine implementation using ONNX Runtime for on-device OCR."""
 
 import threading
-from typing import List, Optional
+from typing import List
 
 from logHandler import log
 from .engine import OcrEngine
@@ -57,8 +57,7 @@ class RapidOcrEngine(OcrEngine):
 				log.info(f"RapidOCR engine initialized (language={language})")
 			except ImportError:
 				log.error(
-					"RapidOCR is not installed. "
-					"Install with: pip install rapidocr onnxruntime",
+					"RapidOCR is not installed. Install with: pip install rapidocr onnxruntime",
 					exc_info=True,
 				)
 				raise RuntimeError("RapidOCR package not available")

--- a/source/contentRecog/onDeviceOcr/resultConverter.py
+++ b/source/contentRecog/onDeviceOcr/resultConverter.py
@@ -1,0 +1,107 @@
+# A part of NonVisual Desktop Access (NVDA)
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+
+"""Convert RapidOCR/PaddleOCR output to NVDA's LinesWordsResult-compatible format.
+
+RapidOCR returns results as a list of (quad, text, confidence) tuples where quad
+is a 4-point polygon [[x1,y1],[x2,y2],[x3,y3],[x4,y4]].
+NVDA's LinesWordsResult expects lines of words as dicts: {x, y, width, height, text}.
+This module handles that conversion plus reading-order line clustering.
+"""
+
+from typing import List, Tuple, Optional
+
+
+# Type alias: RapidOCR single result item
+OcrResultItem = Tuple[List[List[float]], str, float]
+
+
+def quad_to_rect(quad: List[List[float]]) -> dict:
+	"""Convert a 4-point quadrilateral to an axis-aligned bounding rectangle.
+
+	@param quad: Four corner coordinates [[x1,y1],[x2,y2],[x3,y3],[x4,y4]].
+	@return: Dict with keys x, y, width, height (all int, width/height >= 1).
+	"""
+	xs = [p[0] for p in quad]
+	ys = [p[1] for p in quad]
+	x = int(min(xs))
+	y = int(min(ys))
+	width = max(int(max(xs)) - x, 1)
+	height = max(int(max(ys)) - y, 1)
+	return {"x": x, "y": y, "width": width, "height": height}
+
+
+def cluster_into_lines(
+	items: List[dict],
+	y_overlap_threshold: float = 0.5,
+) -> List[List[dict]]:
+	"""Group OCR result items into lines based on vertical position.
+
+	Items whose vertical center is within y_overlap_threshold * item_height
+	of each other are considered the same line. Within each line, items
+	are sorted left-to-right by x coordinate.
+
+	@param items: List of dicts with keys: x, y, width, height, text.
+	@param y_overlap_threshold: Fraction of height used for same-line detection.
+	@return: List of lines, each line is a list of word dicts sorted by x.
+	"""
+	if not items:
+		return []
+
+	# Sort by vertical center, then horizontal position
+	sorted_items = sorted(items, key=lambda it: (it["y"] + it["height"] / 2, it["x"]))
+
+	lines: List[List[dict]] = []
+	current_line = [sorted_items[0]]
+	current_center_y = sorted_items[0]["y"] + sorted_items[0]["height"] / 2
+
+	for item in sorted_items[1:]:
+		item_center_y = item["y"] + item["height"] / 2
+		# Use the average height of current line items as reference
+		avg_height = sum(it["height"] for it in current_line) / len(current_line)
+		if abs(item_center_y - current_center_y) < avg_height * y_overlap_threshold:
+			current_line.append(item)
+		else:
+			# Sort current line left-to-right and start new line
+			current_line.sort(key=lambda it: it["x"])
+			lines.append(current_line)
+			current_line = [item]
+			current_center_y = item_center_y
+
+	# Don't forget the last line
+	current_line.sort(key=lambda it: it["x"])
+	lines.append(current_line)
+
+	return lines
+
+
+def convert_rapidocr_result(
+	raw_result: Optional[List[OcrResultItem]],
+	confidence_threshold: float = 0.0,
+) -> List[List[dict]]:
+	"""Convert RapidOCR output to NVDA LinesWordsResult-compatible data structure.
+
+	@param raw_result: RapidOCR output list of (quad, text, confidence).
+		May be None or empty if no text was detected.
+	@param confidence_threshold: Minimum confidence to include a result (0.0-1.0).
+	@return: List of lines, each line is a list of word dicts:
+		[[{"x": int, "y": int, "width": int, "height": int, "text": str}, ...], ...]
+	"""
+	if not raw_result:
+		return []
+
+	items = []
+	for quad, text, confidence in raw_result:
+		if confidence < confidence_threshold:
+			continue
+		if not text or not text.strip():
+			continue
+		rect = quad_to_rect(quad)
+		rect["text"] = text
+		items.append(rect)
+
+	if not items:
+		return []
+
+	return cluster_into_lines(items)

--- a/source/core.py
+++ b/source/core.py
@@ -566,6 +566,14 @@ def _handleNVDAModuleCleanupBeforeGUIExit():
 
 	# The core is expected to terminate, so we should not treat this as a crash
 	_terminate(watchdog)
+	# Shut down on-device OCR engine before plugin cleanup
+	try:
+		from contentRecog.onDeviceOcr.engine import OcrEngineManager
+		OcrEngineManager.shutdown()
+	except ImportError:
+		pass  # On-device OCR not available
+	except Exception:
+		log.error("Error shutting down on-device OCR engine", exc_info=True)
 	# plugins must be allowed to close safely before we terminate the GUI as dialogs may be unsaved
 	_terminate(globalPluginHandler)
 	# the brailleViewer should be destroyed safely before closing the window

--- a/source/core.py
+++ b/source/core.py
@@ -569,6 +569,7 @@ def _handleNVDAModuleCleanupBeforeGUIExit():
 	# Shut down on-device OCR engine before plugin cleanup
 	try:
 		from contentRecog.onDeviceOcr.engine import OcrEngineManager
+
 		OcrEngineManager.shutdown()
 	except ImportError:
 		pass  # On-device OCR not available

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -4740,6 +4740,77 @@ class GlobalCommands(ScriptableObject):
 
 	@script(
 		# Translators: Describes a command.
+		description=_("Recognizes the content of the current navigator object with on-device OCR"),
+		gesture="kb:NVDA+shift+r",
+	)
+	def script_recognizeWithOnDeviceOcr(self, gesture):
+		from screenCurtain import screenCurtain
+
+		isScreenCurtainRunning = screenCurtain is not None and screenCurtain.enabled
+		if isScreenCurtainRunning:
+			# Translators: Reported when screen curtain is enabled.
+			ui.message(_("Please disable screen curtain before using on-device OCR."))
+			return
+		try:
+			from contentRecog.onDeviceOcr import OnDeviceOcr
+			from contentRecog import recogUi
+
+			recog = OnDeviceOcr()
+			recogUi.recognizeNavigatorObject(recog)
+		except ImportError:
+			# Translators: Reported when on-device OCR dependencies are not installed.
+			ui.message(_("On-device OCR is not available. Required packages may not be installed."))
+		except Exception as e:
+			log.error(f"Failed to start on-device OCR: {e}", exc_info=True)
+			# Translators: Reported when on-device OCR fails to start.
+			ui.message(_("On-device OCR failed to start"))
+
+	@script(
+		# Translators: Describes a command.
+		description=_("Cycles through the available languages for on-device OCR"),
+	)
+	def script_cycleOnDeviceOcrLanguage(self, gesture: inputCore.InputGesture) -> None:
+		try:
+			from contentRecog.onDeviceOcr.engine import OcrEngineManager
+
+			engine = OcrEngineManager.get_engine()
+			languageCodes = engine.get_available_languages()
+			try:
+				index = languageCodes.index(config.conf["onDeviceOcr"]["language"])
+				newIndex = (index + 1) % len(languageCodes)
+			except ValueError:
+				newIndex = 0
+			lang = languageCodes[newIndex]
+			config.conf["onDeviceOcr"]["language"] = lang
+			# Force re-initialization with new language on next recognition
+			if engine.is_initialized:
+				engine.shutdown()
+			ui.message(lang)
+		except ImportError:
+			# Translators: Reported when on-device OCR dependencies are not installed.
+			ui.message(_("On-device OCR is not available"))
+
+	@script(
+		# Translators: Describes a command.
+		description=_("Toggle periodical refresh of an on-device OCR result"),
+	)
+	def script_toggleOnDeviceOcrAutoRefresh(self, gesture: inputCore.InputGesture) -> None:
+		toggleBooleanValue(
+			configSection="onDeviceOcr",
+			configKey="autoRefresh",
+			# Translators: The message announced when toggling automatic refresh
+			enabledMsg=_("Automatic refresh enabled"),
+			# Translators: The message announced when toggling automatic refresh
+			disabledMsg=_("Automatic refresh disabled"),
+		)
+		from contentRecog.recogUi import RecogResultNVDAObject
+
+		focus = api.getFocusObject()
+		if isinstance(focus, RecogResultNVDAObject):
+			focus._scheduleRecognize()
+
+	@script(
+		# Translators: Describes a command.
 		description=_("Cycles through the available languages for Windows OCR"),
 	)
 	def script_cycleOcrLanguage(self, gesture: inputCore.InputGesture) -> None:

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -4197,14 +4197,14 @@ class OnDeviceOcrPanel(SettingsPanel):
 		except Exception:
 			self.languageCodes = ["auto"]
 
-		languageChoices = [
-			self._LANGUAGE_DESCRIPTIONS.get(lang, lang) for lang in self.languageCodes
-		]
+		languageChoices = [self._LANGUAGE_DESCRIPTIONS.get(lang, lang) for lang in self.languageCodes]
 
 		# Translators: Label for language selection in on-device OCR settings.
 		languageLabel = _("Recognition &language:")
 		self.languageChoice = sHelper.addLabeledControl(
-			languageLabel, wx.Choice, choices=languageChoices
+			languageLabel,
+			wx.Choice,
+			choices=languageChoices,
 		)
 		try:
 			langIndex = self.languageCodes.index(config.conf["onDeviceOcr"]["language"])
@@ -4225,16 +4225,14 @@ class OnDeviceOcrPanel(SettingsPanel):
 			wx.CheckBox(self, label=autoSayAllText),
 		)
 		self.autoSayAllOnResultCheckbox.SetValue(
-			config.conf["onDeviceOcr"]["autoSayAllOnResult"]
+			config.conf["onDeviceOcr"]["autoSayAllOnResult"],
 		)
 
 	def onSave(self):
 		lang = self.languageCodes[self.languageChoice.Selection]
 		config.conf["onDeviceOcr"]["language"] = lang
 		config.conf["onDeviceOcr"]["autoRefresh"] = self.autoRefreshCheckbox.IsChecked()
-		config.conf["onDeviceOcr"]["autoSayAllOnResult"] = (
-			self.autoSayAllOnResultCheckbox.IsChecked()
-		)
+		config.conf["onDeviceOcr"]["autoSayAllOnResult"] = self.autoSayAllOnResultCheckbox.IsChecked()
 
 
 class AdvancedPanelControls(

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -4166,6 +4166,77 @@ class UwpOcrPanel(SettingsPanel):
 		config.conf["uwpOcr"]["autoSayAllOnResult"] = self.autoSayAllOnResultCheckbox.IsChecked()
 
 
+class OnDeviceOcrPanel(SettingsPanel):
+	# Translators: The title of the on-device OCR settings panel.
+	title = _("On-device OCR")
+	helpId = "OnDeviceOcrSettings"
+
+	_LANGUAGE_DESCRIPTIONS = {
+		"auto": _("Automatic (Chinese + English)"),
+		"ch": _("Chinese"),
+		"en": _("English"),
+		"japan": _("Japanese"),
+		"korean": _("Korean"),
+		"french": _("French"),
+		"german": _("German"),
+		"arabic": _("Arabic"),
+		"latin": _("Latin script"),
+		"cyrillic": _("Cyrillic script"),
+		"devanagari": _("Devanagari script"),
+	}
+
+	def makeSettings(self, settingsSizer):
+		sHelper = guiHelper.BoxSizerHelper(self, sizer=settingsSizer)
+
+		# Language selection
+		try:
+			from contentRecog.onDeviceOcr.engine import OcrEngineManager
+
+			engine = OcrEngineManager.get_engine()
+			self.languageCodes = engine.get_available_languages()
+		except Exception:
+			self.languageCodes = ["auto"]
+
+		languageChoices = [
+			self._LANGUAGE_DESCRIPTIONS.get(lang, lang) for lang in self.languageCodes
+		]
+
+		# Translators: Label for language selection in on-device OCR settings.
+		languageLabel = _("Recognition &language:")
+		self.languageChoice = sHelper.addLabeledControl(
+			languageLabel, wx.Choice, choices=languageChoices
+		)
+		try:
+			langIndex = self.languageCodes.index(config.conf["onDeviceOcr"]["language"])
+			self.languageChoice.Selection = langIndex
+		except ValueError:
+			self.languageChoice.Selection = 0
+
+		# Translators: Label for auto-refresh option in on-device OCR settings.
+		autoRefreshText = _("Periodically &refresh recognized content")
+		self.autoRefreshCheckbox = sHelper.addItem(
+			wx.CheckBox(self, label=autoRefreshText),
+		)
+		self.autoRefreshCheckbox.SetValue(config.conf["onDeviceOcr"]["autoRefresh"])
+
+		# Translators: Label for auto say all option in on-device OCR settings.
+		autoSayAllText = _("Automatically say all on result")
+		self.autoSayAllOnResultCheckbox = sHelper.addItem(
+			wx.CheckBox(self, label=autoSayAllText),
+		)
+		self.autoSayAllOnResultCheckbox.SetValue(
+			config.conf["onDeviceOcr"]["autoSayAllOnResult"]
+		)
+
+	def onSave(self):
+		lang = self.languageCodes[self.languageChoice.Selection]
+		config.conf["onDeviceOcr"]["language"] = lang
+		config.conf["onDeviceOcr"]["autoRefresh"] = self.autoRefreshCheckbox.IsChecked()
+		config.conf["onDeviceOcr"]["autoSayAllOnResult"] = (
+			self.autoSayAllOnResultCheckbox.IsChecked()
+		)
+
+
 class AdvancedPanelControls(
 	gui.contextHelp.ContextHelpMixin,
 	wx.Panel,  # wxPython does not seem to call base class initializer, put last in MRO
@@ -6326,6 +6397,9 @@ class NVDASettingsDialog(MultiCategorySettingsDialog):
 		categoryClasses.append(TouchInteractionPanel)
 	if winVersion.isUwpOcrAvailable():
 		categoryClasses.append(UwpOcrPanel)
+	# On-device OCR is always available (no OS version dependency).
+	# Import check handles missing rapidocr gracefully in the panel itself.
+	categoryClasses.append(OnDeviceOcrPanel)
 	# And finally the Advanced panel which should always be last.
 	if not globalVars.appArgs.secure:
 		categoryClasses.append(AdvancedPanel)

--- a/tests/unit/contentRecog/test_onDeviceOcr.py
+++ b/tests/unit/contentRecog/test_onDeviceOcr.py
@@ -1,0 +1,153 @@
+# A part of NonVisual Desktop Access (NVDA)
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+
+"""Unit tests for on-device OCR result conversion."""
+
+import unittest
+from contentRecog.onDeviceOcr.resultConverter import (
+	quad_to_rect,
+	cluster_into_lines,
+	convert_rapidocr_result,
+)
+
+
+class TestQuadToRect(unittest.TestCase):
+	"""Test quadrilateral to axis-aligned rectangle conversion."""
+
+	def test_axis_aligned_rectangle(self):
+		quad = [[10, 20], [110, 20], [110, 50], [10, 50]]
+		result = quad_to_rect(quad)
+		self.assertEqual(result, {"x": 10, "y": 20, "width": 100, "height": 30})
+
+	def test_rotated_quad_uses_bounding_box(self):
+		# Slightly rotated text
+		quad = [[12, 20], [112, 22], [110, 52], [10, 50]]
+		result = quad_to_rect(quad)
+		self.assertEqual(result["x"], 10)
+		self.assertEqual(result["y"], 20)
+		self.assertEqual(result["width"], 102)
+		self.assertEqual(result["height"], 32)
+
+	def test_degenerate_point_returns_minimum_size(self):
+		quad = [[50, 50], [50, 50], [50, 50], [50, 50]]
+		result = quad_to_rect(quad)
+		self.assertGreaterEqual(result["width"], 1)
+		self.assertGreaterEqual(result["height"], 1)
+
+	def test_float_coordinates_truncated_to_int(self):
+		quad = [[10.7, 20.3], [60.9, 20.1], [61.2, 40.8], [10.2, 41.1]]
+		result = quad_to_rect(quad)
+		self.assertIsInstance(result["x"], int)
+		self.assertIsInstance(result["y"], int)
+
+
+class TestClusterIntoLines(unittest.TestCase):
+	"""Test grouping OCR results into reading-order lines."""
+
+	def test_single_line_two_words(self):
+		items = [
+			{"x": 10, "y": 20, "width": 50, "height": 15, "text": "Hello"},
+			{"x": 70, "y": 21, "width": 50, "height": 15, "text": "World"},
+		]
+		lines = cluster_into_lines(items)
+		self.assertEqual(len(lines), 1)
+		self.assertEqual(len(lines[0]), 2)
+		self.assertEqual(lines[0][0]["text"], "Hello")
+		self.assertEqual(lines[0][1]["text"], "World")
+
+	def test_two_separate_lines(self):
+		items = [
+			{"x": 10, "y": 20, "width": 50, "height": 15, "text": "Line1"},
+			{"x": 10, "y": 60, "width": 50, "height": 15, "text": "Line2"},
+		]
+		lines = cluster_into_lines(items)
+		self.assertEqual(len(lines), 2)
+		self.assertEqual(lines[0][0]["text"], "Line1")
+		self.assertEqual(lines[1][0]["text"], "Line2")
+
+	def test_words_sorted_left_to_right_within_line(self):
+		items = [
+			{"x": 100, "y": 20, "width": 50, "height": 15, "text": "Second"},
+			{"x": 10, "y": 20, "width": 50, "height": 15, "text": "First"},
+		]
+		lines = cluster_into_lines(items)
+		self.assertEqual(lines[0][0]["text"], "First")
+		self.assertEqual(lines[0][1]["text"], "Second")
+
+	def test_empty_input(self):
+		self.assertEqual(cluster_into_lines([]), [])
+
+	def test_single_item(self):
+		items = [{"x": 10, "y": 20, "width": 50, "height": 15, "text": "Alone"}]
+		lines = cluster_into_lines(items)
+		self.assertEqual(len(lines), 1)
+		self.assertEqual(len(lines[0]), 1)
+
+
+class TestConvertRapidOcrResult(unittest.TestCase):
+	"""Test full RapidOCR result to NVDA format conversion."""
+
+	def test_none_result(self):
+		self.assertEqual(convert_rapidocr_result(None), [])
+
+	def test_empty_result(self):
+		self.assertEqual(convert_rapidocr_result([]), [])
+
+	def test_typical_two_line_result(self):
+		raw = [
+			([[10, 20], [110, 20], [110, 50], [10, 50]], "Hello World", 0.95),
+			([[10, 60], [110, 60], [110, 90], [10, 90]], "Second line", 0.92),
+		]
+		lines = convert_rapidocr_result(raw)
+		self.assertEqual(len(lines), 2)
+		self.assertEqual(lines[0][0]["text"], "Hello World")
+		self.assertEqual(lines[1][0]["text"], "Second line")
+
+	def test_confidence_threshold_filters_low_scores(self):
+		raw = [
+			([[10, 20], [60, 20], [60, 40], [10, 40]], "Good", 0.9),
+			([[10, 60], [60, 60], [60, 80], [10, 80]], "Bad", 0.1),
+		]
+		lines = convert_rapidocr_result(raw, confidence_threshold=0.5)
+		self.assertEqual(len(lines), 1)
+		self.assertEqual(lines[0][0]["text"], "Good")
+
+	def test_empty_text_items_excluded(self):
+		raw = [
+			([[10, 20], [60, 20], [60, 40], [10, 40]], "", 0.9),
+			([[10, 60], [60, 60], [60, 80], [10, 80]], "Real text", 0.9),
+		]
+		lines = convert_rapidocr_result(raw)
+		self.assertEqual(len(lines), 1)
+		self.assertEqual(lines[0][0]["text"], "Real text")
+
+	def test_result_contains_required_keys(self):
+		raw = [
+			([[10, 20], [60, 20], [60, 40], [10, 40]], "Word", 0.99),
+		]
+		lines = convert_rapidocr_result(raw)
+		word = lines[0][0]
+		for key in ("x", "y", "width", "height", "text"):
+			self.assertIn(key, word)
+
+
+class TestLinesWordsResultIntegration(unittest.TestCase):
+	"""Test that converted results integrate correctly with NVDA's LinesWordsResult."""
+
+	def test_converted_result_creates_valid_lineswordsresult(self):
+		from contentRecog import RecogImageInfo, LinesWordsResult
+
+		raw = [
+			([[10, 20], [60, 20], [60, 40], [10, 40]], "Word1", 0.99),
+			([[70, 20], [120, 20], [120, 40], [70, 40]], "Word2", 0.98),
+			([[10, 60], [60, 60], [60, 80], [10, 80]], "Word3", 0.97),
+		]
+		lines_data = convert_rapidocr_result(raw)
+		info = RecogImageInfo(0, 0, 200, 100, 1)
+		result = LinesWordsResult(lines_data, info)
+		self.assertIn("Word1", result.text)
+		self.assertIn("Word2", result.text)
+		self.assertIn("Word3", result.text)
+		# Should have 2 lines
+		self.assertEqual(len(result.lines), 2)


### PR DESCRIPTION
## Summary
- Integrate RapidOCR + ONNX Runtime as an on-device OCR engine for NVDA, providing offline text recognition with significantly better CJK accuracy than Windows UWP OCR
- Add settings panel, keyboard shortcut (NVDA+Shift+R), language cycling, and auto-refresh toggle
- Modular engine architecture (OcrEngine ABC) allows swapping the underlying OCR backend without modifying the recognizer

## New files
- `source/contentRecog/onDeviceOcr/` — engine package (4 modules)
- `tests/unit/contentRecog/test_onDeviceOcr.py` — unit tests

## Modified files
- `configSpec.py` — `[onDeviceOcr]` config section
- `settingsDialogs.py` — `OnDeviceOcrPanel` + registration
- `globalCommands.py` — 3 new scripts (recognize, cycle language, toggle auto-refresh)
- `core.py` — engine shutdown on NVDA exit
- `pyproject.toml` — `rapidocr>=3.3.0`, `onnxruntime>=1.17.0`

## Pre-merge TODO
- [ ] Run `uv lock` on Windows to update `uv.lock`
- [ ] Integration test on Windows with NVDA running

## Test plan
- [ ] Unit tests: `python -m pytest tests/unit/contentRecog/test_onDeviceOcr.py -v`
- [ ] NVDA+Shift+R triggers on-device OCR recognition
- [ ] Settings panel appears and saves language/auto-refresh preferences
- [ ] Language cycle script works
- [ ] Engine shuts down cleanly on NVDA exit

🤖 Generated with [Claude Code](https://claude.com/claude-code)