### PR TITLE
addon store: keep actions button visible when multiple add-ons are selected

### DIFF
--- a/source/gui/addonStoreGui/controls/details.py
+++ b/source/gui/addonStoreGui/controls/details.py
@@ -213,7 +213,16 @@ class AddonDetails(
 			# SetDefaultStyle, however, this means the text control must start empty.
 			self.otherDetailsTextCtrl.SetValue("")
 			if numSelectedAddons > 1:
-				self.contentsPanel.Hide()
+				# Keep the actions button reachable so the user can run a batch action
+				# (the Application key context menu is the only other entry point).
+				# Hide the per-add-on description and other-details fields, since they
+				# can only show information for a single add-on. The descriptionLabel is
+				# already permanently hidden at construction (kept for accessibility name).
+				self.contentsPanel.Show()
+				self.descriptionTextCtrl.Hide()
+				self.otherDetailsLabel.Hide()
+				self.otherDetailsTextCtrl.Hide()
+				self.actionsButton.Show()
 				self.updateAddonName(
 					npgettext(
 						"addonStore",
@@ -231,6 +240,12 @@ class AddonDetails(
 				else:
 					self.updateAddonName(AddonDetails._noAddonSelectedLabelText)
 			else:
+				# Restore the per-add-on fields in case they were hidden by a previous
+				# multi-select refresh. descriptionLabel stays hidden -- it only serves
+				# as the accessible name for descriptionTextCtrl.
+				self.descriptionTextCtrl.Show()
+				self.otherDetailsLabel.Show()
+				self.otherDetailsTextCtrl.Show()
 				self.updateAddonName(details.displayName)
 				self.descriptionLabel.SetLabelText(AddonDetails._descriptionLabelText)
 				# For a ExpandoTextCtr, SetDefaultStyle can not be used to set the style (along with the use


### PR DESCRIPTION
Resolves #19971.

### Summary

When multiple add-ons are selected in the add-on store list, `AddonDetails._refresh()` previously hid the entire `contentsPanel`, which removed the actions button along with the per-add-on description and other-details fields. The user could still open the bulk-action context menu via the Application key, but the button had disappeared, leaving no visible affordance.

### Change

In `source/gui/addonStoreGui/controls/details.py`, reshape the `numSelectedAddons > 1` branch to:

- Keep `contentsPanel` visible
- Hide only the per-add-on `descriptionTextCtrl`, `otherDetailsLabel`, and `otherDetailsTextCtrl`
- Leave `actionsButton` visible (so the bulk-action context menu now has a visible entry point in addition to the Application key)

`descriptionLabel` stays hidden — it is permanently hidden at construction and only serves as the accessible name for `descriptionTextCtrl`.

The single-add-on branch now explicitly `Show()`s the per-add-on fields in case they were hidden by a previous multi-select refresh.

The empty-selection branch is unchanged — it still hides the entire `contentsPanel`, matching the existing "no add-on selected" behavior described in the issue.

### Testing

- The fix is wxPython visibility logic. I do not have access to a Windows NVDA build environment to manually verify in the addon store dialog.
- The change preserves the empty-selection behavior, so the no-selection state is unaffected.
- Tests for the addon store GUI in `tests/` could be extended to assert `actionsButton.IsShown()` after multi-select, but I have not added one because the existing GUI tests do not cover this view.

### Related

Issue: #19971