### PR TITLE
increase magnifier zoom level to 5000% and change zoom to percentages

### DIFF
--- a/source/_magnifier/commands.py
+++ b/source/_magnifier/commands.py
@@ -153,9 +153,7 @@ def zoom(direction: Direction) -> None:
 		return
 	magnifier._zoom(direction)
 	ui.message(
-		ZoomLevel.ZOOM_MESSAGE.format(
-			zoomLevel=f"{magnifier.zoomLevel:.1f}",
-		),
+		ZoomLevel.zoomMessage(magnifier.zoomLevel),
 	)
 
 

--- a/source/_magnifier/config.py
+++ b/source/_magnifier/config.py
@@ -47,7 +47,7 @@ class ZoomLevel:
 			"magnifier",
 			# Translators: Message announced when zooming in with {zoomLevel} being the target zoom level.
 			"{zoomLevel}x",
-		).format(f"{zoomLevel:.1f}")
+		).format(zoomLevel=f"{zoomLevel:.1f}")
 
 
 def getZoomLevel() -> int:

--- a/source/_magnifier/config.py
+++ b/source/_magnifier/config.py
@@ -47,7 +47,7 @@ class ZoomLevel:
 			"magnifier",
 			# Translators: Message announced when zooming in with {zoomLevel} being the target zoom level.
 			"{zoomLevel}x",
-		)
+		).format(f"{zoomLevel:.1f}")
 
 
 def getZoomLevel() -> int:

--- a/source/_magnifier/config.py
+++ b/source/_magnifier/config.py
@@ -39,11 +39,15 @@ class ZoomLevel:
 	MAX_ZOOM: int = 5000
 	MIN_ZOOM: int = 100
 	STEP_FACTOR: int = 50
-	ZOOM_MESSAGE = pgettext(
-		"magnifier",
-		# Translators: Message announced when zooming in with {zoomLevel} being the target zoom level.
-		"{zoomLevel}%",
-	)
+
+	@staticmethod
+	def zoomMessage(zoomLevel: int) -> str:
+		zoomLevel = zoomLevel / 100.0
+		return pgettext(
+			"magnifier",
+			# Translators: Message announced when zooming in with {zoomLevel} being the target zoom level.
+			"{zoomLevel}x",
+		)
 
 
 def getZoomLevel() -> int:
@@ -63,7 +67,7 @@ def getZoomLevelString() -> str:
 	:return: Formatted zoom level string.
 	"""
 	zoomLevel = getZoomLevel()
-	return ZoomLevel.ZOOM_MESSAGE.format(zoomLevel=zoomLevel)
+	return ZoomLevel.zoomMessage(zoomLevel)
 
 
 def setZoomLevel(zoomLevel: int) -> None:

--- a/source/_magnifier/config.py
+++ b/source/_magnifier/config.py
@@ -36,43 +36,21 @@ class ZoomLevel:
 	Constants and utilities for zoom level management.
 	"""
 
-	MAX_ZOOM: float = 10.0
-	MIN_ZOOM: float = 1.0
-	STEP_FACTOR: float = 0.5
+	MAX_ZOOM: int = 5000
+	MIN_ZOOM: int = 100
+	STEP_FACTOR: int = 50
 	ZOOM_MESSAGE = pgettext(
 		"magnifier",
 		# Translators: Message announced when zooming in with {zoomLevel} being the target zoom level.
-		"{zoomLevel}x",
+		"{zoomLevel}%",
 	)
 
-	@classmethod
-	def zoom_range(cls) -> list[float]:
-		"""
-		Return the list of available zoom levels.
-		"""
-		start = round(cls.MIN_ZOOM / cls.STEP_FACTOR)
-		end = round(cls.MAX_ZOOM / cls.STEP_FACTOR)
 
-		return [i * cls.STEP_FACTOR for i in range(start, end + 1)]
-
-	@classmethod
-	def zoom_strings(cls) -> list[str]:
-		"""
-		Return localized zoom level strings.
-		"""
-		return [
-			cls.ZOOM_MESSAGE.format(
-				zoomLevel=f"{value:.1f}",
-			)
-			for value in cls.zoom_range()
-		]
-
-
-def getZoomLevel() -> float:
+def getZoomLevel() -> int:
 	"""
 	Get zoom level from config.
 
-	:return: The zoom level.
+	:return: The zoom level (percentage).
 	"""
 	zoomLevel = config.conf["magnifier"]["zoomLevel"]
 	return zoomLevel
@@ -85,21 +63,21 @@ def getZoomLevelString() -> str:
 	:return: Formatted zoom level string.
 	"""
 	zoomLevel = getZoomLevel()
-	zoomValues = ZoomLevel.zoom_range()
-	zoomStrings = ZoomLevel.zoom_strings()
-	closestIndex = min(
-		range(len(zoomValues)),
-		key=lambda i: abs(zoomValues[i] - zoomLevel),
-	)
-	return zoomStrings[closestIndex]
+	return ZoomLevel.ZOOM_MESSAGE.format(zoomLevel=zoomLevel)
 
 
-def setZoomLevel(zoomLevel: float) -> None:
+def setZoomLevel(zoomLevel: int) -> None:
 	"""
 	Set zoom level from settings.
 
 	:param zoomLevel: The zoom level to set.
 	"""
+	if not isinstance(zoomLevel, int):
+		raise ValueError("Zoom level must be an integer percentage")
+	if not (ZoomLevel.MIN_ZOOM <= zoomLevel <= ZoomLevel.MAX_ZOOM):
+		raise ValueError(f"Zoom level must be between {ZoomLevel.MIN_ZOOM} and {ZoomLevel.MAX_ZOOM}")
+	if zoomLevel % ZoomLevel.STEP_FACTOR != 0:
+		raise ValueError(f"Zoom level must be a multiple of {ZoomLevel.STEP_FACTOR}")
 	config.conf["magnifier"]["zoomLevel"] = zoomLevel
 
 

--- a/source/_magnifier/config.py
+++ b/source/_magnifier/config.py
@@ -56,7 +56,7 @@ def getZoomLevel() -> int:
 
 	:return: The zoom level (percentage).
 	"""
