### PR TITLE
Fix Scintilla crash

### DIFF
--- a/source/NVDAObjects/window/scintilla.py
+++ b/source/NVDAObjects/window/scintilla.py
@@ -1,6 +1,5 @@
-# -*- coding: UTF-8 -*-
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2007-2022 NV Access Limited, Arnold Loubriat, Babbage B.V., Łukasz Golonka, Joseph Lee,
+# Copyright (C) 2007-2026 NV Access Limited, Arnold Loubriat, Babbage B.V., Łukasz Golonka, Joseph Lee,
 # Peter Vágner
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
@@ -16,6 +15,7 @@ import watchdog
 import eventHandler
 import locationHelper
 import textUtils
+from logHandler import log
 
 # Window messages
 SCI_POSITIONFROMPOINT = 2022
@@ -203,6 +203,12 @@ class ScintillaTextInfo(textInfos.offsets.OffsetsTextInfo):
 		return watchdog.cancellableSendMessage(self.obj.windowHandle, SCI_GETLINECOUNT, 0, 0)
 
 	def _getTextRange(self, start, end):
+		if end < start:
+			log.error(
+				f"End offset must be greater than or equal to start offset. Got {start=}, {end=}.",
+				stack_info=True,
+			)
+			return ""
 		bufLen = (end - start) + 1
 		textRange = self.TextRangeStruct()
 		textRange.chrg.cpMin = start

--- a/source/NVDAObjects/window/scintilla.py
+++ b/source/NVDAObjects/window/scintilla.py
@@ -202,7 +202,7 @@ class ScintillaTextInfo(textInfos.offsets.OffsetsTextInfo):
 	def _getLineCount(self):
 		return watchdog.cancellableSendMessage(self.obj.windowHandle, SCI_GETLINECOUNT, 0, 0)
 
-	def _getTextRange(self, start, end):
+	def _getTextRange(self, start: int, end: int) -> str:
 		if end < start:
 			log.error(
 				f"End offset must be greater than or equal to start offset. Got {start=}, {end=}.",


### PR DESCRIPTION
### Link to issue number:
Fixes #19729

### Summary of the issue:
NVDA occasionally causes Notepad++ (and likely other Scintilla-based editors) to crash.

### Description of user facing changes:
The crash should no longer occur.

### Description of developer facing changes:
None

### Description of development approach:
Return early if `end < start` in `ScintillaTextInfo._getTextRange`.

### Testing strategy:

### Known issues with pull request:

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
