### PR TITLE
changed magnifier uninitialize

### DIFF
--- a/source/_magnifier/__init__.py
+++ b/source/_magnifier/__init__.py
@@ -14,6 +14,7 @@ from logHandler import log
 
 from .config import getMagnifiedView, getEnabled, setEnabled
 from .utils.types import MagnifiedView
+from .fullscreenMagnifier import FullScreenMagnifier
 
 if TYPE_CHECKING:
 	from .magnifier import Magnifier
@@ -91,6 +92,8 @@ def terminate() -> None:
 
 	log.debug("Terminating magnifier")
 	stop(persist=False)
+	if isinstance(_magnifier, FullScreenMagnifier):
+		_magnifier._finalUninitializeNativeMagnification()
 	_magnifier = None
 
 

--- a/source/_magnifier/__init__.py
+++ b/source/_magnifier/__init__.py
@@ -14,7 +14,6 @@ from logHandler import log
 
 from .config import getMagnifiedView, getEnabled, setEnabled
 from .utils.types import MagnifiedView
-from .fullscreenMagnifier import FullScreenMagnifier
 
 if TYPE_CHECKING:
 	from .magnifier import Magnifier
@@ -92,8 +91,6 @@ def terminate() -> None:
 
 	log.debug("Terminating magnifier")
 	stop(persist=False)
-	if isinstance(_magnifier, FullScreenMagnifier):
-		_magnifier._finalUninitializeNativeMagnification()
 	_magnifier = None
 
 

--- a/source/_magnifier/fullscreenMagnifier.py
+++ b/source/_magnifier/fullscreenMagnifier.py
@@ -41,6 +41,7 @@ class FullScreenMagnifier(Magnifier):
 		self.currentCoordinates = Coordinates(0, 0)
 		self._spotlightManager = SpotlightManager(self)
 		self._displaySize = Size(self._displayOrientation.width, self._displayOrientation.height)
+		self._nativeApiInitialized: bool = False
 
 	@Magnifier.filterType.setter
 	def filterType(self, value: Filter) -> None:
@@ -85,16 +86,19 @@ class FullScreenMagnifier(Magnifier):
 
 	def _initializeNativeMagnification(self) -> None:
 		"""
-		Initialize the Magnification API and verify it is fully usable.
-
-		Raises OSError if MagInitialize fails or if the initial fullscreen
-		transform fails (e.g. Windows Magnifier already holds the API). If
-		MagSetFullscreenTransform fails after a successful MagInitialize, this
-		method uninitializes the native magnification API before re-raising.
-		Failures from MagInitialize are propagated to the caller.
+		Initialize the Magnification API and apply the initial fullscreen transform.
+		MagInitialize is called only once per instance lifetime: the Initialize →
+		Uninitialize → Initialize cycle within the same process causes
+		MagSetFullscreenTransform to fail with WinError 0. To avoid this, the API
+		stays initialized between magnifier toggles and is only uninitialized on
+		NVDA shutdown via _finalUninitializeNativeMagnification.
+		Raises OSError if MagInitialize fails or if MagSetFullscreenTransform fails
+		(e.g. Windows Magnifier already holds the API).
 		"""
-		magnification.MagInitialize()
-		log.debug("Magnification API initialized")
+		if not self._nativeApiInitialized:
+			magnification.MagInitialize()
+			self._nativeApiInitialized = True
+			log.debug("Magnification API initialized")
 		# Applying the first real update verifies the API is usable without
 		# briefly jumping the magnified view to the top-left corner.
 		try:
@@ -121,11 +125,20 @@ class FullScreenMagnifier(Magnifier):
 	@override
 	def _stopMagnifier(self) -> None:
 		"""
-		Stop the Full-screen magnifier using windows DLL
+		Stop the Full-screen magnifier using windows DLL.
+		The native API is intentionally kept initialized to allow clean restarts;
+		it is only uninitialized on NVDA shutdown via _finalUninitializeNativeMagnification.
 		"""
 		super()._stopMagnifier()
 		self._resetMagnification()
