### PR TITLE
Bump crazy-max/ghaction-virustotal to v5.0.0

### DIFF
--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -674,7 +674,7 @@ jobs:
         path: output
     - name: VirusTotal Scan
       id: virusTotal
-      uses: crazy-max/ghaction-virustotal@v4
+      uses: crazy-max/ghaction-virustotal@v5.0.0
       with:
         vt_api_key: ${{ secrets.VT_API_KEY }}
         files: output/nvda*.exe


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
crazy-max/ghaction-virustotal@v4 uses node 2020. This will [be retired in June](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/). crazy-max/ghaction-virustotal@v5.0.0 uses Node 2024 and is backwards compatible.

### Description of user facing changes:
None

### Description of developer facing changes:
None

### Description of development approach:
Updated tag version

### Testing strategy:
CI

### Known issues with pull request:
None

### Code Review Checklist:
- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
