### PR TITLE
Disable the Copy version number button in secure mode

### DIFF
--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2006-2025 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Mesar Hameed, Joseph Lee,
+# Copyright (C) 2006-2026 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Mesar Hameed, Joseph Lee,
 # Thomas Stivers, Babbage B.V., Accessolutions, Julien Cochuyt, Cyrille Bougot, Luke Davis
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
@@ -418,6 +418,9 @@ class MainFrame(wx.Frame):
 		# Translators: The title of the dialog to show about info for NVDA.
 		aboutDialog = MessageDialog(None, versionInfo.aboutMessage, _("About NVDA"))
 		aboutDialog.addButton(copyButton)
+		if globalVars.appArgs.secure:
+			button = next(c for c in aboutDialog.GetChildren() if c.GetId() == copyButton.id)
+			button.Disable()
 		aboutDialog.Show()
 
 	@blockAction.when(blockAction.Context.SECURE_MODE)


### PR DESCRIPTION
Opened against beta since it's a small fix on a piece of code not yet part of a stable release.

### Link to issue number:
None

### Summary of the issue:
The new "Copy version number" button in About dialog is present and enabled even in secure mode, and pressing it reports "Copied to clipboard", but nothing is actually copied in this mode:

### Description of user facing changes:
When NVDA runs in secure mode, the "Copy version number" button is now disabled.

### Description of developer facing changes:
N/A
### Description of development approach:
See code.

### Testing strategy:
Manual tests:
Run NVDA normally and in secure mode and checked the impact on the button.

### Known issues with pull request:
One may run NVDA in secure mode in normal sessions (i.e. because it has been resticted by system admin or for test purpose). In this case, it may have been useful to be able to copy the version number.
Though, `api.copyToClip` does not work in this case, even in other scripts; I have not been able to figure why.
If one day this issue is fixed, we may disable the button only on secure screens, not when using secure mode in normal sessions.

### Code Review Checklist:


- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
