### PR TITLE
Avoid building dlls twice due to signing postAction

### DIFF
--- a/ci/scripts/setSconsArgs.ps1
+++ b/ci/scripts/setSconsArgs.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = "Stop";
 $sconsDocsOutTargets = "developerGuide changes userGuide keyCommands user_docs"
 $sconsLauncherOutTargets = "launcher client moduleList"
 $sconsArgs = "version=$env:version"
-$sconsCores = "-j1"
+$sconsCores = "--all-cores"
 if ($env:release) {
 	$sconsArgs += " release=1"
 }

--- a/nvdaHelper/archBuild_sconscript
+++ b/nvdaHelper/archBuild_sconscript
@@ -207,16 +207,12 @@ if isNVDACoreArch:
 
 ia2RPCStubs = env.SConscript("ia2_sconscript")
 Export("ia2RPCStubs")
-if signExec:
-	env.AddPostAction(ia2RPCStubs[0], [signExec])
-env.Install(libInstallDir, ia2RPCStubs[0])  # proxy dll
+env.copyAndSign(libInstallDir, ia2RPCStubs[0])  # proxy dll
 if isNVDACoreArch:
 	env.Install(sourceTypelibDir, ia2RPCStubs[1])  # typelib
 
 iSimpleDomRPCStubs = env.SConscript("ISimpleDOM_sconscript")
-if signExec:
-	env.AddPostAction(iSimpleDomRPCStubs[0], [signExec])
-env.Install(libInstallDir, iSimpleDomRPCStubs[0])  # proxy dll
+env.copyAndSign(libInstallDir, iSimpleDomRPCStubs[0])  # proxy dll
 if isNVDACoreArch:
 	env.Install(sourceTypelibDir, iSimpleDomRPCStubs[1])  # typelib
 
@@ -228,39 +224,27 @@ Export("apiHookObj")
 
 localLib = env.SConscript("local/sconscript")
 Export("localLib")
-if signExec:
-	env.AddPostAction(localLib[0], [signExec])
-env.Install(libInstallDir, localLib)
+env.copyAndSign(libInstallDir, localLib)
 
 if isNVDAHelperLocalArch:
 	win10localLib = env.SConscript(
 		"localWin10/sconscript",
 	)
-	if signExec:
-		env.AddPostAction(win10localLib[0], [signExec])
-	env.Install(libInstallDir, win10localLib)
+	env.copyAndSign(libInstallDir, win10localLib)
 	UIARemoteLib = env.SConscript("UIARemote/sconscript")
-	if signExec:
-		env.AddPostAction(UIARemoteLib[0], [signExec])
-	env.Install(libInstallDir, UIARemoteLib)
+	env.copyAndSign(libInstallDir, UIARemoteLib)
 
 clientLib = env.SConscript("client/sconscript")
 Export("clientLib")
-if signExec:
-	env.AddPostAction(clientLib[0], [signExec])
-env.Install(clientInstallDir, clientLib)
+env.copyAndSign(clientInstallDir, clientLib)
 
 remoteLib = env.SConscript("remote/sconscript")
 Export("remoteLib")
-if signExec:
-	env.AddPostAction(remoteLib[0], [signExec])
-env.Install(libInstallDir, remoteLib)
+env.copyAndSign(libInstallDir, remoteLib)
 
 if not isNVDAHelperLocalArch:
 	remoteLoaderProgram = env.SConscript("remoteLoader/sconscript")
-	if signExec:
-		env.AddPostAction(remoteLoaderProgram, [signExec])
-	env.Install(libInstallDir, remoteLoaderProgram)
+	env.copyAndSign(libInstallDir, remoteLoaderProgram)
 
 if isNVDACoreArch:
 	sonicLib = thirdPartyEnv.SConscript("sonic/sconscript")

--- a/nvdaHelper/archBuild_sconscript
+++ b/nvdaHelper/archBuild_sconscript
@@ -207,12 +207,14 @@ if isNVDACoreArch:
 
 ia2RPCStubs = env.SConscript("ia2_sconscript")
 Export("ia2RPCStubs")
-env.copyAndSign(libInstallDir, ia2RPCStubs[0])  # proxy dll
+env.copyAndSign(libInstallDir, ia2RPCStubs[0][0])  # proxy dll
+env.Install(libInstallDir, ia2RPCStubs[0][1:])
 if isNVDACoreArch:
 	env.Install(sourceTypelibDir, ia2RPCStubs[1])  # typelib
 
 iSimpleDomRPCStubs = env.SConscript("ISimpleDOM_sconscript")
