### PR TITLE
Don't use IA2TextTextInfo on the web for object review and read line.

### DIFF
--- a/source/NVDAObjects/IAccessible/ia2Web.py
+++ b/source/NVDAObjects/IAccessible/ia2Web.py
@@ -104,6 +104,10 @@ class IA2WebAnnotation(AnnotationOrigin):
 
 class Ia2Web(IAccessible):
 	IAccessibleTableUsesTableCellIndexAttrib = True
+	# The IAccessibleText implementation in web browsers exposes embedded object
+	# characters which need to be traversed to read the content. That isn't useful
+	# to users.
+	_shouldUseTextInfoForReading = False
 
 	def isDescendantOf(self, obj: "NVDAObjects.NVDAObject") -> bool:
 		if obj.windowHandle != self.windowHandle:
@@ -284,6 +288,9 @@ class Figure(Ia2Web):
 
 class Editor(Ia2Web, DocumentWithTableNavigation):
 	TextInfo = MozillaCompoundTextInfo
+	# MozillaCompoundTextInfo traverses embedded objects and is suitable for
+	# presentation to users.
+	_shouldUseTextInfoForReading = True
 
 	def _getTableCellAt(self, tableID, startPos, destRow, destCol):
 		# Locate the table in the object ancestry of the given document position.

