### PR TITLE
Remove reverted settings dialog debounce changes from Chinese word segmentation branch

### DIFF
--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -1,7 +1,6 @@
 # A part of NonVisual Desktop Access (NVDA)
 # Copyright (C) 2007-2026 NV Access Limited, Babbage B.V., James Teh, Leonard de Ruijter,
-# Thomas Stivers, Accessolutions, Julien Cochuyt, Cyrille Bougot, Kefas Lungu,
-# Wang Chong
+# Thomas Stivers, Accessolutions, Julien Cochuyt, Cyrille Bougot, Kefas Lungu
 # This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
 # For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
 

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -56,7 +56,6 @@ from wx.lib import scrolledpanel
 
 import screenCurtain._screenCurtain
 from utils import mmdevice
-from utils.debounce import debounceLimiter
 from utils.security import isRunningOnSecureDesktop
 from vision.providerBase import VisionEnhancementProviderSettings
 from wx.lib.expando import ExpandoTextCtrl
@@ -751,15 +750,12 @@ class MultiCategorySettingsDialog(SettingsDialog):
 		self.container.Thaw()
 
 	def onCategoryChange(self, evt: wx.ListEvent):
+		currentCat = self.currentCategory
 		newIndex = evt.GetIndex()
-		if self._shouldDoCategoryChange(newIndex):
+		if not currentCat or newIndex != self.categoryClasses.index(currentCat.__class__):
 			self._doCategoryChange(newIndex)
 		else:
 			evt.Skip()
-
-	def _shouldDoCategoryChange(self, index: int) -> bool:
-		currentCat = self.currentCategory
-		return not currentCat or index != self.categoryClasses.index(currentCat.__class__)
 
 	def _validateAllPanels(self):
 		"""Check if all panels are valid, and can be saved
@@ -6461,7 +6457,6 @@ NvdaSettingsDialogWindowHandle = None
 class NVDASettingsDialog(MultiCategorySettingsDialog):
 	# Translators: This is the label for the NVDA settings dialog.
 	title = _("NVDA Settings")
-	_pendingCategoryIndex: int | None = None
 	categoryClasses = [
 		GeneralSettingsPanel,
 		SpeechSettingsPanel,
@@ -6531,36 +6526,13 @@ class NVDASettingsDialog(MultiCategorySettingsDialog):
 			configProfile=NvdaSettingsDialogActiveConfigProfile,
 		)
 
-	def _doCategoryChangeForIndex(self, newIndex: int) -> bool:
-		if self._shouldDoCategoryChange(newIndex):
-			self._doCategoryChange(newIndex)
-			return True
-		return False
-
-	@debounceLimiter(
-		cooldownTimeMs=500,
-		delayTimeMs=500,
-	)
-	def _onCategoryChangeDebounced(self) -> None:
-		if self._pendingCategoryIndex is not None:
-			if self._doCategoryChangeForIndex(self._pendingCategoryIndex):
-				self._doOnCategoryChange()
-			self._pendingCategoryIndex = None
-
 	def onCategoryChange(self, evt: wx.ListEvent):
-		if isRunningOnSecureDesktop():
-			# Secure desktop can cause issues with rapidly changing categories,
-			# so we debounce category changes to avoid this. (#19634)
-			self._pendingCategoryIndex = evt.GetIndex()
-			self._onCategoryChangeDebounced()
-			return
 		super().onCategoryChange(evt)
 		if evt.Skipped:
 			return
 		self._doOnCategoryChange()
 
 	def Destroy(self):
-		self._pendingCategoryIndex = None
 		global NvdaSettingsDialogActiveConfigProfile, NvdaSettingsDialogWindowHandle
 		NvdaSettingsDialogActiveConfigProfile = None
 		NvdaSettingsDialogWindowHandle = None


### PR DESCRIPTION
This removes settings dialog category-change debounce code that was accidentally reintroduced while resolving conflicts. That code was previously reverted by #19846, so this branch should follow current master here and only keep the Document Navigation changes needed for Chinese word segmentation.

This also removes an unrelated copyright-only change in browseMode.py.