### PR TITLE
store scan details in the same format as server

### DIFF
--- a/source/addonStore/models/addon.py
+++ b/source/addonStore/models/addon.py
@@ -1,8 +1,9 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2022-2023 NV Access Limited
-# This file is covered by the GNU General Public License.
-# See the file COPYING for more details.
+# Copyright (C) 2022-2026 NV Access Limited
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
 
+from collections.abc import Generator
 import dataclasses
 import json
 import os
@@ -10,12 +11,8 @@ from datetime import datetime
 from typing import (
 	TYPE_CHECKING,
 	Any,
-	Dict,
-	Generator,
-	List,
 	Optional,
 	Protocol,
-	Union,
 )
 
 from requests.structures import CaseInsensitiveDict
@@ -38,7 +35,7 @@ if TYPE_CHECKING:
 		AddonManifest,
 	)
 
-	AddonGUICollectionT = Dict[Channel, CaseInsensitiveDict["_AddonGUIModel"]]
+	AddonGUICollectionT = dict[Channel, CaseInsensitiveDict["_AddonGUIModel"]]
 	"""
 	Add-ons that have the same ID except differ in casing cause a path collision,
 	as add-on IDs are installed to a case insensitive path.
@@ -97,7 +94,7 @@ class _AddonGUIModel(SupportsAddonState, SupportsVersionCheck, Protocol):
 	def listItemVMId(self) -> str:
 		return f"{self.addonId}-{self.channel}"
 
-	def asdict(self) -> Dict[str, Any]:
+	def asdict(self) -> dict[str, Any]:
 		assert dataclasses.is_dataclass(self)
 		jsonData = dataclasses.asdict(self)
 		for field in jsonData:
@@ -107,6 +104,8 @@ class _AddonGUIModel(SupportsAddonState, SupportsVersionCheck, Protocol):
 			fieldValue = getattr(self, field)
 			if isinstance(fieldValue, MajorMinorPatch):
 				jsonData[field] = fieldValue._asdict()
+			if isinstance(fieldValue, VirusTotalScanResults):
+				jsonData[field] = fieldValue.toDict()
 		return jsonData
 
 
@@ -337,10 +336,10 @@ class CachedAddonsModel:
 	cacheHash: Optional[str]
 	cachedLanguage: str
 	# AddonApiVersionT or the string .network._LATEST_API_VER
-	nvdaAPIVersion: Union[addonAPIVersion.AddonApiVersionT, str]
+	nvdaAPIVersion: addonAPIVersion.AddonApiVersionT | str
 
 
-def _createInstalledStoreModelFromData(addon: Dict[str, Any]) -> InstalledAddonStoreModel:
+def _createInstalledStoreModelFromData(addon: dict[str, Any]) -> InstalledAddonStoreModel:
 	return InstalledAddonStoreModel(
 		addonId=addon["addonId"],
 		publisher=addon["publisher"],
@@ -362,7 +361,7 @@ def _createInstalledStoreModelFromData(addon: Dict[str, Any]) -> InstalledAddonS
 	)
 
 
-def _createStoreModelFromData(addon: Dict[str, Any]) -> AddonStoreModel:
+def _createStoreModelFromData(addon: dict[str, Any]) -> AddonStoreModel:
 	return AddonStoreModel(
 		addonId=addon["addonId"],
 		displayName=addon["displayName"],
@@ -417,7 +416,7 @@ def _createStoreCollectionFromJson(jsonData: str) -> "AddonGUICollectionT":
 	See https://github.com/nvaccess/addon-datastore#api-data-generation-details
 	for details of the data.
 	"""
-	data: List[Dict[str, Any]] = json.loads(jsonData)
+	data: list[dict[str, Any]] = json.loads(jsonData)
 	addonCollection = _createAddonGUICollection()
 
 	for addon in data:

--- a/source/addonStore/models/addon.py
+++ b/source/addonStore/models/addon.py
@@ -97,14 +97,16 @@ class _AddonGUIModel(SupportsAddonState, SupportsVersionCheck, Protocol):
 	def asdict(self) -> dict[str, Any]:
 		assert dataclasses.is_dataclass(self)
 		jsonData = dataclasses.asdict(self)
-		for field in jsonData:
+		jsonDataCopy = jsonData.copy()
+		for field in jsonDataCopy:
 			# dataclasses.asdict parses NamedTuples to JSON arrays,
 			# rather than JSON object dictionaries,
 			# which is expected by add-on infrastructure.
 			fieldValue = getattr(self, field)
 			if isinstance(fieldValue, MajorMinorPatch):
 				jsonData[field] = fieldValue._asdict()
