### PR TITLE
[Experiment] Debounce logviewer refresh

### DIFF
--- a/source/gui/logViewer.py
+++ b/source/gui/logViewer.py
@@ -1,7 +1,7 @@
 # A part of NonVisual Desktop Access (NVDA)
-# This file is covered by the GNU General Public License.
-# See the file COPYING for more details.
-# Copyright (C) 2008-2024 NV Access Limited, Cyrille Bougot
+# Copyright (C) 2008-2026 NV Access Limited, Cyrille Bougot
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
 
 """Provides functionality to view the NVDA log."""
 
@@ -10,6 +10,7 @@ import globalVars
 import gui
 import gui.contextHelp
 from gui import blockAction
+from utils.debounce import debounceLimiter
 
 
 #: The singleton instance of the log viewer UI.
@@ -66,21 +67,29 @@ class LogViewer(
 		self.refresh()
 		self.outputCtrl.SetFocus()
 
-	def refresh(self, evt=None):
+	@debounceLimiter(delayTimeMs=100)
+	def refresh(self, evt: wx.MenuEvent | None = None):
 		# Ignore if log is not initialized
 		if globalVars.appArgs.logFileName is None:
 			return
+
 		pos = self.outputCtrl.GetInsertionPoint()
-		# Append new text to the output control which has been written to the log file since the last refresh.
+
 		try:
 			f = open(globalVars.appArgs.logFileName, "r", encoding="UTF-8")
+		except IOError:
+			return
+
+		# Append new text to the output control which has been written to the log file since the last refresh.
+		try:
 			f.seek(self._lastFilePos)
 			self.outputCtrl.AppendText(f.read())
 			self._lastFilePos = f.tell()
-			self.outputCtrl.SetInsertionPoint(pos)
-			f.close()
 		except IOError:
 			pass
+		finally:
+			self.outputCtrl.SetInsertionPoint(pos)
+			f.close()
 
 	def onActivate(self, evt):
 		if evt.GetActive():


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Fixes #16322

### Summary of the issue:

Log viewer can freeze when dealing with longer sessions.
An assumption is made that this is due to the file seeking/reading and setting the control insertion points are heavy operations, that get flooded as the log updates frequently.

### Description of user facing changes:
Hopefully no more freezes

### Description of developer facing changes:
None

### Description of development approach:
This pull request updates the `logViewer.py` file to enhance the log refresh functionality. The most significant changes include introducing a debounce mechanism for the log refresh method, and improving error handling when accessing the log file.

* Added import of `debounceLimiter` and applied it to the `refresh` method to prevent excessive refresh calls, improving performance and responsiveness. [[1]](diffhunk://#diff-c294b3e7e98f25c59ad90b610474bf2b7f63e06d27e4d04222614f187880a033R13) [[2]](diffhunk://#diff-c294b3e7e98f25c59ad90b610474bf2b7f63e06d27e4d04222614f187880a033L69-R92)
* Improved error handling in the `refresh` method by properly catching `IOError` when opening the log file and ensuring the file is closed in a `finally` block.

### Testing strategy:
User testing
### Known issues with pull request:
none
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [ ] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [ ] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [ ] API is compatible with existing add-ons.
- [ ] Security precautions taken.