+
+	def _finalUninitializeNativeMagnification(self) -> None:
+		"""
+		Uninitialize the Magnification API.
+		Must be called after _stopMagnifier, which already resets the transform.
+		"""
 		self._uninitializeNativeMagnification()
+		self._nativeApiInitialized = False
 
 	@trackNativeMagnifierErrors
 	def _resetMagnification(self) -> None:
@@ -171,6 +184,7 @@ class FullScreenMagnifier(Magnifier):
 		)
 
 		self._uninitializeNativeMagnification()
+		self._nativeApiInitialized = False
 
 		try:
 			# _initializeNativeMagnification also probes MagSetFullscreenTransform,

--- a/source/_magnifier/fullscreenMagnifier.py
+++ b/source/_magnifier/fullscreenMagnifier.py
@@ -94,15 +94,25 @@ class FullScreenMagnifier(Magnifier):
 		MagInitialize. A dummy cycle without any MagSetFullscreenTransform call
 		clears this stale state.
 
-		Raises OSError if MagInitialize fails or if MagSetFullscreenTransform fails
-		(e.g. Windows Magnifier already holds the API).
+		Errors during the dummy MagInitialize/MagUninitialize cycle are intentionally
+		suppressed.
+
+		Raises OSError if the real MagInitialize fails or if MagSetFullscreenTransform
+		fails (e.g. Windows Magnifier already holds the API).
 		"""
 		# Dummy cycle to clear any stale state from a previous MagSetFullscreenTransform.
+		dummyInitSucceeded = False
 		try:
 			magnification.MagInitialize()
-			magnification.MagUninitialize()
+			dummyInitSucceeded = True
 		except OSError:
 			pass
+		finally:
+			if dummyInitSucceeded:
+				try:
+					magnification.MagUninitialize()
+				except OSError:
+					pass
 		magnification.MagInitialize()
 		log.debug("Magnification API initialized")
 		# Applying the first real update verifies the API is usable without
@@ -131,7 +141,7 @@ class FullScreenMagnifier(Magnifier):
 	@override
 	def _stopMagnifier(self) -> None:
 		"""
-		Stop the Full-screen magnifier using windows DLL.
+		Stop the Full-screen magnifier using windows DLL
 		"""
 		super()._stopMagnifier()
 		self._resetMagnification()

--- a/source/_magnifier/fullscreenMagnifier.py
+++ b/source/_magnifier/fullscreenMagnifier.py
@@ -100,6 +100,8 @@ class FullScreenMagnifier(Magnifier):
 		Raises OSError if the real MagInitialize fails or if MagSetFullscreenTransform
 		fails (e.g. Windows Magnifier already holds the API).
 		"""
+		# Best-effort uninit ensures we start from a clean state
+		self._uninitializeNativeMagnification()
 		# Dummy cycle to clear any stale state from a previous MagSetFullscreenTransform.
 		dummyInitSucceeded = False
 		try:

--- a/source/_magnifier/fullscreenMagnifier.py
+++ b/source/_magnifier/fullscreenMagnifier.py
@@ -108,6 +108,7 @@ class FullScreenMagnifier(Magnifier):
 			self._fullscreenMagnifier(coordinates)
 		except OSError:
 			self._uninitializeNativeMagnification()
+			self._nativeApiInitialized = False
 			raise
 
 	@override
