### PR TITLE
appModules/explorer: report Windows build.revision as product version

### DIFF
--- a/source/appModules/explorer.py
+++ b/source/appModules/explorer.py
@@ -1,8 +1,7 @@
-# -*- coding: UTF-8 -*-
 # A part of NonVisual Desktop Access (NVDA)
 # Copyright (C) 2006-2026 NV Access Limited, Joseph Lee, Łukasz Golonka, Julien Cochuyt
-# This file is covered by the GNU General Public License.
-# See the file COPYING for more details.
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
 
 """App module for File Explorer (aka Windows shell, formerly Windows Explorer).
 Provides workarounds for controls such as identifying Start button, notification area and others.

--- a/source/appModules/explorer.py
+++ b/source/appModules/explorer.py
@@ -1,10 +1,10 @@
 # -*- coding: UTF-8 -*-
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2006-2025 NV Access Limited, Joseph Lee, Łukasz Golonka, Julien Cochuyt
+# Copyright (C) 2006-2026 NV Access Limited, Joseph Lee, Łukasz Golonka, Julien Cochuyt
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
-"""App module for Windows Explorer (aka Windows shell and renamed to File Explorer in Windows 8).
+"""App module for File Explorer (aka Windows shell, formerly Windows Explorer).
 Provides workarounds for controls such as identifying Start button, notification area and others.
 """
 

--- a/source/appModules/explorer.py
+++ b/source/appModules/explorer.py
@@ -206,6 +206,19 @@ class WorkerW(IAccessible):
 
 
 class AppModule(appModuleHandler.AppModule):
+	def _setProductInfo(self) -> None:
+		# #19802: customized for File Explorer as product version is wrong (looks at explorer.exe.mui).
+		if not self.processHandle:
+			raise RuntimeError("processHandle is 0")
+		# Even though product version is wrong, use product name supplied by File Explorer.
+		productInfo = self._getExecutableFileInfo()
+		self.productName = productInfo[0]
+		# NVDA claims executable name is "explorer.exe" when in fact it is "explorer.exe.mui".
+		# This means file information would not be accurate, returning the base Windows build.revision.
+		# Therefore, set product version to Windows major.minor.build.revision.
+		winVer = winVersion.getWinVer()
+		self.productVersion = f"{winVer.major}.{winVer.minor}.{winVer.build}.{winVer.revision}"
+
 	# C901 'chooseNVDAObjectOverlayClasses' is too complex
 	# Note: when working on chooseNVDAObjectOverlayClasses, look for opportunities to simplify
 	# and move logic out into smaller helper functions.

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -38,7 +38,8 @@ The triple-press keyboard shortcut (`NVDA+ctrl+r`) is not affected, as it is int
 * NVDA can now be configured to not play error sounds, even in test versions. (#13021, @CyrilleB79)
 * NVDA now supports the Orbit Reader 40 in its proprietary HID mode. (#19756, @trypsynth)
 * NVDA will start in focus mode by default when using WhatsApp 2.2584.3.0 or newer. (#19655, @josephsl)
-* Product version for File Explorer will reflect actual Windows version including correct build and revision numbers. This is more noticeable for Windows releases which are enablement packages on top of an earlier release such as Windows 11 2025 Update based on Windows 11 2024 Update. (#19802, @josephsl)
+* Product version for File Explorer will reflect actual Windows version including correct build and revision numbers.
+This is more noticeable for Windows releases which are enablement packages on top of an earlier release such as Windows 11 2025 Update based on Windows 11 2024 Update. (#19802, @josephsl)
 
 ### Bug Fixes
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -38,6 +38,7 @@ The triple-press keyboard shortcut (`NVDA+ctrl+r`) is not affected, as it is int
 * NVDA can now be configured to not play error sounds, even in test versions. (#13021, @CyrilleB79)
 * NVDA now supports the Orbit Reader 40 in its proprietary HID mode. (#19756, @trypsynth)
 * NVDA will start in focus mode by default when using WhatsApp 2.2584.3.0 or newer. (#19655, @josephsl)
+* Product version for File Explorer will reflect actual Windows version including correct build and revision numbers. This is more noticeable for Windows releases which are enablement packages on top of an earlier release such as Windows 11 2025 Update based on Windows 11 2024 Update. (#19802, @josephsl)
 
 ### Bug Fixes
 


### PR DESCRIPTION
### Link to issue number:
Closes #19802 

### Summary of the issue:
File Explorer app module reports wrong product version (specifically, base Windows version).

### Description of user facing changes:
Product version for File Explorer will reflect current Windows build.revision.

### Description of developer facing changes:
Add-ons and parts of NVDA code that queries app version data will see a more "accurate" (see below) product version for File Explorer.

### Description of development approach:
A custom "est product info" method is defined in the File Explorer app module. This is needed because "productVersion" is a descriptor and one must define "_set_productVersion" to override it. Further, even with the custom product version defined, it can be overridden from the base app module every time set product info method is run. Therefore, a custom 'set product info' method is defined to treat Windows build.revision as File Explorer product version.

This change will be most noticeable if running an enablement package release. For example, Windows 11 24H2's build number is 26100 which is also shown for system files after installing 25H2 (build 26200) because 25H2 is an enablement package on top of 24H2. Further, NVDA is actually dealing with "wxplorer.exe.mui" not "explorer.exe" when asking for file information from Windows.

### Testing strategy:
Manual: make sure File Explorer's produt version reports actual Windows build.revision e.g. 10.0.26200.8039 (March 2026 out of band update) as opposed to 10.0.26100.1743.

### Known issues with pull request:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