-	zoomLevel = config.conf["magnifier"]["zoomLevel"]
+	zoomLevel = config.conf["magnifier"]["zoom"]
 	return zoomLevel
 
 
@@ -82,7 +82,7 @@ def setZoomLevel(zoomLevel: int) -> None:
 		raise ValueError(f"Zoom level must be between {ZoomLevel.MIN_ZOOM} and {ZoomLevel.MAX_ZOOM}")
 	if zoomLevel % ZoomLevel.STEP_FACTOR != 0:
 		raise ValueError(f"Zoom level must be a multiple of {ZoomLevel.STEP_FACTOR}")
-	config.conf["magnifier"]["zoomLevel"] = zoomLevel
+	config.conf["magnifier"]["zoom"] = zoomLevel
 
 
 def getPanStep() -> int:

--- a/source/_magnifier/fullscreenMagnifier.py
+++ b/source/_magnifier/fullscreenMagnifier.py
@@ -230,7 +230,7 @@ class FullScreenMagnifier(Magnifier):
 		"""
 		params = self._getMagnifierParameters(coordinates)
 		magnification.MagSetFullscreenTransform(
-			self.zoomLevel,
+			self.zoomLevelRatio,
 			params.coordinates.x,
 			params.coordinates.y,
 		)
@@ -340,7 +340,7 @@ class FullScreenMagnifier(Magnifier):
 		:return: The (x, y) coordinates of the magnifier center
 		"""
 
-		zoom = self.zoomLevel
+		zoom = self.zoomLevelRatio
 		mouseX, mouseY = coordinates
 		magnifierWidth = self._displayOrientation.width / zoom
 		magnifierHeight = self._displayOrientation.height / zoom
@@ -388,8 +388,8 @@ class FullScreenMagnifier(Magnifier):
 		"""
 		x, y = coordinates
 		# Calculate the size of the capture area at the current zoom level
-		magnifierWidth = self._displayOrientation.width / self.zoomLevel
-		magnifierHeight = self._displayOrientation.height / self.zoomLevel
+		magnifierWidth = self._displayOrientation.width / self.zoomLevelRatio
+		magnifierHeight = self._displayOrientation.height / self.zoomLevelRatio
 
 		# Compute the top-left corner so that (x, y) is at the center
 		left = int(x - (magnifierWidth / 2))

--- a/source/_magnifier/magnifier.py
+++ b/source/_magnifier/magnifier.py
@@ -320,7 +320,7 @@ class Magnifier:
 
 		minX, minY, maxX, maxY = self._getScreenLimits()
 
-		panPixels = int(self._displayOrientation.width * self._panStep / self.zoomLevel)
+		panPixels = int((self._displayOrientation.width / self.zoomLevelRatio) * self._panStep / 100)
 
 		match action:
 			case MagnifierAction.PAN_LEFT:

--- a/source/_magnifier/magnifier.py
+++ b/source/_magnifier/magnifier.py
@@ -70,23 +70,29 @@ class Magnifier:
 		self._filterType = value
 
 	@property
+	def zoomLevelRatio(self) -> float:
+		"""Get the zoom level as a float (e.g., 2.0 for 200% zoom)"""
+		return self._zoomLevel / 100.0
+
+	@property
 	def zoomLevel(self) -> float:
+		"""Get the zoom level as a percentage (e.g., 200 for 200% zoom)"""
 		return self._zoomLevel
 
 	@zoomLevel.setter
-	def zoomLevel(self, value: float) -> None:
+	def zoomLevel(self, value: int) -> None:
 		"""
 		Set zoom level, ensuring it's a valid value in the zoom range.
 
 		:param value: The zoom level to set
 		:raises ValueError: If the value is not in the valid zoom range
 		"""
-		validZoomValues = ZoomLevel.zoom_range()
-		if value not in validZoomValues:
-			# Find the closest valid zoom value
-			closestZoom = min(validZoomValues, key=lambda x: abs(x - value))
-			log.warning(f"Invalid zoom level {value}, using closest valid value {closestZoom}")
-			value = closestZoom
+		if not isinstance(value, int):
+			raise ValueError("Zoom level must be an integer percentage")
+		if not (ZoomLevel.MIN_ZOOM <= value <= ZoomLevel.MAX_ZOOM):
+			raise ValueError(f"Zoom level must be between {ZoomLevel.MIN_ZOOM} and {ZoomLevel.MAX_ZOOM}")
+		if value % ZoomLevel.STEP_FACTOR != 0:
+			raise ValueError(f"Zoom level must be a multiple of {ZoomLevel.STEP_FACTOR}")
 		self._zoomLevel = value
 
 	@property
@@ -119,8 +125,8 @@ class Magnifier:
 			return (0, 0, self._displayOrientation.width, self._displayOrientation.height)
 		else:
 			# In normal mode: calculate limits to keep view within screen
-			visibleWidth = self._displayOrientation.width / self.zoomLevel
-			visibleHeight = self._displayOrientation.height / self.zoomLevel
+			visibleWidth = self._displayOrientation.width / self.zoomLevelRatio
+			visibleHeight = self._displayOrientation.height / self.zoomLevelRatio
 			minX = int(visibleWidth / 2)
 			minY = int(visibleHeight / 2)
 			maxX = int(self._displayOrientation.width - (visibleWidth / 2))
@@ -313,7 +319,7 @@ class Magnifier:
 
 		minX, minY, maxX, maxY = self._getScreenLimits()
 
-		panPixels = int((self._displayOrientation.width / self.zoomLevel) * self._panStep / 100)
+		panPixels = int((self._displayOrientation.width / self.zoomLevelRatio) * self._panStep / 100)
 
 		match action:
 			case MagnifierAction.PAN_LEFT:

--- a/source/_magnifier/magnifier.py
+++ b/source/_magnifier/magnifier.py
@@ -154,6 +154,7 @@ class Magnifier:
 
 		:param value: The zoom level to set (can be any intermediate value)
 		"""
