### PR TITLE
Fix JAB freeze when navigating in JetBrains IDEs

### DIFF
--- a/source/JABHandler.py
+++ b/source/JABHandler.py
@@ -986,6 +986,8 @@ def internal_event_activeDescendantChange(vmID, event, source, oldDescendant, ne
 	sourceContext = JABContext(hwnd=hwnd, vmID=vmID, accContext=source)
 	if internal_hasFocus(sourceContext):
 		internalQueueFunction(event_gainFocus, vmID, newDescendant, hwnd)
+	else:
+		bridgeDll.releaseJavaObject(vmID, newDescendant)
 	for accContext in [event, oldDescendant]:
 		bridgeDll.releaseJavaObject(vmID, accContext)
 

--- a/source/JABHandler.py
+++ b/source/JABHandler.py
@@ -1213,6 +1213,9 @@ def terminate():
 		return
 	bridgeDll.setFocusGainedFP(None)
 	bridgeDll.setPropertyActiveDescendentChangeFP(None)
+	bridgeDll.setPropertyNameChangeFP(None)
+	bridgeDll.setPropertyDescriptionChangeFP(None)
+	bridgeDll.setPropertyValueChangeFP(None)
 	bridgeDll.setPropertyStateChangeFP(None)
 	bridgeDll.setPropertyCaretChangeFP(None)
 	h = bridgeDll._handle

--- a/source/JABHandler.py
+++ b/source/JABHandler.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2007-2025 NV Access Limited, Peter Vágner, Renaud Paquay, Babbage B.V.
+# Copyright (C) 2007-2026 NV Access Limited, Peter Vágner, Renaud Paquay, Babbage B.V.
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 

--- a/source/JABHandler.py
+++ b/source/JABHandler.py
@@ -3,6 +3,7 @@
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
+from collections.abc import Callable
 from enum import IntEnum, IntFlag
 import os
 import queue
@@ -547,32 +548,44 @@ internalFunctionQueue = queue.Queue(1000)
 internalFunctionQueue.__name__ = "JABHandler.internalFunctionQueue"
 
 
-def internalQueueFunction(func, *args, **kwargs):
+def _releaseQueuedAccContext(func: Callable, args: tuple) -> None:
+	"""Release the JOBJECT64 accContext held by a queued JAB callback.
+
+	All handlers queued via :func:`internalQueueFunction` except
+	:func:`enterJavaWindow_helper` follow the ``(vmID, accContext, ...)``
+	convention where ``args[1]`` is a JOBJECT64 handle. This helper
+	releases that handle to prevent JOBJECT64 reference leaks when an
+	event is evicted from the queue or cannot be enqueued at all.
+	"""
+	if func is not enterJavaWindow_helper and len(args) >= 2:
+		bridgeDll.releaseJavaObject(args[0], args[1])
+
+
+def internalQueueFunction(func: Callable, *args, **kwargs) -> None:
 	"""Queue a function for execution on the main thread.
 
 	When the queue is full, the oldest event is evicted to make room.
-	JOBJECT64 handles owned by evicted events are released to avoid leaks.
+	JOBJECT64 handles owned by evicted or dropped events are released
+	via :func:`_releaseQueuedAccContext` to avoid leaks.
 
 	.. note::
 		All queued handler functions except :func:`enterJavaWindow_helper`
 		follow the convention ``(vmID, accContext, ...)``, where ``args[1]``
 		is a JOBJECT64 handle.  If a new handler with a different signature
-		is added, the eviction cleanup below must be updated.
+		is added, :func:`_releaseQueuedAccContext` must be updated.
 	"""
 	try:
 		internalFunctionQueue.put_nowait((func, args, kwargs))
 	except queue.Full:
 		try:
 			evictedFunc, evictedArgs, _evictedKwargs = internalFunctionQueue.get_nowait()
-			# Release the JOBJECT64 accContext handle from the evicted event.
-			# All handlers except enterJavaWindow_helper have args[1] as accContext.
-			if evictedFunc is not enterJavaWindow_helper and len(evictedArgs) >= 2:
-				bridgeDll.releaseJavaObject(evictedArgs[0], evictedArgs[1])
+			_releaseQueuedAccContext(evictedFunc, evictedArgs)
 		except queue.Empty:
 			pass
 		try:
 			internalFunctionQueue.put_nowait((func, args, kwargs))
 		except queue.Full:
+			_releaseQueuedAccContext(func, args)
 			log.debugWarning("JAB internal function queue full, failed to re-queue after eviction")
 			return
 		log.debugWarning("JAB internal function queue full, evicted oldest event")
@@ -981,7 +994,13 @@ def event_gainFocus(vmID, accContext, hwnd):
 
 
 @AccessBridge_PropertyActiveDescendentChangeFP
-def internal_event_activeDescendantChange(vmID, event, source, oldDescendant, newDescendant):
+def internal_event_activeDescendantChange(
+	vmID: int,
+	event: int,
+	source: int,
+	oldDescendant: int,
+	newDescendant: int,
+) -> None:
 	hwnd = getWindowHandleFromAccContext(vmID, source)
 	sourceContext = JABContext(hwnd=hwnd, vmID=vmID, accContext=source)
 	if internal_hasFocus(sourceContext):
@@ -1001,12 +1020,18 @@ def internal_hasFocus(sourceContext):
 
 
 @AccessBridge_PropertyNameChangeFP
-def internal_event_nameChange(vmID, event, source, oldVal, newVal):
+def internal_event_nameChange(
+	vmID: int,
+	event: int,
+	source: int,
+	oldVal: str | None,
+	newVal: str | None,
+) -> None:
 	internalQueueFunction(event_nameChange, vmID, source)
 	bridgeDll.releaseJavaObject(vmID, event)
 
 
-def event_nameChange(vmID, accContext):
+def event_nameChange(vmID: int, accContext: int) -> None:
 	jabContext = JABContext(vmID=vmID, accContext=accContext)
 	if jabContext.hwnd:
 		focus = api.getFocusObject()
@@ -1022,12 +1047,18 @@ def event_nameChange(vmID, accContext):
 
 
 @AccessBridge_PropertyDescriptionChangeFP
-def internal_event_descriptionChange(vmID, event, source, oldVal, newVal):
+def internal_event_descriptionChange(
+	vmID: int,
+	event: int,
+	source: int,
+	oldVal: str | None,
+	newVal: str | None,
+) -> None:
 	internalQueueFunction(event_descriptionChange, vmID, source)
 	bridgeDll.releaseJavaObject(vmID, event)
 
 
-def event_descriptionChange(vmID, accContext):
+def event_descriptionChange(vmID: int, accContext: int) -> None:
 	jabContext = JABContext(vmID=vmID, accContext=accContext)
 	if jabContext.hwnd:
 		focus = api.getFocusObject()
@@ -1043,12 +1074,18 @@ def event_descriptionChange(vmID, accContext):
 
 
 @AccessBridge_PropertyValueChangeFP
-def internal_event_valueChange(vmID, event, source, oldVal, newVal):
+def internal_event_valueChange(
+	vmID: int,
+	event: int,
+	source: int,
+	oldVal: str | None,
+	newVal: str | None,
+) -> None:
 	internalQueueFunction(event_valueChange, vmID, source)
 	bridgeDll.releaseJavaObject(vmID, event)
 
 
-def event_valueChange(vmID, accContext):
+def event_valueChange(vmID: int, accContext: int) -> None:
 	jabContext = JABContext(vmID=vmID, accContext=accContext)
 	if jabContext.hwnd:
 		focus = api.getFocusObject()

--- a/source/JABHandler.py
+++ b/source/JABHandler.py
@@ -548,7 +548,34 @@ internalFunctionQueue.__name__ = "JABHandler.internalFunctionQueue"
 
 
 def internalQueueFunction(func, *args, **kwargs):
-	internalFunctionQueue.put_nowait((func, args, kwargs))
+	"""Queue a function for execution on the main thread.
+
+	When the queue is full, the oldest event is evicted to make room.
+	JOBJECT64 handles owned by evicted events are released to avoid leaks.
+
+	.. note::
+		All queued handler functions except :func:`enterJavaWindow_helper`
+		follow the convention ``(vmID, accContext, ...)``, where ``args[1]``
+		is a JOBJECT64 handle.  If a new handler with a different signature
+		is added, the eviction cleanup below must be updated.
+	"""
+	try:
+		internalFunctionQueue.put_nowait((func, args, kwargs))
+	except queue.Full:
+		try:
+			evictedFunc, evictedArgs, _evictedKwargs = internalFunctionQueue.get_nowait()
+			# Release the JOBJECT64 accContext handle from the evicted event.
+			# All handlers except enterJavaWindow_helper have args[1] as accContext.
+			if evictedFunc is not enterJavaWindow_helper and len(evictedArgs) >= 2:
+				bridgeDll.releaseJavaObject(evictedArgs[0], evictedArgs[1])
+		except queue.Empty:
+			pass
+		try:
+			internalFunctionQueue.put_nowait((func, args, kwargs))
+		except queue.Full:
+			log.debugWarning("JAB internal function queue full, failed to re-queue after eviction")
+			return
+		log.debugWarning("JAB internal function queue full, evicted oldest event")
 	core.requestPump()
 
 
@@ -972,8 +999,13 @@ def internal_hasFocus(sourceContext):
 
 
 @AccessBridge_PropertyNameChangeFP
-def event_nameChange(vmID, event, source, oldVal, newVal):
-	jabContext = JABContext(vmID=vmID, accContext=source)
+def internal_event_nameChange(vmID, event, source, oldVal, newVal):
+	internalQueueFunction(event_nameChange, vmID, source)
+	bridgeDll.releaseJavaObject(vmID, event)
+
+
+def event_nameChange(vmID, accContext):
+	jabContext = JABContext(vmID=vmID, accContext=accContext)
 	if jabContext.hwnd:
 		focus = api.getFocusObject()
 		obj = (
@@ -985,12 +1017,16 @@ def event_nameChange(vmID, event, source, oldVal, newVal):
 			eventHandler.queueEvent("nameChange", obj)
 	else:
 		log.debugWarning("Unable to obtain window handle for accessible context")
-	bridgeDll.releaseJavaObject(vmID, event)
 
 
 @AccessBridge_PropertyDescriptionChangeFP
-def event_descriptionChange(vmID, event, source, oldVal, newVal):
-	jabContext = JABContext(vmID=vmID, accContext=source)
+def internal_event_descriptionChange(vmID, event, source, oldVal, newVal):
+	internalQueueFunction(event_descriptionChange, vmID, source)
+	bridgeDll.releaseJavaObject(vmID, event)
+
+
+def event_descriptionChange(vmID, accContext):
+	jabContext = JABContext(vmID=vmID, accContext=accContext)
 	if jabContext.hwnd:
 		focus = api.getFocusObject()
 		obj = (
@@ -1002,12 +1038,16 @@ def event_descriptionChange(vmID, event, source, oldVal, newVal):
 			eventHandler.queueEvent("descriptionChange", obj)
 	else:
 		log.debugWarning("Unable to obtain window handle for accessible context")
-	bridgeDll.releaseJavaObject(vmID, event)
 
 
 @AccessBridge_PropertyValueChangeFP
-def event_valueChange(vmID, event, source, oldVal, newVal):
-	jabContext = JABContext(vmID=vmID, accContext=source)
+def internal_event_valueChange(vmID, event, source, oldVal, newVal):
+	internalQueueFunction(event_valueChange, vmID, source)
+	bridgeDll.releaseJavaObject(vmID, event)
+
+
+def event_valueChange(vmID, accContext):
+	jabContext = JABContext(vmID=vmID, accContext=accContext)
 	if jabContext.hwnd:
 		focus = api.getFocusObject()
 		obj = (
@@ -1019,7 +1059,6 @@ def event_valueChange(vmID, event, source, oldVal, newVal):
 			eventHandler.queueEvent("valueChange", obj)
 	else:
 		log.debugWarning("Unable to obtain window handle for accessible context")
-	bridgeDll.releaseJavaObject(vmID, event)
 
 
 @AccessBridge_PropertyStateChangeFP
@@ -1155,9 +1194,9 @@ def initialize():
 	# Register java events
 	bridgeDll.setFocusGainedFP(internal_event_focusGained)
 	bridgeDll.setPropertyActiveDescendentChangeFP(internal_event_activeDescendantChange)
-	bridgeDll.setPropertyNameChangeFP(event_nameChange)
-	bridgeDll.setPropertyDescriptionChangeFP(event_descriptionChange)
-	bridgeDll.setPropertyValueChangeFP(event_valueChange)
+	bridgeDll.setPropertyNameChangeFP(internal_event_nameChange)
+	bridgeDll.setPropertyDescriptionChangeFP(internal_event_descriptionChange)
+	bridgeDll.setPropertyValueChangeFP(internal_event_valueChange)
 	bridgeDll.setPropertyStateChangeFP(internal_event_stateChange)
 	bridgeDll.setPropertyCaretChangeFP(internal_event_caretChange)
 	isRunning = True

--- a/source/NVDAObjects/JAB/__init__.py
+++ b/source/NVDAObjects/JAB/__init__.py
@@ -248,12 +248,43 @@ class JAB(Window):
 			clsList.append(ComboBox)
 		elif role == "table":
 			clsList.append(Table)
-		elif self.parent and isinstance(self.parent, Table) and self.parent._jabTableInfo:
+		elif self._hasTableParent():
 			clsList.append(TableCell)
 		elif role == "progress bar":
 			clsList.append(ProgressBar)
 
 		clsList.append(JAB)
+
+	def _hasTableParent(self) -> bool:
+		"""Lightweight check if the immediate parent is a Table.
+
+		On the fast path (parent already cached), returns immediately
+		without any bridge calls.  On the first call, checks the parent's
+		role via a lightweight bridge call and only creates a full NVDAObject
+		when the role is "table" (which involves additional bridge calls).
+		"""
+		if hasattr(self, "_parent"):
+			parent = self._parent
+			return parent is not None and isinstance(parent, Table) and parent._jabTableInfo
+		parentContext = self.jabContext.getAccessibleParentFromContext()
+		if not parentContext:
+			return False
+		try:
+			parentInfo = parentContext.getAccessibleContextInfo()
+		except RuntimeError:
+			log.debugWarning("Could not get accessible context info for parent", exc_info=True)
+			return False
+		if parentInfo.role_en_US != "table":
+			return False
+		if self.indexInParent is None:
+			# Without indexInParent we cannot construct a valid JAB parent;
+			# _get_parent would also fall back to the Window ancestor here.
+			return False
+		# Parent is a table — create the full parent object reusing the context
+		# we already hold, so _get_parent doesn't make a redundant bridge call.
+		self._parent = JAB(jabContext=parentContext)
+		parent = self._parent
+		return parent is not None and isinstance(parent, Table) and parent._jabTableInfo
 
 	@classmethod
 	def kwargsFromSuper(cls, kwargs, relation: str | None = None) -> bool:

--- a/source/NVDAObjects/JAB/__init__.py
+++ b/source/NVDAObjects/JAB/__init__.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2006-2025 NV Access Limited, Leonard de Ruijter, Joseph Lee, Renaud Paquay, pvagner, hwf1324
+# Copyright (C) 2006-2026 NV Access Limited, Leonard de Ruijter, Joseph Lee, Renaud Paquay, pvagner, hwf1324
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 

--- a/source/NVDAObjects/JAB/__init__.py
+++ b/source/NVDAObjects/JAB/__init__.py
@@ -258,10 +258,18 @@ class JAB(Window):
 	def _hasTableParent(self) -> bool:
 		"""Lightweight check if the immediate parent is a Table.
 
-		On the fast path (parent already cached), returns immediately
-		without any bridge calls.  On the first call, checks the parent's
-		role via a lightweight bridge call and only creates a full NVDAObject
-		when the role is "table" (which involves additional bridge calls).
+		Avoids the expensive recursive parent-NVDAObject construction that
+		``isinstance(self.parent, Table)`` would otherwise perform via
+		``findOverlayClasses``.
+
+		On the fast path (parent already cached via ``self._parent``),
+		reuses the cached object; this may still trigger a
+		``getAccessibleTableInfo`` bridge call through ``parent._jabTableInfo``.
+		On the first call, queries the parent's role via a lightweight
+		``getAccessibleContextInfo`` bridge call and only materialises the
+		full NVDAObject when the role is ``"table"``; in that case it also
+		caches the NVDAObject in ``self._parent`` as a side effect, so a
+		subsequent ``_get_parent`` call does not repeat the bridge work.
 		"""
 		if hasattr(self, "_parent"):
 			parent = self._parent

--- a/tests/unit/test_javaAccessBridge.py
+++ b/tests/unit/test_javaAccessBridge.py
@@ -1,11 +1,14 @@
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-# Copyright (C) 2022 NV Access Limited, American Printing House for the Blind
+# Copyright (C) 2022-2026 NV Access Limited, American Printing House for the Blind
 
 """Unit tests for Java Access Bridge"""
 
+import queue
 import unittest
+from unittest.mock import call, MagicMock, patch
+
 from NVDAObjects import JAB
 import JABHandler
 from JABHandler import AccessibleKeystroke
@@ -99,3 +102,120 @@ class TestJavaAccessBridgeShortcutKeys(unittest.TestCase):
 				with self.subTest(controlCode=c, label=v, modifiers=modifiers, modLabels=modLabels):
 					expected = modLabels + [v]
 					self.assertListEqual(expected, JABHandler._getKeyLabels(modifiers, chr(c)))
+
+
+class TestInternalQueueFunction(unittest.TestCase):
+	"""Tests for :func:`JABHandler.internalQueueFunction` eviction behaviour.
+
+	These tests focus on the queue-full / eviction / retry-fail paths where
+	JOBJECT64 handle leaks would otherwise occur when JAB events are produced
+	faster than the main thread can consume them.
+	"""
+
+	@staticmethod
+	def _placeholderHandler(vmID, accContext):
+		"""Stand-in for a handler following the ``(vmID, accContext, ...)`` contract."""
+
+	def test_normalEnqueue_doesNotReleaseHandle(self):
+		"""A successful enqueue must not release the handle or touch bridgeDll."""
+		fakeQueue = queue.Queue(3)
+		with (
+			patch.object(JABHandler, "bridgeDll") as mockBridgeDll,
+			patch.object(JABHandler, "core") as mockCore,
+			patch.object(JABHandler, "internalFunctionQueue", fakeQueue),
+		):
+			JABHandler.internalQueueFunction(self._placeholderHandler, 1, 100)
+		mockBridgeDll.releaseJavaObject.assert_not_called()
+		mockCore.requestPump.assert_called_once()
+		self.assertEqual(fakeQueue.qsize(), 1)
+
+	def test_fullQueue_evictsOldestAndReleasesItsHandle(self):
+		"""When the queue is full, the oldest event's handle must be released."""
+		fakeQueue = queue.Queue(3)
+		with (
+			patch.object(JABHandler, "bridgeDll") as mockBridgeDll,
+			patch.object(JABHandler, "core") as mockCore,
+			patch.object(JABHandler, "internalFunctionQueue", fakeQueue),
+		):
+			# Fill the queue to capacity.
+			JABHandler.internalQueueFunction(self._placeholderHandler, 1, 100)
+			JABHandler.internalQueueFunction(self._placeholderHandler, 1, 101)
+			JABHandler.internalQueueFunction(self._placeholderHandler, 1, 102)
+			self.assertEqual(mockBridgeDll.releaseJavaObject.call_count, 0)
+			# One more — oldest (vmID=1, accContext=100) must be evicted and released.
+			JABHandler.internalQueueFunction(self._placeholderHandler, 1, 9999)
+		mockBridgeDll.releaseJavaObject.assert_called_once_with(1, 100)
+		self.assertEqual(fakeQueue.qsize(), 3)
+		self.assertEqual(mockCore.requestPump.call_count, 4)
+
+	def test_fullQueue_withEnterJavaWindowHelper_skipsRelease(self):
+		"""If the evicted event is enterJavaWindow_helper, no handle is released."""
+		fakeQueue = queue.Queue(3)
+		with (
+			patch.object(JABHandler, "bridgeDll") as mockBridgeDll,
+			patch.object(JABHandler, "core"),
+			patch.object(JABHandler, "internalFunctionQueue", fakeQueue),
+		):
+			# Fill the queue with enterJavaWindow_helper calls (single-arg, no JOBJECT64).
+			JABHandler.internalQueueFunction(JABHandler.enterJavaWindow_helper, 500)
+			JABHandler.internalQueueFunction(JABHandler.enterJavaWindow_helper, 501)
+			JABHandler.internalQueueFunction(JABHandler.enterJavaWindow_helper, 502)
+			# Add a normal event — oldest is enterJavaWindow_helper → release must be skipped.
+			JABHandler.internalQueueFunction(self._placeholderHandler, 1, 9999)
+		mockBridgeDll.releaseJavaObject.assert_not_called()
+
+	def test_evictionGuardsAgainstShortArgs(self):
+		"""If an evicted non-enterJavaWindow_helper handler happens to carry fewer
+		than two args, the guard must prevent a release attempt.
+
+		This is defensive coverage: all current handlers follow the
+		``(vmID, accContext, ...)`` contract, but the guard should still protect
+		future additions from silent leaks or index errors.
+		"""
+
+		def shortArgsHandler(singleArg):
+			pass
+
+		fakeQueue = MagicMock()
+		fakeQueue.put_nowait.side_effect = [queue.Full, None]
+		fakeQueue.get_nowait.return_value = (shortArgsHandler, (42,), {})
+		with (
+			patch.object(JABHandler, "bridgeDll") as mockBridgeDll,
+			patch.object(JABHandler, "core"),
+			patch.object(JABHandler, "internalFunctionQueue", fakeQueue),
+		):
+			JABHandler.internalQueueFunction(self._placeholderHandler, 1, 9999)
+		mockBridgeDll.releaseJavaObject.assert_not_called()
+
+	def test_retryFullAfterEviction_releasesNewEventHandle(self):
+		"""If the retry put_nowait also raises queue.Full, the new event's handle must be released."""
+		fakeQueue = MagicMock()
+		fakeQueue.put_nowait.side_effect = queue.Full
+		fakeQueue.get_nowait.return_value = (self._placeholderHandler, (1, 100), {})
+		with (
+			patch.object(JABHandler, "bridgeDll") as mockBridgeDll,
+			patch.object(JABHandler, "core") as mockCore,
+			patch.object(JABHandler, "internalFunctionQueue", fakeQueue),
+		):
+			JABHandler.internalQueueFunction(self._placeholderHandler, 1, 9999)
+		# Both handles released: evicted oldest (1, 100) and dropped new (1, 9999).
+		self.assertEqual(
+			mockBridgeDll.releaseJavaObject.call_args_list,
+			[call(1, 100), call(1, 9999)],
+		)
+		# Early return before requestPump.
+		mockCore.requestPump.assert_not_called()
+
+	def test_emptyQueueDuringEviction_handlesGracefully(self):
+		"""If get_nowait raises Empty and retry put_nowait still fails, only new handle is released."""
+		fakeQueue = MagicMock()
+		fakeQueue.put_nowait.side_effect = queue.Full
+		fakeQueue.get_nowait.side_effect = queue.Empty
+		with (
+			patch.object(JABHandler, "bridgeDll") as mockBridgeDll,
+			patch.object(JABHandler, "core") as mockCore,
+			patch.object(JABHandler, "internalFunctionQueue", fakeQueue),
+		):
+			JABHandler.internalQueueFunction(self._placeholderHandler, 1, 9999)
+		mockBridgeDll.releaseJavaObject.assert_called_once_with(1, 9999)
+		mockCore.requestPump.assert_not_called()

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -58,6 +58,7 @@ This is more noticeable for Windows releases which are enablement packages on to
 * Configuration profile triggers now activate when the Add-on Store is open. (#19583, @bramd)
 * Decorative Unicode letters such as negative squared, negative circled, and regional indicator symbol characters are now normalized to their base Latin letters when Unicode normalization is enabled. (#19608, @bramd)
 * NVDA no longer crashes when the Add-on Store download directory cannot be cleaned up due to file permission errors. (#19202, @christopherpross)
+* Fixed NVDA freezing when navigating in JetBrains IDEs. (#16741, @christopherpross)
 
 ### Changes for Developers
 


### PR DESCRIPTION
### Link to issue number:

Closes #16741

### Summary of the issue:

NVDA freezes for 10-15 seconds when navigating in JetBrains IDEs. Holding arrow keys in the editor causes the watchdog to trigger and eventually force recovery.

### Description of user facing changes:

Navigation in JetBrains IDEs no longer causes NVDA to freeze. This may also help with other rapid interaction patterns like scrolling with the mouse and clicking on code repeatedly.

### Description of developer facing changes:

None.

### Description of development approach:

Two compounding issues in JABHandler caused the freeze:

1. **Synchronous property change callbacks:** `event_nameChange`, `event_descriptionChange`, and `event_valueChange` were registered directly as JAB callbacks, doing heavy work (NVDAObject creation, bridge queries, event queuing) on the callback thread. This blocked the main thread during `wx.Yield()`. The fix wraps them in `internalQueueFunction`, matching the pattern already used by `event_focusGained`, `event_stateChange`, and `event_caretChange`.

2. **Recursive parent traversal in `findOverlayClasses`:** The table-cell check `self.parent and isinstance(self.parent, Table)` called `_get_parent()`, which created a full NVDAObject for the parent, recursively triggering `findOverlayClasses` up the entire component tree. Each level makes at least 2 cross-process bridge calls (`getAccessibleParentFromContext` + `getAccessibleContextInfo`). In JetBrains Rider, the editor text field sits 19 levels deep in the Java component hierarchy, so a single `findOverlayClasses` call caused 19 recursive NVDAObject instantiations with ~38 bridge calls. The fix introduces `_hasTableParent()` which checks the immediate parent's role via a lightweight bridge call and only creates a full NVDAObject when the role is "table" (which involves additional bridge calls).

3. **Incomplete callback cleanup:** 4 of 7 registered JAB callbacks were deregistered in `terminate()`, the 3 property change callbacks (name, description, value) were missing. All 7 are now symmetrically deregistered.

4. **Evict-oldest queue overflow strategy:** When the internal event queue (1000 items) is full, the oldest event is evicted to make room for the newest. JOBJECT64 handles owned by evicted events are released to prevent JNI reference leaks. This also fixes a pre-existing leak in `internal_event_activeDescendantChange` where `newDescendant` was never released when the source object did not have focus.

This PR was developed with AI assistance (Claude Code) with human review and manual testing.

### Testing strategy:

1. Open a JetBrains IDE (tested with Rider)
2. Open a code file with enough lines to scroll through (or create one by copying and pasting content a few times)
3. Focus the code editor
4. Hold the down arrow key for several seconds
5. Before fix: watchdog triggers within seconds, freeze lasts 10-15s
6. After fix: navigation stays fluid, no watchdog trigger

Also tested alt-tabbing in/out of the IDE, rapid Ctrl+Home/End navigation, and navigating tables in Rider's settings dialog with no regressions.

### Known issues with pull request:

Moving the three callbacks onto the internal queue initially caused `queue.Full` exceptions under rapid key repeat, producing error sounds. Catching the exception and dropping the newest event fixed the errors, but the final caret/name event was silently discarded, so the user never heard the line they landed on. Adding handle cleanup for dropped events (from Copilot AI review feedback) introduced additional bridge calls in the overflow path, which made the overflow worse. Making the queue unbounded was considered but rejected because a chatty Java app could grow the queue without limit. Switching to an evict-oldest strategy solved the announcement problem, but initially leaked the JOBJECT64 handles of evicted events. The current solution evicts the oldest event and releases its handle using a positional convention (`args[0]` = vmID, `args[1]` = accContext for all handlers except `enterJavaWindow_helper`). This convention is documented in the `internalQueueFunction` docstring but not enforced at the type level. Open to suggestions if anyone sees a cleaner approach.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.