### PR TITLE
Don't use IA2TextTextInfo on the web

### DIFF
--- a/source/NVDAObjects/IAccessible/ia2TextMozilla.py
+++ b/source/NVDAObjects/IAccessible/ia2TextMozilla.py
@@ -29,9 +29,9 @@ from logHandler import log
 
 
 def _getRawTextInfo(obj) -> Type[offsets.OffsetsTextInfo]:
-	if obj.TextInfo is NVDAObjectTextInfo:
-		return NVDAObjectTextInfo
-	return IA2TextTextInfo
+	if hasattr(obj, "IAccessibleTextObject"):
+		return IA2TextTextInfo
+	return NVDAObjectTextInfo
 
 
 def _getEmbedded(obj, offset) -> typing.Optional[IAccessible]:

--- a/source/NVDAObjects/IAccessible/ia2Web.py
+++ b/source/NVDAObjects/IAccessible/ia2Web.py
@@ -107,7 +107,7 @@ class Ia2Web(IAccessible):
 	# The IAccessibleText implementation in web browsers exposes embedded object
 	# characters which need to be traversed to read the content. That isn't useful
 	# to users.
-	_shouldUseTextInfoForReading = False
+	TextInfo = NVDAObjects.NVDAObjectTextInfo
 
 	def isDescendantOf(self, obj: "NVDAObjects.NVDAObject") -> bool:
 		if obj.windowHandle != self.windowHandle:

--- a/source/NVDAObjects/__init__.py
+++ b/source/NVDAObjects/__init__.py
@@ -1605,12 +1605,6 @@ class NVDAObject(
 		else:
 			return False
 
-	#: Whether the TextInfo should be used for the review cursor, the read current
-	#: line command, etc. This should be False where the TextInfo is only used
-	#: internally and doesn't provide text that is suitable for presentation to the
-	#: user; e.g. it includes raw embedded object characters.
-	_shouldUseTextInfoForReading: bool = True
-
 	def _get_hasIrrelevantLocation(self):
 		"""Returns whether the location of this object is irrelevant for mouse or magnification tracking or highlighting,
 		either because it is programatically hidden (State.INVISIBLE), off screen or the object has no location."""

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -262,22 +262,15 @@ class GlobalCommands(ScriptableObject):
 	def script_reportCurrentLine(self, gesture):
 		obj = api.getFocusObject()
 		treeInterceptor = obj.treeInterceptor
-		useTextInfo: bool = False
 		if (
 			isinstance(treeInterceptor, treeInterceptorHandler.DocumentTreeInterceptor)
 			and not treeInterceptor.passThrough
 		):
 			obj = treeInterceptor
-			useTextInfo = True
-		else:
-			useTextInfo = obj._shouldUseTextInfoForReading
-		if useTextInfo:
-			try:
-				info = obj.makeTextInfo(textInfos.POSITION_CARET)
-			except (NotImplementedError, RuntimeError):
-				info = obj.makeTextInfo(textInfos.POSITION_FIRST)
-		else:
-			info = NVDAObjectTextInfo(obj, textInfos.POSITION_FIRST)
+		try:
+			info = obj.makeTextInfo(textInfos.POSITION_CARET)
+		except (NotImplementedError, RuntimeError):
+			info = obj.makeTextInfo(textInfos.POSITION_FIRST)
 		info.expand(textInfos.UNIT_LINE)
 		scriptCount = getLastScriptRepeatCount()
 		if scriptCount == 0:

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -2785,6 +2785,7 @@ class GlobalCommands(ScriptableObject):
 			relation' in that range, and we don't yet have a way for the user to select which one to report.
 			For now, we minimise this risk by only reporting details at the current location.
 		"""
+		_isDebugLogCatEnabled = bool(config.conf["debugLog"]["annotations"])
 		try:
 			# Common cases use Caret Position: vbuf available or object supports text range
 			# Eg editable text, or regular web content
@@ -2792,28 +2793,26 @@ class GlobalCommands(ScriptableObject):
 			caret: textInfos.TextInfo = api.getCaretPosition()
 		except RuntimeError:
 			log.debugWarning("Unable to get the caret position.", exc_info=True)
-			return None
-		caret.expand(textInfos.UNIT_CHARACTER)
-		objAtStart: NVDAObject = caret.NVDAObjectAtStart
-		_isDebugLogCatEnabled = bool(config.conf["debugLog"]["annotations"])
-		if _isDebugLogCatEnabled:
-			log.debug(f"Trying with nvdaObject : {objAtStart}")
-
-		if objAtStart.annotations:
+		else:
+			caret.expand(textInfos.UNIT_CHARACTER)
+			objAtStart: NVDAObject = caret.NVDAObjectAtStart
 			if _isDebugLogCatEnabled:
-				log.debug("NVDAObjectAtStart of caret has details")
-			return objAtStart
-		elif api.getFocusObject():
+				log.debug(f"Trying with nvdaObject : {objAtStart}")
+			if objAtStart.annotations:
+				if _isDebugLogCatEnabled:
+					log.debug("NVDAObjectAtStart of caret has details")
+				return objAtStart
+
+		focus: NVDAObject = api.getFocusObject()
+		if focus:
 			# If fetching from the caret position fails, try via the focus object
 			# This case is to support where there is no virtual buffer or text interface and a caret position can
 			# not be fetched.
 			# There may still be an object with focus that has details.
-			# There isn't a known test case for this, however there isn't a known downside to attempt this.
-			focus = api.getFocusObject()
 			if _isDebugLogCatEnabled:
 				log.debug(f"Trying focus object: {focus}")
 
-			if objAtStart.annotations:
+			if focus.annotations:
 				if _isDebugLogCatEnabled:
 					log.debug("focus object has details, able to proceed")
 				return focus

--- a/source/review.py
+++ b/source/review.py
@@ -26,22 +26,18 @@ def getObjectPosition(obj: NVDAObject) -> tuple[textInfos.TextInfo, ScriptableOb
 	:param obj: the NVDAObject to review
 	:return: the TextInfo instance and the Scriptable object the TextInfo instance is referencing, or None on error.
 	"""
-	useTextInfo: bool = obj._shouldUseTextInfoForReading
-	if useTextInfo:
+	try:
+		pos = obj.makeTextInfo(textInfos.POSITION_CARET)
+	except (NotImplementedError, RuntimeError):
+		# No caret supported, try first position instead
 		try:
-			pos = obj.makeTextInfo(textInfos.POSITION_CARET)
+			pos = obj.makeTextInfo(textInfos.POSITION_FIRST)
 		except (NotImplementedError, RuntimeError):
-			# No caret supported, try first position instead
-			try:
-				pos = obj.makeTextInfo(textInfos.POSITION_FIRST)
-			except (NotImplementedError, RuntimeError):
-				log.debugWarning(
-					f"{obj.TextInfo} does not support POSITION_FIRST, falling back to NVDAObjectTextInfo",
-				)
-				# First position not supported either, return first position from a generic NVDAObjectTextInfo
-				useTextInfo = False
-	if not useTextInfo:
-		return NVDAObjectTextInfo(obj, textInfos.POSITION_FIRST), obj
+			log.debugWarning(
+				"%s does not support POSITION_FIRST, falling back to NVDAObjectTextInfo" % obj.TextInfo,
+			)
+			# First position not supported either, return first position from a generic NVDAObjectTextInfo
+			return NVDAObjectTextInfo(obj, textInfos.POSITION_FIRST), obj
 	return pos, pos.obj
 
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -9,6 +9,8 @@
 ### Changes
 
 ### Bug Fixes
+* In focus mode in web browsers, it is now possible to review and spell the labels of controls when those labels are specifically provided for accessibility; e.g. via aria-label or aria-labelledby. (#15159, @jcsteh)
+* In Mozilla Firefox, reporting annotation details now works correctly in focus mode on controls which are not editable text. (#20132, @jcsteh)
 
 ### Changes for Developers
 
@@ -93,8 +95,6 @@ The setting is disabled by default. (#20013, @LeonarddeR)
 * Fixed NVDA freezing when navigating in JetBrains IDEs. (#16741, @christopherpross)
 * Speech dictionary entries of type Whole word now correctly handle words containing Unicode combining marks (e.g. Hebrew niqqud, Arabic harakat). (#20013, @LeonarddeR)
   * In particular, Whole word entries no longer incorrectly match inside larger words when those words contain combining marks.
-* In focus mode in web browsers, it is now possible to review and spell the labels of controls when those labels are specifically provided for accessibility; e.g. via aria-label or aria-labelledby. (#15159, @jcsteh)
-* In Mozilla Firefox, reporting annotation details now works correctly in focus mode on controls which are not editable text. (#20132, @jcsteh)
 
 ### Changes for Developers
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -94,6 +94,7 @@ The setting is disabled by default. (#20013, @LeonarddeR)
 * Speech dictionary entries of type Whole word now correctly handle words containing Unicode combining marks (e.g. Hebrew niqqud, Arabic harakat). (#20013, @LeonarddeR)
   * In particular, Whole word entries no longer incorrectly match inside larger words when those words contain combining marks.
 * In focus mode in web browsers, it is now possible to review and spell the labels of controls when those labels are specifically provided for accessibility; e.g. via aria-label or aria-labelledby. (#15159, @jcsteh)
+* In Mozilla Firefox, reporting annotation details now works correctly in focus mode on controls which are not editable text. (#20132, @jcsteh)
 
 ### Changes for Developers
 


### PR DESCRIPTION
### Link to issue number:
Follow-up to #20096, which was a fix for #15159.

### Summary of the issue:
As noted in https://github.com/nvaccess/nvda/pull/20096#issuecomment-4441767982, the implementation in #20096 still reviewed the wrong content if you focused a control by pressing tab in focus mode or if you used the review top/bottom line commands.

### Description of user facing changes:
1. In web browsers, the review cursor now reviews the correct content after tabbing in focus mode or using the review top/bottom line commands. This doesn't need a change log entry because this bug was never in a release.
2. In Mozilla Firefox, reporting annotation details now works correctly in focus mode on controls which are not editable text.

### Description of development approach:
I reverted the functional changes in #20096, opting for a different approach. Rather than altering how read line and review fetch the TextInfo using an attribute, Ia2Web.TextInfo is now directly set to NVDAObjectTextInfo, ensuring that makeTextInfo will always use that for Ia2Web objects.

I didn't do this initially because by itself, it breaks script_reportDetailsSummary. However, it turns out that script_reportDetailsSummary had some incorrect assumptions and contained code that was intended to execute but never did. It assumed that browsers always set the caret even for non-editable controls, but that isn't always true, especially in Firefox. Even though it had code to fall back to using the focus, it returned early before that was ever executed. I fixed those problems, which actually fixes script_reportDetailsSummary in Firefox in focus mode on non-editable controls.

I also discovered that MozillaCompoundTextInfo explicitly checked for cases where an embedded object's TextInfo was NVDAObjectTextInfo. However, this only applied to images, etc. which don't support IAccessibleText, as per the IAccessible.TextInfo implementation. So, I simply made this check more explicit: it now checks for IAccessibleText and uses IA2TextTextInfo in that case, NVDAObjectTextInfo otherwise.

### Testing strategy:
All the tests described for #20096, plus, in both Firefox and Edge, with this test case:

`data:text/html,<button aria-label="1"></button><button aria-label="2"></button><button aria-details="d">3</button><p id="d">d</p><div contenteditable role="textbox">a<span aria-details="d">b</span></div>`

1. Switched to focus mode.
2. Tabbed to the "2" button.
3. Pressed numpad8 to review the current line. Result: 2
4. Pressed shift+numpad7 to move review to top line. Result: 2
5. Tabbed to the "3" button.
6. Pressed shift+d to report details. Result: d
7. Tabbed to the text box.
8. Pressed home to move to start of line.
9. Pressed NVDA+d to report details. Result: no additional details
10. Pressed right arrow to move to "b".
11. Pressed NVDA+d to report details. Result: d
12. Switched to browse mode.
13. Pressed control+home, then b repeatedly to move to the "3" button.
14. Pressed NVDA+d to report details. Result: d

### Known issues with pull request:
I looked for other non-obvious instances where we rely on the previous behaviour internally like script_reportDetailsSummary or MozillaCompoundTextInfo, but didn't find any. However, I can't be certain that I didn't miss anything else.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
