### PR TITLE
Make input help message for math navigation translatable, and exclude from input gestures dialog

### DIFF
--- a/source/mathPres/MathCAT/MathCAT.py
+++ b/source/mathPres/MathCAT/MathCAT.py
@@ -139,12 +139,17 @@ class MathCATInteraction(mathPres.MathInteractionNVDAObject):
 				"9",
 			}
 		):
-			return self.script_navigate
+			return self._do_navigate
 		else:
 			return super().getScript(gesture)
 
-	def script_navigate(self, gesture: KeyboardInputGesture) -> None:
+	def _do_navigate(self, gesture: KeyboardInputGesture) -> None:
 		"""Performs the specified navigation command.
+
+		.. note::
+			This is not a ``script_`` method, as there is custom logic for determining whether it should be used.
+			Furthermore, if it were it would appear in the input gestures dialog as it has a docstring,
+			and applying the usual gesture handling logic to this script could lead to unexpected results.
 
 		:param gesture: The keyboard command which specified the navigation command to perform.
 		"""
@@ -183,6 +188,12 @@ class MathCATInteraction(mathPres.MathInteractionNVDAObject):
 			log.exception()
 			# Translators: this message alerts users to an error brailling math.
 			ui.message(pgettext("math", "Error in brailling math"))
+
+	# We do not want to use the developer-facing docstring as the input help description of math navigation commands.
+	# Static analysis tools only consider the string literal immediately following the function header as the docstring,
+	# so we can overwrite it at run-time to use a user-friendly description.
+	# Translators: Description of a MathCAT navigation gesture.
+	_do_navigate.__doc__ = _("Navigates within math")
 
 	_startsWithMath: re.Pattern = re.compile("\\s*?<math")
 
@@ -429,4 +440,4 @@ class MathCAT(mathPres.MathPresentationProvider):
 		"""
 		interaction = MathCATInteraction(provider=self, mathMl=mathml)
 		interaction.setFocus()
-		interaction.script_navigate(None)
+		interaction._do_navigate(None)


### PR DESCRIPTION
### Link to issue number:

Interrim fix for #19815

### Summary of the issue:

Math navigation commands report the developer docstring in input help mode. This is neither translatable nor relevant to end users.
Users can also assign gestures to this script, which could lead to unexpected results.

### Description of user facing changes:

Math navigation gestures now have a translatable input help message.
The single script which dispatches to MathCAT is no-longer available in the input gestures dialog.

### Description of developer facing changes:

`mathPres.MathCAT.MathCAT.MathCATInteraction.script_navigate` has been removed from the public API.

### Description of development approach:

Renamed `mathPres.MathCAT.MathCAT.MathCATInteraction.script_navigate` to `_do_navigate`. Since `mathPres.MathCAT.MathCAT.MathCATInteraction.getScript` has custom logic for returning this method, it does not need the `script_` prefix. Since we want it to have a docstring (so something is reported in input help mode), this is also the only way of removing it from the input gestures dialog.

After the definition of `mathPres.MathCAT.MathCAT.MathCATInteraction._do_navigate`, set its docstring to a translatable, user-friendly string. Since static analysis tools only consider string literals immediately following function headers as docstrings, this should preserve the developer docstring while providing a more appropriate value for input help.

### Testing strategy:

Ran from source. Interracted with math. Activated input help. Ensured that pressing arrows, space, enter, and numrow keys reported the expected message. Opened the input gestures dialog while interacting with math and checked that the navigation command was not present.

### Known issues with pull request:

This is a temporary fix. Longer term we want to move to discrete gestures per MathCAT navigation command.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
