### PR TITLE
Add translation for Norwegian for MathCAT speech languages

### DIFF
--- a/source/localesData.py
+++ b/source/localesData.py
@@ -15,6 +15,8 @@ LANG_NAMES_TO_LOCALIZED_DESCS: dict[str, str] = {
 	# Translators: The name of a language supported by NVDA.
 	"an": pgettext("languageName", "Aragonese"),
 	# Translators: The name of a language supported by NVDA.
+	"nb": pgettext("languageName", "Norwegian Bokmål"),
+	# Translators: The name of a language supported by NVDA.
 	"ckb": pgettext("languageName", "Central Kurdish"),
 	# Translators: The name of a language supported by NVDA.
 	"kmr": pgettext("languageName", "Northern Kurdish"),


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
spawned from #19689 

### Summary of the issue:
The norwegian entry under math speech languages is untranslated.
This gives a less than ideal representation in the language list as just "nb".

### Description of user facing changes:
Adds a display translation for norwegian.
