### PR TITLE
Refine Unicode normalization paragraph in User Guide

### DIFF
--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -2190,9 +2190,10 @@ If you find that NVDA is reading punctuation in the wrong language for a particu
 
 ##### Unicode normalization {#SpeechUnicodeNormalization}
 
-When this option is enabled, unicode normalization is performed on the text that is spoken by NVDA.
+When this option is enabled, Unicode normalization is performed on the text that is spoken by NVDA.
 This is beneficial when speaking characters that can be represented in several forms.
-NVDA uses the NFKC (Normalization Form Compatibility Composition) algorithm, which provides the following benefits, among others:
+NVDA uses the NFKC (Normalization Form Compatibility Composition) algorithm, with additional normalization applied.
+NFKC provides the following benefits, among others:
 
 1. The bold and italic versions of characters that are part of the Unicode standard and are commonly used on social media are normalized to their most common compatible equivalent.
 For example, the Latin letter "h" can also be presented as "𝐡" (bold), "ℎ" (italic), etc. but will always be spoken as "h" when normalization is enabled.
@@ -2206,11 +2207,11 @@ This aspect of normalization also aids in reading equations in the Microsoft Wor
 
    Unicode normalization ensures that only one form will be used throughout all speech output, which is the single-character variant.
 
-1. Decomposition of some ligatures, Including "ĳ" (ligature ij) to their two letter form ("ij").
+1. Decomposition of some ligatures, including "ĳ" (ligature ij) to their two letter form ("ij").
 
 1. Stable ordering of modifiers in composite characters, for example in ancient Hebrew.
 
-1. Normalization of decorative letter variants that the standard NFKC algorithm does not decompose.
+The additional normalization in NVDA handles decorative letter variants that the standard NFKC algorithm does not decompose.
 Certain Unicode characters, such as negative circled Latin capital letters (🅐–🅩) and negative squared Latin capital letters (🅲–🅩), are treated as autonomous symbols by the Unicode standard and have no compatibility decomposition.
 NVDA extends NFKC by mapping these characters to their plain Latin letter equivalents (A–Z).
 Note that a small number of negative squared letters that have emoji semantics (🅰, 🅱, 🅾, 🅿) are excluded from this mapping to preserve their distinct meaning.


### PR DESCRIPTION
### Link to issue number:
Fix-up of #19608

### Summary of the issue:
With the introduction of #19608, the logic of the Unicode normalization paragraph in the User Guide has been broken. Namely, the information regarding additional (non-NFKC) normalization has been added as a bullet in the list of NVKC benefits.
### Description of user facing changes:
Unicode normalization paragraph modified / updated.

### Description of developer facing changes:
N/A
### Description of development approach:
* Separate description of N FKC benefits and additional NVDA normalization.
* Also other small fixes, e.g. upper/lowercase, etc.
### Testing strategy:
Check generated User Guide
### Known issues with pull request:
None
### Code Review Checklist:


- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