-env.copyAndSign(libInstallDir, iSimpleDomRPCStubs[0])  # proxy dll
+env.copyAndSign(libInstallDir, iSimpleDomRPCStubs[0][0])  # proxy dll
+env.Install(libInstallDir, iSimpleDomRPCStubs[0][1:])
 if isNVDACoreArch:
 	env.Install(sourceTypelibDir, iSimpleDomRPCStubs[1])  # typelib
 
@@ -224,27 +226,35 @@ Export("apiHookObj")
 
 localLib = env.SConscript("local/sconscript")
 Export("localLib")
-env.copyAndSign(libInstallDir, localLib)
+env.copyAndSign(libInstallDir, localLib[0])
+env.Install(libInstallDir, localLib[1:])
 
 if isNVDAHelperLocalArch:
 	win10localLib = env.SConscript(
 		"localWin10/sconscript",
 	)
-	env.copyAndSign(libInstallDir, win10localLib)
+	env.copyAndSign(libInstallDir, win10localLib[0])
+	env.Install(libInstallDir, win10localLib[1:])
 	UIARemoteLib = env.SConscript("UIARemote/sconscript")
-	env.copyAndSign(libInstallDir, UIARemoteLib)
+	env.copyAndSign(libInstallDir, UIARemoteLib[0])
+	env.Install(libInstallDir, UIARemoteLib[1:])
 
-clientLib = env.SConscript("client/sconscript")
+clientLib, clientHeaders = env.SConscript("client/sconscript")
 Export("clientLib")
-env.copyAndSign(clientInstallDir, clientLib)
+Export("clientHeaders")
+env.copyAndSign(clientInstallDir, clientLib[0])
+env.Install(clientInstallDir, clientLib[1:])
+env.Install(clientInstallDir, clientHeaders)
 
 remoteLib = env.SConscript("remote/sconscript")
 Export("remoteLib")
-env.copyAndSign(libInstallDir, remoteLib)
+env.copyAndSign(libInstallDir, remoteLib[0])
+env.Install(libInstallDir, remoteLib[1:])
 
 if not isNVDAHelperLocalArch:
 	remoteLoaderProgram = env.SConscript("remoteLoader/sconscript")
-	env.copyAndSign(libInstallDir, remoteLoaderProgram)
+	env.copyAndSign(libInstallDir, remoteLoaderProgram[0])
+	env.Install(libInstallDir, remoteLoaderProgram[1:])
 
 if isNVDACoreArch:
 	sonicLib = thirdPartyEnv.SConscript("sonic/sconscript")

--- a/nvdaHelper/liblouis/sconscript
+++ b/nvdaHelper/liblouis/sconscript
@@ -98,9 +98,7 @@ sourceFiles = [
 ]
 objs = [env.Object("%s.obj" % f, louisSourceDir.File(f)) for f in sourceFiles]
 louisLib = env.SharedLibrary("liblouis", objs)
