### PR TITLE
Fix #20148: set disabled state if starting magnifier failed

### DIFF
--- a/source/_magnifier/__init__.py
+++ b/source/_magnifier/__init__.py
@@ -99,7 +99,7 @@ def start() -> None:
 		log.error("Attempted to start magnifier, but it is not initialized.")
 		return
 	_magnifier._startMagnifier()
-	setEnabled(True)
+	setEnabled(isActive())
 
 
 def stop(persist: bool = True) -> None:
@@ -110,7 +110,7 @@ def stop(persist: bool = True) -> None:
 	if isActive():
 		_magnifier._stopMagnifier()
 		if persist:
-			setEnabled(False)
+			setEnabled(isActive())
 	else:
 		log.debug("Attempted to stop magnifier, but it is not active.")
 


### PR DESCRIPTION

### Link to issue number:
Fix #20148

### Summary of the issue:

If the magnifier failed to start (E.g. if screen curtain or win mag was running), the enabled state was still set to True

### Description of user facing changes:
magnifier state now accurately reflects if magnifier failed to start

### Description of developer facing changes:
none
### Description of development approach:
check if running when setting state
### Testing strategy:
tested steps from #20148
### Known issues with pull request:
none
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
