### PR TITLE
handle conflicts between Windows magnifier and NVDA magnifier

### DIFF
--- a/source/_magnifier/fullscreenMagnifier.py
+++ b/source/_magnifier/fullscreenMagnifier.py
@@ -64,14 +64,14 @@ class FullScreenMagnifier(Magnifier):
 		try:
 			self._initializeNativeMagnification()
 		except OSError:
-			log.error("Failed to initialize magnification API", exc_info=True)
+			log.exception("Failed to initialize magnification API")
 			# _isActive is True from super(), so _stopMagnifier properly unregisters
 			self._stopMagnifier()
 			ui.message(
 				pgettext(
 					"magnifier",
-					# Translators: Message when NVDA Magnifier cannot start because another magnifier is already using the magnification API.
-					"Cannot start magnifier: the magnification API is unavailable. Windows Magnifier may already be running.",
+					# Translators: Message when NVDA's Magnifier cannot start because another magnifier is already running.
+					"Cannot start magnifier. Another magnifier application may already be running.",
 				),
 			)
 			return

--- a/source/_magnifier/fullscreenMagnifier.py
+++ b/source/_magnifier/fullscreenMagnifier.py
@@ -9,6 +9,7 @@ Full-screen magnifier module.
 
 from logHandler import log
 import screenCurtain
+import speech
 import ui
 import winUser
 from winBindings import magnification
@@ -67,13 +68,12 @@ class FullScreenMagnifier(Magnifier):
 			log.exception("Failed to initialize magnification API")
 			# _isActive is True from super(), so _stopMagnifier properly unregisters
 			self._stopMagnifier()
