### PR TITLE
Overhaul guide for non-trivial contributions

### DIFF
--- a/.github/ISSUE_TEMPLATE/06-adr_major_project.yaml
+++ b/.github/ISSUE_TEMPLATE/06-adr_major_project.yaml
@@ -34,6 +34,7 @@ body:
     attributes:
       label: Impact area
       description: Choose the area most impacted by this decision.
+      multiple: true
       options:
         - Core architecture
         - Add-on API / infrastructure

--- a/.github/ISSUE_TEMPLATE/06-adr_major_project.yaml
+++ b/.github/ISSUE_TEMPLATE/06-adr_major_project.yaml
@@ -1,0 +1,171 @@
+name: ADR for major project
+description: Propose an Architecture Decision Record for a major NVDA project
+type: Task
+labels: ["ADR", "audience/nvda-dev"]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        This template is intended for major technical changes where an Architecture Decision Record (ADR) is needed before implementation.
+
+        Use this issue to document context, options, decision rationale, technical design, and expected impact.
+        For smaller changes, use other issue templates.
+
+        Strong ADRs include:
+        - user stories that clarify UX impact,
+        - architecture plans that map to concrete code changes,
+        - explicit impact and risk analysis.
+
+  - type: dropdown
+    id: decisionStatus
+    attributes:
+      label: ADR status
+      options:
+        - Proposed
+        - Accepted
+        - Rejected
+        - Superseded
+    validations:
+      required: true
+
+  - type: dropdown
+    id: impactArea
+    attributes:
+      label: Impact area
+      description: Choose the area most impacted by this decision.
+      options:
+        - Core architecture
+        - Add-on API / infrastructure
+        - Build / CI / tooling
+        - Performance
+        - Security / privacy
+        - Accessibility behavior
+        - Testing strategy
+        - Documentation / process
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: related
+    attributes:
+      label: Related issues, PRs, discussions, or mailing list threads (optional)
+      description: Add issues/PR/discussion/thread links if relevant.
+      placeholder: |
+        #12345
+        https://github.com/nvaccess/nvda/discussions/12345
+    validations:
+      required: false
+
+  - type: textarea
+    id: contextProblem
+    attributes:
+      label: Context and problem statement
+      description: Describe the current state, pain points, constraints, and why this decision is needed now.
+    validations:
+      required: true
+
+  - type: textarea
+    id: uxUserStories
+    attributes:
+      label: UX impact via user stories
+      description: Provide user stories that make the UX impact concrete. Include expected behavior changes for end users and/or add-on developers where relevant.
+      placeholder: |
+        As a ..., I want ..., so that ...
+        As a ..., I want ..., so that ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: decisionDrivers
+    attributes:
+      label: Decision drivers
+      description: List key criteria influencing this decision, such as maintainability, compatibility, performance, accessibility impact, or team capacity.
+    validations:
+      required: true
+
+  - type: textarea
+    id: optionsConsidered
+    attributes:
+      label: Options considered
+      description: Describe realistic options, including at least one non-adoption / status quo option.
+      placeholder: |
+        Option A - ...
+        Option B - ...
+        Option C (status quo) - ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: technicalDesign
+    attributes:
+      label: Proposed technical design
+    validations:
+      required: true
+
+  - type: textarea
+    id: decisionOutcome
+    attributes:
+      label: Proposed decision and rationale
+      description: State the proposed option and explain why it is preferred over alternatives.
+    validations:
+      required: true
+
+  - type: textarea
+    id: consequences
+    attributes:
+      label: Impact analysis
+      description: Outline expected positive, neutral, and negative impacts across UX, code maintainability, performance, reliability, security/privacy, and API/add-on compatibility.
+    validations:
+      required: true
+
+  - type: textarea
+    id: implementationPlan
+    attributes:
+      label: Architecture and code change plan
+      description: |
+        Provide a concrete implementation plan.
+        Identify modules/files likely to change, new abstractions, migration steps, sequencing, rollout strategy, and fallback/rollback plans.
+      placeholder: |
+        Planned architecture changes:
+        Target modules/files:
+        API compatibility strategy:
+    validations:
+      required: true
+
+  - type: textarea
+    id: integrationPlan
+    attributes:
+      label: Integration plan
+      description: |
+        Provide a concrete integration plan.
+      placeholder: |
+        Planned integration steps:
+        Rollback strategy:
+    validations:
+      required: true
+
+  - type: textarea
+    id: riskMitigations
+    attributes:
+      label: Risks and mitigations
+      description: Identify technical, product, or process risks and how they will be mitigated.
+    validations:
+      required: true
+
+  - type: textarea
+    id: validationPlan
+    attributes:
+      label: Validation and success criteria
+      description: Describe how UX outcomes and technical outcomes will be validated (tests, manual scenarios, telemetry if any, and measurable success criteria).
+    validations:
+      required: true
+
+  - type: textarea
+    id: openQuestions
+    attributes:
+      label: Open questions
+      description: List unresolved points requiring feedback.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/16-adr_major_project.md
+++ b/.github/ISSUE_TEMPLATE/16-adr_major_project.md
@@ -1,0 +1,42 @@
+---
+name: (Advanced) ADR for major project
+about: Free text ADR template for those familiar with GitHub.
+type: Task
+labels: ["ADR", "audience/nvda-dev"]
+
+---
+
+### ADR status
+
+* [x] Proposed
+* [ ] Accepted
+* [ ] Rejected
+* [ ] Superseded
+
+### Impact area
+
+### Related issues, PRs, discussions, or mailing list threads
+
+### Context and problem statement
+
+### UX impact via user stories
+
+### Decision drivers
+
+### Options considered
+
+### Proposed technical design
+
+### Proposed decision and rationale
+
+### Impact analysis
+
+### Architecture and code change plan
+
+### Integration plan
+
+### Risks and mitigations
+
+### Validation and success criteria
+
+### Open questions

