### PR TITLE
Fix add-on store crash when download directory cleanup fails

### DIFF
--- a/source/addonStore/network.py
+++ b/source/addonStore/network.py
@@ -1,7 +1,7 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2022-2024 NV Access Limited
-# This file is covered by the GNU General Public License.
-# See the file COPYING for more details.
+# Copyright (C) 2022-2026 NV Access Limited
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
 
 from concurrent.futures import (
 	Future,

--- a/source/addonStore/network.py
+++ b/source/addonStore/network.py
@@ -112,7 +112,13 @@ class AddonFileDownloader:
 		if NVDAState.shouldWriteToDisk():
 			# empty temporary downloads
 			if os.path.exists(WritePaths.addonStoreDownloadDir):
-				shutil.rmtree(WritePaths.addonStoreDownloadDir)
+				try:
+					shutil.rmtree(WritePaths.addonStoreDownloadDir)
+				except OSError:
+					log.error(
+						f"Failed to remove addon store download directory: {WritePaths.addonStoreDownloadDir}",
+						exc_info=True,
+					)
 			# ensure downloads dir exist
 			pathlib.Path(WritePaths.addonStoreDownloadDir).mkdir(parents=True, exist_ok=True)
 
@@ -198,7 +204,14 @@ class AddonFileDownloader:
 		with self.DOWNLOAD_LOCK:
 			self.progress.clear()
 			self._pending.clear()
-		shutil.rmtree(WritePaths.addonStoreDownloadDir)
+		if NVDAState.shouldWriteToDisk() and os.path.exists(WritePaths.addonStoreDownloadDir):
+			try:
+				shutil.rmtree(WritePaths.addonStoreDownloadDir)
+			except OSError:
+				log.error(
+					f"Failed to remove addon store download directory: {WritePaths.addonStoreDownloadDir}",
+					exc_info=True,
+				)
 
 	def _downloadAddonToPath(
 		self,

--- a/tests/unit/test_addonStoreNetwork.py
+++ b/tests/unit/test_addonStoreNetwork.py
@@ -1,0 +1,171 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2026 NV Access Limited, Christopher Pross
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
+
+"""Unit tests for the addonStore.network module."""
+
+import unittest
+from unittest.mock import patch, MagicMock
+
+from addonStore.network import AddonFileDownloader
+from NVDAState import WritePaths
+
+
+class TestAddonFileDownloaderInit(unittest.TestCase):
+	"""Tests for AddonFileDownloader.__init__ error handling of shutil.rmtree."""
+
+	def setUp(self):
+		self.downloader = None
+
+	def tearDown(self):
+		if self.downloader is not None and self.downloader._executor is not None:
+			with patch("addonStore.network.NVDAState.shouldWriteToDisk", return_value=False):
+				self.downloader.cancelAll()
+
+	@patch("addonStore.network.log.error")
+	@patch("addonStore.network.pathlib.Path.mkdir")
+	@patch("addonStore.network.os.path.exists", return_value=True)
+	@patch("addonStore.network.shutil.rmtree", side_effect=OSError("locked by cloud sync"))
+	@patch("addonStore.network.NVDAState.shouldWriteToDisk", return_value=True)
+	def test_init_rmtreeOSError_doesNotCrashAndLogsError(
+		self,
+		mockShouldWrite: MagicMock,
+		mockRmtree: MagicMock,
+		mockExists: MagicMock,
+		mockMkdir: MagicMock,
+		mockLogError: MagicMock,
+	) -> None:
+		"""AddonFileDownloader should not crash and should log an error when rmtree raises OSError."""
+		try:
+			self.downloader = AddonFileDownloader()
+		except OSError as e:
+			self.fail(f"AddonFileDownloader raised OSError when it should have been caught: {e}")
+		mockRmtree.assert_called_once_with(WritePaths.addonStoreDownloadDir)
+		mockMkdir.assert_called_once()
+		mockLogError.assert_called_once()
+
+	@patch("addonStore.network.pathlib.Path.mkdir")
+	@patch("addonStore.network.os.path.exists", return_value=True)
+	@patch("addonStore.network.shutil.rmtree")
+	@patch("addonStore.network.NVDAState.shouldWriteToDisk", return_value=True)
+	def test_init_rmtreeSucceeds_downloadsDirectoryCleanedAndRecreated(
+		self,
+		mockShouldWrite: MagicMock,
+		mockRmtree: MagicMock,
+		mockExists: MagicMock,
+		mockMkdir: MagicMock,
+	) -> None:
+		"""AddonFileDownloader should call rmtree and mkdir when shouldWriteToDisk is True."""
+		self.downloader = AddonFileDownloader()
+		mockRmtree.assert_called_once_with(WritePaths.addonStoreDownloadDir)
+		mockMkdir.assert_called_once()
+
+	@patch("addonStore.network.pathlib.Path.mkdir")
+	@patch("addonStore.network.os.path.exists", return_value=False)
+	@patch("addonStore.network.shutil.rmtree")
+	@patch("addonStore.network.NVDAState.shouldWriteToDisk", return_value=True)
+	def test_init_downloadDirNotExists_rmtreeNotCalledButMkdirCalled(
+		self,
+		mockShouldWrite: MagicMock,
+		mockRmtree: MagicMock,
+		mockExists: MagicMock,
+		mockMkdir: MagicMock,
+	) -> None:
+		"""AddonFileDownloader should skip rmtree but still call mkdir when download dir does not exist."""
+		self.downloader = AddonFileDownloader()
+		mockRmtree.assert_not_called()
+		mockMkdir.assert_called_once()
+
+	@patch("addonStore.network.pathlib.Path.mkdir")
+	@patch("addonStore.network.shutil.rmtree")
+	@patch("addonStore.network.NVDAState.shouldWriteToDisk", return_value=False)
+	def test_init_shouldNotWriteToDisk_rmtreeNotCalled(
+		self,
+		mockShouldWrite: MagicMock,
+		mockRmtree: MagicMock,
+		mockMkdir: MagicMock,
+	) -> None:
+		"""AddonFileDownloader should not call rmtree or mkdir when shouldWriteToDisk is False."""
+		self.downloader = AddonFileDownloader()
+		mockRmtree.assert_not_called()
+		mockMkdir.assert_not_called()
+
+
+class TestAddonFileDownloaderCancelAll(unittest.TestCase):
+	"""Tests for AddonFileDownloader.cancelAll error handling of shutil.rmtree."""
+
+	def setUp(self):
+		self.downloader = None
+
+	def tearDown(self):
+		if self.downloader is not None and self.downloader._executor is not None:
+			with patch("addonStore.network.NVDAState.shouldWriteToDisk", return_value=False):
+				self.downloader.cancelAll()
+
+	def _createDownloader(self) -> None:
+		"""Create an AddonFileDownloader and assign to self.downloader.
+
+		shouldWriteToDisk is patched to False to skip __init__ rmtree.
+		"""
+		with patch("addonStore.network.NVDAState.shouldWriteToDisk", return_value=False):
+			self.downloader = AddonFileDownloader()
+
+	@patch("addonStore.network.log.error")
+	@patch("addonStore.network.os.path.exists", return_value=True)
+	@patch("addonStore.network.shutil.rmtree", side_effect=OSError("access denied"))
+	@patch("addonStore.network.NVDAState.shouldWriteToDisk", return_value=True)
+	def test_cancelAll_rmtreeOSError_doesNotCrashAndLogsError(
+		self,
+		mockShouldWrite: MagicMock,
+		mockRmtree: MagicMock,
+		mockExists: MagicMock,
+		mockLogError: MagicMock,
+	) -> None:
+		"""cancelAll should not crash and should log an error when rmtree raises OSError."""
+		self._createDownloader()
+		try:
+			self.downloader.cancelAll()
+		except OSError as e:
+			self.fail(f"cancelAll raised OSError when it should have been caught: {e}")
+		mockLogError.assert_called_once()
+
+	@patch("addonStore.network.shutil.rmtree")
+	@patch("addonStore.network.os.path.exists", return_value=False)
+	@patch("addonStore.network.NVDAState.shouldWriteToDisk", return_value=True)
+	def test_cancelAll_dirNotExists_rmtreeNotCalled(
+		self,
+		mockShouldWrite: MagicMock,
+		mockExists: MagicMock,
+		mockRmtree: MagicMock,
+	) -> None:
+		"""cancelAll should not call rmtree when the download directory does not exist."""
+		self._createDownloader()
+		self.downloader.cancelAll()
+		mockRmtree.assert_not_called()
+
+	@patch("addonStore.network.os.path.exists", return_value=True)
+	@patch("addonStore.network.shutil.rmtree")
+	@patch("addonStore.network.NVDAState.shouldWriteToDisk", return_value=True)
+	def test_cancelAll_rmtreeSucceeds_directoryRemoved(
+		self,
+		mockShouldWrite: MagicMock,
+		mockRmtree: MagicMock,
+		mockExists: MagicMock,
+	) -> None:
+		"""cancelAll should call rmtree when completing normally."""
+		self._createDownloader()
+		self.downloader.cancelAll()
+		mockRmtree.assert_called_once_with(WritePaths.addonStoreDownloadDir)
+
+	@patch("addonStore.network.shutil.rmtree")
+	@patch("addonStore.network.NVDAState.shouldWriteToDisk", return_value=False)
+	def test_cancelAll_shouldNotWriteToDisk_rmtreeNotCalled(
+		self,
+		mockShouldWrite: MagicMock,
+		mockRmtree: MagicMock,
+	) -> None:
+		"""cancelAll should not call rmtree when shouldWriteToDisk is False."""
+		self._createDownloader()
+		self.downloader.cancelAll()
+		mockRmtree.assert_not_called()

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -49,6 +49,7 @@ The triple-press keyboard shortcut (`NVDA+ctrl+r`) is not affected, as it is int
 * Capital indicators are now correctly announced when selecting single characters. (#19505, @cary-rowen)
 * Configuration profile triggers now activate when the Add-on Store is open. (#19583, @bramd)
 * Decorative Unicode letters such as negative squared, negative circled, and regional indicator symbol characters are now normalized to their base Latin letters when Unicode normalization is enabled. (#19608, @bramd)
+* NVDA no longer crashes when the Add-on Store download directory cannot be cleaned up due to file permission errors. (#19202, @christopherpross)
 
 ### Changes for Developers
 


### PR DESCRIPTION
### Link to issue number:

Fixes #19202

### Summary of the issue:

When the add-on store download directory (`addonStore/_dl`) is locked by an external process, `shutil.rmtree` raises an unhandled `PermissionError` during `AddonFileDownloader.__init__`. `AddonFileDownloader` is instantiated as a class-level attribute of `AddonStoreVM`. The exception propagates through module initialization and causes a `CRITICAL - core failure` that crashes NVDA.

A similar unprotected `shutil.rmtree` call exists in `AddonFileDownloader.cancelAll`. This would crash NVDA when closing the add-on store dialog if the directory is locked.

### Description of user facing changes:

NVDA no longer crashes when the add-on store download directory cannot be cleaned up due to file permission errors. If cleanup fails, NVDA logs a warning and continues normally. The existing `__init__` cleanup will retry removal on the next startup.

### Description of developer facing changes:

None.

### Description of development approach:

Both `shutil.rmtree` calls in `AddonFileDownloader` (`__init__` and `cancelAll`) are wrapped in `try-except OSError` blocks with `log.error(exc_info=True)` (was `log.debugWarning` but maintainer asked to change this to `log.error`).

`OSError` is used because `shutil.rmtree` can raise various `OSError` subclasses depending on the failure mode. This matches the pattern used in `installer.py` (e.g. `tryRemoveFile` and `_deleteFileGroupOrFail`).

In `__init__`, the `mkdir(parents=True, exist_ok=True)` call remains outside the try-except block. This ensures the download directory always exists, even if cleanup of the previous contents failed.

In `cancelAll`, a failed cleanup is not critical. `_downloader` is a class-level attribute that is only re-created on the next NVDA restart. At that point `__init__` will retry the cleanup.

This PR was developed with AI assistance (Claude Code) with human review and manual testing.

### Testing strategy:

**Unit tests (7 tests, all passing):**

A new test file `tests/unit/test_addonStoreNetwork.py` covers:
- `__init__`: rmtree raises `OSError`, does not crash, logs warning, mkdir still called
- `__init__`: rmtree succeeds, directory cleaned and recreated
- `__init__`: download directory does not exist, rmtree not called, mkdir still called
- `__init__`: `shouldWriteToDisk` returns `False`, neither rmtree nor mkdir called
- `cancelAll`: rmtree raises `OSError`, does not crash, logs warning
- `cancelAll`: rmtree raises `FileNotFoundError`, does not crash, logs warning
- `cancelAll`: rmtree succeeds, directory removed

**Manual testing:**

To test without the fix applied, the changes were stashed with `git stash` first. After confirming the crash, the fix was restored with `git stash pop` and the same test was repeated.

A separate config directory was used to avoid interfering with the installed NVDA instance:

1. Create the download directory and lock a file inside it:
```powershell
New-Item -ItemType Directory -Force -Path "C:\temp\nvda_test_config\addonStore\_dl"
$f = [IO.File]::Open("C:\temp\nvda_test_config\addonStore\_dl\lockfile", 'Create', 'ReadWrite', 'None')
```

2. Keep the PowerShell window open. In a separate terminal, start NVDA from source with the separate config directory:
```
C:\programmierung\nvda\runnvda.bat -c "C:\temp\nvda_test_config" --log-level=15
```

3. Without the fix: NVDA crashes with `CRITICAL - core failure` and `PermissionError: [WinError 32]`.

4. With the fix: NVDA starts normally. The log (at debug warning level) shows `DEBUGWARNING` with the full `PermissionError` traceback. NVDA continues to initialize successfully.

### Known issues with pull request:

`log.debugWarning` is only visible when the log level is set to "Debug warning" or lower. At the default "Info" level the warning is not shown. Feedback on whether a higher log level would be more appropriate is welcome.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
