### PR TITLE
Fix synthDriverHost freeze when rapidly adjusting SAPI4 voice/rate

### DIFF
--- a/source/_synthDrivers32/sapi4.py
+++ b/source/_synthDrivers32/sapi4.py
@@ -526,6 +526,11 @@ class SynthDriverAudio(COMObject):
 			self._player.pause(False)
 		except OSError:
 			log.debugWarning("Error starting audio", exc_info=True)
+			# Do not transition to STARTED state when the audio device
+			# fails to resume, as this would leave the state machine
+			# in an inconsistent state where the audio thread tries
+			# to feed audio to a non-playing device, causing a freeze.
+			raise ReturnHRESULT(AudioError.WAVE_DEVICE_BUSY, None)
 		with self._audioCond:
 			self._deviceState = _AudioState.STARTED
 			self._audioCond.notify()
@@ -545,6 +550,12 @@ class SynthDriverAudio(COMObject):
 			self._player.pause(True)
 		except OSError:
 			log.debugWarning("Error stopping audio", exc_info=True)
+			# If pausing fails, stop the player entirely to prevent
+			# the audio device from remaining in an inconsistent state.
+			try:
+				self._player.stop()
+			except OSError:
+				log.debugWarning("Error force-stopping audio after pause failure", exc_info=True)
 		with self._audioCond:
 			self._audioCond.notify()
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -47,6 +47,7 @@ This is more noticeable for Windows releases which are enablement packages on to
 
 ### Bug Fixes
 
+* Fixed a freeze in the synthDriverHost process when rapidly adjusting voice or rate settings with the SAPI4 speech synthesizer. (#19819)
 * In Firefox browse mode, the accessible name of form controls (such as checkboxes and radio buttons) is now correctly announced when the control has an `aria-label` and an associated `<label>` element that contains only `aria-hidden` content. (#19409, @bramd)
 * The "Toggles on and off if the screen layout is preserved while rendering the document content" item in the "Browse mode" category of the Input Gestures dialog now behaves correctly. (#18378)
 * In Microsoft Word with UIA enabled, page changes are now correctly announced when navigating table rows that span multiple pages. (#19386, @akj)


### PR DESCRIPTION
### Link to issue number:
Fixes #19819

### Summary of the issue:
When using the SAPI4 speech synthesizer, rapidly adjusting voice or rate settings causes the synthDriverHost process to freeze. The root cause is a race condition in `SynthDriverAudio.IAudio_Start`: when the audio device fails to resume playback (Windows error 0x88890005), the `OSError` exception is caught and logged, but the state machine still transitions to `STARTED`. This leaves the audio thread trying to feed audio data to a non-playing device, causing the process to hang indefinitely.

### Description of user facing changes:
NVDA no longer freezes when rapidly adjusting voice or rate settings with SAPI4 synthesizers. If the audio device is temporarily busy, the error is handled gracefully and the TTS engine can retry.

### Description of developer facing changes:
None

### Description of development approach:
**IAudio_Start**: When `self._player.pause(False)` raises an `OSError`, instead of silently continuing and transitioning to `_AudioState.STARTED`, the method now raises `ReturnHRESULT(AudioError.WAVE_DEVICE_BUSY, None)`. This prevents the state machine from entering an inconsistent state and allows the TTS engine to handle the error appropriately (e.g., by retrying).

**IAudio_Stop**: When `self._player.pause(True)` raises an `OSError`, the player is now force-stopped via `self._player.stop()` as a fallback, preventing the audio device from remaining in an inconsistent state where the state machine says playback is paused but the device is still active.

### Testing strategy:
This change is specific to SAPI4 on Windows, which requires a Windows environment with SAPI4 voices installed for manual testing. The fix was verified by code review against the state machine logic:

- Confirmed that `_AudioState.STARTED` is only set when `pause(False)` succeeds
- Confirmed that `WAVE_DEVICE_BUSY` is an existing SAPI4 error code that TTS engines are expected to handle
- Confirmed that the `_logTrace` decorator properly handles `ReturnHRESULT` exceptions
- Confirmed that the audio thread correctly waits when state is not `STARTED`/`UNCLAIMING`/`RECLAIMING`

### Known issues with pull request:
None

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.