--- a/projectDocs/dev/contributing.md
+++ b/projectDocs/dev/contributing.md
@@ -4,7 +4,7 @@
 
 ### First time contributors
 
-When making your first PR, we encourage starting with on the following issues.
+When making your first PR, we encourage starting with one of the following issues.
 This will help introduce you to the project.
 To get used to the contribution process, please wait for feedback on your first PR before opening any other PRs.
 
@@ -30,7 +30,7 @@ A `triaged` label is an indicator that an issue is ready for a fix.
 A triaged issue should have a priority, as a developer, consider focusing on higher priority issues (p1-p3) instead of lower priority issues (p4-p5).
 Consider starting a [GitHub discussion](https://github.com/nvaccess/nvda/discussions) to see if there is interest.
 
-If the issue has a `ADR-required` label, this is a complex change.
+If the issue has an `ADR-required` label, this is a complex change.
 Refer to ["Proposing Major Changes"](./proposingMajorChanges.md) before opening a PR.
 
 Once triaged and ready please comment on the issue or ADR to confirm you plan to work on it.
@@ -49,7 +49,7 @@ PRs which have not been reviewed and tested by the author will be closed.
 Unrelated changes should be addressed in separate issues and PRs.
 
 Avoid PRs over 500 lines of code (LOC).
-PRs over 500 LOC may be rejected at the reviewers discretion.
+PRs over 500 LOC may be rejected at the reviewers' discretion.
 
 500-1000 line PRs can typically be broken into smaller changes such as automated tests, refactors, data-structures and core changes.
 These can be merged as stacked PRs if they depend on each other (e.g. `branchX` targets `master`, `branchY` targets `branchX`).

--- a/projectDocs/dev/contributing.md
+++ b/projectDocs/dev/contributing.md
@@ -56,7 +56,7 @@ These can be merged as stacked PRs if they depend on each other (e.g. `branchX` 
 
 Large refactors should instead target specific symbols/files/modules per PR to minimize mass changes.
 
-On-going feature development that cannot be merged straight to `master` can occur on `try-` branches, done in pieces.
+Ongoing feature development that cannot be merged straight to `master` can occur on `try-` branches, done in pieces.
 Ask NV Access on the [ADR](./proposingMajorChanges.md) to create a `try-` breach.
 
 ## Overview of contribution process:

--- a/projectDocs/dev/contributing.md
+++ b/projectDocs/dev/contributing.md
@@ -64,7 +64,7 @@ Ask NV Access on the corresponding ADR to create a `try-` branch.
 1. [Setup your development environment](./createDevEnvironment.md).
    * Alternatively, you can use GitHub Actions to build NVDA for you, without setting up a local development environment, by following [our CI/CD README](../../ci/README.md).
 1. Ensure the issue you plan to fix is [triaged](../issues/triage.md)
-1. If the issue has a `ADR-required` label, this is a complex change.
+1. If the issue has an `ADR-required` label, this is a complex change.
 Refer to ["Proposing Major Changes"](./proposingMajorChanges.md) before opening a PR.
 1. Create a branch for the contribution, to be used for a pull request.
 	* Pull requests should be based on the latest commit in the official master branch.

--- a/projectDocs/dev/contributing.md
+++ b/projectDocs/dev/contributing.md
@@ -37,7 +37,7 @@ Once triaged and ready please comment on the issue or ADR to confirm you plan to
 
 ### PR submission rules
 
-Avoid having multiple concurrent PRs (e.g. 3+ ongoing).
+Avoid having too many concurrent PRs (e.g. more than 3 ongoing).
 NV Access is a small team and will try to respond to PRs within a couple of days.
 Having multiple ongoing PRs increases the time to merge for each of them.
 

--- a/projectDocs/dev/contributing.md
+++ b/projectDocs/dev/contributing.md
@@ -57,7 +57,7 @@ These can be merged as stacked PRs if they depend on each other (e.g. `branchX` 
 Large refactors should instead target specific symbols/files/modules per PR to minimize mass changes.
 
 Ongoing feature development that cannot be merged straight to `master` can occur on `try-` branches, done in pieces.
-Ask NV Access on the [ADR](./proposingMajorChanges.md) to create a `try-` breach.
+Ask NV Access on the corresponding ADR to create a `try-` branch.
 
 ## Overview of contribution process:
 

--- a/projectDocs/dev/contributing.md
+++ b/projectDocs/dev/contributing.md
@@ -48,7 +48,7 @@ PRs which have not been reviewed and tested by the author will be closed.
 
 Unrelated changes should be addressed in separate issues and PRs.
 
-Avoid PRs over 500 lines of code (LOC).
+Avoid PRs where over 500 lines of code (LOC) is added.
 PRs over 500 LOC may be rejected at the reviewers' discretion.
 
 500-1000 line PRs can typically be broken into smaller changes such as automated tests, refactors, data-structures and core changes.

--- a/projectDocs/dev/contributing.md
+++ b/projectDocs/dev/contributing.md
@@ -28,7 +28,6 @@ Please understand that we very likely will not accept non-trivial changes that a
 
 A `triaged` label is an indicator that an issue is ready for a fix.
 A triaged issue should have a priority, as a developer, consider focusing on higher priority issues (p1-p3) instead of lower priority issues (p4-p5).
-Consider starting a [GitHub discussion](https://github.com/nvaccess/nvda/discussions) to see if there is interest.
 
 If the issue has an `ADR-required` label, this is a complex change.
 Refer to ["Proposing Major Changes"](./proposingMajorChanges.md) before opening a PR.

--- a/projectDocs/dev/contributing.md
+++ b/projectDocs/dev/contributing.md
@@ -1,36 +1,71 @@
 # Code/Docs contributions
 
-If you are new to the project, or looking for some way to help take a look at:
+## Guidelines:
+
+### First time contributors
+
+When making your first PR, we encourage starting with on the following issues.
+This will help introduce you to the project.
+To get used to the contribution process, please wait for feedback on your first PR before opening any other PRs.
 
 * [label:"good first issue"](https://github.com/nvaccess/nvda/issues?q=label%3A%22good+first+issue%22)
 * [label:component/documentation](https://github.com/nvaccess/nvda/issues?q=label%3Acomponent%2Fdocumentation)
 * [label:closed/needs-new-author](https://github.com/nvaccess/nvda/issues?q=label%3Aclosed%2Fneeds-new-author)
 * [label:Abandoned](https://github.com/nvaccess/nvda/issues?q=label%3AAbandoned)
 
-## Guidelines:
+### Trivial changes
 
-* For anything other than minor bug fixes, please comment on an existing issue or create a new issue providing details about your proposed change.
-* Unrelated changes should be addressed in separate issues.
-* Include information about use cases, design, user experience, etc.
-  * This allows us to discuss these aspects and any other concerns that might arise, thus potentially avoiding a great deal of wasted time.
-* It is recommended to wait for acceptance of your proposal before you start coding.
-  * A `triaged` label is an indicator that an issue is ready for a fix.
-  * A triaged issue should have a priority, as a developer, consider focusing on higher priority issues (p1-p3) instead of lower priority issues (p4-p5).
-  * Please understand that we very likely will not accept changes that are not discussed first.
-  * Consider starting a [GitHub discussion](https://github.com/nvaccess/nvda/discussions) or [mailing list topic](https://groups.io/g/nvda-devel/topics) to see if there is interest.
-* A minor/trivial change which definitely wouldn't require design, user experience or implementation discussion, you can just create a pull request rather than using an issue first.
-  * e.g. a fix for a typo/obvious coding error or a simple synthesizer/braille display driver
-  * This should be fairly rare.
-* If in doubt, use an issue first.
-Use this issue to discuss the alternatives you have considered in regards to implementation, design, and user experience.
-Then give people time to offer feedback.
-* Issues with translations should be reported to the [NVDA Translators list](https://groups.io/g/nvda-translations).
+A minor/trivial change which definitely wouldn't require design, user experience or implementation discussion, you can just create a pull request rather than using an issue first.
+
+e.g. a fix for a typo/obvious coding error, or typing improvements.
+
+Issues with the translations of the NVDA interface, Changes or User Guide should be reported to the [NVDA Translators list](https://groups.io/g/nvda-translations).
+
+### Non-trivial changes
+
+For anything other than minor bug fixes, ensure an issue has been filed and triaged.
+Please understand that we very likely will not accept non-trivial changes that are not discussed first.
+
+A `triaged` label is an indicator that an issue is ready for a fix.
+A triaged issue should have a priority, as a developer, consider focusing on higher priority issues (p1-p3) instead of lower priority issues (p4-p5).
+Consider starting a [GitHub discussion](https://github.com/nvaccess/nvda/discussions) to see if there is interest.
+
+If the issue has a `ADR-required` label, this is a complex change.
+Refer to ["Proposing Major Changes"](./proposingMajorChanges.md) before opening a PR.
+
+Once triaged and ready please comment on the issue or ADR to confirm you plan to work on it.
+
+### PR submission rules
+
+Avoid having multiple concurrent PRs (e.g. 3+ ongoing).
+NV Access is a small team and will try to respond to PRs within a couple of days.
+Having multiple ongoing PRs increases the time to merge for each of them.
+
+All PRs must be submitted by a human.
+PRs which have not been reviewed and tested by the author will be closed.
+
+### PR scope and size
+
+Unrelated changes should be addressed in separate issues and PRs.
+
+Avoid PRs over 500 lines of code (LOC).
+PRs over 500 LOC may be rejected at the reviewers discretion.
+
+500-1000 line PRs can typically be broken into smaller changes such as automated tests, refactors, data-structures and core changes.
+These can be merged as stacked PRs if they depend on each other (e.g. `branchX` targets `master`, `branchY` targets `branchX`).
+
+Large refactors should instead target specific symbols/files/modules per PR to minimize mass changes.
+
+On-going feature development that cannot be merged straight to `master` can occur on `try-` branches, done in pieces.
+Ask NV Access on the [ADR](./proposingMajorChanges.md) to create a `try-` breach.
 
 ## Overview of contribution process:
 
 1. [Setup your development environment](./createDevEnvironment.md).
    * Alternatively, you can use GitHub Actions to build NVDA for you, without setting up a local development environment, by following [our CI/CD README](../../ci/README.md).
 1. Ensure the issue you plan to fix is [triaged](../issues/triage.md)
+1. If the issue has a `ADR-required` label, this is a complex change.
+Refer to ["Proposing Major Changes"](./proposingMajorChanges.md) before opening a PR.
 1. Create a branch for the contribution, to be used for a pull request.
 	* Pull requests should be based on the latest commit in the official master branch.
 	This helps reduce the chance of merge conflicts.
@@ -70,6 +105,8 @@ Then give people time to offer feedback.
 		Sometimes system tests fail unexpectedly.
 		If you believe the failure is unrelated, feel free to ignore it unless it is raised by a reviewer.
 		* Security checks will be run.
+		* If this is your first PR, GitHub will require manual approval from NV Access before running CI/CD.
+		We encourage testing in your fork in this scenario (e.g. open a practice PR in your own fork).
 1. Participate in the code review process
 	* This process requires core NVDA developers to understand the intent of the change, read the code changes, asking questions or suggesting changes.
 	Please participate in this process, answering questions, and discussing the changes.

--- a/projectDocs/dev/proposingMajorChanges.md
+++ b/projectDocs/dev/proposingMajorChanges.md
@@ -1,0 +1,99 @@
+# Proposing Major Changes (ADR Process)
+
+This page explains how to propose major changes to NVDA using an Architecture Decision Record (ADR).
+
+Use this process when an issue has the `ADR-required` label, or when your change significantly affects architecture, APIs, UX behavior, compatibility, performance, or long-term maintenance.
+
+## What an ADR is for
+
+An ADR is a decision document created as a GitHub issue.
+It helps reviewers understand:
+
+* what problem is being solved,
+* what options were considered,
+* why a technical design was chosen,
+* what impact and risks are expected,
+* how implementation will be delivered through PRs.
+
+## How to create an ADR
+
+1. Open a new issue using one of the ADR templates:
+
+    * `ADR for major project` (form template)
+    * `(Advanced) ADR for major project` (markdown template)
+
+1. Link any relevant existing issues, PRs, discussions, or mailing list threads.
+1. Fill in each section with concrete detail.
+Treat this as an implementation planning document, not just an idea pitch.
+1. Request feedback from NV Access and other contributors.
+1. Iterate on the ADR based on feedback until there is clear agreement.
+1. Do not begin large-scale implementation until the ADR is accepted/triaged for implementation.
+
+## What is expected in an ADR
+
+### Problem and UX expectations
+
+* Describe the current problem and constraints clearly.
+* Include user stories for UX impact, for example:
+  * As a screen reader user, I want ..., so that ...
+  * As an add-on developer, I want ..., so that ...
+* State what user-visible behavior should change and what should remain stable.
+
+### Options and decision rationale
+
+* Compare realistic options, including keeping the current approach.
+* Explain trade-offs and why the selected option is preferred.
+* Call out known downsides and why they are acceptable.
+
+### Impact and risk analysis
+
+Cover expected impacts across:
+
+* UX and accessibility behavior
+* performance and reliability
+* API/add-on compatibility
+* security/privacy
+* maintainability and developer workflow
+
+For major risks, include mitigation and rollback/fallback plans.
+
+### Architecture and code change planning
+
+Provide a concrete plan that maps decisions to implementation work:
+
+* likely modules/files and abstraction changes,
+* migration strategy,
+* rollout sequence,
+* validation strategy (tests, manual checks, success criteria).
+
+## Integration strategy
+
+Every ADR should include a PR integration strategy.
+In general:
+
+* Prefer PRs around 500 LOC where possible.
+* If changes are interdependent, use stacked PRs with clear ordering.
+* For long-running feature work that cannot merge directly to `master`, request a `try-` branch and integrate in pieces.
+* Separate unrelated work into separate issues/PRs.
+
+When describing your plan, include:
+
+* expected PR breakdown,
+* dependency order between PRs,
+* merge strategy,
+* rollback strategy if integration reveals issues.
+
+## Review and implementation flow
+
+1. ADR is opened and discussed.
+1. ADR is refined until concerns are addressed.
+1. ADR is accepted/triaged for implementation.
+1. Implementation PRs are opened following the ADR split/integration plan.
+1. If implementation findings require changing the decision, update the ADR and re-confirm before proceeding.
+
+## Tips for faster review
+
+* Keep language concrete and specific.
+* Use short sections and bullet points.
+* Link supporting material (benchmarks, prototypes, logs, related issues/PRs).
+* Clearly identify open questions and decisions needed from reviewers.

--- a/projectDocs/issues/githubIssueTemplateExplanationAndExamples.md
+++ b/projectDocs/issues/githubIssueTemplateExplanationAndExamples.md
@@ -20,7 +20,8 @@ We currently have the following templates:
   * The goal is to identify functionality that is essential for the core NVDA user experience.
 * For [Architecture Design Records to plan for major changes](https://github.com/nvaccess/nvda/issues/new?template=6-adr_major_project.yaml):
   * This template is intended for proposing major changes to NVDA.
-  It may be requested by NV Access before starting work which requires significant design decisions. e.g a new feature or refactor.
+  It may be requested by NV Access before starting work which require significant design decisions.
+  e.g a new feature or refactor.
   * Review [Proposing Major Changes](../dev/proposingMajorChanges.md) for more information.
 * For [security vulnerabilities](https://github.com/nvaccess/nvda/security/advisories/new)
   * Please note that these are reported differently, for more information refer to our [disclosure policy/procedure](https://github.com/nvaccess/nvda/blob/master/security.md)

--- a/projectDocs/issues/githubIssueTemplateExplanationAndExamples.md
+++ b/projectDocs/issues/githubIssueTemplateExplanationAndExamples.md
@@ -18,6 +18,10 @@ We currently have the following templates:
 * For [integrating functionality from a community add-on into NVDA](https://github.com/nvaccess/nvda/issues/new?template=5-addon_integration_request.yaml):
   * This template is intended for proposing a specific feature from an existing community add-on to be integrated into NVDA.
   * The goal is to identify functionality that is essential for the core NVDA user experience.
+* For [Architecture Design Records to plan for major changes](https://github.com/nvaccess/nvda/issues/new?template=6-adr_major_project.yaml):
+  * This template is intended for proposing major changes to NVDA.
+  It may be requested by NV Access before starting work which requires significant design decisions. e.g a new feature or refactor.
+  * Review [Proposing Major Changes](../dev/proposingMajorChanges.md) for more information.
 * For [security vulnerabilities](https://github.com/nvaccess/nvda/security/advisories/new)
   * Please note that these are reported differently, for more information refer to our [disclosure policy/procedure](https://github.com/nvaccess/nvda/blob/master/security.md)
 

--- a/projectDocs/issues/triage.md
+++ b/projectDocs/issues/triage.md
@@ -188,7 +188,9 @@ If an issue has been checked by NV Access, and needs further triage, the `needs-
 Please notify NV Access when you believe the issue is ready for the `triaged` label.
 You can do this by tagging [relevant NV Access employees](../community/expertsList.md#nv-access) or emailing <info@nvaccess.org>.
 
-A `triaged` issue that requires a complex fix may require advice from NV Access, such as a project plan, before implementation is started.
+A `triaged` issue that requires a complex fix may require advice from NV Access before implementation is started.
+In this case the `ADR-required` label will be applied, and NV Access will require an ADR to be submitted for review before work is started.
+See [Proposing Major Changes](../dev/proposingMajorChanges.md) for more information.
 
 An issue with a simple solution should get labelled `good first issue`.
 If it is a complex issue, technical investigation may be required.

--- a/projectDocs/issues/triage.md
+++ b/projectDocs/issues/triage.md
@@ -189,7 +189,7 @@ Please notify NV Access when you believe the issue is ready for the `triaged` la
 You can do this by tagging [relevant NV Access employees](../community/expertsList.md#nv-access) or emailing <info@nvaccess.org>.
 
 A `triaged` issue that requires a complex fix may require advice from NV Access before implementation is started.
-In this case the `ADR-required` label will be applied, and NV Access will require an ADR to be submitted for review before work is started.
+In this case, the `ADR-required` label will be applied, and NV Access will require an ADR to be submitted for review before work is started.
 See [Proposing Major Changes](../dev/proposingMajorChanges.md) for more information.
 
 An issue with a simple solution should get labelled `good first issue`.


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Closes #19719 

Discussion thread: https://groups.io/g/nvda-devel/topic/call_for_feedback_on_updates/118376537

### Summary of the issue:
Complex changes to NVDA suffer through the following problems:

- Slow review process due to large diffs
- Late debates: architecture discussions after implementation has already been pushed, meaning work has to be restarted
- AI assisted tools working on limited design information with minimal review

### Description of developer facing changes:
This pull request introduces a formal process for proposing major changes to NVDA, including new guidelines for contributors and detailed instructions for submitting Architecture Decision Records (ADRs). The changes clarify when and how ADRs should be used, update contribution guidelines to emphasize issue triage and ADR requirements, and provide new templates and documentation for ADR submission. ADRs can serve as more useful bases for using AI agents to fix complex issues.

Contributor guidelines and ADR process:

* Discourage larger PRs
* Discourage multiple concurrent PRs
* Discourage unsupervised AI PRs
* Added a new page `projectDocs/dev/proposingMajorChanges.md` that explains the ADR process, including when an ADR is required, what it should contain, and how to plan integration and implementation.
* Updated `projectDocs/dev/contributing.md` to clarify rules for first-time contributors, trivial and non-trivial changes, PR scope and size, and the requirement to use ADRs for complex changes. Also added guidance for CI/CD approval for first-time PRs. [[1]](diffhunk://#diff-3b8f90697ee87b0f58265155ed4beb6963a6b88680040cf8a666766d9caba54fL3-R68) [[2]](diffhunk://#diff-3b8f90697ee87b0f58265155ed4beb6963a6b88680040cf8a666766d9caba54fR108-R109)
* Revised `projectDocs/issues/triage.md` to explain that issues labeled `ADR-required` need an ADR before implementation, with a reference to the new ADR documentation.

ADR templates for major changes:

* Added `.github/ISSUE_TEMPLATE/06-adr_major_project.yaml` as a structured form template for submitting ADRs, guiding contributors through context, options, decision rationale, technical design, impact analysis, and integration planning.
* Added `.github/ISSUE_TEMPLATE/16-adr_major_project.md` as a free-text markdown template for advanced users to submit ADRs with similar required sections.
