### PR TITLE
Fix secrets logging

### DIFF
--- a/source/logHandler.py
+++ b/source/logHandler.py
@@ -291,7 +291,7 @@ class Logger(logging.Logger):
 				"".join(traceback.format_list(stack_info)).rstrip(),
 			)
 
-		if redactSecrets and self.getEffectiveLevel() < self.SECRETS:
+		if redactSecrets and self.getEffectiveLevel() > self.SECRETS:
 			from detect_secrets.core.scan import scan_line
 			from detect_secrets.settings import default_settings
 

--- a/tests/unit/test_logHandler.py
+++ b/tests/unit/test_logHandler.py
@@ -16,7 +16,7 @@ import logHandler
 class TestLoggerSecretRedaction(unittest.TestCase):
 	def setUp(self):
 		self.logger = logHandler.Logger("testLogHandler")
-		self.logger.setLevel(logging.NOTSET)
+		self.logger.setLevel(logging.INFO)
 		self.logger.parent = None
 
 	def test_logWithoutRedactionPassesMessageAndArgsThrough(self):


### PR DESCRIPTION
Found while testing #20173
### Link to issue number:
Fix-up of #19966

### Summary of the issue:
#19966 introduces secrets logging level. Though, manually testing, we can see that secrets are never masked, no matter the log level.

### Description of user facing changes:
Secrets are now masked in log for log levels higher than "secrets".

### Description of developer facing changes:
N/A
### Description of development approach:
* Fixed comparison logic bug.
* Also fixed unit tests which passed only by chance in #19966, setting default test log level to `INFO` instead of `NOTSET`.
### Testing strategy:
Manual tests at "debug" and "secrets" levels.
### Known issues with pull request:
None
### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