+		value = max(ZoomLevel.MIN_ZOOM, min(value, ZoomLevel.MAX_ZOOM))
 		self._zoomLevel = value
 
 	def _onDisplayChanged(self, orientationState: OrientationState) -> None:

--- a/source/_magnifier/magnifier.py
+++ b/source/_magnifier/magnifier.py
@@ -93,7 +93,7 @@ class Magnifier:
 			raise ValueError(f"Zoom level must be between {ZoomLevel.MIN_ZOOM} and {ZoomLevel.MAX_ZOOM}")
 		if value % ZoomLevel.STEP_FACTOR != 0:
 			raise ValueError(f"Zoom level must be a multiple of {ZoomLevel.STEP_FACTOR}")
-		self._zoomLevel = value
+		self._zoomLevel = float(value)
 
 	@property
 	def currentCoordinates(self) -> Coordinates:
@@ -300,11 +300,11 @@ class Magnifier:
 		:param direction: Direction.IN to zoom in, Direction.OUT to zoom out
 		"""
 		if direction == Direction.IN:
-			newZoom = self.zoomLevel + ZoomLevel.STEP_FACTOR
+			newZoom = int(self.zoomLevel + ZoomLevel.STEP_FACTOR)
 			if newZoom <= ZoomLevel.MAX_ZOOM:
 				self.zoomLevel = newZoom
 		elif direction == Direction.OUT:
-			newZoom = self.zoomLevel - ZoomLevel.STEP_FACTOR
+			newZoom = int(self.zoomLevel - ZoomLevel.STEP_FACTOR)
 			if newZoom >= ZoomLevel.MIN_ZOOM:
 				self.zoomLevel = newZoom
 
@@ -320,7 +320,7 @@ class Magnifier:
 
 		minX, minY, maxX, maxY = self._getScreenLimits()
 
-		panPixels = int((self._displayOrientation.width / self.zoomLevelRatio) * self._panStep / 100)
+		panPixels = int(self._displayOrientation.width * self._panStep / self.zoomLevel)
 
 		match action:
 			case MagnifierAction.PAN_LEFT:

--- a/source/_magnifier/utils/spotlightManager.py
+++ b/source/_magnifier/utils/spotlightManager.py
@@ -30,7 +30,7 @@ class SpotlightManager:
 		self._animationSteps: int = 40
 		self._animationStepDelay: int = 12
 		self._currentCoordinates: Coordinates = fullscreenMagnifier._focusManager.getCurrentFocusCoordinates()
-		self._originalZoomLevel: float = 0.0
+		self._originalZoomLevel: int = 0
 		self._currentZoomLevel: float = 0.0
 		self._originalMode: FullScreenMode | None = None
 
@@ -92,8 +92,8 @@ class SpotlightManager:
 		)
 
 		self._animationStepsList = self._computeAnimationSteps(
-			self._currentZoomLevel,
-			target.zoomLevel,
+			round(self._currentZoomLevel),
+			round(target.zoomLevel),
 			self._currentCoordinates,
 			target.coordinates,
 		)
@@ -175,8 +175,8 @@ class SpotlightManager:
 
 	def _computeAnimationSteps(
 		self,
-		zoomStart: float,
-		zoomEnd: float,
+		zoomStart: int,
+		zoomEnd: int,
 		coordinateStart: Coordinates,
 		coordinateEnd: Coordinates,
 	) -> list[ZoomHistory]:
@@ -196,7 +196,7 @@ class SpotlightManager:
 
 		startX, startY = coordinateStart
 		endX, endY = coordinateEnd
-		animationSteps = []
+		animationSteps: list[ZoomHistory] = []
 
 		zoomDelta = (zoomEnd - zoomStart) / self._animationSteps
 		coordDeltaX = (endX - startX) / self._animationSteps

--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -13,7 +13,7 @@ from . import configDefaults
 #: provide an upgrade step (@see profileUpgradeSteps.py). An upgrade step does not need to be added when
 #: just adding a new element to (or removing from) the schema, only when old versions of the config
 #: (conforming to old schema versions) will not work correctly with the new schema.
-latestSchemaVersion = 23
+latestSchemaVersion = 22
 
 #: The configuration specification string
 #: @type: String
@@ -118,7 +118,7 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 [magnifier]
 	enabled = boolean(default=false)
 	magnifiedView = string(default="fullscreen")
-	zoomLevel = integer(min=100, max=5000, default=200)
+	zoom = integer(min=100, max=5000, default=200)
 	isTrueCentered = boolean(default=False)
 	filter = string(default="normal")
 	followMouse = boolean(default=True)

--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -13,7 +13,7 @@ from . import configDefaults
 #: provide an upgrade step (@see profileUpgradeSteps.py). An upgrade step does not need to be added when
 #: just adding a new element to (or removing from) the schema, only when old versions of the config
 #: (conforming to old schema versions) will not work correctly with the new schema.
-latestSchemaVersion = 22
+latestSchemaVersion = 23
 
 #: The configuration specification string
 #: @type: String
@@ -118,7 +118,7 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 [magnifier]
 	enabled = boolean(default=false)
 	magnifiedView = string(default="fullscreen")
-	zoomLevel = float(min=1.0, max=10.0, default=2.0)
+	zoomLevel = integer(min=100, max=5000, default=200)
 	isTrueCentered = boolean(default=False)
 	filter = string(default="normal")
 	followMouse = boolean(default=True)

--- a/source/config/profileUpgradeSteps.py
+++ b/source/config/profileUpgradeSteps.py
@@ -687,27 +687,3 @@ def upgradeConfigFrom_21_to_22(profile: ConfigObj):
 	if language.casefold() == "auto":
 		speechConf["language"] = "en"
 		log.debug("Changed math.speech.language from 'Auto' to 'en'.")
-
-
-def upgradeConfigFrom_22_to_23(profile: ConfigObj):
-	"""Turn magnifier zoom from ratio to percentage."""
-	magnifierConf = profile.get("magnifier")
-	if not magnifierConf:
-		log.debug("No magnifier section in profile. No action taken.")
-		return
-	zoom = magnifierConf.get("zoomLevel")
-	if zoom is None:
-		log.debug("magnifier.zoomLevel not set in profile. No action taken.")
-		return
-	try:
-		zoomRatio = float(zoom)
-	except ValueError:
-		log.error(
-			f"Invalid magnifier.zoomLevel value during profile upgrade: "
-			f"expected a string representing a float, got {zoom!r}. Skipping upgrade step.",
-		)
-		return
-	# Convert ratio to percentage and round to nearest 50%
-	zoomPercentage = round(zoomRatio * 100.0 / 50.0) * 50
-	magnifierConf["zoomLevel"] = zoomPercentage
-	log.debug(f"Converted magnifier.zoomLevel from ratio {zoomRatio} to percentage {zoomPercentage}%.")

--- a/source/config/profileUpgradeSteps.py
+++ b/source/config/profileUpgradeSteps.py
@@ -707,7 +707,7 @@ def upgradeConfigFrom_22_to_23(profile: ConfigObj):
 			f"expected a string representing a float, got {zoom!r}. Skipping upgrade step.",
 		)
 		return
-	# Convert ratio to percentage and round to nearest 10%
-	zoomPercentage = round(zoomRatio * 100 / 10) * 10
+	# Convert ratio to percentage and round to nearest 50%
+	zoomPercentage = round(zoomRatio * 100.0 / 50.0) * 50
 	magnifierConf["zoomLevel"] = zoomPercentage
 	log.debug(f"Converted magnifier.zoomLevel from ratio {zoomRatio} to percentage {zoomPercentage}%.")

--- a/source/config/profileUpgradeSteps.py
+++ b/source/config/profileUpgradeSteps.py
@@ -688,6 +688,7 @@ def upgradeConfigFrom_21_to_22(profile: ConfigObj):
 		speechConf["language"] = "en"
 		log.debug("Changed math.speech.language from 'Auto' to 'en'.")
 
+
 def upgradeConfigFrom_22_to_23(profile: ConfigObj):
 	"""Turn magnifier zoom from ratio to percentage."""
 	magnifierConf = profile.get("magnifier")

--- a/source/config/profileUpgradeSteps.py
+++ b/source/config/profileUpgradeSteps.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2016-2025 NV Access Limited, Bill Dengler, Cyrille Bougot, Łukasz Golonka, Leonard de Ruijter, Cary-rowen
+# Copyright (C) 2016-2026 NV Access Limited, Bill Dengler, Cyrille Bougot, Łukasz Golonka, Leonard de Ruijter, Cary-rowen
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -687,3 +687,26 @@ def upgradeConfigFrom_21_to_22(profile: ConfigObj):
 	if language.casefold() == "auto":
 		speechConf["language"] = "en"
 		log.debug("Changed math.speech.language from 'Auto' to 'en'.")
+
+def upgradeConfigFrom_22_to_23(profile: ConfigObj):
+	"""Turn magnifier zoom from ratio to percentage."""
+	magnifierConf = profile.get("magnifier")
+	if not magnifierConf:
+		log.debug("No magnifier section in profile. No action taken.")
+		return
+	zoom = magnifierConf.get("zoomLevel")
+	if zoom is None:
+		log.debug("magnifier.zoomLevel not set in profile. No action taken.")
+		return
+	try:
+		zoomRatio = float(zoom)
+	except ValueError:
+		log.error(
+			f"Invalid magnifier.zoomLevel value during profile upgrade: "
+			f"expected a string representing a float, got {zoom!r}. Skipping upgrade step.",
+		)
+		return
+	# Convert ratio to percentage and round to nearest 10%
+	zoomPercentage = round(zoomRatio * 100 / 10) * 10
+	magnifierConf["zoomLevel"] = zoomPercentage
+	log.debug(f"Converted magnifier.zoomLevel from ratio {zoomRatio} to percentage {zoomPercentage}%.")

--- a/source/gui/nvdaControls.py
+++ b/source/gui/nvdaControls.py
@@ -695,3 +695,7 @@ class SpinStepCtrl(wx.SpinCtrl):
 			self.SetValue(pos - 1 + self.step)
 		else:
 			self.SetValue(pos + 1 - self.step)
+
+	def SetValue(self, pos: int) -> None:
+		pos = round(pos / self.step) * self.step
+		return super().SetValue(pos)

--- a/source/gui/nvdaControls.py
+++ b/source/gui/nvdaControls.py
@@ -681,21 +681,3 @@ class _CheckListCtrl(AutoWidthColumnListCtrl):  # pyright: ignore[reportUnusedCl
 		if res:
 			self._checkboxlessIndices.add(itemIndex)
 		return bool(res)
-
-
-class SpinStepCtrl(wx.SpinCtrl):
-	def __init__(self, *args, step: int = 1, **kwargs):
-		super().__init__(*args, **kwargs)
-		self.step = step
-		self.Bind(wx.EVT_SPINCTRL, self.OnSpin)
-
-	def OnSpin(self, event: wx.SpinEvent):
-		pos = event.GetPosition()
-		if (pos - 1) % self.step == 0:
-			self.SetValue(pos - 1 + self.step)
-		else:
-			self.SetValue(pos + 1 - self.step)
-
-	def SetValue(self, pos: int) -> None:
-		pos = round(pos / self.step) * self.step
-		return super().SetValue(pos)

--- a/source/gui/nvdaControls.py
+++ b/source/gui/nvdaControls.py
@@ -681,3 +681,17 @@ class _CheckListCtrl(AutoWidthColumnListCtrl):  # pyright: ignore[reportUnusedCl
 		if res:
 			self._checkboxlessIndices.add(itemIndex)
 		return bool(res)
+
+
+class SpinStepCtrl(wx.SpinCtrl):
+	def __init__(self, *args, step: int = 1, **kwargs):
+		super().__init__(*args, **kwargs)
+		self.step = step
+		self.Bind(wx.EVT_SPINCTRL, self.OnSpin)
+
+	def OnSpin(self, event: wx.SpinEvent):
+		pos = event.GetPosition()
+		if (pos - 1) % self.step == 0:
+			self.SetValue(pos - 1 + self.step)
+		else:
+			self.SetValue(pos + 1 - self.step)

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -10,7 +10,6 @@
 # This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
 # For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
 
-import bisect
 import copy
 import logging
 import math
@@ -6072,7 +6071,6 @@ class MagnifierPanel(SettingsPanel):
 			step=magnifierConfig.ZoomLevel.STEP_FACTOR,
 			min=magnifierConfig.ZoomLevel.MIN_ZOOM,
 			max=magnifierConfig.ZoomLevel.MAX_ZOOM,
-
 		)
 		self.bindHelpEvent(
 			"MagnifierZoom",

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -6063,7 +6063,7 @@ class MagnifierPanel(SettingsPanel):
 
 		# ZOOM SETTINGS
 		# Translators: The label for a setting in magnifier settings to select the zoom level.
-		zoomLabelText = _("&Zoom level:")
+		zoomLabelText = _("&Zoom (%):")
 
 		self.zoomCtrl = sHelper.addLabeledControl(
 			zoomLabelText,

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -6066,30 +6066,22 @@ class MagnifierPanel(SettingsPanel):
 		# Translators: The label for a setting in magnifier settings to select the zoom level.
 		zoomLabelText = _("&Zoom level:")
 
-		zoomValues = magnifierConfig.ZoomLevel.zoom_range()
-		zoomChoices = magnifierConfig.ZoomLevel.zoom_strings()
-
-		self.zoomList = sHelper.addLabeledControl(
+		self.zoomCtrl = sHelper.addLabeledControl(
 			zoomLabelText,
-			wx.Choice,
-			choices=zoomChoices,
+			nvdaControls.SpinStepCtrl,
+			step=magnifierConfig.ZoomLevel.STEP_FACTOR,
+			min=magnifierConfig.ZoomLevel.MIN_ZOOM,
+			max=magnifierConfig.ZoomLevel.MAX_ZOOM,
+
 		)
 		self.bindHelpEvent(
 			"MagnifierZoom",
-			self.zoomList,
+			self.zoomCtrl,
 		)
 
 		# Set value from config
 		zoomLevel = magnifierConfig.getZoomLevel()
-		zoomIndex = bisect.bisect_left(zoomValues, zoomLevel)
-		# Find the closest value
-		if zoomIndex == 0:
-			closestIndex = 0
-		elif zoomIndex >= len(zoomValues):
-			closestIndex = len(zoomValues) - 1
-		else:
-			closestIndex = min(zoomIndex - 1, zoomIndex, key=lambda i: abs(zoomValues[i] - zoomLevel))
-		self.zoomList.SetSelection(closestIndex)
+		self.zoomCtrl.SetValue(zoomLevel)
 
 		# PAN SETTINGS
 		# Translators: The label for a setting in magnifier settings to select the pan step size (in percentage).
@@ -6102,7 +6094,7 @@ class MagnifierPanel(SettingsPanel):
 			max=100,
 		)
 		self.bindHelpEvent(
-			"magnifierPanStep",
+			"MagnifierPanningStepSize",
 			self.panSpinCtrl,
 		)
 
@@ -6195,8 +6187,8 @@ class MagnifierPanel(SettingsPanel):
 		"""Save the current selections to config."""
 		magnifierConfig.setEnabled(self.enableMagnifierCheckBox.GetValue())
 
-		selectedZoom = self.zoomList.GetSelection()
-		magnifierConfig.setZoomLevel(magnifierConfig.ZoomLevel.zoom_range()[selectedZoom])
+		selectedZoom = self.zoomCtrl.GetValue()
+		magnifierConfig.setZoomLevel(selectedZoom)
 
 		magnifierConfig.setPanStep(self.panSpinCtrl.GetValue())
 

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -6067,11 +6067,11 @@ class MagnifierPanel(SettingsPanel):
 
 		self.zoomCtrl = sHelper.addLabeledControl(
 			zoomLabelText,
-			nvdaControls.SpinStepCtrl,
-			step=magnifierConfig.ZoomLevel.STEP_FACTOR,
+			wx.SpinCtrl,
 			min=magnifierConfig.ZoomLevel.MIN_ZOOM,
 			max=magnifierConfig.ZoomLevel.MAX_ZOOM,
 		)
+		self.zoomCtrl.SetIncrement(magnifierConfig.ZoomLevel.STEP_FACTOR)
 		self.bindHelpEvent(
 			"MagnifierZoom",
 			self.zoomCtrl,

--- a/tests/unit/test_magnifier/test_fullscreenMagnifier.py
+++ b/tests/unit/test_magnifier/test_fullscreenMagnifier.py
@@ -1,13 +1,14 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2025 NV Access Limited, Antoine Haffreingue
+# Copyright (C) 2025-2026 NV Access Limited, Antoine Haffreingue
 # This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
 # For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
 
 from unittest.mock import MagicMock, patch
+from _magnifier.config import ZoomLevel
+from _magnifier.magnifier import Magnifier
 from _magnifier.utils.types import Filter, FullScreenMode, MagnifiedView, Direction, Coordinates
 from _magnifier.fullscreenMagnifier import FullScreenMagnifier
 from tests.unit.test_magnifier.test_magnifier import _TestMagnifier
-from _magnifier.magnifier import Magnifier
 from winAPI._displayTracking import getPrimaryDisplayOrientation
 
 
@@ -19,7 +20,7 @@ class TestFullscreenMagnifierEndToEnd(_TestMagnifier):
 		magnifier = FullScreenMagnifier()
 		magnifier._startMagnifier()
 
-		self.assertEqual(magnifier.zoomLevel, 2.0)
+		self.assertEqual(magnifier.zoomLevel, 200)
 		self.assertEqual(magnifier.filterType, Filter.NORMAL)
 		self.assertEqual(magnifier._fullscreenMode, FullScreenMode.CENTER)
 		self.assertEqual(magnifier._MAGNIFIED_VIEW, MagnifiedView.FULLSCREEN)
@@ -32,17 +33,17 @@ class TestFullscreenMagnifierEndToEnd(_TestMagnifier):
 		magnifier = FullScreenMagnifier()
 		magnifier._startMagnifier()
 
-		# Set initial zoom to 1.0 for predictable testing
-		magnifier.zoomLevel = 1.0
+		# Set initial zoom to 100 for predictable testing
+		magnifier.zoomLevel = 100
 
 		# Test zoom in
 		magnifier._zoom(Direction.IN)
-		self.assertEqual(magnifier.zoomLevel, 1.5)
+		self.assertEqual(magnifier.zoomLevel, 150)
 
 		# Test zoom out
 		magnifier._zoom(Direction.OUT)
-		self.assertEqual(magnifier.zoomLevel, 1.0)
-		self.assertEqual(magnifier.zoomLevel, 1.0)
+		self.assertEqual(magnifier.zoomLevel, 100)
+		self.assertEqual(magnifier.zoomLevel, 100)
 
 		# Cleanup
 		magnifier._stopMagnifier()
@@ -132,16 +133,16 @@ class TestFullscreenMagnifierEndToEnd(_TestMagnifier):
 		"""Test zoom boundaries."""
 		magnifier = FullScreenMagnifier()
 		magnifier._startMagnifier()
-		magnifier.zoomLevel = 1.0
+		magnifier.zoomLevel = ZoomLevel.MIN_ZOOM
 
 		# Test minimum boundary
 		magnifier._zoom(Direction.OUT)  # Try to zoom out below minimum
-		self.assertEqual(magnifier.zoomLevel, 1.0)
+		self.assertEqual(magnifier.zoomLevel, ZoomLevel.MIN_ZOOM)
 
 		# Test maximum boundary
-		magnifier.zoomLevel = 10.0
+		magnifier.zoomLevel = ZoomLevel.MAX_ZOOM
 		magnifier._zoom(Direction.IN)  # Try to zoom in above maximum
-		self.assertEqual(magnifier.zoomLevel, 10.0)
+		self.assertEqual(magnifier.zoomLevel, ZoomLevel.MAX_ZOOM)
 
 		# Cleanup
 		magnifier._stopMagnifier()
@@ -202,11 +203,11 @@ class TestFullscreenMagnifierEndToEnd(_TestMagnifier):
 		magnifier = FullScreenMagnifier()
 		magnifier._startMagnifier()
 		self.assertTrue(magnifier._isActive)
-		self.assertEqual(magnifier.zoomLevel, 2.0)
+		self.assertEqual(magnifier.zoomLevel, 200)
 
 		# Zoom a bit
 		magnifier._zoom(Direction.IN)
-		self.assertEqual(magnifier.zoomLevel, 2.5)
+		self.assertEqual(magnifier.zoomLevel, 250)
 
 		# Set some coordinates
 		magnifier._currentCoordinates = (200, 300)
@@ -239,7 +240,7 @@ class TestFullscreenMagnifierEndToEnd(_TestMagnifier):
 
 			mock_mag.MagUninitialize.assert_called_once()
 			mock_mag.MagInitialize.assert_called_once()
-			mock_mag.MagSetFullscreenTransform.assert_called_once_with(magnifier.zoomLevel, 0, 0)
+			mock_mag.MagSetFullscreenTransform.assert_called_once_with(magnifier.zoomLevel / 100.0, 0, 0)
 			mock_mag.MagSetFullscreenColorEffect.assert_called_once()
 			self.assertEqual(magnifier._consecutiveErrors, 0)
 			magnifier._startTimer.assert_called_once_with(magnifier._updateMagnifier)

--- a/tests/unit/test_magnifier/test_magnifier.py
+++ b/tests/unit/test_magnifier/test_magnifier.py
@@ -299,7 +299,7 @@ class TestMagnifier(_TestMagnifier):
 		centerY = self.screenHeight // 2
 		self.magnifier.currentCoordinates = Coordinates(centerX, centerY)
 		expectedPanPixels = int(
-			(self.screenWidth / self.magnifier.zoomLevel) * 10 / 100,
+			(self.screenWidth / self.magnifier.zoomLevelRatio) * 10 / 100,
 		)
 		return centerX, centerY, expectedPanPixels
 

--- a/tests/unit/test_magnifier/test_magnifier.py
+++ b/tests/unit/test_magnifier/test_magnifier.py
@@ -1,8 +1,9 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2025 NV Access Limited, Antoine Haffreingue
+# Copyright (C) 2025-2026 NV Access Limited, Antoine Haffreingue
 # This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
 # For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
 
+from _magnifier.config import ZoomLevel
 from _magnifier.magnifier import Magnifier
 from _magnifier.utils.types import Filter, Direction, Coordinates, MagnifierAction
 from comtypes import COMError
@@ -63,7 +64,7 @@ class TestMagnifier(_TestMagnifier):
 
 	def testMagnifierCreation(self):
 		"""Can we create a magnifier with valid parameters?"""
-		self.assertEqual(self.magnifier.zoomLevel, 2.0)
+		self.assertEqual(self.magnifier.zoomLevel, 200)
 		self.assertEqual(self.magnifier._filterType, Filter.NORMAL)
 		self.assertFalse(self.magnifier._isActive)
 		self.assertIsNotNone(self.magnifier._focusManager)
@@ -72,25 +73,25 @@ class TestMagnifier(_TestMagnifier):
 	def testZoomLevelProperty(self):
 		"""ZoomLevel property."""
 		# Test valid directions
-		self.magnifier.zoomLevel = 5.0
-		self.assertEqual(self.magnifier.zoomLevel, 5.0)
+		self.magnifier.zoomLevel = 500
+		self.assertEqual(self.magnifier.zoomLevel, 500)
 
-		self.magnifier.zoomLevel = 1.0
+		self.magnifier.zoomLevel = 100
 		self.magnifier._zoom(Direction.IN)
-		self.assertEqual(self.magnifier.zoomLevel, 1.5)
+		self.assertEqual(self.magnifier.zoomLevel, 150)
 
-		self.magnifier.zoomLevel = 10.0
+		self.magnifier.zoomLevel = 1000
 		self.magnifier._zoom(Direction.OUT)
-		self.assertEqual(self.magnifier.zoomLevel, 9.5)
+		self.assertEqual(self.magnifier.zoomLevel, 950)
 
 		# Test limits
-		self.magnifier.zoomLevel = 1.0
+		self.magnifier.zoomLevel = ZoomLevel.MIN_ZOOM
 		self.magnifier._zoom(Direction.OUT)  # Should stay at min
-		self.assertEqual(self.magnifier.zoomLevel, 1.0)
+		self.assertEqual(self.magnifier.zoomLevel, ZoomLevel.MIN_ZOOM)
 
-		self.magnifier.zoomLevel = 10.0
+		self.magnifier.zoomLevel = ZoomLevel.MAX_ZOOM
 		self.magnifier._zoom(Direction.IN)  # Should stay at max
-		self.assertEqual(self.magnifier.zoomLevel, 10.0)
+		self.assertEqual(self.magnifier.zoomLevel, ZoomLevel.MAX_ZOOM)
 
 	def testStartMagnifier(self):
 		"""Activating the magnifier."""
@@ -269,25 +270,25 @@ class TestMagnifier(_TestMagnifier):
 	def testZoom(self):
 		"""zoom in and out with valid values and check boundaries."""
 		# Set initial zoom to 1.0 for predictable testing
-		self.magnifier.zoomLevel = 1.0
+		self.magnifier.zoomLevel = 100
 
 		# Test zoom in
 		self.magnifier._zoom(Direction.IN)
-		self.assertEqual(self.magnifier.zoomLevel, 1.5)
+		self.assertEqual(self.magnifier.zoomLevel, 150)
 
 		# Test zoom out
 		self.magnifier._zoom(Direction.OUT)
-		self.assertEqual(self.magnifier.zoomLevel, 1.0)
+		self.assertEqual(self.magnifier.zoomLevel, 100)
 
 		# Test zoom in at maximum boundary
-		self.magnifier.zoomLevel = 10.0
+		self.magnifier.zoomLevel = ZoomLevel.MAX_ZOOM
 		self.magnifier._zoom(Direction.IN)
-		self.assertEqual(self.magnifier.zoomLevel, 10.0)  # Should remain at max
+		self.assertEqual(self.magnifier.zoomLevel, ZoomLevel.MAX_ZOOM)  # Should remain at max
 
 		# Test zoom out at minimum boundary
-		self.magnifier.zoomLevel = 1.0
+		self.magnifier.zoomLevel = ZoomLevel.MIN_ZOOM
 		self.magnifier._zoom(Direction.OUT)
-		self.assertEqual(self.magnifier.zoomLevel, 1.0)  # Should remain at min
+		self.assertEqual(self.magnifier.zoomLevel, ZoomLevel.MIN_ZOOM)  # Should remain at min
 
 	def _setupPanTest(self):
 		"""Common setup for pan tests."""
@@ -510,7 +511,7 @@ class TestMagnifier(_TestMagnifier):
 	def testClampCoordinates(self):
 		"""Test all boundary clamps (left, right, top, bottom) for both modes."""
 		for isTrueCentered in (False, True):
-			self.magnifier.zoomLevel = 2.0
+			self.magnifier.zoomLevel = 200
 			with patch("_magnifier.magnifier.isTrueCentered", return_value=isTrueCentered):
 				minX, minY, maxX, maxY = self.magnifier._getScreenLimits()
 
@@ -536,7 +537,7 @@ class TestMagnifier(_TestMagnifier):
 
 	def testClampCoordinatesWithinBounds(self):
 		"""Coordinates within bounds are not modified."""
-		self.magnifier.zoomLevel = 2.0
+		self.magnifier.zoomLevel = 200
 		with patch("_magnifier.magnifier.isTrueCentered", return_value=False):
 			minX, minY, maxX, maxY = self.magnifier._getScreenLimits()
 			centerX = (minX + maxX) // 2

--- a/tests/unit/test_magnifier/test_magnifierCommands.py
+++ b/tests/unit/test_magnifier/test_magnifierCommands.py
@@ -23,7 +23,7 @@ class TestZoomCommand(unittest.TestCase):
 	def _makeMockMagnifier(self, isActive: bool):
 		magnifier = MagicMock()
 		magnifier.configure_mock(**{"_isActive": isActive})
-		magnifier.zoomLevel = 2.0
+		magnifier.zoomLevel = 200
 		return magnifier
 
 	def testInactiveZoomIn(self):

--- a/tests/unit/test_magnifier/test_spotlightManager.py
+++ b/tests/unit/test_magnifier/test_spotlightManager.py
@@ -20,7 +20,7 @@ class TestSpotlightManager(_TestMagnifier):
 		self.assertIsNotNone(spotlightManager)
 		self.assertFalse(spotlightManager._spotlightIsActive)
 		self.assertEqual(spotlightManager._animationSteps, 40)
-		self.assertEqual(spotlightManager._originalZoomLevel, 0.0)
+		self.assertEqual(spotlightManager._originalZoomLevel, 0)
 		self.assertEqual(spotlightManager._currentZoomLevel, 0.0)
 
 		magnifier._stopMagnifier()
@@ -74,8 +74,8 @@ class TestSpotlightManager(_TestMagnifier):
 
 		# Test animation from zoom 2.0 to 1.0, coordinates (500, 400) to (960, 540)
 		steps = spotlightManager._computeAnimationSteps(
-			2.0,
-			1.0,
+			200,
+			100,
 			(500, 400),
 			(960, 540),
 		)
@@ -85,21 +85,21 @@ class TestSpotlightManager(_TestMagnifier):
 
 		# First step should be closer to start
 		firstZoom, firstCoords = steps[0]
-		self.assertLess(abs(firstZoom - 2.0), abs(firstZoom - 1.0))
+		self.assertLess(abs(firstZoom - 200), abs(firstZoom - 100))
 
 		# Last step should be at target
 		lastZoom, lastCoords = steps[-1]
-		self.assertEqual(lastZoom, 1.0)
+		self.assertEqual(lastZoom, 100)
 		self.assertEqual(lastCoords, (960, 540))
 
-		# Steps should progress linearly (decreasing from 2.0 to 1.0)
+		# Steps should progress linearly (decreasing from 200 to 100)
 		for i in range(len(steps) - 1):
 			currentZoom, _ = steps[i]
 			nextZoom, _ = steps[i + 1]
 			self.assertGreater(
 				currentZoom,
 				nextZoom,
-			)  # Zoom should decrease from 2.0 to 1.0
+			)  # Zoom should decrease from 200 to 100
 
 		magnifier._stopMagnifier()
 
@@ -116,7 +116,7 @@ class TestSpotlightManager(_TestMagnifier):
 			spotlightManager._startMouseMonitoring()
 
 			# Verify initial state
-			self.assertEqual(spotlightManager._lastMousePosition, (100, 200))
+			self.assertEqual(spotlightManager._lastMousePosition, Coordinates(100, 200))
 			self.assertIsNotNone(spotlightManager._timer)
 
 		magnifier._stopMagnifier()
@@ -127,7 +127,7 @@ class TestSpotlightManager(_TestMagnifier):
 		spotlightManager = magnifier._spotlightManager
 
 		# Set initial position
-		spotlightManager._lastMousePosition = (100, 200)
+		spotlightManager._lastMousePosition = Coordinates(100, 200)
 
 		# Mock wx.GetMousePosition to return same position (idle)
 		with patch("wx.GetMousePosition") as mockGetMousePosition:
@@ -148,7 +148,7 @@ class TestSpotlightManager(_TestMagnifier):
 		spotlightManager = magnifier._spotlightManager
 
 		# Set initial position
-		spotlightManager._lastMousePosition = (100, 200)
+		spotlightManager._lastMousePosition = Coordinates(100, 200)
 
 		# Mock wx.GetMousePosition to return different position (moved)
 		with patch("wx.GetMousePosition") as mockGetMousePosition:

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -2898,8 +2898,8 @@ You can always adjust the zoom level on the fly using the zoom in (`NVDA+shift+e
 
 | . {.hideHeaderRow} |.|
 |---|---|
-| Options | 1.0 to 10.0 |
-| Default | 2.0 |
+|Options |1.0 to 40.0|
+|Default |2.0|
 
 ##### Filter {#MagnifierFilter}
 

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -2890,16 +2890,16 @@ The selected state is also saved for future NVDA sessions, so if you enable Magn
 
 ##### Zoom level {#MagnifierZoom}
 
-This slider allows you to set the zoom level when using the magnifier.
-The zoom level can range from 1.0 (no magnification) to 10.0 (maximum magnification).
-The default value is 2.0 (200% zoom).
+This setting allows you to set the zoom level when using the magnifier.
+The zoom level can range from 100% (no magnification) to 5000% (maximum magnification).
+The default value is 200%.
 
 You can always adjust the zoom level on the fly using the zoom in (`NVDA+shift+equals`) and zoom out (`NVDA+shift+minus`) commands while the magnifier is active.
 
 | . {.hideHeaderRow} |.|
 |---|---|
-|Options |1.0 to 40.0|
-|Default |2.0|
+| Options | 100% to 5000% |
+| Default | 200% |
 
 ##### Filter {#MagnifierFilter}
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Fixes #19486

### Summary of the issue:
- the magnifier zoom level is capped at 10x, which quite low
- the dropdown list of zoom in settings is quite awkward, particularly with more options


### Description of user facing changes:
- higher zoom value (50x/5000%)
- zoom is a percentage now
- the zoom setting is a spin control rather than a drop down.

### Description of developer facing changes:
Added a `StepSpinCtrl` that allows step values for integer spin controls

### Description of development approach:

- Use integer zoom percentage values as wx.spinctrldouble is inaccessible

### Testing strategy:

- tested manually by upping/lowering zoom values  in settings with buttons and arrow keys
- tested upgrading a config

### Known issues with pull request:

None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
