### PR TITLE
Exclude math panel when running on secure desktop

### DIFF
--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -52,8 +52,6 @@ from wx.lib import scrolledpanel
 
 import screenCurtain._screenCurtain
 from utils import mmdevice
-from utils.debounce import debounceLimiter
-from utils.security import isRunningOnSecureDesktop
 from vision.providerBase import VisionEnhancementProviderSettings
 from wx.lib.expando import ExpandoTextCtrl
 import wx.lib.newevent
@@ -744,16 +742,13 @@ class MultiCategorySettingsDialog(SettingsDialog):
 		self.container.SetupScrolling()
 		self.container.Thaw()
 
-	def onCategoryChange(self, evt: wx.ListEvent):
+	def onCategoryChange(self, evt):
+		currentCat = self.currentCategory
 		newIndex = evt.GetIndex()
-		if self._shouldDoCategoryChange(newIndex):
+		if not currentCat or newIndex != self.categoryClasses.index(currentCat.__class__):
 			self._doCategoryChange(newIndex)
 		else:
 			evt.Skip()
-
-	def _shouldDoCategoryChange(self, index: int) -> bool:
-		currentCat = self.currentCategory
-		return not currentCat or index != self.categoryClasses.index(currentCat.__class__)
 
 	def _validateAllPanels(self):
 		"""Check if all panels are valid, and can be saved
@@ -6143,7 +6138,6 @@ NvdaSettingsDialogWindowHandle = None
 class NVDASettingsDialog(MultiCategorySettingsDialog):
 	# Translators: This is the label for the NVDA settings dialog.
 	title = _("NVDA Settings")
-	_pendingCategoryIndex: int | None = None
 	categoryClasses = [
 		GeneralSettingsPanel,
 		SpeechSettingsPanel,
@@ -6207,40 +6201,17 @@ class NVDASettingsDialog(MultiCategorySettingsDialog):
 			configProfile=NvdaSettingsDialogActiveConfigProfile,
 		)
 
-	def _doCategoryChangeForIndex(self, newIndex: int) -> bool:
-		if self._shouldDoCategoryChange(newIndex):
-			self._doCategoryChange(newIndex)
-			return True
-		return False
-
-	@debounceLimiter(
-		cooldownTimeMs=500,
-		delayTimeMs=500,
-	)
-	def _onCategoryChangeDebounced(self) -> None:
-		if self._pendingCategoryIndex is not None:
-			if self._doCategoryChangeForIndex(self._pendingCategoryIndex):
-				self._doOnCategoryChange()
-			self._pendingCategoryIndex = None
-
-	def onCategoryChange(self, evt: wx.ListEvent):
-		if isRunningOnSecureDesktop():
-			# Secure desktop can cause issues with rapidly changing categories,
-			# so we debounce category changes to avoid this. (#19634)
-			self._pendingCategoryIndex = evt.GetIndex()
-			self._onCategoryChangeDebounced()
-			return
-		super().onCategoryChange(evt)
+	def onCategoryChange(self, evt):
+		super(NVDASettingsDialog, self).onCategoryChange(evt)
 		if evt.Skipped:
 			return
 		self._doOnCategoryChange()
 
 	def Destroy(self):
-		self._pendingCategoryIndex = None
 		global NvdaSettingsDialogActiveConfigProfile, NvdaSettingsDialogWindowHandle
 		NvdaSettingsDialogActiveConfigProfile = None
 		NvdaSettingsDialogWindowHandle = None
-		super().Destroy()
+		super(NVDASettingsDialog, self).Destroy()
 
 
 class AddSymbolDialog(

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -742,7 +742,7 @@ class MultiCategorySettingsDialog(SettingsDialog):
 		self.container.SetupScrolling()
 		self.container.Thaw()
 
-	def onCategoryChange(self, evt):
+	def onCategoryChange(self, evt: wx.ListEvent):
 		currentCat = self.currentCategory
 		newIndex = evt.GetIndex()
 		if not currentCat or newIndex != self.categoryClasses.index(currentCat.__class__):
@@ -6201,8 +6201,8 @@ class NVDASettingsDialog(MultiCategorySettingsDialog):
 			configProfile=NvdaSettingsDialogActiveConfigProfile,
 		)
 
-	def onCategoryChange(self, evt):
-		super(NVDASettingsDialog, self).onCategoryChange(evt)
+	def onCategoryChange(self, evt: wx.ListEvent):
+		super().onCategoryChange(evt)
 		if evt.Skipped:
 			return
 		self._doOnCategoryChange()
@@ -6211,7 +6211,7 @@ class NVDASettingsDialog(MultiCategorySettingsDialog):
 		global NvdaSettingsDialogActiveConfigProfile, NvdaSettingsDialogWindowHandle
 		NvdaSettingsDialogActiveConfigProfile = None
 		NvdaSettingsDialogWindowHandle = None
-		super(NVDASettingsDialog, self).Destroy()
+		super().Destroy()
 
 
 class AddSymbolDialog(

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -43,6 +43,7 @@ import queueHandler
 import requests
 import speech
 import systemUtils
+from utils.security import isRunningOnSecureDesktop
 import vision
 import vision.providerBase
 import vision.providerInfo
@@ -6153,9 +6154,14 @@ class NVDASettingsDialog(MultiCategorySettingsDialog):
 		BrowseModePanel,
 		DocumentFormattingPanel,
 		DocumentNavigationPanel,
-		MathSettingsPanel,
 		RemoteSettingsPanel,
 	]
+	# #19634: the desktop heap on the secure desktop is quite restrictive.
+	# The math settings panel contains many controls,
+	# none of which are particularly relevant when running on the secure desktop.
+	# Exclude this panel to try and avoid exhausting the desktop heap.
+	if not isRunningOnSecureDesktop():
+		categoryClasses.append(MathSettingsPanel)
 	# In secure mode, add-on update is disabled, so AddonStorePanel should not appear since it only contains
 	# add-on update related controls.
 	if not globalVars.appArgs.secure:


### PR DESCRIPTION
### Link to issue number:
Temporary workaround for #19634

### Summary of the issue:
NVDA exhibits GUI corruption and eventually crashes when successively navigating to each panel in the settings dialog on secure screens.

### Description of user facing changes:
* Math panel is no-longer shown on secure desktops
* The "Math" category now comes after the "Remote Access" category in the categories list of the settings dialog.
* Issue hopefully no-longer occurs

### Description of developer facing changes:
The presence of `MathSettingsPanel` in `NVDASettingsDialog.categoryClasses ` is now dependent on `isRunningOnSecureDesktop()` returning `False`.

### Description of development approach:
Remove `MathSettingsPanel` from the definition of `NVDASettingsDialog.categoryClasses`, and append it thereto in a `if` block.

### Testing strategy:
Created a self-signed dist. Installed from same. Switched to the secure desktop (`alt+ctrl+del`). Opened NVDA settings, and visited each category in turn, tabbing through all controls to ensure that no corruption had occured.
Did this several times, navigating slowly and rapidly, closing and re-opening the settings dialog several times in some cases.

### Known issues with pull request:
This is a temporary workaround and does not address the underlying problem.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
