### PR TITLE
Fix creating user guide with l10nUtil

### DIFF
--- a/source/setup.py
+++ b/source/setup.py
@@ -26,6 +26,7 @@ from versionInfo import (  # noqa: E402
 )
 from py2exe import freeze  # noqa: E402
 from py2exe.dllfinder import DllFinder  # noqa: E402
+import py2exe  # noqa: E402
 import wx  # noqa: E402
 import importlib.machinery  # noqa: E402
 
@@ -46,6 +47,18 @@ def determine_dll_type(self, imagename):
 
 
 DllFinder.determine_dll_type = determine_dll_type
+
+
+def hook_latex2mathml(finder, module):
+	import latex2mathml
+	import winsound
+
+	dir = os.path.dirname(latex2mathml.__file__)
+	finder.add_datafile_to_zip(r"latex2mathml\unimathsymbols.txt", os.path.join(dir, "unimathsymbols.txt"))
+	winsound.Beep(500, 100)
+
+
+py2exe.hooks.hook_latex2mathml = hook_latex2mathml
 
 
 def _parsePartialArguments() -> argparse.Namespace:
@@ -246,6 +259,7 @@ freeze(
 			"mdx_truly_sane_lists",
 			"mdx_gh_links",
 			"pymdownx",
+			"l2m4m",
 		],
 		"includes": [
 			"nvdaBuiltin",

--- a/source/setup.py
+++ b/source/setup.py
@@ -83,6 +83,10 @@ def hook_latex2mathml_symbols_parser(finder: Scanner, module: Module) -> None:
 	class Transformer(NodeTransformer):
 		"""Rewrite the ``SYMBOLS_FILE`` path to resolve relative to the frozen executable."""
 
+		def __init__(self):
+			super().__init__()
+			self.rewritten: bool = False
+
 		def visit_AnnAssign(self, node: AnnAssign) -> AnnAssign:
 			# 1 indicates a "simple" target.
 			# That is, a target that consists solely of a Name node that does not appear between parentheses.
@@ -94,12 +98,18 @@ def hook_latex2mathml_symbols_parser(finder: Scanner, module: Module) -> None:
 					# We only want the value of that expression.
 					parse(f"os.path.join(os.path.dirname(sys.executable), {RELPATH!r})").body[0].value
 				)
+				self.rewritten = True
 			return node
 
 	tree = parse(module.__source__)
 	# Inject ``import sys`` so the rewritten path expression can reference it.
 	tree.body.insert(0, parse("import sys").body[0])
-	newTree = fix_missing_locations(Transformer().visit(tree))
+	transformer = Transformer()
+	newTree = fix_missing_locations(transformer.visit(tree))
+	if not transformer.rewritten:
+		raise RuntimeError(
+			"py2exe hook failed to rewrite SYMBOLS_FILE in latex2mathml.symbols_parser. The upstream module may have changed its variable declaration.",
+		)
 	module.__code_object__ = compile(newTree, module.__file__, "exec", optimize=module.__optimize__)
 
 
