### PR TITLE
Fix restype of CancellableSendMessage

### DIFF
--- a/source/NVDAHelper/localLib.py
+++ b/source/NVDAHelper/localLib.py
@@ -8,6 +8,7 @@ from ctypes import (
 	c_ushort,
 	c_void_p,
 	c_size_t,
+	c_ssize_t,
 	cdll,
 	CFUNCTYPE,
 	Structure,
@@ -42,6 +43,7 @@ from winBindings.mmeapi import WAVEFORMATEX
 
 
 DWORD_PTR = c_size_t
+LRESULT = c_ssize_t
 
 
 dll = cdll.LoadLibrary(NVDAState.ReadPaths.nvdaHelperLocalDll)
@@ -63,7 +65,7 @@ createRemoteBindingHandle.argtypes = (
 )
 
 cancellableSendMessageTimeout = dll.cancellableSendMessageTimeout
-cancellableSendMessageTimeout.restype = c_int
+cancellableSendMessageTimeout.restype = LRESULT
 # we use c_void_p for WPARAM and LPARAM as this gives us the greatest flexibility
 # of passing in Python native ints, ctypes arrays, pointers etc.
 cancellableSendMessageTimeout.argtypes = (


### PR DESCRIPTION
### Link to issue number:
May fix #19729

### Summary of the issue:
* as defined in `nvdaHelper/local/nvdaHelperLocal.cpp`, the return type of `cancellableSendMessageTimeout` is `LRESULT`.
* `LRESULT` is defined as `__int64` on 64-bit Windows, and `long` on 32-bit Windows. That is, `LRESULT` is the signed machine-word-sized integer type.
* However, in `source/NVDAHelper/localLib.py`, its return type was set to `c_int`. That is, the signed 32-bit integer type.
* This may be a contributing factor to #19729, as `ScintillaTextInfo` uses `cancellableSendMessageTimeout` when getting the text offset from point. Since the the return type is signed, very large (but still positive 64-bit two's compliment) integers may be interpreted as negative due to being truncated.
* On the other hand, if my math is correct, this would only start manifesting in files that are 2GiB or larger, though the reporters did say the files were large.

### Description of user facing changes:
Unknown, but may fix a crash in Notepad++ (and potentially other cases)

### Description of developer facing changes:
`NVDAHelper.localLib.cancellableSendMessageTimeout.restype` is now `c_longlong`

### Description of development approach:
Defined `LRESULT` as `c_ssize_t` (`c_long` on 32-bit; `c_longlong` on 64-bit), and set  `NVDAHelper.localLib.cancellableSendMessageTimeout`'s `restype` to `LRESULT`.

### Testing strategy:
Ran from source and did normal work.
I don't think this has the potential to cause issues, unless we introduced code relying on the incorrect restype during the 64-bit migration, as the return type was fine on 32-bit builds (`c_int is c_long`).

### Known issues with pull request:
None

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
