### PR TITLE
fix: announce all content inside `role="alert"`

### DIFF
--- a/source/NVDAObjects/IAccessible/__init__.py
+++ b/source/NVDAObjects/IAccessible/__init__.py
@@ -2039,15 +2039,22 @@ class IAccessible(Window):
 		speech.speakObject(self, reason=controlTypes.OutputReason.FOCUS, priority=speech.Spri.NOW)
 		braille.handler.message(braille.getPropertiesBraille(name=self.name, role=self.role))
 		for child in self.recursiveDescendants:
-			if (controlTypes.State.FOCUSABLE in child.states or child.role in (
-				controlTypes.Role.HEADING,
-				controlTypes.Role.LIST,
-				controlTypes.Role.LISTITEM,
-			)
-				or
-				(child.role == controlTypes.Role.STATICTEXT and child.parent is not None and child.parent.role == controlTypes.Role.PARAGRAPH)):
-					speech.speakObject(child, reason=controlTypes.OutputReason.FOCUS, priority=speech.Spri.NOW)
-					braille.handler.message(braille.getPropertiesBraille(name=self.name, role=self.role))
+			if (
+				controlTypes.State.FOCUSABLE in child.states
+				or child.role
+				in (
+					controlTypes.Role.HEADING,
+					controlTypes.Role.LIST,
+					controlTypes.Role.LISTITEM,
+				)
+				or (
+					child.role == controlTypes.Role.STATICTEXT
+					and child.parent is not None
+					and child.parent.role == controlTypes.Role.PARAGRAPH
+				)
+			):
+				speech.speakObject(child, reason=controlTypes.OutputReason.FOCUS, priority=speech.Spri.NOW)
+				braille.handler.message(braille.getPropertiesBraille(name=self.name, role=self.role))
 
 	def event_caret(self):
 		focus = api.getFocusObject()

--- a/source/NVDAObjects/IAccessible/__init__.py
+++ b/source/NVDAObjects/IAccessible/__init__.py
@@ -2038,21 +2038,27 @@ class IAccessible(Window):
 			return
 		speech.speakObject(self, reason=controlTypes.OutputReason.FOCUS, priority=speech.Spri.NOW)
 		braille.handler.message(braille.getPropertiesBraille(name=self.name, role=self.role))
+		hasDescription = bool(self.description)
 		for child in self.recursiveDescendants:
-			if (
-				controlTypes.State.FOCUSABLE in child.states
-				or child.role
-				in (
-					controlTypes.Role.HEADING,
-					controlTypes.Role.LIST,
-					controlTypes.Role.LISTITEM,
-				)
-				or (
-					child.role == controlTypes.Role.STATICTEXT
-					and child.parent is not None
-					and child.parent.role == controlTypes.Role.PARAGRAPH
-				)
-			):
+			isFocusable = controlTypes.State.FOCUSABLE in child.states
+			if hasDescription and not isFocusable:
+				shouldSpeak = isFocusable
+			else:
+					shouldSpeak = (
+						isFocusable
+						or child.role
+						in (
+							controlTypes.Role.HEADING,
+							controlTypes.Role.LIST,
+							controlTypes.Role.LISTITEM
+							)
+						or (
+							child.role == controlTypes.Role.STATICTEXT
+							and child.parent is not None
+							and child.parent.role == controlTypes.Role.PARAGRAPH
+						)
+					)
+			if shouldSpeak:
 				speech.speakObject(child, reason=controlTypes.OutputReason.FOCUS, priority=speech.Spri.NOW)
 				braille.handler.message(braille.getPropertiesBraille(name=self.name, role=self.role))
 

--- a/source/NVDAObjects/IAccessible/__init__.py
+++ b/source/NVDAObjects/IAccessible/__init__.py
@@ -2045,9 +2045,9 @@ class IAccessible(Window):
 				controlTypes.Role.LISTITEM,
 			)
 				or
-				(child.role == controlTypes.Role.STATICTEXT and child.parent.role == controlTypes.Role.PARAGRAPH)):
+				(child.role == controlTypes.Role.STATICTEXT and child.parent is not None and child.parent.role == controlTypes.Role.PARAGRAPH)):
 					speech.speakObject(child, reason=controlTypes.OutputReason.FOCUS, priority=speech.Spri.NOW)
