### PR TITLE
Avoid bundling duplicate libmathcat_py.pyd

### DIFF
--- a/source/setup.py
+++ b/source/setup.py
@@ -381,6 +381,7 @@ freeze(
 		+ getRecursiveDataFiles(
 			"include/nvda-mathcat/assets",
 			"../include/nvda-mathcat/assets",
+			excludes=tuple(f"*{ext}" for ext in importlib.machinery.all_suffixes()),
 		)
 		+ getRecursiveDataFiles(
 			"synthDrivers",

--- a/source/setup.py
+++ b/source/setup.py
@@ -379,9 +379,8 @@ freeze(
 			else []
 		)
 		+ getRecursiveDataFiles(
-			"include/nvda-mathcat/assets",
-			"../include/nvda-mathcat/assets",
-			excludes=tuple(f"*{ext}" for ext in importlib.machinery.all_suffixes()),
+			"include/nvda-mathcat/assets/Rules",
+			"../include/nvda-mathcat/assets/Rules",
 		)
 		+ getRecursiveDataFiles(
 			"synthDrivers",


### PR DESCRIPTION
### Link to issue number:

Closes #20046

### Summary of the issue:

`libmathcat_py.pyd` is created both in the NVDA installation directory and in `include\nvda-mathcat\assets`.

### Description of user facing changes:

Reduces the size of the launcher by ~4 MB.

### Description of developer facing changes:

None; `libmathcat_py` can still be imported the same way. The duplicate being removed was not imported or used by any other code.

### Description of development approach:

Excludes importable files in the same way that is already used for `synthDrivers` on line 389 of `setup.py`.

### Testing strategy:

Built and checked that `libmathcat_py.pyd` is no longer duplicated, and read math in Chrome as a smoke test.

### Known issues with pull request:

None.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
