### PR TITLE
Revert "Rate limiting against gui crash"

### DIFF
--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -52,8 +52,6 @@ from wx.lib import scrolledpanel
 
 import screenCurtain._screenCurtain
 from utils import mmdevice
-from utils.debounce import debounceLimiter
-from utils.security import isRunningOnSecureDesktop
 from vision.providerBase import VisionEnhancementProviderSettings
 from wx.lib.expando import ExpandoTextCtrl
 import wx.lib.newevent
@@ -744,16 +742,13 @@ class MultiCategorySettingsDialog(SettingsDialog):
 		self.container.SetupScrolling()
 		self.container.Thaw()
 
-	def onCategoryChange(self, evt: wx.ListEvent):
+	def onCategoryChange(self, evt):
+		currentCat = self.currentCategory
 		newIndex = evt.GetIndex()
-		if self._shouldDoCategoryChange(newIndex):
+		if not currentCat or newIndex != self.categoryClasses.index(currentCat.__class__):
 			self._doCategoryChange(newIndex)
 		else:
 			evt.Skip()
-
-	def _shouldDoCategoryChange(self, index: int) -> bool:
-		currentCat = self.currentCategory
-		return not currentCat or index != self.categoryClasses.index(currentCat.__class__)
 
 	def _validateAllPanels(self):
 		"""Check if all panels are valid, and can be saved
@@ -6143,7 +6138,6 @@ NvdaSettingsDialogWindowHandle = None
 class NVDASettingsDialog(MultiCategorySettingsDialog):
 	# Translators: This is the label for the NVDA settings dialog.
 	title = _("NVDA Settings")
-	_pendingCategoryIndex: int | None = None
 	categoryClasses = [
 		GeneralSettingsPanel,
 		SpeechSettingsPanel,
@@ -6207,40 +6201,17 @@ class NVDASettingsDialog(MultiCategorySettingsDialog):
 			configProfile=NvdaSettingsDialogActiveConfigProfile,
 		)
 
-	def _doCategoryChangeForIndex(self, newIndex: int) -> bool:
-		if self._shouldDoCategoryChange(newIndex):
-			self._doCategoryChange(newIndex)
-			return True
-		return False
-
-	@debounceLimiter(
-		cooldownTimeMs=500,
-		delayTimeMs=500,
-	)
-	def _onCategoryChangeDebounced(self) -> None:
-		if self._pendingCategoryIndex is not None:
-			if self._doCategoryChangeForIndex(self._pendingCategoryIndex):
-				self._doOnCategoryChange()
-			self._pendingCategoryIndex = None
-
-	def onCategoryChange(self, evt: wx.ListEvent):
-		if isRunningOnSecureDesktop():
-			# Secure desktop can cause issues with rapidly changing categories,
-			# so we debounce category changes to avoid this. (#19634)
-			self._pendingCategoryIndex = evt.GetIndex()
-			self._onCategoryChangeDebounced()
-			return
-		super().onCategoryChange(evt)
+	def onCategoryChange(self, evt):
+		super(NVDASettingsDialog, self).onCategoryChange(evt)
 		if evt.Skipped:
 			return
 		self._doOnCategoryChange()
 
 	def Destroy(self):
-		self._pendingCategoryIndex = None
 		global NvdaSettingsDialogActiveConfigProfile, NvdaSettingsDialogWindowHandle
 		NvdaSettingsDialogActiveConfigProfile = None
 		NvdaSettingsDialogWindowHandle = None
-		super().Destroy()
+		super(NVDASettingsDialog, self).Destroy()
 
 
 class AddSymbolDialog(

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -742,7 +742,7 @@ class MultiCategorySettingsDialog(SettingsDialog):
 		self.container.SetupScrolling()
 		self.container.Thaw()
 
-	def onCategoryChange(self, evt):
+	def onCategoryChange(self, evt: wx.ListEvent):
 		currentCat = self.currentCategory
 		newIndex = evt.GetIndex()
 		if not currentCat or newIndex != self.categoryClasses.index(currentCat.__class__):
@@ -6201,8 +6201,8 @@ class NVDASettingsDialog(MultiCategorySettingsDialog):
 			configProfile=NvdaSettingsDialogActiveConfigProfile,
 		)
 
-	def onCategoryChange(self, evt):
-		super(NVDASettingsDialog, self).onCategoryChange(evt)
+	def onCategoryChange(self, evt: wx.ListEvent):
+		super().onCategoryChange(evt)
 		if evt.Skipped:
 			return
 		self._doOnCategoryChange()
@@ -6211,7 +6211,7 @@ class NVDASettingsDialog(MultiCategorySettingsDialog):
 		global NvdaSettingsDialogActiveConfigProfile, NvdaSettingsDialogWindowHandle
 		NvdaSettingsDialogActiveConfigProfile = None
 		NvdaSettingsDialogWindowHandle = None
-		super(NVDASettingsDialog, self).Destroy()
+		super().Destroy()
 
 
 class AddSymbolDialog(


### PR DESCRIPTION
### Reverts PR
Reverts #19686

### Issues fixed
None

### Issues reopened
#19634

### Reason for revert
Flawed approach

### Can this PR be reimplemented? If so, what is required for the next attempt
We are going to limit which panels are available on secure desktops as a temporary mitigation attempt.
