### PR TITLE
Include winBindings.cfgmgr32 in binary builds

### DIFF
--- a/source/setup.py
+++ b/source/setup.py
@@ -330,6 +330,8 @@ freeze(
 			"win32file",
 			"win32event",
 			"win32pipe",
+			# Referenced dynamically by hwPortUtils deprecation aliases.
+			"winBindings.cfgmgr32",
 		],
 	},
 	data_files=[

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -2,7 +2,7 @@
 
 ## 2026.1.1
 
-This is a patch release to fix a security issue and an add-on API issue.
+This is a patch release to fix a security issue.
 
 ### Security fixes
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -2,12 +2,9 @@
 
 ## 2026.1.1
 
-This is a patch release to fix a bug for add-on developers.
-
 ### Changes for Developers
 
-* The `winBindings.cfgmgr32` module is now included in NVDA binary builds.
-This allows add-ons to import `CM_Get_Device_ID`, `CR_SUCCESS`, and `MAX_DEVICE_ID_LEN` from `winBindings.cfgmgr32` as documented in NVDA 2026.1. (#20089, @Cary-rowen)
+* The `winBindings.cfgmgr32` module is now included in NVDA binary builds. (#20089, @Cary-rowen)
 
 ## 2026.1
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -1,5 +1,14 @@
 # What's New in NVDA
 
+## 2026.1.1
+
+This is a patch release to fix a bug for add-on developers.
+
+### Changes for Developers
+
+* The `winBindings.cfgmgr32` module is now included in NVDA binary builds.
+This allows add-ons to import `CM_Get_Device_ID`, `CR_SUCCESS`, and `MAX_DEVICE_ID_LEN` from `winBindings.cfgmgr32` as documented in NVDA 2026.1. (#20089, @Cary-rowen)
+
 ## 2026.1
 
 This release includes support for reading math content with MathCAT, which is now built-in to NVDA.


### PR DESCRIPTION
### Link to issue number:
Closes #20089

### Summary of the issue:
`winBindings.cfgmgr32` is documented in the 2026.1 developer changes as the replacement location for several deprecated `hwPortUtils` symbols, but it is not included in binary builds.

### Description of user facing changes:
None.

### Description of developer facing changes:
`winBindings.cfgmgr32` will be available in binary builds, matching the documented add-on API migration path.

### Description of development approach:
Explicitly include `winBindings.cfgmgr32` in the py2exe `includes` list, since it is referenced dynamically by `hwPortUtils` deprecation aliases and is not discovered by static import analysis.

### Testing strategy:
Manual testing:
Attempted to import `winBindings.cfgmgr32` from the NVDA Python Console.


### Known issues with pull request:
None known.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [ ] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [ ] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [ ] API is compatible with existing add-ons.
- [ ] Security precautions taken.