-			ui.message(
-				pgettext(
-					"magnifier",
-					# Translators: Message when NVDA's Magnifier cannot start because another magnifier is already running.
-					"Cannot start magnifier. Another magnifier application may already be running.",
-				),
+			message = pgettext(
+				"magnifier",
+				# Translators: Message when NVDA's Magnifier cannot start because another magnifier is already running.
+				"Cannot start magnifier. Another magnifier application may already be running.",
 			)
+			ui.message(message, speechPriority=speech.priorities.Spri.NOW)
 			return
 
 		if self._isActive:
@@ -84,16 +84,21 @@ class FullScreenMagnifier(Magnifier):
 		"""
 		Initialize the Magnification API and verify it is fully usable.
 
-		Raises OSError if MagInitialize fails or if MagSetFullscreenTransform
-		fails (e.g. Windows Magnifier already holds the API). Cleans up after
-		itself on failure so the caller does not need to.
+		Raises OSError if MagInitialize fails or if the initial fullscreen
+		transform fails (e.g. Windows Magnifier already holds the API). If
+		MagSetFullscreenTransform fails after a successful MagInitialize, this
+		method uninitializes the native magnification API before re-raising.
+		Failures from MagInitialize are propagated to the caller.
 		"""
 		magnification.MagInitialize()
 		log.debug("Magnification API initialized")
-		# MagSetFullscreenTransform is what actually fails when Windows Magnifier
-		# is running, even though MagInitialize succeeds in that case.
+		# Applying the first real update verifies the API is usable without
+		# briefly jumping the magnified view to the top-left corner.
 		try:
-			magnification.MagSetFullscreenTransform(self.zoomLevel, 0, 0)
+			coordinates = self._getCoordinatesForMode(self._currentCoordinates)
+			# Save screen position for mode continuity, matching _doUpdate.
+			self._lastScreenPosition = coordinates
+			self._fullscreenMagnifier(coordinates)
 		except OSError:
 			self._uninitializeNativeMagnification()
 			raise
@@ -172,7 +177,6 @@ class FullScreenMagnifier(Magnifier):
 			return
 
 		self._consecutiveErrors = 0
-		self._recoveryAttempts = 0
 		log.info("Full-screen magnifier recovery succeeded")
 		self._startTimer(self._updateMagnifier)
 

--- a/source/_magnifier/fullscreenMagnifier.py
+++ b/source/_magnifier/fullscreenMagnifier.py
@@ -21,6 +21,8 @@ from .utils.errorHandling import trackNativeMagnifierErrors
 
 
 class FullScreenMagnifier(Magnifier):
+	_MAX_RECOVERY_ATTEMPTS: int = 3
+
 	def __init__(self):
 		super().__init__()
 		self._fullscreenMode = getDefaultFullscreenMode()
@@ -59,21 +61,42 @@ class FullScreenMagnifier(Magnifier):
 		log.debug(
 			f"Starting magnifier with zoom level {self.zoomLevel} and filter {self.filterType} and full-screen mode {self._fullscreenMode}",
 		)
-		# Initialize Magnification API if not already initialized
-		self._initializeNativeMagnification()
+		try:
+			self._initializeNativeMagnification()
+		except OSError:
+			log.error("Failed to initialize magnification API", exc_info=True)
+			# _isActive is True from super(), so _stopMagnifier properly unregisters
+			self._stopMagnifier()
+			ui.message(
+				pgettext(
+					"magnifier",
+					# Translators: Message when NVDA Magnifier cannot start because another magnifier is already using the magnification API.
+					"Cannot start magnifier: the magnification API is unavailable. Windows Magnifier may already be running.",
+				),
+			)
+			return
 
 		if self._isActive:
 			self._applyFilter()
 		self._startTimer(self._updateMagnifier)
 
-	@trackNativeMagnifierErrors
 	def _initializeNativeMagnification(self) -> None:
 		"""
-		Initialize the Magnification API.
-		If already initialized or on failure, continues anyway.
+		Initialize the Magnification API and verify it is fully usable.
+
+		Raises OSError if MagInitialize fails or if MagSetFullscreenTransform
+		fails (e.g. Windows Magnifier already holds the API). Cleans up after
+		itself on failure so the caller does not need to.
 		"""
 		magnification.MagInitialize()
 		log.debug("Magnification API initialized")
+		# MagSetFullscreenTransform is what actually fails when Windows Magnifier
+		# is running, even though MagInitialize succeeds in that case.
+		try:
+			magnification.MagSetFullscreenTransform(self.zoomLevel, 0, 0)
+		except OSError:
+			self._uninitializeNativeMagnification()
+			raise
 
 	def _doUpdate(self):
 		"""
@@ -120,34 +143,36 @@ class FullScreenMagnifier(Magnifier):
 		Attempt to recover from repeated Magnification API errors by
 		reinitializing the API. If recovery fails, the magnifier is stopped.
 
-		Each step (uninitialize, initialize, apply filter, restart timer) is
-		controlled independently. If any critical step fails, recovery is aborted.
+		Capped at _MAX_RECOVERY_ATTEMPTS to prevent an infinite restart loop
+		when the API is permanently unavailable (e.g. Windows Magnifier running).
 		"""
-		log.info("Attempting full-screen magnifier recovery via API reinitialization")
+		self._recoveryAttempts += 1
+		if self._recoveryAttempts > self._MAX_RECOVERY_ATTEMPTS:
+			log.error(
+				f"Max recovery attempts ({self._MAX_RECOVERY_ATTEMPTS}) reached, stopping magnifier",
+			)
+			self._conductRecoveryFailure()
+			return
 
-		# Step 1: Uninitialize (best effort, may already be uninitialized)
+		log.info(
+			f"Attempting full-screen magnifier recovery "
+			f"(attempt {self._recoveryAttempts}/{self._MAX_RECOVERY_ATTEMPTS})",
+		)
+
 		self._uninitializeNativeMagnification()
 
-		# Step 2: Initialize (critical - raises on failure)
 		try:
-			magnification.MagInitialize()
-			log.debug("Magnification API initialized during recovery")
-		except OSError:
-			log.error("MagInitialize during recovery failed, aborting recovery", exc_info=True)
-			self._conductRecoveryFailure()
-			return
-
-		# Step 3: Apply filter (critical - raises on failure)
-		try:
+			# _initializeNativeMagnification also probes MagSetFullscreenTransform,
+			# which is the call that fails when Windows Magnifier is running.
+			self._initializeNativeMagnification()
 			magnification.MagSetFullscreenColorEffect(self._getFilterMatrix().value)
-			log.debug("Filter applied during recovery")
 		except OSError:
-			log.error("Failed to apply filter during recovery, aborting recovery", exc_info=True)
+			log.error("Recovery failed", exc_info=True)
 			self._conductRecoveryFailure()
 			return
 
-		# All steps succeeded
 		self._consecutiveErrors = 0
+		self._recoveryAttempts = 0
 		log.info("Full-screen magnifier recovery succeeded")
 		self._startTimer(self._updateMagnifier)
 

--- a/source/_magnifier/magnifier.py
+++ b/source/_magnifier/magnifier.py
@@ -40,6 +40,7 @@ from .utils.focusManager import FocusManager
 class Magnifier:
 	_TIMER_INTERVAL_MS: int = 12
 	_MARGIN_BORDER: int = 50
+	_MAX_CONSECUTIVE_ERRORS: int = 3
 
 	def __init__(self):
 		self._displayOrientation = getPrimaryDisplayOrientation()
@@ -55,6 +56,7 @@ class Magnifier:
 		self._filterType: Filter = getDefaultFilter()
 		self._isManualPanning: bool = False
 		self._consecutiveErrors: int = 0
+		self._recoveryAttempts: int = 0
 		# Register for display changes
 		_displayTracking.displayChanged.register(self._onDisplayChanged)
 		self._screenCurtainIsActive: bool = False
@@ -135,8 +137,6 @@ class Magnifier:
 		self._isActive = True
 		self._currentCoordinates = self._focusManager.getCurrentFocusCoordinates()
 
-	_MAX_CONSECUTIVE_ERRORS: int = 3
-
 	def _updateMagnifier(self) -> None:
 		"""
 		Update the magnifier position and content.
@@ -154,6 +154,7 @@ class Magnifier:
 				self._keepMouseCentered()
 			self._doUpdate()
 			self._consecutiveErrors = 0
+			self._recoveryAttempts = 0
 		except (OSError, COMError):
 			self._consecutiveErrors += 1
 			if self._consecutiveErrors >= self._MAX_CONSECUTIVE_ERRORS:

--- a/tests/unit/test_magnifier/test_fullscreenMagnifier.py
+++ b/tests/unit/test_magnifier/test_fullscreenMagnifier.py
@@ -224,6 +224,7 @@ class TestMagnifierEndToEnd(_TestMagnifier):
 
 			mock_mag.MagUninitialize.assert_called_once()
 			mock_mag.MagInitialize.assert_called_once()
+			mock_mag.MagSetFullscreenTransform.assert_called_once_with(magnifier.zoomLevel, 0, 0)
 			mock_mag.MagSetFullscreenColorEffect.assert_called_once()
 			self.assertEqual(magnifier._consecutiveErrors, 0)
 			magnifier._startTimer.assert_called_once_with(magnifier._updateMagnifier)
@@ -267,6 +268,66 @@ class TestMagnifierEndToEnd(_TestMagnifier):
 		magnifier._startTimer.assert_called_with(magnifier._updateMagnifier)
 
 		magnifier._stopMagnifier()
+
+
+class TestFullScreenMagnifierApiConflict(_TestMagnifier):
+	"""Tests for Windows Magnification API conflict detection at startup and during recovery."""
+
+	def testCannotStartWhenWindowsMagnifierRunning(self):
+		"""
+		MagInitialize succeeds but MagSetFullscreenTransform fails: Windows Magnifier is running.
+		NVDA Magnifier must not start, the user must be notified, and no timer must be started.
+		"""
+		self.mock_mag_fs.MagSetFullscreenTransform.side_effect = OSError("API in use by another magnifier")
+
+		with patch("_magnifier.fullscreenMagnifier.ui.message") as mock_message:
+			magnifier = FullScreenMagnifier()
+
+		self.assertFalse(magnifier._isActive)
+		mock_message.assert_called_once()
+		self.assertIsNone(magnifier._timer)
+
+	def testCannotStartWhenMagInitializeFails(self):
+		"""
+		MagInitialize itself fails: NVDA Magnifier must not start and the user must be notified.
+		"""
+		self.mock_mag_fs.MagInitialize.side_effect = OSError("Cannot initialize magnification API")
+
+		with patch("_magnifier.fullscreenMagnifier.ui.message") as mock_message:
+			magnifier = FullScreenMagnifier()
+
+		self.assertFalse(magnifier._isActive)
+		mock_message.assert_called_once()
+		self.assertIsNone(magnifier._timer)
+
+	def testRecoveryCapStopsMagnifier(self):
+		"""
+		After _MAX_RECOVERY_ATTEMPTS failed attempts, the magnifier stops and the user is notified.
+		"""
+		magnifier = FullScreenMagnifier()
+		magnifier._recoveryAttempts = FullScreenMagnifier._MAX_RECOVERY_ATTEMPTS
+
+		with patch("_magnifier.fullscreenMagnifier.ui.message") as mock_message:
+			magnifier._attemptRecovery()
+
+		self.assertFalse(magnifier._isActive)
+		mock_message.assert_called_once()
+
+	def testRecoveryFailsWhenTransformStillUnavailable(self):
+		"""
+		Recovery declares failure if MagSetFullscreenTransform still raises after reinit.
+		This is the root cause of the Windows Magnifier conflict infinite loop.
+		"""
+		magnifier = FullScreenMagnifier()
+		magnifier._startTimer = MagicMock()
+
+		with patch("_magnifier.fullscreenMagnifier.magnification") as mock_mag:
+			mock_mag.MagSetFullscreenTransform.side_effect = OSError("Still in use")
+			with patch("_magnifier.fullscreenMagnifier.ui.message"):
+				magnifier._attemptRecovery()
+
+		self.assertFalse(magnifier._isActive)
+		magnifier._startTimer.assert_not_called()
 
 
 class TestFullScreenMagnifierKeepMouseCentered(_TestMagnifier):


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
fix #20012

### Summary of the issue:
When Windows Magnifier was already running, NVDA Magnifier could still start because MagInitialize() succeeds even when the API is held by another process. Only MagSetFullscreenTransform() would fail, triggering the recovery loop — which itself only tested MagInitialize() and MagSetFullscreenColorEffect(), both of which succeed, causing it to falsely declare victory and restart the timer indefinitely.

### Description of user facing changes:
NVDA now shows a clear message ("Cannot start magnifier: the magnification API is unavailable. Windows Magnifier may already be running.") when the magnification API cannot be fully initialized at startup. If the conflict occurs after startup, the recovery mechanism is now capped at 3 attempts before stopping the magnifier and notifying the user, preventing log spam.

### Description of developer facing changes:
_initializeNativeMagnification() no longer uses @trackNativeMagnifierErrors — it now raises OSError on failure (including a MagSetFullscreenTransform probe that detects the Windows Magnifier conflict). _startMagnifier() catches this error, calls _stopMagnifier() to properly unregister the display change handler, and returns early. _attemptRecovery() reuses _initializeNativeMagnification() to avoid duplicating the probe logic, and is now capped by _MAX_RECOVERY_ATTEMPTS = 3.

### Description of development approach:
The fix centers on making _initializeNativeMagnification() a reliable gate: it probes MagSetFullscreenTransform (the actual failing call) as part of initialization and raises on failure rather than silently returning. This single change fixes both the startup path and the recovery path, since _attemptRecovery() can delegate to the same method. A _recoveryAttempts counter (capped at _MAX_RECOVERY_ATTEMPTS) prevents the infinite restart loop when the API remains permanently unavailable.

### Testing strategy:
unit test

### Known issues with pull request:

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
