### PR TITLE
Persist screen curtain state when changed through settings dialog

### DIFF
--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -6104,7 +6104,7 @@ class PrivacyAndSecuritySettingsPanel(SettingsPanel):
 				self._screenCurtainEnabledCheckbox.SetValue(False)
 			else:
 				try:
-					screenCurtain.screenCurtain.enable()
+					screenCurtain.screenCurtain.enable(persist=True)
 				except Exception:
 					log.error("Error enabling Screen Curtain.", exc_info=True)
 					ui.message(

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -5968,6 +5968,7 @@ class PrivacyAndSecuritySettingsPanel(SettingsPanel):
 				label=_("Make screen black (immediate effect)"),
 			),
 		)
+		self._screenCurtainCheckboxChanged: bool = False
 		isScreenCurtainAvailable = screenCurtain.screenCurtain is not None
 		if isScreenCurtainAvailable:
 			self._cachedScreenCurtainConfigEnabled = screenCurtain.screenCurtain.settings["enabled"]
@@ -6052,8 +6053,11 @@ class PrivacyAndSecuritySettingsPanel(SettingsPanel):
 		super().onDiscard()
 
 	def onSave(self):
-		# We intentionally don't save whether the screen curtain is enabled here,
+		# We only save whether the screen curtain is enabled here if the user has toggled the checkbox,
 		# so we don't unintentionally persist a temporary screen curtain to config.
+		if self._screenCurtainCheckboxChanged:
+			# We don't need to change the state of the screen curtain, as that is done when the checkbox is checked/unchecked.
+			self._screenCurtainConfig["enabled"] = self._screenCurtainEnabledCheckbox.IsChecked()
 		self._screenCurtainConfig["warnOnLoad"] = self._screenCurtainWarnOnLoadCheckbox.IsChecked()
 		self._screenCurtainConfig["playToggleSounds"] = (
 			self._screenCurtainPlayToggleSoundsCheckbox.IsChecked()
@@ -6104,7 +6108,8 @@ class PrivacyAndSecuritySettingsPanel(SettingsPanel):
 				self._screenCurtainEnabledCheckbox.SetValue(False)
 			else:
 				try:
-					screenCurtain.screenCurtain.enable(persist=True)
+					screenCurtain.screenCurtain.enable(persist=False)
+					self._screenCurtainCheckboxChanged = True
 				except Exception:
 					log.error("Error enabling Screen Curtain.", exc_info=True)
 					ui.message(
@@ -6113,7 +6118,8 @@ class PrivacyAndSecuritySettingsPanel(SettingsPanel):
 					)
 					self._screenCurtainEnabledCheckbox.SetValue(False)
 		elif not shouldBeEnabled and currentlyEnabled:
-			screenCurtain.screenCurtain.disable()
+			screenCurtain.screenCurtain.disable(persist=False)
+			self._screenCurtainCheckboxChanged = True
 
 	def _confirmEnableScreenCurtainWithUser(self) -> bool:
 		"""Confirm with the user before enabling Screen Curtain, if configured to do so.


### PR DESCRIPTION
### Link to issue number:

Fixes 19783

### Summary of the issue:

When modified through the settings dialog, the state of the screen curtain is not persisted to the config.

### Description of user facing changes:

The screen curtain state is now persisted to the config when changed through the settings dialog.

### Description of developer facing changes:

None

### Description of development approach:

Added a `_screenCurtainCheckboxChanged` bool to the privacy and security panel. Initially set to `False`, it is set to `True` when the user successfully interacts with the checkbox (that is, uses it to enable or disable the screen curtain). It is never set back to `False`. In `onSave`, store the state of the checkbox as the value of `config.conf["screenCurtain"]["enabled"] if and only if this new flag is `True`.

### Testing strategy:

Tested altering the screen curtain state from the Privacy and Security settings panel as follows:

| Screen curtain | `config.conf["screenCurtain"]["enabled"]` | Screen is | Open privasy and security and... | `config.conf["screenCurtain"]["enabled"]` | Screen is | Then... | `config.conf["screenCurtain"]["enabled"]` | Screen is |
|---|---|---|---|---|---|---|---|---|
| Disabled | `False` | Visible | Do nothing | `False` | Visible | Press Cancel | `False` | Visible |
| Disabled | `False` | Visible | Do nothing | `False` | Visible | Press OK | `False` | Visible |
| Disabled | `False` | Visible | Check to enable | `False` | Obscured | Press Cancel | `False` |Visible |
| Disabled | `False` | Visible | Check to enable | `False` | Obscured | Press OK | `True` | Obscured |
| Disabled | `False` | Visible | Check then uncheck to enable then disable | `False` | Visible | Press Cancel | `False` | Visible |
| Disabled | `False` | Visible | Check then uncheck to enable then disable | `False` | Visible | Press OK | `False` | Visible |
| Temporary | `False` | Obscured | Do nothing | `False` | Obscured | Press Cancel | `False` | Obscured |
| Temporary | `False` | Obscured | Do nothing | `False` | Obscured | Press OK | `False` | Obscured |
| Temporary | `False` | Obscured | Uncheck to disable | `False` | Visible | Press Cancel | `False` | Obscured |
| Temporary | `False` | Obscured | Uncheck to disable | `False` | Visible | Press OK | `False` | Visible |
| Temporary | `False` | Obscured | Uncheck then check to disable then enable | `False` | Obscured | Press Cancel | `False` | Obscured |
| Temporary | `False` | Obscured | Uncheck then check to disable then enable | `False` | Obscured | Press OK | `True` | Obscured |
| Enabled | `True` | Obscured | Do nothing | `True` | Obscured | Press Cancel | `True` | Obscured |
| Enabled | `True` | Obscured | Do nothing | `True` | Obscured | Press OK | `True` | Obscured |
| Enabled | `True` | Obscured | Uncheck to disable | `True` | Visible | Press Cancel | `True` | Obscured |
| Enabled | `True` | Obscured | Uncheck to disable | `True` | Visible | Press OK | `False` | Visible |
| Enabled | `True` | Obscured | Uncheck then check to disable then enable | `True` | Obscured | Press Cancel | `True` | Obscured |
| Enabled | `True` | Obscured | Uncheck then check to disable then enable | `True` | Obscured | Press OK | `True` | Obscured |

### Known issues with pull request:

It's possibly slightly unintuitive that starting from a temporary screen curtain, if one unchecks then checks the screen curtain checkbox and saves settings, the screen curtain will subsequently be enabled, not temporary.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