--- a/source/NVDAObjects/__init__.py
+++ b/source/NVDAObjects/__init__.py
@@ -1605,6 +1605,12 @@ class NVDAObject(
 		else:
 			return False
 
+	#: Whether the TextInfo should be used for the review cursor, the read current
+	#: line command, etc. This should be False where the TextInfo is only used
+	#: internally and doesn't provide text that is suitable for presentation to the
+	#: user; e.g. it includes raw embedded object characters.
+	_shouldUseTextInfoForReading: bool = True
+
 	def _get_hasIrrelevantLocation(self):
 		"""Returns whether the location of this object is irrelevant for mouse or magnification tracking or highlighting,
 		either because it is programatically hidden (State.INVISIBLE), off screen or the object has no location."""

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -262,15 +262,22 @@ class GlobalCommands(ScriptableObject):
 	def script_reportCurrentLine(self, gesture):
 		obj = api.getFocusObject()
 		treeInterceptor = obj.treeInterceptor
+		useTextInfo: bool = False
 		if (
 			isinstance(treeInterceptor, treeInterceptorHandler.DocumentTreeInterceptor)
 			and not treeInterceptor.passThrough
 		):
 			obj = treeInterceptor
-		try:
-			info = obj.makeTextInfo(textInfos.POSITION_CARET)
-		except (NotImplementedError, RuntimeError):
-			info = obj.makeTextInfo(textInfos.POSITION_FIRST)
+			useTextInfo = True
+		else:
+			useTextInfo = obj._shouldUseTextInfoForReading
+		if useTextInfo:
+			try:
+				info = obj.makeTextInfo(textInfos.POSITION_CARET)
+			except (NotImplementedError, RuntimeError):
+				info = obj.makeTextInfo(textInfos.POSITION_FIRST)
+		else:
+			info = NVDAObjectTextInfo(obj, textInfos.POSITION_FIRST)
 		info.expand(textInfos.UNIT_LINE)
 		scriptCount = getLastScriptRepeatCount()
 		if scriptCount == 0:

--- a/source/review.py
+++ b/source/review.py
@@ -20,26 +20,28 @@ import textInfos
 import config
 
 
-def getObjectPosition(obj):
+def getObjectPosition(obj: NVDAObject) -> tuple[textInfos.TextInfo, ScriptableObject] | None:
 	"""
 	Fetches a TextInfo instance suitable for reviewing the text in  the given object.
-	@param obj: the NVDAObject to review
-	@type obj: L{NVDAObject}
-	@return: the TextInfo instance and the Scriptable object the TextInfo instance is referencing, or None on error.
-	@rtype: (L{TextInfo},L{ScriptableObject})
+	:param obj: the NVDAObject to review
+	:return: the TextInfo instance and the Scriptable object the TextInfo instance is referencing, or None on error.
 	"""
-	try:
-		pos = obj.makeTextInfo(textInfos.POSITION_CARET)
-	except (NotImplementedError, RuntimeError):
-		# No caret supported, try first position instead
+	useTextInfo: bool = obj._shouldUseTextInfoForReading
+	if useTextInfo:
 		try:
-			pos = obj.makeTextInfo(textInfos.POSITION_FIRST)
+			pos = obj.makeTextInfo(textInfos.POSITION_CARET)
 		except (NotImplementedError, RuntimeError):
-			log.debugWarning(
-				"%s does not support POSITION_FIRST, falling back to NVDAObjectTextInfo" % obj.TextInfo,
-			)
-			# First position not supported either, return first position from a generic NVDAObjectTextInfo
-			return NVDAObjectTextInfo(obj, textInfos.POSITION_FIRST), obj
+			# No caret supported, try first position instead
+			try:
+				pos = obj.makeTextInfo(textInfos.POSITION_FIRST)
+			except (NotImplementedError, RuntimeError):
+				log.debugWarning(
+					f"{obj.TextInfo} does not support POSITION_FIRST, falling back to NVDAObjectTextInfo",
+				)
+				# First position not supported either, return first position from a generic NVDAObjectTextInfo
+				useTextInfo = False
+	if not useTextInfo:
+		return NVDAObjectTextInfo(obj, textInfos.POSITION_FIRST), obj
 	return pos, pos.obj
 
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -73,6 +73,7 @@ The setting is disabled by default. (#20013, @LeonarddeR)
 * Fixed NVDA freezing when navigating in JetBrains IDEs. (#16741, @christopherpross)
 * Speech dictionary entries of type Whole word now correctly handle words containing Unicode combining marks (e.g. Hebrew niqqud, Arabic harakat). (#20013, @LeonarddeR)
   * In particular, Whole word entries no longer incorrectly match inside larger words when those words contain combining marks.
+* In focus mode in web browsers, it is now possible to review and spell the labels of controls when those labels are specifically provided for accessibility; e.g. via aria-label or aria-labelledby. (#15159, @jcsteh)
 
 ### Changes for Developers
 


### PR DESCRIPTION
### Link to issue number:
Fixes #15159.

### Summary of the issue:
In focus mode in web browsers, when a control specifies a label using aria-label or aria-labelledby, it is impossible to review or spell that label; e.g. using read current line or the review cursor. This is particularly annoying and detrimental to efficiency when using web apps such as Gmail and Slack, among others, where you have to switch to browse mode to work around this even though it might be more efficient to use focus mode for navigation.

### Description of user facing changes:
In focus mode in web browsers, it is now possible to review and spell the labels of controls when those labels are specifically provided for accessibility; e.g. via aria-label or aria-labelledby.

### Description of development approach:
When in focus mode, for non-editable controls, both speech and braille report the name, description, value, etc. of the control; they don't use the TextInfo. However, previously, the review cursor and the read line command always used the TextInfo. Since IA2TextTextInfo is used for all objects supporting IAccessibleText, this meant that if the content wasn't a flat piece of text equal to the label, the review cursor and read line command would report something different, often nothing at all.

To fix this, for IA2Web objects that aren't editors, use NVDAObjectTextInfo instead of the object's TextInfo for object review and the read line command. I first attempted to do this generically in #18271 using `_hasNavigableText`, but this caused problems elsewhere. Instead, the scope of this change is very specific, introducing a new `_shouldUseTextInfoForReview` NVDAObject attribute which is only set to False for Ia2Web objects.

### Testing strategy:
In both Firefox and Edge:

1. Followed and verified the steps to reproduce in https://github.com/nvaccess/nvda/issues/15159#issue-1808844106.
2. Also tested with the review cursor in the Gmail message list, where previously, the review cursor couldn't read the message details. With this change, it can. Same for read current line.
3. Verified that braille remains the same as before (the expected behaviour) in all of these scenarios.
4. Also tested this test case:
    `data:text/html,<textarea>ab`
    Verified that in focus mode, formatting info is still reported for the review cursor, indicating that the correct TextInfo is being used. Also verified that the review cursor tracks the caret.
5. With a multi line message in Gmail, verified that read current line reports the correct line when on the second or subsequent lines.
6. I wasn't able to reproduce #11285 myself. However, @amirsol81 [verified that this change fixes that too](https://github.com/nvaccess/nvda/issues/11285#issuecomment-2996421115).

### Known issues with pull request:
The narrow scoping here means that this probably doesn't fix #11285 in the Chrome UI. I was never able to reproduce it, so I can't verify that. Regardless, I think that should be addressed separately, though the new property should make that much simpler.

Similarly, this may mean we can revert VS Code specific changes such as #17573 and #16248. However, I'm not willing to risk that at this stage, given the churn this caused last time and the fact that I don't use VS Code myself and am unwilling to test it. There is no conflict here and it can easily be addressed in a follow-up if this proves to be feasible.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.