### PR TITLE
Allow retry when system testing fails

### DIFF
--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -405,7 +405,7 @@ jobs:
     name: Run system tests
     runs-on: ${{ matrix.runner }}
     needs: [matrix, createLauncher]
-    timeout-minutes: 10
+    timeout-minutes: 50
     strategy:
       fail-fast: false
       matrix:

--- a/ci/scripts/setSconsArgs.ps1
+++ b/ci/scripts/setSconsArgs.ps1
@@ -2,7 +2,11 @@ $ErrorActionPreference = "Stop";
 $sconsDocsOutTargets = "developerGuide changes userGuide keyCommands user_docs"
 $sconsLauncherOutTargets = "launcher client moduleList"
 $sconsArgs = "version=$env:version"
-$sconsCores = "-j1"
+if ($env:RUNNER_DEBUG -ne "1" -and $env:GITHUB_EVENT_NAME -eq "pull_request") {
+	$sconsCores = "--all-cores"
+} else {
+	$sconsCores = "-j1"
+}
 if ($env:release) {
 	$sconsArgs += " release=1"
 }

--- a/ci/scripts/tests/systemTests.ps1
+++ b/ci/scripts/tests/systemTests.ps1
@@ -44,14 +44,38 @@ $includeTags = $tagsForTestArray | ForEach-Object {
 }
 
 $nvdaLauncherFile=$(Resolve-Path "$env:nvdaLauncherDir\nvda*.exe")
-.\runsystemtests.bat `
---variable whichNVDA:installed `
---variable installDir:"${nvdaLauncherFile}" `
---variable verboseDebugLogging:"${verboseDebugLogging}" `
-@includeTags `
-# last line intentionally blank, allowing all lines to have line continuations.
-if ($LastExitCode -ne 0) {
-	Write-Output "FAIL: System tests (tags: ${tagsForTest}). See test results for more information."  >> $env:GITHUB_STEP_SUMMARY
-	Write-Output "testFailExitCode=$LastExitCode" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+# Maximum number of retry attempts
+$maxAttempts = 5
+$attempt = 1
+$testFailed = $true
+
+while ($attempt -le $maxAttempts -and $testFailed) {
+	Write-Output "System test attempt $attempt of $maxAttempts"
+	
+	.\runsystemtests.bat `
+	--variable whichNVDA:installed `
+	--variable installDir:"${nvdaLauncherFile}" `
+	--variable verboseDebugLogging:"${verboseDebugLogging}" `
+	@includeTags `
+	# last line intentionally blank, allowing all lines to have line continuations.
+	
+	if ($LastExitCode -eq 0) {
+		Write-Output "System tests passed on attempt $attempt"
+		$testFailed = $false
+	} elseif ($attempt -lt $maxAttempts) {
+		Write-Output "System tests failed with exit code $LastExitCode on attempt $attempt. Retrying..."
+		$attempt++
+	} else {
+		Write-Output "System tests failed with exit code $LastExitCode on final attempt $attempt"
+		$attempt++
+	}
 }
-exit $LastExitCode
+
+# Handle the final result
+if ($testFailed) {
+	Write-Output "FAIL: System tests (tags: ${tagsForTest}) after $maxAttempts attempts. See test results for more information."  >> $env:GITHUB_STEP_SUMMARY
+	Write-Output "testFailExitCode=$LastExitCode" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+	exit $LastExitCode
+}
+
+exit 0

--- a/ci/scripts/tests/systemTests.ps1
+++ b/ci/scripts/tests/systemTests.ps1
@@ -51,14 +51,14 @@ $testFailed = $true
 
 while ($attempt -le $maxAttempts -and $testFailed) {
 	Write-Output "System test attempt $attempt of $maxAttempts"
-	
+
 	.\runsystemtests.bat `
 	--variable whichNVDA:installed `
 	--variable installDir:"${nvdaLauncherFile}" `
 	--variable verboseDebugLogging:"${verboseDebugLogging}" `
 	@includeTags `
 	# last line intentionally blank, allowing all lines to have line continuations.
-	
+
 	if ($LastExitCode -eq 0) {
 		Write-Output "System tests passed on attempt $attempt"
 		$testFailed = $false


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
<!-- Use Closes/Fixes/Resolves #xxx to link this PR to the issue it is responding to. -->
None

### Summary of the issue:
System tests frequently fail, although they can often succeed after multiple retry attempts.

### Description of user facing changes:
None

### Description of developer facing changes:
System tests should no longer fail.

### Description of development approach:
- Added a retry mechanism to the system test scripts
- Tests will automatically re-run when they fail
- Tests will only be considered failed after 5 consecutive failed attempts
- Set the `$sconsCores` variable to `"--all-cores"` when running on PRs to speed up build and test times
  - This typically does not cause adverse effects
  - To run CI/CD linearly, enable debug mode or push code to a try-xxx branch

### Testing strategy:
Failure examples:
https://github.com/nvaccess/nvda/actions/runs/23324827612
### Known issues with pull request:
None
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [x]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
