### PR TITLE
The Add-on Store no longer fails to reopen after an add-on installation and before NVDA restart

### DIFF
--- a/source/addonStore/models/addon.py
+++ b/source/addonStore/models/addon.py
@@ -231,8 +231,12 @@ class _AddonManifestModel(_AddonGUIModel):
 		return changelog
 
 	@property
-	def installDate(self) -> datetime:
-		return datetime.fromtimestamp(os.path.getctime(self.installPath))
+	def installDate(self) -> datetime | None:
+		try:
+			return datetime.fromtimestamp(os.path.getctime(self.installPath))
+		except FileNotFoundError:
+			# When add-ons are "pending install", they are not yet at their final path.
+			return None
 
 	@property
 	def author(self) -> str:

--- a/source/gui/addonStoreGui/controls/details.py
+++ b/source/gui/addonStoreGui/controls/details.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2022-2025 NV Access Limited, Cyrille Bougot
+# Copyright (C) 2022-2026 NV Access Limited, Cyrille Bougot
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -348,12 +348,13 @@ class AddonDetails(
 						)
 
 				if isinstance(details, _AddonManifestModel):
-					# Installed add-ons with a manifest only
-					self._appendDetailsLabelValue(
-						# Translators: Label for an extra detail field for the selected add-on in the add-on store dialog.
-						pgettext("addonStore", "Install date:"),
-						details.installDate.strftime("%x"),
-					)
+					if details.installDate is not None:
+						# Installed add-ons with a manifest only
+						self._appendDetailsLabelValue(
+							# Translators: Label for an extra detail field for the selected add-on in the add-on store dialog.
+							pgettext("addonStore", "Install date:"),
+							details.installDate.strftime("%x"),
+						)
 
 				if isinstance(details, _AddonStoreModel):
 					if details.publicationDate is not None:

--- a/source/gui/addonStoreGui/viewModels/addonList.py
+++ b/source/gui/addonStoreGui/viewModels/addonList.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2022-2025 NV Access Limited, Cyrille Bougot
+# Copyright (C) 2022-2026 NV Access Limited, Cyrille Bougot
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from enum import Enum
 
 from locale import strxfrm
+from datetime import datetime
 from typing import (
 	Any,
 	FrozenSet,
@@ -325,7 +326,10 @@ class AddonListVM:
 		if field is AddonListField.channel:
 			return listItemVM.model.channel.displayString
 		if field is AddonListField.installDate:
-			return listItemVM.model.installDate.strftime("%x")
+			if listItemVM.model.installDate is None:
+				return ""
+			else:
+				return listItemVM.model.installDate.strftime("%x")
 		if field is AddonListField.minimumNVDAVersion:
 			return formatVersionForGUI(*listItemVM.model.minimumNVDAVersion)
 		if field is AddonListField.lastTestedVersion:
@@ -422,8 +426,10 @@ class AddonListVM:
 					return listItemVM.model.submissionTime
 				return 0
 			if self._sortByModelField == AddonListField.installDate:
-				listItemVM = cast(AddonListItemVM[_AddonManifestModel], listItemVM)
-				return listItemVM.model.installDate
+				if getattr(listItemVM.model, "installDate", None):
+					listItemVM = cast(AddonListItemVM[_AddonManifestModel], listItemVM)
+					return listItemVM.model.installDate
+				return datetime.max
 			return strxfrm(self._getAddonFieldText(listItemVM, self._sortByModelField))
 
 		def _containsTerm(detailsVM: AddonListItemVM, term: str) -> bool:

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -261,6 +261,7 @@ Use `config.configFlags.LoggingLevel` instead. (#19296)
 * `config.setSystemConfigToCurrentConfig` now takes a `Collection` of add-on IDs (as strings) to copy to the system configuration.
 Only add-ons with the given IDs will be copied. (#19446)
 * `browseMode.ElementsListDialog.filterTimer` has been removed. (#19702)
+* The type of the `installDate` property of `addonStore.models.addon.AddonManifestModel` and `addonStore.models.addon.InstalledAddonStoreModel` is now `datetime | None`. (#19901, @CyrilleB79)
 
 #### Deprecations
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -118,6 +118,7 @@ It currently includes Screen Curtain's settings (previously in the "Vision" cate
 * NVDA no longer fails to read the contents of wx Web View controls. (#17273, @LeonarddeR)
 * When NVDA is configured to update add-ons automatically in the background, add-ons can be properly updated. (#18965, @nvdaes)
 * Attempting to install an add-on that requires a newer version of NVDA from File Explorer no longer fails silently or shows the incompatible add-ons dialog. (#19260, #19261)
+* The Add-on Store no longer fails to reopen after an add-on has been installed. (#19900, @CyrilleB79)
 * Fixed a case where braille output would fail with an error. (#19025, @LeonarddeR)
 * Battery time announcements now skip redundant "0 hours" and "0 minutes" and use proper singular/plural forms. (#9003, @tareh7z)
 * When a synthesizer has a fallback language for the current dialect, the language of the text being read will no longer be reported as unsupported. (#18876, @nvdaes)


### PR DESCRIPTION
### Link to issue number:
Fixes #19900 

### Summary of the issue:
After an add-on had been installed and the Store closed, the Store could not be reopened until NVDA was restarted.

### Description of user facing changes:
The Add-on Store can now be reopened after an add-on has been installed, even before NVDA has been restarted.
For add-ons pending install, the install date is not provided since the installation is completed after NVDA has restarted.
Add-ons without install date are sorted after all other add-ons.

### Description of developer facing changes:
N/A
### Description of development approach:
* `_AddonManifestModel.installDate` now returns `None` if the add-on is not completely installed; take this into account when using this value.
* If the `installDate` is `None`, use `datetime.max` to sort the add-on after all other ones.
### Testing strategy:
Manual tests:
* Tested #19900 STR and checked details field and install date column.
* Sorted add-ons by install date column in the list.
### Known issues with pull request:
None
### Code Review Checklist:


- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
