### PR TITLE
Address review feedback for Chinese word segmentation

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,7 +28,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
+        - language: csharp
+          build-mode: none
         - language: python
+          build-mode: none
+        - language: c-cpp
+          build-mode: none
+        - language: actions
           build-mode: none
     steps:
     - name: Checkout repository

--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -59,7 +59,7 @@ jobs:
     name: Build NVDA
     needs: matrix
     runs-on: ${{ needs.matrix.outputs.defaultRunner }}
-    timeout-minutes: 15
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -99,6 +99,8 @@ jobs:
       run: ci/scripts/setBuildVersionVars.ps1
     - name: Set scons args
       run: ci/scripts/setSconsArgs.ps1
+      env:
+        apiSigningToken: ${{ github.event_name == 'push' && secrets.API_SIGNING_TOKEN || '' }}
     - name: Set cache key for SCons MSVC Cache
       shell: bash
       run: echo "SCONS_CACHE_KEY=${RUNNER_OS}-${ImageVersion}" >> $GITHUB_ENV
@@ -110,6 +112,15 @@ jobs:
       with:
         path: ${{ env.SCONS_CACHE_MSVC_CONFIG }}
         key: ${{ env.SCONS_CACHE_KEY }}
+    - name: Install signPath
+      env:
+        apiSigningToken: ${{ github.event_name == 'push' && secrets.API_SIGNING_TOKEN || '' }}
+      if: ${{ env.apiSigningToken }}
+      shell: cmd
+      run: |
+        PowerShell -Command "Set-ExecutionPolicy Bypass"
+        PowerShell -Command "Set-PSRepository PSGallery -InstallationPolicy Trusted"
+        PowerShell -Command "Install-Module -Name SignPath -Force"
     - name: Prepare source code
       shell: cmd
       run: scons source %sconsArgs% %sconsCores%
@@ -359,13 +370,21 @@ jobs:
       shell: cmd
       run: scons %sconsDocsOutTargets% %sconsArgs% %sconsCores%
     # Run launcher separately as we can't safely generate that in parallel to docs scons targets (#18867)
-    - name: Create launcher and controller client
+    - name: Install signpath
+      env:
+        apiSigningToken: ${{ github.event_name == 'push' && secrets.API_SIGNING_TOKEN || '' }}
+      if: ${{ env.apiSigningToken }}
       shell: cmd
       run: |
         PowerShell -Command "Set-ExecutionPolicy Bypass"
         PowerShell -Command "Set-PSRepository PSGallery -InstallationPolicy Trusted"
         PowerShell -Command "Install-Module -Name SignPath -Force"
-        scons %sconsLauncherOutTargets% %sconsArgs% %sconsCores%
+    - name: Build NVDAController client
+      shell: cmd
+      run: scons client %sconsArgs% %sconsCores%
+    - name: Create NVDA launcher
+      shell: cmd
+      run: scons %sconsLauncherOutTargets% %sconsArgs%
     - name: Upload launcher
       id: uploadLauncher
       uses: actions/upload-artifact@v7

--- a/ci/scripts/setSconsArgs.ps1
+++ b/ci/scripts/setSconsArgs.ps1
@@ -1,10 +1,17 @@
 $ErrorActionPreference = "Stop";
 $sconsDocsOutTargets = "developerGuide changes userGuide keyCommands user_docs"
-$sconsLauncherOutTargets = "launcher client moduleList"
+$sconsLauncherOutTargets = "launcher moduleList"
 $sconsArgs = "version=$env:version"
