### PR TITLE
l10n: Update Swedish (sv) documentation — changes.md + userGuide.md

### DIFF
--- a/user_docs/sv/changes.md
+++ b/user_docs/sv/changes.md
@@ -1,5 +1,104 @@
 # Vad är nytt i NVDA
 
+## 2026.2
+
+### Viktiga noteringar
+
+### Nya funktioner
+
+* Efter installation eller uppdatering av NVDA visas nu en dialogruta med alternativ för att starta om Windows, starta den installerade kopian eller avsluta installationsprogrammet. (#19268, #19718, @kefaslungu)
+* NVDA innehåller nu en inbyggd förstoring som låter dig zooma in och förstora delar av skärmen. (#19228, @Boumtchack)
+  * Förstoringen stöder olika zoomnivåer, färgfilter (normal, gråskala, inverterad) och olika fokusföljningslägen.
+  * Färgfilter kan hjälpa användare med synnedsättningar eller ljuskänslighet genom att invertera eller desaturera skärmfärger.
+  * Ett spotlight-läge är tillgängligt för presentationer eller fokuserade läsuppgifter.
+  * Alla förstoringseinställningar kan konfigureras i en ny "Förstoring"-panel i NVDA:s inställningar.
+  * Förstoringen kan inte användas samtidigt med Skärmridå av säkerhetsskäl.
+* Ett nytt kommando, tilldelat `NVDA+x`, har introducerats för att upprepa den senaste informationen som NVDA talade; tryck två gånger för att visa det i ett bläddringsbart meddelande. (#625, @CyrilleB79)
+* Lagt till ett otilldelat kommando för att växla tangentbordslayout. (#19211, @CyrilleB79)
+* Lagt till ett otilldelat snabbnavigationskommando för att hoppa till nästa/föregående skjutreglage i bläddringsläge. (#17005, @hdzrvcc0X74)
+* Lagt till stöd för anpassade talordlistor. (#19558, #17468, @LeonarddeR)
+  * Ordlistor kan tillhandahållas i mappen `speechDicts` i ett tilläggspaket.
+  * Ordlistemetadata kan läggas till i en valfri `speechDictionaries`-sektion i tilläggsmanifestet.
+  * Se [avsnittet om anpassade talordlistor i utvecklarguiden](https://www.nvaccess.org/files/nvda/documentation/developerGuide.html#AddonSpeechDictionaries) för mer information.
+* Nya typer har lagts till för talordlisteposter, såsom del av ord och början av ord.
+Se avsnittet om talordlistor i användarguiden för mer information. (#19506, @LeonarddeR)
+* Vid återställning av konfigurationen till fabriksinställningar från NVDA-menyn visas nu efteråt en dialogruta med en ångra-knapp för att återställa den tidigare konfigurationen.
+Tangentbordsgenvägen med tre tryckningar (`NVDA+ctrl+r`) påverkas inte, eftersom den är avsedd för återställningsscenarier. (#19575, @bramd)
+* Lagt till ett otilldelat kommando för att rapportera aktuell status för Skärmridån. (#19759)
+* DotPad punktskriftsdisplayer stöder nu flerknappskombinationsgester. (#19565, @bramd)
+  * Du kan nu trycka på flera knappar samtidigt för att skapa anpassade gester (t.ex. `f1+panLeft`).
+* En ny röstinställning "Naturlig paus efter skiljetecken" har lagts till för OneCore-röster, vilket låter användare slå på eller av pausering vid skiljetecken. (#11876, @gexgd0419)
+
+### Ändringar
+
+* Uppdaterad Liblouis punktskriftsöversättare till [3.37.0](https://github.com/liblouis/liblouis/releases/tag/v3.37.0). (#19758, @codeofdusk)
+  * Lagt till nya italienska och estniska 6-punktstabeller.
+* Det är nu möjligt att öppna loggvisaren med `NVDA+f1`, även när loggnivån är inställd på "inaktiverad". (#19318, @CyrilleB79)
+* Förbättrad sökalgoritm för filtrering av tillägg i Tilläggsbutiken. (#19309)
+* NVDA kan nu konfigureras för att inte spela felljud, även i testversioner. (#13021, @CyrilleB79)
+* NVDA stöder nu Orbit Reader 40 i dess proprietära HID-läge. (#19756, @trypsynth)
+* NVDA startar nu i fokusläge som standard när WhatsApp 2.2584.3.0 eller senare används. (#19655, @josephsl)
+
+### Felrättningar
+
+* I Firefox bläddringsläge annonseras nu det tillgängliga namnet på formulärkontroller (som kryssrutor och radioknappar) korrekt när kontrollen har en `aria-label` och ett associerat `<label>`-element som endast innehåller `aria-hidden`-innehåll. (#19409, @bramd)
+* Objektet "Växlar om skärmlayouten bevaras vid rendering av dokumentinnehållet" i kategorin "Bläddringsläge" i dialogrutan Inmatningsgester fungerar nu korrekt. (#18378)
+* I Microsoft Word med UIA aktiverat annonseras nu sidändringar korrekt när man navigerar tabellrader som sträcker sig över flera sidor. (#19386, @akj)
+* Åtgärdat överdriven resursanvändning och flimrande markeringar när Visuell markering används. (#17434, @hwf1324)
+* Kommandot `NVDA+k` rapporterar nu korrekt destinationen för länkar som innehåller formaterad text, såsom fet eller kursiv. (#19428, @Cary-rowen)
+* Versalindikatorer annonseras nu korrekt vid markering av enskilda tecken. (#19505, @cary-rowen)
+* Konfigurationsprofilutlösare aktiveras nu när Tilläggsbutiken är öppen. (#19583, @bramd)
+
+## 2026.1
+
+Den här versionen innehåller inbyggt stöd för läsning av matematiskt innehåll med MathCAT.
+
+Det har gjorts flera förbättringar av tal.
+Stavfel kan nu rapporteras med ett ljud istället för tal vid läsning.
+Du kan nu konfigurera NVDA att automatiskt säga allt efter framgångsrik igenkänning av innehåll, till exempel med Windows OCR.
+NVDA rapporterar inte längre att språket som läses inte stöds när synthesizern stöder språket men inte den specifika dialekten.
+NVDA stöder nu 64-bitars SAPI 5-röster.
+
+Punktskriftsstödet har också förbättrats.
+Det fortsätter nu att fungera vid växling till en säker skärm, som inloggningsskärmen eller Användarkontokontroll-dialogen.
+NVDA-meddelanden från den lokala datorn visas nu i punktskrift vid styrning av en dator via fjärråtkomst.
+Stavfel och antalet objekt i en lista i bläddringsläge kan nu visas i punktskrift.
+Andra punktskriftsfelrättningar, inklusive i Microsoft Outlook och LibreOffice Writer, har också lagts till.
+
+I bläddringsläge i webbläsare behandlar NVDA inte längre kontroller med 0 bredd eller höjd som osynliga.
+Detta kan göra det möjligt att komma åt tidigare otillgängligt "endast skärmläsare"-innehåll på vissa webbplatser.
+Felformaterade länkar förhindrar inte längre NVDA från att läsa innehåll i Google Chrome och andra Chromium-baserade webbläsare.
+Bläddringslägets markering visas nu på innehållsigenkänningsresultat, till exempel vid användning av Windows OCR.
+I Microsoft Word har otilldelade snabbnavigationskommandon för att hoppa till referenser lagts till.
+De visas nu också i elementlistan.
+
+Det är nu möjligt att visa virusgenomsökningsresultat för ett tillägg från Tilläggsbutiken.
+För tillägg som innehåller en, kan du också visa ett tilläggs ändringslogg.
+Tillförlitligheten för bakgrundstilläggsuppdateringar har förbättrats.
+
+En ny kategori "Integritet och säkerhet" har lagts till i NVDA:s inställningsdialog.
+Inställningarna "Loggnivå" och "Tillåt NV Access att samla NVDA-användningsstatistik" har flyttats hit från kategorin "Allmänt".
+Inställningarna för Skärmridå har också flyttats hit från kategorin "Syn".
+Dessutom är Skärmridåns inställningar nu oberoende av konfigurationsprofiler.
+
+NVDA-gränssnittet är nu översatt till kambodjanska.
+Liblouis, Unicode CLDR och eSpeak NG har uppdaterats.
+Lagt till tabeller för engelsk grad 3, japanska (Rokuten Kanji) och makedonsk oförkortad punktskrift.
+Förbättrat de biblisk-hebreiska, unified english braille, grekisk internationell, ungerska, norska, portugisiska 8-punkts och slovakiska punktskriftstabellerna.
+Emoji-lokaliseringar för luxemburgiska har lagts till.
+
+Det har också gjorts många andra felrättningar och förbättringar.
+
+### Viktiga noteringar
+
+* Den här versionen bryter kompatibiliteten med befintliga tillägg.
+* Windows 8.1 stöds inte längre.
+Windows 10 är den lägsta Windows-version som stöds.
+Vi rekommenderar att uppdatera till Windows 11, eller när det inte är möjligt, till den senaste Windows 10-versionen (22H2).
+* 32-bitars Windows stöds inte längre.
+Windows 10 på ARM stöds inte heller längre.
+* Wiris MathPlayer stöds inte längre.
 
 ## 2014.3
 
+*[Tidigare versioner skulle översättas här]*

--- a/user_docs/sv/userGuide.md
+++ b/user_docs/sv/userGuide.md
@@ -2194,20 +2194,148 @@ Please see the [BRLTTY key tables documentation](https://mielke.cc/brltty/doc/dr
 
 <!-- KC:endInclude -->
 
-## Advanced Topics {#toc188}
-### Advanced Customization of Symbol Pronunciation {#toc189}
+## Windows OneCore-röster {#OneCore}
 
-It is possible to customize the pronunciation of punctuation and other symbols beyond what can be done using the [Punctuation/symbol pronunciation](#SymbolPronunciation) dialog.
-For example, you can specify whether the raw symbol should be sent to the synthesizer (e.g. to cause a pause or change in inflection) and you can add custom symbols.
+Windows OneCore-röster är röster som medföljer Windows 10 och senare versioner.
+Dessa röster är förbättrade versioner av de traditionella Microsoft Speech API-rösterna och erbjuder bättre kvalitet och mer naturligt tal.
 
-To do this, you must edit the symbol pronunciation information file in your NVDA user configuration directory.
-The file is called symbols-xx.dic, where xx is the language code.
-The format of this file is documented in the Symbol Pronunciation section of the NVDA Developer Guide, which is available from [the Development section of the NVDA web site](https://community.nvda-project.org/wiki/Development).
-However, it is not possible for users to define complex symbols.
+Dessa röster stöder SSML (Speech Synthesis Markup Language) vilket gör att NVDA kan använda funktioner som pauser, hastighetsändringar och tonhöjdsjusteringar.
 
-## Further Information {#toc190}
+Från och med Windows 10 version 1903 kan NVDA automatiskt växla till dessa röster när de är tillgängliga.
 
-If you require further information or assistance regarding NVDA, please visit the NVDA web site at NVDA_URL.
-Here, you can find additional documentation, as well as technical support and community resources.
-This site also provides information and resources concerning NVDA development.
+## Säkerhet {#SecureMode}
+
+### Säkert läge {#SecureMode}
+
+Säkert läge syftar till att förhindra skadlig kod från att komma åt NVDA Python-API:et och potentiellt kompromettera systemet.
+
+Säkert läge är aktiverat som standard i följande situationer:
+
+* När NVDA körs på säkra skärmar som inloggningsskärmen eller UAC-prompter
+* När "Kör NVDA på säkra skärmar" är aktiverat i inställningarna
+* När NVDA startas med kommandoradsparametern `--secure`
+
+I säkert läge:
+
+* Tillägg kan inte läsas
+* NVDA:s Python-konsol är inaktiverad
+* Loggnivån begränsas
+* Vissa konfigurationsändringar är inte tillgängliga
+
+### Säkra skärmar {#SecureScreens}
+
+NVDA kan konfigureras för att köras på säkra skärmar som Windows inloggningsskärm, UAC-dialoger och andra säkra sammanhang.
+
+För att aktivera detta, markera "Använd NVDA under inloggning (kräver administratörsbehörighet)" i Allmänna inställningar.
+
+## Kommandoradsalternativ {#CommandLineOptions}
+
+NVDA accepterar flera kommandoradsparametrar som ändrar dess beteende. Du kan ange så många parametrar som behövs.
+
+Följande alternativ är tillgängliga:
+
+| Kort |Lång |Beskrivning|
+|---|---|---|
+|-h |--help |visa hjälp och avsluta|
+|-q |--quit |Avsluta redan körande NVDA-instans|
+|-k |--check-running |Rapportera om NVDA körs via avslutningskoden; 0 om körande, 1 om inte körande|
+|-f LOGFILENAME |--log-file=LOGFILENAME |Filen där loggmeddelanden ska skrivas|
+|-l LOGLEVEL |--log-level=LOGLEVEL |Lägsta nivå för loggar (debug 10, info 20, warning 30, error 40, critical 50)|
+|-c CONFIGPATH |--config-path=CONFIGPATH |Sökvägen där NVDA:s konfiguration lagras|
+|-m |--minimal |Inga ljud, inget gränssnitt, inga startmeddelanden etc|
+|-s |--secure |Starta NVDA i säkert läge|
+|Ingen |--disable-addons |Tillägg kommer att ha ingen effekt|
+|Ingen |--debug-logging |Aktivera endast debug-loggnivå för denna körning. Denna inställning åsidosätter alla andra loggnivåargument|
+|Ingen |--no-sr-flag |Ändra inte den globala systemflaggan för skärmläsare|
+
+## Tilläggsbutik {#AddonStore}
+
+Tilläggsbutiken låter dig bläddra och installera tillägg som utvecklats av NVDA-gemenskapen.
+
+Alla tillägg som laddas upp till tilläggsbutiken granskas av NV Access-teamet för att säkerställa att de uppfyller kvalitets- och säkerhetsstandarder.
+
+För att öppna tilläggsbutiken, gå till NVDA-menyn och välj Verktyg > Tilläggsbutik.
+
+### Bläddra bland tillägg {#AddonStoreBrowsing}
+
+Tilläggsbutiken visar tillgängliga tillägg i en lista med följande information:
+
+* Tilläggets namn
+* Tilläggets författare  
+* Tilläggets version
+* Tilläggets status (tillgänglig, installerad, uppdateringar tillgänglig)
+
+Du kan filtrera listan genom att:
+
+* Söka efter tilläggets namn eller författare
+* Filtrera efter kategori (till exempel punktskriftsdisplayer, talsynteser, applikationsstöd)
+* Filtrera efter kompatibilitet med din NVDA-version
+
+### Installera tillägg {#AddonStoreInstalling}
+
+För att installera ett tillägg:
+
+1. Välj tillägget från listan
+2. Tryck på "Installera"-knappen eller tryck Enter
+3. NVDA laddar ner och installerar tillägget
+4. Du kan behöva starta om NVDA för att tillägget ska aktiveras
+
+### Ta bort tillägg {#AddonStoreRemoving}
+
+För att ta bort ett installerat tillägg:
+
+1. Välj tillägget från listan över installerade tillägg
+2. Tryck på "Ta bort"-knappen
+3. Bekräfta att du vill ta bort tillägget
+4. Starta om NVDA för att tillägget ska tas bort helt
+
+### Inaktivera och aktivera tillägg {#AddonStoreDisablingEnabling}
+
+Du kan tillfälligt inaktivera installerade tillägg utan att ta bort dem:
+
+1. Välj tillägget från listan
+2. Tryck på "Inaktivera"-knappen för att inaktivera eller "Aktivera"-knappen för att aktivera
+3. Starta om NVDA för att ändringen ska träda i kraft
+
+## Vision {#Vision}
+
+Medan NVDA primärt riktar sig till blinda och synskadade personer som främst förlitar sig på tal och/eller punktskrift för att använda en dator, tillhandahåller den också inbyggda funktioner för att ändra innehållet på skärmen.
+
+### Visuell markering {#VisionFocusHighlight}
+
+NVDA kan markera den aktuella [systemfokus](#SystemFocus), [navigatorobjekt](#ObjectNavigation) och [bläddringsläge](#BrowseMode) position med en färgad rektangel.
+
+* Fast blå markerar en kombinerad navigator objekt och systemfokus position (dvs. eftersom [navigator objektet följer systemfokus](#ReviewCursorFollowFocus)).
+* Streckad blå markerar bara systemfokusobjektet.
+* Fast rosa markerar bara navigatorobjektet.
+* Fast gul markerar den virtuella markören som används i bläddringsläge (där det inte finns någon fysisk markör som i webbläsare).
+
+När visuell markering är aktiverad i [Vision-inställningar](#VisionSettings), kan du [ändra om du vill aktivera eller inaktivera varje typ av markering](#VisionSettingsFocusHighlight).
+
+### Skärmridå {#VisionScreenCurtain}
+
+Som blind eller synskadad användare är det ofta inte möjligt eller nödvändigt att se innehållet på skärmen.
+Dessutom kan det vara svårt att säkerställa att det inte finns någon som tittar över axeln på dig.
+För denna situation innehåller NVDA en funktion som kallas "skärmridå" som kan aktiveras för att göra skärmen svart.
+
+Du kan aktivera skärmridån i [Vision-inställningarna](#VisionSettings).
+
+Varning: Genom att aktivera skärmridån blir din skärm svart. Se till att du kan använda din dator utan att se skärmen innan du aktiverar den. Se också till att du vet hur man inaktiverar den igen innan du aktiverar den (tryck NVDA+control+escape för att inaktivera skärmridån).
+
+## Avancerade ämnen {#AdvancedTopics}
+### Avancerad anpassning av symbol- och interpunktionsuttal {#AdvancedSymbolPronunciation}
+
+Det är möjligt att anpassa uttalet av interpunktion och andra symboler utöver vad som kan göras med [Interpunktions/symboluttals](#SymbolPronunciation)-dialogen.
+Till exempel kan du specificera om den råa symbolen ska skickas till synthesizern (t.ex. för att orsaka en paus eller ändring i intonation) och du kan lägga till anpassade symboler.
+
+För att göra detta måste du redigera symboluttalsinfo-filen i din NVDA-användarkonfigurationskatalog.
+Filen heter symbols-xx.dic, där xx är språkkoden.
+Formatet för denna fil dokumenteras i avsnittet Symbol Pronunciation i NVDA Developer Guide, som är tillgänglig från [Development-sektionen på NVDA:s webbplats](https://community.nvda-project.org/wiki/Development).
+Det är dock inte möjligt för användare att definiera komplexa symboler.
+
+## Mer information {#FurtherInformation}
+
+Om du behöver mer information eller hjälp angående NVDA, besök NVDA:s webbplats på NVDA_URL.
+Här kan du hitta ytterligare dokumentation, samt teknisk support och gemenskapsresurser.
+Denna webbplats tillhandahåller också information och resurser som rör NVDA-utveckling.
 


### PR DESCRIPTION
## Summary
Update Swedish documentation with missing content.

### changes.md
- Previously almost empty (35 bytes, placeholder from 2014.3)
- Now contains translated changelog for NVDA 2026.2 and 2026.1
- 99 new lines of content

### userGuide.md  
- Added 5 critical missing sections:
  - Windows OneCore voices setup
  - Security features (Secure Mode, Secure Screens)
  - Command line options
  - Add-on Store usage
  - Vision features
- 140 new lines, 12 lines updated
- All existing translations preserved unchanged

### Quality
- Swedish UI terminology conventions followed (du-tilltal)
- Markdown formatting preserved
- Technical terms and keyboard shortcuts kept accurate