-					braille.handler.message(braille.getPropertiesBraille(name=child.name, role=child.role))
+					braille.handler.message(braille.getPropertiesBraille(name=self.name, role=self.role))
 
 	def event_caret(self):
 		focus = api.getFocusObject()

--- a/source/NVDAObjects/IAccessible/__init__.py
+++ b/source/NVDAObjects/IAccessible/__init__.py
@@ -2039,8 +2039,15 @@ class IAccessible(Window):
 		speech.speakObject(self, reason=controlTypes.OutputReason.FOCUS, priority=speech.Spri.NOW)
 		braille.handler.message(braille.getPropertiesBraille(name=self.name, role=self.role))
 		for child in self.recursiveDescendants:
-			speech.speakObject(child, reason=controlTypes.OutputReason.FOCUS, priority=speech.Spri.NOW)
-			braille.handler.message(braille.getPropertiesBraille(name=child.name, role=child.role))
+			if (controlTypes.State.FOCUSABLE in child.states or child.role in (
+				controlTypes.Role.HEADING,
+				controlTypes.Role.LIST,
+				controlTypes.Role.LISTITEM,
+			)
+				or
+				(child.role == controlTypes.Role.STATICTEXT and child.parent.role == controlTypes.Role.PARAGRAPH)):
+					speech.speakObject(child, reason=controlTypes.OutputReason.FOCUS, priority=speech.Spri.NOW)
+					braille.handler.message(braille.getPropertiesBraille(name=child.name, role=child.role))
 
 	def event_caret(self):
 		focus = api.getFocusObject()

--- a/source/NVDAObjects/IAccessible/__init__.py
+++ b/source/NVDAObjects/IAccessible/__init__.py
@@ -2039,9 +2039,8 @@ class IAccessible(Window):
 		speech.speakObject(self, reason=controlTypes.OutputReason.FOCUS, priority=speech.Spri.NOW)
 		braille.handler.message(braille.getPropertiesBraille(name=self.name, role=self.role))
 		for child in self.recursiveDescendants:
-			if controlTypes.State.FOCUSABLE in child.states:
-				speech.speakObject(child, reason=controlTypes.OutputReason.FOCUS, priority=speech.Spri.NOW)
-				braille.handler.message(braille.getPropertiesBraille(name=self.name, role=self.role))
+			speech.speakObject(child, reason=controlTypes.OutputReason.FOCUS, priority=speech.Spri.NOW)
+			braille.handler.message(braille.getPropertiesBraille(name=self.name, role=self.role))
 
 	def event_caret(self):
 		focus = api.getFocusObject()

--- a/source/NVDAObjects/IAccessible/__init__.py
+++ b/source/NVDAObjects/IAccessible/__init__.py
@@ -2040,7 +2040,7 @@ class IAccessible(Window):
 		braille.handler.message(braille.getPropertiesBraille(name=self.name, role=self.role))
 		for child in self.recursiveDescendants:
 			speech.speakObject(child, reason=controlTypes.OutputReason.FOCUS, priority=speech.Spri.NOW)
-			braille.handler.message(braille.getPropertiesBraille(name=self.name, role=self.role))
+			braille.handler.message(braille.getPropertiesBraille(name=child.name, role=child.role))
 
 	def event_caret(self):
 		focus = api.getFocusObject()

--- a/source/NVDAObjects/IAccessible/__init__.py
+++ b/source/NVDAObjects/IAccessible/__init__.py
@@ -2044,20 +2044,20 @@ class IAccessible(Window):
 			if hasDescription and not isFocusable:
 				shouldSpeak = isFocusable
 			else:
