### PR TITLE
Change Secrets logging level name to Debug (unredacted)

### DIFF
--- a/source/config/configFlags.py
+++ b/source/config/configFlags.py
@@ -421,7 +421,7 @@ class LoggingLevel(DisplayStringIntEnum):
 	DEBUGWARNING = Logger.DEBUGWARNING
 	IO = Logger.IO
 	DEBUG = Logger.DEBUG
-	SECRETS = Logger.SECRETS
+	DEBUG_UNREDACTED = Logger.DEBUG_UNREDACTED
 
 	@property
 	def _displayStringLabels(self) -> dict[int, str]:
@@ -436,8 +436,9 @@ class LoggingLevel(DisplayStringIntEnum):
 			self.IO: _("input/output"),
 			# Translators: One of the log levels of NVDA (the debug mode shows debug messages as NVDA runs).
 			self.DEBUG: _("debug"),
-			# Translators: One of the log levels of NVDA (the secrets mode logs debug messages without redacting secrets).
-			self.SECRETS: _("secrets"),
+			# Translators: One of the log levels of NVDA (the "debug (unredacted)" mode mode logs debug messages
+			# without redacting secrets).
+			self.DEBUG_UNREDACTED: _("debug (unredacted)"),
 		}
 
 

--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -24,7 +24,7 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 	saveConfigurationOnExit = boolean(default=True)
 	askToExit = boolean(default=true)
 	playStartAndExitSounds = boolean(default=true)
-	# possible log levels are SECRETS, DEBUG, IO, DEBUGWARNING, INFO and OFF
+	# possible log levels are DEBUG_UNREDACTED, DEBUG, IO, DEBUGWARNING, INFO and OFF
 	loggingLevel = string(default="INFO")
 	showWelcomeDialogAtStartup = boolean(default=true)
 	preventDisplayTurningOff = boolean(default=true)

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -6238,16 +6238,16 @@ class PrivacyAndSecuritySettingsPanel(SettingsPanel):
 		return list(LoggingLevel)[selection]
 
 	def _confirmLogLevelChange(self, selectedLogLevel: LoggingLevel) -> bool:
-		if selectedLogLevel == LoggingLevel.SECRETS:
+		if selectedLogLevel == LoggingLevel.DEBUG_UNREDACTED:
 			message = _(
-				# Translators: Warning shown when enabling the secrets log level from NVDA settings.
-				"Setting the logging level to secrets will write sensitive information to the log without redaction, "
+				# Translators: Warning shown when enabling the "debug (unredacted)" log level from NVDA settings.
+				'Setting the logging level to "debug (unredacted)" will write sensitive information to the log without redaction, '
 				"including passwords, API keys, or other private data. "
 				"Only enable this temporarily if you explicitly need unredacted diagnostic logs. "
 				"Do you want to continue?",
 			)
 			caption = _(
-				# Translators: Title of the warning dialog shown when enabling the secrets log level.
+				# Translators: Title of the warning dialog shown when enabling the "debug (unredacted)" log level.
 				"High risk logging level",
 			)
 		else:

--- a/source/logHandler.py
+++ b/source/logHandler.py
@@ -699,7 +699,14 @@ def setLogLevelFromConfig():
 	level = logging.getLevelNamesMapping().get(levelName)
 	# The lone exception to level higher than INFO is "OFF" (100).
 	# Setting a log level to something other than options found in the GUI is unsupported.
-	if level is None or level not in (log.DEBUG_UNREDACTED, log.DEBUG, log.IO, log.DEBUGWARNING, log.INFO, log.OFF):
+	if level is None or level not in (
+		log.DEBUG_UNREDACTED,
+		log.DEBUG,
+		log.IO,
+		log.DEBUGWARNING,
+		log.INFO,
+		log.OFF,
+	):
 		log.warning("invalid setting for logging level: %s" % levelName)
 		level = log.INFO
 		config.conf["general"]["loggingLevel"] = logging.getLevelName(log.INFO)

--- a/source/logHandler.py
+++ b/source/logHandler.py
@@ -224,7 +224,7 @@ class Logger(logging.Logger):
 	from logging import DEBUG, INFO, WARNING, WARN, ERROR, CRITICAL
 
 	# Our custom levels.
-	SECRETS = 5
+	DEBUG_UNREDACTED = 5
 	IO = 12
 	DEBUGWARNING = 15
 	OFF = 100
@@ -291,7 +291,7 @@ class Logger(logging.Logger):
 				"".join(traceback.format_list(stack_info)).rstrip(),
 			)
 
-		if redactSecrets and self.getEffectiveLevel() > self.SECRETS:
+		if redactSecrets and self.getEffectiveLevel() > self.DEBUG_UNREDACTED:
 			from detect_secrets.core.scan import scan_line
 			from detect_secrets.settings import default_settings
 
