### PR TITLE
Make detection of not supported languages more robust

### DIFF
--- a/source/synthDriverHandler.py
+++ b/source/synthDriverHandler.py
@@ -344,15 +344,21 @@ class SynthDriver(driverHandler.Driver):
 		"""
 		if lang is None:
 			return True
+		normalizedLang = languageHandler.normalizeLanguage(lang)
+		if normalizedLang is None:
+			return False
+		rootLang = normalizedLang.split("_")[0]
+		normalizedAvailableLangs: set[str] = set()
 		for availableLang in self.availableLanguages:
-			if availableLang is not None and (
-				lang == languageHandler.normalizeLanguage(availableLang)
-				or lang == languageHandler.normalizeLanguage(availableLang).split("_")[0]
-			):
-				return True
-		rootLang = languageHandler.normalizeLanguage(lang).split("_")[0]
-		fallbackLang = f"{rootLang}-{rootLang}"
-		if fallbackLang in self.availableLanguages:
+			if availableLang is None:
+				continue
+			normalizedAvailableLang = languageHandler.normalizeLanguage(availableLang)
+			if normalizedAvailableLang is None:
+				continue
+			normalizedAvailableLangs.add(normalizedAvailableLang)
+		if normalizedLang in normalizedAvailableLangs:
+			return True
+		if any(rootLang == availableLang.split("_")[0] for availableLang in normalizedAvailableLangs):
 			return True
 		return False
 

--- a/tests/unit/test_synthDriverHandler.py
+++ b/tests/unit/test_synthDriverHandler.py
@@ -132,3 +132,39 @@ class test_synthDriverHandler(unittest.TestCase):
 			**expectedKwargs,
 		):
 			synthDriverHandler.setSynth("auto")
+
+
+class TestLanguageIsSupported(unittest.TestCase):
+	def setUp(self) -> None:
+		self._synth = MockSynth(FAKE_DEFAULT_SYNTH_NAME)
+		self._synth.availableLanguages = set()
+
+	def tearDown(self) -> None:
+		del self._synth
+
+	def _languageIsSupported(self, lang: str | None) -> bool:
+		return synthDriverHandler.SynthDriver.languageIsSupported(self._synth, lang)
+
+	def test_noneLanguageIsSupported(self):
+		self._synth.availableLanguages = {"en_US"}
+		self.assertTrue(self._languageIsSupported(None))
+
+	def test_normalizedExactLanguageMatch(self):
+		self._synth.availableLanguages = {"en_US"}
+		self.assertTrue(self._languageIsSupported("en-us"))
+
+	def test_rootLanguageMatch(self):
+		self._synth.availableLanguages = {"en_GB"}
+		self.assertTrue(self._languageIsSupported("en"))
+
+	def test_unsupportedLanguage(self):
+		self._synth.availableLanguages = {"en_US"}
+		self.assertFalse(self._languageIsSupported("fr"))
+
+	def test_metaAndNoneAvailableLanguagesIgnored(self):
+		self._synth.availableLanguages = {None, "x-western", "en_US"}
+		self.assertTrue(self._languageIsSupported("en"))
+
+	def test_metaInputLanguageNotSupported(self):
+		self._synth.availableLanguages = {"en_US"}
+		self.assertFalse(self._languageIsSupported("x-western"))

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -56,7 +56,7 @@ The setting is disabled by default. (#20013, @LeonarddeR)
 
 ### Bug Fixes
 
-* Fixed an error when a synthesizer doesn't have available languages, and NVDA tries to report if a language is supported. (#20080, @nvdaes)
+* Fixed an error that could occur when NVDA checked whether a language is supported for a synthesizer with invalid languages. (#20080, @nvdaes)
 * NVDA will attempt to recover more quickly from freezes in some applications, especially those written in Java. (#14396, @thgcode)
 * In Firefox browse mode, the accessible name of form controls (such as checkboxes and radio buttons) is now correctly announced when the control has an `aria-label` and an associated `<label>` element that contains only `aria-hidden` content. (#19409, @bramd)
 * The "Toggles on and off if the screen layout is preserved while rendering the document content" item in the "Browse mode" category of the Input Gestures dialog now behaves correctly. (#18378)


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
<!-- Use Closes/Fixes/Resolves #xxx to link this PR to the issue it is responding to. -->
None. Fixup of PR #20100
### Summary of the issue:
Synthesizers may return None for normalized languages, and this is not addressed in #20100.
### Description of user facing changes:
None known.
### Description of developer facing changes:
None.
### Description of development approach:
Considered the situation where the normalized language is None, improved the function to check if a language is supported, and added unit tests for this function.
### Testing strategy:
Tested Reading text of the following Codepen pages, based on tests proposed by @cyrilleB79:

- [Webpage with multiple languages](https://codepen.io/nvdaes/pen/KwKyVpR)
-[webpage with English, French an Italian](https://codepen.io/nvdaes/pen/WbrXxZL)

Also, run unit tests.

### Known issues with pull request:
None.
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
