### PR TITLE
Catch key, index and type error when getting scan results

### DIFF
--- a/source/addonStore/models/scanResults.py
+++ b/source/addonStore/models/scanResults.py
@@ -1,10 +1,12 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2025 NV Access Limited
+# Copyright (C) 2025-2026 NV Access Limited
 # This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
 # For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
 
 from dataclasses import dataclass
 from typing import Any
+
+from logHandler import log
 
 
 @dataclass(frozen=True)
@@ -22,7 +24,11 @@ class VirusTotalScanResults:
 	@classmethod
 	def fromDict(cls, addon: dict[str, Any]) -> "VirusTotalScanResults | None":
 		try:
-			analysisStats = addon["scanResults"]["virusTotal"][0]["last_analysis_stats"]
+			scanResults = addon["scanResults"]
+		except KeyError:
+			return None
+		try:
+			analysisStats = scanResults["virusTotal"][0]["last_analysis_stats"]
 			return cls(
 				scanUrl=addon["vtScanUrl"],
 				malicious=analysisStats["malicious"],
@@ -34,7 +40,8 @@ class VirusTotalScanResults:
 				confirmedTimeout=analysisStats["confirmed-timeout"],
 				typeUnsupported=analysisStats["type-unsupported"],
 			)
-		except KeyError:
+		except (KeyError, IndexError, TypeError):
+			log.error(f"Malformed add-on scan results.: {addon!r}", exc_info=True)
 			return None
 
 	@property


### PR DESCRIPTION
### Link to issue number:
Fixes #19952

### Summary of the issue:
The add-on store fails to load if invalid data is returned from the server.

### Description of user facing changes:
Crash no-longer occurs.

### Description of developer facing changes:
None.

### Description of development approach:
When extracting scan results, catch `TypeError` and `IndexError` as well as `KeyError`.

### Testing strategy:
Created a faulty cache:

```
jq `
'.data|=(fromjson|.[0].scanResults.virusTotal|=null|tostring)' `
_cachedCompatibleAddons.old.json > _cachedCompatibleAddons.json 
```

Ran from source and checked that the add-on store opened.

### Known issues with pull request:
In my testing, the invalid file also caused NVDA not to start, but the OP didn't report any such problem, so their problem may have been slightly different? Nevertheless this fix solves an actual bug.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
