### PR TITLE
Fix MathCAT links

### DIFF
--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -1173,7 +1173,7 @@ However, for scenarios where you wish to copy an entire table or paragraph of ri
 ## Reading Mathematical Content {#ReadingMath}
 
 NVDA can read and navigate mathematical content on the web and in other applications, providing access in both speech and braille.
-NVDA uses [MathCAT](https://nsoiffer.github.io/MathCAT/) for reading mathematical content.
+NVDA uses [MathCAT](https://daisy.github.io/MathCAT/) for reading mathematical content.
 
 ### Supported math content {#SupportedMathContent}
 
@@ -3246,7 +3246,7 @@ If speech rules for the main language cannot be found, English ("en") is used.
 Different styles can be used to speak mathematical content:
 
 * ClearSpeak was developed by the Educational Testing Service for use on university-admission and other high-stakes tests in the United States.
-Refer to the [ClearSpeak specification details in this Word document](https://nsoiffer.github.io/MathCAT/ClearSpeakRulesAndPreferences.docx).
+Refer to the [ClearSpeak specification details in this Word document](https://daisy.github.io/MathCAT/ClearSpeakRulesAndPreferences.docx).
 * SimpleSpeak tries to minimize speech by speaking simple expressions such as $\frac{a}{b}$ quickly without bracketing words ("a over b").
 These are distinguished from more complex expressions such as $\frac{a}{b+1}$ which will always have bracketing words ("fraction a over b plus 1 end fraction").
 * LiteralSpeak tells MathCAT to speak math expressions almost exactly as written, without interpreting the symbols or meaning.


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
MathCAT links points to @nsoiffer's GitHub page while it now uses @daisy's one.
As a consequence, the ClearSpeak specification cannot be downloaded and the general MathCAT page is reachable after a redirection.

### Description of user facing changes:
ClearSpeak specification can be downloaded again from the link in the User Guide and the MathCAT page is reachable without any redirection when clicking its link in the UG.

### Description of developer facing changes:
N/A
### Description of development approach:
Updated links in the UG.
### Testing strategy:
Manual check of the links in the generated UG.

### Known issues with pull request:
None
### Code Review Checklist:


- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