-			if isinstance(fieldValue, VirusTotalScanResults):
+			elif isinstance(fieldValue, VirusTotalScanResults):
+				jsonData["vtScanUrl"] = fieldValue.scanUrl
 				jsonData[field] = fieldValue.toDict()
 		return jsonData
 

--- a/source/addonStore/models/scanResults.py
+++ b/source/addonStore/models/scanResults.py
@@ -62,10 +62,10 @@ class VirusTotalScanResults:
 							"timeout": self.timeout,
 							"confirmed-timeout": self.confirmedTimeout,
 							"type-unsupported": self.typeUnsupported,
-						}
-					}
-				]
-			}
+						},
+					},
+				],
+			},
 		}
 
 	@property

--- a/source/addonStore/models/scanResults.py
+++ b/source/addonStore/models/scanResults.py
@@ -44,6 +44,30 @@ class VirusTotalScanResults:
 			log.error(f"Malformed add-on scan results.: {addon!r}", exc_info=True)
 			return None
 
+	def toDict(self) -> dict[str, int | str]:
+		"""Store scan data in the same format as the original add-on scan results.
+
+		:return: A dictionary representing the scan results.
+		"""
+		return {
+			"scanResults": {
+				"virusTotal": [
+					{
+						"last_analysis_stats": {
+							"malicious": self.malicious,
+							"undetected": self.undetected,
+							"harmless": self.harmless,
+							"suspicious": self.suspicious,
+							"failure": self.failure,
+							"timeout": self.timeout,
+							"confirmed-timeout": self.confirmedTimeout,
+							"type-unsupported": self.typeUnsupported,
+						}
+					}
+				]
+			}
+		}
+
 	@property
 	def totalScans(self) -> int:
 		return self.malicious + self.undetected + self.harmless + self.suspicious

--- a/source/addonStore/models/scanResults.py
+++ b/source/addonStore/models/scanResults.py
@@ -44,7 +44,7 @@ class VirusTotalScanResults:
 			log.error(f"Malformed add-on scan results.: {addon!r}", exc_info=True)
 			return None
 
-	def toDict(self) -> dict[str, Any]:
+	def toDict(self) -> dict[str, list[dict[str, dict[str, int]]]]:
 		"""Store scan data in the same format as the original add-on scan results.
 
 		:return: A dictionary representing the scan results.

--- a/source/addonStore/models/scanResults.py
+++ b/source/addonStore/models/scanResults.py
@@ -50,22 +50,20 @@ class VirusTotalScanResults:
 		:return: A dictionary representing the scan results.
 		"""
 		return {
-			"scanResults": {
-				"virusTotal": [
-					{
-						"last_analysis_stats": {
-							"malicious": self.malicious,
-							"undetected": self.undetected,
-							"harmless": self.harmless,
-							"suspicious": self.suspicious,
-							"failure": self.failure,
-							"timeout": self.timeout,
-							"confirmed-timeout": self.confirmedTimeout,
-							"type-unsupported": self.typeUnsupported,
-						},
+			"virusTotal": [
+				{
+					"last_analysis_stats": {
+						"malicious": self.malicious,
+						"undetected": self.undetected,
+						"harmless": self.harmless,
+						"suspicious": self.suspicious,
+						"failure": self.failure,
+						"timeout": self.timeout,
+						"confirmed-timeout": self.confirmedTimeout,
+						"type-unsupported": self.typeUnsupported,
 					},
-				],
-			},
+				},
+			],
 		}
 
 	@property

--- a/source/addonStore/models/scanResults.py
+++ b/source/addonStore/models/scanResults.py
@@ -44,7 +44,7 @@ class VirusTotalScanResults:
 			log.error(f"Malformed add-on scan results.: {addon!r}", exc_info=True)
 			return None
 
-	def toDict(self) -> dict[str, int | str]:
+	def toDict(self) -> dict[str, Any]:
 		"""Store scan data in the same format as the original add-on scan results.
 
 		:return: A dictionary representing the scan results.


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Closes #19984

### Summary of the issue:
Once an add-on is installed, VirusTotal scan results would be cached in a different format than what was served by the server.
This would cause issues in unpacking the scanned data.
This would cause scan results to fail to be loaded for installed add-ons.

### Description of user facing changes:
Viewing scan results for installed add-ons should be fixed

### Description of developer facing changes:
None

### Description of development approach:

* Added a `toDict` method to the `VirusTotalScanResults` class in `scanResults.py`, enabling conversion of scan result objects to a dictionary format matching the original scan results structure.
* Updated the `asdict` method in `AddonStoreModel` to use `toDict` for `VirusTotalScanResults` fields, ensuring correct serialization.

### Testing strategy:

Manual testing via add-on store manual test plan

### Known issues with pull request:
none
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