-$sconsCores = "-j1"
+$sconsCores = "--all-cores"
+if ($env:RUNNER_DEBUG -eq "1") {
+	# Run scons linearly if we are in debug mode, so logs can be easily parsed
+	$sconsCores = "-j1"
+}
 if ($env:release) {
 	$sconsArgs += " release=1"
+	# Run scons linearly for release builds, so we can debug if something goes wrong,
+	# as we cannot safely re-run a released build
+	$sconsCores = "-j1"
 }
 if ($env:versionType) {
 	$sconsArgs += " updateVersionType=$env:versionType"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ dependencies = [
 	"mdx-gh-links==0.4",
 	"l2m4m==1.0.4",
 	"pymdown-extensions==10.17.1",
+	"pyphen==0.17.2",
 	# pinned due to incompatibility with py2exe
 	# https://github.com/py2exe/py2exe/issues/241
 	"charset-normalizer==3.4.4",

--- a/source/NVDAObjects/window/edit.py
+++ b/source/NVDAObjects/window/edit.py
@@ -168,7 +168,7 @@ class EditTextInfo(textInfos.offsets.OffsetsTextInfo):
 	charSegFlag = CharSegFlag.UNISCRIBE
 
 	@property
-	def wordSegFlag(self):
+	def wordSegFlag(self) -> WordSegFlag:
 		return WordSegFlag.UNISCRIBE
 
 	def _getPointFromOffset(self, offset):

--- a/source/braille.py
+++ b/source/braille.py
@@ -72,6 +72,7 @@ from autoSettingsUtils.driverSetting import BooleanDriverSetting, NumericDriverS
 from utils.security import objectBelowLockScreenAndWindowsIsLocked, post_sessionLockStateChanged
 from winAPI.secureDesktop import post_secureDesktopStateChange
 from textUtils import isUnicodeNormalized, OffsetConverter, UnicodeNormalizationOffsetConverter
+from textUtils.wordSeg.wordSegUtils import WordSegWithSeparatorOffsetConverter
 import hwIo
 from editableText import EditableText
 from gui.guiHelper import wxCallOnMain
@@ -539,6 +540,21 @@ def getDisplayList(excludeNegativeChecks=True) -> List[Tuple[str, str]]:
 	return displayList
 
 
+def _applyOffsetConverter(
+	converter: OffsetConverter,
+	textToTranslateTypeforms: list[int] | None,
+	cursorPos: int | None,
+) -> tuple[str, list[int] | None, int | None]:
+	if textToTranslateTypeforms is not None:
+		textToTranslateTypeforms = [
+			textToTranslateTypeforms[typing.cast(int, converter.encodedToStrOffsets(encodedOffset))]
+			for encodedOffset in range(converter.encodedStringLength)
+		]
+	if cursorPos is not None:
+		cursorPos = typing.cast(int, converter.strToEncodedOffsets(cursorPos))
+	return typing.cast(str, getattr(converter, "encoded")), textToTranslateTypeforms, cursorPos
+
+
 class Region(object):
 	"""A region of braille to be displayed.
 	Each portion of braille to be displayed is represented by a region.
@@ -605,28 +621,26 @@ class Region(object):
 		textToTranslateTypeforms = self.rawTextTypeforms
 		cursorPos = self.cursorPos
 
-		def _applyConverter(converter: OffsetConverter) -> None:
-			nonlocal cursorPos, textToTranslate, textToTranslateTypeforms
-			if textToTranslateTypeforms is not None:
-				textToTranslateTypeforms = [
-					textToTranslateTypeforms[converter.encodedToStrOffsets(encodedOffset)]
-					for encodedOffset in range(converter.encodedStringLength)
-				]
-			if cursorPos is not None:
-				cursorPos = converter.strToEncodedOffsets(cursorPos)
-			textToTranslate = converter.encoded
-			converters.append(converter)
-
 		if (
 			config.conf["braille"]["translationTable"].startswith("zh")
 			or config.conf["braille"]["translationTable"] == "auto"
 			and brailleTables.getDefaultTableForCurLang(brailleTables.TableType.OUTPUT).startswith("zh")
 		):
-			from textUtils.wordSeg.wordSegUtils import WordSegWithSeparatorOffsetConverter  # noqa: F401
-
-			_applyConverter(WordSegWithSeparatorOffsetConverter(textToTranslate))
+			converter = WordSegWithSeparatorOffsetConverter(textToTranslate)
+			textToTranslate, textToTranslateTypeforms, cursorPos = _applyOffsetConverter(
+				converter,
+				textToTranslateTypeforms,
+				cursorPos,
+			)
+			converters.append(converter)
 		if config.conf["braille"]["unicodeNormalization"] and not isUnicodeNormalized(textToTranslate):
-			_applyConverter(UnicodeNormalizationOffsetConverter(textToTranslate))
+			converter = UnicodeNormalizationOffsetConverter(textToTranslate)
+			textToTranslate, textToTranslateTypeforms, cursorPos = _applyOffsetConverter(
+				converter,
+				textToTranslateTypeforms,
+				cursorPos,
+			)
+			converters.append(converter)
 		self.brailleCells, brailleToRawPos, rawToBraillePos, self.brailleCursorPos = louisHelper.translate(
 			[handler.table.fileName, "braille-patterns.cti"],
 			textToTranslate,

--- a/source/braille.py
+++ b/source/braille.py
@@ -11,6 +11,7 @@ from typing import (
 	TYPE_CHECKING,
 	Any,
 	Callable,
+	cast,
 	Dict,
 	Final,
 	Generator,
@@ -547,12 +548,12 @@ def _applyOffsetConverter(
 ) -> tuple[str, list[int] | None, int | None]:
 	if textToTranslateTypeforms is not None:
 		textToTranslateTypeforms = [
-			textToTranslateTypeforms[typing.cast(int, converter.encodedToStrOffsets(encodedOffset))]
+			textToTranslateTypeforms[cast(int, converter.encodedToStrOffsets(encodedOffset))]
 			for encodedOffset in range(converter.encodedStringLength)
 		]
 	if cursorPos is not None:
-		cursorPos = typing.cast(int, converter.strToEncodedOffsets(cursorPos))
-	return typing.cast(str, getattr(converter, "encoded")), textToTranslateTypeforms, cursorPos
+		cursorPos = cast(int, converter.strToEncodedOffsets(cursorPos))
+	return cast(str, getattr(converter, "encoded")), textToTranslateTypeforms, cursorPos
 
 
 class Region(object):

--- a/source/config/featureFlagEnums.py
+++ b/source/config/featureFlagEnums.py
@@ -142,6 +142,11 @@ class FontFormattingBrailleModeFlag(DisplayStringEnum):
 class WordNavigationUnitFlag(DisplayStringEnum):
 	"""Enumeration for word navigation."""
 
+	DEFAULT = enum.auto()
+	AUTO = enum.auto()
+	UNISCRIBE = enum.auto()
+	CHINESE = enum.auto()
+
 	@property
 	def _displayStringLabels(self):
 		return {
@@ -152,11 +157,6 @@ class WordNavigationUnitFlag(DisplayStringEnum):
 			# Translators: Label for a method of word segmentation.
 			self.CHINESE: _("Chinese"),
 		}
-
-	DEFAULT = enum.auto()
-	AUTO = enum.auto()
-	UNISCRIBE = enum.auto()
-	CHINESE = enum.auto()
 
 
 def getAvailableEnums() -> typing.Generator[typing.Tuple[str, FlagValueEnum], None, None]:

--- a/source/core.py
+++ b/source/core.py
@@ -930,12 +930,8 @@ def main():
 
 	from textUtils import wordSeg
 
-	log.debug("Initializing word segmentation module")
-
 	try:
 		wordSeg.initialize()
-	except RuntimeError:
-		log.warning("Word segmentation module disabled in configuration")
 	except Exception:
 		log.error("Error initializing word segmentation module", exc_info=True)
 

--- a/source/displayModel.py
+++ b/source/displayModel.py
@@ -530,7 +530,7 @@ class DisplayModelTextInfo(OffsetsTextInfo):
 	charSegFlag = CharSegFlag.NONE
 
 	@property
-	def wordSegFlag(self):
+	def wordSegFlag(self) -> WordSegFlag:
 		return WordSegFlag.NONE
 
 	def _getTextRange(self, start, end):

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -3553,7 +3553,7 @@ class DocumentNavigationPanel(SettingsPanel):
 			keyPath=["documentNavigation", "wordSegmentationStandard"],
 			conf=config.conf,
 		)
-		self.bindHelpEvent("wordSegmentationStandard", self.wordSegCombo)
+		self.bindHelpEvent("WordSegmentationStandard", self.wordSegCombo)
 
 		# Translators: This is a label for the paragraph navigation style in the document navigation dialog
 		paragraphStyleLabel = _("&Paragraph style:")
@@ -3572,12 +3572,8 @@ class DocumentNavigationPanel(SettingsPanel):
 	def postSave(self):
 		from textUtils import wordSeg
 
-		log.debug("Reinitializing word segmentation module")
-
 		try:
 			wordSeg.initialize()
-		except RuntimeError:
-			log.warning("Word segmentation module disabled in configuration")
 		except Exception:
 			log.error("Error reinitializing word segmentation module", exc_info=True)
 

--- a/source/setup.py
+++ b/source/setup.py
@@ -1,12 +1,12 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2006-2026 NV Access Limited, Peter Vágner, Joseph Lee
+# Copyright (C) 2006-2026 NV Access Limited, Peter Vágner, Joseph Lee, Leonard de Ruijter
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
 from __future__ import annotations
 
 import argparse
-from ast import NodeTransformer, fix_missing_locations, parse
+from ast import AST, Assign, NodeTransformer, Try, fix_missing_locations, parse
 import os
 import sys
 import gettext
@@ -119,6 +119,71 @@ def _hook_latex2mathml_symbols_parser(finder: Scanner, module: Module) -> None:
 # py2exe discovers hooks by name:
 # ``hook_<dotted_module_name_with_underscores>`` on the ``py2exe.hooks`` module.
 py2exe.hooks.hook_latex2mathml_symbols_parser = _hook_latex2mathml_symbols_parser
+
+
+class _PyphenTransformer(NodeTransformer):
+	"""Rewrite pyphen's ``dictionaries`` assignment to resolve relative to the frozen executable."""
+
+	def __init__(self, relpath: str):
+		super().__init__()
+		self.rewritten: bool = False
+		self.relpath = relpath
+
+	def visit_Try(self, node: Try) -> AST:
+		# Match the upstream try/except TypeError block whose first body statement
+		# is ``dictionaries = resources.files('pyphen.dictionaries')``.
+		firstStmt = node.body[0] if node.body else None
+		if (
+			isinstance(firstStmt, Assign)
+			and len(firstStmt.targets) == 1
+			and getattr(firstStmt.targets[0], "id", None) == "dictionaries"
+		):
+			replacement = parse(
+				f"dictionaries = Path(os.path.dirname(sys.executable)) / {self.relpath!r}",
+			).body[0]
+			self.rewritten = True
+			return replacement
+		return self.generic_visit(node)
+
+
+def _hook_pyphen(finder: Scanner, module: Module) -> None:
+	"""py2exe hook for the pyphen package.
+
+	pyphen locates its ``dictionaries/*.dic`` data files at runtime relative to
+	its own package directory (via ``importlib.resources`` or ``__file__``).
+	After freezing, pyphen lives inside ``library.zip`` and those paths no
+	longer resolve, leaving ``pyphen.LANGUAGES`` empty. This hook:
+
+	1. Copies every ``hyph_*.dic`` file into ``pyphenDictionaries/`` next to
+		the frozen executable.
+	2. Rewrites the module's ``dictionaries`` assignment via an AST
+		transformation so it resolves to
+		``Path(os.path.dirname(sys.executable)) / 'pyphenDictionaries'``.
+	"""
+	import pyphen
+
+	DEST_DIR: Final[str] = "pyphenDictionaries"
+	sourceDir = os.path.join(os.path.dirname(pyphen.__file__), "dictionaries")
+	for sourceFile in glob(os.path.join(sourceDir, "hyph_*.dic")):
+		finder.add_datafile(
+			os.path.join(DEST_DIR, os.path.basename(sourceFile)),
+			sourceFile,
+		)
+	tree = parse(module.__source__)
+	# Inject imports needed by the rewritten expression.
+	tree.body.insert(0, parse("import os").body[0])
+	tree.body.insert(0, parse("import sys").body[0])
+	tree.body.insert(0, parse("from pathlib import Path").body[0])
+	transformer = _PyphenTransformer(DEST_DIR)
+	newTree = fix_missing_locations(transformer.visit(tree))
+	if not transformer.rewritten:
+		raise RuntimeError(
+			"py2exe hook failed to rewrite the dictionaries assignment in pyphen. The upstream module may have changed its layout.",
+		)
+	module.__code_object__ = compile(newTree, module.__file__, "exec", optimize=module.__optimize__)
+
+
+py2exe.hooks.hook_pyphen = _hook_pyphen
 
 
 def _parsePartialArguments() -> argparse.Namespace:
@@ -318,6 +383,7 @@ freeze(
 			"brailleDisplayDrivers.eurobraille",
 			"brailleDisplayDrivers.dotPad",
 			"synthDrivers",
+			"textUtils",
 			"visionEnhancementProviders",
 			# Required for markdown, markdown implicitly imports this so it isn't picked up
 			"html.parser",

--- a/source/textUtils/hyphenation.py
+++ b/source/textUtils/hyphenation.py
@@ -1,0 +1,44 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2026 NV Access Limited, Leonard de Ruijter
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
+
+"""Utilities for hyphenation."""
+
+from characterProcessing import LocaleDataMap
+from logHandler import log
+from pyphen import Pyphen, language_fallback
+
+
+def _pyphenFactory(lang: str) -> Pyphen:
+	"""Factory for Pyphen instances."""
+	pyphenLang = language_fallback(lang)
+	if not pyphenLang:
+		raise LookupError(f"No Pyphen language found for locale '{lang}'")
+	elif "_" in lang and "_" not in pyphenLang:
+		raise LookupError(
+			f"Pyphen resolved {lang!r} to {pyphenLang!r} but the original locale contains a region subtag. "
+			"Fallbacks should be handled by LocaleDataMap instead",
+		)
+	return Pyphen(lang=pyphenLang)
+
+
+_hyphenationMap: LocaleDataMap[Pyphen] = LocaleDataMap(_pyphenFactory)
+
+
+def getHyphenPositions(text: str, locale: str) -> tuple[int, ...]:
+	"""Get the positions of hyphenation points in the given text for the given locale.
+
+	If no hyphenation dictionary is available for the locale, an empty tuple is returned
+	and a debug message is logged (once per locale per map lifetime).
+
+	:param text: The text to find hyphenation points in.
+	:param locale: The locale of the text.
+	:return: A tuple of positions in the text where hyphenation points occur.
+	"""
+	try:
+		pyphen = _hyphenationMap.fetchLocaleData(locale=locale)
+	except LookupError:
+		log.debug(f"No Pyphen dictionary available for locale {locale!r}; hyphenation disabled.")
+		return ()
+	return tuple(pyphen.positions(text))

--- a/source/textUtils/segFlag.py
+++ b/source/textUtils/segFlag.py
@@ -14,15 +14,15 @@ _CHINESE: int = 1 << 2
 class CharSegFlag(IntFlag):
 	"""Character-level segmentation flags."""
 
-	NONE: int = 0
-	AUTO: int = _AUTO
-	UNISCRIBE: int = _UNISCRIBE
+	NONE = 0
+	AUTO = _AUTO
+	UNISCRIBE = _UNISCRIBE
 
 
 class WordSegFlag(IntFlag):
 	"""Word-level segmentation flags."""
 
-	NONE: int = 0
-	AUTO: int = _AUTO
-	UNISCRIBE: int = _UNISCRIBE
-	CHINESE: int = _CHINESE
+	NONE = 0
+	AUTO = _AUTO
+	UNISCRIBE = _UNISCRIBE
+	CHINESE = _CHINESE

--- a/source/textUtils/wordSeg/__init__.py
+++ b/source/textUtils/wordSeg/__init__.py
@@ -10,6 +10,8 @@ from typing import Any
 
 from logHandler import log
 
+from . import wordSegStrategy
+
 
 def _runInitializer(
 	initializer: Callable[..., Any],
@@ -38,7 +40,6 @@ def initialize() -> None:
 	"""
 
 	log.debug("Initializing word segmentation module")
-	from . import wordSegStrategy
 
 	for module_name, qualname, func_obj, args, kwargs in wordSegStrategy.initializerList:
 		callable_to_call: Callable[..., Any] = func_obj
@@ -61,6 +62,7 @@ def initialize() -> None:
 			threading.Thread(
 				target=_runInitializer,
 				args=(callable_to_call, module_name, qualname, args, kwargs),
+				name=f"wordSeg initializer {module_name}.{qualname}",
 				daemon=True,
 			).start()
 		except Exception:

--- a/source/textUtils/wordSeg/__init__.py
+++ b/source/textUtils/wordSeg/__init__.py
@@ -4,10 +4,27 @@
 # For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
 
 import importlib
+import threading
+from collections.abc import Callable
+from typing import Any
+
 from logHandler import log
 
 
-def initialize():
+def _runInitializer(
+	initializer: Callable[..., Any],
+	module_name: str,
+	qualname: str,
+	args: tuple[Any, ...],
+	kwargs: dict[str, Any],
+) -> None:
+	try:
+		initializer(*args, **kwargs)
+	except Exception:
+		log.exception(f"Initializer {module_name}.{qualname} failed")
+
+
+def initialize() -> None:
 	"""
 	Call all registered initializer functions recorded in wordSegStrategy.initializerList.
 
@@ -20,12 +37,11 @@ def initialize():
 	failing initializer doesn't stop the rest.
 	"""
 
+	log.debug("Initializing word segmentation module")
 	from . import wordSegStrategy
-	from threading import Thread
 
 	for module_name, qualname, func_obj, args, kwargs in wordSegStrategy.initializerList:
-		callable_to_call = None
-		# try to resolve module + qualname to a current attribute (handles classmethod/staticmethod)
+		callable_to_call: Callable[..., Any] = func_obj
 		try:
 			mod = importlib.import_module(module_name)
 			obj = mod
@@ -33,13 +49,19 @@ def initialize():
 				obj = getattr(obj, part)
 			callable_to_call = obj
 		except Exception:
-			# fallback to original function object captured during decoration
-			callable_to_call = func_obj
+			log.debugWarning(
+				f"Could not resolve initializer {module_name}.{qualname}; falling back to the registered function",
+				exc_info=True,
+			)
 
-		# Final call with its args/kwargs and exception handling
+		if not callable(callable_to_call):
+			log.debugWarning(f"Resolved initializer {module_name}.{qualname} is not callable; skipping")
+			continue
 		try:
-			if not callable(callable_to_call):
-				raise TypeError(f"Resolved initializer is not callable: {module_name}.{qualname}")
-			Thread(target=callable_to_call, args=args, kwargs=kwargs, daemon=True).start()
-		except Exception as e:
-			log.debug("Initializer %s.%s failed: %s", module_name, qualname, e)
+			threading.Thread(
+				target=_runInitializer,
+				args=(callable_to_call, module_name, qualname, args, kwargs),
+				daemon=True,
+			).start()
+		except Exception:
+			log.exception(f"Failed to start initializer {module_name}.{qualname}")

--- a/tests/unit/test_braille/test_routing.py
+++ b/tests/unit/test_braille/test_routing.py
@@ -32,7 +32,7 @@ class CursorManager(CursorManager):
 	TextInfo = CursorManagerTextInfo
 
 
-def _segmentedTextWithSeparator(_sep: str, newSepIndex: list[int]) -> str:
+def _segmentedTextWithSeparator(sep: str, newSepIndex: list[int]) -> str:
 	newSepIndex.append(1)
 	return "你 ℌ"
 

--- a/tests/unit/test_braille/test_routing.py
+++ b/tests/unit/test_braille/test_routing.py
@@ -41,14 +41,14 @@ class TestBrailleOffsetConverters(unittest.TestCase):
 	def setUp(self) -> None:
 		self._originalTranslationTable = config.conf["braille"]["translationTable"]
 		self._originalUnicodeNormalization = config.conf["braille"]["unicodeNormalization"]
-		config.conf["braille"]["translationTable"] = "zh-chn.ctb"
-		config.conf["braille"]["unicodeNormalization"] = "enabled"
 
 	def tearDown(self) -> None:
 		config.conf["braille"]["translationTable"] = self._originalTranslationTable
 		config.conf["braille"]["unicodeNormalization"] = self._originalUnicodeNormalization
 
 	def test_chineseWordSegmentationAndUnicodeNormalizationOffsetsAreComposed(self):
+		config.conf["braille"]["translationTable"] = "zh-chn.ctb"
+		config.conf["braille"]["unicodeNormalization"] = "enabled"
 		wordSegmenter = Mock()
 		wordSegmenter.segmentedText.side_effect = _segmentedTextWithSeparator
 		translate = Mock(return_value=([1, 2, 3], [0, 1, 2], [0, 1, 2], 2))

--- a/tests/unit/test_braille/test_routing.py
+++ b/tests/unit/test_braille/test_routing.py
@@ -32,40 +32,42 @@ class CursorManager(CursorManager):
 	TextInfo = CursorManagerTextInfo
 
 
+def _segmentedTextWithSeparator(_sep: str, newSepIndex: list[int]) -> str:
+	newSepIndex.append(1)
+	return "你 ℌ"
+
+
 class TestBrailleOffsetConverters(unittest.TestCase):
-	def test_chineseWordSegmentationAndUnicodeNormalizationOffsetsAreComposed(self):
-		originalTranslationTable = config.conf["braille"]["translationTable"]
-		originalUnicodeNormalization = config.conf["braille"]["unicodeNormalization"]
+	def setUp(self) -> None:
+		self._originalTranslationTable = config.conf["braille"]["translationTable"]
+		self._originalUnicodeNormalization = config.conf["braille"]["unicodeNormalization"]
 		config.conf["braille"]["translationTable"] = "zh-chn.ctb"
 		config.conf["braille"]["unicodeNormalization"] = "enabled"
 
-		def segmentedText(sep, newSepIndex):
-			newSepIndex.append(1)
-			return "你 ℌ"
+	def tearDown(self) -> None:
+		config.conf["braille"]["translationTable"] = self._originalTranslationTable
+		config.conf["braille"]["unicodeNormalization"] = self._originalUnicodeNormalization
 
+	def test_chineseWordSegmentationAndUnicodeNormalizationOffsetsAreComposed(self):
 		wordSegmenter = Mock()
-		wordSegmenter.segmentedText.side_effect = segmentedText
+		wordSegmenter.segmentedText.side_effect = _segmentedTextWithSeparator
 		translate = Mock(return_value=([1, 2, 3], [0, 1, 2], [0, 1, 2], 2))
-		try:
-			with (
-				patch("textUtils.wordSeg.wordSegUtils.WordSegmenter", return_value=wordSegmenter),
-				patch("braille.louisHelper.translate", translate),
-			):
-				region = braille.Region()
-				region.rawText = "你ℌ"
-				region.rawTextTypeforms = [11, 22]
-				region.cursorPos = 1
+		with (
+			patch("textUtils.wordSeg.wordSegUtils.WordSegmenter", return_value=wordSegmenter),
+			patch("braille.louisHelper.translate", translate),
+		):
+			region = braille.Region()
+			region.rawText = "你ℌ"
+			region.rawTextTypeforms = [11, 22]
+			region.cursorPos = 1
 
-				region.update()
+			region.update()
 
-			self.assertEqual(translate.call_args.args[1], "你 H")
-			self.assertEqual(translate.call_args.kwargs["cursorPos"], 2)
-			self.assertEqual(translate.call_args.kwargs["typeform"], [11, 22, 22])
-			self.assertEqual(region.brailleToRawPos, [0, 1, 1])
-			self.assertEqual(region.rawToBraillePos, [0, 2])
-		finally:
-			config.conf["braille"]["translationTable"] = originalTranslationTable
-			config.conf["braille"]["unicodeNormalization"] = originalUnicodeNormalization
+		self.assertEqual(translate.call_args.args[1], "你 H")
+		self.assertEqual(translate.call_args.kwargs["cursorPos"], 2)
+		self.assertEqual(translate.call_args.kwargs["typeform"], [11, 22, 22])
+		self.assertEqual(region.brailleToRawPos, [0, 1, 1])
+		self.assertEqual(region.rawToBraillePos, [0, 2])
 
 
 class TestReviewRoutingMovesSystemCaretInNavigableText(unittest.TestCase):

--- a/tests/unit/test_hyphenation.py
+++ b/tests/unit/test_hyphenation.py
@@ -1,0 +1,31 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2026 NV Access Limited, Leonard de Ruijter
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
+
+"""Unit tests for textUtils.hyphenation."""
+
+import unittest
+
+from textUtils import hyphenation
+
+
+class TestGetHyphenPositions(unittest.TestCase):
+	def test_knownLanguage(self):
+		"""Known language returns a non-empty tuple of ints within range(len(text))."""
+		text = "hyphenation"
+		positions = hyphenation.getHyphenPositions(text, "en_US")
+		self.assertIsInstance(positions, tuple)
+		self.assertGreater(len(positions), 0)
+		for pos in positions:
+			self.assertIsInstance(pos, int)
+			self.assertGreaterEqual(pos, 0)
+			self.assertLess(pos, len(text))
+
+	def test_unknownLanguage_returnsEmptyTuple(self):
+		"""Unknown language returns an empty tuple and does not raise."""
+		positions = hyphenation.getHyphenPositions("anything", "zz_ZZ")
+		self.assertEqual(positions, ())
+		# Calling again should still return () and not raise.
+		positions = hyphenation.getHyphenPositions("anything", "zz_ZZ")
+		self.assertEqual(positions, ())

--- a/tests/unit/test_textInfos.py
+++ b/tests/unit/test_textInfos.py
@@ -193,15 +193,16 @@ class TestWordExpansion(unittest.TestCase):
 		self.assertEqual(ti.offsets, (7, 7))
 
 
-class TestWordSegFlag(unittest.TestCase):
-	class _UnknownWordSegConf:
-		def calculated(self):
-			return "unexpected"
+class _UnknownWordSegConf:
+	def calculated(self) -> str:
+		return "unexpected"
 
+
+class TestWordSegFlag(unittest.TestCase):
 	def test_unknownWordSegConfigReturnsNoneAfterLogging(self):
 		obj = BasicTextProvider(text="abc")
 		ti = obj.makeTextInfo(Offsets(0, 0))
-		ti.wordSegConf = self._UnknownWordSegConf()
+		ti.wordSegConf = _UnknownWordSegConf()
 
 		with patch("textInfos.offsets.log.error") as mockLogError:
 			self.assertIsNone(ti.wordSegFlag)

--- a/tests/unit/test_textUtils.py
+++ b/tests/unit/test_textUtils.py
@@ -644,9 +644,7 @@ class TestWordSegInitialize(unittest.TestCase):
 			def start(self) -> None:
 				self.target(*self.args, **self.kwargs)
 
-		initializerList: list[
-			tuple[str, str, Callable[..., Any], tuple[Any, ...], dict[str, Any]]
-		] = [
+		initializerList: list[tuple[str, str, Callable[..., Any], tuple[Any, ...], dict[str, Any]]] = [
 			("missingModule", "firstInitializer", firstInitializer, (), {}),
 			("missingModule", "secondInitializer", secondInitializer, (), {}),
 		]

--- a/tests/unit/test_textUtils.py
+++ b/tests/unit/test_textUtils.py
@@ -625,11 +625,12 @@ class TestWordSegInitialize(unittest.TestCase):
 			calls.append("second")
 
 		class ImmediateThread:
-			def __init__(self, target, args=None, kwargs=None, daemon=False):
+			def __init__(self, target, args=None, kwargs=None, daemon=False, name=None):
 				self.target = target
 				self.args = () if args is None else args
 				self.kwargs = {} if kwargs is None else kwargs
 				self.daemon = daemon
+				self.name = name
 
 			def start(self):
 				self.target(*self.args, **self.kwargs)

--- a/tests/unit/test_textUtils.py
+++ b/tests/unit/test_textUtils.py
@@ -6,7 +6,9 @@
 """Unit tests for the textUtils module."""
 
 import unittest
+from collections.abc import Callable
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import Mock, patch
 
 from textUtils import UnicodeNormalizationOffsetConverter, WideStringOffsetConverter, WordSegmenter
@@ -616,26 +618,35 @@ class TestWordSegInitialize(unittest.TestCase):
 		from textUtils import wordSeg
 		from textUtils.wordSeg import wordSegStrategy
 
-		calls = []
+		calls: list[str] = []
 
-		def firstInitializer():
+		def firstInitializer() -> None:
 			calls.append("first")
 
-		def secondInitializer():
+		def secondInitializer() -> None:
 			calls.append("second")
 
 		class ImmediateThread:
-			def __init__(self, target, args=None, kwargs=None, daemon=False, name=None):
-				self.target = target
-				self.args = () if args is None else args
-				self.kwargs = {} if kwargs is None else kwargs
-				self.daemon = daemon
-				self.name = name
+			def __init__(
+				self,
+				target: Callable[..., Any],
+				args: tuple[Any, ...] | None = None,
+				kwargs: dict[str, Any] | None = None,
+				daemon: bool = False,
+				name: str | None = None,
+			) -> None:
+				self.target: Callable[..., Any] = target
+				self.args: tuple[Any, ...] = () if args is None else args
+				self.kwargs: dict[str, Any] = {} if kwargs is None else kwargs
+				self.daemon: bool = daemon
+				self.name: str | None = name
 
-			def start(self):
+			def start(self) -> None:
 				self.target(*self.args, **self.kwargs)
 
-		initializerList = [
+		initializerList: list[
+			tuple[str, str, Callable[..., Any], tuple[Any, ...], dict[str, Any]]
+		] = [
 			("missingModule", "firstInitializer", firstInitializer, (), {}),
 			("missingModule", "secondInitializer", secondInitializer, (), {}),
 		]

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -6,6 +6,10 @@
 
 ### New Features
 
+* Chinese text can now be navigated by word using built-in input gestures.
+  Several GUI elements were added to configure this in the `Document Navigation` panel. (#18735, @CrazySteve0605)
+* Braille output for Chinese now includes spaces between words. (#18865, @CrazySteve0605)
+
 ### Changes
 
 ### Bug Fixes
@@ -15,6 +19,8 @@
 ### Changes for Developers
 
 Please refer to [the developer guide](https://download.nvaccess.org/documentation/developerGuide.html#API) for information on NVDA's API deprecation and removal process.
+
+* Added [cppjieba](https://github.com/yanyiwu/cppjieba) as a git submodule for Chinese word segmentation. (#18548, @CrazySteve0605)
 
 #### Deprecations
 
@@ -50,9 +56,6 @@ Please refer to [the developer guide](https://download.nvaccess.org/documentatio
 Consult the speech dictionaries section in the User Guide for more details. (#19506, @LeonarddeR)
 * When resetting the configuration to factory defaults from the NVDA menu, a dialog is now shown afterwards with an Undo button to restore the previous configuration.
 The triple-press keyboard shortcut (`NVDA+ctrl+r`) is not affected, as it is intended for recovery scenarios. (#19575, @bramd)
-* Chinese text can now be navigated by word using built-in input gestures.
-  Several GUI elements were added to configure this in the `Document Navigation` panel. (#18735, @CrazySteve0605)
-* Braille output for Chinese now includes spaces between words. (#18865, @CrazySteve0605)
 * Added an unassigned command to report the current status of the Screen Curtain. (#19759)
 * DotPad braille displays now support multi-button combination gestures. (#19565, @bramd)
   * You can now press multiple buttons simultaneously to create custom gestures (e.g., `f1+panLeft`).
@@ -125,7 +128,6 @@ It only ran the translation string comment check, which is equivalent to `scons 
 The `scons checkPot` target has also been replaced with `runcheckpot.bat`.
 Use the individual test commands instead: `runcheckpot.bat`, `rununittests.bat`, `runsystemtests.bat`, `runlint.bat`. (#19606, #19676, @bramd)
 * Updated Python 3.13.11 to 3.13.12 (#19572, @dpy013)
-* Added [cppjieba](https://github.com/yanyiwu/cppjieba) as a git submodule for Chinese word segmentation. (#18548, @CrazySteve0605)
 * Added a private `_asyncioEventLoop` module that provides an asyncio event loop running on a background thread for use by NVDA components. (#19816, @bramd)
 * Added several functions related to the braille auto-scroll feature. (#18573, @nvdaes):
   * Added an `autoScroll` method to `braille.handler`.

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -7,7 +7,7 @@
 ### New Features
 
 * Chinese text can now be navigated by word using built-in input gestures.
-  Several GUI elements were added to configure this in the `Document Navigation` panel. (#18735, @CrazySteve0605)
+  Several GUI elements were added to configure this in the "Document Navigation" panel. (#18735, @CrazySteve0605)
 * Braille output for Chinese now includes spaces between words. (#18865, @CrazySteve0605)
 
 ### Changes

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -3553,6 +3553,8 @@ This may be useful when reading a document where blank lines are used to separat
 
 This category allows you to adjust various aspects of document navigation.
 
+##### Word Segmentation Standard {#WordSegmentationStandard}
+
 ##### Paragraph Style {#ParagraphStyle}
 
 | . {.hideHeaderRow} |.|

--- a/uv.lock
+++ b/uv.lock
@@ -552,6 +552,7 @@ dependencies = [
     { name = "nh3", marker = "sys_platform == 'win32'" },
     { name = "pycaw", marker = "sys_platform == 'win32'" },
     { name = "pymdown-extensions", marker = "sys_platform == 'win32'" },
+    { name = "pyphen", marker = "sys_platform == 'win32'" },
     { name = "pyserial", marker = "sys_platform == 'win32'" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
     { name = "regex", marker = "sys_platform == 'win32'" },
@@ -612,6 +613,7 @@ requires-dist = [
     { name = "nh3", specifier = "==0.3.2" },
     { name = "pycaw", specifier = "==20251023" },
     { name = "pymdown-extensions", specifier = "==10.17.1" },
+    { name = "pyphen", specifier = "==0.17.2" },
     { name = "pyserial", specifier = "==3.5" },
     { name = "pywin32", specifier = "==311" },
     { name = "regex", specifier = "==2026.4.4" },
@@ -861,6 +863,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e8/52/d87eba7cb129b81563019d1679026e7a112ef76855d6159d24754dbd2a51/pyperclip-1.11.0.tar.gz", hash = "sha256:244035963e4428530d9e3a6101a1ef97209c6825edab1567beac148ccc1db1b6", size = 12185, upload-time = "2025-09-26T14:40:37.245Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/df/80/fc9d01d5ed37ba4c42ca2b55b4339ae6e200b456be3a1aaddf4a9fa99b8c/pyperclip-1.11.0-py3-none-any.whl", hash = "sha256:299403e9ff44581cb9ba2ffeed69c7aa96a008622ad0c46cb575ca75b5b84273", size = 11063, upload-time = "2025-09-26T14:40:36.069Z" },
+]
+
+[[package]]
+name = "pyphen"
+version = "0.17.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/69/56/e4d7e1bd70d997713649c5ce530b2d15a5fc2245a74ca820fc2d51d89d4d/pyphen-0.17.2.tar.gz", hash = "sha256:f60647a9c9b30ec6c59910097af82bc5dd2d36576b918e44148d8b07ef3b4aa3", size = 2079470, upload-time = "2025-01-20T13:18:36.296Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/1f/c2142d2edf833a90728e5cdeb10bdbdc094dde8dbac078cee0cf33f5e11b/pyphen-0.17.2-py3-none-any.whl", hash = "sha256:3a07fb017cb2341e1d9ff31b8634efb1ae4dc4b130468c7c39dd3d32e7c3affd", size = 2079358, upload-time = "2025-01-20T13:18:29.629Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR addresses selected review suggestions from Sean on PR #19166 and syncs the branch with the latest master.

Completed:
- [x] Move the braille offset converter helper out of the nested function.
- [x] Move the word segmentation braille converter import out of the local scope.
- [x] Move the word segmentation initialization debug log into initialize().
- [x] Remove unsupported RuntimeError-specific handling around wordSeg.initialize().
- [x] Log word segmentation initializer resolution and execution failures.
- [x] Add missing return type annotations for wordSegFlag properties.
- [x] Remove redundant int annotations from IntFlag members.
- [x] Move test helper objects out of nested scopes and add type hints.
- [x] Move braille test configuration setup/cleanup into setUp and tearDown.
- [x] Update the help ID casing for the word segmentation setting.
- [x] Add a user guide section for the word segmentation setting.
- [x] Move the Chinese word segmentation change log entries to 2026.3.
- [x] Sync with the latest nvaccess/master.

Remaining:
- [ ] Confirm whether the new config option should be exposed in the UI.