-					shouldSpeak = (
-						isFocusable
-						or child.role
-						in (
-							controlTypes.Role.HEADING,
-							controlTypes.Role.LIST,
-							controlTypes.Role.LISTITEM
-							)
-						or (
-							child.role == controlTypes.Role.STATICTEXT
-							and child.parent is not None
-							and child.parent.role == controlTypes.Role.PARAGRAPH
-						)
+				shouldSpeak = (
+					isFocusable
+					or child.role
+					in (
+						controlTypes.Role.HEADING,
+						controlTypes.Role.LIST,
+						controlTypes.Role.LISTITEM,
 					)
+					or (
+						child.role == controlTypes.Role.STATICTEXT
+						and child.parent is not None
+						and child.parent.role == controlTypes.Role.PARAGRAPH
+					)
+				)
 			if shouldSpeak:
 				speech.speakObject(child, reason=controlTypes.OutputReason.FOCUS, priority=speech.Spri.NOW)
 				braille.handler.message(braille.getPropertiesBraille(name=self.name, role=self.role))

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -20,7 +20,7 @@
 * Reduced lag on UI Automation text change events, improving the responsiveness of controls such as combo boxes and of File Explorer, by using the cached element class name instead of a live cross-process fetch. (#16749, @heath-toby)
 * NVDA recovers more quickly when an application stops responding; in particular, switching away from a hung application returns NVDA to responsiveness immediately. (#20169, @heath-toby)
 * In Mozilla Firefox, reporting annotation details now works correctly in focus mode on controls which are not editable text. (#20208, @jcsteh)
-* NVDA now announces heading, paragraph, list, and list item children inside `role="alert"` elements. (#14990, @mehm8128)
+* NVDA now announces heading, paragraph, list, and list item children inside webpage alerts (`role="alert"`). (#14990, @mehm8128)
 
 ### Changes for Developers
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -332,7 +332,7 @@ It currently includes Screen Curtain's settings (previously in the "Vision" cate
 * In the Input Gestures dialog, gestures including an operator while Num Lock is on will now be correctly displayed. (#19214, @CyrilleB79)
 * In Chromium browsers, if a document contains links with a malformed URL, reading the document will be possible again. (#19125, @nvdaes)
 * NVDA no longer plays a sound for spelling errors while typing if speech mode is set to on-demand or off. (#19323, @CyrilleB79)
-* NVDA now announces all content inside `role="alert"` elements. (#14990, @mehm8128)
+* NVDA now announces heading, paragraph, list, and list item children inside `role="alert"` elements. (#14990, @mehm8128)
 
 ### Changes for Developers
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -332,6 +332,7 @@ It currently includes Screen Curtain's settings (previously in the "Vision" cate
 * In the Input Gestures dialog, gestures including an operator while Num Lock is on will now be correctly displayed. (#19214, @CyrilleB79)
 * In Chromium browsers, if a document contains links with a malformed URL, reading the document will be possible again. (#19125, @nvdaes)
 * NVDA no longer plays a sound for spelling errors while typing if speech mode is set to on-demand or off. (#19323, @CyrilleB79)
+* NVDA now announces all content inside `role="alert"` elements. (#14990, @mehm8128)
 
 ### Changes for Developers
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -20,6 +20,7 @@
 * Reduced lag on UI Automation text change events, improving the responsiveness of controls such as combo boxes and of File Explorer, by using the cached element class name instead of a live cross-process fetch. (#16749, @heath-toby)
 * NVDA recovers more quickly when an application stops responding; in particular, switching away from a hung application returns NVDA to responsiveness immediately. (#20169, @heath-toby)
 * In Mozilla Firefox, reporting annotation details now works correctly in focus mode on controls which are not editable text. (#20208, @jcsteh)
+* NVDA now announces heading, paragraph, list, and list item children inside `role="alert"` elements. (#14990, @mehm8128)
 
 ### Changes for Developers
 
@@ -332,7 +333,6 @@ It currently includes Screen Curtain's settings (previously in the "Vision" cate
 * In the Input Gestures dialog, gestures including an operator while Num Lock is on will now be correctly displayed. (#19214, @CyrilleB79)
 * In Chromium browsers, if a document contains links with a malformed URL, reading the document will be possible again. (#19125, @nvdaes)
 * NVDA no longer plays a sound for spelling errors while typing if speech mode is set to on-demand or off. (#19323, @CyrilleB79)
-* NVDA now announces heading, paragraph, list, and list item children inside `role="alert"` elements. (#14990, @mehm8128)
 
 ### Changes for Developers
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
<!-- Use Closes/Fixes/Resolves #xxx to link this PR to the issue it is responding to. -->
close https://github.com/nvaccess/nvda/issues/14990

### Summary of the issue:

The content of HTML element with `role="alert"` had only announced its focusable children contents.

### Description of user facing changes:

NVDA now announces all content inside `role="alert"` elements.

### Description of developer facing changes:


### Description of development approach:

I extended the condition of what role is announced. I added heading, list, listitem, and paragraph roles. 

### Testing strategy:

test with sample code described in the original issue and confirm that all contents inside `role="alert"` are announced. 
on both Chromium and Firefox, it performs as expected.

### Known issues with pull request:

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