@@ -139,6 +140,21 @@ class FullScreenMagnifier(Magnifier):
 		"""
 		self._uninitializeNativeMagnification()
 		self._nativeApiInitialized = False
+
+	@override
+	def onScreenCurtainEnabled(self) -> None:
+		"""
+		Release the Magnification API before the screen curtain takes ownership.
+		The screen curtain performs its own MagInitialize/MagUninitialize cycle,
+		which resets the Windows API state and allows the magnifier to re-initialize
+		cleanly when the screen curtain is disabled.
+		Without this, the screen curtain's MagUninitialize would kill our
+		kept-alive initialization, causing WinError 1 on the next magnifier start.
+		"""
+		super().onScreenCurtainEnabled()
+		if self._nativeApiInitialized:
+			self._uninitializeNativeMagnification()
+			self._nativeApiInitialized = False
 
 	@trackNativeMagnifierErrors
 	def _resetMagnification(self) -> None:

--- a/source/_magnifier/fullscreenMagnifier.py
+++ b/source/_magnifier/fullscreenMagnifier.py
@@ -41,7 +41,6 @@ class FullScreenMagnifier(Magnifier):
 		self.currentCoordinates = Coordinates(0, 0)
 		self._spotlightManager = SpotlightManager(self)
 		self._displaySize = Size(self._displayOrientation.width, self._displayOrientation.height)
-		self._nativeApiInitialized: bool = False
 
 	@Magnifier.filterType.setter
 	def filterType(self, value: Filter) -> None:
@@ -87,18 +86,25 @@ class FullScreenMagnifier(Magnifier):
 	def _initializeNativeMagnification(self) -> None:
 		"""
 		Initialize the Magnification API and apply the initial fullscreen transform.
-		MagInitialize is called only once per instance lifetime: the Initialize →
-		Uninitialize → Initialize cycle within the same process causes
-		MagSetFullscreenTransform to fail with WinError 0. To avoid this, the API
-		stays initialized between magnifier toggles and is only uninitialized on
-		NVDA shutdown via _finalUninitializeNativeMagnification.
+
+		A dummy MagInitialize/MagUninitialize cycle is performed before the real
+		initialization. This is a workaround for a Windows bug: after a previous
+		MagSetFullscreenTransform call, MagUninitialize leaves internal state that
+		causes MagSetFullscreenTransform to fail with WinError 0 on the next
+		MagInitialize. A dummy cycle without any MagSetFullscreenTransform call
+		clears this stale state.
+
 		Raises OSError if MagInitialize fails or if MagSetFullscreenTransform fails
 		(e.g. Windows Magnifier already holds the API).
 		"""
-		if not self._nativeApiInitialized:
+		# Dummy cycle to clear any stale state from a previous MagSetFullscreenTransform.
+		try:
 			magnification.MagInitialize()
-			self._nativeApiInitialized = True
-			log.debug("Magnification API initialized")
+			magnification.MagUninitialize()
+		except OSError:
+			pass
+		magnification.MagInitialize()
+		log.debug("Magnification API initialized")
 		# Applying the first real update verifies the API is usable without
 		# briefly jumping the magnified view to the top-left corner.
 		try:
@@ -108,7 +114,6 @@ class FullScreenMagnifier(Magnifier):
 			self._fullscreenMagnifier(coordinates)
 		except OSError:
 			self._uninitializeNativeMagnification()
-			self._nativeApiInitialized = False
 			raise
 
 	@override
@@ -127,34 +132,10 @@ class FullScreenMagnifier(Magnifier):
 	def _stopMagnifier(self) -> None:
 		"""
 		Stop the Full-screen magnifier using windows DLL.
