### PR TITLE
resolve a bug where keeping mouse center would make it drift up

### DIFF
--- a/source/_magnifier/fullscreenMagnifier.py
+++ b/source/_magnifier/fullscreenMagnifier.py
@@ -167,11 +167,7 @@ class FullScreenMagnifier(Magnifier):
 		):
 			log.debug("Mouse button pressed, skipping cursor repositioning to avoid interfering with click")
 			return
-		left, top, visibleWidth, visibleHeight = self._getMagnifierPosition(
-			self._currentCoordinates,
-		)
-		centerX = int(left + (visibleWidth / 2))
-		centerY = int(top + (visibleHeight / 2))
+		centerX, centerY = self._currentCoordinates
 		winUser.setCursorPos(centerX, centerY)
 
 	def _borderPos(

--- a/source/_magnifier/fullscreenMagnifier.py
+++ b/source/_magnifier/fullscreenMagnifier.py
@@ -167,7 +167,10 @@ class FullScreenMagnifier(Magnifier):
 		):
 			log.debug("Mouse button pressed, skipping cursor repositioning to avoid interfering with click")
 			return
-		centerX, centerY = self._currentCoordinates
+		coords = self._getCoordinatesForMode(self._currentCoordinates)
+		left, top, visibleWidth, visibleHeight = self._getMagnifierPosition(coords)
+		centerX = left + visibleWidth // 2
+		centerY = top + visibleHeight // 2
 		winUser.setCursorPos(centerX, centerY)
 
 	def _borderPos(

--- a/tests/unit/test_magnifier/test_fullscreenMagnifier.py
+++ b/tests/unit/test_magnifier/test_fullscreenMagnifier.py
@@ -3,11 +3,12 @@
 # This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
 # For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
 
-from unittest.mock import MagicMock
-from _magnifier.utils.types import Filter, FullScreenMode, MagnifierType, Direction
+from unittest.mock import MagicMock, patch
+from _magnifier.utils.types import Filter, FullScreenMode, MagnifierType, Direction, Coordinates
 from _magnifier.fullscreenMagnifier import FullScreenMagnifier
 from tests.unit.test_magnifier.test_magnifier import _TestMagnifier
 from _magnifier.magnifier import Magnifier
+from winAPI._displayTracking import getPrimaryDisplayOrientation
 
 
 class TestMagnifierEndToEnd(_TestMagnifier):
@@ -211,3 +212,117 @@ class TestMagnifierEndToEnd(_TestMagnifier):
 		# Stop magnifier
 		magnifier._stopMagnifier()
 		self.assertFalse(magnifier._isActive)
+
+
+class TestFullScreenMagnifierKeepMouseCentered(_TestMagnifier):
+	"""Tests for _keepMouseCentered in FullScreenMagnifier."""
+
+	def setUp(self):
+		super().setUp()
+		self.magnifier = FullScreenMagnifier()
+		self.screen = getPrimaryDisplayOrientation()
+
+	def tearDown(self):
+		self.magnifier._stopMagnifier()
+		super().tearDown()
+
+	def _expectedCenter(self, rawCoords: Coordinates) -> tuple[int, int]:
+		"""Compute the expected cursor position using the same pipeline as _keepMouseCentered."""
+		coords = self.magnifier._getCoordinatesForMode(rawCoords)
+		left, top, w, h = self.magnifier._getMagnifierPosition(coords)
+		return left + w // 2, top + h // 2
+
+	def testSkipsWhenLeftButtonPressed(self):
+		"""Cursor is not moved when the left mouse button is held."""
+		self.magnifier._currentCoordinates = Coordinates(500, 400)
+		with (
+			patch(
+				"_magnifier.fullscreenMagnifier.winUser.getKeyState",
+				side_effect=lambda key: -1 if key == 1 else 0,
+			),
+			patch("_magnifier.fullscreenMagnifier.winUser.setCursorPos") as mockSet,
+		):
+			self.magnifier._keepMouseCentered()
+			mockSet.assert_not_called()
+
+	def testSkipsWhenRightButtonPressed(self):
+		"""Cursor is not moved when the right mouse button is held."""
+		self.magnifier._currentCoordinates = Coordinates(500, 400)
+		with (
+			patch(
+				"_magnifier.fullscreenMagnifier.winUser.getKeyState",
+				side_effect=lambda key: -1 if key == 2 else 0,
+			),
+			patch("_magnifier.fullscreenMagnifier.winUser.setCursorPos") as mockSet,
+		):
+			self.magnifier._keepMouseCentered()
+			mockSet.assert_not_called()
+
+	def testSkipsWhenMiddleButtonPressed(self):
+		"""Cursor is not moved when the middle mouse button is held."""
+		self.magnifier._currentCoordinates = Coordinates(500, 400)
+		with (
+			patch(
+				"_magnifier.fullscreenMagnifier.winUser.getKeyState",
+				side_effect=lambda key: -1 if key == 4 else 0,
+			),
+			patch("_magnifier.fullscreenMagnifier.winUser.setCursorPos") as mockSet,
+		):
+			self.magnifier._keepMouseCentered()
+			mockSet.assert_not_called()
+
+	def testCenterModeMiddleOfScreen(self):
+		"""CENTER mode at screen center: cursor placed at the mode-adjusted, clamped center."""
+		self.magnifier._fullscreenMode = FullScreenMode.CENTER
+		raw = Coordinates(self.screen.width // 2, self.screen.height // 2)
+		self.magnifier._currentCoordinates = raw
+		expectedX, expectedY = self._expectedCenter(raw)
+		with (
+			patch("_magnifier.fullscreenMagnifier.winUser.getKeyState", return_value=0),
+			patch("_magnifier.fullscreenMagnifier.winUser.setCursorPos") as mockSet,
+		):
+			self.magnifier._keepMouseCentered()
+			mockSet.assert_called_once_with(expectedX, expectedY)
+
+	def testCenterModeAtEdge(self):
+		"""CENTER mode near top-left corner: cursor lands at clamped view center, not raw coordinates."""
+		self.magnifier._fullscreenMode = FullScreenMode.CENTER
+		raw = Coordinates(10, 10)
+		self.magnifier._currentCoordinates = raw
+		expectedX, expectedY = self._expectedCenter(raw)
+		# Clamping should shift the center away from (10, 10)
+		self.assertNotEqual((expectedX, expectedY), (raw.x, raw.y))
+		with (
+			patch("_magnifier.fullscreenMagnifier.winUser.getKeyState", return_value=0),
+			patch("_magnifier.fullscreenMagnifier.winUser.setCursorPos") as mockSet,
+		):
+			self.magnifier._keepMouseCentered()
+			mockSet.assert_called_once_with(expectedX, expectedY)
+
+	def testRelativeMode(self):
+		"""RELATIVE mode: cursor placed at the computed relative center, not raw coordinates."""
+		self.magnifier._fullscreenMode = FullScreenMode.RELATIVE
+		raw = Coordinates(self.screen.width // 4, self.screen.height // 4)
+		self.magnifier._currentCoordinates = raw
+		expectedX, expectedY = self._expectedCenter(raw)
+		with (
+			patch("_magnifier.fullscreenMagnifier.winUser.getKeyState", return_value=0),
+			patch("_magnifier.fullscreenMagnifier.winUser.setCursorPos") as mockSet,
+		):
+			self.magnifier._keepMouseCentered()
+			mockSet.assert_called_once_with(expectedX, expectedY)
+
+	def testBorderModeNoMovement(self):
+		"""BORDER mode with focus inside margins: cursor placed at center of current screen position."""
+		self.magnifier._fullscreenMode = FullScreenMode.BORDER
+		screenCenter = Coordinates(self.screen.width // 2, self.screen.height // 2)
+		self.magnifier._lastScreenPosition = screenCenter
+		# Focus is inside the visible area margins — no scroll needed
+		self.magnifier._currentCoordinates = screenCenter
+		expectedX, expectedY = self._expectedCenter(screenCenter)
+		with (
+			patch("_magnifier.fullscreenMagnifier.winUser.getKeyState", return_value=0),
+			patch("_magnifier.fullscreenMagnifier.winUser.setCursorPos") as mockSet,
+		):
+			self.magnifier._keepMouseCentered()
+			mockSet.assert_called_once_with(expectedX, expectedY)


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
fix a bug introduced with #19782

### Summary of the issue:
Mouse would drift up if `shouldKeepMouseCentered=True`
### Description of user facing changes:
Mouse no more drft up
### Description of developer facing changes:
N/A
### Description of development approach:
deleted code that was recalculating center
### Testing strategy:
manual
### Known issues with pull request:

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
