### PR TITLE
Fix race condition in nvwave._idleCheck

### DIFF
--- a/source/nvwave.py
+++ b/source/nvwave.py
@@ -232,7 +232,7 @@ class WavePlayer(garbageHandler.TrackedObject):
 		format.wBitsPerSample = bitsPerSample
 		format.nBlockAlign: int = bitsPerSample // 8 * channels
 		format.nAvgBytesPerSec = samplesPerSec * format.nBlockAlign
-		self._lastActiveTime: typing.Optional[float] = None
+		self._lastActiveTime: float | None = None
 		self._audioDucker = None
 		if wantDucking:
 			import audioDucking

--- a/source/nvwave.py
+++ b/source/nvwave.py
@@ -232,6 +232,7 @@ class WavePlayer(garbageHandler.TrackedObject):
 		format.wBitsPerSample = bitsPerSample
 		format.nBlockAlign: int = bitsPerSample // 8 * channels
 		format.nAvgBytesPerSec = samplesPerSec * format.nBlockAlign
+		self._lastActiveTime: typing.Optional[float] = None
 		self._audioDucker = None
 		if wantDucking:
 			import audioDucking
@@ -249,7 +250,6 @@ class WavePlayer(garbageHandler.TrackedObject):
 		self._doneCallbacks = {}
 		self._instances[self._player] = self
 		self.open()
-		self._lastActiveTime: typing.Optional[float] = None
 		self._isPaused: bool = False
 		if config.conf["audio"]["audioAwakeTime"] > 0 and WavePlayer._silenceDevice != outputDevice:
 			# The output device has changed. (Re)initialize silence.


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Fixes #19005

### Summary of the issue:
In rare cases, an exception occurs when playing sound using nvwave player: `AttributeError: 'WavePlayer' object has no attribute '_lastActiveTime'`

### Description of user facing changes:
NVDA will stop throwing exception when doing idle check.
### Description of developer facing changes:
None
### Description of development approach:
Reordered lines in WavePlayer constructor, so the _lastActiveTime attribute created before more resource intensive operations like ducking and cpp wrapper initialization.
### Testing strategy:
Manually tested (running from source) using code sample from #19005 with timeout set to 0.
No exception occurred during two minutes.
### Known issues with pull request:
None
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [ ] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