-		The native API is intentionally kept initialized to allow clean restarts;
-		it is only uninitialized on NVDA shutdown via _finalUninitializeNativeMagnification.
 		"""
 		super()._stopMagnifier()
 		self._resetMagnification()
-
-	def _finalUninitializeNativeMagnification(self) -> None:
-		"""
-		Uninitialize the Magnification API.
-		Must be called after _stopMagnifier, which already resets the transform.
-		"""
 		self._uninitializeNativeMagnification()
-		self._nativeApiInitialized = False
-
-	@override
-	def onScreenCurtainEnabled(self) -> None:
-		"""
-		Release the Magnification API before the screen curtain takes ownership.
-		The screen curtain performs its own MagInitialize/MagUninitialize cycle,
-		which resets the Windows API state and allows the magnifier to re-initialize
-		cleanly when the screen curtain is disabled.
-		Without this, the screen curtain's MagUninitialize would kill our
-		kept-alive initialization, causing WinError 1 on the next magnifier start.
-		"""
-		super().onScreenCurtainEnabled()
-		if self._nativeApiInitialized:
-			self._uninitializeNativeMagnification()
-			self._nativeApiInitialized = False
 
 	@trackNativeMagnifierErrors
 	def _resetMagnification(self) -> None:
@@ -198,9 +179,6 @@ class FullScreenMagnifier(Magnifier):
 			f"Attempting full-screen magnifier recovery "
 			f"(attempt {self._recoveryAttempts}/{self._MAX_RECOVERY_ATTEMPTS})",
 		)
-
-		self._uninitializeNativeMagnification()
-		self._nativeApiInitialized = False
 
 		try:
 			# _initializeNativeMagnification also probes MagSetFullscreenTransform,

--- a/tests/unit/test_magnifier/test_fullscreenMagnifier.py
+++ b/tests/unit/test_magnifier/test_fullscreenMagnifier.py
@@ -235,15 +235,16 @@ class TestFullscreenMagnifierEndToEnd(_TestMagnifier):
 		magnifier._consecutiveErrors = 3
 		magnifier._startTimer = MagicMock()
 
-		with patch("_magnifier.fullscreenMagnifier.magnification") as mock_mag:
-			magnifier._attemptRecovery()
+		self.mock_mag_fs.reset_mock()
+		magnifier._attemptRecovery()
 
-			mock_mag.MagUninitialize.assert_called_once()
-			mock_mag.MagInitialize.assert_called_once()
-			mock_mag.MagSetFullscreenTransform.assert_called_once_with(magnifier.zoomLevel / 100.0, 0, 0)
-			mock_mag.MagSetFullscreenColorEffect.assert_called_once()
-			self.assertEqual(magnifier._consecutiveErrors, 0)
-			magnifier._startTimer.assert_called_once_with(magnifier._updateMagnifier)
+		self.mock_mag_fs.MagUninitialize.assert_called_once()
+		# MagInitialize: once in the dummy cycle + once for the real init
+		self.assertEqual(self.mock_mag_fs.MagInitialize.call_count, 2)
+		self.mock_mag_fs.MagSetFullscreenTransform.assert_called_once_with(magnifier.zoomLevel / 100.0, 0, 0)
+		self.mock_mag_fs.MagSetFullscreenColorEffect.assert_called_once()
+		self.assertEqual(magnifier._consecutiveErrors, 0)
+		magnifier._startTimer.assert_called_once_with(magnifier._updateMagnifier)
 
 		magnifier._stopMagnifier()
 

--- a/tests/unit/test_magnifier/test_fullscreenMagnifier.py
+++ b/tests/unit/test_magnifier/test_fullscreenMagnifier.py
@@ -238,7 +238,8 @@ class TestFullscreenMagnifierEndToEnd(_TestMagnifier):
 		self.mock_mag_fs.reset_mock()
 		magnifier._attemptRecovery()
 
-		self.mock_mag_fs.MagUninitialize.assert_called_once()
+		# MagUninitialize: once best-effort at start + once in the dummy cycle finally block
+		self.assertEqual(self.mock_mag_fs.MagUninitialize.call_count, 2)
 		# MagInitialize: once in the dummy cycle + once for the real init
 		self.assertEqual(self.mock_mag_fs.MagInitialize.call_count, 2)
 		self.mock_mag_fs.MagSetFullscreenTransform.assert_called_once_with(magnifier.zoomLevel / 100.0, 0, 0)


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
fix #20068

### Summary of the issue:
Stopping and restarting the fullscreen magnifier fails with OSError: [WinError 0] from MagSetFullscreenTransform.
### Description of user facing changes:
The fullscreen magnifier can now be stopped and restarted reliably.
### Description of developer facing changes:
- _stopMagnifier() no longer calls MagUninitialize(), only resets the transform to neutral
- New _finalUninitializeNativeMagnification() called from terminate() on NVDA shutdown
- _nativeApiInitialized flag ensures MagInitialize() is only called once per session
### Description of development approach:
The MagInitialize → MagUninitialize → MagInitialize cycle within the same process causes MagSetFullscreenTransform to silently return FALSE with no error code. The fix keeps the API initialized for the NVDA session lifetime and defers MagUninitialize() to shutdown.
### Testing strategy:
manual
### Known issues with pull request:

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [ ] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [ ] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [ ] API is compatible with existing add-ons.
- [ ] Security precautions taken.
