### PR TITLE
Fix-up of #19767 introducing the report screen curtain state command

### DIFF
--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -4972,7 +4972,7 @@ class GlobalCommands(ScriptableObject):
 			# Translators: Describes a command.
 			"Reports the state of the screen curtain.",
 		),
-		category=SCRCAT_VISION,
+		speakOnDemand=True,
 	)
 	def script_reportScreenCurtainState(self, gesture: inputCore.InputGesture) -> None:
 		import screenCurtain


### PR DESCRIPTION
### Link to issue number:
Fix-up of #19767

### Summary of the issue:
PR #19767 has introduced a command to report the state of the screen curtain.
1. In the Input gesture dialog, this command has been put in Vision category; that is not consistent with the screen curtain toggle command which is in the Miscellaneous category. 
2. This new command does nothing else than reporting an information, so it should be speaking when used in on-demand speech mode. Today, it does not.

### Description of user facing changes:
1. In the Input gestures dialog, the "Reports the state of the screen curtain." command is now in the Miscellaneous category, as the toggle screen curtain command. Note that Screen curtain is not a visual aid, and as such, does not belong to Vision category, neither in Input gestures dialog, nor in the settings dialog.
2. The command to report the state of the screen curtain now also speaks when in on-demand speech mode.

### Description of developer facing changes:
None
### Description of development approach:
1. Removed the "category" parameter of the `@script` decorator so that the command lands in misc. category.
2. Passed the `speakOnDemand=True` argument to the `@script` decorator.
### Testing strategy:
Manual tests:
1. Checked the position of the command in the input gestures dialog
2. Used the command in all existing speech modes
### Known issues with pull request:
None
### Code Review Checklist:


- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x]] Security precautions taken.
