### PR TITLE
Rework magnifier edge messages to ease translation

### DIFF
--- a/source/_magnifier/commands.py
+++ b/source/_magnifier/commands.py
@@ -59,25 +59,25 @@ PAN_ACTION_TO_EDGE_MESSAGES = {
 		"magnifier",
 		# Translators: Message announced when already at left edge of the screen while panning the magnified view
 		# to left edge
-		"left",
+		"left edge",
 	),
 	MagnifierAction.PAN_RIGHT_EDGE: pgettext(
 		"magnifier",
 		# Translators: Message announced when already at right edge of the screen while panning the magnified view
 		# to right edge
-		"right",
+		"right edge",
 	),
 	MagnifierAction.PAN_TOP_EDGE: pgettext(
 		"magnifier",
 		# Translators: Message announced when already at top edge of the screen while panning the magnified view
 		# to top edge
-		"top",
+		"top edge",
 	),
 	MagnifierAction.PAN_BOTTOM_EDGE: pgettext(
 		"magnifier",
 		# Translators: Message announced when already at left edge of the screen while panning the magnified view
 		# to left edge
-		"bottom",
+		"bottom edge",
 	),
 }
 

--- a/source/_magnifier/commands.py
+++ b/source/_magnifier/commands.py
@@ -34,45 +34,49 @@ from .utils.types import (
 )
 from logHandler import log
 
-PAN_ACTION_TO_EDGE_NAME = {
+PAN_ACTION_TO_EDGE_MESSAGES = {
 	MagnifierAction.PAN_LEFT: pgettext(
 		"magnifier",
-		# Translators: Short name for the left edge, used in messages.
-		"left",
+		# Translators: Message announced when already at left edge of the screen while panning the magnified view
+		"left edge",
 	),
 	MagnifierAction.PAN_RIGHT: pgettext(
 		"magnifier",
-		# Translators: Short name for the right edge, used in messages.
-		"right",
+		# Translators: Message announced when already at right edge of the screen while panning the magnified view
+		"right edge",
 	),
 	MagnifierAction.PAN_UP: pgettext(
 		"magnifier",
-		# Translators: Short name for the top edge, used in messages.
-		"top",
+		# Translators: Message announced when already at top edge of the screen while panning the magnified view
+		"top edge",
 	),
 	MagnifierAction.PAN_DOWN: pgettext(
 		"magnifier",
-		# Translators: Short name for the bottom edge, used in messages.
-		"bottom",
+		# Translators: Message announced when already at bottom edge of the screen while panning the magnified view
+		"bottom edge",
 	),
 	MagnifierAction.PAN_LEFT_EDGE: pgettext(
 		"magnifier",
-		# Translators: Short name for the left edge, used in messages.
+		# Translators: Message announced when already at left edge of the screen while panning the magnified view
+		# to left edge
 		"left",
 	),
 	MagnifierAction.PAN_RIGHT_EDGE: pgettext(
 		"magnifier",
-		# Translators: Short name for the right edge, used in messages.
+		# Translators: Message announced when already at right edge of the screen while panning the magnified view
+		# to right edge
 		"right",
 	),
 	MagnifierAction.PAN_TOP_EDGE: pgettext(
 		"magnifier",
-		# Translators: Short name for the top edge, used in messages.
+		# Translators: Message announced when already at top edge of the screen while panning the magnified view
+		# to top edge
 		"top",
 	),
 	MagnifierAction.PAN_BOTTOM_EDGE: pgettext(
 		"magnifier",
-		# Translators: Short name for the bottom edge, used in messages.
+		# Translators: Message announced when already at left edge of the screen while panning the magnified view
+		# to left edge
 		"bottom",
 	),
 }
@@ -165,14 +169,7 @@ def pan(action: MagnifierAction) -> None:
 	if magnifierIsActiveVerify(magnifier, action):
 		hasMoved = magnifier._pan(action)
 		if not hasMoved:
-			edgeName = PAN_ACTION_TO_EDGE_NAME.get(action)
-			ui.message(
-				pgettext(
-					"magnifier",
-					# Translators: Message announced when arriving at the {edge} edge.
-					"{edge} edge",
-				).format(edge=edgeName),
-			)
+			ui.message(PAN_ACTION_TO_EDGE_MESSAGES[action])
 
 
 def toggleFilter() -> None:


### PR DESCRIPTION
### Link to issue number:
Reported in [this thread](https://groups.io/g/nvda-translations/topic/magnifier_strings_for_2026_2/119266182) of the translators mailing list.

### Summary of the issue:

Magnifier had 2 strings "left" for 2 different uses:
* one used as adverb when panning left command was used while already at left edge of the screen to report no move
* one other used in compound string "{edge} edge" as an adjective when panning to left edge command was used while already at left of the screen

In some languages, both strings do not translate the same.

Same for "right", "top" and "bottom" strings.

### Description of user facing changes:
Panning command feedback when at edge can now be correctly translated.
### Description of developer facing changes:
N/A
### Description of development approach:
* Used 1 string per action with no duplicate
* Do not use a compound string since it is no longer needed; this coumpound string was useful only when paning commands were always reporting something but this behaviour has been withdrawn. Moreover, compound strings may be less easy to translate for translators.
### Testing strategy:
* Manual tests of all 8 paning commands at 8 edges.
### Known issues with pull request:
None
### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
