### PR TITLE
Revert "Notify user when connecting as follower fails (#19477)"

### DIFF
--- a/source/_remoteClient/client.py
+++ b/source/_remoteClient/client.py
@@ -295,8 +295,6 @@ class RemoteClient:
 
 	def disconnectAsFollower(self):
 		"""Close follower session and clean up related resources."""
-		if self.followerTransport:
-			self.followerTransport.transportConnectionFailed.unregister(self.onConnectAsFollowerFailed)
 		self.followerSession.close()
 		self.followerSession = None
 		self.followerTransport = None
@@ -318,21 +316,6 @@ class RemoteClient:
 				caption=_("Error Connecting"),
 				# Translators: Message shown when unable to connect to the remote computer.
 				message=_("Unable to connect to the remote computer"),
-				style=wx.OK | wx.ICON_WARNING,
-			)
-
-	@alwaysCallAfter
-	def onConnectAsFollowerFailed(self):
-		if self.followerTransport and self.followerTransport.successfulConnects == 0:
-			log.error(f"Failed to connect to {self.followerTransport.address}")
-			self.disconnectAsFollower()
-			# Translators: Title of the connection error dialog.
-			gui.messageBox(
-				parent=gui.mainFrame,
-				# Translators: Title of the connection error dialog.
-				caption=pgettext("remote", "Error Connecting"),
-				# Translators: Message shown when unable to connect to the remote computer.
-				message=pgettext("remote", "Unable to connect to the remote computer"),
 				style=wx.OK | wx.ICON_WARNING,
 			)
 
@@ -451,7 +434,6 @@ class RemoteClient:
 			self.onFollowerCertificateFailed,
 		)
 		transport.transportConnected.register(self.onConnectedAsFollower)
-		transport.transportConnectionFailed.register(self.onConnectAsFollowerFailed)
 		transport.transportDisconnected.register(self.onDisconnectedAsFollower)
 		transport.reconnectorThread.start()
 		if self.menu:

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -11,6 +11,11 @@ Please responsibly disclose security issues following NVDA's [security policy](h
 * Fixed an issue which could cause NVDA to connect to an untrusted Remote Access server. ([GHSA-m268-mc77-j2cr](https://github.com/nvaccess/nvda/security/advisories/GHSA-m268-mc77-j2cr))
 * Prevents a situation which could cause unselected add-ons to be copied to the system-wide configuration. ([GHSA-669f-7gpr-5vqm](https://github.com/nvaccess/nvda/security/advisories/GHSA-669f-7gpr-5vqm))
 
+### Changes
+
+* Remote Access once again attempts automatic reconnection after a failed initial connection as the controlled computer, rather than failing immediately.
+  This means that headless or otherwise physically inaccessible machines configured to automatically connect at startup will be reachable once the network is available. (#20122)
+
 <!-- Beyond this point, Markdown should not be linted, as we don't modify old change log sections. -->
 <!-- markdownlint-disable -->
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -3,7 +3,7 @@
 ## 2026.1.1
 
 This is a patch release to fix a security issue.
-We have also removed a change we introduced in 2026.1 with how we handle connection issues with Remote Access.
+A change introduced in 2026.1 with how NVDA handles connection issues with Remote Access was removed.
 
 ### Security fixes
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -3,6 +3,7 @@
 ## 2026.1.1
 
 This is a patch release to fix a security issue.
+We have also removed a change we introduced in 2026.1 with how we handle connection issues with Remote Access.
 
 ### Security fixes
 


### PR DESCRIPTION
### Reverts PR

Reverts #19477

### Issues fixed

Fixes #20122

### Issues reopened

Reopens #19103

### Reason for revert

The referenced commit breaks the use-case where the user is using NVDA Remote Access as their primary means of accessing a headless or otherwise physically inaccessible machine, if the network is unavailable when Remote Access attempts the initial connection.

### Can this PR be reimplemented? If so, what is required for the next attempt

Yes. For automatic connections, continue to retry establishing the connection indefinitely, or with some configurable timeout.
