### PR TITLE
Remove automatic language option from MathCAT speech settings

### DIFF
--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -375,7 +375,7 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 	[[speech]]
 		impairment = option("LearningDisability", "Blindness", "LowVision", default="Blindness")
 		# any known language code and sub-code -- could be en-uk, etc
-		language = string(default="Auto")
+		language = string(default="en")
 		verbosity = option("Terse", "Medium", "Verbose", default="Medium")
 		# Change from text speech rate (%)
 		mathRate = integer(default=100, min=10, max=100)

--- a/source/mathPres/MathCAT/localization.py
+++ b/source/mathPres/MathCAT/localization.py
@@ -137,14 +137,6 @@ def getLanguages() -> list[LanguageInfo]:
 	languages: list[LanguageInfo] = []
 	addRegionalLanguages = _createAddRegionalLanguagesFunction(languages)
 
-	languages.append(
-		LanguageInfo(
-			code="Auto",
-			# Translators: Math language settings menu item: Automatic uses the voice's language.
-			description=pgettext("math", "Automatic"),
-		),
-	)
-
 	# populate the available language names in the dialog
 	# the implemented languages are in folders named using the relevant ISO 639-1
 	# code https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes

--- a/source/mathPres/MathCAT/localization.py
+++ b/source/mathPres/MathCAT/localization.py
@@ -16,8 +16,6 @@ import wx
 from languageHandler import getLanguageDescription
 from logHandler import log
 from NVDAState import ReadPaths
-from speech import getCurrentLanguage
-from speechXml import toXmlLang
 
 from . import rulesUtils
 
@@ -25,32 +23,23 @@ from . import rulesUtils
 RE_MATH_LANG: re.Pattern = re.compile(r"""<math .*(xml:)?lang=["']([^'"]+)["'].*>""")
 
 
-def getLanguageToUse(mathMl: str = "") -> str:
-	"""Get the language specified in a math tag if the language pref is Auto, else the language preference.
+def getLanguageToUse(_mathMl: str = "") -> str:
+	"""Get the language preference, falling back to English if it is Auto.
 
-	:param mathMl: The MathML string to examine for language. Defaults to an empty string.
+	:param _mathMl: The MathML string to examine for language. Not used. Defaults to the empty string.
 	:returns: The language string to use.
 	"""
-	mathCATLanguageSetting: str = "Auto"
+	mathCATLanguageSetting: str = "en"
 	try:
 		# ignore regional differences if the MathCAT language setting doesn't have it.
 		mathCATLanguageSetting = libmathcat.GetPreference("Language")
 	except Exception:
 		log.exception()
 
-	if mathCATLanguageSetting != "Auto":
-		return mathCATLanguageSetting
-
-	languageMatch: re.Match | None = RE_MATH_LANG.search(mathMl)
-	language: str = (
-		languageMatch.group(2) if languageMatch else getCurrentLanguage()
-	)  # seems to be current voice's language
-	language = toXmlLang(language.lower())
-	if language == "cmn":
-		language = "zh-cmn"
-	elif language == "yue":
-		language = "zh-yue"
-	return language
+	if mathCATLanguageSetting == "Auto":
+		log.debugWarning("Math language 'Auto' is unsupported. Falling back to 'en'.")
+		mathCATLanguageSetting = "en"
+	return mathCATLanguageSetting
 
 
 def pathToLanguagesFolder() -> str:
@@ -128,8 +117,6 @@ def getLanguages() -> list[LanguageInfo]:
 
 	This method scans the language folders and adds entries for each language and its
 	regional dialects. Language folders use ISO 639-1 codes and regional variants use ISO 3166-1 alpha-2 codes.
-
-	It also adds a special "Automatic ({language})" option at the beginning, using the current voice's language.
 
 	:return: A list of LanguageInfo objects representing the available languages.
 	"""
@@ -222,8 +209,9 @@ def getSpeechStyles(languageCode: str) -> list[str]:
 
 	resultSpeechStyles = []
 	if languageCode == "Auto":
-		# list the speech styles for the current voice rather than have none listed
-		languageCode = toXmlLang(getCurrentLanguage().lower())
+		# Fall back to English
+		log.debugWarning("Math language 'Auto' is not supported. Using 'en'.")
+		languageCode = "en"
 	languageCode = languageCode.replace("-", "\\")
 
 	languagePath = pathToLanguagesFolder() + "\\"

--- a/source/mathPres/MathCAT/preferences.py
+++ b/source/mathPres/MathCAT/preferences.py
@@ -11,8 +11,6 @@ import languageHandler
 from logHandler import log
 from NVDAState import ReadPaths
 from mathPres.MathCAT import localization
-from speech.speech import getCurrentLanguage
-from speechXml import toXmlLang
 from utils.displayString import DisplayStringStrEnum
 
 import libmathcat_py as libmathcat
@@ -342,15 +340,10 @@ class MathCATUserPreferences:
 	def _createConfigForSpeechStyle(mathLang: str) -> str:
 		mathConf = config.conf["math"]
 		if mathLang == "Auto":
-			normalizedLang = languageHandler.normalizeLanguage(getCurrentLanguage())
-			if normalizedLang is not None:
-				mathLang = toXmlLang(normalizedLang)
-			else:
-				log.error(
-					f"Could not determine current language for Auto setting from language code '{normalizedLang}', "
-					"defaulting to en for speech style",
-				)
-				mathLang = "en"
+			log.debugWarning(
+				"Math language 'Auto' is not supported. defaulting to en for speech style",
+			)
+			mathLang = "en"
 		if mathLang not in mathConf["speech"]:
 			mathConf["speech"][mathLang] = {"speechStyle": ""}
 		return mathLang


### PR DESCRIPTION
### Link to issue number:

Closes #19811

### Summary of the issue:

The automatic language option for MathCAT speech was confusing and didn't respond as expected to speech voice/synthesizer language changes.

### Description of user facing changes:

Removes the "Automatic" option from MathCAT speech. The default is now English.

### Description of developer facing changes:

None

### Description of development approach:

Removed calls pertaining to retrieving the speech language based on the speech language. Given how close we are to a final release, I have not touched any supporting code.
Set the default for `config.conf["math"]["speech"]["language"]` to `"en"` rather than `"Auto"`.

### Testing strategy:

Ran from source. Read math.
Changed the MathCAT speech language (to German). Read math and.
Changed language back to English and read math.
Overrode the math language to "Auto", saved the config, restarted NVDA, and read math.

### Known issues with pull request:

MathCAT's "Auto" option (which pulls the language from the math tag) is still supported, though it is not surfaced in NVDA's GUI.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
