### PR TITLE
Fix: Mouse bug -> switch getKeyState with getAsyncKeyState 

### DIFF
--- a/source/_magnifier/fullscreenMagnifier.py
+++ b/source/_magnifier/fullscreenMagnifier.py
@@ -234,9 +234,9 @@ class FullScreenMagnifier(Magnifier):
 		Skips if a mouse button is currently pressed to avoid interfering with clicks.
 		"""
 		if (
-			winUser.getKeyState(winUser.VK_LBUTTON) < 0
-			or winUser.getKeyState(winUser.VK_RBUTTON) < 0
-			or winUser.getKeyState(winUser.VK_MBUTTON) < 0
+			winUser.getAsyncKeyState(winUser.VK_LBUTTON) < 0
+			or winUser.getAsyncKeyState(winUser.VK_RBUTTON) < 0
+			or winUser.getAsyncKeyState(winUser.VK_MBUTTON) < 0
 		):
 			log.debug("Mouse button pressed, skipping cursor repositioning to avoid interfering with click")
 			return

--- a/source/_magnifier/utils/focusManager.py
+++ b/source/_magnifier/utils/focusManager.py
@@ -12,7 +12,6 @@ from comtypes import COMError
 from logHandler import log
 import api
 import winUser
-import mouseHandler
 import time
 import locationHelper
 import textInfos
@@ -60,7 +59,11 @@ class FocusManager:
 		systemFocusPosition = self._getSystemFocusPosition()
 		reviewPosition = self._getReviewPosition()
 		navigatorPosition = self._getNavigatorObjectPosition()
-		isClickPressed = mouseHandler.isLeftMouseButtonLocked()
+		isClickPressed = (
+			winUser.getAsyncKeyState(winUser.VK_LBUTTON) < 0
+			or winUser.getAsyncKeyState(winUser.VK_RBUTTON) < 0
+			or winUser.getAsyncKeyState(winUser.VK_MBUTTON) < 0
+		)
 
 		# Cache settings once — each call reads from config.conf
 		isFollowMouse = getFollowState(MagnifierFollowFocusType.MOUSE)

--- a/source/_magnifier/utils/focusManager.py
+++ b/source/_magnifier/utils/focusManager.py
@@ -59,11 +59,7 @@ class FocusManager:
 		systemFocusPosition = self._getSystemFocusPosition()
 		reviewPosition = self._getReviewPosition()
 		navigatorPosition = self._getNavigatorObjectPosition()
-		isClickPressed = (
-			winUser.getAsyncKeyState(winUser.VK_LBUTTON) < 0
-			or winUser.getAsyncKeyState(winUser.VK_RBUTTON) < 0
-			or winUser.getAsyncKeyState(winUser.VK_MBUTTON) < 0
-		)
+		isClickPressed = winUser.getAsyncKeyState(winUser.VK_LBUTTON) < 0
 
 		# Cache settings once — each call reads from config.conf
 		isFollowMouse = getFollowState(MagnifierFollowFocusType.MOUSE)
@@ -207,8 +203,8 @@ class FocusManager:
 				if coords != Coordinates(0, 0):
 					self._lastValidReviewPosition = coords
 				return coords
-			except (NotImplementedError, LookupError, AttributeError, COMError):
-				# Review position may not support pointAtStart
+			except (NotImplementedError, LookupError, AttributeError, COMError, RuntimeError):
+				# Review position may not support pointAtStart, or COM object may not be IAccessible
 				pass
 		return None
 
@@ -222,7 +218,7 @@ class FocusManager:
 		"""
 		try:
 			return textInfo.pointAtStart
-		except (NotImplementedError, LookupError, AttributeError, COMError) as e:
+		except (NotImplementedError, LookupError, AttributeError, COMError, RuntimeError) as e:
 			log.debug(f"pointAtStart failed for {textInfo!r}: {e}", exc_info=True)
 			originalExc = e
 

--- a/tests/unit/test_magnifier/test_focusManager.py
+++ b/tests/unit/test_magnifier/test_focusManager.py
@@ -8,7 +8,6 @@ from _magnifier.utils.focusManager import FocusManager
 from _magnifier.utils.types import Coordinates, MagnifierFollowFocusType
 import unittest
 from unittest.mock import MagicMock, Mock, patch
