### PR TITLE
Introduce regex backend shim with opt-in feature flag

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ dependencies = [
 	"mdx-gh-links==0.4",
 	"l2m4m==1.0.4",
 	"pymdown-extensions==10.17.1",
+	"regex>=2026.4.4",
 ]
 
 [project.urls]

--- a/source/IAccessibleHandler/__init__.py
+++ b/source/IAccessibleHandler/__init__.py
@@ -11,7 +11,7 @@ from winBindings import user32
 # should be used to export it.
 from .types import RelationType  # noqa: F401
 
-import re
+from textUtils import _regex as re
 import struct
 from typing import (
 	Optional,

--- a/source/IAccessibleHandler/__init__.py
+++ b/source/IAccessibleHandler/__init__.py
@@ -11,7 +11,7 @@ from winBindings import user32
 # should be used to export it.
 from .types import RelationType  # noqa: F401
 
-from textUtils import _regex as re
+import _regex as re
 import struct
 from typing import (
 	Optional,

--- a/source/NVDAObjects/IAccessible/__init__.py
+++ b/source/NVDAObjects/IAccessible/__init__.py
@@ -23,7 +23,7 @@ from comtypes.hresult import S_OK, S_FALSE
 import comtypes.client
 import ctypes
 import os
-from textUtils import _regex as re
+import _regex as re
 import sys
 import itertools
 import importlib

--- a/source/NVDAObjects/IAccessible/__init__.py
+++ b/source/NVDAObjects/IAccessible/__init__.py
@@ -23,7 +23,7 @@ from comtypes.hresult import S_OK, S_FALSE
 import comtypes.client
 import ctypes
 import os
-import re
+from textUtils import _regex as re
 import sys
 import itertools
 import importlib

--- a/source/NVDAObjects/IAccessible/msOffice.py
+++ b/source/NVDAObjects/IAccessible/msOffice.py
@@ -10,7 +10,7 @@ import controlTypes
 import winUser
 from . import IAccessible, getNVDAObjectFromEvent
 import eventHandler
-from textUtils import _regex as re
+import _regex as re
 
 """Miscellaneous support for Microsoft Office applications.
 """

--- a/source/NVDAObjects/IAccessible/msOffice.py
+++ b/source/NVDAObjects/IAccessible/msOffice.py
@@ -10,7 +10,7 @@ import controlTypes
 import winUser
 from . import IAccessible, getNVDAObjectFromEvent
 import eventHandler
-import re
+from textUtils import _regex as re
 
 """Miscellaneous support for Microsoft Office applications.
 """

--- a/source/NVDAObjects/JAB/__init__.py
+++ b/source/NVDAObjects/JAB/__init__.py
@@ -4,7 +4,7 @@
 # See the file COPYING for more details.
 
 import ctypes
-import re
+from textUtils import _regex as re
 from typing import (
 	Any,
 )

--- a/source/NVDAObjects/JAB/__init__.py
+++ b/source/NVDAObjects/JAB/__init__.py
@@ -4,7 +4,7 @@
 # See the file COPYING for more details.
 
 import ctypes
-from textUtils import _regex as re
+import _regex as re
 from typing import (
 	Any,
 )

--- a/source/NVDAObjects/UIA/excel.py
+++ b/source/NVDAObjects/UIA/excel.py
@@ -28,7 +28,7 @@ from scriptHandler import script
 import ui
 from logHandler import log
 from . import UIA
-import re
+from textUtils import _regex as re
 
 
 class ExcelCustomProperties:

--- a/source/NVDAObjects/UIA/excel.py
+++ b/source/NVDAObjects/UIA/excel.py
@@ -28,7 +28,7 @@ from scriptHandler import script
 import ui
 from logHandler import log
 from . import UIA
-from textUtils import _regex as re
+import _regex as re
 
 
 class ExcelCustomProperties:

--- a/source/NVDAObjects/UIA/web.py
+++ b/source/NVDAObjects/UIA/web.py
@@ -20,7 +20,7 @@ from . import (
 from logHandler import log
 import controlTypes
 import cursorManager
-import re
+from textUtils import _regex as re
 import aria
 import textInfos
 from UIAHandler.browseMode import (

--- a/source/NVDAObjects/UIA/web.py
+++ b/source/NVDAObjects/UIA/web.py
@@ -20,7 +20,7 @@ from . import (
 from logHandler import log
 import controlTypes
 import cursorManager
-from textUtils import _regex as re
+import _regex as re
 import aria
 import textInfos
 from UIAHandler.browseMode import (

--- a/source/NVDAObjects/window/__init__.py
+++ b/source/NVDAObjects/window/__init__.py
@@ -3,7 +3,7 @@
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
-from textUtils import _regex as re
+import _regex as re
 import ctypes
 import ctypes.wintypes
 from winBindings import user32

--- a/source/NVDAObjects/window/__init__.py
+++ b/source/NVDAObjects/window/__init__.py
@@ -3,7 +3,7 @@
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
-import re
+from textUtils import _regex as re
 import ctypes
 import ctypes.wintypes
 from winBindings import user32

--- a/source/NVDAObjects/window/_msOfficeChart.py
+++ b/source/NVDAObjects/window/_msOfficeChart.py
@@ -11,7 +11,7 @@ import math
 import controlTypes
 import colors
 import inputCore
-import re
+from textUtils import _regex as re
 from logHandler import log
 import browseMode
 from scriptHandler import script

--- a/source/NVDAObjects/window/_msOfficeChart.py
+++ b/source/NVDAObjects/window/_msOfficeChart.py
@@ -11,7 +11,7 @@ import math
 import controlTypes
 import colors
 import inputCore
-from textUtils import _regex as re
+import _regex as re
 from logHandler import log
 import browseMode
 from scriptHandler import script

--- a/source/NVDAObjects/window/excel.py
+++ b/source/NVDAObjects/window/excel.py
@@ -21,7 +21,7 @@ import inputCore
 import wx
 import time
 import winsound
-from textUtils import _regex as re
+import _regex as re
 import uuid
 import NVDAHelper
 import oleacc

--- a/source/NVDAObjects/window/excel.py
+++ b/source/NVDAObjects/window/excel.py
@@ -21,7 +21,7 @@ import inputCore
 import wx
 import time
 import winsound
-import re
+from textUtils import _regex as re
 import uuid
 import NVDAHelper
 import oleacc

--- a/source/_bridge/runtimes/synthDriverHost/main.pyw
+++ b/source/_bridge/runtimes/synthDriverHost/main.pyw
@@ -12,6 +12,8 @@ import tempfile
 from winBindings.kernel32 import GetCurrentProcessId
 
 oldRecordFactory = logging.getLogRecordFactory()
+
+
 def recordFactory(*args, **kwargs):
 	record = oldRecordFactory(*args, **kwargs)
 	frame = inspect.currentframe()
@@ -27,6 +29,8 @@ def recordFactory(*args, **kwargs):
 		# co_qualname may be unavailable for some frames; in that case, keep the default record.name
 		pass
 	return record
+
+
 logging.setLogRecordFactory(recordFactory)
 
 exeName = os.path.splitext(os.path.basename(sys.executable))[0]
@@ -36,7 +40,7 @@ logging.basicConfig(
 	filename=logPath,
 	filemode="w",
 	level=logging.DEBUG,
-	format="%(levelname)s - %(module)s.%(name)s (%(asctime)s):\n%(message)s"
+	format="%(levelname)s - %(module)s.%(name)s (%(asctime)s):\n%(message)s",
 )
 log = logging.getLogger(exeName)
 # No comtypes debug logging
@@ -46,6 +50,7 @@ log.info(f"Logging initialized, log file: {logPath}")
 try:
 	gettext.install("nvda", names=["pgettext", "npgettext", "ngettext"])
 	import core
+
 	core.main()
 except Exception:
 	log.exception("Unhandled exception")

--- a/source/_regex.py
+++ b/source/_regex.py
@@ -12,7 +12,7 @@ Changes to the setting therefore require an NVDA restart.
 
 Intended usage::
 
-	from textUtils import _regex as re
+	import _regex as re
 
 	pattern = re.compile(r"\\w+", re.IGNORECASE)
 

--- a/source/addonAPIVersion.py
+++ b/source/addonAPIVersion.py
@@ -5,7 +5,7 @@
 
 
 import buildVersion
-from textUtils import _regex as re
+import _regex as re
 
 
 """

--- a/source/addonAPIVersion.py
+++ b/source/addonAPIVersion.py
@@ -5,7 +5,7 @@
 
 
 import buildVersion
-import re
+from textUtils import _regex as re
 
 
 """

--- a/source/appModules/code.py
+++ b/source/appModules/code.py
@@ -8,7 +8,7 @@
 import api
 import appModuleHandler
 import controlTypes
-from textUtils import _regex as re
+import _regex as re
 from collections import deque
 from logHandler import log
 from NVDAObjects.behaviors import EditableTextBase

--- a/source/appModules/code.py
+++ b/source/appModules/code.py
@@ -8,7 +8,7 @@
 import api
 import appModuleHandler
 import controlTypes
-import re
+from textUtils import _regex as re
 from collections import deque
 from logHandler import log
 from NVDAObjects.behaviors import EditableTextBase

--- a/source/appModules/foobar2000.py
+++ b/source/appModules/foobar2000.py
@@ -5,7 +5,7 @@
 # See the file COPYING for more details.
 
 from datetime import datetime
-from textUtils import _regex as re
+import _regex as re
 from typing import (
 	Dict,
 	NamedTuple,

--- a/source/appModules/foobar2000.py
+++ b/source/appModules/foobar2000.py
@@ -5,7 +5,7 @@
 # See the file COPYING for more details.
 
 from datetime import datetime
-import re
+from textUtils import _regex as re
 from typing import (
 	Dict,
 	NamedTuple,

--- a/source/appModules/lync.py
+++ b/source/appModules/lync.py
@@ -10,7 +10,7 @@ from NVDAObjects.UIA import UIA
 import appModuleHandler
 from logHandler import log
 
-from textUtils import _regex as re
+import _regex as re
 
 
 class NetUIRicherLabel(UIA):

--- a/source/appModules/lync.py
+++ b/source/appModules/lync.py
@@ -10,7 +10,7 @@ from NVDAObjects.UIA import UIA
 import appModuleHandler
 from logHandler import log
 
-import re
+from textUtils import _regex as re
 
 
 class NetUIRicherLabel(UIA):

--- a/source/appModules/securecrt.py
+++ b/source/appModules/securecrt.py
@@ -6,7 +6,7 @@
 
 """App module for SecureCRT"""
 
-import re
+from textUtils import _regex as re
 import oleacc
 from NVDAObjects.behaviors import Terminal
 from NVDAObjects.window import DisplayModelEditableText, DisplayModelLiveText

--- a/source/appModules/securecrt.py
+++ b/source/appModules/securecrt.py
@@ -6,7 +6,7 @@
 
 """App module for SecureCRT"""
 
-from textUtils import _regex as re
+import _regex as re
 import oleacc
 from NVDAObjects.behaviors import Terminal
 from NVDAObjects.window import DisplayModelEditableText, DisplayModelLiveText

--- a/source/bdDetect.py
+++ b/source/bdDetect.py
@@ -31,7 +31,7 @@ import winUser
 import config
 import appModuleHandler
 from baseObject import AutoPropertyObject
-from textUtils import _regex as re
+import _regex as re
 from winAPI import messageWindow
 import extensionPoints
 from logHandler import log

--- a/source/bdDetect.py
+++ b/source/bdDetect.py
@@ -31,7 +31,7 @@ import winUser
 import config
 import appModuleHandler
 from baseObject import AutoPropertyObject
-import re
+from textUtils import _regex as re
 from winAPI import messageWindow
 import extensionPoints
 from logHandler import log

--- a/source/braille.py
+++ b/source/braille.py
@@ -60,7 +60,7 @@ import textInfos
 import brailleDisplayDrivers
 import inputCore
 import brailleTables
-import re
+from textUtils import _regex as re
 import scriptHandler
 import collections
 import extensionPoints

--- a/source/braille.py
+++ b/source/braille.py
@@ -60,7 +60,7 @@ import textInfos
 import brailleDisplayDrivers
 import inputCore
 import brailleTables
-from textUtils import _regex as re
+import _regex as re
 import scriptHandler
 import collections
 import extensionPoints

--- a/source/brailleDisplayDrivers/eurobraille/driver.py
+++ b/source/brailleDisplayDrivers/eurobraille/driver.py
@@ -5,7 +5,7 @@
 
 from collections import defaultdict
 from typing import Dict, Any, List, Union
-from textUtils import _regex as re
+import _regex as re
 
 from io import BytesIO
 import serial

--- a/source/brailleDisplayDrivers/eurobraille/driver.py
+++ b/source/brailleDisplayDrivers/eurobraille/driver.py
@@ -5,7 +5,7 @@
 
 from collections import defaultdict
 from typing import Dict, Any, List, Union
-import re
+from textUtils import _regex as re
 
 from io import BytesIO
 import serial

--- a/source/brailleDisplayDrivers/seikantk.py
+++ b/source/brailleDisplayDrivers/seikantk.py
@@ -8,7 +8,7 @@ Braille display driver for Seika Notetaker, a product from Nippon Telesoft
 see www.seika-braille.com for more details
 """
 
-from textUtils import _regex as re
+import _regex as re
 from io import BytesIO
 import typing
 from typing import Dict, List, Optional, Set

--- a/source/brailleDisplayDrivers/seikantk.py
+++ b/source/brailleDisplayDrivers/seikantk.py
@@ -8,7 +8,7 @@ Braille display driver for Seika Notetaker, a product from Nippon Telesoft
 see www.seika-braille.com for more details
 """
 
-import re
+from textUtils import _regex as re
 from io import BytesIO
 import typing
 from typing import Dict, List, Optional, Set

--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -12,7 +12,7 @@ import collections
 import winsound
 import time
 import weakref
-from textUtils import _regex as re
+import _regex as re
 from comtypes import COMError
 
 import wx

--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -12,7 +12,7 @@ import collections
 import winsound
 import time
 import weakref
-import re
+from textUtils import _regex as re
 from comtypes import COMError
 
 import wx

--- a/source/characterProcessing.py
+++ b/source/characterProcessing.py
@@ -12,7 +12,7 @@ from locale import strxfrm
 import os
 import codecs
 import collections
-from textUtils import _regex as re
+import _regex as re
 from typing import (
 	Callable,
 	Dict,

--- a/source/characterProcessing.py
+++ b/source/characterProcessing.py
@@ -12,7 +12,7 @@ from locale import strxfrm
 import os
 import codecs
 import collections
-import re
+from textUtils import _regex as re
 from typing import (
 	Callable,
 	Dict,

--- a/source/colors.py
+++ b/source/colors.py
@@ -6,7 +6,7 @@
 from collections import namedtuple
 import colorsys
 from ctypes.wintypes import COLORREF
-from textUtils import _regex as re
+import _regex as re
 from functools import lru_cache
 from typing import Union
 

--- a/source/colors.py
+++ b/source/colors.py
@@ -6,7 +6,7 @@
 from collections import namedtuple
 import colorsys
 from ctypes.wintypes import COLORREF
-import re
+from textUtils import _regex as re
 from functools import lru_cache
 from typing import Union
 

--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -356,6 +356,8 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 	cancelExpiredFocusSpeech = integer(0, 2, default=0)
 	# 0: Only in test versions, 1: Yes, 2: No
 	playErrorSound = integer(0, 2, default=0)
+	# 0:default (re), 1:regex, 2:re
+	regexBackend = integer(0, 2, default=0)
 
 [addonStore]
 	automaticUpdates = option("notify", "update", "disabled", default="notify")

--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -356,8 +356,7 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 	cancelExpiredFocusSpeech = integer(0, 2, default=0)
 	# 0: Only in test versions, 1: Yes, 2: No
 	playErrorSound = integer(0, 2, default=0)
-	# 0:default (re), 1:regex, 2:re
-	regexBackend = integer(0, 2, default=0)
+	regexBackend = featureFlag(optionsEnum="RegexBackendFlag", behaviorOfDefault="RE")
 
 [addonStore]
 	automaticUpdates = option("notify", "update", "disabled", default="notify")

--- a/source/config/featureFlagEnums.py
+++ b/source/config/featureFlagEnums.py
@@ -139,6 +139,23 @@ class FontFormattingBrailleModeFlag(DisplayStringEnum):
 		}
 
 
+class RegexBackendFlag(DisplayStringEnum):
+	"""Feature flag for selecting the regular expression backend."""
+
+	DEFAULT = enum.auto()
+	RE = enum.auto()
+	REGEX = enum.auto()
+
+	@property
+	def _displayStringLabels(self) -> dict["RegexBackendFlag", str]:
+		return {
+			# Translators: Label for the regex backend feature flag option using stdlib re.
+			RegexBackendFlag.RE: _("Python re"),
+			# Translators: Label for the regex backend feature flag option using the regex module.
+			RegexBackendFlag.REGEX: _("regex"),
+		}
+
+
 def getAvailableEnums() -> typing.Generator[typing.Tuple[str, FlagValueEnum], None, None]:
 	for name, value in globals().items():
 		if (

--- a/source/controlTypes/formatFields.py
+++ b/source/controlTypes/formatFields.py
@@ -3,7 +3,7 @@
 # See the file COPYING for more details.
 # Copyright (C) 2021-2023 NV Access Limited, Cyrille Bougot
 
-from textUtils import _regex as re
+import _regex as re
 from typing import Dict
 
 from logHandler import log

--- a/source/controlTypes/formatFields.py
+++ b/source/controlTypes/formatFields.py
@@ -3,7 +3,7 @@
 # See the file COPYING for more details.
 # Copyright (C) 2021-2023 NV Access Limited, Cyrille Bougot
 
-import re
+from textUtils import _regex as re
 from typing import Dict
 
 from logHandler import log

--- a/source/core.py
+++ b/source/core.py
@@ -712,6 +712,9 @@ def main():
 	import config
 
 	config.initialize()
+	from textUtils import _regex
+
+	_regex.initialize()
 	if config.conf["development"]["enableScratchpadDir"]:
 		log.info("Developer Scratchpad mode enabled")
 	if languageHandler.isLanguageForced():

--- a/source/core.py
+++ b/source/core.py
@@ -712,7 +712,7 @@ def main():
 	import config
 
 	config.initialize()
-	from textUtils import _regex
+	import _regex
 
 	_regex.initialize()
 	if config.conf["development"]["enableScratchpadDir"]:

--- a/source/documentNavigation/sentenceHelper.py
+++ b/source/documentNavigation/sentenceHelper.py
@@ -4,7 +4,7 @@
 # This file may be used under the terms of the GNU General Public License, version 2 or later.
 # For more details see: https://www.gnu.org/licenses/gpl-2.0.html
 
-from textUtils import _regex as re
+import _regex as re
 from typing import Optional
 
 WESTERN_TERMINATORS = "[.?!](?: |\r|\n|$)+"

--- a/source/documentNavigation/sentenceHelper.py
+++ b/source/documentNavigation/sentenceHelper.py
@@ -4,7 +4,7 @@
 # This file may be used under the terms of the GNU General Public License, version 2 or later.
 # For more details see: https://www.gnu.org/licenses/gpl-2.0.html
 
-import re
+from textUtils import _regex as re
 from typing import Optional
 
 WESTERN_TERMINATORS = "[.?!](?: |\r|\n|$)+"

--- a/source/gui/inputGestures.py
+++ b/source/gui/inputGestures.py
@@ -8,7 +8,7 @@
 # See the file COPYING for more details.
 
 import itertools
-import re
+from textUtils import _regex as re
 from typing import Tuple, Union, Dict
 
 import wx

--- a/source/gui/inputGestures.py
+++ b/source/gui/inputGestures.py
@@ -8,7 +8,7 @@
 # See the file COPYING for more details.
 
 import itertools
-from textUtils import _regex as re
+import _regex as re
 from typing import Tuple, Union, Dict
 
 import wx

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -4704,9 +4704,7 @@ class AdvancedPanelControls(
 			_("re"),
 		]
 		# Translators: Label for the regex backend combobox in the Advanced settings panel.
-		regexBackendLabel = _(
-			"Regular expression &backend (already-loaded patterns keep their original backend until restart):",
-		)
+		regexBackendLabel = _("Regular expression &backend (requires restart):")
 		self.regexBackendCombo: wx.Choice = sHelper.addLabeledControl(
 			regexBackendLabel,
 			wx.Choice,

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -15,7 +15,7 @@ import copy
 import logging
 import math
 import os
-import re
+from textUtils import _regex as re
 from abc import ABCMeta, abstractmethod
 from collections.abc import Callable, Container
 from enum import IntEnum
@@ -4695,6 +4695,27 @@ class AdvancedPanelControls(
 			["virtualBuffers", "textParagraphRegex"],
 		)
 
+		regexBackendChoices = [
+			# Translators: One of the choices for the regex backend combobox in the Advanced settings panel.
+			_("Default (re)"),
+			# Translators: One of the choices for the regex backend combobox in the Advanced settings panel.
+			_("regex"),
+			# Translators: One of the choices for the regex backend combobox in the Advanced settings panel.
+			_("re"),
+		]
+		# Translators: Label for the regex backend combobox in the Advanced settings panel.
+		regexBackendLabel = _(
+			"Regular expression &backend (already-loaded patterns keep their original backend until restart):",
+		)
+		self.regexBackendCombo: wx.Choice = sHelper.addLabeledControl(
+			regexBackendLabel,
+			wx.Choice,
+			choices=regexBackendChoices,
+		)
+		self.bindHelpEvent("RegexBackend", self.regexBackendCombo)
+		self.regexBackendCombo.SetSelection(config.conf["featureFlag"]["regexBackend"])
+		self.regexBackendCombo.defaultValue = self._getDefaultValue(["featureFlag", "regexBackend"])
+
 		self.Layout()
 
 	def isValid(self) -> bool:
@@ -4751,6 +4772,7 @@ class AdvancedPanelControls(
 			and set(self.logCategoriesList.CheckedItems) == set(self.logCategoriesList.defaultCheckedItems)
 			and self.playErrorSoundCombo.GetSelection() == self.playErrorSoundCombo.defaultValue
 			and self.textParagraphRegexEdit.GetValue() == self.textParagraphRegexEdit.defaultValue
+			and self.regexBackendCombo.GetSelection() == self.regexBackendCombo.defaultValue
 			and True  # reduce noise in diff when the list is extended.
 		)
 
@@ -4780,6 +4802,7 @@ class AdvancedPanelControls(
 		self.logCategoriesList.CheckedItems = self.logCategoriesList.defaultCheckedItems
 		self.playErrorSoundCombo.SetSelection(self.playErrorSoundCombo.defaultValue)
 		self.textParagraphRegexEdit.SetValue(self.textParagraphRegexEdit.defaultValue)
+		self.regexBackendCombo.SetSelection(self.regexBackendCombo.defaultValue)
 		self._defaultsRestored = True
 
 	def onSave(self):
@@ -4825,6 +4848,7 @@ class AdvancedPanelControls(
 			config.conf["debugLog"][key] = self.logCategoriesList.IsChecked(index)
 		config.conf["featureFlag"]["playErrorSound"] = self.playErrorSoundCombo.GetSelection()
 		config.conf["virtualBuffers"]["textParagraphRegex"] = self.textParagraphRegexEdit.GetValue()
+		config.conf["featureFlag"]["regexBackend"] = self.regexBackendCombo.GetSelection()
 
 		if shouldResetSynth:
 			currentSynth = getSynth()

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -15,7 +15,7 @@ import copy
 import logging
 import math
 import os
-from textUtils import _regex as re
+import _regex as re
 from abc import ABCMeta, abstractmethod
 from collections.abc import Callable, Container
 from enum import IntEnum

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -4695,24 +4695,15 @@ class AdvancedPanelControls(
 			["virtualBuffers", "textParagraphRegex"],
 		)
 
-		regexBackendChoices = [
-			# Translators: One of the choices for the regex backend combobox in the Advanced settings panel.
-			_("Default (re)"),
-			# Translators: One of the choices for the regex backend combobox in the Advanced settings panel.
-			_("regex"),
-			# Translators: One of the choices for the regex backend combobox in the Advanced settings panel.
-			_("re"),
-		]
 		# Translators: Label for the regex backend combobox in the Advanced settings panel.
 		regexBackendLabel = _("Regular expression &backend (requires restart):")
-		self.regexBackendCombo: wx.Choice = sHelper.addLabeledControl(
-			regexBackendLabel,
-			wx.Choice,
-			choices=regexBackendChoices,
+		self.regexBackendCombo: nvdaControls.FeatureFlagCombo = sHelper.addLabeledControl(
+			labelText=regexBackendLabel,
+			wxCtrlClass=nvdaControls.FeatureFlagCombo,
+			keyPath=["featureFlag", "regexBackend"],
+			conf=config.conf,
 		)
 		self.bindHelpEvent("RegexBackend", self.regexBackendCombo)
-		self.regexBackendCombo.SetSelection(config.conf["featureFlag"]["regexBackend"])
-		self.regexBackendCombo.defaultValue = self._getDefaultValue(["featureFlag", "regexBackend"])
 
 		self.Layout()
 
@@ -4770,7 +4761,7 @@ class AdvancedPanelControls(
 			and set(self.logCategoriesList.CheckedItems) == set(self.logCategoriesList.defaultCheckedItems)
 			and self.playErrorSoundCombo.GetSelection() == self.playErrorSoundCombo.defaultValue
 			and self.textParagraphRegexEdit.GetValue() == self.textParagraphRegexEdit.defaultValue
-			and self.regexBackendCombo.GetSelection() == self.regexBackendCombo.defaultValue
+			and self.regexBackendCombo.isValueConfigSpecDefault()
 			and True  # reduce noise in diff when the list is extended.
 		)
 
@@ -4800,7 +4791,7 @@ class AdvancedPanelControls(
 		self.logCategoriesList.CheckedItems = self.logCategoriesList.defaultCheckedItems
 		self.playErrorSoundCombo.SetSelection(self.playErrorSoundCombo.defaultValue)
 		self.textParagraphRegexEdit.SetValue(self.textParagraphRegexEdit.defaultValue)
-		self.regexBackendCombo.SetSelection(self.regexBackendCombo.defaultValue)
+		self.regexBackendCombo.resetToConfigSpecDefault()
 		self._defaultsRestored = True
 
 	def onSave(self):
@@ -4846,7 +4837,7 @@ class AdvancedPanelControls(
 			config.conf["debugLog"][key] = self.logCategoriesList.IsChecked(index)
 		config.conf["featureFlag"]["playErrorSound"] = self.playErrorSoundCombo.GetSelection()
 		config.conf["virtualBuffers"]["textParagraphRegex"] = self.textParagraphRegexEdit.GetValue()
-		config.conf["featureFlag"]["regexBackend"] = self.regexBackendCombo.GetSelection()
+		self.regexBackendCombo.saveCurrentValueToConf()
 
 		if shouldResetSynth:
 			currentSynth = getSynth()

--- a/source/gui/speechDict.py
+++ b/source/gui/speechDict.py
@@ -5,7 +5,7 @@
 # For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
 
 from abc import abstractmethod
-from textUtils import _regex as re
+import _regex as re
 
 import globalVars
 import wx

--- a/source/gui/speechDict.py
+++ b/source/gui/speechDict.py
@@ -5,7 +5,7 @@
 # For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
 
 from abc import abstractmethod
-from re import error as RegexpError
+from textUtils import _regex as re
 
 import globalVars
 import wx
@@ -104,7 +104,7 @@ class DictionaryEntryDialog(
 				bool(self.caseSensitiveCheckBox.GetValue()),
 				entryType,
 			)
-		except RegexpError as e:
+		except re.error as e:
 			log.debugWarning(f"Could not add dictionary entry due to regex error in the pattern field : {e}")
 			if entryType != EntryType.REGEXP:
 				raise e
@@ -120,7 +120,7 @@ class DictionaryEntryDialog(
 			return
 		try:
 			dictEntry.sub("test")  # Ensure there are no grouping error (#11407)
-		except RegexpError as e:
+		except re.error as e:
 			log.debugWarning(
 				f"Could not add dictionary entry due to regex error in the replacement field : {e}",
 			)

--- a/source/keyCommandsDoc.py
+++ b/source/keyCommandsDoc.py
@@ -14,7 +14,7 @@ https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/userGuideStandards.
 """
 
 from enum import auto, Enum, IntEnum, StrEnum
-from textUtils import _regex as re
+import _regex as re
 from collections.abc import Iterator
 
 from markdown import Extension, Markdown

--- a/source/keyCommandsDoc.py
+++ b/source/keyCommandsDoc.py
@@ -14,7 +14,7 @@ https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/userGuideStandards.
 """
 
 from enum import auto, Enum, IntEnum, StrEnum
-import re
+from textUtils import _regex as re
 from collections.abc import Iterator
 
 from markdown import Extension, Markdown

--- a/source/keyboardHandler.py
+++ b/source/keyboardHandler.py
@@ -7,7 +7,7 @@
 
 import ctypes
 import time
-from textUtils import _regex as re
+import _regex as re
 import typing
 from typing import (
 	Tuple,

--- a/source/keyboardHandler.py
+++ b/source/keyboardHandler.py
@@ -7,7 +7,7 @@
 
 import ctypes
 import time
-import re
+from textUtils import _regex as re
 import typing
 from typing import (
 	Tuple,

--- a/source/l10nUtil.py
+++ b/source/l10nUtil.py
@@ -13,7 +13,7 @@ import markdownTranslate
 import md2html
 import requests
 import codecs
-import re
+from textUtils import _regex as re
 import subprocess
 import sys
 import zipfile

--- a/source/l10nUtil.py
+++ b/source/l10nUtil.py
@@ -13,7 +13,7 @@ import markdownTranslate
 import md2html
 import requests
 import codecs
-from textUtils import _regex as re
+import re
 import subprocess
 import sys
 import zipfile

--- a/source/markdownTranslate.py
+++ b/source/markdownTranslate.py
@@ -11,7 +11,7 @@ import contextlib
 import lxml.etree
 import argparse
 import uuid
-from textUtils import _regex as re
+import re
 from itertools import zip_longest
 from xml.sax.saxutils import escape as xmlEscape
 import difflib

--- a/source/markdownTranslate.py
+++ b/source/markdownTranslate.py
@@ -11,7 +11,7 @@ import contextlib
 import lxml.etree
 import argparse
 import uuid
-import re
+from textUtils import _regex as re
 from itertools import zip_longest
 from xml.sax.saxutils import escape as xmlEscape
 import difflib

--- a/source/mathPres/MathCAT/MathCAT.py
+++ b/source/mathPres/MathCAT/MathCAT.py
@@ -3,7 +3,7 @@
 # This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
 # For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
 
-import re
+from textUtils import _regex as re
 from collections.abc import Generator
 from ctypes import (
 	Array,

--- a/source/mathPres/MathCAT/MathCAT.py
+++ b/source/mathPres/MathCAT/MathCAT.py
@@ -3,7 +3,7 @@
 # This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
 # For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
 
-from textUtils import _regex as re
+import _regex as re
 from collections.abc import Generator
 from ctypes import (
 	Array,

--- a/source/mathPres/MathCAT/speech.py
+++ b/source/mathPres/MathCAT/speech.py
@@ -3,7 +3,7 @@
 # This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
 # For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
 
-import re
+from textUtils import _regex as re
 from speech.commands import (
 	BaseProsodyCommand,
 	BeepCommand,

--- a/source/mathPres/MathCAT/speech.py
+++ b/source/mathPres/MathCAT/speech.py
@@ -3,7 +3,7 @@
 # This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
 # For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
 
-from textUtils import _regex as re
+import _regex as re
 from speech.commands import (
 	BaseProsodyCommand,
 	BeepCommand,

--- a/source/mathPres/__init__.py
+++ b/source/mathPres/__init__.py
@@ -10,7 +10,7 @@ Plugins can register their own implementation for any or all of these
 using L{registerProvider}.
 """
 
-from textUtils import _regex as re
+import _regex as re
 import typing
 from typing import List, Optional, Union
 

--- a/source/mathPres/__init__.py
+++ b/source/mathPres/__init__.py
@@ -10,7 +10,7 @@ Plugins can register their own implementation for any or all of these
 using L{registerProvider}.
 """
 
-import re
+from textUtils import _regex as re
 import typing
 from typing import List, Optional, Union
 

--- a/source/md2html.py
+++ b/source/md2html.py
@@ -6,7 +6,7 @@
 import argparse
 from copy import deepcopy
 import io
-from textUtils import _regex as re
+import re
 import shutil
 from typing import Any
 from l2m4m import LaTeX2MathMLExtension

--- a/source/md2html.py
+++ b/source/md2html.py
@@ -6,7 +6,7 @@
 import argparse
 from copy import deepcopy
 import io
-import re
+from textUtils import _regex as re
 import shutil
 from typing import Any
 from l2m4m import LaTeX2MathMLExtension

--- a/source/pythonConsole.py
+++ b/source/pythonConsole.py
@@ -15,7 +15,7 @@ import code
 import codeop
 import sys
 import pydoc
-import re
+from textUtils import _regex as re
 import itertools
 import rlcompleter
 import wx

--- a/source/pythonConsole.py
+++ b/source/pythonConsole.py
@@ -15,7 +15,7 @@ import code
 import codeop
 import sys
 import pydoc
-from textUtils import _regex as re
+import _regex as re
 import itertools
 import rlcompleter
 import wx

--- a/source/speech/shortcutKeys.py
+++ b/source/speech/shortcutKeys.py
@@ -5,7 +5,7 @@
 
 """Functions to create speech sequences for shortcut keys."""
 
-from textUtils import _regex as re
+import _regex as re
 
 import characterProcessing
 from logHandler import log

--- a/source/speech/shortcutKeys.py
+++ b/source/speech/shortcutKeys.py
@@ -5,7 +5,7 @@
 
 """Functions to create speech sequences for shortcut keys."""
 
-import re
+from textUtils import _regex as re
 
 import characterProcessing
 from logHandler import log

--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -19,7 +19,7 @@ from controlTypes import OutputReason, TextPosition
 from controlTypes.state import State
 import tones
 from synthDriverHandler import getSynth
-from textUtils import _regex as re
+import _regex as re
 import textInfos
 import speechDictHandler
 import characterProcessing

--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -19,7 +19,7 @@ from controlTypes import OutputReason, TextPosition
 from controlTypes.state import State
 import tones
 from synthDriverHandler import getSynth
-import re
+from textUtils import _regex as re
 import textInfos
 import speechDictHandler
 import characterProcessing

--- a/source/speech/speechWithoutPauses.py
+++ b/source/speech/speechWithoutPauses.py
@@ -4,7 +4,7 @@
 # Copyright (C) 2006-2021 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Babbage B.V., Bill Dengler,
 # Julien Cochuyt
 
-import re
+from textUtils import _regex as re
 
 from .commands import (
 	# Commands that are used in this file.

--- a/source/speech/speechWithoutPauses.py
+++ b/source/speech/speechWithoutPauses.py
@@ -4,7 +4,7 @@
 # Copyright (C) 2006-2021 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Babbage B.V., Bill Dengler,
 # Julien Cochuyt
 
-from textUtils import _regex as re
+import _regex as re
 
 from .commands import (
 	# Commands that are used in this file.

--- a/source/speechDictHandler/types.py
+++ b/source/speechDictHandler/types.py
@@ -7,7 +7,7 @@
 
 import fnmatch
 import os
-import regex as re
+from textUtils import _regex as re
 from dataclasses import dataclass, field
 from functools import cached_property
 from typing import (

--- a/source/speechDictHandler/types.py
+++ b/source/speechDictHandler/types.py
@@ -7,7 +7,7 @@
 
 import fnmatch
 import os
-import re
+import regex as re
 from dataclasses import dataclass, field
 from functools import cached_property
 from typing import (

--- a/source/speechDictHandler/types.py
+++ b/source/speechDictHandler/types.py
@@ -7,7 +7,7 @@
 
 import fnmatch
 import os
-from textUtils import _regex as re
+import _regex as re
 from dataclasses import dataclass, field
 from functools import cached_property
 from typing import (

--- a/source/speechXml.py
+++ b/source/speechXml.py
@@ -10,7 +10,7 @@ You can subclass this to support specific XML schemas.
 L{SsmlConverter} is an implementation for conversion to SSML.
 """
 
-from textUtils import _regex as re
+import _regex as re
 from collections import OrderedDict, namedtuple
 from collections.abc import Callable, Generator
 from xml.parsers import expat

--- a/source/speechXml.py
+++ b/source/speechXml.py
@@ -10,7 +10,7 @@ You can subclass this to support specific XML schemas.
 L{SsmlConverter} is an implementation for conversion to SSML.
 """
 
-import re
+from textUtils import _regex as re
 from collections import OrderedDict, namedtuple
 from collections.abc import Callable, Generator
 from xml.parsers import expat

--- a/source/textInfos/__init__.py
+++ b/source/textInfos/__init__.py
@@ -12,7 +12,7 @@ A default implementation, L{NVDAObjects.NVDAObjectTextInfo}, is used to enable t
 from abc import abstractmethod
 from enum import Enum
 import weakref
-import re
+from textUtils import _regex as re
 import typing
 from typing import (
 	Any,

--- a/source/textInfos/__init__.py
+++ b/source/textInfos/__init__.py
@@ -12,7 +12,7 @@ A default implementation, L{NVDAObjects.NVDAObjectTextInfo}, is used to enable t
 from abc import abstractmethod
 from enum import Enum
 import weakref
-from textUtils import _regex as re
+import _regex as re
 import typing
 from typing import (
 	Any,

--- a/source/textInfos/offsets.py
+++ b/source/textInfos/offsets.py
@@ -4,7 +4,7 @@
 # For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
 
 from abc import abstractmethod
-import re
+from textUtils import _regex as re
 import ctypes
 import unicodedata
 import NVDAHelper

--- a/source/textInfos/offsets.py
+++ b/source/textInfos/offsets.py
@@ -4,7 +4,7 @@
 # For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
 
 from abc import abstractmethod
-from textUtils import _regex as re
+import _regex as re
 import ctypes
 import unicodedata
 import NVDAHelper

--- a/source/textUtils/_regex.py
+++ b/source/textUtils/_regex.py
@@ -6,7 +6,9 @@
 """Internal regex backend shim.
 
 Forwards attribute access to either stdlib :mod:`re` or the third-party :mod:`regex`
-module, selected at every access via the ``regexBackend`` feature flag in user config.
+module. The backend is chosen once by :func:`initialize` from the ``regexBackend``
+feature flag in user config and is then frozen for the lifetime of the process.
+Changes to the setting therefore require an NVDA restart.
 
 Intended usage::
 
@@ -14,49 +16,33 @@ Intended usage::
 
 	pattern = re.compile(r"\\w+", re.IGNORECASE)
 
-Because module attributes are not cached after :pep:`562` ``__getattr__`` returns,
-each ``re.compile(...)``/``re.IGNORECASE``/``re.error`` access re-resolves the active
-backend. Toggling the feature flag therefore takes effect immediately for new
-compilations; ``Pattern`` objects already compiled stay bound to the backend that
-created them until NVDA is restarted.
-
-Before :func:`initialize` runs (early bootstrap, unit tests outside startup) or if
-config is unavailable, attribute access falls back to stdlib :mod:`re`.
+Before :func:`initialize` runs (early bootstrap, unit tests outside startup),
+attribute access falls back to stdlib :mod:`re`.
 """
 
 import re as _re
 
 
-_regexModule = None
+_backend = _re
 
 
 def initialize() -> None:
-	"""Eagerly import the :mod:`regex` module and configure VERSION1 semantics.
+	"""Resolve the regex backend from user config and freeze it for this process.
 
-	Call once after :func:`config.initialize` so that subsequent attribute access can
-	resolve the ``regex`` backend without paying import cost on a hot path. Idempotent.
+	Call once after :func:`config.initialize`. Subsequent calls are ignored.
 	"""
-	global _regexModule
-	if _regexModule is not None:
+	global _backend
+	if _backend is not _re:
+		return
+	import config
+
+	if config.conf["featureFlag"]["regexBackend"] != 1:
 		return
 	import regex
 
 	regex.DEFAULT_VERSION = regex.VERSION1
-	_regexModule = regex
-
-
-def _getBackend():
-	if _regexModule is None:
-		return _re
-	try:
-		import config
-
-		if config.conf["featureFlag"]["regexBackend"] == 1:
-			return _regexModule
-	except Exception:
-		pass
-	return _re
+	_backend = regex
 
 
 def __getattr__(name: str):
-	return getattr(_getBackend(), name)
+	return getattr(_backend, name)

--- a/source/textUtils/_regex.py
+++ b/source/textUtils/_regex.py
@@ -1,0 +1,62 @@
+# A part of NonVisual Desktop Access (NVDA)
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+# Copyright (C) 2026 NV Access Limited
+
+"""Internal regex backend shim.
+
+Forwards attribute access to either stdlib :mod:`re` or the third-party :mod:`regex`
+module, selected at every access via the ``regexBackend`` feature flag in user config.
+
+Intended usage::
+
+	from textUtils import _regex as re
+
+	pattern = re.compile(r"\\w+", re.IGNORECASE)
+
+Because module attributes are not cached after :pep:`562` ``__getattr__`` returns,
+each ``re.compile(...)``/``re.IGNORECASE``/``re.error`` access re-resolves the active
+backend. Toggling the feature flag therefore takes effect immediately for new
+compilations; ``Pattern`` objects already compiled stay bound to the backend that
+created them until NVDA is restarted.
+
+Before :func:`initialize` runs (early bootstrap, unit tests outside startup) or if
+config is unavailable, attribute access falls back to stdlib :mod:`re`.
+"""
+
+import re as _re
+
+
+_regexModule = None
+
+
+def initialize() -> None:
+	"""Eagerly import the :mod:`regex` module and configure VERSION1 semantics.
+
+	Call once after :func:`config.initialize` so that subsequent attribute access can
+	resolve the ``regex`` backend without paying import cost on a hot path. Idempotent.
+	"""
+	global _regexModule
+	if _regexModule is not None:
+		return
+	import regex
+
+	regex.DEFAULT_VERSION = regex.VERSION1
+	_regexModule = regex
+
+
+def _getBackend():
+	if _regexModule is None:
+		return _re
+	try:
+		import config
+
+		if config.conf["featureFlag"]["regexBackend"] == 1:
+			return _regexModule
+	except Exception:
+		pass
+	return _re
+
+
+def __getattr__(name: str):
+	return getattr(_getBackend(), name)

--- a/source/textUtils/_regex.py
+++ b/source/textUtils/_regex.py
@@ -35,8 +35,9 @@ def initialize() -> None:
 	if _backend is not _re:
 		return
 	import config
+	from config.featureFlagEnums import RegexBackendFlag
 
-	if config.conf["featureFlag"]["regexBackend"] != 1:
+	if config.conf["featureFlag"]["regexBackend"].calculated() != RegexBackendFlag.REGEX:
 		return
 	import regex
 

--- a/source/touchHandler.py
+++ b/source/touchHandler.py
@@ -37,7 +37,7 @@ from ctypes.wintypes import (
 	MSG,
 	RECT,
 )
-from textUtils import _regex as re
+import _regex as re
 from winAPI.winUser.constants import SystemMetrics
 import winBindings.kernel32
 from winBindings import user32

--- a/source/touchHandler.py
+++ b/source/touchHandler.py
@@ -37,7 +37,7 @@ from ctypes.wintypes import (
 	MSG,
 	RECT,
 )
-import re
+from textUtils import _regex as re
 from winAPI.winUser.constants import SystemMetrics
 import winBindings.kernel32
 from winBindings import user32

--- a/tests/unit/test_regex.py
+++ b/tests/unit/test_regex.py
@@ -8,7 +8,7 @@
 import re as _stdlibRe
 import unittest
 
-from textUtils import _regex as shim
+import _regex as shim
 
 
 class TestRegexShim(unittest.TestCase):

--- a/tests/unit/test_regex.py
+++ b/tests/unit/test_regex.py
@@ -8,73 +8,58 @@
 import re as _stdlibRe
 import unittest
 
-import config
-import regex as _regexModule
-
 from textUtils import _regex as shim
 
 
 class TestRegexShim(unittest.TestCase):
-	"""Tests that the shim correctly forwards to the active backend."""
+	"""Tests that the shim exposes a usable, internally-consistent re-like API.
 
-	def setUp(self):
-		shim.initialize()
-		self._originalBackend = config.conf["featureFlag"]["regexBackend"]
+	The backend is selected once by :func:`textUtils._regex.initialize` from user
+	config and is then frozen for the lifetime of the process. Unit tests cannot
+	toggle it, so these tests assert behavior of whichever backend is active and
+	check internal consistency rather than which concrete module is in use.
+	"""
 
-	def tearDown(self):
-		config.conf["featureFlag"]["regexBackend"] = self._originalBackend
-
-	def _useStdlib(self):
-		config.conf["featureFlag"]["regexBackend"] = 0
-
-	def _useRegex(self):
-		config.conf["featureFlag"]["regexBackend"] = 1
-
-	def test_compileForwardsToStdlibByDefault(self):
-		self._useStdlib()
+	def test_compileReturnsActiveBackendPattern(self):
+		"""``shim.compile`` returns a Pattern of the active backend's type."""
 		pattern = shim.compile(r"\w+")
-		self.assertIsInstance(pattern, _stdlibRe.Pattern)
+		self.assertIsInstance(pattern, shim.Pattern)
 
-	def test_compileForwardsToRegexWhenEnabled(self):
-		self._useRegex()
-		pattern = shim.compile(r"\w+")
-		self.assertIsInstance(pattern, _regexModule.Pattern)
+	def test_errorClassMatchesActiveBackend(self):
+		"""``shim.error`` is the active backend's error class.
 
-	def test_errorClassTracksBackend(self):
-		self._useStdlib()
-		self.assertIs(shim.error, _stdlibRe.error)
-		self._useRegex()
-		self.assertIs(shim.error, _regexModule.error)
-
-	def test_flagConstantsTrackBackend(self):
-		self._useStdlib()
-		self.assertEqual(shim.IGNORECASE, _stdlibRe.IGNORECASE)
-		self._useRegex()
-		self.assertEqual(shim.IGNORECASE, _regexModule.IGNORECASE)
-
-	def test_exceptHandlerCatchesActiveBackendError(self):
-		"""``except shim.error`` re-resolves the class on each entry."""
-		self._useStdlib()
-		with self.assertRaises(shim.error):
-			shim.compile(r"(unbalanced")
-		self._useRegex()
+		``except shim.error`` must catch errors raised by ``shim.compile`` etc.
+		"""
 		with self.assertRaises(shim.error):
 			shim.compile(r"(unbalanced")
 
-	def test_regexBackendUsesVersion1(self):
-		"""When the regex backend is active, full Unicode case-folding applies (V1)."""
-		self._useRegex()
-		self.assertIsNotNone(shim.match(r"(?i)ss", "ß"))
+	def test_flagConstantsArePresent(self):
+		"""Standard re flag constants are exposed by the shim."""
+		self.assertTrue(hasattr(shim, "IGNORECASE"))
+		self.assertTrue(hasattr(shim, "DOTALL"))
+		self.assertTrue(hasattr(shim, "MULTILINE"))
+		self.assertTrue(hasattr(shim, "UNICODE"))
+		self.assertTrue(hasattr(shim, "VERBOSE"))
+
+	def test_basicMatchingWorks(self):
+		"""Smoke check that core re API surface is callable through the shim."""
+		self.assertIsNotNone(shim.match(r"\d+", "123abc"))
+		self.assertIsNotNone(shim.search(r"\d+", "abc123"))
+		self.assertEqual(shim.findall(r"\d+", "a1 b22 c333"), ["1", "22", "333"])
+		self.assertEqual(shim.sub(r"\d", "X", "a1b2"), "aXbX")
+		self.assertEqual(shim.escape("a.b"), _stdlibRe.escape("a.b"))
 
 
-class TestRegexShimPreInit(unittest.TestCase):
-	"""Behavior before initialize() has run: must fall back to stdlib re."""
+class TestRegexShimUninitialized(unittest.TestCase):
+	"""Pre-initialize behavior: shim must fall back to stdlib re.
 
-	def test_preInitFallsBackToStdlib(self):
-		# initialize() may already have been called by another test in this run; we
-		# can't easily un-initialize. Instead, verify the documented contract that the
-		# fallback path exists by inspecting the private state when uninitialized.
-		# This is a smoke check that the attribute is present and callable.
+	Unit tests typically run after :func:`initialize` has been called by NVDA's
+	startup, but the shim must still be safely usable in early-bootstrap contexts
+	where config is not yet available. This is verified indirectly by ensuring
+	that the shim's API surface is callable regardless of init state.
+	"""
+
+	def test_apiCallableRegardlessOfInitState(self):
 		self.assertTrue(callable(shim.compile))
 		self.assertTrue(callable(shim.search))
 		self.assertTrue(callable(shim.escape))

--- a/tests/unit/test_regex.py
+++ b/tests/unit/test_regex.py
@@ -1,0 +1,80 @@
+# A part of NonVisual Desktop Access (NVDA)
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+# Copyright (C) 2026 NV Access Limited
+
+"""Unit tests for the textUtils._regex backend shim."""
+
+import re as _stdlibRe
+import unittest
+
+import config
+import regex as _regexModule
+
+from textUtils import _regex as shim
+
+
+class TestRegexShim(unittest.TestCase):
+	"""Tests that the shim correctly forwards to the active backend."""
+
+	def setUp(self):
+		shim.initialize()
+		self._originalBackend = config.conf["featureFlag"]["regexBackend"]
+
+	def tearDown(self):
+		config.conf["featureFlag"]["regexBackend"] = self._originalBackend
+
+	def _useStdlib(self):
+		config.conf["featureFlag"]["regexBackend"] = 0
+
+	def _useRegex(self):
+		config.conf["featureFlag"]["regexBackend"] = 1
+
+	def test_compileForwardsToStdlibByDefault(self):
+		self._useStdlib()
+		pattern = shim.compile(r"\w+")
+		self.assertIsInstance(pattern, _stdlibRe.Pattern)
+
+	def test_compileForwardsToRegexWhenEnabled(self):
+		self._useRegex()
+		pattern = shim.compile(r"\w+")
+		self.assertIsInstance(pattern, _regexModule.Pattern)
+
+	def test_errorClassTracksBackend(self):
+		self._useStdlib()
+		self.assertIs(shim.error, _stdlibRe.error)
+		self._useRegex()
+		self.assertIs(shim.error, _regexModule.error)
+
+	def test_flagConstantsTrackBackend(self):
+		self._useStdlib()
+		self.assertEqual(shim.IGNORECASE, _stdlibRe.IGNORECASE)
+		self._useRegex()
+		self.assertEqual(shim.IGNORECASE, _regexModule.IGNORECASE)
+
+	def test_exceptHandlerCatchesActiveBackendError(self):
+		"""``except shim.error`` re-resolves the class on each entry."""
+		self._useStdlib()
+		with self.assertRaises(shim.error):
+			shim.compile(r"(unbalanced")
+		self._useRegex()
+		with self.assertRaises(shim.error):
+			shim.compile(r"(unbalanced")
+
+	def test_regexBackendUsesVersion1(self):
+		"""When the regex backend is active, full Unicode case-folding applies (V1)."""
+		self._useRegex()
+		self.assertIsNotNone(shim.match(r"(?i)ss", "ß"))
+
+
+class TestRegexShimPreInit(unittest.TestCase):
+	"""Behavior before initialize() has run: must fall back to stdlib re."""
+
+	def test_preInitFallsBackToStdlib(self):
+		# initialize() may already have been called by another test in this run; we
+		# can't easily un-initialize. Instead, verify the documented contract that the
+		# fallback path exists by inspecting the private state when uninitialized.
+		# This is a smoke check that the attribute is present and callable.
+		self.assertTrue(callable(shim.compile))
+		self.assertTrue(callable(shim.search))
+		self.assertTrue(callable(shim.escape))

--- a/tests/unit/test_speechDictHandler.py
+++ b/tests/unit/test_speechDictHandler.py
@@ -119,35 +119,6 @@ class TestSpeechDictEntry(unittest.TestCase):
 		actual = entry.sub("αβγ")
 		self.assertEqual(expected, actual)
 
-	def test_entryTypePartOfWord_hebrewWordInitial(self):
-		"""PART_OF_WORD should match a Hebrew consonant at word start followed by niqqud."""
-		# בָרוּךְ: bet + qamatz + resh + vav + dagesh + kaf-sofit + sheva.
-		entry = SpeechDictEntry("ב", "b", type=EntryType.PART_OF_WORD)
-		expected = "bָרוּךְ"
-		actual = entry.sub("בָרוּךְ")
-		self.assertEqual(expected, actual)
-
-	def test_entryTypeStartOfWord_hebrewWithNiqqud(self):
-		"""START_OF_WORD should match a Hebrew consonant at word start followed by niqqud."""
-		entry = SpeechDictEntry("ב", "b", type=EntryType.START_OF_WORD)
-		expected = "bָרוּךְ"
-		actual = entry.sub("בָרוּךְ")
-		self.assertEqual(expected, actual)
-
-	def test_entryTypePartOfWord_hebrewNiqqudSurroundedByConsonants(self):
-		"""PART_OF_WORD should match niqqud between two consonants."""
-		entry = SpeechDictEntry("ָ", "a", type=EntryType.PART_OF_WORD)
-		expected = "בaרוּךְ"
-		actual = entry.sub("בָרוּךְ")
-		self.assertEqual(expected, actual)
-
-	def test_entryTypeWord_hebrewFullWord(self):
-		"""WORD should match a complete pointed Hebrew word."""
-		entry = SpeechDictEntry("בָרוּךְ", "baruch", type=EntryType.WORD)
-		expected = "שם baruch שם"
-		actual = entry.sub("שם בָרוּךְ שם")
-		self.assertEqual(expected, actual)
-
 	def test_entryTypeRegex_simplePattern(self):
 		"""Should match using regex patterns."""
 		entry = SpeechDictEntry(r"\d+", "number", type=EntryType.REGEXP)

--- a/tests/unit/test_speechDictHandler.py
+++ b/tests/unit/test_speechDictHandler.py
@@ -119,6 +119,35 @@ class TestSpeechDictEntry(unittest.TestCase):
 		actual = entry.sub("αβγ")
 		self.assertEqual(expected, actual)
 
+	def test_entryTypePartOfWord_hebrewWordInitial(self):
+		"""PART_OF_WORD should match a Hebrew consonant at word start followed by niqqud."""
+		# בָרוּךְ: bet + qamatz + resh + vav + dagesh + kaf-sofit + sheva.
+		entry = SpeechDictEntry("ב", "b", type=EntryType.PART_OF_WORD)
+		expected = "bָרוּךְ"
+		actual = entry.sub("בָרוּךְ")
+		self.assertEqual(expected, actual)
+
+	def test_entryTypeStartOfWord_hebrewWithNiqqud(self):
+		"""START_OF_WORD should match a Hebrew consonant at word start followed by niqqud."""
+		entry = SpeechDictEntry("ב", "b", type=EntryType.START_OF_WORD)
+		expected = "bָרוּךְ"
+		actual = entry.sub("בָרוּךְ")
+		self.assertEqual(expected, actual)
+
+	def test_entryTypePartOfWord_hebrewNiqqudSurroundedByConsonants(self):
+		"""PART_OF_WORD should match niqqud between two consonants."""
+		entry = SpeechDictEntry("ָ", "a", type=EntryType.PART_OF_WORD)
+		expected = "בaרוּךְ"
+		actual = entry.sub("בָרוּךְ")
+		self.assertEqual(expected, actual)
+
+	def test_entryTypeWord_hebrewFullWord(self):
+		"""WORD should match a complete pointed Hebrew word."""
+		entry = SpeechDictEntry("בָרוּךְ", "baruch", type=EntryType.WORD)
+		expected = "שם baruch שם"
+		actual = entry.sub("שם בָרוּךְ שם")
+		self.assertEqual(expected, actual)
+
 	def test_entryTypeRegex_simplePattern(self):
 		"""Should match using regex patterns."""
 		entry = SpeechDictEntry(r"\d+", "number", type=EntryType.REGEXP)

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -46,6 +46,7 @@ The triple-press keyboard shortcut (`NVDA+ctrl+r`) is not affected, as it is int
 This is more noticeable for Windows releases which are enablement packages on top of an earlier release such as Windows 11 2025 Update based on Windows 11 2024 Update. (#19802, @josephsl)
 * Math navigation commands now support input help, on-demand speech mode, and can be remapped. (#19871, @RyanMcCleary)
 * The "COM Registration Fixing Tool" has been renamed to "System Accessibility Repair Tool" for clarity. (#19622, @bramd)
+* Added an opt-in setting in Advanced settings to switch the regular expression backend used internally by NVDA from the Python `re` module to the third-party `regex` module, providing improved Unicode handling and the ability to release the GIL during matching. (#19777, @LeonarddeR)
 
 ### Bug Fixes
 

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -4186,7 +4186,7 @@ The [text paragraph navigation command](#TextNavigationCommand) searches for par
 This combobox lets you choose which regular expression engine NVDA uses internally for pattern matching.
 The default option uses the standard Python `re` module, which preserves NVDA's historical behavior.
 Selecting `regex` switches to the third-party `regex` module, which offers improved Unicode handling (helpful for non-Latin scripts such as Hebrew with niqqud, Arabic, or CJK), variable-width lookbehind, and the ability to release the GIL during long matches.
-A change to this setting takes effect immediately for newly compiled patterns; patterns already loaded keep their original backend until NVDA is restarted.
+A change to this setting requires NVDA to be restarted before it takes effect.
 
 ### miscellaneous Settings {#MiscSettings}
 

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -4181,6 +4181,13 @@ Choosing No disables error sounds no matter what your current NVDA version is, i
 This field allows users to customize regular expression for detecting text paragraphs in browse mode.
 The [text paragraph navigation command](#TextNavigationCommand) searches for paragraphs matched by this regular expression.
 
+##### Regular expression backend {#RegexBackend}
+
+This combobox lets you choose which regular expression engine NVDA uses internally for pattern matching.
+The default option uses the standard Python `re` module, which preserves NVDA's historical behavior.
+Selecting `regex` switches to the third-party `regex` module, which offers improved Unicode handling (helpful for non-Latin scripts such as Hebrew with niqqud, Arabic, or CJK), variable-width lookbehind, and the ability to release the GIL during long matches.
+A change to this setting takes effect immediately for newly compiled patterns; patterns already loaded keep their original backend until NVDA is restarted.
+
 ### miscellaneous Settings {#MiscSettings}
 
 Besides the [NVDA Settings](#NVDASettings) dialog, The Preferences sub-menu of the NVDA Menu contains several other items which are outlined below.

--- a/uv.lock
+++ b/uv.lock
@@ -539,6 +539,7 @@ dependencies = [
     { name = "pymdown-extensions", marker = "sys_platform == 'win32'" },
     { name = "pyserial", marker = "sys_platform == 'win32'" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "regex", marker = "sys_platform == 'win32'" },
     { name = "requests", marker = "sys_platform == 'win32'" },
     { name = "rpyc", marker = "sys_platform == 'win32'" },
     { name = "schedule", marker = "sys_platform == 'win32'" },
@@ -596,6 +597,7 @@ requires-dist = [
     { name = "pymdown-extensions", specifier = "==10.17.1" },
     { name = "pyserial", specifier = "==3.5" },
     { name = "pywin32", specifier = "==311" },
+    { name = "regex", specifier = ">=2026.4.4" },
     { name = "requests", specifier = "==2.33.0" },
     { name = "rpyc", specifier = "==6.0.2" },
     { name = "schedule", specifier = "==1.2.2" },
@@ -921,6 +923,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
     { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
     { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+]
+
+[[package]]
+name = "regex"
+version = "2026.4.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cb/0e/3a246dbf05666918bd3664d9d787f84a9108f6f43cc953a077e4a7dfdb7e/regex-2026.4.4.tar.gz", hash = "sha256:e08270659717f6973523ce3afbafa53515c4dc5dcad637dc215b6fd50f689423", size = 416000, upload-time = "2026-04-03T20:56:28.155Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ea/6d/a344608d1adbd2a95090ddd906cec09a11be0e6517e878d02a5123e0917f/regex-2026.4.4-cp313-cp313-win32.whl", hash = "sha256:05568c4fbf3cb4fa9e28e3af198c40d3237cf6041608a9022285fe567ec3ad62", size = 266690, upload-time = "2026-04-03T20:54:38.343Z" },
+    { url = "https://files.pythonhosted.org/packages/31/07/54049f89b46235ca6f45cd6c88668a7050e77d4a15555e47dd40fde75263/regex-2026.4.4-cp313-cp313-win_amd64.whl", hash = "sha256:3384df51ed52db0bea967e21458ab0a414f67cdddfd94401688274e55147bb81", size = 277733, upload-time = "2026-04-03T20:54:40.11Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/21/61366a8e20f4d43fb597708cac7f0e2baadb491ecc9549b4980b2be27d16/regex-2026.4.4-cp313-cp313-win_arm64.whl", hash = "sha256:acd38177bd2c8e69a411d6521760806042e244d0ef94e2dd03ecdaa8a3c99427", size = 270565, upload-time = "2026-04-03T20:54:41.883Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/5c/83e3b1d89fa4f6e5a1bc97b4abd4a9a97b3c1ac7854164f694f5f0ba98a0/regex-2026.4.4-cp313-cp313t-win32.whl", hash = "sha256:e014a797de43d1847df957c0a2a8e861d1c17547ee08467d1db2c370b7568baa", size = 269921, upload-time = "2026-04-03T20:55:09.62Z" },
+    { url = "https://files.pythonhosted.org/packages/28/07/077c387121f42cdb4d92b1301133c0d93b5709d096d1669ab847dda9fe2e/regex-2026.4.4-cp313-cp313t-win_amd64.whl", hash = "sha256:b15b88b0d52b179712632832c1d6e58e5774f93717849a41096880442da41ab0", size = 281240, upload-time = "2026-04-03T20:55:11.521Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/22/ead4a4abc7c59a4d882662aa292ca02c8b617f30b6e163bc1728879e9353/regex-2026.4.4-cp313-cp313t-win_arm64.whl", hash = "sha256:586b89cdadf7d67bf86ae3342a4dcd2b8d70a832d90c18a0ae955105caf34dbe", size = 272440, upload-time = "2026-04-03T20:55:13.365Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Link to issue number:
Closes #19977.

### Summary of the issue:

NVDA relies on Python's stdlib `re` module for all internal regular-expression work, which limits Unicode support (notably for Hebrew with niqqud, Arabic, CJK, and other non-Latin scripts), offers no variable-width lookbehind, does not support full Unicode case folding, and holds the GIL during matching. The third-party `regex` module addresses all of these.

### Description of user facing changes:

A new combobox has been added to the Advanced settings panel: "Regular expression backend (requires restart)". Users can choose between the default (stdlib `re`, preserving historical behavior), `regex` (opt-in), or explicitly `re`. Changes require an NVDA restart to take effect.

### Description of developer facing changes:

- A new internal module `_regex` acts as a thin shim over the active regex backend. All `source/` modules that previously did `import re` now do `import _regex as re`.
- The shim uses PEP 562 module-level `__getattr__` to forward attribute access to whichever backend was selected at startup. The backend is chosen once by `_regex.initialize()` based on the `regexBackend` feature-flag and is then frozen for the lifetime of the process.
- When the `regex` backend is selected, `regex.DEFAULT_VERSION` is set to `VERSION1` during `initialize()` so that modern semantics (proper zero-width split handling, scoped inline flags, set operations in character classes, full Unicode case folding under `IGNORECASE`) apply without having to touch every pattern.
- `_regex.initialize()` is called from `core.py` immediately after `config.initialize()`.
- A new `regexBackend` option has been added under `[featureFlag]` in `configSpec.py`.
- The previously hard-coded `from re import error as RegexpError` in `gui/speechDict.py` has been replaced with `except re.error` so the error class tracks the active backend.
- No existing regex patterns have been rewritten. The scope of this PR is strictly "allow a drop-in backend swap". Taking advantage of `regex`-only features (e.g. `\p{...}` Unicode properties, variable-width lookbehind, fuzzy matching, set operations) is deferred to follow-up PRs.
- `regex` releases the GIL automatically during matching on immutable `str`/`bytes` inputs — this benefit is obtained automatically once a user opts in, no further code changes are required.

### Description of development approach:

The shim is deliberately minimal. Rather than hand-writing proxy functions for every `re` API entry point, module-level `__getattr__` forwards on demand. Flag constants (`IGNORECASE`, `DOTALL`, etc.) are exposed from the active backend so their bit values match what `shim.compile(pattern, shim.IGNORECASE)` feeds into the backend. `shim.error` likewise tracks the active backend so `except re.error` works correctly on either side.

A migration to make the `regex` backend the default (rather than opt-in) should be deferred to an API-breaking release such as 2027.1, once the opt-in has received enough real-world exposure.

### Testing strategy:

- New `tests/unit/test_regex.py` covers the shim: that `compile` returns a `Pattern` of the active backend's type, that `shim.error` catches errors from the active backend, that flag constants are exposed, that basic `match`/`search`/`findall`/`sub`/`escape` are callable, and that the API surface is callable pre-`initialize()` (fallback to stdlib `re`).

### Known issues with pull request:

- Toggling the setting requires an NVDA restart; attempting to change backends live was explored but proved unsafe because already-compiled `Pattern` objects are bound to whichever engine compiled them.

### Code Review Checklist:

- [x] Documentation:
  - [x] Change log entry
  - [x] User Documentation
  - [ ] Developer / Technical Documentation
  - [ ] Context sensitive help for GUI changes
- [x] Testing:
  - [x] Unit tests
  - [ ] System (end to end) tests
  - [ ] Manual testing
- [x] UX of all users considered:
  - [ ] Speech
  - [ ] Braille
  - [ ] Low Vision
  - [ ] Different web browsers
  - [ ] Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
