### PR TITLE
Move and clarify the native word math support option

### DIFF
--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -2988,16 +2988,20 @@ class MathSettingsPanel(SettingsPanel):
 			),
 		)
 
-		# Translators: Text for the general group.
-		generalGroupSizer = wx.StaticBoxSizer(wx.VERTICAL, self, label=pgettext("math", "General"))
-		generalGroupBox = generalGroupSizer.GetStaticBox()
-		generalGroup = guiHelper.BoxSizerHelper(self, sizer=generalGroupSizer)
-		sHelper.addItem(generalGroup)
+		appSupportGroupSizer = wx.StaticBoxSizer(
+			wx.VERTICAL,
+			self,
+			# Translators: Text for the application support group in MathCAT options.
+			label=pgettext("math", "Application support"),
+		)
+		appSupportGroupBox = appSupportGroupSizer.GetStaticBox()
+		appSupportGroup = guiHelper.BoxSizerHelper(self, sizer=appSupportGroupSizer)
+		sHelper.addItem(appSupportGroup)
 
 		# Translators: label for checkbox to use native math presentation support instead of MathCAT in Word and Outlook
 		useWordNativeMathText = pgettext("math", "Use native math support in Word and Outlook")
-		self.useWordNativeMathCheckBox = generalGroup.addItem(
-			wx.CheckBox(generalGroupBox, label=useWordNativeMathText),
+		self.useWordNativeMathCheckBox = appSupportGroup.addItem(
+			wx.CheckBox(appSupportGroupBox, label=useWordNativeMathText),
 		)
 		self.bindHelpEvent("MathUseWordNative", self.useWordNativeMathCheckBox)
 		self.useWordNativeMathCheckBox.SetValue(config.conf["math"]["other"]["useWordNativeMath"])

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -2878,14 +2878,6 @@ class MathSettingsPanel(SettingsPanel):
 		else:
 			self.navSpeechList.SetSelection(0)
 
-		# Translators: label for checkbox to use native math speech instead of MathCAT in Word and Outlook
-		useWordNativeMathText = pgettext("math", "Use native math speech in Word and Outlook")
-		self.useWordNativeMathCheckBox = speechGroup.addItem(
-			wx.CheckBox(speechGroupBox, label=useWordNativeMathText),
-		)
-		self.bindHelpEvent("MathUseWordNative", self.useWordNativeMathCheckBox)
-		self.useWordNativeMathCheckBox.SetValue(config.conf["math"]["other"]["useWordNativeMath"])
-
 		# Translators: Text for the navigation group.
 		navGroupText = pgettext("math", "Navigation")
 		navGroupSizer = wx.StaticBoxSizer(wx.VERTICAL, self, label=navGroupText)
@@ -2995,6 +2987,20 @@ class MathSettingsPanel(SettingsPanel):
 				config.conf["math"]["braille"]["brailleNavHighlight"],
 			),
 		)
+
+		# Translators: Text for the general group.
+		generalGroupSizer = wx.StaticBoxSizer(wx.VERTICAL, self, label=pgettext("math", "General"))
+		generalGroupBox = generalGroupSizer.GetStaticBox()
+		generalGroup = guiHelper.BoxSizerHelper(self, sizer=generalGroupSizer)
+		sHelper.addItem(generalGroup)
+
+		# Translators: label for checkbox to use native math presentation support instead of MathCAT in Word and Outlook
+		useWordNativeMathText = pgettext("math", "Use native math support in Word and Outlook")
+		self.useWordNativeMathCheckBox = generalGroup.addItem(
+			wx.CheckBox(generalGroupBox, label=useWordNativeMathText),
+		)
+		self.bindHelpEvent("MathUseWordNative", self.useWordNativeMathCheckBox)
+		self.useWordNativeMathCheckBox.SetValue(config.conf["math"]["other"]["useWordNativeMath"])
 
 	def onSave(self):
 		from mathPres.MathCAT.preferences import MathCATUserPreferences

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -3405,7 +3405,7 @@ The options allow for either no highlighting, only highlighting of the first cha
 | Options | Off, First Character, Endpoints, All |
 | Default | Endpoints |
 
-##### General Options {#MathGeneralOptions}
+##### Application support {#MathApplicationSupport}
 
 ###### Use native math support in Word and Outlook {#MathUseWordNative}
 

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -3331,15 +3331,6 @@ Whether to speak the expression after moving to it or give an overview.
 | Options | Speak, Describe overview |
 | Default | Speak |
 
-###### Use native math speech in Word and Outlook {#MathUseWordNative}
-
-When enabled, NVDA uses Microsoft Word's built-in math presentation (speech, braille, and interaction) instead of MathCAT when reading and interacting with equations in Word documents.
-
-| . {.hideHeaderRow} | . |
-|---|---|
-| Options | Checked, Unchecked |
-| Default | Unchecked |
-
 ##### Navigation Options {#MathNavigation}
 
 ###### Default navigation mode {#MathNavMode}
@@ -3413,6 +3404,21 @@ The options allow for either no highlighting, only highlighting of the first cha
 |---|---|
 | Options | Off, First Character, Endpoints, All |
 | Default | Endpoints |
+
+##### General Options {#MathGeneralOptions}
+
+###### Use native math support in Word and Outlook {#MathUseWordNative}
+
+This option disables MathCAT when reading and interacting with equations in Microsoft Word or Outlook.
+This allows you to use the math presentation (speech, braille, and interaction) that is built-in to these programs.
+
+You cannot use MathCAT in Microsoft Word or Outlook when this option is enabled.
+This option does not affect MathCAT support in other programs.
+
+| . {.hideHeaderRow} | . |
+|---|---|
+| Options | Checked, Unchecked |
+| Default | Unchecked |
 
 #### Add-on Store Settings {#AddonStoreSettings}
 


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
The "Use native math speech in Word and Outlook" option is misleading, as it affects speech, braille and navigation.

### Description of user facing changes:
The option has been renamed to "Use native math support in Word and Outlook", and moved to a new "Application support" section of the Math settings panel.
The user guide has also been updated to clarify how the option works, and that this prevents using MathCAT in Word and Outlook altogether.

### Description of developer facing changes:
None.

### Description of development approach:
Created a new group in the math panel. Moved the checkbox creation after creation of that panel, and changed it to point to the new group.
Rewrote the UG as appropriate.

### Testing strategy:
Ran from source and checked that the settings panel looks correct.
Built the user guide from source and checked the output.
Ran from source, tabbed to the native word math checkbox and hit `F1` and checked that I was moved to the correct section of the user guide.

### Known issues with pull request:
None

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