@@ -308,8 +318,6 @@ freeze(
 			"mdx_truly_sane_lists",
 			"mdx_gh_links",
 			"pymdownx",
-			# LaTeX-to-MathML Markdown extension, used by md2html to render math notation.
-			"l2m4m",
 		],
 		"includes": [
 			"nvdaBuiltin",

--- a/source/setup.py
+++ b/source/setup.py
@@ -2,6 +2,7 @@
 # Copyright (C) 2006-2026 NV Access Limited, Peter Vágner, Joseph Lee
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
+
 from __future__ import annotations
 
 import argparse

--- a/source/setup.py
+++ b/source/setup.py
@@ -2,11 +2,14 @@
 # Copyright (C) 2006-2025 NV Access Limited, Peter Vágner, Joseph Lee
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
+from __future__ import annotations
 
 import argparse
+from ast import NodeTransformer, fix_missing_locations, parse
 import os
 import sys
 import gettext
+from typing import TYPE_CHECKING, Final
 from buildVersion import (
 	formatBuildVersionString,
 	name,
@@ -26,9 +29,14 @@ from versionInfo import (  # noqa: E402
 )
 from py2exe import freeze  # noqa: E402
 from py2exe.dllfinder import DllFinder  # noqa: E402
-import py2exe  # noqa: E402
+import py2exe.hooks  # noqa: E402
 import wx  # noqa: E402
 import importlib.machinery  # noqa: E402
+
+if TYPE_CHECKING:
+	from ast import AnnAssign
+	from py2exe.dllfinder import Scanner
+	from py2exe.mf310 import Module
 
 RT_MANIFEST = 24
 manifestTemplateFilePath = "manifest.template.xml"
@@ -49,54 +57,32 @@ def determine_dll_type(self, imagename):
 DllFinder.determine_dll_type = determine_dll_type
 
 
-def hook_latex2mathml_symbols_parser(finder, module):
+def hook_latex2mathml_symbols_parser(finder: Scanner, module: Module) -> None:
 	import latex2mathml.symbols_parser
-	import winsound
-	import ast
 
-	winsound.Beep(500, 100)
-	print("finder=", finder)
-	print("module=", module)
+	FILENAME: Final[str] = "unimathsymbols.txt"
+	RELPATH: Final[str] = os.path.join("latex2mathml", FILENAME)
+	finder.add_datafile(
+		RELPATH,
+		os.path.join(os.path.dirname(latex2mathml.symbols_parser.__file__), FILENAME),
+	)
 
-	dir = os.path.dirname(latex2mathml.symbols_parser.__file__)
-	finder.add_datafile(r"latex2mathml\unimathsymbols.txt", os.path.join(dir, "unimathsymbols.txt"))
-
-	class NT(ast.NodeTransformer):
-		def visit_AnnAssign(self, node: ast.AnnAssign) -> ast.AnnAssign:
-			print(ast.dump(node))
+	class Transformer(NodeTransformer):
+		def visit_AnnAssign(self, node: AnnAssign) -> AnnAssign:
 			if node.simple == 1 and node.target.id == "SYMBOLS_FILE":
-				print("Found target: ", node)
 				node.value = (
-					ast.parse(
-						"os.path.join(os.path.dirname(sys.executable), 'latex2mathml', 'unimathsymbols.txt')",
-					)
-					.body[0]
-					.value
+					parse(f"os.path.join(os.path.dirname(sys.executable), {RELPATH!r})").body[0].value
 				)
 			return node
 
-	transformer = NT()
-	with open("1-module.__source__.txt", "wt") as file:
-		file.write(module.__source__)
-	tree = ast.parse(module.__source__)
-	with open("2-dump.txt", "wt") as file:
-		file.write(ast.dump(tree, indent="\t"))
-	print("tree=", tree)
-	tree.body.insert(0, ast.parse("import sys").body[0])
-	fixed = transformer.visit(tree)
-	print("fixed=", fixed)
-	ast.fix_missing_locations(fixed)
-	# print("res=",res)
-	print("fixed=", fixed)
-	with open("3-dump.txt", "wt") as file:
-		file.write(ast.dump(fixed, indent="\t"))
+	tree = parse(module.__source__)
+	tree.body.insert(0, parse("import sys").body[0])
+	fixed = fix_missing_locations(Transformer().visit(tree))
 	module.__code_object__ = compile(fixed, module.__file__, "exec", optimize=module.__optimize__)
-	print("Replaced code")
-	winsound.Beep(1000, 100)
-	# raise RuntimeError
 
 
 py2exe.hooks.hook_latex2mathml_symbols_parser = hook_latex2mathml_symbols_parser
+del hook_latex2mathml_symbols_parser
 
 
 def _parsePartialArguments() -> argparse.Namespace:

--- a/source/setup.py
+++ b/source/setup.py
@@ -57,7 +57,30 @@ def determine_dll_type(self, imagename):
 DllFinder.determine_dll_type = determine_dll_type
 
 
-def hook_latex2mathml_symbols_parser(finder: Scanner, module: Module) -> None:
+class _Latex2mathmlSymbolsParserTransformer(NodeTransformer):
+	"""Rewrite the ``SYMBOLS_FILE`` path to resolve relative to the frozen executable."""
+
+	def __init__(self, relpath: str):
+		super().__init__()
+		self.rewritten: bool = False
+		self.relpath = relpath
+
+	def visit_AnnAssign(self, node: AnnAssign) -> AnnAssign:
+		# 1 indicates a "simple" target.
+		# That is, a target that consists solely of a Name node that does not appear between parentheses.
+		if node.simple == 1 and node.target.id == "SYMBOLS_FILE":
+			# Replace the original path expression with one based on sys.executable,
+			# so the frozen build finds the bundled unimathsymbols.txt.
+			node.value = (
+				# the result of parse is a ``ast.Module`` whose body contains one ``ast.Expr`` node.
+				# We only want the value of that expression.
+				parse(f"os.path.join(os.path.dirname(sys.executable), {self.relpath!r})").body[0].value
+			)
+			self.rewritten = True
+		return node
+
+
+def _hook_latex2mathml_symbols_parser(finder: Scanner, module: Module) -> None:
 	"""py2exe hook for the latex2mathml.symbols_parser module.
 
 	latex2mathml locates its ``unimathsymbols.txt`` data file at runtime
@@ -79,32 +102,10 @@ def hook_latex2mathml_symbols_parser(finder: Scanner, module: Module) -> None:
 		RELPATH,
 		os.path.join(os.path.dirname(latex2mathml.symbols_parser.__file__), FILENAME),
 	)
-
-	class Transformer(NodeTransformer):
-		"""Rewrite the ``SYMBOLS_FILE`` path to resolve relative to the frozen executable."""
-
-		def __init__(self):
-			super().__init__()
-			self.rewritten: bool = False
-
-		def visit_AnnAssign(self, node: AnnAssign) -> AnnAssign:
-			# 1 indicates a "simple" target.
-			# That is, a target that consists solely of a Name node that does not appear between parentheses.
-			if node.simple == 1 and node.target.id == "SYMBOLS_FILE":
-				# Replace the original path expression with one based on sys.executable,
-				# so the frozen build finds the bundled unimathsymbols.txt.
-				node.value = (
-					# the result of parse is a ``ast.Module`` whose body contains one ``ast.Expr`` node.
-					# We only want the value of that expression.
-					parse(f"os.path.join(os.path.dirname(sys.executable), {RELPATH!r})").body[0].value
-				)
-				self.rewritten = True
-			return node
-
 	tree = parse(module.__source__)
 	# Inject ``import sys`` so the rewritten path expression can reference it.
 	tree.body.insert(0, parse("import sys").body[0])
-	transformer = Transformer()
+	transformer = _Latex2mathmlSymbolsParserTransformer(RELPATH)
 	newTree = fix_missing_locations(transformer.visit(tree))
 	if not transformer.rewritten:
 		raise RuntimeError(
@@ -116,8 +117,7 @@ def hook_latex2mathml_symbols_parser(finder: Scanner, module: Module) -> None:
 # Register the hook with py2exe.
 # py2exe discovers hooks by name:
 # ``hook_<dotted_module_name_with_underscores>`` on the ``py2exe.hooks`` module.
-py2exe.hooks.hook_latex2mathml_symbols_parser = hook_latex2mathml_symbols_parser
-del hook_latex2mathml_symbols_parser
+py2exe.hooks.hook_latex2mathml_symbols_parser = _hook_latex2mathml_symbols_parser
 
 
 def _parsePartialArguments() -> argparse.Namespace:

--- a/source/setup.py
+++ b/source/setup.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2006-2025 NV Access Limited, Peter Vágner, Joseph Lee
+# Copyright (C) 2006-2026 NV Access Limited, Peter Vágner, Joseph Lee
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 from __future__ import annotations
@@ -58,29 +58,54 @@ DllFinder.determine_dll_type = determine_dll_type
 
 
 def hook_latex2mathml_symbols_parser(finder: Scanner, module: Module) -> None:
+	"""py2exe hook for the latex2mathml.symbols_parser module.
+
+	latex2mathml locates its ``unimathsymbols.txt`` data file at runtime
+	relative to its own package directory (via ``__file__``).
+	After the application is frozen, that path no longer exists, so this hook:
+
+	1. Copies the data file into the frozen distribution
+		so it ships alongside the executable.
+	2. Rewrites the module's ``SYMBOLS_FILE`` assignment via an AST transformation
+		so it resolves relative to ``sys.executable`` (the frozen exe)
+		instead of the original package location.
+	"""
 	import latex2mathml.symbols_parser
 
 	FILENAME: Final[str] = "unimathsymbols.txt"
 	RELPATH: Final[str] = os.path.join("latex2mathml", FILENAME)
+	# Include the data file in the frozen build output.
 	finder.add_datafile(
 		RELPATH,
 		os.path.join(os.path.dirname(latex2mathml.symbols_parser.__file__), FILENAME),
 	)
 
 	class Transformer(NodeTransformer):
+		"""Rewrite the ``SYMBOLS_FILE`` path to resolve relative to the frozen executable."""
+
 		def visit_AnnAssign(self, node: AnnAssign) -> AnnAssign:
+			# 1 indicates a "simple" target.
+			# That is, a target that consists solely of a Name node that does not appear between parentheses.
 			if node.simple == 1 and node.target.id == "SYMBOLS_FILE":
+				# Replace the original path expression with one based on sys.executable,
+				# so the frozen build finds the bundled unimathsymbols.txt.
 				node.value = (
+					# the result of parse is a ``ast.Module`` whose body contains one ``ast.Expr`` node.
+					# We only want the value of that expression.
 					parse(f"os.path.join(os.path.dirname(sys.executable), {RELPATH!r})").body[0].value
 				)
 			return node
 
 	tree = parse(module.__source__)
+	# Inject ``import sys`` so the rewritten path expression can reference it.
 	tree.body.insert(0, parse("import sys").body[0])
-	fixed = fix_missing_locations(Transformer().visit(tree))
-	module.__code_object__ = compile(fixed, module.__file__, "exec", optimize=module.__optimize__)
+	newTree = fix_missing_locations(Transformer().visit(tree))
+	module.__code_object__ = compile(newTree, module.__file__, "exec", optimize=module.__optimize__)
 
 
+# Register the hook with py2exe.
+# py2exe discovers hooks by name:
+# ``hook_<dotted_module_name_with_underscores>`` on the ``py2exe.hooks`` module.
 py2exe.hooks.hook_latex2mathml_symbols_parser = hook_latex2mathml_symbols_parser
 del hook_latex2mathml_symbols_parser
 
@@ -283,6 +308,7 @@ freeze(
 			"mdx_truly_sane_lists",
 			"mdx_gh_links",
 			"pymdownx",
+			# LaTeX-to-MathML Markdown extension, used by md2html to render math notation.
 			"l2m4m",
 		],
 		"includes": [

--- a/source/setup.py
+++ b/source/setup.py
@@ -49,16 +49,54 @@ def determine_dll_type(self, imagename):
 DllFinder.determine_dll_type = determine_dll_type
 
 
-def hook_latex2mathml(finder, module):
-	import latex2mathml
+def hook_latex2mathml_symbols_parser(finder, module):
+	import latex2mathml.symbols_parser
 	import winsound
+	import ast
 
-	dir = os.path.dirname(latex2mathml.__file__)
-	finder.add_datafile_to_zip(r"latex2mathml\unimathsymbols.txt", os.path.join(dir, "unimathsymbols.txt"))
 	winsound.Beep(500, 100)
+	print("finder=", finder)
+	print("module=", module)
+
+	dir = os.path.dirname(latex2mathml.symbols_parser.__file__)
+	finder.add_datafile(r"latex2mathml\unimathsymbols.txt", os.path.join(dir, "unimathsymbols.txt"))
+
+	class NT(ast.NodeTransformer):
+		def visit_AnnAssign(self, node: ast.AnnAssign) -> ast.AnnAssign:
+			print(ast.dump(node))
+			if node.simple == 1 and node.target.id == "SYMBOLS_FILE":
+				print("Found target: ", node)
+				node.value = (
+					ast.parse(
+						"os.path.join(os.path.dirname(sys.executable), 'latex2mathml', 'unimathsymbols.txt')",
+					)
+					.body[0]
+					.value
+				)
+			return node
+
+	transformer = NT()
+	with open("1-module.__source__.txt", "wt") as file:
+		file.write(module.__source__)
+	tree = ast.parse(module.__source__)
+	with open("2-dump.txt", "wt") as file:
+		file.write(ast.dump(tree, indent="\t"))
+	print("tree=", tree)
+	tree.body.insert(0, ast.parse("import sys").body[0])
+	fixed = transformer.visit(tree)
+	print("fixed=", fixed)
+	ast.fix_missing_locations(fixed)
+	# print("res=",res)
+	print("fixed=", fixed)
+	with open("3-dump.txt", "wt") as file:
+		file.write(ast.dump(fixed, indent="\t"))
+	module.__code_object__ = compile(fixed, module.__file__, "exec", optimize=module.__optimize__)
+	print("Replaced code")
+	winsound.Beep(1000, 100)
+	# raise RuntimeError
 
 
-py2exe.hooks.hook_latex2mathml = hook_latex2mathml
+py2exe.hooks.hook_latex2mathml_symbols_parser = hook_latex2mathml_symbols_parser
 
 
 def _parsePartialArguments() -> argparse.Namespace:


### PR DESCRIPTION
### Link to issue number:

Fixes #19814

### Summary of the issue:

Using `l10nUtil` to build the user guide does not work from frozen copies of NVDA.

### Description of user facing changes:

Translators can once again use l10nUtil to build the user guide with installed or portable copies of NVDA.

### Description of developer facing changes:

None

### Description of development approach:

Added a py2exe hook for latex2mathml.

latex2mathml relies on a data file, `unimathsymbols.txt`, which is located along side its source files. There are two problems with this:

1. py2exe doesn't include this file, as it is not a python file.
2. latex2mathml is not aware it is being run from a zip file, so attempts to load this file from a nonexistant location (treating `library.zip` as a directory).

To work around this, explicitly include `unimathsymbols.txt` in frozen distributions, in a `latex2mathml` directory alongside `library.zip`, and rewrite `latex2mathml.symbols_parser` to set `SYMBOLS_FILE` to this new path. The approach here is based on the [hooks that ship with py2exe](https://github.com/py2exe/py2exe/blob/v0.14.0.0/py2exe/hooks.py).

### Testing strategy:

From a clean checkout, built a portable copy of NVDA (1), cleaned the French user guide directory (2), then built the user guide using the binary l10nUtil (3). Checked that math was present in this `user_docs/fr/userGuide.html`.

```ps1
PS D:\projects\nvda-beta> uv sync
Using CPython 3.13.12 interpreter at: C:\Users\SaschaCowley\AppData\Local\Python\pythoncore-3.13-64\python.exe
Creating virtual environment at: .venv
Resolved 106 packages in 15ms
...
 + win32-setctime==1.2.0
 + wrapt==2.0.1
 + wxpython==4.2.4
PS D:\projects\nvda-beta> ./scons dist -j1  # (1)
scons: Reading SConscript files ...
Warning: Building with 1 concurrent job while 16 CPU threads are available. Running SCONS with the parameter '-j16' may lead to a faster build. Running SCONS with parameter '--all-cores' will automatically pick all available cores.
scons: done reading SConscript files.
...
Delete("source\__pycache__\_buildVersion.cpython-313.pyc")
uninstaller\uninstGen.exe
scons: done building targets.
PS D:\projects\nvda-beta> git clean -xf user_docs/fr/  # (2)
Removing user_docs/fr/changes.html
Removing user_docs/fr/changes.md
Removing user_docs/fr/changes.md.sub
...
Removing user_docs/fr/userGuide.html
Removing user_docs/fr/userGuide.md
Removing user_docs/fr/userGuide.md.sub
PS D:\projects\nvda-beta> ./dist/l10nUtil.exe xliff2html -t userGuide user_docs\fr\userGuide.xliff user_docs\fr\userGuide.html  # (3)
Detected language fr for xliff file user_docs\fr\userGuide.xliff, source=False
Generating markdown file C:\Users\SASCHA~1\AppData\Local\Temp\tmpoc3xc5nr.md from user_docs\fr\userGuide.xliff...
Generated markdown file with 6042 total lines, 4068 translatable strings, and 3756 translated strings. Ignoring 312 bad translated strings
Converting userGuide (lang='fr') at C:\Users\SASCHA~1\AppData\Local\Temp\tmpoc3xc5nr.md to user_docs\fr\userGuide.html
PS D:\projects\nvda-beta>
```

### Known issues with pull request:

This approach is reliant on the structure of latex2mathml. An update to this dependency may break it. However, this shouldn't have a production impact, as the py2exe hook will cause the build to fail if it is unable to patch latex2mathml, meaning we should know about the breakage before it becomes a runtime failure.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
