### PR TITLE
ci: Fix inclusion of NVDA lib dll/exe/pdb files in symbols artifact.

### DIFF
--- a/ci/scripts/buildSymbolStore.ps1
+++ b/ci/scripts/buildSymbolStore.ps1
@@ -4,12 +4,17 @@ foreach ($syms in
 	# We don't just include source\*.dll because that would include system dlls.
 	"source\liblouis.dll",
 	"source\*.pdb",
-	"source\lib\*.dll",
-	"source\lib\*.pdb",
-	# We include source\lib64\*.exe to cover nvdaHelperRemoteLoader.
-	"source\lib64\*.dll",
-	"source\lib64\*.exe",
-	"source\lib64\*.pdb",
+	"source\lib\x64\*.dll",
+	"source\lib\x64\*.pdb",
+	"source\lib\x86\*.dll",
+	"source\lib\x86\*.pdb",
+	# We include *.exe to cover nvdaHelperRemoteLoader.
+	"source\lib\x86\*.exe",
+	"source\lib\arm64\*.dll",
+	"source\lib\arm64\*.pdb",
+	"source\lib\arm64\*.exe",
+	"source\lib\arm64ec\*.dll",
+	"source\lib\arm64ec\*.pdb",
 	"source\synthDrivers\*.dll",
 	"source\synthDrivers\*.pdb"
 ) {


### PR DESCRIPTION
### Link to issue number:
None.

### Summary of the issue:
The symbols artifact on CI doesn't include any of the dll/exe/pdb files from NVDA's lib directory. This makes it almost impossible to debug problems in NVDA C++ code unless you are using a local build. This is particularly problematic when trying to debug nvdaHelperRemote crashes experienced by users who aren't developers.

### Description of user facing changes:
None.

### Description of developer facing changes:
The symbols artifact on CI now includes dll/exe/pdb files from NVDA's lib directory.

I don't think this needs a change log entry because it doesn't change anything in NVDA itself.

### Description of development approach:
Once upon a time, NVDA had `lib\*.dll`, `lib64\*.dll`, etc. Some time ago, the directory structure changed to `lib\x64\*.dll`, `lib\x86\*.dll`, etc. In addition, arm64 and arm64ec libraries were added. However, the CI symbol store creation code was never updated accordingly. This PR updates the paths in the script.

### Testing strategy:
Checked the log output from the `Run ci/scripts/buildSymbolStore.ps1` step on GitHub actions for this pull request. Verified that it includes all files.
Also downloaded the artifact and checked that it contains all expected files.

### Known issues with pull request:
None.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
