### PR TITLE
Turn cache expiration time into a variable

### DIFF
--- a/.github/workflows/clearCaches.yml
+++ b/.github/workflows/clearCaches.yml
@@ -8,10 +8,11 @@ on:
     inputs:
       cache_expiration:
         description: 'Delete all caches older than X hours'
+        type: number
         required: false
 
 env:
-  CACHE_EXPIRATION_HOUR: ${{ inputs.cache_expiration || vars.CACHE_EXPIRATION_HOUR || 6 }}
+  CACHE_EXPIRATION_HOUR: ${{ inputs.cache_expiration || fromJSON(vars.CACHE_EXPIRATION_HOUR) || 6 }}
 
 jobs:
   cleanupCache:

--- a/.github/workflows/clearCaches.yml
+++ b/.github/workflows/clearCaches.yml
@@ -7,11 +7,11 @@ on:
   workflow_dispatch:
     inputs:
       cache_expiration:
-        description: 'Delete all caches older than X hours (Default 6 hours)'
+        description: 'Delete all caches older than X hours'
         required: false
 
 env:
-  CACHE_EXPIRATION_HOUR: ${{ inputs.cache_expiration || 6 }}
+  CACHE_EXPIRATION_HOUR: ${{ inputs.cache_expiration || vars.CACHE_EXPERITATION_HOURS }}
 
 jobs:
   cleanupCache:

--- a/.github/workflows/clearCaches.yml
+++ b/.github/workflows/clearCaches.yml
@@ -11,7 +11,7 @@ on:
         required: false
 
 env:
-  CACHE_EXPIRATION_HOUR: ${{ inputs.cache_expiration || vars.CACHE_EXPERITATION_HOURS }}
+  CACHE_EXPIRATION_HOUR: ${{ inputs.cache_expiration || vars.CACHE_EXPIRATION_HOUR || 6 }}
 
 jobs:
   cleanupCache:


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
Caches expire after 6 hours, it would be nice if we could increase that number higher, to maybe 8-12.

### Description of user facing changes:
None

### Description of developer facing changes:
We can tweak cache expiration via github variables

### Description of development approach:
Add variable

### Testing strategy:
Test workflow run for the branch: https://github.com/nvaccess/nvda/actions/runs/25411277902

Will test more thoroughly on prod, it's low danger

### Known issues with pull request:
None