@@ -620,7 +620,7 @@ def initialize(shouldDoRemoteLogging=False):
 	@type shouldDoRemoteLogging: bool
 	"""
 	global log, logHandler
-	logging.addLevelName(Logger.SECRETS, "SECRETS")
+	logging.addLevelName(Logger.DEBUG_UNREDACTED, "DEBUG_UNREDACTED")
 	logging.addLevelName(Logger.DEBUGWARNING, "DEBUGWARNING")
 	logging.addLevelName(Logger.IO, "IO")
 	logging.addLevelName(Logger.OFF, "OFF")
@@ -699,7 +699,7 @@ def setLogLevelFromConfig():
 	level = logging.getLevelNamesMapping().get(levelName)
 	# The lone exception to level higher than INFO is "OFF" (100).
 	# Setting a log level to something other than options found in the GUI is unsupported.
-	if level is None or level not in (log.SECRETS, log.DEBUG, log.IO, log.DEBUGWARNING, log.INFO, log.OFF):
+	if level is None or level not in (log.DEBUG_UNREDACTED, log.DEBUG, log.IO, log.DEBUGWARNING, log.INFO, log.OFF):
 		log.warning("invalid setting for logging level: %s" % levelName)
 		level = log.INFO
 		config.conf["general"]["loggingLevel"] = logging.getLevelName(log.INFO)

--- a/tests/unit/test_logHandler.py
+++ b/tests/unit/test_logHandler.py
@@ -133,9 +133,9 @@ class TestLoggerSecretRedaction(unittest.TestCase):
 			self.assertIn("****", loggedMsg)
 			self.assertNotIn("86851a5bab3f33abc2858eca0922c34c34c38f0a", loggedMsg)
 
-	def test_logWithRedactionBypassesMaskingAtSecretsLevel(self):
+	def test_logWithRedactionBypassesMaskingAtDebugUnredactedLevel(self):
 		secret = types.SimpleNamespace(secret_value="secret-value")
-		self.logger.setLevel(logHandler.Logger.SECRETS)
+		self.logger.setLevel(logHandler.Logger.DEBUG_UNREDACTED)
 
 		with (
 			mock.patch.object(logging.Logger, "_log") as superLog,

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -115,7 +115,7 @@ Please refer to [the developer guide](https://download.nvaccess.org/documentatio
   * When set to `True`, logging output will be sanitized to replace detected secrets with asterisks.
   * This is set to `False` by default for performance purposes.
   * It is encouraged to enable this when logging anything particularly sensitive e.g. clipboard content.
-  * Added a `SECRETS` logging level for cases where developers explicitly need debug logging without `redactSecrets` masking.
+  * Added a `DEBUG_UNREDACTED` logging level for cases where developers explicitly need debug logging without `redactSecrets` masking.
 * NVDA libraries built by the build system are now linked with the [/SETCOMPAT](https://learn.microsoft.com/en-us/cpp/build/reference/cetcompat) flag, improving protection against certain malware attacks. (#19435, @LeonarddeR)
 * Subclasses of `browseMode.BrowseModeDocumentTreeInterceptor` that support screen layout being on and off should override the `_toggleScreenLayout` method, rather than implementing `script_toggleScreenLayout` directly. (#19487)
 * A new method has been added to the UIA.UIA class, called `_getUIACacheablePropertyValue_handleCOMErrors`. (#19713, @Emil-18)

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -2823,7 +2823,7 @@ The available logging levels are:
 If you are concerned about privacy, do not set the logging level to this option.
 * Debug: In addition to info, warning, and input/output messages, additional debug messages will be logged.
 Just like input/output, if you are concerned about privacy, you should not set the logging level to this option.
-* Secrets: In addition to debug logging, NVDA will not redact secrets such as passwords and API keys from logs.
+* Debug (unredacted): In addition to debug logging, NVDA will not redact secrets such as passwords and API keys from logs.
 Only enable this temporarily when important debugging information is being redacted.
 
 ##### Allow NV Access to gather NVDA usage statistics {#GeneralSettingsGatherUsageStats}
@@ -6380,7 +6380,7 @@ Following are the command line options for NVDA:
 |`-q` |`--quit` |Quit already running copy of NVDA|
 |`-k` |`--check-running` |Report whether NVDA is running via the exit code; 0 if running, 1 if not running|
 |`-f LOGFILENAME` |`--log-file=LOGFILENAME` |The file where log messages should be written to. Logging is always disabled if secure mode is enabled.|
-| `-l LOGLEVEL` | `--log-level=LOGLEVEL` | The lowest level of message logged (secrets 5, debug 10, input/output 12, debug warning 15, info 20, disabled 100). Logging is always disabled if secure mode is enabled. |
+| `-l LOGLEVEL` | `--log-level=LOGLEVEL` | The lowest level of message logged (debug (unredacted) 5, debug 10, input/output 12, debug warning 15, info 20, disabled 100). Logging is always disabled if secure mode is enabled. |
 |`-c CONFIGPATH` |`--config-path=CONFIGPATH` |The path where all settings for NVDA are stored. The default value is forced if secure mode is enabled.|
 |`-n LANGUAGE` |`--lang=LANGUAGE` |Override the configured NVDA language. Set to "Windows" for current user default, "en" for English, etc.|
 |`-m` |`--minimal` |No sounds, no interface, no start message, etc.|


### PR DESCRIPTION
### Link to issue number:
Closes #20125
(discussion)

Follow-up of #19966

### Summary of the issue:

The log level with unredacted secrets was called "secrets". This name was not found to be the most suitable.

### Description of user facing changes:
The lower log level with unredacted secrets is now called "debug (unredacted)"

People running alpha / beta who have saved SECRET level as their logging level will have their logging level unrecognized and restored to default (INFO). This is acceptable during alpha/beta phase.

### Description of developer facing changes:
N/A
### Description of development approach:
* Updated code.
* I have not implemented a config upgrade from SECRET to DEBUG_UNREDACTED, since the drawback (level restored to INFO) is acceptable during alpha/beta phase; and implementing a config upgrade step would add just more code to avoid a not very penalizing issue for alpha / early beta tester.
### Testing strategy:
* [x] Unit tests
* [x] manual tests
### Known issues with pull request:
None
### Code Review Checklist:


- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
