### PR TITLE
Add DotPad buffered-receive and skipped BLE tests

### DIFF
--- a/source/brailleDisplayDrivers/dotPad/defs.py
+++ b/source/brailleDisplayDrivers/dotPad/defs.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2024 NV Access Limited
+# Copyright (C) 2024-2026 NV Access Limited, Dot Incorporated, Bram Duvigneau
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -130,3 +130,4 @@ class DP_KeyGroup(enum.IntEnum):
 
 
 DP_CHECKSUM_BASE = 0xA5
+DP_MAX_PACKET_SIZE = 512

--- a/source/brailleDisplayDrivers/dotPad/defs.py
+++ b/source/brailleDisplayDrivers/dotPad/defs.py
@@ -130,6 +130,18 @@ class DP_KeyGroup(enum.IntEnum):
 
 
 DP_CHECKSUM_BASE = 0xA5
-# Largest plausible total packet size (sync bytes + length header + body). Real DotPad
-# packets are far smaller; a declared length beyond this signals a desync or false header.
+
 DP_MAX_PACKET_SIZE = 512
+"""Largest plausible total packet size (sync bytes + length header + body).
+
+Real DotPad packets are far smaller; a declared length beyond this signals a
+desync or false header.
+"""
+
+DP_MIN_PACKET_SIZE = 4 + 5
+"""Smallest valid total packet size.
+
+A 4-byte header (2 sync bytes + 2-byte length) plus the 5-byte minimum body:
+destination + 2-byte command + sequence number + checksum. A declared length
+below this signals a desync or false header.
+"""

--- a/source/brailleDisplayDrivers/dotPad/defs.py
+++ b/source/brailleDisplayDrivers/dotPad/defs.py
@@ -130,4 +130,6 @@ class DP_KeyGroup(enum.IntEnum):
 
 
 DP_CHECKSUM_BASE = 0xA5
+# Largest plausible total frame size (sync bytes + length header + body). Real DotPad
+# frames are far smaller; a declared length beyond this signals a desync or false header.
 DP_MAX_PACKET_SIZE = 512

--- a/source/brailleDisplayDrivers/dotPad/defs.py
+++ b/source/brailleDisplayDrivers/dotPad/defs.py
@@ -130,6 +130,6 @@ class DP_KeyGroup(enum.IntEnum):
 
 
 DP_CHECKSUM_BASE = 0xA5
-# Largest plausible total frame size (sync bytes + length header + body). Real DotPad
-# frames are far smaller; a declared length beyond this signals a desync or false header.
+# Largest plausible total packet size (sync bytes + length header + body). Real DotPad
+# packets are far smaller; a declared length beyond this signals a desync or false header.
 DP_MAX_PACKET_SIZE = 512

--- a/source/brailleDisplayDrivers/dotPad/defs.py
+++ b/source/brailleDisplayDrivers/dotPad/defs.py
@@ -1,7 +1,7 @@
 # A part of NonVisual Desktop Access (NVDA)
 # Copyright (C) 2024-2026 NV Access Limited, Dot Incorporated, Bram Duvigneau
-# This file is covered by the GNU General Public License.
-# See the file COPYING for more details.
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
 
 
 import enum

--- a/source/brailleDisplayDrivers/dotPad/driver.py
+++ b/source/brailleDisplayDrivers/dotPad/driver.py
@@ -1,7 +1,7 @@
 # A part of NonVisual Desktop Access (NVDA)
 # Copyright (C) 2024-2026 NV Access Limited, Dot Incorporated, Bram Duvigneau
-# This file is covered by the GNU General Public License.
-# See the file COPYING for more details.
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
 
 
 import struct

