### PR TITLE
Fix error when a synthesizer don't expose available languages

### DIFF
--- a/source/synthDriverHandler.py
+++ b/source/synthDriverHandler.py
@@ -345,12 +345,9 @@ class SynthDriver(driverHandler.Driver):
 		if lang is None:
 			return True
 		for availableLang in self.availableLanguages:
-			if (
-				availableLang is not None
-				and (
-					lang == languageHandler.normalizeLanguage(availableLang)
-					or lang == languageHandler.normalizeLanguage(availableLang).split("_")[0]
-				)
+			if availableLang is not None and (
+				lang == languageHandler.normalizeLanguage(availableLang)
+				or lang == languageHandler.normalizeLanguage(availableLang).split("_")[0]
 			):
 				return True
 		rootLang = languageHandler.normalizeLanguage(lang).split("_")[0]

--- a/source/synthDriverHandler.py
+++ b/source/synthDriverHandler.py
@@ -346,8 +346,11 @@ class SynthDriver(driverHandler.Driver):
 			return True
 		for availableLang in self.availableLanguages:
 			if (
-				lang == languageHandler.normalizeLanguage(availableLang)
-				or lang == languageHandler.normalizeLanguage(availableLang).split("_")[0]
+				availableLang is not None
+				and (
+					lang == languageHandler.normalizeLanguage(availableLang)
+					or lang == languageHandler.normalizeLanguage(availableLang).split("_")[0]
+				)
 			):
 				return True
 		rootLang = languageHandler.normalizeLanguage(lang).split("_")[0]

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -56,6 +56,7 @@ The setting is disabled by default. (#20013, @LeonarddeR)
 
 ### Bug Fixes
 
+* Fixed an error when a synthesizer doesn't have available languages, and NVDA tries to report if a language is supported. (#20080, @nvdaes)
 * NVDA will attempt to recover more quickly from freezes in some applications, especially those written in Java. (#14396, @thgcode)
 * In Firefox browse mode, the accessible name of form controls (such as checkboxes and radio buttons) is now correctly announced when the control has an `aria-label` and an associated `<label>` element that contains only `aria-hidden` content. (#19409, @bramd)
 * The "Toggles on and off if the screen layout is preserved while rendering the document content" item in the "Browse mode" category of the Input Gestures dialog now behaves correctly. (#18378)


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
<!-- Use Closes/Fixes/Resolves #xxx to link this PR to the issue it is responding to. -->
Fixes #20080
### Summary of the issue:
When NVDA is configured to report if the language of the text been read is supported, an error is produced if the syntesizer exposes available languages as None.
### Description of user facing changes:
Fixed an error with certain syntesizers when reporting if the language of the text been read is supported.
### Description of developer facing changes:

### Description of development approach:
Check if available language is None.
### Testing strategy:
None yet.
### Known issues with pull request:
None.
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
