### PR TITLE
Fix MathCAT with MultiLang add-on"

### DIFF
--- a/source/mathPres/MathCAT/speech.py
+++ b/source/mathPres/MathCAT/speech.py
@@ -113,9 +113,10 @@ def convertSSMLTextForNVDA(text: str) -> list[str | SpeechCommand]:
 				out.append(command(multiplier=int(m.group(m.lastgroup)) / 100.0))
 				resetProsody.append(command)
 		elif m.lastgroup == "prosodyReset":
-			# for command in resetProsody:    # only supported commands were added, so no need to check
-			command: type["BaseProsodyCommand"] = resetProsody.pop()
-			out.append(command(multiplier=1))
+			while len(resetProsody) > 0:
+				# only supported commands were added, so no need to check
+				command: type["BaseProsodyCommand"] = resetProsody.pop()
+				out.append(command(multiplier=1))
 		elif m.lastgroup == "phonemeText":
 			if usePhoneme:
 				out.append(PhonemeCommand(m.group("ipa"), text=m.group("phonemeText")))


### PR DESCRIPTION
### Link to issue number:
Fixes #19784

### Summary of the issue:
When using the [MultiLang speech synth driver](https://blindhelp.net/software/multilang) with MathCAT's relative speech rate at anything other than 1x, math will fail to read.

### Description of user facing changes:
Math can once again be read with this add-on if the relative rate is not 100%. Note that the relative rate will have no effect, since `MultiLang` does not support the `RateCommand`.

### Description of developer facing changes:
None

### Description of development approach:
Rather than simply popping from `resetProsody` once in `mathPres.MathCAT.speech.convertSSMLTextForNVDA`, pop from it while it is not empty. This means that we:
* Will reset all prosody parameters in the reverse order to which they were set; and
* We won't try and pop from an empty list (which was the cause of this bug).

### Testing strategy:

With math relative speech rate set to 50%:
1. Reproduced the issue by launching a version of NVDA without this patch.
1. Read some MathML.
1. In the python console, executed `from speech.speech import getSynth;getSynth().supportedCommands.clear()`.
1. Attempted to read the same math.
1. Confirmed the fix by running the patched version from source, and repeating steps 2 through 4 inclusive with no issue.

### Known issues with pull request:
None

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
