### PR TITLE
Fix title of user guide

### DIFF
--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -1,5 +1,3 @@
-<!-- markdownlint-disable-file MD060 -->
-
 # NVDA NVDA_VERSION User Guide
 
 [TOC]
@@ -6336,3 +6334,5 @@ The following values can be set under this registry key:
 If you require further information or assistance regarding NVDA, please visit the [NVDA web site](NVDA_URL).
 Here, you can find additional documentation, as well as technical support and community resources.
 This site also provides information and resources concerning NVDA development.
+
+<!-- markdownlint-disable-file MD060 -->


### PR DESCRIPTION
### Link to issue number:
Follow-up to #19736

### Summary of the issue:

Since #19736, the title of the user guide has been "&lt;!-- markdownlint-disable-file MD060 --&gt;".

### Description of user facing changes:

The user guide's title is back to being "NVDA [version] User Guide"

### Description of developer facing changes:

Linter comment is now at bottom of file.

### Description of development approach:

Moved the linter comment to the bottom of the user guide.
I could have fixed title extraction, but that seems rather at odds with the current sloppy approach in `md2html.py` (and elsewhere).

### Testing strategy:

Built docs from source and ensured the title was the same as the first heading.

### Known issues with pull request:

This will break again when someone adds anything before the first heading in `user_docs/en/userGuide.md`.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
