### PR TITLE
Remove automatic language option from MathCAT speech settings

### DIFF
--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -13,7 +13,7 @@ from . import configDefaults
 #: provide an upgrade step (@see profileUpgradeSteps.py). An upgrade step does not need to be added when
 #: just adding a new element to (or removing from) the schema, only when old versions of the config
 #: (conforming to old schema versions) will not work correctly with the new schema.
-latestSchemaVersion = 21
+latestSchemaVersion = 22
 
 #: The configuration specification string
 #: @type: String

--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -375,7 +375,7 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 	[[speech]]
 		impairment = option("LearningDisability", "Blindness", "LowVision", default="Blindness")
 		# any known language code and sub-code -- could be en-uk, etc
-		language = string(default="Auto")
+		language = string(default="en")
 		verbosity = option("Terse", "Medium", "Verbose", default="Medium")
 		# Change from text speech rate (%)
 		mathRate = integer(default=100, min=10, max=100)

--- a/source/config/profileUpgradeSteps.py
+++ b/source/config/profileUpgradeSteps.py
@@ -678,6 +678,12 @@ def upgradeConfigFrom_21_to_22(profile: ConfigObj):
 	if language is None:
 		log.debug("math.speech.language not set in profile. No action taken.")
 		return
+	if not isinstance(language, str):
+		log.error(
+			f"Invalid math.speech.language value during profile upgrade: "
+			f"expected str, got {type(language).__name__}. Skipping upgrade step.",
+		)
+		return
 	if language.casefold() == "auto":
 		speechConf["language"] = "en"
 		log.debug("Changed math.speech.language from 'Auto' to 'en'.")

--- a/source/config/profileUpgradeSteps.py
+++ b/source/config/profileUpgradeSteps.py
@@ -662,3 +662,22 @@ def upgradeConfigFrom_20_to_21(profile: ConfigObj):
 		speechConf["sapi5_32"] = sapi5Conf
 		del speechConf["sapi5"]
 		log.debug("Moved old sapi5 configuration values to sapi5_32")
+
+
+def upgradeConfigFrom_21_to_22(profile: ConfigObj):
+	"""Change math speech language from 'Auto' to 'en'."""
+	mathConf = profile.get("math")
+	if not mathConf:
+		log.debug("No math section in profile. No action taken.")
+		return
+	speechConf = mathConf.get("speech")
+	if not speechConf:
+		log.debug("No math.speech section in profile. No action taken.")
+		return
+	language = speechConf.get("language")
+	if language is None:
+		log.debug("math.speech.language not set in profile. No action taken.")
+		return
+	if language.casefold() == "auto":
+		speechConf["language"] = "en"
+		log.debug("Changed math.speech.language from 'Auto' to 'en'.")

--- a/source/mathPres/MathCAT/MathCAT.py
+++ b/source/mathPres/MathCAT/MathCAT.py
@@ -363,7 +363,7 @@ class MathCAT(mathPres.MathPresentationProvider):
 		synthConfig = config.conf["speech"][synth.name]
 		try:
 			# need to set Language before the MathML for DecimalSeparator canonicalization
-			language: str = getLanguageToUse(mathml)
+			language: str = getLanguageToUse()
 			# MathCAT should probably be extended to accept "extlang" tagging, but it uses lang-region tagging at the moment
 			libmathcat.SetPreference("Language", language)
 			libmathcat.SetMathML(mathml)

--- a/source/mathPres/MathCAT/localization.py
+++ b/source/mathPres/MathCAT/localization.py
@@ -137,14 +137,6 @@ def getLanguages() -> list[LanguageInfo]:
 	languages: list[LanguageInfo] = []
 	addRegionalLanguages = _createAddRegionalLanguagesFunction(languages)
 
-	languages.append(
-		LanguageInfo(
-			code="Auto",
-			# Translators: Math language settings menu item: Automatic uses the voice's language.
-			description=pgettext("math", "Automatic"),
-		),
-	)
-
 	# populate the available language names in the dialog
 	# the implemented languages are in folders named using the relevant ISO 639-1
 	# code https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes

