### PR TITLE
Make system restart the secondary action in the post-update dialog to avoid potential data loss and maintain user expectations

### DIFF
--- a/source/gui/installerGui.py
+++ b/source/gui/installerGui.py
@@ -91,15 +91,26 @@ def _showPostInstallDialog(isUpdate: bool, startAfterInstall: bool) -> None:
 		buttons=None,
 		helpId="RestartWindowsAfterInstall",
 	)
-	# Translators: Button in the post-install dialog to restart Windows immediately.
-	dialog.addButton(ReturnCode.CUSTOM_1, label=_("Restart &Windows"), defaultFocus=True)
 	if startAfterInstall:
 		# Translators: Button in the post-install dialog to start the newly installed NVDA.
-		dialog.addButton(ReturnCode.CUSTOM_2, label=_("&Start NVDA"), fallbackAction=True)
+		dialog.addButton(ReturnCode.CUSTOM_1, label=_("&Start NVDA"), defaultFocus=True, fallbackAction=True)
+	# Translators: Button in the post-install dialog to restart Windows immediately.
+	dialog.addButton(
+		ReturnCode.CUSTOM_2,
+		label=_("Restart &Windows"),
+		defaultFocus=not startAfterInstall,
+	)
 	# Translators: Button in the post-install dialog to exit NVDA.
 	dialog.addButton(ReturnCode.CANCEL, label=_("E&xit NVDA"), fallbackAction=not startAfterInstall)
 	match dialog.ShowModal():
 		case ReturnCode.CUSTOM_1:
+			newNVDA = core.NewNVDAInstance(
+				filePath=os.path.join(WritePaths.defaultInstallDir, "nvda.exe"),
+				parameters=_generate_executionParameters(),
+			)
+			if not core.triggerNVDAExit(newNVDA):
+				log.error("NVDA already in process of exiting, this indicates a logic error.")
+		case ReturnCode.CUSTOM_2:
 			if _restartWindows():
 				if not core.triggerNVDAExit(None):
 					log.error("NVDA already in process of exiting, this indicates a logic error.")
@@ -123,13 +134,6 @@ def _showPostInstallDialog(isUpdate: bool, startAfterInstall: bool) -> None:
 				else:
 					if not core.triggerNVDAExit(None):
 						log.error("NVDA already in process of exiting, this indicates a logic error.")
-		case ReturnCode.CUSTOM_2:
-			newNVDA = core.NewNVDAInstance(
-				filePath=os.path.join(WritePaths.defaultInstallDir, "nvda.exe"),
-				parameters=_generate_executionParameters(),
-			)
-			if not core.triggerNVDAExit(newNVDA):
-				log.error("NVDA already in process of exiting, this indicates a logic error.")
 		case ReturnCode.CANCEL:
 			if not core.triggerNVDAExit(None):
 				log.error("NVDA already in process of exiting, this indicates a logic error.")

--- a/source/gui/installerGui.py
+++ b/source/gui/installerGui.py
@@ -94,10 +94,12 @@ def _showPostInstallDialog(isUpdate: bool, startAfterInstall: bool) -> None:
 	if startAfterInstall:
 		# Translators: Button in the post-install dialog to start the newly installed NVDA.
 		dialog.addButton(ReturnCode.CUSTOM_1, label=_("&Start NVDA"), defaultFocus=True, fallbackAction=True)
-	# Translators: Button in the post-install dialog to restart Windows immediately.
 	dialog.addButton(
 		ReturnCode.CUSTOM_2,
-		label=_("Restart &Windows"),
+		label=_(
+			# Translators: Button in the post-install dialog to restart Windows immediately.
+			"Restart &Windows",
+		),
 		defaultFocus=not startAfterInstall,
 	)
 	# Translators: Button in the post-install dialog to exit NVDA.


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
https://github.com/nvaccess/nvda/pull/19718#issuecomment-4436232185

### Summary of the issue:
The "restart Windows" action is *primary* (invokes with <kbd>Enter</kbd>) in the update dialog. This is a sudden change in behaviour which is likely to surprise long-time NVDA users. Generally, destructive actions like this (that can lead to loss of unsaved data or similar) are secondary in UIs.

### Description of how this pull request fixes the issue:
Mark the new restart action as secondary in the dialog, preserving default behaviour.

### Testing strategy:
Alpha/beta testing.

### Known issues with pull request:
None known

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
