### PR TITLE
Fix scons devDocs target

### DIFF
--- a/projectDocs/dev/developerGuide/sconscript
+++ b/projectDocs/dev/developerGuide/sconscript
@@ -4,7 +4,6 @@
 # See the file COPYING for more details.
 
 import sys
-from SCons.Script import Move
 
 Import("env", "outputDir", "sourceDir", "userDocsDir")
 

--- a/projectDocs/dev/developerGuide/sconscript
+++ b/projectDocs/dev/developerGuide/sconscript
@@ -1,7 +1,4 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2019-2023 NV Access Limited
-# This file is covered by the GNU General Public License.
-# A part of NonVisual Desktop Access (NVDA)
 # Copyright (C) 2019-2026 NV Access Limited
 # This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
 # For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt

--- a/projectDocs/dev/developerGuide/sconscript
+++ b/projectDocs/dev/developerGuide/sconscript
@@ -4,6 +4,7 @@
 # See the file COPYING for more details.
 
 import sys
+from SCons.Script import Move
 
 Import("env", "outputDir", "sourceDir", "userDocsDir")
 
@@ -30,8 +31,6 @@ devGuide = env.Command(
 	target=userDocsDir.File("developerGuide.html"), source=htmlFile, action=Move("$TARGET", "$SOURCE")
 )
 env.Alias("developerGuide", devGuide)
-# Return the developer docs targets so they can be used as dependencies
-Return(["devGuide"])
 
 devDocs_nvdaHelper_temp = env.Doxygen(source="../../../nvdaHelper/doxyfile")
 devDocs_nvdaHelper = env.Command(
@@ -94,3 +93,6 @@ sphinxHtml = env.Command(
 devDocs_nvda = env.Command(devDocsOutputDir.Dir("NVDA"), sphinxHtml, Move("$TARGET", "$SOURCE"))
 env.Alias("devDocs", [devGuide, devDocs_nvda])
 env.Clean("devDocs", [devGuide, devDocs_nvda])
+
+# Return the developer docs targets so they can be used as dependencies
+Return(["devGuide"])

--- a/projectDocs/dev/developerGuide/sconscript
+++ b/projectDocs/dev/developerGuide/sconscript
@@ -1,7 +1,10 @@
 # A part of NonVisual Desktop Access (NVDA)
 # Copyright (C) 2019-2023 NV Access Limited
 # This file is covered by the GNU General Public License.
-# See the file COPYING for more details.
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2019-2026 NV Access Limited
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
 
 import sys
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
<!-- Use Closes/Fixes/Resolves #xxx to link this PR to the issue it is responding to. -->
Fixes #19803 
### Summary of the issue:

The `devDocs` target fails to build when running:

```
scons devDocs
```

SCons reports:

```
scons: *** Do not know how to make File target `devDocs'
```

This occurs because `projectDocs/dev/developerGuide/sconscript` exits early due to a misplaced `Return()` statement. As a result, the remaining build logic is never executed and the `devDocs` alias is not defined.

### Description of user facing changes:

Developers can now successfully run:

```
scons devDocs
```

to build all developer documentation without errors.

### Description of developer facing changes:

* Ensures that all documentation targets (developer guide and devDocs) are properly registered.
* Restores the `devDocs` alias so it can be resolved by SCons.
* Maintains existing dependency behavior for `dist` by continuing to return `"devGuide"`.

Additionally:

* Explicitly imports `Move` from `SCons.Script` for clarity and robustness.

  * While `Move` may be available implicitly in some environments, relying on implicit availability can lead to issues in stricter or different SCons configurations.
  * This makes the script self-contained and more predictable.

### Description of development approach:
The fix moves the `Return(["devGuide"])` statement to the end of `projectDocs/dev/developerGuide/sconscript`.

Previously, the early `Return()` caused SCons to stop executing the script before:

* nvdaHelper documentation targets were defined
* Sphinx documentation targets were defined
* the `devDocs` alias was created

By moving `Return()` to the end:

* the full build graph is constructed
* all targets and aliases are registered correctly
* the intended dependency behavior is preserved

This is a minimal and non invasive change.

### Testing strategy:
Manual testing performed:

1. Ran `scons devDocs`

   * Verified that developer guide, Doxygen, and Sphinx documentation are generated successfully
2. Ran `scons dist`

   * Verified that the developer guide is correctly included
3. Confirmed no regressions in documentation generation workflow


### Known issues with pull request:

None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [ ] Documentation:
  - Change log entry
  - User Documentation
  - [x] Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - [x] Unit tests - Not applicable
  - [x] System (end to end) tests - Not applicable
  - [x] Manual testing
- [x] UX of all users considered:
  - [x] Speech - Not applicable
  - [x] Braille - Not applicable
  - [x] Low Vision  - Not applicable
  - [x] Different web browsers  - Not applicable
  - [x] Localization in other languages / culture than English  - Not applicable
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