--- a/source/mathPres/MathCAT/localization.py
+++ b/source/mathPres/MathCAT/localization.py
@@ -31,7 +31,7 @@ def getLanguageToUse() -> str:
 	except Exception:
 		log.exception()
 
-	if mathCATLanguageSetting == "Auto":
+	if mathCATLanguageSetting.casefold() == "auto":
 		log.debugWarning("Math language 'Auto' is unsupported. Falling back to 'en'.")
 		mathCATLanguageSetting = "en"
 	return mathCATLanguageSetting

--- a/source/mathPres/MathCAT/localization.py
+++ b/source/mathPres/MathCAT/localization.py
@@ -203,7 +203,7 @@ def getSpeechStyles(languageCode: str) -> list[str]:
 	"""
 
 	resultSpeechStyles = []
-	if languageCode == "Auto":
+	if languageCode.casefold() == "auto":
 		# Fall back to English
 		log.debugWarning("Math language 'Auto' is not supported. Using 'en'.")
 		languageCode = "en"

--- a/source/mathPres/MathCAT/localization.py
+++ b/source/mathPres/MathCAT/localization.py
@@ -16,8 +16,6 @@ import wx
 from languageHandler import getLanguageDescription
 from logHandler import log
 from NVDAState import ReadPaths
-from speech import getCurrentLanguage
-from speechXml import toXmlLang
 
 from . import rulesUtils
 
@@ -25,32 +23,23 @@ from . import rulesUtils
 RE_MATH_LANG: re.Pattern = re.compile(r"""<math .*(xml:)?lang=["']([^'"]+)["'].*>""")
 
 
-def getLanguageToUse(mathMl: str = "") -> str:
-	"""Get the language specified in a math tag if the language pref is Auto, else the language preference.
+def getLanguageToUse(_mathMl: str = "") -> str:
+	"""Get the language preference, falling back to English if it is Auto.
 
-	:param mathMl: The MathML string to examine for language. Defaults to an empty string.
+	:param _mathMl: The MathML string to examine for language. Not used. Defaults to the empty string.
 	:returns: The language string to use.
 	"""
-	mathCATLanguageSetting: str = "Auto"
+	mathCATLanguageSetting: str = "en"
 	try:
 		# ignore regional differences if the MathCAT language setting doesn't have it.
 		mathCATLanguageSetting = libmathcat.GetPreference("Language")
 	except Exception:
 		log.exception()
 
-	if mathCATLanguageSetting != "Auto":
-		return mathCATLanguageSetting
-
-	languageMatch: re.Match | None = RE_MATH_LANG.search(mathMl)
-	language: str = (
-		languageMatch.group(2) if languageMatch else getCurrentLanguage()
-	)  # seems to be current voice's language
-	language = toXmlLang(language.lower())
-	if language == "cmn":
-		language = "zh-cmn"
-	elif language == "yue":
-		language = "zh-yue"
-	return language
+	if mathCATLanguageSetting == "Auto":
+		log.debugWarning("Math language 'Auto' is unsupported. Falling back to 'en'.")
+		mathCATLanguageSetting = "en"
+	return mathCATLanguageSetting
 
 
 def pathToLanguagesFolder() -> str:
@@ -128,8 +117,6 @@ def getLanguages() -> list[LanguageInfo]:
 
 	This method scans the language folders and adds entries for each language and its
 	regional dialects. Language folders use ISO 639-1 codes and regional variants use ISO 3166-1 alpha-2 codes.
-
-	It also adds a special "Automatic ({language})" option at the beginning, using the current voice's language.
 
 	:return: A list of LanguageInfo objects representing the available languages.
 	"""
@@ -222,8 +209,9 @@ def getSpeechStyles(languageCode: str) -> list[str]:
 
 	resultSpeechStyles = []
 	if languageCode == "Auto":
-		# list the speech styles for the current voice rather than have none listed
-		languageCode = toXmlLang(getCurrentLanguage().lower())
+		# Fall back to English
+		log.debugWarning("Math language 'Auto' is not supported. Using 'en'.")
+		languageCode = "en"
 	languageCode = languageCode.replace("-", "\\")
 
 	languagePath = pathToLanguagesFolder() + "\\"

