### PR TITLE
Fix NVDA not being able to cancel Access Bridge call (#14396)

### DIFF
--- a/nvdaHelper/local/nvdaHelperLocal.cpp
+++ b/nvdaHelper/local/nvdaHelperLocal.cpp
@@ -107,7 +107,9 @@ LRESULT cancellableSendMessageTimeoutTemplate(SendMessageFunction realSendMessag
 	return ret;
 }
 
-// Fix for nvdaHelperLocal.def
+// Keep this non-template wrapper with this exact name/signature because it is
+// exported via nvdaHelperLocal.def and used by source/NVDAHelper/localLib.py.
+// cancellableSendMessageTimeoutTemplate is only the internal implementation detail.
 LRESULT cancellableSendMessageTimeout(HWND hwnd, UINT Msg, WPARAM wParam, LPARAM lParam, UINT fuFlags, UINT uTimeout, PDWORD_PTR lpdwResult) {
 	return cancellableSendMessageTimeoutTemplate(real_SendMessageTimeoutW, hwnd, Msg, wParam, lParam, fuFlags, uTimeout, lpdwResult);
 }

--- a/nvdaHelper/local/nvdaHelperLocal.cpp
+++ b/nvdaHelper/local/nvdaHelperLocal.cpp
@@ -19,8 +19,9 @@ For more details see: https://www.gnu.org/licenses/gpl-2.0.html
 
 decltype(&SendMessageW) real_SendMessageW = nullptr;
 decltype(&SendMessageTimeoutW) real_SendMessageTimeoutW = nullptr;
+decltype(&SendMessageA) real_SendMessageA = nullptr;
+decltype(&SendMessageTimeoutA) real_SendMessageTimeoutA = nullptr;
 decltype(&OpenClipboard) real_OpenClipboard = nullptr;
-
 
 handle_t createRemoteBindingHandle(wchar_t* uuidString) {
 	RPC_STATUS rpcStatus;
@@ -56,7 +57,8 @@ DWORD mainThreadId = 0;
 HANDLE cancelCallEvent = NULL;
 void(__stdcall *_notifySendMessageCancelled)() = NULL;
 
-LRESULT cancellableSendMessageTimeout(HWND hwnd, UINT Msg, WPARAM wParam, LPARAM lParam, UINT fuFlags, UINT uTimeout, PDWORD_PTR lpdwResult) {
+template<typename SendMessageFunction>
+LRESULT cancellableSendMessageTimeoutTemplate(SendMessageFunction realSendMessageFunction, HWND hwnd, UINT Msg, WPARAM wParam, LPARAM lParam, UINT fuFlags, UINT uTimeout, PDWORD_PTR lpdwResult) {
 	if (!hwnd) {
 		// Return as early as possible when no hwnd is given.
 		SetLastError(ERROR_INVALID_WINDOW_HANDLE);
@@ -66,7 +68,7 @@ LRESULT cancellableSendMessageTimeout(HWND hwnd, UINT Msg, WPARAM wParam, LPARAM
 	DWORD currentThreadId = GetCurrentThreadId();
 	if (GetWindowThreadProcessId(hwnd, NULL) == currentThreadId) {
 		// We're sending a message to the current thread, so just forward the call.
-		return real_SendMessageTimeoutW(hwnd, Msg, wParam, lParam, fuFlags, uTimeout, lpdwResult);
+		return realSendMessageFunction(hwnd, Msg, wParam, lParam, fuFlags, uTimeout, lpdwResult);
 	}
 
 	if (WaitForSingleObject(cancelCallEvent, 0) == WAIT_OBJECT_0) {
@@ -96,7 +98,7 @@ LRESULT cancellableSendMessageTimeout(HWND hwnd, UINT Msg, WPARAM wParam, LPARAM
 			SetLastError(ERROR_CANCELLED);
 			return 0;
 		}
-		if ((ret = real_SendMessageTimeoutW(hwnd, Msg, wParam, lParam, fuFlags, std::min(remainingTimeout, CANCELSENDMESSAGE_CHECK_INTERVAL), lpdwResult)) != 0 || GetLastError() != ERROR_TIMEOUT) {
+		if ((ret = realSendMessageFunction(hwnd, Msg, wParam, lParam, fuFlags, std::min(remainingTimeout, CANCELSENDMESSAGE_CHECK_INTERVAL), lpdwResult)) != 0 || GetLastError() != ERROR_TIMEOUT) {
 			// Success or error other than timeout.
 			return ret;
 		}
@@ -105,14 +107,29 @@ LRESULT cancellableSendMessageTimeout(HWND hwnd, UINT Msg, WPARAM wParam, LPARAM
 	return ret;
 }
 
+// Fix for nvdaHelperLocal.def
+LRESULT cancellableSendMessageTimeout(HWND hwnd, UINT Msg, WPARAM wParam, LPARAM lParam, UINT fuFlags, UINT uTimeout, PDWORD_PTR lpdwResult) {
+	return cancellableSendMessageTimeoutTemplate(real_SendMessageTimeoutW, hwnd, Msg, wParam, lParam, fuFlags, uTimeout, lpdwResult);
+}
+
 LRESULT WINAPI fake_SendMessageW(HWND hwnd, UINT Msg, WPARAM wParam, LPARAM lParam) {
 	DWORD_PTR result = 0;
-	cancellableSendMessageTimeout(hwnd, Msg, wParam, lParam, 0, 60000, &result);
+	cancellableSendMessageTimeoutTemplate(real_SendMessageTimeoutW, hwnd, Msg, wParam, lParam, 0, 60000, &result);
 	return (LRESULT)result;
 }
 
 LRESULT WINAPI fake_SendMessageTimeoutW(HWND hwnd, UINT Msg, WPARAM wParam, LPARAM lParam, UINT fuFlags, UINT uTimeout, PDWORD_PTR lpdwResult) {
-	return cancellableSendMessageTimeout(hwnd, Msg, wParam, lParam, fuFlags, uTimeout, lpdwResult);
+	return cancellableSendMessageTimeoutTemplate(real_SendMessageTimeoutW, hwnd, Msg, wParam, lParam, fuFlags, uTimeout, lpdwResult);
+}
+
+LRESULT WINAPI fake_SendMessageA(HWND hwnd, UINT Msg, WPARAM wParam, LPARAM lParam) {
+	DWORD_PTR result = 0;
+	cancellableSendMessageTimeoutTemplate(real_SendMessageTimeoutA, hwnd, Msg, wParam, lParam, 0, 60000, &result);
+	return (LRESULT)result;
+}
+
+LRESULT WINAPI fake_SendMessageTimeoutA(HWND hwnd, UINT Msg, WPARAM wParam, LPARAM lParam, UINT fuFlags, UINT uTimeout, PDWORD_PTR lpdwResult) {
+	return cancellableSendMessageTimeoutTemplate(real_SendMessageTimeoutA, hwnd, Msg, wParam, lParam, fuFlags, uTimeout, lpdwResult);
 }
 
 //A replacement OpenClipboard function to disable the use of the clipboard in a secure mode NVDA process
@@ -131,6 +148,10 @@ void nvdaHelperLocal_initialize(bool secureMode) {
 	// we can cancel such calls when they would otherwise freeze NVDA's process.
 	apiHook_hookFunction_safe(SendMessageW, fake_SendMessageW, &real_SendMessageW);
 	apiHook_hookFunction_safe(SendMessageTimeoutW, fake_SendMessageTimeoutW, &real_SendMessageTimeoutW);
+	// Hook also SendMessageA and SendMessageTimeoutA as Java Access  Bridge uses them
+	apiHook_hookFunction_safe(SendMessageA, fake_SendMessageA, &real_SendMessageA);
+	apiHook_hookFunction_safe(SendMessageTimeoutA, fake_SendMessageTimeoutA, &real_SendMessageTimeoutA);
+
 	// For secure mode NVDA process, hook OpenClipboard to disable usage of the clipboard
 	if (secureMode) {
 		apiHook_hookFunction_safe(OpenClipboard, fake_OpenClipboard, &real_OpenClipboard);

--- a/nvdaHelper/local/nvdaHelperLocal.cpp
+++ b/nvdaHelper/local/nvdaHelperLocal.cpp
@@ -148,7 +148,7 @@ void nvdaHelperLocal_initialize(bool secureMode) {
 	// we can cancel such calls when they would otherwise freeze NVDA's process.
 	apiHook_hookFunction_safe(SendMessageW, fake_SendMessageW, &real_SendMessageW);
 	apiHook_hookFunction_safe(SendMessageTimeoutW, fake_SendMessageTimeoutW, &real_SendMessageTimeoutW);
-	// Hook also SendMessageA and SendMessageTimeoutA as Java Access  Bridge uses them
+	// Hook also SendMessageA and SendMessageTimeoutA as Java Access Bridge uses them
 	apiHook_hookFunction_safe(SendMessageA, fake_SendMessageA, &real_SendMessageA);
 	apiHook_hookFunction_safe(SendMessageTimeoutA, fake_SendMessageTimeoutA, &real_SendMessageTimeoutA);
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -49,6 +49,7 @@ This is more noticeable for Windows releases which are enablement packages on to
 
 ### Bug Fixes
 
+* NVDA will attempt to recover more quickly from freezes in some applications, especially those written in Java. (#14396, @thgcode)
 * In Firefox browse mode, the accessible name of form controls (such as checkboxes and radio buttons) is now correctly announced when the control has an `aria-label` and an associated `<label>` element that contains only `aria-hidden` content. (#19409, @bramd)
 * The "Toggles on and off if the screen layout is preserved while rendering the document content" item in the "Browse mode" category of the Input Gestures dialog now behaves correctly. (#18378)
 * In Microsoft Word with UIA enabled, page changes are now correctly announced when navigating table rows that span multiple pages. (#19386, @akj)


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Fixes #14396

### Summary of the issue:
NVDA freezes and takes a long time to recover if Java Access Bridge takes a long time to return.

### Description of user facing changes:
NVDA will recover more quickly when Access Bridge takes a long time to return.

### Description of developer facing changes:
Nvda will hook `SendMessageA` and `SendMessageTimeoutA` functions.

### Description of development approach:
Java Access Bridge is compiled without the `UNICODE` preprocessor macro defined on the C++ side, so it uses the `SendMessageTimeoutA` and `SendMessageA` functions. NVDA is hooking only the unicode versions (I.E., `SendMessageTimeoutW` and `SendMessageW`) functions from the Windows API. This code creates a template that makes possible to hook both versions of the functions (unicode and non-unicode), so that they can be cancelled by NVDA.

### Testing strategy:
Tested with the provided example on the issue, with the sleep call set to 20000 MS, and tabbing through the example and changing Windows. I will paste the logs of the main thread (when the hook was not applied) and after applying the hook.

First log:

```
INFO - watchdog.waitForFreezeRecovery (20:58:03.545) - watchdog (764):
Starting freeze recovery after 1.0008748999998716 seconds.
ERROR - watchdog.waitForFreezeRecovery (20:58:18.562) - watchdog (764):
Core frozen in stack! (16.017321499999525 seconds)
INFO - watchdog.waitForFreezeRecovery (20:58:18.584) - watchdog (764):
Listing stacks for Python threads:

Python stack for thread 6880 (MainThread):
  File "D:\nvda\source\nvda.pyw", line 309, in <module>
    core.main()
  File "D:\nvda\source\core.py", line 1070, in main
    app.MainLoop()
  File "D:\nvda\.venv\Lib\site-packages\wx\core.py", line 2254, in MainLoop
    rv = wx.PyApp.MainLoop(self)
  File "D:\nvda\source\core.py", line 1011, in Notify
    JABHandler.pumpAll()
  File "D:\nvda\source\JABHandler.py", line 1246, in pumpAll
    queueHandler.flushQueue(internalFunctionQueue)
  File "D:\nvda\source\queueHandler.py", line 67, in flushQueue
    func(*args, **kwargs)
  File "D:\nvda\source\JABHandler.py", line 633, in __del__
    bridgeDll.releaseJavaObject(self.vmID, self.accContext)

    INFO - watchdog.waitForFreezeRecovery (20:58:22.577) - watchdog (764):
    Recovered from freeze after 20.033046499999728 seconds.
```

Second log (no stack trace):

```
INFO - watchdog.waitForFreezeRecovery (21:01:54.449) - watchdog (1880):
Starting freeze recovery after 1.0019885000001523 seconds.
INFO - watchdog.waitForFreezeRecovery (21:01:54.702) - watchdog (1880):
Recovered from freeze after 1.2551013000002058 seconds.
```

### Known issues with pull request:
NVDA still freezes due to the nature of the provided example, but the delay should be smaller and allow the user to recover access to the computer more quickly.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [ ] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [ ] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [ ] API is compatible with existing add-ons.
- [ ] Security precautions taken.