-import winUser
 import _ctypes
 
 
@@ -322,8 +321,6 @@ class TestFocusManager(unittest.TestCase):
 				)
 				self.focusManager._getSystemFocusPosition = MagicMock(return_value=param.systemFocusPos)
 				self.focusManager._getReviewPosition = MagicMock(return_value=param.reviewPos)
-				winUser.getAsyncKeyState = MagicMock(side_effect=lambda _key: -1 if param.leftPressed else 0)
-				winUser.getCursorPos = MagicMock(return_value=param.mousePos)
 
 				followStateSideEffect = _makeFollowStateSideEffect(
 					followMouse=param.followMouse,
@@ -332,9 +329,19 @@ class TestFocusManager(unittest.TestCase):
 					followNavigatorObject=param.followNavigatorObject,
 				)
 
-				with patch(
-					"_magnifier.utils.focusManager.getFollowState",
-					side_effect=followStateSideEffect,
+				with (
+					patch(
+						"_magnifier.utils.focusManager.getFollowState",
+						side_effect=followStateSideEffect,
+					),
+					patch(
+						"_magnifier.utils.focusManager.winUser.getAsyncKeyState",
+						side_effect=lambda _key: -1 if param.leftPressed else 0,
+					),
+					patch(
+						"_magnifier.utils.focusManager.winUser.getCursorPos",
+						return_value=param.mousePos,
+					),
 				):
 					# Execute
 					focusCoordinates = self.focusManager.getCurrentFocusCoordinates()
@@ -368,7 +375,6 @@ class TestFollowSettings(unittest.TestCase):
 		self.focusManager._getSystemFocusPosition = MagicMock(return_value=Coordinates(20, 20))
 		self.focusManager._getReviewPosition = MagicMock(return_value=Coordinates(30, 30))
 		self.focusManager._getNavigatorObjectPosition = MagicMock(return_value=Coordinates(40, 40))
-		winUser.getAsyncKeyState = MagicMock(return_value=0)
 
 		followStateSideEffect = _makeFollowStateSideEffect(
 			followMouse=followMouse,
@@ -377,9 +383,12 @@ class TestFollowSettings(unittest.TestCase):
 			followNavigatorObject=followNavigatorObject,
 		)
 
-		with patch(
-			"_magnifier.utils.focusManager.getFollowState",
-			side_effect=followStateSideEffect,
+		with (
+			patch(
+				"_magnifier.utils.focusManager.getFollowState",
+				side_effect=followStateSideEffect,
+			),
+			patch("_magnifier.utils.focusManager.winUser.getAsyncKeyState", return_value=0),
 		):
 			return self.focusManager.getCurrentFocusCoordinates()
 
@@ -433,7 +442,6 @@ class TestFollowSettings(unittest.TestCase):
 		self.focusManager._getSystemFocusPosition = MagicMock(return_value=Coordinates(20, 20))
 		self.focusManager._getReviewPosition = MagicMock(return_value=Coordinates(30, 30))
 		self.focusManager._getNavigatorObjectPosition = MagicMock(return_value=Coordinates(40, 40))
-		winUser.getAsyncKeyState = MagicMock(return_value=0)
 
 		followEnabledSideEffect = _makeFollowStateSideEffect(
 			followMouse=True,
@@ -441,9 +449,12 @@ class TestFollowSettings(unittest.TestCase):
 			followReview=True,
 			followNavigatorObject=True,
 		)
-		with patch(
-			"_magnifier.utils.focusManager.getFollowState",
-			side_effect=followEnabledSideEffect,
+		with (
+			patch(
+				"_magnifier.utils.focusManager.getFollowState",
+				side_effect=followEnabledSideEffect,
+			),
+			patch("_magnifier.utils.focusManager.winUser.getAsyncKeyState", return_value=0),
 		):
 			coords = self.focusManager.getCurrentFocusCoordinates()
 		self.assertEqual(coords, Coordinates(10, 10))
@@ -459,9 +470,12 @@ class TestFollowSettings(unittest.TestCase):
 			followReview=False,
 			followNavigatorObject=False,
 		)
-		with patch(
-			"_magnifier.utils.focusManager.getFollowState",
-			side_effect=followDisabledSideEffect,
+		with (
+			patch(
+				"_magnifier.utils.focusManager.getFollowState",
+				side_effect=followDisabledSideEffect,
+			),
+			patch("_magnifier.utils.focusManager.winUser.getAsyncKeyState", return_value=0),
 		):
 			coords = self.focusManager.getCurrentFocusCoordinates()
 
@@ -474,7 +488,6 @@ class TestFollowSettings(unittest.TestCase):
 		self.focusManager._getSystemFocusPosition = MagicMock(return_value=Coordinates(20, 20))
 		self.focusManager._getReviewPosition = MagicMock(return_value=Coordinates(30, 30))
 		self.focusManager._getNavigatorObjectPosition = MagicMock(return_value=Coordinates(40, 40))
-		winUser.getAsyncKeyState = MagicMock(return_value=-1)
 
 		followStateSideEffect = _makeFollowStateSideEffect(
 			followMouse=True,
@@ -483,9 +496,12 @@ class TestFollowSettings(unittest.TestCase):
 			followNavigatorObject=True,
 		)
 
-		with patch(
-			"_magnifier.utils.focusManager.getFollowState",
-			side_effect=followStateSideEffect,
+		with (
+			patch(
+				"_magnifier.utils.focusManager.getFollowState",
+				side_effect=followStateSideEffect,
+			),
+			patch("_magnifier.utils.focusManager.winUser.getAsyncKeyState", return_value=-1),
 		):
 			coords = self.focusManager.getCurrentFocusCoordinates()
 
@@ -506,7 +522,6 @@ class TestFollowSettings(unittest.TestCase):
 		self.focusManager._getSystemFocusPosition = MagicMock(return_value=Coordinates(20, 20))
 		self.focusManager._getReviewPosition = MagicMock(return_value=None)
 		self.focusManager._getNavigatorObjectPosition = MagicMock(return_value=Coordinates(40, 40))
-		winUser.getAsyncKeyState = MagicMock(return_value=0)
 
 		followStateSideEffect = _makeFollowStateSideEffect(
 			followMouse=False,
@@ -515,9 +530,12 @@ class TestFollowSettings(unittest.TestCase):
 			followNavigatorObject=True,
 		)
 
-		with patch(
-			"_magnifier.utils.focusManager.getFollowState",
-			side_effect=followStateSideEffect,
+		with (
+			patch(
+				"_magnifier.utils.focusManager.getFollowState",
+				side_effect=followStateSideEffect,
+			),
+			patch("_magnifier.utils.focusManager.winUser.getAsyncKeyState", return_value=0),
 		):
 			coords = self.focusManager.getCurrentFocusCoordinates()
 
@@ -537,7 +555,6 @@ class TestFollowSettings(unittest.TestCase):
 		self.focusManager._getSystemFocusPosition = MagicMock(return_value=Coordinates(20, 20))
 		self.focusManager._getReviewPosition = MagicMock(return_value=None)
 		self.focusManager._getNavigatorObjectPosition = MagicMock(return_value=Coordinates(40, 40))
-		winUser.getAsyncKeyState = MagicMock(return_value=0)
 
 		followStateSideEffect = _makeFollowStateSideEffect(
 			followMouse=False,
@@ -546,9 +563,12 @@ class TestFollowSettings(unittest.TestCase):
 			followNavigatorObject=True,
 		)
 
-		with patch(
-			"_magnifier.utils.focusManager.getFollowState",
-			side_effect=followStateSideEffect,
+		with (
+			patch(
+				"_magnifier.utils.focusManager.getFollowState",
+				side_effect=followStateSideEffect,
+			),
+			patch("_magnifier.utils.focusManager.winUser.getAsyncKeyState", return_value=0),
 		):
 			coords = self.focusManager.getCurrentFocusCoordinates()
 
@@ -568,7 +588,6 @@ class TestFollowSettings(unittest.TestCase):
 		self.focusManager._getSystemFocusPosition = MagicMock(return_value=Coordinates(20, 20))
 		self.focusManager._getReviewPosition = MagicMock(return_value=Coordinates(30, 30))
 		self.focusManager._getNavigatorObjectPosition = MagicMock(return_value=Coordinates(40, 40))
-		winUser.getAsyncKeyState = MagicMock(return_value=0)
 
 		followStateSideEffect = _makeFollowStateSideEffect(
 			followMouse=False,
@@ -577,9 +596,12 @@ class TestFollowSettings(unittest.TestCase):
 			followNavigatorObject=True,
 		)
 
-		with patch(
-			"_magnifier.utils.focusManager.getFollowState",
-			side_effect=followStateSideEffect,
+		with (
+			patch(
+				"_magnifier.utils.focusManager.getFollowState",
+				side_effect=followStateSideEffect,
+			),
+			patch("_magnifier.utils.focusManager.winUser.getAsyncKeyState", return_value=0),
 		):
 			coords = self.focusManager.getCurrentFocusCoordinates()
 

--- a/tests/unit/test_magnifier/test_focusManager.py
+++ b/tests/unit/test_magnifier/test_focusManager.py
@@ -8,7 +8,6 @@ from _magnifier.utils.focusManager import FocusManager
 from _magnifier.utils.types import Coordinates, MagnifierFollowFocusType
 import unittest
 from unittest.mock import MagicMock, Mock, patch
-import mouseHandler
 import winUser
 import _ctypes
 
@@ -323,7 +322,7 @@ class TestFocusManager(unittest.TestCase):
 				)
 				self.focusManager._getSystemFocusPosition = MagicMock(return_value=param.systemFocusPos)
 				self.focusManager._getReviewPosition = MagicMock(return_value=param.reviewPos)
-				mouseHandler.isLeftMouseButtonLocked = MagicMock(return_value=param.leftPressed)
+				winUser.getAsyncKeyState = MagicMock(side_effect=lambda _key: -1 if param.leftPressed else 0)
 				winUser.getCursorPos = MagicMock(return_value=param.mousePos)
 
 				followStateSideEffect = _makeFollowStateSideEffect(
@@ -369,7 +368,7 @@ class TestFollowSettings(unittest.TestCase):
 		self.focusManager._getSystemFocusPosition = MagicMock(return_value=Coordinates(20, 20))
 		self.focusManager._getReviewPosition = MagicMock(return_value=Coordinates(30, 30))
 		self.focusManager._getNavigatorObjectPosition = MagicMock(return_value=Coordinates(40, 40))
-		mouseHandler.isLeftMouseButtonLocked = MagicMock(return_value=False)
+		winUser.getAsyncKeyState = MagicMock(return_value=0)
 
 		followStateSideEffect = _makeFollowStateSideEffect(
 			followMouse=followMouse,
@@ -434,7 +433,7 @@ class TestFollowSettings(unittest.TestCase):
 		self.focusManager._getSystemFocusPosition = MagicMock(return_value=Coordinates(20, 20))
 		self.focusManager._getReviewPosition = MagicMock(return_value=Coordinates(30, 30))
 		self.focusManager._getNavigatorObjectPosition = MagicMock(return_value=Coordinates(40, 40))
-		mouseHandler.isLeftMouseButtonLocked = MagicMock(return_value=False)
+		winUser.getAsyncKeyState = MagicMock(return_value=0)
 
 		followEnabledSideEffect = _makeFollowStateSideEffect(
 			followMouse=True,
@@ -475,7 +474,7 @@ class TestFollowSettings(unittest.TestCase):
 		self.focusManager._getSystemFocusPosition = MagicMock(return_value=Coordinates(20, 20))
 		self.focusManager._getReviewPosition = MagicMock(return_value=Coordinates(30, 30))
 		self.focusManager._getNavigatorObjectPosition = MagicMock(return_value=Coordinates(40, 40))
-		mouseHandler.isLeftMouseButtonLocked = MagicMock(return_value=True)
+		winUser.getAsyncKeyState = MagicMock(return_value=-1)
 
 		followStateSideEffect = _makeFollowStateSideEffect(
 			followMouse=True,
@@ -507,7 +506,7 @@ class TestFollowSettings(unittest.TestCase):
 		self.focusManager._getSystemFocusPosition = MagicMock(return_value=Coordinates(20, 20))
 		self.focusManager._getReviewPosition = MagicMock(return_value=None)
 		self.focusManager._getNavigatorObjectPosition = MagicMock(return_value=Coordinates(40, 40))
-		mouseHandler.isLeftMouseButtonLocked = MagicMock(return_value=False)
+		winUser.getAsyncKeyState = MagicMock(return_value=0)
 
 		followStateSideEffect = _makeFollowStateSideEffect(
 			followMouse=False,
@@ -538,7 +537,7 @@ class TestFollowSettings(unittest.TestCase):
 		self.focusManager._getSystemFocusPosition = MagicMock(return_value=Coordinates(20, 20))
 		self.focusManager._getReviewPosition = MagicMock(return_value=None)
 		self.focusManager._getNavigatorObjectPosition = MagicMock(return_value=Coordinates(40, 40))
-		mouseHandler.isLeftMouseButtonLocked = MagicMock(return_value=False)
+		winUser.getAsyncKeyState = MagicMock(return_value=0)
 
 		followStateSideEffect = _makeFollowStateSideEffect(
 			followMouse=False,
@@ -569,7 +568,7 @@ class TestFollowSettings(unittest.TestCase):
 		self.focusManager._getSystemFocusPosition = MagicMock(return_value=Coordinates(20, 20))
 		self.focusManager._getReviewPosition = MagicMock(return_value=Coordinates(30, 30))
 		self.focusManager._getNavigatorObjectPosition = MagicMock(return_value=Coordinates(40, 40))
-		mouseHandler.isLeftMouseButtonLocked = MagicMock(return_value=False)
+		winUser.getAsyncKeyState = MagicMock(return_value=0)
 
 		followStateSideEffect = _makeFollowStateSideEffect(
 			followMouse=False,

--- a/tests/unit/test_magnifier/test_fullscreenMagnifier.py
+++ b/tests/unit/test_magnifier/test_fullscreenMagnifier.py
@@ -221,7 +221,11 @@ class TestFullscreenMagnifierEndToEnd(_TestMagnifier):
 
 	def testAttemptRecoverySuccess(self):
 		"""FullScreenMagnifier._attemptRecovery reinitialises API and restarts timer on success."""
-		magnifier = FullScreenMagnifier()
+		with patch(
+			"_magnifier.magnifier.FocusManager.getCurrentFocusCoordinates",
+			return_value=Coordinates(0, 0),
+		):
+			magnifier = FullScreenMagnifier()
 		magnifier._consecutiveErrors = 3
 		magnifier._startTimer = MagicMock()
 

--- a/tests/unit/test_magnifier/test_fullscreenMagnifier.py
+++ b/tests/unit/test_magnifier/test_fullscreenMagnifier.py
@@ -301,7 +301,7 @@ class TestFullScreenMagnifierKeepMouseCentered(_TestMagnifier):
 		self.magnifier._currentCoordinates = Coordinates(500, 400)
 		with (
 			patch(
-				"_magnifier.fullscreenMagnifier.winUser.getKeyState",
+				"_magnifier.fullscreenMagnifier.winUser.getAsyncKeyState",
 				side_effect=lambda key: -1 if key == 1 else 0,
 			),
 			patch("_magnifier.fullscreenMagnifier.winUser.setCursorPos") as mockSet,
@@ -314,7 +314,7 @@ class TestFullScreenMagnifierKeepMouseCentered(_TestMagnifier):
 		self.magnifier._currentCoordinates = Coordinates(500, 400)
 		with (
 			patch(
-				"_magnifier.fullscreenMagnifier.winUser.getKeyState",
+				"_magnifier.fullscreenMagnifier.winUser.getAsyncKeyState",
 				side_effect=lambda key: -1 if key == 2 else 0,
 			),
 			patch("_magnifier.fullscreenMagnifier.winUser.setCursorPos") as mockSet,
@@ -327,7 +327,7 @@ class TestFullScreenMagnifierKeepMouseCentered(_TestMagnifier):
 		self.magnifier._currentCoordinates = Coordinates(500, 400)
 		with (
 			patch(
-				"_magnifier.fullscreenMagnifier.winUser.getKeyState",
+				"_magnifier.fullscreenMagnifier.winUser.getAsyncKeyState",
 				side_effect=lambda key: -1 if key == 4 else 0,
 			),
 			patch("_magnifier.fullscreenMagnifier.winUser.setCursorPos") as mockSet,
@@ -342,7 +342,7 @@ class TestFullScreenMagnifierKeepMouseCentered(_TestMagnifier):
 		self.magnifier._currentCoordinates = raw
 		expectedX, expectedY = self._expectedCenter(raw)
 		with (
-			patch("_magnifier.fullscreenMagnifier.winUser.getKeyState", return_value=0),
+			patch("_magnifier.fullscreenMagnifier.winUser.getAsyncKeyState", return_value=0),
 			patch("_magnifier.fullscreenMagnifier.winUser.setCursorPos") as mockSet,
 		):
 			self.magnifier._keepMouseCentered()
@@ -357,7 +357,7 @@ class TestFullScreenMagnifierKeepMouseCentered(_TestMagnifier):
 		# Clamping should shift the center away from (10, 10)
 		self.assertNotEqual((expectedX, expectedY), (raw.x, raw.y))
 		with (
-			patch("_magnifier.fullscreenMagnifier.winUser.getKeyState", return_value=0),
+			patch("_magnifier.fullscreenMagnifier.winUser.getAsyncKeyState", return_value=0),
 			patch("_magnifier.fullscreenMagnifier.winUser.setCursorPos") as mockSet,
 		):
 			self.magnifier._keepMouseCentered()
@@ -370,7 +370,7 @@ class TestFullScreenMagnifierKeepMouseCentered(_TestMagnifier):
 		self.magnifier._currentCoordinates = raw
 		expectedX, expectedY = self._expectedCenter(raw)
 		with (
-			patch("_magnifier.fullscreenMagnifier.winUser.getKeyState", return_value=0),
+			patch("_magnifier.fullscreenMagnifier.winUser.getAsyncKeyState", return_value=0),
 			patch("_magnifier.fullscreenMagnifier.winUser.setCursorPos") as mockSet,
 		):
 			self.magnifier._keepMouseCentered()
@@ -385,7 +385,7 @@ class TestFullScreenMagnifierKeepMouseCentered(_TestMagnifier):
 		self.magnifier._currentCoordinates = screenCenter
 		expectedX, expectedY = self._expectedCenter(screenCenter)
 		with (
-			patch("_magnifier.fullscreenMagnifier.winUser.getKeyState", return_value=0),
+			patch("_magnifier.fullscreenMagnifier.winUser.getAsyncKeyState", return_value=0),
 			patch("_magnifier.fullscreenMagnifier.winUser.setCursorPos") as mockSet,
 		):
 			self.magnifier._keepMouseCentered()


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
fixes #19691

### Summary of the issue:
When using the fullscreen magnifier in Center mode, clicking on controls in certain apps (Discord, Microsoft Teams, HyperX NGENUITY Beta) had no effect. The magnifier transform could shift between the physical button press and Windows applying it to the click coordinates, causing the click to land at the wrong logical position.

### Description of user facing changes:
Mouse clicks on controls in apps such as Discord, Microsoft Teams, and HyperX NGENUITY Beta should work correctly when the fullscreen magnifier is running in Center mode.

### Description of developer facing changes:
Replaced winUser.getKeyState / mouseHandler.isLeftMouseButtonLocked with winUser.getAsyncKeyState in FocusManager.getCurrentFocusCoordinates and FullScreenMagnifier._keepMouseCentered. Updated tests accordingly.

### Description of development approach:
tKeyState is queue-based and can return a stale button state in the wx main thread when the message queue hasn't yet processed the click event. Switching to GetAsyncKeyState ensures the magnifier detects a button press immediately, preventing the Center mode transform from shifting between the physical press and Windows applying it to the click coordinates.

### Testing strategy:

Unit

### Known issues with pull request:

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