--- a/source/mathPres/MathCAT/localization.py
+++ b/source/mathPres/MathCAT/localization.py
@@ -7,7 +7,6 @@ from collections.abc import Callable
 from dataclasses import dataclass
 import glob
 import os
-import re
 from zipfile import ZipFile
 
 import libmathcat_py as libmathcat
@@ -20,13 +19,9 @@ from NVDAState import ReadPaths
 from . import rulesUtils
 
 
-RE_MATH_LANG: re.Pattern = re.compile(r"""<math .*(xml:)?lang=["']([^'"]+)["'].*>""")
-
-
-def getLanguageToUse(_mathMl: str = "") -> str:
+def getLanguageToUse() -> str:
 	"""Get the language preference, falling back to English if it is Auto.
 
-	:param _mathMl: The MathML string to examine for language. Not used. Defaults to the empty string.
 	:returns: The language string to use.
 	"""
 	mathCATLanguageSetting: str = "en"

--- a/source/mathPres/MathCAT/preferences.py
+++ b/source/mathPres/MathCAT/preferences.py
@@ -11,8 +11,6 @@ import languageHandler
 from logHandler import log
 from NVDAState import ReadPaths
 from mathPres.MathCAT import localization
-from speech.speech import getCurrentLanguage
-from speechXml import toXmlLang
 from utils.displayString import DisplayStringStrEnum
 
 import libmathcat_py as libmathcat
@@ -342,15 +340,10 @@ class MathCATUserPreferences:
 	def _createConfigForSpeechStyle(mathLang: str) -> str:
 		mathConf = config.conf["math"]
 		if mathLang == "Auto":
-			normalizedLang = languageHandler.normalizeLanguage(getCurrentLanguage())
-			if normalizedLang is not None:
-				mathLang = toXmlLang(normalizedLang)
-			else:
-				log.error(
-					f"Could not determine current language for Auto setting from language code '{normalizedLang}', "
-					"defaulting to en for speech style",
-				)
-				mathLang = "en"
+			log.debugWarning(
+				"Math language 'Auto' is not supported. defaulting to en for speech style",
+			)
+			mathLang = "en"
 		if mathLang not in mathConf["speech"]:
 			mathConf["speech"][mathLang] = {"speechStyle": ""}
 		return mathLang

--- a/source/mathPres/MathCAT/preferences.py
+++ b/source/mathPres/MathCAT/preferences.py
@@ -339,6 +339,8 @@ class MathCATUserPreferences:
 	@staticmethod
 	def _createConfigForSpeechStyle(mathLang: str) -> str:
 		mathConf = config.conf["math"]
+		if mathLang.casefold() == "auto":
+			mathLang = "en"
 		if mathLang not in mathConf["speech"]:
 			mathConf["speech"][mathLang] = {"speechStyle": ""}
 		return mathLang

--- a/source/mathPres/MathCAT/preferences.py
+++ b/source/mathPres/MathCAT/preferences.py
@@ -339,11 +339,6 @@ class MathCATUserPreferences:
 	@staticmethod
 	def _createConfigForSpeechStyle(mathLang: str) -> str:
 		mathConf = config.conf["math"]
-		if mathLang == "Auto":
-			log.debugWarning(
-				"Math language 'Auto' is not supported. defaulting to en for speech style",
-			)
-			mathLang = "en"
 		if mathLang not in mathConf["speech"]:
 			mathConf["speech"][mathLang] = {"speechStyle": ""}
 		return mathLang

--- a/source/mathPres/MathCAT/speech.py
+++ b/source/mathPres/MathCAT/speech.py
@@ -17,7 +17,6 @@ from speech.commands import (
 	SpeechCommand,
 	SynthCommand,
 )
-from logHandler import log
 from synthDriverHandler import getSynth, SynthDriver
 from .localization import getLanguageToUse
 from speech import getCurrentLanguage

--- a/source/mathPres/MathCAT/speech.py
+++ b/source/mathPres/MathCAT/speech.py
@@ -19,7 +19,6 @@ from speech.commands import (
 )
 from logHandler import log
 from synthDriverHandler import getSynth, SynthDriver
-import libmathcat_py as libmathcat
 from .localization import getLanguageToUse
 from speech import getCurrentLanguage
 from speechXml import toXmlLang
