### PR TITLE
Fix error when displaying math panel

### DIFF
--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -2768,9 +2768,12 @@ class MathSettingsPanel(SettingsPanel):
 		self.languageList.Bind(wx.EVT_CHOICE, self.onLanguageChange)
 		mathLang = config.conf["math"]["speech"]["language"]
 		try:
-			languageIndex = next(filter(lambda idxLang: idxLang[1].code == mathLang, self.languageOptions))[0]
+			languageIndex = next(
+				idxLang for idxLang, langInfo in enumerate(self.languageOptions) if langInfo.code == mathLang
+			)
 		except StopIteration:
-			languageIndex = 0  # auto
+			log.debugWarning(f'Language "{mathLang}" not supported; restoring to "Auto".')
+			languageIndex = 0
 		self.languageList.SetSelection(languageIndex)
 
 		# Translators: MathCAT decimal separator option.


### PR DESCRIPTION
### Link to issue number:
Fix-up of #19740


### Summary of the issue:

After the merge of #19740, the math panel cannot be displayed and the following error is logged:
```
ERROR - unhandled exception (15:06:18.687) - MainThread (1844):
Traceback (most recent call last):
  File "gui\settingsDialogs.py", line 6230, in onCategoryChange
    super().onCategoryChange(evt)
    ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^
  File "gui\settingsDialogs.py", line 750, in onCategoryChange
    self._doCategoryChange(newIndex)
    ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
  File "gui\settingsDialogs.py", line 733, in _doCategoryChange
    newCat = self._getCategoryPanel(newCatId)
  File "gui\settingsDialogs.py", line 660, in _getCategoryPanel
    panel = cls(parent=self.container)
  File "gui\settingsDialogs.py", line 392, in __init__
    self._buildGui()
    ~~~~~~~~~~~~~~^^
  File "gui\settingsDialogs.py", line 402, in _buildGui
    self.makeSettings(self.settingsSizer)
    ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^
  File "gui\settingsDialogs.py", line 2771, in makeSettings
    languageIndex = next(filter(lambda idxLang: idxLang[1].code == mathLang, self.languageOptions))[0]
                    ~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "gui\settingsDialogs.py", line 2771, in <lambda>
    languageIndex = next(filter(lambda idxLang: idxLang[1].code == mathLang, self.languageOptions))[0]
                                                ~~~~~~~^^^
TypeError: 'LanguageInfo' object is not subscriptable
I
```
### Description of user facing changes:

The math panel can be displayed again.

### Description of developer facing changes:
None
### Description of development approach:
* Used `enumerate` on the language list to be able to retrieve its index.
* Also used a generator expression instead of the use of the `filter` function + lambda since the previous code seemed less readable and less modern Python syntax. This is debatable though, and I can restore the old syntax, just adding `enumerate`, if you prefer.
* Added a `DEBUGWARNING` log when the config language is not found in supported languages.
### Testing strategy:
Manual tests:
* Checked that the math panel displays, with language set to "Auto" and to "en" in config
* Also tried to manually set language to "zz" in config and checked that the debug warning is logged and that Automatic is selected in the panel.

### Known issues with pull request:
None
### Code Review Checklist:


- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
