### PR TITLE
French gestures - Add second Magnifier zoom out gesture

### DIFF
--- a/source/locale/fr/gestures.ini
+++ b/source/locale/fr/gestures.ini
@@ -10,6 +10,10 @@
 	toggleRightMouseButton = kb(laptop):nvda+control+*
 	navigatorObject_previousInFlow = kb(laptop):nvda+shift+ù
 	navigatorObject_nextInFlow = kb(laptop):nvda+shift+*
+	# Add zoom out for fr-fr keyboard since no key is called "-" in this layout (it is on the "5" key)
+	# NVDA+shift+- is not removed since it is useful in fr-ca and fr-ch layouts
+	# In fr-be layout, both NVDA+shift+- and NVDA+shift+) can be used.
+	zoomOut = kb:nvda+shift+)
 
 # For Word and Outlook
 [NVDAObjects.window.winword.WordDocument]


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
On French fr-fr keyboard layout, the magnifier zoom out gesture NVDA+shift+_ does not exist: "_" is on the "8" key and the name of the key is "8", not "_".

### Description of user facing changes:
`NVDA+shift+)` can be used as magnifier zoom out gesture. On fr-fr keyboard layout, it is located next to the zoom in gesture.

NVDA+shift+_ remains assigned, for other French keyboard layouts (fr-ca, fr-ch).

Both gestures work on fr-be layout.

### Description of developer facing changes:
N/A
### Description of development approach:
Updated `gestures.ini` file.

### Testing strategy:
Tested with various French keyboard layouts.
### Known issues with pull request:
fr-be layout have 2 valid gestures for zoom out.
That's not a big problem and in general, the fr `gestures.ini` is made in priority for French (France) layout, where there are probably more French users.

### Code Review Checklist:


- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