-if signExec:
-	env.AddPostAction(louisLib[0], [signExec])
-env.Install(sourceDir, louisLib)
+env.copyAndSign(sourceDir, louisLib)
 
 louisPython = env.Substfile(
 	outDir.File("__init__.py"),

--- a/nvdaHelper/liblouis/sconscript
+++ b/nvdaHelper/liblouis/sconscript
@@ -98,7 +98,8 @@ sourceFiles = [
 ]
 objs = [env.Object("%s.obj" % f, louisSourceDir.File(f)) for f in sourceFiles]
 louisLib = env.SharedLibrary("liblouis", objs)
-env.copyAndSign(sourceDir, louisLib)
+env.copyAndSign(sourceDir, louisLib[0])
+env.Install(sourceDir, louisLib[1:])
 
 louisPython = env.Substfile(
 	outDir.File("__init__.py"),

--- a/sconstruct
+++ b/sconstruct
@@ -511,6 +511,7 @@ def ZipArchiveAction(target, source, env):
 env["BUILDERS"]["ZipArchive"] = Builder(action=ZipArchiveAction)
 
 uninstFile = File("dist/uninstall.exe")
+# Build the uninstaller generator executable.
 uninstGen = env.Command(
 	File("uninstaller/uninstGen.exe"),
 	"uninstaller/uninst.nsi",
@@ -529,10 +530,14 @@ uninstGen = env.Command(
 			"/DINSTEXE=${TARGET.abspath}",
 			"$SOURCE",
 		],
-		env["signExec"]
 	],
 )
-uninstaller = env.Command(uninstFile, uninstGen, [uninstGen])
+# Actually generate the final uninstaller executable.
+# optionally signing it if required.
+actions = [uninstGen]
+if certFile or apiSigningToken: 
+	actions.append(env["signExec"])
+uninstaller = env.Command(uninstFile, uninstGen, actions)
 
 devDocTargets = env.SConscript(
 	"projectDocs/dev/developerGuide/sconscript",
@@ -548,6 +553,11 @@ env.Clean(dist, dist)
 # Clean the intermediate build directory.
 env.Clean([dist], buildDir)
 
+# A command to build the NvDA launcher file,
+# Optionally signing if required.
+extraActions = []
+if certFile or apiSigningToken:
+	extraActions.append(env["signExec"])
 launcher = env.Command(
 	outputDir.File("%s.exe" % outFilePrefix),
 	["launcher/nvdaLauncher.nsi", dist],
@@ -566,7 +576,7 @@ launcher = env.Command(
 			"/DLAUNCHEREXE=${TARGET.abspath}",
 			"$SOURCE",
 		],
-		env["signExec"]
+		*extraActions,
 	],
 )
 

--- a/sconstruct
+++ b/sconstruct
@@ -561,7 +561,7 @@ env.Clean(dist, dist)
 # Clean the intermediate build directory.
 env.Clean([dist], buildDir)
 
-# A command to build the NvDA launcher file,
+# A command to build the NVDA launcher file,
 # Optionally signing if required.
 extraActions = []
 if certFile or apiSigningToken:

--- a/sconstruct
+++ b/sconstruct
@@ -249,6 +249,10 @@ def copyAndSign(env, targetDir, source):
 	]
 	signExec = env.get("signExec")
 	if signExec:
+		# Force SCons to check content to see if the signed file has changed rather than timestamp.
+		# As Github actions cache restore seems to confuse SCons timestamping for these files.
+		env = env.Clone()
+		env.Decider("content")
 		actions.append(signExec)
 	target = env.Dir(targetDir).File(source.name)
 	return env.Command(

--- a/sconstruct
+++ b/sconstruct
@@ -236,13 +236,19 @@ elif certFile:
 
 # A builder that copies and optionally signs the file if signing info is provided.
 def copyAndSign(env, targetDir, source):
+	"""
+	Copies a file to the target directory, and optionally signs it if signing information is provided in the environment.
+	:param env: The scons environment to use to perform the copy and optional signing.
+	:param targetDir: The directory to which the file should be copied.
+	:param source: The file to copy, as a SCons File node.
+	:return: A SCons Node representing the copied (and possibly signed) file in the target directory.
+	"""
 	actions = [
 		Copy("$TARGET", "$SOURCE"),
 	]
 	if certFile or apiSigningToken:
 		actions.append(env["signExec"])
-	firstSource = env.Flatten(source)[0]
-	target = env.Dir(targetDir).File(firstSource.name)
+	target = env.Dir(targetDir).File(source.name)
 	return env.Command(
 		target=target,
 		source=source,
@@ -796,4 +802,3 @@ env.Command(
 	sourceDir.File("speech/types.py"),
 	Copy("$TARGET", "$SOURCE"),
 )
-

--- a/sconstruct
+++ b/sconstruct
@@ -234,6 +234,23 @@ elif certFile:
 	# Export via scons environment so other libraries can be signed
 	env["signExec"] = signExecCert
 
+# A builder that copies and optionally signs the file if signing info is provided.
+def copyAndSign(env, targetDir, source):
+	actions = [
+		Copy("$TARGET", "$SOURCE"),
+	]
+	if certFile or apiSigningToken:
+		actions.append(env["signExec"])
+	firstSource = env.Flatten(source)[0]
+	target = env.Dir(targetDir).File(firstSource.name)
+	return env.Command(
+		target=target,
+		source=source,
+		action=actions,
+	)
+
+env.AddMethod(copyAndSign, "copyAndSign")
+
 # architecture-specific environments
 archTools = ["default", "midl", "msrpc"]
 env32 = env.Clone(TARGET_ARCH="x86", tools=archTools)
@@ -512,11 +529,10 @@ uninstGen = env.Command(
 			"/DINSTEXE=${TARGET.abspath}",
 			"$SOURCE",
 		],
+		env["signExec"]
 	],
 )
 uninstaller = env.Command(uninstFile, uninstGen, [uninstGen])
