### PR TITLE
Fix SetWindowLongPtr binding in 32-bit synth host

### DIFF
--- a/source/winBindings/user32.py
+++ b/source/winBindings/user32.py
@@ -1056,7 +1056,9 @@ class GWLP(IntEnum):
 	"""Sets a new address for the window procedure."""
 
 
-SetWindowLongPtr = WINFUNCTYPE(None)(("SetWindowLongPtrW", dll))
+# On 32-bit Windows, SetWindowLongPtr is a macro alias for SetWindowLong and is not exported separately.
+_setWindowLongPtrName = "SetWindowLongW" if sizeof(c_void_p) == sizeof(LONG) else "SetWindowLongPtrW"
+SetWindowLongPtr = WINFUNCTYPE(None)((_setWindowLongPtrName, dll))
 """Changes an attribute of the specified window.
 
 .. seealso::


### PR DESCRIPTION
### Link to issue number:
N/A

### Summary of the issue:

From `2026.1beta9`, selecting the SAPI4 synthesizer fails.

### Description of user facing changes:

Selecting "Microsoft Speech API version 4" works again.

### Description of developer facing changes:

No public API changes.

### Description of development approach:

The issue was caused by `winBindings.user32` binding `SetWindowLongPtr` directly to `SetWindowLongPtrW`.
This works in 64-bit processes, but fails in the 32-bit synth driver host used by SAPI4.

This change keeps the public `SetWindowLongPtr` symbol unchanged, but maps it to:

* `SetWindowLongPtrW` in 64-bit processes
* `SetWindowLongW` in 32-bit processes

This keeps the fix in `winBindings.user32`, which is the correct layer for Win32 API compatibility.

Microsoft reference: https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setwindowlongptra

### Testing strategy:


1. Run NVDA from source or a built copy.
2. Open the synthesizer selection dialog.
3. Select "Microsoft Speech API version 4".
4. Confirm the synthesizer loads successfully and the log no longer contains `SetWindowLongPtrW not found`.

### Known issues with pull request:

None known.

### Code Review Checklist:

- [X] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [X] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [ ] API is compatible with existing add-ons.
- [ ] Security precautions taken.
