### PR TITLE
Review 2026.2 changelog documentation changes

### DIFF
--- a/projectDocs/dev/developerGuide/developerGuide.md
+++ b/projectDocs/dev/developerGuide/developerGuide.md
@@ -25,7 +25,7 @@ Add-ons relying on private symbols do so at their own risk.
 * **Pip packages:**
 These may be updated, downgraded or removed at any time.
 It is recommended to package any pip dependency directly with your add-on, rather than using NVDA's version of the package.
-The exception to this is `wxPython`, which must be used from NVDA.
+The exception to this is `wxPython`, where any breaking changes from `wxPython` will be treated as an API breaking change.
 
 #### The API release cycle
 
@@ -75,7 +75,7 @@ We aim to avoid silent breaks of add-on code.
 When removing or changing APIs in a breaking release (e.g. 2026.1) or due to an urgent security improvement (e.g. 2026.1.2):
 
 1. We will mark functions as deprecated, where possible, in the releases leading up to the break (e.g. raising a `DeprecationWarning` in 2025.4).
-2. All API breaking changes will be listed in the "Changes for Developers" section of the What's New document, and the [NVDA Add-on API Announcements](https://groups.google.com/a/nvaccess.org/g/nvda-api) email group.
+1. All API breaking changes will be listed in the "Changes for Developers" section of the What's New document, and the [NVDA Add-on API Announcements](https://groups.google.com/a/nvaccess.org/g/nvda-api) email group.
 
 #### Stability of transitive imports in the API {#APIImports}
 
@@ -1190,13 +1190,13 @@ For example:
 
 ```ini
 [symbolDictionaries]
-[[greek]]
-displayName = Greek
-mandatory = false
+	[[greek]]
+		displayName = Greek
+		mandatory = false
 
-[[hebrew]]
-displayName = Biblical Hebrew
-mandatory = true
+	[[hebrew]]
+		displayName = Biblical Hebrew
+		mandatory = true
 ```
 
 In the above example, `greek` is a symbol dictionary that is optional and will be listed in the speech category of NVDA's settings dialog under the "Extra dictionaries for character and symbol processing" setting.
@@ -1211,8 +1211,8 @@ For example, add the following to `locale\fr\manifest.ini`:
 
 ```ini
 [symbolDictionaries]
-[[hebrew]]
-displayName = Hébreu Biblique
+	[[hebrew]]
+		displayName = Hébreu Biblique
 ```
 
 ### Speech dictionaries {#AddonSpeechDictionaries}
@@ -1228,9 +1228,9 @@ For example:
 
 ```ini
 [speechDictionaries]
-[[pronunciation]]
-displayName = Dodgy Dictionary
-mandatory = false
+	[[pronunciation]]
+		displayName = Dodgy Dictionary
+		mandatory = false
 ```
 
 In the above example, `pronunciation` is a dictionary that is optional and will be listed in the speech category of NVDA's settings dialog under the "Speech Dictionaries" setting.
@@ -1242,8 +1242,8 @@ For example, add the following to `locale\fr\manifest.ini`:
 
 ```ini
 [speechDictionaries]
-[[pronunciation]]
-displayName = Dictionnaire douteux
+	[[pronunciation]]
+		displayName = Dictionnaire douteux
 ```
 
 Unlike symbol dictionaries, speech dictionaries are currently locale-agnostic.
@@ -1310,7 +1310,7 @@ This means that the word "LOL" (case insensitive, whole word) should be spoken a
 
 This uses Unix shell-style wildcards to match any string ending in ".txt" and replaces it with "text file".
 