-if certFile or apiSigningToken:
-	env.AddPostAction(uninstaller, [env["signExec"]])
 
 devDocTargets = env.SConscript(
 	"projectDocs/dev/developerGuide/sconscript",
@@ -550,10 +566,10 @@ launcher = env.Command(
 			"/DLAUNCHEREXE=${TARGET.abspath}",
 			"$SOURCE",
 		],
+		env["signExec"]
 	],
 )
-if certFile or apiSigningToken:
-	env.AddPostAction(launcher, [env["signExec"]])
+
 env.Alias("launcher", launcher)
 
 clientArchive = env.ZipArchive(
@@ -770,3 +786,4 @@ env.Command(
 	sourceDir.File("speech/types.py"),
 	Copy("$TARGET", "$SOURCE"),
 )
+

--- a/sconstruct
+++ b/sconstruct
@@ -234,6 +234,7 @@ elif certFile:
 	# Export via scons environment so other libraries can be signed
 	env["signExec"] = signExecCert
 
+
 # A builder that copies and optionally signs the file if signing info is provided.
 def copyAndSign(env, targetDir, source):
 	"""
@@ -254,6 +255,7 @@ def copyAndSign(env, targetDir, source):
 		source=source,
 		action=actions,
 	)
+
 
 env.AddMethod(copyAndSign, "copyAndSign")
 
@@ -541,7 +543,7 @@ uninstGen = env.Command(
 # Actually generate the final uninstaller executable.
 # optionally signing it if required.
 actions = [uninstGen]
-if certFile or apiSigningToken: 
+if certFile or apiSigningToken:
 	actions.append(env["signExec"])
 uninstaller = env.Command(uninstFile, uninstGen, actions)
 

--- a/sconstruct
+++ b/sconstruct
@@ -247,8 +247,9 @@ def copyAndSign(env, targetDir, source):
 	actions = [
 		Copy("$TARGET", "$SOURCE"),
 	]
-	if certFile or apiSigningToken:
-		actions.append(env["signExec"])
+	signExec = env.get("signExec")
+	if signExec:
+		actions.append(signExec)
 	target = env.Dir(targetDir).File(source.name)
 	return env.Command(
 		target=target,


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
<!-- Use Closes/Fixes/Resolves #xxx to link this PR to the issue it is responding to. -->
Fixes #20033

### Summary of the issue:
Signing of dlls and executables  during NVDA build was implemented in SCons as post actions, as in once the dll or exe target was fully created, then a separate post-action for signing was run. The problems with this approach are:
* when building with multiple processor cores, further actions that depend on a dll (such as packaging, might start running before the dll or exe is actually signed, as SCons thinks the source already exists.
* When building as separate steps (E.g. source, then launcher) it is possible in environments such as Github actions, that the second running of SCons may think that  some DLLs or EXEs are outdated because the signing postAction changed them, so therefore they are re-build and re-signed. This is especially problematic as   collecting of these dls and exes for debug symbols  may have archived the copies from the first build, rather than the second. (See #22033).
  
### Description of user facing changes:

### Description of developer facing changes:

### Description of development approach:
* Rather than using AddPostAction to sign files, make  a new copyAndSign builder  that copies  a source file to the target, and then signs the target all in the same action, thus Scons treats the target as complete once signed.
* Replace any usage of env.AddPostAction and then env.Install with env.copyAndSign.
* When building the launcher and uninstaller, optionally add the signing step as one of the actions, rather than running a post action later.
* Github CI again tells Scons to build with all cores. This should be safe enough now.

### Testing strategy:
* [x] Build locally with and without signing info. Ensure builds succeeed. For a build with signing info, ensure each of the dlls and exes are really signed. 
* [x] Make a try build and verify that dlls and exes are correctly signed.
* [ ] Check try build log Create Launcher job to ensure that dlls are no longer copied and signed.

### Known issues with pull request:
None known.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
