### PR TITLE
Improve speech XML function usage

### DIFF
--- a/source/mathPres/MathCAT/speech.py
+++ b/source/mathPres/MathCAT/speech.py
@@ -1,3 +1,8 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2022-2026 NV Access Limited, Neil Soiffer, Ryan McCleary
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
+
 import re
 from speech.commands import (
 	BaseProsodyCommand,
@@ -17,6 +22,7 @@ from synthDriverHandler import getSynth, SynthDriver
 import libmathcat_py as libmathcat
 from .localization import getLanguageToUse
 from speech import getCurrentLanguage
+from speechXml import toXmlLang
 
 
 PROSODY_COMMANDS: dict[str, BaseProsodyCommand] = {
@@ -62,7 +68,7 @@ def convertSSMLTextForNVDA(text: str) -> list[str | SpeechCommand]:
 	except Exception as e:
 		log.exception(e)
 	language: str = getLanguageToUse()
-	nvdaLanguage: str = getCurrentLanguage().replace("_", "-")
+	nvdaLanguage: str = toXmlLang(getCurrentLanguage())
 
 	synth: SynthDriver = getSynth()
 	# I tried the engines on a 180 word excerpt. The speeds do not change linearly and differ a it between engines

--- a/source/synthDrivers/_espeak.py
+++ b/source/synthDrivers/_espeak.py
@@ -1,6 +1,5 @@
-# -*- coding: UTF-8 -*-
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2007-2024 NV Access Limited, Peter Vágner
+# Copyright (C) 2007-2026 NV Access Limited, Peter Vágner
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -13,6 +12,8 @@ import config
 import globalVars
 from logHandler import log
 import os
+
+from speechXml import toXmlLang
 
 isSpeaking = False
 onIndexReached = None
@@ -330,7 +331,7 @@ def setVoiceAndVariant(voice=None, variant=None):
 
 def _setVoiceByLanguage(lang):
 	v = espeak_VOICE()
-	lang = lang.replace("_", "-")
+	lang = toXmlLang(lang)
 	v.languages = encodeEspeakString(lang)
 	try:
 		espeakDLL.espeak_SetVoiceByProperties(byref(v))  # noqa: F405

--- a/source/synthDrivers/espeak.py
+++ b/source/synthDrivers/espeak.py
@@ -5,7 +5,6 @@
 
 import os
 from collections import OrderedDict
-)
 
 from . import _espeak
 from languageHandler import (

--- a/source/synthDrivers/espeak.py
+++ b/source/synthDrivers/espeak.py
@@ -1,16 +1,10 @@
-# -*- coding: UTF-8 -*-
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2007-2022 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Leonard de Ruijter
+# Copyright (C) 2007-2026 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Leonard de Ruijter
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
 import os
 from collections import OrderedDict
-from typing import (
-	Dict,
-	List,
-	Optional,
-	Set,
 )
 
 from . import _espeak
@@ -32,6 +26,7 @@ from speech.commands import (
 	VolumeCommand,
 	PhonemeCommand,
 )
+from speechXml import toXmlLang
 
 
 class SynthDriver(SynthDriver):
@@ -73,7 +68,7 @@ class SynthDriver(SynthDriver):
 		"fr": "fr-fr",
 	}
 
-	availableLanguages: Set[Optional[str]]
+	availableLanguages: set[str | None]
 	"""
 	For eSpeak commit 7e5457f91e10, this is equivalent to:
 	{
@@ -259,9 +254,9 @@ class SynthDriver(SynthDriver):
 		lowerCaseAvailableLangs = set(lang.lower() for lang in self.availableLanguages)
 		# Use default language if no command.lang is supplied
 		langWithLocale = command.lang if command.lang else self._language
-		langWithLocale = langWithLocale.lower().replace("_", "-")
+		langWithLocale = toXmlLang(langWithLocale.lower())
 
-		langWithoutLocale: Optional[str] = stripLocaleFromLangCode(langWithLocale)
+		langWithoutLocale: str | None = stripLocaleFromLangCode(langWithLocale)
 
 		# Check for any language where the language code matches, regardless of dialect: e.g. ru-ru to ru
 		matchingLangs = filter(
@@ -321,9 +316,9 @@ class SynthDriver(SynthDriver):
 	# Note: when working on speak, look for opportunities to simplify
 	# and move logic out into smaller helper functions.
 	def speak(self, speechSequence: SpeechSequence):  # noqa: C901
-		textList: List[str] = []
+		textList: list[str] = []
 		langChanged = False
-		prosody: Dict[str, int] = {}
+		prosody: dict[str, int] = {}
 		# We output malformed XML, as we might close an outer tag after opening an inner one; e.g.
 		# <voice><prosody></voice></prosody>.
 		# However, eSpeak doesn't seem to mind.

--- a/source/synthDrivers/oneCore.py
+++ b/source/synthDrivers/oneCore.py
@@ -109,7 +109,7 @@ class _OcSsmlConverter(speechXml.SsmlConverter):
 			log.debugWarning(f"Invalid language: {command.lang}")
 			return None
 
-		normalizedLanguage = command.lang.lower().replace("-", "_")
+		normalizedLanguage = speechXml.toNvdaLang(command.lang.lower())
 		normalizedLanguageWithoutLocale = normalizedLanguage.split("_")[0]
 		if (
 			normalizedLanguage not in self.lowerCaseAvailableLanguages
@@ -491,13 +491,13 @@ class OneCoreSynthDriver(SynthDriver):
 				log.debug("Done pushing audio")
 		self._processQueue()
 
-	def _getVoiceInfoFromOnecoreVoiceString(self, voiceStr):
+	def _getVoiceInfoFromOnecoreVoiceString(self, voiceStr: str):
 		"""
 		Produces an NVDA VoiceInfo object representing the given voice string from Onecore speech.
 		"""
 		# The voice string is made up of the ID, the language, and the display name.
 		ID, language, name = voiceStr.split(":")
-		language = language.replace("-", "_")
+		language = speechXml.toNvdaLang(language)
 		return VoiceInfo(ID, name, language=language)
 
 	def _getAvailableVoices(self):


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Spawned from #19740 

### Summary of the issue:
It was hard to track all the different places language codes are normalized in NVDA.

### Description of developer facing changes:


This pull request standardizes language code formatting across the NVDA codebase by introducing and using the `toXmlLang` and `toNvdaLang` utility functions from `speechXml`. This ensures consistent handling of language codes (e.g., converting between underscores and hyphens) when interacting with speech synthesis engines and related components.


### Description of development approach:
Replaced manual string manipulation for language codes (such as `replace("_", "-")` or `replace("-", "_")`) with the use of `toXmlLang` and `toNvdaLang` utility functions in `speech.py`, `_espeak.py`, `espeak.py`, and `oneCore.py` to ensure consistent formatting for speech engine interoperability. 



