### PR TITLE
Fix deprecated usage of getLevelName

### DIFF
--- a/source/config/__init__.py
+++ b/source/config/__init__.py
@@ -590,7 +590,7 @@ class ConfigManager(object):
 		self.profiles.append(profile)
 		self._handleProfileSwitch()
 
-	def _loadConfig(self, fn, fileError=False):
+	def _loadConfig(self, fn: str, fileError: bool = False) -> ConfigObj:
 		log.info("Loading config: {0}".format(fn))
 		profile = ConfigObj(fn, indent_type="\t", encoding="UTF-8", file_error=fileError)
 		# Python converts \r\n to \n when reading files in Windows, so ConfigObj can't determine the true line ending.
@@ -609,10 +609,15 @@ class ConfigManager(object):
 		# since profile settings are not yet imported we have to "peek" to see
 		# if debug level logging is enabled.
 		try:
-			logLevelName = profile["general"]["loggingLevel"]
+			logLevelName: str  = profile["general"]["loggingLevel"]
+			if not logLevelName:
+				level = None
+			else:
+				level = logging.getLevelNamesMapping().get(logLevelName)
 		except KeyError:
-			logLevelName = None
-		if log.isEnabledFor(log.DEBUG) or (logLevelName and DEBUG >= logging.getLevelName(logLevelName)):
+			level = None
+
+		if log.isEnabledFor(log.DEBUG) or (level and DEBUG >= level):
 			# Log at level info to ensure that the profile is logged.
 			log.info(
 				"Config loaded (after upgrade, and in the state it will be used by NVDA):\n{0}".format(

--- a/source/config/__init__.py
+++ b/source/config/__init__.py
@@ -590,7 +590,7 @@ class ConfigManager(object):
 		self.profiles.append(profile)
 		self._handleProfileSwitch()
 
-	def _loadConfig(self, fn: str, fileError: bool = False) -> ConfigObj:
+	def _loadConfig(self, fn: str | None, fileError: bool = False) -> ConfigObj:
 		log.info("Loading config: {0}".format(fn))
 		profile = ConfigObj(fn, indent_type="\t", encoding="UTF-8", file_error=fileError)
 		# Python converts \r\n to \n when reading files in Windows, so ConfigObj can't determine the true line ending.

--- a/source/config/__init__.py
+++ b/source/config/__init__.py
@@ -609,7 +609,7 @@ class ConfigManager(object):
 		# since profile settings are not yet imported we have to "peek" to see
 		# if debug level logging is enabled.
 		try:
-			logLevelName: str  = profile["general"]["loggingLevel"]
+			logLevelName: str = profile["general"]["loggingLevel"]
 			if not logLevelName:
 				level = None
 			else:

--- a/source/logHandler.py
+++ b/source/logHandler.py
@@ -658,10 +658,10 @@ def setLogLevelFromConfig():
 	import config
 
 	levelName: str = config.conf["general"]["loggingLevel"]
-	level = logging.getLevelNamesMapping().get(levelName, log.INFO)
+	level = logging.getLevelNamesMapping().get(levelName)
 	# The lone exception to level higher than INFO is "OFF" (100).
 	# Setting a log level to something other than options found in the GUI is unsupported.
-	if level not in (log.DEBUG, log.IO, log.DEBUGWARNING, log.INFO, log.OFF):
+	if level is None or level not in (log.DEBUG, log.IO, log.DEBUGWARNING, log.INFO, log.OFF):
 		log.warning("invalid setting for logging level: %s" % levelName)
 		level = log.INFO
 		config.conf["general"]["loggingLevel"] = logging.getLevelName(log.INFO)

--- a/source/logHandler.py
+++ b/source/logHandler.py
@@ -657,9 +657,8 @@ def setLogLevelFromConfig():
 		return
 	import config
 
-	levelName = config.conf["general"]["loggingLevel"]
-	# logging.getLevelName can give you a level number if given a name.
-	level = logging.getLevelName(levelName)
+	levelName: str = config.conf["general"]["loggingLevel"]
+	level = logging.getLevelNamesMapping().get(levelName, log.INFO)
 	# The lone exception to level higher than INFO is "OFF" (100).
 	# Setting a log level to something other than options found in the GUI is unsupported.
 	if level not in (log.DEBUG, log.IO, log.DEBUGWARNING, log.INFO, log.OFF):


### PR DESCRIPTION
Converting loglevel name strings to integers via `getLevelName` is deprecated. Instead you are meant to use `getLevelNamesMapping` now.