-For more information on speech dictionaries, see the NVDA user guide section on speech.
+For more information on speech dictionaries, refer to the [User Guide](https://download.nvaccess.org/documentation/userGuide.html#SpeechDictionaries).
 
 ### Add-on Documentation {#AddonDoc}
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -11,8 +11,8 @@ Touch support has been significantly expanded with new pinch gestures and touch-
 You can now navigate between links, headings, form fields, and other elements using touch flicks.
 
 Speech features have been enhanced with support for custom speech dictionaries that can be provided by add-ons and new dictionary entry types for more granular control.
-A new voice setting for OneCore voices was added to control pauses after punctuation
-A new command allows repeating the last spoken information, with the ability to display it in a browseable message.
+A new voice setting for OneCore voices was added to control pauses after punctuation.
+A new command allows repeating the last spoken information, with the ability to display it in a browsable message.
 
 The braille display can now automatically scroll and DotPad devices support multi-button combinations.
 
@@ -106,7 +106,6 @@ Please refer to [the developer guide](https://download.nvaccess.org/documentatio
 
 * Clarified NV Access's policy on API breaking changes in the [Developer Guide](https://download.nvaccess.org/documentation/developerGuide.html#API). (#19599)
 * Updated components:
-  * Python from 3.13.11 to 3.13.12. (#19572, @dpy013)
   * Ruff to 0.15.9. (#19736, #19908)
   * uv to 0.11.7. (#19736, #19908, #19968)
   * Requests to 2.33.0. (#19877)

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -2,47 +2,71 @@
 
 ## 2026.2
 
+This release includes a new built-in Magnifier feature, improvements to touch gestures and navigation, and expanded speech and braille capabilities.
+
+The Magnifier provides zoom and color filtering options to assist users with visual impairments.
+The Magnifier currently only supports fullscreen mode, with docked modes planned in a future release.
+
+Touch support has been significantly expanded with new pinch gestures and touch-based browse mode navigation for web content.
+You can now navigate between links, headings, form fields, and other elements using touch flicks.
+
+Speech features have been enhanced with support for custom speech dictionaries that can be provided by add-ons and new dictionary entry types for more granular control.
+A new voice setting for OneCore voices was added to control pauses after punctuation
+A new command allows repeating the last spoken information, with the ability to display it in a browseable message.
+
+The braille display can now automatically scroll and DotPad devices support multi-button combinations.
+
+Liblouis has been updated with new Italian and Estonian braille tables.
+
+When resetting NVDA to factory defaults, an Undo button is now available to restore the previous configuration.
+
 ### Important notes
 
 ### New Features
 
-* Added pinch in and pinch out touch gestures, allowing two-finger pinch gestures to be bound to scripts. (#19938, @kefaslungu)
-* Added the ability to automatically scroll the braille display. (#18573, @nvdaes)
-* After installing or updating NVDA, a dialog now offers options to restart Windows, start the installed copy, or exit the installer. (#19268, #19718, @kefaslungu)
-* NVDA now includes a built-in Magnifier feature that allows you to zoom and magnify parts of the screen. (#19228, @Boumtchack)
+* Magnifier:
+  * NVDA now includes a built-in Magnifier feature that allows you to zoom and magnify parts of the screen. (#19228, @Boumtchack)
   * The magnifier supports various zoom levels, color filters (normal, grayscale, inverted), and different focus tracking modes.
   * Color filters can help users with visual impairments or light sensitivity by inverting or desaturating screen colors.
   * A spotlight mode is available for presentations or focused reading tasks.
   * All magnifier settings can be configured in a new "Magnifier" panel in NVDA Settings.
   * The magnifier cannot be used simultaneously with Screen Curtain for security reasons.
-* A new command, assigned to `NVDA+x`, has been introduced to repeat the last information spoken by NVDA; pressing it twice shows it in a browseable message. (#625, @CyrilleB79)
+* Speech:
+  * A new voice setting "Natural pause after punctuation" was added for OneCore voices, allowing users to turn punctuation pauses on or off. (#11876, @gexgd0419)
+  * A new command, assigned to `NVDA+x`, has been introduced to repeat the last information spoken by NVDA; pressing it twice shows it in a browseable message. (#625, @CyrilleB79)
+* Braille:
+  * Added the ability to automatically scroll the braille display. (#18573, @nvdaes)
+  * DotPad braille displays now support multi-button combination gestures. (#19565, @bramd)
+    * You can now press multiple buttons simultaneously to create custom gestures (e.g., `f1+panLeft`).
+* Touch:
+  * Added pinch in and pinch out touch gestures, allowing two-finger pinch gestures to be bound to scripts. (#19938, @kefaslungu)
+  * Added touch based navigation of browse mode elements, allowing touch screen users to move between links, headings, form fields, lists, tables and other quick navigation elements. (#3424, @kefaslungu)
+    * Flick down or up to cycle through element types; flick right or left to navigate between elements of the selected type.
+    * The element types shown when cycling can be configured in the Browse Mode settings panel.
+* Speech dictionaries:
+  * Added support for custom speech dictionaries. (#19558, #17468, @LeonarddeR)
+    * Dictionaries can be provided in the `speechDicts` folder in an add-on package.
+    * Dictionary metadata can be added to an optional `speechDictionaries` section in the add-on manifest.
+    * Please consult the [Custom speech dictionaries section in the developer guide](https://www.nvaccess.org/files/nvda/documentation/developerGuide.html#AddonSpeechDictionaries) for more details.
+  * New types have been added for speech dictionary entries, such as part of word and start of word.
+  Consult the speech dictionaries section in the User Guide for more details. (#19506, @LeonarddeR)
+* After installing or updating NVDA, a dialog now offers options to restart Windows, start the installed copy, or exit the installer. (#19268, #19718, @kefaslungu)
 * Added an unassigned command to toggle keyboard layout. (#19211, @CyrilleB79)
 * Added an unassigned Quick Navigation Command for jumping to next/previous slider in browse mode. (#17005, @tareh7z)
-* Added touch based navigation of browse mode elements, allowing touch screen users to move between links, headings, form fields, lists, tables and other quick navigation elements. (#3424, @kefaslungu)
-  * Flick down or up to cycle through element types; flick right or left to navigate between elements of the selected type.
-  * The element types shown when cycling can be configured in the Browse Mode settings panel.
-* Added support for custom speech dictionaries. (#19558, #17468, @LeonarddeR)
-  * Dictionaries can be provided in the `speechDicts` folder in an add-on package.
-  * Dictionary metadata can be added to an optional `speechDictionaries` section in the add-on manifest.
-  * Please consult the [Custom speech dictionaries section in the developer guide](https://www.nvaccess.org/files/nvda/documentation/developerGuide.html#AddonSpeechDictionaries) for more details.
-* New types have been added for Speech Dictionary entries, such as part of word and start of word.
-Consult the speech dictionaries section in the User Guide for more details. (#19506, @LeonarddeR)
 * When resetting the configuration to factory defaults from the NVDA menu, a dialog is now shown afterwards with an Undo button to restore the previous configuration.
 The triple-press keyboard shortcut (`NVDA+ctrl+r`) is not affected, as it is intended for recovery scenarios. (#19575, @bramd)
 * Added an unassigned command to report the current status of the Screen Curtain. (#19759)
-* DotPad braille displays now support multi-button combination gestures. (#19565, @bramd)
-  * You can now press multiple buttons simultaneously to create custom gestures (e.g., `f1+panLeft`).
-* A new voice setting "Natural pause after punctuation" was added for OneCore voices, allowing users to turn punctuation pauses on or off. (#11876, @gexgd0419)
 
 ### Changes
 
-* When NVDA is started, if the screen curtain is enabled and a sound is played to inform about this, the state of the screen curtain will be also displayed in braille. (19441, @nvdaes)
 * Updated Liblouis Braille translator to [3.37.0](https://github.com/liblouis/liblouis/releases/tag/v3.37.0). (#19758, @codeofdusk)
   * Added new Italian and Estonian 6 dot tables.
+* Braille:
+  * When NVDA is started, if the screen curtain is enabled and a sound is played to inform about this, the state of the screen curtain will be also displayed in braille. (#19441, @nvdaes)
+  * NVDA now supports the Orbit Reader 40 in its proprietary HID mode. (#19756, @trypsynth)
 * It is now possible to open the log viewer with `NVDA+f1`, even when the log level is set to "disabled". (#19318, @CyrilleB79)
 * Improved search algorithm for filtering add-ons in the Add-on Store. (#19309)
 * NVDA can now be configured to not play error sounds, even in test versions. (#13021, @CyrilleB79)
-* NVDA now supports the Orbit Reader 40 in its proprietary HID mode. (#19756, @trypsynth)
 * NVDA will start in focus mode by default when using WhatsApp 2.2584.3.0 or newer. (#19655, @josephsl)
 * Input help mode has been improved: (#17629, @Cary-rowen, @Emil-18)
   * When a key combination would produce a character in normal input mode, the key combination is reported first, followed by the character.
@@ -57,6 +81,10 @@ The setting is disabled by default. (#20013, @LeonarddeR)
 
 ### Bug Fixes
 
+* Add-on Store:
+  * NVDA no longer crashes when the Add-on Store download directory cannot be cleaned up due to file permission errors. (#19202, @christopherpross)
+  * After cancelling an add-on download and reopening the Add-on Store, downloading another add-on no longer fails. (#20015, @Cary-rowen)
+  * Configuration profile triggers now activate when the Add-on Store is open. (#19583, @bramd)
 * Fixed an error that could occur when NVDA checked whether a language is supported for a synthesizer with invalid languages. (#20080, @nvdaes)
 * NVDA will attempt to recover more quickly from freezes in some applications, especially those written in Java. (#14396, @thgcode)
 * In Firefox browse mode, the accessible name of form controls (such as checkboxes and radio buttons) is now correctly announced when the control has an `aria-label` and an associated `<label>` element that contains only `aria-hidden` content. (#19409, @bramd)
@@ -66,12 +94,9 @@ The setting is disabled by default. (#20013, @LeonarddeR)
 * Braille should no longer stop following focus when moving around in the Microsoft Copilot application. (#19646, @Emil-18)
 * The `NVDA+k` command now correctly reports the destination of links containing formatted text, such as bold or italics. (#19428, @Cary-rowen)
 * Capital indicators are now correctly announced when selecting single characters. (#19505, @cary-rowen)
-* Configuration profile triggers now activate when the Add-on Store is open. (#19583, @bramd)
-* After cancelling an add-on download and reopening the Add-on Store, downloading another add-on no longer fails. (#20015, @Cary-rowen)
 * In File Explorer, pressing `ctrl+f` once again focuses the search box without subsequently reporting a pane. (#20021, @Cary-rowen)
 * MathML in Chromium is more reliably read after NVDA starts or restarts. (#19813, @RyanMcCleary)
 * Decorative Unicode letters such as negative squared, negative circled, and regional indicator symbol characters are now normalized to their base Latin letters when Unicode normalization is enabled. (#19608, @bramd)
-* NVDA no longer crashes when the Add-on Store download directory cannot be cleaned up due to file permission errors. (#19202, @christopherpross)
 * Fixed NVDA freezing when navigating in JetBrains IDEs. (#16741, @christopherpross)
 * Speech dictionary entries of type Whole word now correctly handle words containing Unicode combining marks (e.g. Hebrew niqqud, Arabic harakat). (#20013, @LeonarddeR)
   * In particular, Whole word entries no longer incorrectly match inside larger words when those words contain combining marks.
@@ -79,6 +104,7 @@ The setting is disabled by default. (#20013, @LeonarddeR)
 ### Changes for Developers
 
 Please refer to [the developer guide](https://download.nvaccess.org/documentation/developerGuide.html#API) for information on NVDA's API deprecation and removal process.
+This section has been thoroughly updated in this release.
 
 * Updated components:
   * Python from 3.13.11 to 3.13.12. (#19572, @dpy013)
@@ -100,7 +126,7 @@ Please refer to [the developer guide](https://download.nvaccess.org/documentatio
 It only ran the translation string comment check, which is equivalent to `scons checkPot`.
 The `scons checkPot` target has also been replaced with `runcheckpot.bat`.
 Use the individual test commands instead: `runcheckpot.bat`, `rununittests.bat`, `runsystemtests.bat`, `runlint.bat`. (#19606, #19676, @bramd)
-* Updated Python 3.13.11 to 3.13.12 (#19572, @dpy013)
+* Updated Python 3.13.11 to 3.13.12. (#19572, @dpy013)
 * Added a private `_asyncioEventLoop` module that provides an asyncio event loop running on a background thread for use by NVDA components. (#19816, @bramd)
 * Added several functions related to the braille auto-scroll feature. (#18573, @nvdaes):
   * Added an `autoScroll` method to `braille.handler`.

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -39,7 +39,7 @@ When resetting NVDA to factory defaults, an Undo button is now available to rest
   * DotPad braille displays now support multi-button combination gestures. (#19565, @bramd)
     * You can now press multiple buttons simultaneously to create custom gestures (e.g., `f1+panLeft`).
 * Touch:
-  * Added pinch in and pinch out touch gestures, allowing two-finger pinch gestures to be bound to scripts. (#19938, @kefaslungu)
+  * Added pinch in and pinch out touch gestures, allowing two-finger pinch gestures to be bound to scripts. (#19963, @kefaslungu)
   * Added touch based navigation of browse mode elements, allowing touch screen users to move between links, headings, form fields, lists, tables and other quick navigation elements. (#3424, @kefaslungu)
     * Flick down or up to cycle through element types; flick right or left to navigate between elements of the selected type.
     * The element types shown when cycling can be configured in the Browse Mode settings panel.
@@ -68,14 +68,14 @@ The triple-press keyboard shortcut (`NVDA+control+r`) is not affected, as it is 
 * Improved search algorithm for filtering add-ons in the Add-on Store. (#19309)
 * NVDA can now be configured to not play error sounds, even in test versions. (#13021, @CyrilleB79)
 * NVDA will start in focus mode by default when using WhatsApp 2.2584.3.0 or newer. (#19655, @josephsl)
-* Input help mode has been improved: (#17629, @Cary-rowen, @Emil-18)
+* Input help mode has been improved: (#6621, @Cary-rowen, @Emil-18)
   * When a key combination would produce a character in normal input mode, the key combination is reported first, followed by the character.
   * If the key combination corresponds to an NVDA command, the behavior remains the same as before, i.e. the description of the command is reported.
 * Product version for File Explorer will reflect actual Windows version including correct build and revision numbers.
 This is more noticeable for Windows releases which are enablement packages on top of an earlier release such as Windows 11 2025 Update based on Windows 11 2024 Update. (#19802, @josephsl)
 * Math navigation commands now support input help, on-demand speech mode, and can be remapped. (#19871, @RyanMcCleary)
 * The "COM Registration Fixing Tool" has been renamed to "System Accessibility Repair Tool" for clarity. (#19622, @bramd)
-* Added an advanced setting to opt regular expression speech dictionary entries into a more modern `[regex](https://pypi.org/project/regex/)` engine.
+* Added an advanced setting to opt regular expression speech dictionary entries into a more modern [`regex`](https://pypi.org/project/regex/) engine.
 This provides Unicode-aware `\w` and `\b` and additional regex features.
 The setting is disabled by default. (#20013, @LeonarddeR)
 
@@ -94,7 +94,7 @@ The setting is disabled by default. (#20013, @LeonarddeR)
 * Braille should no longer stop following focus when moving around in the Microsoft Copilot application. (#19646, @Emil-18)
 * The `NVDA+k` command now correctly reports the destination of links containing formatted text, such as bold or italics. (#19428, @Cary-rowen)
 * Capital indicators are now correctly announced when selecting single characters. (#19505, @cary-rowen)
-* MathML in Chromium is more reliably read after NVDA starts or restarts. (#19813, @RyanMcCleary)
+* MathML in Chromium is more reliably read after NVDA starts or restarts. (#20049, @RyanMcCleary)
 * Decorative Unicode letters such as negative squared, negative circled, and regional indicator symbol characters are now normalized to their base Latin letters when Unicode normalization is enabled. (#19608, @bramd)
 * Fixed NVDA freezing when navigating in JetBrains IDEs. (#16741, @christopherpross)
 * Speech dictionary entries of type Whole word now correctly handle words containing Unicode combining marks (e.g. Hebrew niqqud, Arabic harakat). (#20013, @LeonarddeR)
@@ -103,31 +103,29 @@ The setting is disabled by default. (#20013, @LeonarddeR)
 ### Changes for Developers
 
 Please refer to [the developer guide](https://download.nvaccess.org/documentation/developerGuide.html#API) for information on NVDA's API deprecation and removal process.
-This section has been thoroughly updated in this release.
 
+* Clarified NV Access's policy on API breaking changes in the [Developer Guide](https://download.nvaccess.org/documentation/developerGuide.html#API). (#19599)
 * Updated components:
   * Python from 3.13.11 to 3.13.12. (#19572, @dpy013)
-  * Ruff to 0.15.9. (#19548, #19908)
-  * uv to 0.11.7. (#19548, #19908, #19968)
+  * Ruff to 0.15.9. (#19736, #19908)
+  * uv to 0.11.7. (#19736, #19908, #19968)
   * Requests to 2.33.0. (#19877)
   * cryptography to 46.0.7. (#19877, #19968)
 * A new parameter `redactSecrets` has been added to logging functions e.g. `log.debug`. (#19966)
   * When set to `True`, logging output will be sanitized to replace detected secrets with asterisks.
   * This is set to `False` by default for performance purposes.
   * It is encouraged to enable this when logging anything particularly sensitive e.g. clipboard content.
-  * Added a `SECRETS` logging level for cases where developers explicitly need debug logging without `redactSecrets` masking. (#19966)
+  * Added a `SECRETS` logging level for cases where developers explicitly need debug logging without `redactSecrets` masking.
 * NVDA libraries built by the build system are now linked with the [/SETCOMPAT](https://learn.microsoft.com/en-us/cpp/build/reference/cetcompat) flag, improving protection against certain malware attacks. (#19435, @LeonarddeR)
 * Subclasses of `browseMode.BrowseModeDocumentTreeInterceptor` that support screen layout being on and off should override the `_toggleScreenLayout` method, rather than implementing `script_toggleScreenLayout` directly. (#19487)
-* A new method has been added to the UIA.UIA class, called `_getUIACacheablePropertyValue_handleCOMErrors`. (#19646, @Emil-18)
+* A new method has been added to the UIA.UIA class, called `_getUIACacheablePropertyValue_handleCOMErrors`. (#19713, @Emil-18)
   * This method calls `_getUIACacheablePropertyValue`, and takes an extra argument (`onError`) that specifies the value that should be returned if a `COMError` is raised.
-* Clarified NV Access's policy on API breaking changes in the Developer Guide. (#19599)
 * The `scons tests` build target has been removed, as it was misleadingly named.
 It only ran the translation string comment check, which is equivalent to `scons checkPot`.
 The `scons checkPot` target has also been replaced with `runcheckpot.bat`.
 Use the individual test commands instead: `runcheckpot.bat`, `rununittests.bat`, `runsystemtests.bat`, `runlint.bat`. (#19606, #19676, @bramd)
-* Updated Python 3.13.11 to 3.13.12. (#19572, @dpy013)
 * Added a private `_asyncioEventLoop` module that provides an asyncio event loop running on a background thread for use by NVDA components. (#19816, @bramd)
-* Added several functions related to the braille auto-scroll feature. (#18573, @nvdaes):
+* Added several functions related to the braille auto-scroll feature. (#19126, @nvdaes):
   * Added an `autoScroll` method to `braille.handler`.
   * Added several functions for handling configuration value conversions and updates in `config.conf`:
     * Added a `getConfigValue` function to get the value for a provided configuration key path.

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -62,7 +62,7 @@ The triple-press keyboard shortcut (`NVDA+control+r`) is not affected, as it is 
 * Updated Liblouis Braille translator to [3.37.0](https://github.com/liblouis/liblouis/releases/tag/v3.37.0). (#19758, @codeofdusk)
   * Added new Italian and Estonian 6 dot tables.
 * Braille:
-  * When NVDA is started, if the screen curtain is enabled and a sound is played to inform about this, the state of the screen curtain will be also displayed in braille. (#19441, @nvdaes)
+  * The braille message when NVDA is started was updated to mention if screen curtain is enabled. (#19441, @nvdaes)
   * NVDA now supports the Orbit Reader 40 in its proprietary HID mode. (#19756, @trypsynth)
 * It is now possible to open the log viewer with `NVDA+f1`, even when the log level is set to "disabled". (#19318, @CyrilleB79)
 * Improved search algorithm for filtering add-ons in the Add-on Store. (#19309)

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -13,6 +13,7 @@ You can now navigate between links, headings, form fields, and other elements us
 Speech features have been enhanced with support for custom speech dictionaries that can be provided by add-ons and new dictionary entry types for more granular control.
 A new voice setting for OneCore voices was added to control pauses after punctuation.
 A new command allows repeating the last spoken information, with the ability to display it in a browsable message.
+The default gesture to repeat the last spoken information is `NVDA+x`, which can be changed in the Input Gestures dialog.
 
 The braille display can now automatically scroll and DotPad devices support multi-button combinations.
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -54,7 +54,7 @@ When resetting NVDA to factory defaults, an Undo button is now available to rest
 * Added an unassigned command to toggle keyboard layout. (#19211, @CyrilleB79)
 * Added an unassigned Quick Navigation Command for jumping to next/previous slider in browse mode. (#17005, @tareh7z)
 * When resetting the configuration to factory defaults from the NVDA menu, a dialog is now shown afterwards with an Undo button to restore the previous configuration.
-The triple-press keyboard shortcut (`NVDA+ctrl+r`) is not affected, as it is intended for recovery scenarios. (#19575, @bramd)
+The triple-press keyboard shortcut (`NVDA+control+r`) is not affected, as it is intended for recovery scenarios. (#19575, @bramd)
 * Added an unassigned command to report the current status of the Screen Curtain. (#19759)
 
 ### Changes
@@ -94,7 +94,6 @@ The setting is disabled by default. (#20013, @LeonarddeR)
 * Braille should no longer stop following focus when moving around in the Microsoft Copilot application. (#19646, @Emil-18)
 * The `NVDA+k` command now correctly reports the destination of links containing formatted text, such as bold or italics. (#19428, @Cary-rowen)
 * Capital indicators are now correctly announced when selecting single characters. (#19505, @cary-rowen)
-* In File Explorer, pressing `ctrl+f` once again focuses the search box without subsequently reporting a pane. (#20021, @Cary-rowen)
 * MathML in Chromium is more reliably read after NVDA starts or restarts. (#19813, @RyanMcCleary)
 * Decorative Unicode letters such as negative squared, negative circled, and regional indicator symbol characters are now normalized to their base Latin letters when Unicode normalization is enabled. (#19608, @bramd)
 * Fixed NVDA freezing when navigating in JetBrains IDEs. (#16741, @christopherpross)

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -245,7 +245,7 @@ The actual commands will not execute while in input help mode.
 |Read window |`NVDA+b` |`NVDA+b` |Reads the entire current window (useful for dialogs)|
 |Read status bar |`NVDA+end` |`NVDA+shift+end` |Reports the Status Bar if NVDA finds one. Pressing twice will spell the information. Pressing three times will copy it to the clipboard|
 |Read time |`NVDA+f12` |`NVDA+f12` |Pressing once reports the current time, pressing twice reports the date. The time and date are reported in the format specified in Windows settings for the system tray clock.|
-| Repeat last spoken information | `NVDA+x` |`NVDA+x` | Repeats the last information spoken by NVDA. Pressing twice shows it in a browseable window |
+| Repeat last spoken information | `NVDA+x` | `NVDA+x` | Repeats the last information spoken by NVDA. Pressing twice shows it in a browseable window |
 |Report text formatting |`NVDA+f` |`NVDA+f` |Reports text formatting. Pressing twice shows the information in a window|
 |Report link destination |`NVDA+k` |`NVDA+k` |Pressing once speaks the destination URL of the link at the current caret or focus position. Pressing twice shows it in a window for more careful review|
 
@@ -669,7 +669,7 @@ When the menu comes up, You can use the arrow keys to navigate the menu, and the
 |Starts or restarts NVDA |Control+alt+n |Control+alt+n |none |Starts or restarts NVDA from the Desktop, if this Windows shortcut is enabled during NVDA's installation process. This is a Windows specific shortcut and therefore it cannot be reassigned in the input gestures dialog.|
 |Stop speech |Control |control |2-finger tap |Instantly stops speaking|
 |Pause Speech |shift |shift |none |Instantly pauses speech. Pressing it again will continue speaking where it left off (if pausing is supported by the current synthesizer)|
-| Repeat last spoken information | `NVDA+x` | `NVDA+x` | None |Repeats the last information spoken by NVDA. Pressing twice shows it in a browseable window |
+| Repeat last spoken information | `NVDA+x` | `NVDA+x` | None | Repeats the last information spoken by NVDA. Pressing twice shows it in a browseable window |
 |NVDA Menu |NVDA+n |NVDA+n |2-finger double-tap |Pops up the NVDA menu to allow you to access preferences, tools, help, etc.|
 |Toggle Input Help Mode |NVDA+1 |NVDA+1 |none |Pressing any key in this mode will report the key, and the description of any NVDA command associated with it|
 |Quit NVDA |NVDA+q |NVDA+q |none |Exits NVDA|

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -2929,7 +2929,6 @@ The available options are:
 |---|---|
 | Options | Center, Border, Relative |
 | Default | Center |
-| Toggle command | None |
 
 | Option | Description |
 |---|---|
@@ -4399,10 +4398,10 @@ After resetting, a dialog will appear allowing you to undo the reset and restore
 The following NVDA key commands are also useful:
 <!-- KC:beginInclude -->
 
-| Name | Desktop key | Laptop key | Description |
-|---|---|---|---|
-| Save configuration | `NVDA+control+c` | `NVDA+control+c` | Saves your current configuration so that it is not lost when you exit NVDA |
-| Revert configuration | `NVDA+control+r` | `NVDA+control+r` | Pressing once resets your configuration to when you last saved it. Pressing three times will reset it back to factory defaults without showing the undo dialog. |
+| Name | Key | Description |
+|---|---|---|
+| Save configuration | `NVDA+control+c` | Saves your current configuration so that it is not lost when you exit NVDA |
+| Revert configuration | `NVDA+control+r` | Pressing once resets your configuration to when you last saved it. Pressing three times will reset it back to factory defaults without showing the undo dialog. |
 
 <!-- KC:endInclude -->
 

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -245,7 +245,7 @@ The actual commands will not execute while in input help mode.
 |Read window |`NVDA+b` |`NVDA+b` |Reads the entire current window (useful for dialogs)|
 |Read status bar |`NVDA+end` |`NVDA+shift+end` |Reports the Status Bar if NVDA finds one. Pressing twice will spell the information. Pressing three times will copy it to the clipboard|
 |Read time |`NVDA+f12` |`NVDA+f12` |Pressing once reports the current time, pressing twice reports the date. The time and date are reported in the format specified in Windows settings for the system tray clock.|
-|Repeat last spoken information |`NVDA+x` |`NVDA+x` |Repeats the last information spoken by NVDA. Pressing twice shows it in a browseable window |
+| Repeat last spoken information | `NVDA+x` |`NVDA+x` | Repeats the last information spoken by NVDA. Pressing twice shows it in a browseable window |
 |Report text formatting |`NVDA+f` |`NVDA+f` |Reports text formatting. Pressing twice shows the information in a window|
 |Report link destination |`NVDA+k` |`NVDA+k` |Pressing once speaks the destination URL of the link at the current caret or focus position. Pressing twice shows it in a window for more careful review|
 
@@ -669,7 +669,7 @@ When the menu comes up, You can use the arrow keys to navigate the menu, and the
 |Starts or restarts NVDA |Control+alt+n |Control+alt+n |none |Starts or restarts NVDA from the Desktop, if this Windows shortcut is enabled during NVDA's installation process. This is a Windows specific shortcut and therefore it cannot be reassigned in the input gestures dialog.|
 |Stop speech |Control |control |2-finger tap |Instantly stops speaking|
 |Pause Speech |shift |shift |none |Instantly pauses speech. Pressing it again will continue speaking where it left off (if pausing is supported by the current synthesizer)|
-|Repeat last spoken information |`NVDA+x` |`NVDA+x` |none |Repeats the last information spoken by NVDA. Pressing twice shows it in a browseable window |
+| Repeat last spoken information | `NVDA+x` | `NVDA+x` | None |Repeats the last information spoken by NVDA. Pressing twice shows it in a browseable window |
 |NVDA Menu |NVDA+n |NVDA+n |2-finger double-tap |Pops up the NVDA menu to allow you to access preferences, tools, help, etc.|
 |Toggle Input Help Mode |NVDA+1 |NVDA+1 |none |Pressing any key in this mode will report the key, and the description of any NVDA command associated with it|
 |Quit NVDA |NVDA+q |NVDA+q |none |Exits NVDA|
@@ -1584,22 +1584,22 @@ Once the magnifier is enabled, you can use the following keyboard commands to co
 
 <!-- KC:beginInclude -->
 
-| Name |Key |Description|
+| Name | Key | Description |
 |---|---|---|
-|Toggles the magnifier on and off |`NVDA+shift+w` |Enables or disables the magnifier|
+| Toggles the magnifier on and off | `NVDA+shift+w` | Enables or disables the magnifier |
 | Increases the magnification level of the magnifier | `NVDA+shift+equals` | Increases the zoom level. Starts the magnifier if it's not already running. |
-|Decreases the magnification level of the magnifier |`NVDA+shift+minus` |Decreases the zoom level|
-|Toggle filter of the magnifier |`NVDA+shift+i` |Cycles through available color filters (normal, grayscale, inverted)|
-|Toggle focus mode for the full-screen magnifier |None |Cycles through focus tracking modes (center, border, relative)|
-|Launch spotlight if magnifier is full-screen |`NVDA+shift+l` |Activates spotlight mode for focused reading or presentations|
-|Pan left |`NVDA+alt+leftArrow` |Pan the magnified view to the left by the specified panning step size|
-|Pan right |`NVDA+alt+rightArrow` |Pan the magnified view to the right by the specified panning step size|
-|Pan up |`NVDA+alt+upArrow` |Pan the magnified view upwards by the specified panning step size|
-|Pan down |`NVDA+alt+downArrow` |Pan the magnified view downwards by the specified panning step size|
-|Pan to left edge |`NVDA+shift+alt+leftArrow` |Pan the magnified view directly to the left edge of the screen|
-|Pan to right edge |`NVDA+shift+alt+rightArrow` |Pan the magnified view directly to the right edge of the screen|
-|Pan to top edge |`NVDA+shift+alt+upArrow` |Pan the magnified view directly to the top edge of the screen|
-|Pan to bottom edge |`NVDA+shift+alt+downArrow` |Pan the magnified view directly to the bottom edge of the screen|
+| Decreases the magnification level of the magnifier | `NVDA+shift+minus` | Decreases the zoom level |
+| Toggle filter of the magnifier | `NVDA+shift+i` | Cycles through available color filters (normal, grayscale, inverted) |
+| Toggle focus mode for the full-screen magnifier | None | Cycles through focus tracking modes (center, border, relative) |
+| Launch spotlight if magnifier is full-screen | `NVDA+shift+l` | Activates spotlight mode for focused reading or presentations |
+| Pan left | `NVDA+alt+leftArrow` | Pan the magnified view to the left by the specified panning step size |
+| Pan right | `NVDA+alt+rightArrow` | Pan the magnified view to the right by the specified panning step size |
+| Pan up | `NVDA+alt+upArrow` | Pan the magnified view upwards by the specified panning step size |
+| Pan down | `NVDA+alt+downArrow` | Pan the magnified view downwards by the specified panning step size |
+| Pan to left edge | `NVDA+shift+alt+leftArrow` | Pan the magnified view directly to the left edge of the screen |
+| Pan to right edge | `NVDA+shift+alt+rightArrow` | Pan the magnified view directly to the right edge of the screen |
+| Pan to top edge | `NVDA+shift+alt+upArrow` | Pan the magnified view directly to the top edge of the screen |
+| Pan to bottom edge | `NVDA+shift+alt+downArrow` | Pan the magnified view directly to the bottom edge of the screen |
 
 <!-- KC:endInclude -->
 
@@ -2885,8 +2885,8 @@ The selected state is also saved for future NVDA sessions, so if you enable Magn
 
 | . {.hideHeaderRow} |.|
 |---|---|
-|Options |Disabled, Enabled|
-|Default |Disabled|
+| Options | Disabled, Enabled |
+| Default | Disabled |
 
 ##### Zoom level {#MagnifierZoom}
 
@@ -2898,8 +2898,8 @@ You can always adjust the zoom level on the fly using the zoom in (`NVDA+shift+e
 
 | . {.hideHeaderRow} |.|
 |---|---|
-|Options |1.0 to 10.0|
-|Default |2.0|
+| Options | 1.0 to 10.0 |
+| Default | 2.0 |
 
 ##### Filter {#MagnifierFilter}
 
@@ -2909,9 +2909,9 @@ The available options are:
 
 | . {.hideHeaderRow} |.|
 |---|---|
-|Options | Normal, Grayscale, Inverted |
-|Default |Normal |
-|Toggle command |`NVDA+shift+i` |
+| Options | Normal, Grayscale, Inverted |
+| Default | Normal |
+| Toggle command | `NVDA+shift+i` |
 
 | Option | Description |
 |---|---|
@@ -2927,9 +2927,9 @@ The available options are:
 
 | . {.hideHeaderRow} |.|
 |---|---|
-|Options |Center, Border, Relative|
-|Default |Center|
-|Toggle command |None |
+| Options | Center, Border, Relative |
+| Default | Center |
+| Toggle command | None |
 
 | Option | Description |
 |---|---|
@@ -2952,8 +2952,8 @@ Available pan actions include:
 
 | . {.hideHeaderRow} |.|
 |---|---|
-|Options |1 to 100|
-|Default |10|
+| Options | 1 to 100 |
+| Default | 10 |
 
 ##### Use true center {#MagnifierUseTrueCenter}
 
@@ -2964,8 +2964,8 @@ This option is disabled by default.
 
 | . {.hideHeaderRow} |.|
 |---|---|
-|Options |Disabled, Enabled|
-|Default |Disabled|
+| Options | Disabled, Enabled |
+| Default | Disabled |
 
 #### Follow mouse {#MagnifierFollowMouse}
 
@@ -2976,8 +2976,8 @@ This option is enabled by default.
 
 | . {.hideHeaderRow} |.|
 |---|---|
-|Options |Disabled, Enabled|
-|Default |Enabled|
+| Options | Disabled, Enabled |
+| Default | Enabled |
 
 #### Follow system focus {#MagnifierFollowSystemFocus}
 
@@ -2988,8 +2988,8 @@ This option is enabled by default.
 
 | . {.hideHeaderRow} |.|
 |---|---|
-|Options |Disabled, Enabled|
-|Default |Enabled|
+| Options | Disabled, Enabled |
+| Default | Enabled |
 
 #### Follow review cursor {#MagnifierFollowReviewCursor}
 
@@ -3000,8 +3000,8 @@ This option is enabled by default.
 
 | . {.hideHeaderRow} |.|
 |---|---|
-|Options |Disabled, Enabled|
-|Default |Enabled|
+| Options | Disabled, Enabled |
+| Default | Enabled |
 
 #### Follow navigator object {#MagnifierFollowNavigatorObject}
 
@@ -3012,8 +3012,8 @@ This option is enabled by default.
 
 | . {.hideHeaderRow} |.|
 |---|---|
-|Options |Disabled, Enabled|
-|Default |Enabled|
+| Options | Disabled, Enabled |
+| Default | Enabled |
 
 ##### Keep mouse centered {#MagnifierKeepMouseCentered}
 
@@ -3024,8 +3024,8 @@ This option is disabled by default.
 
 | . {.hideHeaderRow} |.|
 |---|---|
-|Options |Disabled, Enabled|
-|Default |Disabled|
+| Options | Disabled, Enabled |
+| Default | Disabled |
 
 #### Keyboard {#KeyboardSettings}
 
@@ -4226,8 +4226,8 @@ The [modern engine](https://pypi.org/project/regex/) has better support for non-
 
 | . {.hideHeaderRow} |.|
 |---|---|
-|Options |Default (Disabled), Disabled, Enabled|
-|Default |Disabled|
+| Options | Default (Disabled), Disabled, Enabled |
+| Default | Disabled |
 
 ##### Caret move timeout (in MS) {#AdvancedSettingsCaretMoveTimeout}
 
@@ -4250,9 +4250,9 @@ Only turn one of these on if specifically instructed to by an NVDA developer e.g
 ##### Play a sound for logged errors {#PlayErrorSound}
 
 This option allows you to specify if NVDA will play an error sound in case an error is logged.
-Choosing Only in test versions (default) makes NVDA play error sounds only if the current NVDA version is a test version (alpha, beta or run from source).
-Choosing Yes allows to enable error sounds whatever your current NVDA version is.
-Choosing No disables error sounds no matter what your current NVDA version is, i.e. even in test versions.
+Choosing "Only in test versions (default)" makes NVDA play error sounds only if the current NVDA version is a test version (alpha, beta or run from source).
+Choosing "Yes" allows to enable error sounds whatever your current NVDA version is.
+Choosing "No" disables error sounds no matter what your current NVDA version is, i.e. even in test versions.
 
 ##### Regular expression for text paragraph quick navigation commands {#TextParagraphRegexEdit}
 
@@ -4399,10 +4399,10 @@ After resetting, a dialog will appear allowing you to undo the reset and restore
 The following NVDA key commands are also useful:
 <!-- KC:beginInclude -->
 
-| Name |Desktop key |Laptop key |Description|
+| Name | Desktop key | Laptop key | Description |
 |---|---|---|---|
-|Save configuration |`NVDA+control+c` |`NVDA+control+c` |Saves your current configuration so that it is not lost when you exit NVDA|
-|Revert configuration |`NVDA+control+r` |`NVDA+control+r` |Pressing once resets your configuration to when you last saved it. Pressing three times will reset it back to factory defaults without showing the undo dialog.|
+| Save configuration | `NVDA+control+c` | `NVDA+control+c` | Saves your current configuration so that it is not lost when you exit NVDA |
+| Revert configuration | `NVDA+control+r` | `NVDA+control+r` | Pressing once resets your configuration to when you last saved it. Pressing three times will reset it back to factory defaults without showing the undo dialog. |
 
 <!-- KC:endInclude -->
 
@@ -6284,10 +6284,10 @@ Make sure to lift your hand entirely off the device when navigating with NVDA, a
 
 <!-- KC:beginInclude -->
 
-| Name |Key|
+| Name | Key |
 |---|---|
-|Scroll braille display back | `panLeft` |
-|Scroll braille display forward | `panRight` |
+| Scroll braille display back | `panLeft` |
+| Scroll braille display forward | `panRight` |
 
 <!-- KC:endInclude -->
 
@@ -6381,7 +6381,7 @@ Following are the command line options for NVDA:
 |`-q` |`--quit` |Quit already running copy of NVDA|
 |`-k` |`--check-running` |Report whether NVDA is running via the exit code; 0 if running, 1 if not running|
 |`-f LOGFILENAME` |`--log-file=LOGFILENAME` |The file where log messages should be written to. Logging is always disabled if secure mode is enabled.|
-|`-l LOGLEVEL` |`--log-level=LOGLEVEL` |The lowest level of message logged (secrets 5, debug 10, input/output 12, debug warning 15, info 20, disabled 100). Logging is always disabled if secure mode is enabled.|
+| `-l LOGLEVEL` | `--log-level=LOGLEVEL` | The lowest level of message logged (secrets 5, debug 10, input/output 12, debug warning 15, info 20, disabled 100). Logging is always disabled if secure mode is enabled. |
 |`-c CONFIGPATH` |`--config-path=CONFIGPATH` |The path where all settings for NVDA are stored. The default value is forced if secure mode is enabled.|
 |`-n LANGUAGE` |`--lang=LANGUAGE` |Override the configured NVDA language. Set to "Windows" for current user default, "en" for English, etc.|
 |`-m` |`--minimal` |No sounds, no interface, no start message, etc.|


### PR DESCRIPTION
**Must be a squash merge**

Changes from this PR to the previous release:
- Files to check: `user_docs/en/userGuide.md`, `user_docs/en/changes.md` `developerGuide.md`
- [Compare this branch to the previous release](https://github.com/nvaccess/nvda/compare/release-2026.1.1rc1...docs2026.2?expand=1)
- Comparison command:
`git diff rrelease-2026.1.1rc1...docs2026.2  -- "**/en/*.md" "**/developerGuide.md"`

Common mistakes to check for:
- Issue/PR reference in changes file is incorrect
- Incorrect spelling.
- Shortcuts added without code markdown (e.g. `NVDA+d`)
- List items not indented by a multiple of 2 spaces (regex `^ (  )*\*`)
- Double spaces (regex `[^ ]  `)
- Inconsistent use of single vs double quote. (regex `' `)