@@ -52,7 +51,6 @@ RE_MATHML_SPEECH: re.Pattern = re.compile(
 def convertSSMLTextForNVDA(text: str) -> list[str | SpeechCommand]:
 	"""
 	Change the SSML in the text into NVDA's command structure.
-	The environment is examined to determine whether a language switch is needed.
 
 	:param text: The SSML text to convert.
 	:returns: A list of strings and SpeechCommand objects.
@@ -60,13 +58,6 @@ def convertSSMLTextForNVDA(text: str) -> list[str | SpeechCommand]:
 	# MathCAT's default rate is 180 wpm.
 	# Assume that 0% is 80 wpm and 100% is 450 wpm and scale accordingly.
 
-	# find MathCAT's language setting and store it away (could be "Auto")
-	# if MathCAT's setting doesn't match NVDA's language setting, change the language that is used
-	mathCATLanguageSetting: str = "en"  # set in case GetPreference fails
-	try:
-		mathCATLanguageSetting = libmathcat.GetPreference("Language")
-	except Exception as e:
-		log.exception(e)
 	language: str = getLanguageToUse()
 	nvdaLanguage: str = toXmlLang(getCurrentLanguage())
 	synth: SynthDriver = getSynth()
@@ -81,12 +72,6 @@ def convertSSMLTextForNVDA(text: str) -> list[str | SpeechCommand]:
 	# as of 7/23, oneCore voices do not implement the CharacterModeCommand despite it being in supported_commands
 	useCharacter: bool = CharacterModeCommand in supportedCommands and synth.name != "oneCore"
 	out: list[str | SpeechCommand] = []
-	if mathCATLanguageSetting.casefold() != language.casefold():
-		try:
-			libmathcat.SetPreference("Language", language)
-		except Exception as e:
-			log.exception(e)
-			language = mathCATLanguageSetting  # didn't set the language
 	if language != nvdaLanguage:
 		out.append(LangChangeCommand(language))
 
@@ -128,12 +113,6 @@ def convertSSMLTextForNVDA(text: str) -> list[str | SpeechCommand]:
 	# there is a bug in MS Word that concats the math and the next character outside of math, so we add a space
 	out.append(" ")
 
-	if mathCATLanguageSetting.casefold() != language.casefold():
-		# restore the old value (probably "Auto")
-		try:
-			libmathcat.SetPreference("Language", mathCATLanguageSetting)
-		except Exception:
-			log.exception()
 	if language.casefold() != nvdaLanguage.casefold():
 		out.append(LangChangeCommand(None))
 	return out

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1230,7 +1230,10 @@ class Config_profileUpgradeSteps_upgradeConfigFrom_21_to_22(unittest.TestCase):
 
 	def test_noSpeechSection_unchanged(self):
 		"""Profile with [math] but no [[speech]] sub-section is not modified."""
-		configString = "[math]"
+		configString = """
+[math]
+	impairment = Blindness
+"""
 		profile = _loadProfile(configString)
 		upgradeConfigFrom_21_to_22(profile)
 		with self.assertRaises(KeyError):
@@ -1240,7 +1243,9 @@ class Config_profileUpgradeSteps_upgradeConfigFrom_21_to_22(unittest.TestCase):
 		"""Profile with [math] / [[speech]] but no language key is not modified."""
 		configString = """
 [math]
+	impairment = Blindness
 	[[speech]]
+		verbosity = Medium
 """
 		profile = _loadProfile(configString)
 		upgradeConfigFrom_21_to_22(profile)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -38,6 +38,7 @@ from config.profileUpgradeSteps import (
 	upgradeConfigFrom_16_to_17,
 	upgradeConfigFrom_17_to_18,
 	upgradeConfigFrom_18_to_19,
+	upgradeConfigFrom_21_to_22,
 )
 from config.configFlags import (
 	NVDAKey,
@@ -1217,3 +1218,75 @@ class Config_upgradeProfileSteps_upgradeProfileFrom_18_to_19(unittest.TestCase):
 		self.assertEqual(profile["documentFormatting"]["reportSpellingErrors"], "notABool")
 		with self.assertRaises(KeyError):
 			profile["documentFormatting"]["reportSpellingErrors2"]
+
+
+class Config_profileUpgradeSteps_upgradeConfigFrom_21_to_22(unittest.TestCase):
+	def test_noMathSection_unchanged(self):
+		"""Profile with no [math] section is not modified."""
+		profile = _loadProfile("")
+		upgradeConfigFrom_21_to_22(profile)
+		with self.assertRaises(KeyError):
+			profile["math"]
+
+	def test_noSpeechSection_unchanged(self):
+		"""Profile with [math] but no [[speech]] sub-section is not modified."""
+		configString = "[math]"
+		profile = _loadProfile(configString)
+		upgradeConfigFrom_21_to_22(profile)
+		with self.assertRaises(KeyError):
+			profile["math"]["speech"]
+
+	def test_noLanguageKey_unchanged(self):
+		"""Profile with [math] / [[speech]] but no language key is not modified."""
+		configString = """
+[math]
+	[[speech]]
+"""
+		profile = _loadProfile(configString)
+		upgradeConfigFrom_21_to_22(profile)
+		with self.assertRaises(KeyError):
+			profile["math"]["speech"]["language"]
+
+	def test_autoMixedCase_migratedToEn(self):
+		"""language = Auto (canonical old default) is migrated to 'en'."""
+		configString = """
+[math]
+	[[speech]]
+		language = Auto
+"""
+		profile = _loadProfile(configString)
+		upgradeConfigFrom_21_to_22(profile)
+		self.assertEqual(profile["math"]["speech"]["language"], "en")
+
+	def test_autoLowerCase_migratedToEn(self):
+		"""language = auto (all lowercase) is migrated to 'en'."""
+		configString = """
+[math]
+	[[speech]]
+		language = auto
+"""
+		profile = _loadProfile(configString)
+		upgradeConfigFrom_21_to_22(profile)
+		self.assertEqual(profile["math"]["speech"]["language"], "en")
+
+	def test_autoUpperCase_migratedToEn(self):
+		"""language = AUTO (all uppercase) is migrated to 'en'."""
+		configString = """
+[math]
+	[[speech]]
+		language = AUTO
+"""
+		profile = _loadProfile(configString)
+		upgradeConfigFrom_21_to_22(profile)
+		self.assertEqual(profile["math"]["speech"]["language"], "en")
+
+	def test_nonAutoLanguage_unchanged(self):
+		"""language set to a valid non-Auto value is not modified."""
+		configString = """
+[math]
+	[[speech]]
+		language = fr
+"""
+		profile = _loadProfile(configString)
+		upgradeConfigFrom_21_to_22(profile)
+		self.assertEqual(profile["math"]["speech"]["language"], "fr")


### PR DESCRIPTION
### Link to issue number:

Closes #19811
I am opening this PR as a follow-up to #19888 at the request of @seanbudd 

### Summary of the issue:

The automatic language option for MathCAT speech was confusing and didn't respond as expected to speech voice/synthesizer language changes. (from #19888)

### Description of user facing changes:

Removes the "Automatic" option from MathCAT speech. The default is now English. (from #19888)

### Description of developer facing changes:

None

### Description of development approach:

Removed the `_mathMl` parameter from `getLanguageToUse`, the save/set/restore language pattern from `convertSSMLTextForNVDA`, and the "Auto" fallback in `_createConfigForSpeechStyle`. Added a config profile upgrade step to migrate `language = Auto` to `en`.

### Testing strategy:

Unit testing: added unit tests to `tests\unit\test_config.py`.

Manual testing: Set the math language to English, read math and made sure everything was behaving as before.
Then, tested with a variety of combinations of NVDA language, synthesizer language (with eSpeak), and math language.
Specifically, I tested:
- NVDA language of English, synth language of Spanish, math language of Spanish
- NVDA language of English, synth language of Spanish, math language of English
- NVDA language of English, synth language of Spanish, math language of English
- NVDA language of English, synth language of French, math language of Dutch
- NVDA language of Dutch, synth language of Dutch, math language of Dutch
- NVDA language of Dutch, synth language of English, math language of Spanish
- NVDA language of Dutch, synth language of Chinese (cantonese), math language of German

In all cases, the math language option overrode the more general synth language and NVDA language options.

### Known issues with pull request:

None

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
