### PR TITLE
Reload mathPres when reloading config

### DIFF
--- a/source/core.py
+++ b/source/core.py
@@ -323,11 +323,14 @@ def resetConfiguration(factoryDefaults=False):
 	import tones
 	import audio
 	import screenCurtain
+	import mathPres
 
 	log.debug("Terminating vision")
 	vision.terminate()
 	log.debug("Terminating Screen Curtain")
 	screenCurtain.terminate()
+	log.debug("Terminating math presentation")
+	mathPres.terminate()
 	log.debug("Terminating braille")
 	braille.terminate()
 	log.debug("Terminating brailleInput")
@@ -388,6 +391,9 @@ def resetConfiguration(factoryDefaults=False):
 	brailleInput.initialize()
 	log.debug("Initializing braille")
 	braille.initialize()
+	# Math
+	log.debug("Initializing math presentation")
+	mathPres.initialize()
 	# Vision
 	log.debug("initializing vision")
 	vision.initialize()


### PR DESCRIPTION
### Link to issue number:

Fixes the issue described in https://github.com/nvaccess/nvda/issues/19811#issuecomment-4118942647

### Summary of the issue:

When the config is reset, MathCAT's settings are not restored.

### Description of user facing changes:

MathCAT settings are restored to the saved/default values when resetting the config.

### Description of developer facing changes:

None

### Description of development approach:

`terminate()` then `initialize()` `mathPres` in `core.resetConfiguration()`. While we could have reapplied the restored settings to MathCAT, it is not guaranteed to be the math presentation provider, so I thought this approach was simpler and easier to understand and debug.

### Testing strategy:

Ran from source. Read some math with speech style set to "simple speak". Switched to "literal speak". Read the math again. Restored settings. Read the speech a third time and ensured it was once again "simple speak".

### Known issues with pull request:

This approach is going to be marginally slower than reapplying MathCAT settings if it is the running math presentation provider.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
