### PR TITLE
Fix Word legacy spelling errors reporting

### DIFF
--- a/source/NVDAObjects/window/winword.py
+++ b/source/NVDAObjects/window/winword.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2006-2025 NV Access Limited, Manish Agrawal, Derek Riemer, Babbage B.V., Cyrille Bougot,
+# Copyright (C) 2006-2026 NV Access Limited, Manish Agrawal, Derek Riemer, Babbage B.V., Cyrille Bougot,
 # Leonard de Ruijter
 # This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
 # For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
@@ -494,7 +494,7 @@ formatConfigFlagsMap = {
 	"reportColor": 0x8,
 	"reportAlignment": 0x10,
 	"reportStyle": 0x20,
-	"reportSpellingErrors": 0x40,
+	"reportSpellingErrors2": 0x40,
 	"reportPage": 0x80,
 	"reportLineNumber": 0x100,
 	"reportTables": 0x200,


### PR DESCRIPTION
### Link to issue number:
Fix-up of #17997

[Reported](https://groups.io/g/nvda-fr/topic/nvda_2026_1_beta_et_l_annonce/118894622) on French mailing list.

### Summary of the issue:
In 2026.1beta versions, spelling errors are no longer reported in Word legacy.

### Description of user facing changes:
Spelling errors can now again be reported in Word legacy.

### Description of developer facing changes:
N/A
### Description of development approach:
In #17997, the config key "reportSpellingErrors" has been modified to "reportSpellingErrors2" due to upgrade. But one use of this config key has been forgotten. It is being fixed here.

### Testing strategy:
Manual tests with legacy and UIA Word.

### Known issues with pull request:
N/A
### Code Review Checklist:


- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