--- a/source/brailleDisplayDrivers/dotPad/driver.py
+++ b/source/brailleDisplayDrivers/dotPad/driver.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2024-2025 NV Access Limited, Dot Incorporated, Bram Duvigneau
+# Copyright (C) 2024-2026 NV Access Limited, Dot Incorporated, Bram Duvigneau
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -24,6 +24,7 @@ from .defs import (
 	DP_Command,
 	DP_DisplayResponse,
 	DP_Features,
+	DP_MAX_PACKET_SIZE,
 	DP_PacketSeqFlag,
 	DP_PacketSyncByte,
 	DP_PerkinsKey,
@@ -158,20 +159,61 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 			return response.data
 		return b""
 
-	def _onReceive(self, header1: bytes):
-		if ord(header1) != DP_PacketSyncByte.SYNC1:
-			raise RuntimeError(f"Bad {header1=}")
-		header2 = self._dev.read(1)
-		if ord(header2) != DP_PacketSyncByte.SYNC2:
-			raise RuntimeError(f"bad {header2=}")
-		length = struct.unpack(">H", self._dev.read(2))[0]
-		packetBody = self._dev.read(length)
-		dest, cmdHigh, cmdLow, seqNum, *data, checksum = packetBody
+	def _onReceive(self, data: bytes) -> None:
+		"""Handle received data from either Serial (1 byte) or BLE (full packets).
+
+		Buffers incoming data and extracts complete packets as they arrive.
+		Works with both byte-at-a-time delivery (Serial) and packet-based
+		delivery (BLE).
+
+		:param data: Received data (1 byte for Serial, variable length for BLE).
+		"""
+		self._receiveBuffer.extend(data)
+
+		if len(self._receiveBuffer) > DP_MAX_PACKET_SIZE:
+			log.warning(
+				f"Receive buffer exceeded {DP_MAX_PACKET_SIZE} bytes, discarding data and resyncing",
+			)
+			self._receiveBuffer.clear()
+			return
+
+		while len(self._receiveBuffer) >= 4:
+			if self._receiveBuffer[0] != DP_PacketSyncByte.SYNC1:
+				log.debug(f"Bad first sync byte: 0x{self._receiveBuffer[0]:02x}, discarding")
+				self._receiveBuffer.pop(0)
+				continue
+
+			if self._receiveBuffer[1] != DP_PacketSyncByte.SYNC2:
+				log.debug(f"Bad second sync byte: 0x{self._receiveBuffer[1]:02x}, discarding")
+				self._receiveBuffer.pop(0)
+				continue
+
+			packetLength = struct.unpack(">H", bytes(self._receiveBuffer[2:4]))[0]
+			totalLength = 4 + packetLength
+
+			if len(self._receiveBuffer) < totalLength:
+				break
+
+			packet = bytes(self._receiveBuffer[:totalLength])
+			self._receiveBuffer = self._receiveBuffer[totalLength:]
+
+			try:
+				self._processPacket(packet[4:])
+			except (RuntimeError, ValueError, struct.error):
+				log.error("Error processing packet", exc_info=True)
+
+	def _processPacket(self, packetBody: bytes) -> None:
+		"""Process a complete packet body (after sync bytes and length header).
+
+		:param packetBody: The packet body containing dest, command, sequence,
+			data, and checksum.
+		"""
+		dest, cmdFirstByte, cmdSecondByte, seqNum, *data, checksum = packetBody
 		data = bytes(data)
 		if checksum != functools.reduce(operator.xor, packetBody[:-1], DP_CHECKSUM_BASE):
 			raise RuntimeError("bad checksum")
-		cmd = DP_Command(struct.unpack(">H", bytes([cmdHigh, cmdLow]))[0])
-		log.debug(f"Received responce  {cmd.name}, {dest=}, {seqNum=}, data={bytes(data)}")
+		cmd = DP_Command(struct.unpack(">H", bytes([cmdFirstByte, cmdSecondByte]))[0])
+		log.debug(f"Received response {cmd.name}, {dest=}, {seqNum=}, data={bytes(data)}")
 		if cmd.name.startswith("RSP_"):
 			self._recordCommandResponse(cmd, data, dest, seqNum)
 		elif cmd.name.startswith("NTF_"):
@@ -265,6 +307,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 				self._keysPressed.clear()
 
 	def __init__(self, port: str = "auto"):
+		self._receiveBuffer: bytearray = bytearray()
 		if port == "auto":
 			# Try autodetection
 			for portType, portId, port, portInfo in self._getTryPorts(port):

--- a/source/brailleDisplayDrivers/dotPad/driver.py
+++ b/source/brailleDisplayDrivers/dotPad/driver.py
@@ -25,6 +25,7 @@ from .defs import (
 	DP_DisplayResponse,
 	DP_Features,
 	DP_MAX_PACKET_SIZE,
+	DP_MIN_PACKET_SIZE,
 	DP_PacketSeqFlag,
 	DP_PacketSyncByte,
 	DP_PerkinsKey,
@@ -184,10 +185,11 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 			packetLength = struct.unpack(">H", bytes(self._receiveBuffer[2:4]))[0]
 			totalLength = 4 + packetLength
 
-			# Real DotPad packets are small. A declared length beyond the plausible
-			# maximum means we locked onto a false header (line noise or desync), so
-			# discard one byte and resync rather than stalling on a huge bogus length.
-			if totalLength > DP_MAX_PACKET_SIZE:
+			# Real DotPad packets fall within a narrow size range. A declared length
+			# outside the plausible bounds means we locked onto a false header (line
+			# noise or desync): discard one byte and resync rather than stalling on a
+			# huge bogus length or trying to unpack a runt packet.
+			if not DP_MIN_PACKET_SIZE <= totalLength <= DP_MAX_PACKET_SIZE:
 				log.debug(f"Implausible length {packetLength}, resyncing")
 				self._receiveBuffer.pop(0)
 				continue
@@ -201,7 +203,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 			try:
 				self._processPacket(packet[4:])
 			except (RuntimeError, ValueError, struct.error):
-				log.error("Error processing packet", exc_info=True)
+				log.exception("Error processing packet")
 
 	def _processPacket(self, packetBody: bytes) -> None:
 		"""Process a complete packet body (after sync bytes and length header).

--- a/source/brailleDisplayDrivers/dotPad/driver.py
+++ b/source/brailleDisplayDrivers/dotPad/driver.py
@@ -184,7 +184,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 			packetLength = struct.unpack(">H", bytes(self._receiveBuffer[2:4]))[0]
 			totalLength = 4 + packetLength
 
-			# Real DotPad frames are small. A declared length beyond the plausible
+			# Real DotPad packets are small. A declared length beyond the plausible
 			# maximum means we locked onto a false header (line noise or desync), so
 			# discard one byte and resync rather than stalling on a huge bogus length.
 			if totalLength > DP_MAX_PACKET_SIZE:

--- a/source/brailleDisplayDrivers/dotPad/driver.py
+++ b/source/brailleDisplayDrivers/dotPad/driver.py
@@ -170,13 +170,6 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 		"""
 		self._receiveBuffer.extend(data)
 
-		if len(self._receiveBuffer) > DP_MAX_PACKET_SIZE:
-			log.warning(
-				f"Receive buffer exceeded {DP_MAX_PACKET_SIZE} bytes, discarding data and resyncing",
-			)
-			self._receiveBuffer.clear()
-			return
-
 		while len(self._receiveBuffer) >= 4:
 			if self._receiveBuffer[0] != DP_PacketSyncByte.SYNC1:
 				log.debug(f"Bad first sync byte: 0x{self._receiveBuffer[0]:02x}, discarding")
@@ -190,6 +183,14 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 
 			packetLength = struct.unpack(">H", bytes(self._receiveBuffer[2:4]))[0]
 			totalLength = 4 + packetLength
+
+			# Real DotPad frames are small. A declared length beyond the plausible
+			# maximum means we locked onto a false header (line noise or desync), so
+			# discard one byte and resync rather than stalling on a huge bogus length.
+			if totalLength > DP_MAX_PACKET_SIZE:
+				log.debug(f"Implausible length {packetLength}, resyncing")
+				self._receiveBuffer.pop(0)
+				continue
 
 			if len(self._receiveBuffer) < totalLength:
 				break
@@ -346,6 +347,9 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 		:param port: The port to connect to.
 		:return: True if connection successful, False otherwise.
 		"""
+		# Start each probe with a clean buffer so stray bytes from a previously
+		# probed (non-DotPad) port can't corrupt this device's first response.
+		self._receiveBuffer.clear()
 		try:
 			self._dev = hwIo.Serial(
 				port=port,

--- a/tests/unit/brailleDisplayDrivers/__init__.py
+++ b/tests/unit/brailleDisplayDrivers/__init__.py
@@ -1,4 +1,4 @@
 # A part of NonVisual Desktop Access (NVDA)
 # Copyright (C) 2026 NV Access Limited, Dot Incorporated, Bram Duvigneau
-# This file is covered by the GNU General Public License.
-# See the file COPYING for more details.
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt

--- a/tests/unit/brailleDisplayDrivers/__init__.py
+++ b/tests/unit/brailleDisplayDrivers/__init__.py
@@ -1,0 +1,4 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2026 NV Access Limited, Dot Incorporated, Bram Duvigneau
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.

--- a/tests/unit/brailleDisplayDrivers/test_dotPad.py
+++ b/tests/unit/brailleDisplayDrivers/test_dotPad.py
@@ -81,6 +81,8 @@ class TestDotPadBufferedReceive(unittest.TestCase):
 		self.driver._onReceive(packet)
 
 		self.assertEqual(len(self.processedPackets), 1)
+		# The packet body passed on is the frame with the 4-byte sync/length header stripped.
+		self.assertEqual(self.processedPackets[0], packet[4:])
 		self.assertEqual(len(self.driver._receiveBuffer), 0)
 
 	def test_byteAtATime(self) -> None:
@@ -131,13 +133,23 @@ class TestDotPadBufferedReceive(unittest.TestCase):
 		self.assertEqual(len(self.processedPackets), 1)
 		self.assertEqual(len(self.driver._receiveBuffer), 0)
 
-	def test_bufferOverflow_cleared(self) -> None:
-		"""Test that buffer overflow triggers a clear and doesn't crash."""
-		oversizedData = b"\xaa" * (DP_MAX_PACKET_SIZE + 1)
+	def test_implausibleLength_resynchronize(self) -> None:
+		"""Test that a header declaring an oversized length is treated as a false header.
 
-		self.driver._onReceive(oversizedData)
+		Valid sync bytes followed by a length beyond DP_MAX_PACKET_SIZE indicate a
+		desync rather than a real packet, so the driver should discard a byte, resync,
+		and still process a valid packet that follows.
+		"""
+		bogusHeader = bytes([DP_PacketSyncByte.SYNC1, DP_PacketSyncByte.SYNC2]) + struct.pack(
+			">H",
+			DP_MAX_PACKET_SIZE,
+		)
+		goodPacket = self._createPacket(dest=0, cmd=DP_Command.RSP_DEVICE_NAME, seqNum=1, data=b"OK")
 
-		self.assertEqual(len(self.processedPackets), 0)
+		self.driver._onReceive(bogusHeader + goodPacket)
+
+		self.assertEqual(len(self.processedPackets), 1)
+		self.assertEqual(self.processedPackets[0], goodPacket[4:])
 		self.assertEqual(len(self.driver._receiveBuffer), 0)
 
 	def test_incompletePacketInBuffer(self) -> None:

--- a/tests/unit/brailleDisplayDrivers/test_dotPad.py
+++ b/tests/unit/brailleDisplayDrivers/test_dotPad.py
@@ -81,7 +81,7 @@ class TestDotPadBufferedReceive(unittest.TestCase):
 		self.driver._onReceive(packet)
 
 		self.assertEqual(len(self.processedPackets), 1)
-		# The packet body passed on is the frame with the 4-byte sync/length header stripped.
+		# The body passed on is the packet with the 4-byte sync/length header stripped.
 		self.assertEqual(self.processedPackets[0], packet[4:])
 		self.assertEqual(len(self.driver._receiveBuffer), 0)
 

--- a/tests/unit/brailleDisplayDrivers/test_dotPad.py
+++ b/tests/unit/brailleDisplayDrivers/test_dotPad.py
@@ -15,11 +15,13 @@ import struct
 import unittest
 from unittest.mock import MagicMock
 
+import bdDetect
 from brailleDisplayDrivers.dotPad.driver import BrailleDisplayDriver
 from brailleDisplayDrivers.dotPad.defs import (
 	DP_CHECKSUM_BASE,
 	DP_Command,
 	DP_MAX_PACKET_SIZE,
+	DP_MIN_PACKET_SIZE,
 	DP_PacketSyncByte,
 )
 
@@ -136,13 +138,36 @@ class TestDotPadBufferedReceive(unittest.TestCase):
 	def test_implausibleLength_resynchronize(self) -> None:
 		"""Test that a header declaring an oversized length is treated as a false header.
 
-		Valid sync bytes followed by a length beyond DP_MAX_PACKET_SIZE indicate a
-		desync rather than a real packet, so the driver should discard a byte, resync,
-		and still process a valid packet that follows.
+		Valid sync bytes followed by a length that pushes the total packet size beyond
+		DP_MAX_PACKET_SIZE indicate a desync rather than a real packet, so the driver
+		should discard a byte, resync, and still process a valid packet that follows.
 		"""
+		# A body length that makes totalLength (4-byte header + body) exceed DP_MAX_PACKET_SIZE.
+		oversizedBodyLength = DP_MAX_PACKET_SIZE
 		bogusHeader = bytes([DP_PacketSyncByte.SYNC1, DP_PacketSyncByte.SYNC2]) + struct.pack(
 			">H",
-			DP_MAX_PACKET_SIZE,
+			oversizedBodyLength,
+		)
+		goodPacket = self._createPacket(dest=0, cmd=DP_Command.RSP_DEVICE_NAME, seqNum=1, data=b"OK")
+
+		self.driver._onReceive(bogusHeader + goodPacket)
+
+		self.assertEqual(len(self.processedPackets), 1)
+		self.assertEqual(self.processedPackets[0], goodPacket[4:])
+		self.assertEqual(len(self.driver._receiveBuffer), 0)
+
+	def test_tooSmallLength_resynchronize(self) -> None:
+		"""Test that a header declaring a runt length is treated as a false header.
+
+		Valid sync bytes followed by a length too small to form the minimum packet
+		body indicate a desync rather than a real packet, so the driver should discard
+		a byte, resync, and still process a valid packet that follows.
+		"""
+		# A body length that makes totalLength (4-byte header + body) fall below DP_MIN_PACKET_SIZE.
+		runtBodyLength = DP_MIN_PACKET_SIZE - 4 - 1
+		bogusHeader = bytes([DP_PacketSyncByte.SYNC1, DP_PacketSyncByte.SYNC2]) + struct.pack(
+			">H",
+			runtBodyLength,
 		)
 		goodPacket = self._createPacket(dest=0, cmd=DP_Command.RSP_DEVICE_NAME, seqNum=1, data=b"OK")
 
@@ -205,8 +230,6 @@ class TestDotPadBle(unittest.TestCase):
 
 	def test_addBleDevices_registration(self) -> None:
 		"""addBleDevices registers _isBleDotPad as the BLE match function."""
-		import bdDetect
-
 		registrar = bdDetect.DriverRegistrar(BrailleDisplayDriver.name)
 		BrailleDisplayDriver.registerAutomaticDetection(registrar)
 		matchFunc = registrar._getDriverDict().get(bdDetect.CommunicationType.BLE)

--- a/tests/unit/brailleDisplayDrivers/test_dotPad.py
+++ b/tests/unit/brailleDisplayDrivers/test_dotPad.py
@@ -1,7 +1,7 @@
 # A part of NonVisual Desktop Access (NVDA)
 # Copyright (C) 2026 NV Access Limited, Dot Incorporated, Bram Duvigneau
-# This file is covered by the GNU General Public License.
-# See the file COPYING for more details.
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
 
 """Unit tests for the DotPad braille display driver.
 

--- a/tests/unit/brailleDisplayDrivers/test_dotPad.py
+++ b/tests/unit/brailleDisplayDrivers/test_dotPad.py
@@ -1,0 +1,210 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2026 NV Access Limited, Dot Incorporated, Bram Duvigneau
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+
+"""Unit tests for the DotPad braille display driver.
+
+Tests cover the buffered-receive logic that handles both byte-at-a-time
+delivery (Serial) and packet-based delivery (BLE).
+"""
+
+import functools
+import operator
+import struct
+import unittest
+from unittest.mock import MagicMock
+
+from brailleDisplayDrivers.dotPad.driver import BrailleDisplayDriver
+from brailleDisplayDrivers.dotPad.defs import (
+	DP_CHECKSUM_BASE,
+	DP_Command,
+	DP_MAX_PACKET_SIZE,
+	DP_PacketSyncByte,
+)
+
+
+class TestDotPadBufferedReceive(unittest.TestCase):
+	"""Tests for the DotPad buffered receive logic in _onReceive."""
+
+	def setUp(self) -> None:
+		self.driver = MagicMock(spec=BrailleDisplayDriver)
+		self.driver._receiveBuffer = bytearray()
+		self.driver._lastResponse = {}
+
+		self.processedPackets: list[bytes] = []
+
+		def mockProcessPacket(packetBody: bytes) -> None:
+			self.processedPackets.append(bytes(packetBody))
+
+		self.driver._processPacket = mockProcessPacket
+		self.driver._onReceive = BrailleDisplayDriver._onReceive.__get__(self.driver, type(self.driver))
+
+	def _createPacket(
+		self,
+		dest: int = 0,
+		cmd: int = DP_Command.RSP_DEVICE_NAME,
+		seqNum: int = 0,
+		data: bytes = b"",
+	) -> bytes:
+		"""Create a valid DotPad packet.
+
+		:param dest: Destination address.
+		:param cmd: Command code.
+		:param seqNum: Sequence number.
+		:param data: Packet data payload.
+		:return: Complete packet as bytes.
+		"""
+		packetBody = bytearray([dest])
+		packetBody.extend(struct.pack(">H", cmd))
+		packetBody.append(seqNum)
+		packetBody.extend(data)
+
+		checksum = functools.reduce(operator.xor, packetBody, DP_CHECKSUM_BASE)
+		packetBody.append(checksum)
+
+		packet = bytearray(
+			[
+				DP_PacketSyncByte.SYNC1,
+				DP_PacketSyncByte.SYNC2,
+			],
+		)
+		packet.extend(struct.pack(">H", len(packetBody)))
+		packet.extend(packetBody)
+
+		return bytes(packet)
+
+	def test_completePacketAtOnce(self) -> None:
+		"""Test receiving a complete packet in a single call (BLE behavior)."""
+		packet = self._createPacket(dest=0, cmd=DP_Command.RSP_DEVICE_NAME, seqNum=1, data=b"test")
+
+		self.driver._onReceive(packet)
+
+		self.assertEqual(len(self.processedPackets), 1)
+		self.assertEqual(len(self.driver._receiveBuffer), 0)
+
+	def test_byteAtATime(self) -> None:
+		"""Test receiving a packet one byte at a time (Serial behavior)."""
+		packet = self._createPacket(dest=0, cmd=DP_Command.RSP_DEVICE_NAME, seqNum=1, data=b"AB")
+
+		for byte in packet:
+			self.driver._onReceive(bytes([byte]))
+
+		self.assertEqual(len(self.processedPackets), 1)
+		self.assertEqual(len(self.driver._receiveBuffer), 0)
+
+	def test_partialPacket(self) -> None:
+		"""Test receiving a packet in multiple chunks."""
+		packet = self._createPacket(dest=0, cmd=DP_Command.RSP_DEVICE_NAME, seqNum=1, data=b"test data")
+
+		chunk1 = packet[: len(packet) // 2]
+		chunk2 = packet[len(packet) // 2 :]
+
+		self.driver._onReceive(chunk1)
+		self.assertEqual(len(self.processedPackets), 0)
+		self.assertGreater(len(self.driver._receiveBuffer), 0)
+
+		self.driver._onReceive(chunk2)
+		self.assertEqual(len(self.processedPackets), 1)
+		self.assertEqual(len(self.driver._receiveBuffer), 0)
+
+	def test_multiplePacketsAtOnce(self) -> None:
+		"""Test receiving multiple complete packets in a single call."""
+		packet1 = self._createPacket(dest=0, cmd=DP_Command.RSP_DEVICE_NAME, seqNum=1, data=b"A")
+		packet2 = self._createPacket(dest=0, cmd=DP_Command.REQ_DEVICE_NAME, seqNum=2, data=b"B")
+		packet3 = self._createPacket(dest=0, cmd=DP_Command.REQ_BOARD_INFORMATION, seqNum=3, data=b"C")
+
+		allPackets = packet1 + packet2 + packet3
+
+		self.driver._onReceive(allPackets)
+
+		self.assertEqual(len(self.processedPackets), 3)
+		self.assertEqual(len(self.driver._receiveBuffer), 0)
+
+	def test_badSyncByte_resynchronize(self) -> None:
+		"""Test that bad sync bytes are discarded and driver resynchronizes."""
+		badData = b"\x00\x11\x22"
+		goodPacket = self._createPacket(dest=0, cmd=DP_Command.RSP_DEVICE_NAME, seqNum=1, data=b"OK")
+
+		self.driver._onReceive(badData + goodPacket)
+
+		self.assertEqual(len(self.processedPackets), 1)
+		self.assertEqual(len(self.driver._receiveBuffer), 0)
+
+	def test_bufferOverflow_cleared(self) -> None:
+		"""Test that buffer overflow triggers a clear and doesn't crash."""
+		oversizedData = b"\xaa" * (DP_MAX_PACKET_SIZE + 1)
+
+		self.driver._onReceive(oversizedData)
+
+		self.assertEqual(len(self.processedPackets), 0)
+		self.assertEqual(len(self.driver._receiveBuffer), 0)
+
+	def test_incompletePacketInBuffer(self) -> None:
+		"""Test that an incomplete packet stays in the buffer."""
+		packet = self._createPacket(dest=0, cmd=DP_Command.RSP_DEVICE_NAME, seqNum=1, data=b"test data")
+		partialPacket = packet[:6]
+
+		self.driver._onReceive(partialPacket)
+
+		self.assertEqual(len(self.processedPackets), 0)
+		self.assertEqual(len(self.driver._receiveBuffer), 6)
+
+	def test_emptyData(self) -> None:
+		"""Test that empty data doesn't crash or produce spurious packets."""
+		self.driver._onReceive(b"")
+
+		self.assertEqual(len(self.processedPackets), 0)
+		self.assertEqual(len(self.driver._receiveBuffer), 0)
+
+	def test_partialHeaderOnly(self) -> None:
+		"""Test that a partial header stays buffered without processing."""
+		partialHeader = bytes([DP_PacketSyncByte.SYNC1, DP_PacketSyncByte.SYNC2, 0x00])
+
+		self.driver._onReceive(partialHeader)
+
+		self.assertEqual(len(self.processedPackets), 0)
+		self.assertEqual(len(self.driver._receiveBuffer), 3)
+
+
+@unittest.skip("Requires BLE support from PR C (#19122)")
+class TestDotPadBle(unittest.TestCase):
+	"""Skipped tests for BLE-specific DotPad functionality.
+
+	These tests document the expected BLE behavior and will be unskipped
+	when the BLE driver integration lands in PR C.
+	"""
+
+	def test_isBleDotPad_matching(self) -> None:
+		"""_isBleDotPad returns True for a device ID starting with 'DotPad'."""
+		device = MagicMock()
+		device.name = "DotPad320"
+		self.assertTrue(BrailleDisplayDriver._isBleDotPad(device))
+
+	def test_isBleDotPad_nonMatching(self) -> None:
+		"""_isBleDotPad returns False for an unrelated device."""
+		device = MagicMock()
+		device.name = "SomeOtherDevice"
+		self.assertFalse(BrailleDisplayDriver._isBleDotPad(device))
+
+	def test_check_returnsTrue(self) -> None:
+		"""check() returns True so DotPad always appears in the display list."""
+		self.assertTrue(BrailleDisplayDriver.check())
+
+	def test_addBleDevices_registration(self) -> None:
+		"""addBleDevices registers _isBleDotPad as the BLE match function."""
+		import bdDetect
+
+		registrar = bdDetect.DriverRegistrar(BrailleDisplayDriver.name)
+		BrailleDisplayDriver.registerAutomaticDetection(registrar)
+		matchFunc = registrar._getDriverDict().get(bdDetect.CommunicationType.BLE)
+		self.assertIsNotNone(matchFunc)
+		self.assertTrue(callable(matchFunc))
+
+	def test_tryConnect_bleDevice(self) -> None:
+		"""_tryConnect with a BLE device creates a hwIo.ble.Ble instance.
+
+		Requires hwIo.ble (PR A, #19838) and the _tryConnect BLE branch
+		(PR C). Will mock findDeviceByAddress, hwIo.ble.Ble,
+		_requestDeviceName, and _requestBoardInformation.
+		"""


### PR DESCRIPTION
### Link to issue number:

N/A. This is a follow-up to #19122 (DotPad BLE support) and #19838 (hwIo.ble module). As discussed in those PRs, the work is being split into three smaller PRs. This is "PR B" — the buffered-receive implementation and skipped BLE tests in preparation for the final BLE driver integration in PR C. There is no standalone issue tracking this change.

### Summary of the issue:

The DotPad driver's `_onReceive` method reads remaining packet bytes synchronously via `self._dev.read()` and raises `RuntimeError` on any malformed byte, which can kill the display connection. This approach also cannot handle BLE's packet-based delivery model where entire packets arrive in a single callback. The buffered-receive replaces this with a more robust approach as a prerequisite for BLE support.

### Description of user facing changes:

DotPad braille displays now handle malformed serial data more gracefully. Instead of crashing the display connection on a single corrupted byte, the driver resynchronizes and continues operating. In practice, since DotPad devices currently only connect over USB serial (which is a stable connection), users are unlikely to notice this change. The real benefit comes when BLE support lands in PR C, where packet-based delivery makes the buffered approach essential.

### Description of developer facing changes:

* Replaced `_onReceive(self, header1: bytes)` with a buffered-receive approach `_onReceive(self, data: bytes)` that accepts variable-length input (1 byte from Serial, full packets from BLE).
* Extracted `_processPacket(self, packetBody: bytes)` from the old inline parsing for clarity.
* Added `DP_MAX_PACKET_SIZE` protocol constant to `defs.py`.
* The buffered-receive handles: resynchronization on bad sync bytes, buffer overflow protection, partial-packet buffering, and multiple packets in a single call.

### Description of development approach:

Ported the buffered-receive logic from the `dotpad-ble` branch (#19122), keeping only the transport-agnostic parts. No BLE-specific code is included — that lands in PR C.

The approach replaces synchronous `self._dev.read()` calls within the callback with a `_receiveBuffer` that accumulates bytes across callbacks. Complete packets are extracted from the buffer as they become available.

### Testing strategy:

**Unit tests:** 9 unskipped tests covering:
- Complete packet in one call (BLE-style) and byte-at-a-time (Serial)
- Partial packets split across multiple calls
- Multiple concatenated packets extracted in order
- Bad sync byte resynchronization
- Buffer overflow protection
- Incomplete packet buffering
- Empty data handling
- Partial header buffering

Additionally, 5 skipped BLE-specific tests (`_isBleDotPad`, `check()`, `addBleDevices` registration, `_tryConnect` BLE path) are included as a TDD skeleton for PR C.

`rununittests.bat`: 1095 tests, 5 skipped, all pass. `ruff`, `pyright`, `markdownlint` all pass. `runcheckpot.bat`: 0 errors.

**Manual testing:** Tested with a DotPad connected over USB serial. The display works correctly with the new buffered-receive code — navigation, key input, and braille output all function as expected.

### Known issues with pull request:

None.

### Code Review Checklist:

- [x] Documentation:
  - [x] Change log entry: N/A (internal implementation improvement, will be covered by PR C's BLE changelog entry)
  - [x] User Documentation: N/A
  - [x] Developer / Technical Documentation: docstrings on `_onReceive`, `_processPacket`
  - [x] Context sensitive help for GUI changes: N/A
- [x] Testing:
  - [x] Unit tests
  - [x] System (end to end) tests: N/A
  - [x] Manual testing
- [x] UX of all users considered: N/A (internal change, no UI impact)
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.