### PR TITLE
Revert "Don't use IA2TextTextInfo on the web for object review and re…

### DIFF
--- a/source/NVDAObjects/IAccessible/ia2Web.py
+++ b/source/NVDAObjects/IAccessible/ia2Web.py
@@ -104,10 +104,6 @@ class IA2WebAnnotation(AnnotationOrigin):
 
 class Ia2Web(IAccessible):
 	IAccessibleTableUsesTableCellIndexAttrib = True
-	# The IAccessibleText implementation in web browsers exposes embedded object
-	# characters which need to be traversed to read the content. That isn't useful
-	# to users.
-	_shouldUseTextInfoForReading = False
 
 	def isDescendantOf(self, obj: "NVDAObjects.NVDAObject") -> bool:
 		if obj.windowHandle != self.windowHandle:
@@ -288,9 +284,6 @@ class Figure(Ia2Web):
 
 class Editor(Ia2Web, DocumentWithTableNavigation):
 	TextInfo = MozillaCompoundTextInfo
-	# MozillaCompoundTextInfo traverses embedded objects and is suitable for
-	# presentation to users.
-	_shouldUseTextInfoForReading = True
 
 	def _getTableCellAt(self, tableID, startPos, destRow, destCol):
 		# Locate the table in the object ancestry of the given document position.

--- a/source/NVDAObjects/__init__.py
+++ b/source/NVDAObjects/__init__.py
@@ -1605,12 +1605,6 @@ class NVDAObject(
 		else:
 			return False
 
-	#: Whether the TextInfo should be used for the review cursor, the read current
-	#: line command, etc. This should be False where the TextInfo is only used
-	#: internally and doesn't provide text that is suitable for presentation to the
-	#: user; e.g. it includes raw embedded object characters.
-	_shouldUseTextInfoForReading: bool = True
-
 	def _get_hasIrrelevantLocation(self):
 		"""Returns whether the location of this object is irrelevant for mouse or magnification tracking or highlighting,
 		either because it is programatically hidden (State.INVISIBLE), off screen or the object has no location."""

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -262,22 +262,15 @@ class GlobalCommands(ScriptableObject):
 	def script_reportCurrentLine(self, gesture):
 		obj = api.getFocusObject()
 		treeInterceptor = obj.treeInterceptor
-		useTextInfo: bool = False
 		if (
 			isinstance(treeInterceptor, treeInterceptorHandler.DocumentTreeInterceptor)
 			and not treeInterceptor.passThrough
 		):
 			obj = treeInterceptor
-			useTextInfo = True
-		else:
-			useTextInfo = obj._shouldUseTextInfoForReading
-		if useTextInfo:
-			try:
-				info = obj.makeTextInfo(textInfos.POSITION_CARET)
-			except (NotImplementedError, RuntimeError):
-				info = obj.makeTextInfo(textInfos.POSITION_FIRST)
-		else:
-			info = NVDAObjectTextInfo(obj, textInfos.POSITION_FIRST)
+		try:
+			info = obj.makeTextInfo(textInfos.POSITION_CARET)
+		except (NotImplementedError, RuntimeError):
+			info = obj.makeTextInfo(textInfos.POSITION_FIRST)
 		info.expand(textInfos.UNIT_LINE)
 		scriptCount = getLastScriptRepeatCount()
 		if scriptCount == 0:

--- a/source/review.py
+++ b/source/review.py
@@ -20,28 +20,26 @@ import textInfos
 import config
 
 
-def getObjectPosition(obj: NVDAObject) -> tuple[textInfos.TextInfo, ScriptableObject] | None:
+def getObjectPosition(obj):
 	"""
 	Fetches a TextInfo instance suitable for reviewing the text in  the given object.
-	:param obj: the NVDAObject to review
-	:return: the TextInfo instance and the Scriptable object the TextInfo instance is referencing, or None on error.
+	@param obj: the NVDAObject to review
+	@type obj: L{NVDAObject}
+	@return: the TextInfo instance and the Scriptable object the TextInfo instance is referencing, or None on error.
+	@rtype: (L{TextInfo},L{ScriptableObject})
 	"""
-	useTextInfo: bool = obj._shouldUseTextInfoForReading
-	if useTextInfo:
+	try:
+		pos = obj.makeTextInfo(textInfos.POSITION_CARET)
+	except (NotImplementedError, RuntimeError):
+		# No caret supported, try first position instead
 		try:
-			pos = obj.makeTextInfo(textInfos.POSITION_CARET)
+			pos = obj.makeTextInfo(textInfos.POSITION_FIRST)
 		except (NotImplementedError, RuntimeError):
-			# No caret supported, try first position instead
-			try:
-				pos = obj.makeTextInfo(textInfos.POSITION_FIRST)
-			except (NotImplementedError, RuntimeError):
-				log.debugWarning(
-					f"{obj.TextInfo} does not support POSITION_FIRST, falling back to NVDAObjectTextInfo",
-				)
-				# First position not supported either, return first position from a generic NVDAObjectTextInfo
-				useTextInfo = False
-	if not useTextInfo:
-		return NVDAObjectTextInfo(obj, textInfos.POSITION_FIRST), obj
+			log.debugWarning(
+				"%s does not support POSITION_FIRST, falling back to NVDAObjectTextInfo" % obj.TextInfo,
+			)
+			# First position not supported either, return first position from a generic NVDAObjectTextInfo
+			return NVDAObjectTextInfo(obj, textInfos.POSITION_FIRST), obj
 	return pos, pos.obj
 
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -74,7 +74,6 @@ The setting is disabled by default. (#20013, @LeonarddeR)
 * Fixed NVDA freezing when navigating in JetBrains IDEs. (#16741, @christopherpross)
 * Speech dictionary entries of type Whole word now correctly handle words containing Unicode combining marks (e.g. Hebrew niqqud, Arabic harakat). (#20013, @LeonarddeR)
   * In particular, Whole word entries no longer incorrectly match inside larger words when those words contain combining marks.
-* In focus mode in web browsers, it is now possible to review and spell the labels of controls when those labels are specifically provided for accessibility; e.g. via aria-label or aria-labelledby. (#15159, @jcsteh)
 
 ### Changes for Developers
 


### PR DESCRIPTION
### Reverts PR
Reverts #20096.

### Issues fixed
Fixes https://github.com/nvaccess/nvda/pull/20096#issuecomment-4433278803 and https://github.com/nvaccess/nvda/pull/20096#issuecomment-4441767982.

### Issues reopened
Reopens #15159.

### Reason for revert
The implementation in #20096 still reviewed the wrong content if you focused a control by pressing tab in focus mode or if you used the review top/bottom line commands. I submitted #20132, but given the proximity to beta, it seems safer to wait for 2026.3 instead.

### Can this PR be reimplemented? If so, what is required for the next attempt
See #20132.