### PR TITLE
Update readme with clearer issue reporting guidelines

### DIFF
--- a/projectDocs/issues/githubIssueTemplateExplanationAndExamples.md
+++ b/projectDocs/issues/githubIssueTemplateExplanationAndExamples.md
@@ -27,8 +27,8 @@ We currently have the following templates:
   * Please note that these are reported differently, for more information refer to our [disclosure policy/procedure](https://github.com/nvaccess/nvda/blob/master/security.md)
 * Issues with materials handled by translators should be reported to the [NVDA Translators list](https://groups.io/g/nvda-translations).
 These include:
-  * NVDA interface text that is incorrectly translated from English
-  * Contents of the User Guide and Changes documents that are incorrectly translated from English
+  * NVDA interface text that is incorrect in languages other than English
+  * Contents of the User Guide and Changes documents that are incorrect in languages other than English
   * Input gestures, punctuation/symbol pronunciations, and character descriptions in languages other than English
 
 These templates are fillable forms that guide you through the process of providing the necessary information for your issue.

--- a/projectDocs/issues/githubIssueTemplateExplanationAndExamples.md
+++ b/projectDocs/issues/githubIssueTemplateExplanationAndExamples.md
@@ -29,7 +29,7 @@ We currently have the following templates:
 These include:
   * NVDA interface text that is incorrectly translated from English
   * Contents of the User Guide and Changes documents that are incorrectly translated from English
-  * Locale-specific gestures, symbols and character descriptions
+  * Input gestures, punctuation/symbol pronunciations, and character descriptions in languages other than English
 
 These templates are fillable forms that guide you through the process of providing the necessary information for your issue.
 The "Advanced" versions of these templates listed when [choosing templates for new issues](https://github.com/nvaccess/nvda/issues/new/choose) ask for the same information, but in a more free-form manner that doesn't use separate fields to guide and structure the process.

--- a/projectDocs/issues/githubIssueTemplateExplanationAndExamples.md
+++ b/projectDocs/issues/githubIssueTemplateExplanationAndExamples.md
@@ -26,13 +26,13 @@ We currently have the following templates:
 * For [security vulnerabilities](https://github.com/nvaccess/nvda/security/advisories/new)
   * Please note that these are reported differently, for more information refer to our [disclosure policy/procedure](https://github.com/nvaccess/nvda/blob/master/security.md)
 * Issues with materials handled by translators should be reported to the [NVDA Translators list](https://groups.io/g/nvda-translations).
-This includes:
+These include:
   * NVDA interface text that is incorrectly translated from English
   * Contents of the User Guide and Changes documents that are incorrectly translated from English
   * Locale-specific gestures, symbols and character descriptions
 
 These are a fillable form that guides you through the process of providing the necessary information for your issue.
-The "Advanced" version of these templates listed when [choosing templates for new issues](https://github.com/nvaccess/nvda/issues/new/choose) asks for the same information, but in a more free-form manner, with less supporting information.
+The "Advanced" versions of these templates listed when [choosing templates for new issues](https://github.com/nvaccess/nvda/issues/new/choose) ask for the same information, but in a more free-form manner that doesn't use separate fields to guide and structure the process.
 
 ## Help
 

--- a/projectDocs/issues/githubIssueTemplateExplanationAndExamples.md
+++ b/projectDocs/issues/githubIssueTemplateExplanationAndExamples.md
@@ -25,6 +25,11 @@ We currently have the following templates:
   * Review [Proposing Major Changes](../dev/proposingMajorChanges.md) for more information.
 * For [security vulnerabilities](https://github.com/nvaccess/nvda/security/advisories/new)
   * Please note that these are reported differently, for more information refer to our [disclosure policy/procedure](https://github.com/nvaccess/nvda/blob/master/security.md)
+* Issues with materials handled by translators should be reported to the [NVDA Translators list](https://groups.io/g/nvda-translations).
+This includes:
+  * NVDA interface text that is incorrectly translated from English
+  * User Guide and Changes contents that are incorrectly translated from English
+  * Locale specific gestures, symbols and character descriptions
 
 These are a fillable form that guides you through the process of providing the necessary information for your issue.
 The "Advanced" version of these templates listed when [choosing templates for new issues](https://github.com/nvaccess/nvda/issues/new/choose) asks for the same information, but in a more free-form manner, with less supporting information.

--- a/projectDocs/issues/githubIssueTemplateExplanationAndExamples.md
+++ b/projectDocs/issues/githubIssueTemplateExplanationAndExamples.md
@@ -28,8 +28,8 @@ We currently have the following templates:
 * Issues with materials handled by translators should be reported to the [NVDA Translators list](https://groups.io/g/nvda-translations).
 This includes:
   * NVDA interface text that is incorrectly translated from English
-  * User Guide and Changes contents that are incorrectly translated from English
-  * Locale specific gestures, symbols and character descriptions
+  * Contents of the User Guide and Changes documents that are incorrectly translated from English
+  * Locale-specific gestures, symbols and character descriptions
 
 These are a fillable form that guides you through the process of providing the necessary information for your issue.
 The "Advanced" version of these templates listed when [choosing templates for new issues](https://github.com/nvaccess/nvda/issues/new/choose) asks for the same information, but in a more free-form manner, with less supporting information.

--- a/projectDocs/issues/githubIssueTemplateExplanationAndExamples.md
+++ b/projectDocs/issues/githubIssueTemplateExplanationAndExamples.md
@@ -31,7 +31,7 @@ These include:
   * Contents of the User Guide and Changes documents that are incorrectly translated from English
   * Locale-specific gestures, symbols and character descriptions
 
-These are a fillable form that guides you through the process of providing the necessary information for your issue.
+These templates are fillable forms that guide you through the process of providing the necessary information for your issue.
 The "Advanced" versions of these templates listed when [choosing templates for new issues](https://github.com/nvaccess/nvda/issues/new/choose) ask for the same information, but in a more free-form manner that doesn't use separate fields to guide and structure the process.
 
 ## Help

--- a/projectDocs/issues/githubIssueTemplateExplanationAndExamples.md
+++ b/projectDocs/issues/githubIssueTemplateExplanationAndExamples.md
@@ -27,8 +27,8 @@ We currently have the following templates:
   * Please note that these are reported differently, for more information refer to our [disclosure policy/procedure](https://github.com/nvaccess/nvda/blob/master/security.md)
 * Issues with materials handled by translators should be reported to the [NVDA Translators list](https://groups.io/g/nvda-translations).
 These include:
-  * NVDA interface text that is incorrect in languages other than English
-  * Contents of the User Guide and Changes documents that are incorrect in languages other than English
+  * NVDA interface text that is incorrect in languages other than English
+  * Contents of the User Guide and Changes documents that are incorrect in languages other than English
   * Input gestures, punctuation/symbol pronunciations, and character descriptions in languages other than English
 
 These templates are fillable forms that guide you through the process of providing the necessary information for your issue.

--- a/projectDocs/issues/readme.md
+++ b/projectDocs/issues/readme.md
@@ -5,9 +5,14 @@ Please read the [issue template guide](./githubIssueTemplateExplanationAndExampl
 For advanced reporters, consider reading our [issue triage guide](./triage.md) to ensure the issue can easily be worked on.
 If you don't have a clear idea of the issue, and you are unable to fill out the template, open a [GitHub discussion instead](https://github.com/nvaccess/nvda/discussions).
 
-Do not report security issues via GitHub, instead follow our [security policy](../../security.md).
+Do not report security issues via GitHub issues, instead follow our [security policy](../../security.md).
 
-Issues with translations should be reported to the [NVDA Translators list](https://groups.io/g/nvda-translations).
+Issues with materials handled by translators should be reported to the [NVDA Translators list](https://groups.io/g/nvda-translations).
+This includes:
+
+* NVDA interface text that is incorrectly translated from English
+* User Guide and Changes contents that are incorrectly translated from English
+* Locale specific gestures, symbols and character descriptions
 
 If you are reporting an issue with an application or website, please consider reporting the issue to the [authors of the application/website](./thirdPartyReporting.md) first.
 

--- a/projectDocs/issues/readme.md
+++ b/projectDocs/issues/readme.md
@@ -11,8 +11,8 @@ Issues with materials handled by translators should be reported to the [NVDA Tra
 This includes:
 
 * NVDA interface text that is incorrectly translated from English
-* User Guide and Changes contents that are incorrectly translated from English
-* Locale specific gestures, symbols and character descriptions
+* User Guide and Changes documents/content that are incorrectly translated from English
+* Locale-specific gestures, symbols and character descriptions
 
 If you are reporting an issue with an application or website, please consider reporting the issue to the [authors of the application/website](./thirdPartyReporting.md) first.
 

--- a/projectDocs/issues/readme.md
+++ b/projectDocs/issues/readme.md
@@ -11,7 +11,7 @@ Issues with materials handled by translators should be reported to the [NVDA Tra
 This includes:
 
 * NVDA interface text that is incorrectly translated from English
-* User Guide and Changes documents/content that are incorrectly translated from English
+* Contents of the User Guide and Changes documents that are incorrectly translated from English
 * Locale-specific gestures, symbols and character descriptions
 
 If you are reporting an issue with an application or website, please consider reporting the issue to the [authors of the application/website](./thirdPartyReporting.md) first.

--- a/projectDocs/issues/readme.md
+++ b/projectDocs/issues/readme.md
@@ -5,7 +5,7 @@ Please read the [issue template guide](./githubIssueTemplateExplanationAndExampl
 For advanced reporters, consider reading our [issue triage guide](./triage.md) to ensure the issue can easily be worked on.
 If you don't have a clear idea of the issue, and you are unable to fill out the template, open a [GitHub discussion](https://github.com/nvaccess/nvda/discussions/new/choose) instead.
 
-Do not report security issues via GitHub issues, instead follow our [security policy](../../security.md).
+Do not report security concerns via GitHub issues, instead follow our [security policy](../../security.md).
 
 Issues with materials handled by translators should be reported to the [NVDA Translators list](https://groups.io/g/nvda-translations).
 These include:

--- a/projectDocs/issues/readme.md
+++ b/projectDocs/issues/readme.md
@@ -3,12 +3,12 @@
 Issues can be [reported via GitHub](https://github.com/nvaccess/nvda/issues/new/choose).
 Please read the [issue template guide](./githubIssueTemplateExplanationAndExamples.md) for help filling out the appropriate template.
 For advanced reporters, consider reading our [issue triage guide](./triage.md) to ensure the issue can easily be worked on.
-If you don't have a clear idea of the issue, and you are unable to fill out the template, open a [GitHub discussion instead](https://github.com/nvaccess/nvda/discussions).
+If you don't have a clear idea of the issue, and you are unable to fill out the template, open a [GitHub discussion](https://github.com/nvaccess/nvda/discussions/new/choose) instead.
 
 Do not report security issues via GitHub issues, instead follow our [security policy](../../security.md).
 
 Issues with materials handled by translators should be reported to the [NVDA Translators list](https://groups.io/g/nvda-translations).
-This includes:
+These include:
 
 * NVDA interface text that is incorrectly translated from English
 * Contents of the User Guide and Changes documents that are incorrectly translated from English

--- a/projectDocs/issues/readme.md
+++ b/projectDocs/issues/readme.md
@@ -10,8 +10,8 @@ Do not report security concerns via GitHub issues, instead follow our [security 
 Issues with materials handled by translators should be reported to the [NVDA Translators list](https://groups.io/g/nvda-translations).
 These include:
 
-* NVDA interface text that is incorrectly translated from English
-* Contents of the User Guide and Changes documents that are incorrectly translated from English
+* NVDA interface text that is incorrect in languages other than English
+* Contents of the User Guide and Changes documents that are incorrect in languages other than English
 * Input gestures, punctuation/symbol pronunciations, and character descriptions in languages other than English
 
 If you are reporting an issue with an application or website, please consider reporting the issue to the [authors of the application/website](./thirdPartyReporting.md) first.

--- a/projectDocs/issues/readme.md
+++ b/projectDocs/issues/readme.md
@@ -10,8 +10,8 @@ Do not report security concerns via GitHub issues, instead follow our [security 
 Issues with materials handled by translators should be reported to the [NVDA Translators list](https://groups.io/g/nvda-translations).
 These include:
 
-* NVDA interface text that is incorrect in languages other than English
-* Contents of the User Guide and Changes documents that are incorrect in languages other than English
+* NVDA interface text that is incorrect in languages other than English
+* Contents of the User Guide and Changes documents that are incorrect in languages other than English
 * Input gestures, punctuation/symbol pronunciations, and character descriptions in languages other than English
 
 If you are reporting an issue with an application or website, please consider reporting the issue to the [authors of the application/website](./thirdPartyReporting.md) first.

--- a/projectDocs/issues/readme.md
+++ b/projectDocs/issues/readme.md
@@ -12,7 +12,7 @@ These include:
 
 * NVDA interface text that is incorrectly translated from English
 * Contents of the User Guide and Changes documents that are incorrectly translated from English
-* Locale-specific gestures, symbols and character descriptions
+* Input gestures, punctuation/symbol pronunciations, and character descriptions in languages other than English
 
 If you are reporting an issue with an application or website, please consider reporting the issue to the [authors of the application/website](./thirdPartyReporting.md) first.
 


### PR DESCRIPTION
Clarify instructions on reporting security issues and translations.

<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Closes #19949

### Summary of the issue:
The issues readme says security issues shouldn't be reported via github, but we accept github advisories. We should specify not to use GitHub issues.

It is unclear what materials should be reported to the translators mailing list.

### Description of user facing changes:
This pull request updates the issue reporting guidelines in the `projectDocs/issues/readme.md` file to clarify where to report translation-related issues and to provide more detailed instructions for contributors.

**Documentation updates:**

* Clarified that security issues should not be reported via GitHub issues, but through the security policy.
* Expanded guidance on translation-related issues, specifying that problems with NVDA interface text, User Guide and Changes content, and locale-specific gestures, symbols, and character descriptions should be reported to the NVDA Translators list.

