### PR TITLE
fix: initialize WavePlayer attributes before registering in _instances

### DIFF
--- a/source/nvwave.py
+++ b/source/nvwave.py
@@ -247,10 +247,10 @@ class WavePlayer(garbageHandler.TrackedObject):
 			WavePlayer._callback,
 		)
 		self._doneCallbacks = {}
-		self._instances[self._player] = self
-		self.open()
 		self._lastActiveTime: typing.Optional[float] = None
 		self._isPaused: bool = False
+		self._instances[self._player] = self
+		self.open()
 		if config.conf["audio"]["audioAwakeTime"] > 0 and WavePlayer._silenceDevice != outputDevice:
 			# The output device has changed. (Re)initialize silence.
 			if self._silenceDevice is not None:


### PR DESCRIPTION
### Link to issue number:

Fixes #19005

### Summary of the issue:

Race condition in `WavePlayer.__init__`: the instance is added to `cls._instances` (line 250) before `_lastActiveTime` and `_isPaused` are initialized (lines 252-253). The `_idleCheck` class method iterates `_instances` from a timer callback and can access a player before these attributes exist, causing `AttributeError: 'WavePlayer' object has no attribute '_lastActiveTime'`.

### Description of user facing changes:

Eliminates a rare crash that occurred when short sounds were played from background threads.

### Description of developer facing changes:

Moved `_lastActiveTime` and `_isPaused` initialization before the `_instances[self._player] = self` registration in `WavePlayer.__init__`. This ensures the idle check can never see a player without these attributes.

### Description of development approach:

The fix reorders two lines in `__init__` so that all attributes accessed by `_idleCheck` are initialized before the instance becomes visible to other threads via `_instances`. The `open()` call was also moved after registration since it may trigger callbacks that expect the player to be in `_instances`.

This contribution was developed with AI assistance (Claude Code).

### Testing strategy:

Manual code review confirmed the fix: `_lastActiveTime` and `_isPaused` are now initialized before `_instances[self._player] = self`, so `_idleCheck` can never encounter a partially-initialized player. The `open()` call remains after registration since its callbacks reference `_instances`. No new behavior is introduced; this is strictly a reorder of existing initialization.

### Known issues with pull request:

None. The change is a two-line reorder with no functional side effects.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry: Not applicable (internal fix, no user-visible behavior change beyond crash prevention)
  - User Documentation: Not applicable
  - Developer / Technical Documentation: Not applicable
  - Context sensitive help for GUI changes: Not applicable
- [x] Testing:
  - Unit tests: Existing tests cover WavePlayer; this reorder does not change observable behavior
  - System (end to end) tests: Not applicable (race condition is timing-dependent, not reproducible on demand)
  - Manual testing: Verified by code review that attribute access order is correct
- [x] UX of all users considered:
  - Speech: No change
  - Braille: No change
  - Low Vision: No change
  - Different web browsers: Not applicable
  - Localization in other languages / culture than English: Not applicable
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
