### PR TITLE
ci: upgrade mikepenz/action-junit-report v5 to v6

### DIFF
--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -278,7 +278,7 @@ jobs:
         name: Unit tests results (${{ matrix.pythonVersion }}, ${{ matrix.arch }})
         path: testOutput/unit/unitTests.xml
     - name: Publish unit test report
-      uses: mikepenz/action-junit-report@v5
+      uses: mikepenz/action-junit-report@v6
       if: ${{ failure() }}
       with:
         check_name: Unit tests (${{ matrix.pythonVersion }}, ${{ matrix.arch }})
@@ -477,7 +477,7 @@ jobs:
           testOutput/install
           !testOutput/install/nvda_install_temp.log
     - name: Publish system test report
-      uses: mikepenz/action-junit-report@v5
+      uses: mikepenz/action-junit-report@v6
       if: ${{ failure() }}
       with:
         check_name: "System tests (${{ matrix.testSuite }}) (${{ matrix.runner }}, ${{ matrix.pythonVersion }}, ${{ matrix.arch }})"


### PR DESCRIPTION
[upgrade mikepenz/action-junit-report to v6 to resolve Node.js deprecation](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)

"Node.js deprecation warnings (e.g., mikepenz/action-junit-report@v5 requiring Node.js 20) no longer appear in specific Actions runs, such as this job, following the upgrade to v6."
https://github.com/dpy013/nvda/actions/runs/25235122899/job/74002155719?spm=5176.28103460.0.0.96a02988qH35o5