### PR TITLE
Clean up type hints and style for Chinese word segmentation

### DIFF
--- a/nvdaHelper/cppjieba/sconscript
+++ b/nvdaHelper/cppjieba/sconscript
@@ -4,7 +4,6 @@
 # For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
 
 import typing  # noqa: E402
-import os
 
 Import(
 	[
@@ -19,14 +18,13 @@ cppjiebaPath = Dir("#include/cppjieba")
 cppjiebaSrcPath = cppjiebaPath.Dir("include/cppjieba")
 cppjiebaDictPath = cppjiebaPath.Dir("dict")
 outDir = sourceDir.Dir("cppjieba")
-unitTestDictsDir = env.Dir("#tests/unit/cppjiebaDicts")
-LimonpPath = cppjiebaPath.Dir("deps/limonp")  # cppjieba's dependency
-LimonpSrcPath = LimonpPath.Dir("include/limonp")
+limonpPath = cppjiebaPath.Dir("deps/limonp")  # cppjieba's dependency
+limonpSrcPath = limonpPath.Dir("include/limonp")
 
 env.Prepend(
 	CPPPATH=[
 		cppjiebaSrcPath,
-		LimonpSrcPath.Dir(".."),
+		limonpSrcPath.Dir(".."),
 	]
 )
 
@@ -36,8 +34,8 @@ sourceFiles = [
 ]
 
 env.AppendUnique(
-    CCFLAGS=['/wd4819'],
-    CXXFLAGS=['/wd4819'],
+	CCFLAGS=["/wd4819"],
+	CXXFLAGS=["/wd4819"],
 )
 
 cppjiebaLib = env.SharedLibrary(target="cppjieba", source=sourceFiles)
@@ -51,7 +49,7 @@ env.Install(
 			"user.dict.utf8",
 			"hmm_model.utf8",
 		)
-	]
+	],
 )
 
 Return("cppjiebaLib")

--- a/source/config/featureFlagEnums.py
+++ b/source/config/featureFlagEnums.py
@@ -148,7 +148,7 @@ class WordNavigationUnitFlag(DisplayStringEnum):
 	CHINESE = enum.auto()
 
 	@property
-	def _displayStringLabels(self):
+	def _displayStringLabels(self) -> dict["WordNavigationUnitFlag", str]:
 		return {
 			# Translators: Label for a method of word segmentation.
 			self.AUTO: _("Auto"),

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -3565,11 +3565,11 @@ class DocumentNavigationPanel(SettingsPanel):
 		)
 		self.bindHelpEvent("ParagraphStyle", self.paragraphStyleCombo)
 
-	def onSave(self):
+	def onSave(self) -> None:
 		self.wordSegCombo.saveCurrentValueToConf()
 		self.paragraphStyleCombo.saveCurrentValueToConf()
 
-	def postSave(self):
+	def postSave(self) -> None:
 		from textUtils import wordSeg
 
 		try:

--- a/source/textInfos/offsets.py
+++ b/source/textInfos/offsets.py
@@ -19,13 +19,17 @@ import textUtils
 from textUtils.segFlag import CharSegFlag, WordSegFlag
 from dataclasses import dataclass
 from typing import (
-	Optional,
-	Tuple,
 	Dict,
 	List,
+	Optional,
 	Self,
+	Tuple,
+	TYPE_CHECKING,
 )
 from logHandler import log
+
+if TYPE_CHECKING:
+	from NVDAObjects import NVDAObject
 
 
 @dataclass
@@ -585,7 +589,7 @@ class OffsetsTextInfo(textInfos.TextInfo):
 	def expand(self, unit):
 		if unit == textInfos.UNIT_WORD and self.isCollapsed and self._startOffset == self._getStoryLength():
 			try:
-				flowsTo: object | None = self.obj.flowsTo
+				flowsTo: "NVDAObject | None" = self.obj.flowsTo
 			except (AttributeError, NotImplementedError):
 				flowsTo = None
 			if not flowsTo:

--- a/source/textInfos/offsets.py
+++ b/source/textInfos/offsets.py
@@ -11,6 +11,7 @@ import NVDAHelper
 import config.featureFlagEnums
 import NVDAState
 import config
+from config.featureFlag import FeatureFlag
 import textInfos
 import locationHelper
 from treeInterceptorHandler import TreeInterceptor
@@ -494,9 +495,7 @@ class OffsetsTextInfo(textInfos.TextInfo):
 		Subclasses may extend this to perform implementation specific initialisation, calling their superclass method afterwards.
 		"""
 		super(OffsetsTextInfo, self).__init__(obj, position)
-		self.wordSegConf: config.featureFlag.FeatureFlag = config.conf["documentNavigation"][
-			"wordSegmentationStandard"
-		]
+		self.wordSegConf: FeatureFlag = config.conf["documentNavigation"]["wordSegmentationStandard"]
 
 		from NVDAObjects import NVDAObject
 
@@ -586,7 +585,7 @@ class OffsetsTextInfo(textInfos.TextInfo):
 	def expand(self, unit):
 		if unit == textInfos.UNIT_WORD and self.isCollapsed and self._startOffset == self._getStoryLength():
 			try:
-				flowsTo = self.obj.flowsTo
+				flowsTo: object | None = self.obj.flowsTo
 			except (AttributeError, NotImplementedError):
 				flowsTo = None
 			if not flowsTo:

--- a/source/textUtils/__init__.py
+++ b/source/textUtils/__init__.py
@@ -592,11 +592,16 @@ class WordSegmenter:
 
 	# Precompiled patterns
 	# Chinese characters and Japanese kanji (CJK Unified Ideographs U+4E00 - U+9FFF)
-	_CHINESE_CHARACTER_AND_JAPANESE_KANJI: re.Pattern = re.compile(r"[\u4E00-\u9FFF]")
+	_CHINESE_CHARACTER_AND_JAPANESE_KANJI: re.Pattern[str] = re.compile(r"[\u4E00-\u9FFF]")
 	# Japanese kana (Hiragana U+3040 - U+309F, Katakana U+30A0 - U+30FF)
-	_KANA: re.Pattern = re.compile(r"[\u3040-\u309F\u30A0-\u30FF]")
+	_KANA: re.Pattern[str] = re.compile(r"[\u3040-\u309F\u30A0-\u30FF]")
 
-	def __init__(self, text: str, encoding: str = "UTF-8", wordSegFlag: WordSegFlag = WordSegFlag.AUTO):
+	def __init__(
+		self,
+		text: str,
+		encoding: str | None = "UTF-8",
+		wordSegFlag: WordSegFlag = WordSegFlag.AUTO,
+	) -> None:
 		self.text: str = text
 		self.encoding: str | None = encoding
 		self.wordSegFlag: WordSegFlag = wordSegFlag

--- a/source/textUtils/__init__.py
+++ b/source/textUtils/__init__.py
@@ -630,7 +630,7 @@ class WordSegmenter:
 					if wordSegStrategy.ChineseWordSegmentationStrategy._lib:
 						return wordSegStrategy.ChineseWordSegmentationStrategy(self.text, self.encoding)
 					else:
-						log.debugWarning("Chinese word segmenter is loading. Falling back to Uniscribe.")
+						log.debugWarning("Chinese word segmenter is currently unavailable. Falling back to Uniscribe.")
 						return wordSegStrategy.UniscribeWordSegmentationStrategy(self.text, self.encoding)
 				case _:
 					return wordSegStrategy.UniscribeWordSegmentationStrategy(self.text, self.encoding)

--- a/source/textUtils/__init__.py
+++ b/source/textUtils/__init__.py
@@ -631,7 +631,7 @@ class WordSegmenter:
 						return wordSegStrategy.ChineseWordSegmentationStrategy(self.text, self.encoding)
 					else:
 						log.debugWarning(
-							"Chinese word segmenter is currently unavailable. Falling back to Uniscribe."
+							"Chinese word segmenter is currently unavailable. Falling back to Uniscribe.",
 						)
 						return wordSegStrategy.UniscribeWordSegmentationStrategy(self.text, self.encoding)
 				case _:

--- a/source/textUtils/__init__.py
+++ b/source/textUtils/__init__.py
@@ -630,7 +630,9 @@ class WordSegmenter:
 					if wordSegStrategy.ChineseWordSegmentationStrategy._lib:
 						return wordSegStrategy.ChineseWordSegmentationStrategy(self.text, self.encoding)
 					else:
-						log.debugWarning("Chinese word segmenter is currently unavailable. Falling back to Uniscribe.")
+						log.debugWarning(
+							"Chinese word segmenter is currently unavailable. Falling back to Uniscribe."
+						)
 						return wordSegStrategy.UniscribeWordSegmentationStrategy(self.text, self.encoding)
 				case _:
 					return wordSegStrategy.UniscribeWordSegmentationStrategy(self.text, self.encoding)

--- a/source/textUtils/wordSeg/__init__.py
+++ b/source/textUtils/wordSeg/__init__.py
@@ -15,7 +15,7 @@ from . import wordSegStrategy
 
 def _runInitializer(
 	initializer: Callable[..., Any],
-	module_name: str,
+	moduleName: str,
 	qualname: str,
 	args: tuple[Any, ...],
 	kwargs: dict[str, Any],
@@ -23,17 +23,17 @@ def _runInitializer(
 	try:
 		initializer(*args, **kwargs)
 	except Exception:
-		log.exception(f"Initializer {module_name}.{qualname} failed")
+		log.exception(f"Initializer {moduleName}.{qualname} failed")
 
 
 def initialize() -> None:
 	"""
-	Call all registered initializer functions recorded in wordSegStrategy.initializerList.
+	Call all registered initializer functions recorded in wordSegStrategy.
 
-	Each entry is a tuple: (module_name, qualname, func_obj, args, kwargs).
+	Each entry is a tuple: (moduleName, qualname, funcObj, args, kwargs).
 	We try to resolve the callable from the module and qualname at runtime
-	(this handles classmethod/staticmethod wrapping order). If resolution fails,
-	we fall back to the stored func_obj.
+	(this handles classmethod/staticmethod wrapping order).
+	If resolution fails, we fall back to the stored funcObj.
 
 	Exceptions from individual initializers are caught and logged so that one
 	failing initializer doesn't stop the rest.
@@ -41,29 +41,29 @@ def initialize() -> None:
 
 	log.debug("Initializing word segmentation module")
 
-	for module_name, qualname, func_obj, args, kwargs in wordSegStrategy.initializerList:
-		callable_to_call: Callable[..., Any] = func_obj
+	for moduleName, qualname, funcObj, args, kwargs in wordSegStrategy.iterInitializers():
+		callableToCall: Callable[..., Any] = funcObj
 		try:
-			mod = importlib.import_module(module_name)
+			mod = importlib.import_module(moduleName)
 			obj = mod
 			for part in qualname.split("."):
 				obj = getattr(obj, part)
-			callable_to_call = obj
+			callableToCall = obj
 		except Exception:
 			log.debugWarning(
-				f"Could not resolve initializer {module_name}.{qualname}; falling back to the registered function",
+				f"Could not resolve initializer {moduleName}.{qualname}; falling back to the registered function",
 				exc_info=True,
 			)
 
-		if not callable(callable_to_call):
-			log.debugWarning(f"Resolved initializer {module_name}.{qualname} is not callable; skipping")
+		if not callable(callableToCall):
+			log.debugWarning(f"Resolved initializer {moduleName}.{qualname} is not callable; skipping")
 			continue
 		try:
 			threading.Thread(
 				target=_runInitializer,
-				args=(callable_to_call, module_name, qualname, args, kwargs),
-				name=f"wordSeg initializer {module_name}.{qualname}",
+				args=(callableToCall, moduleName, qualname, args, kwargs),
+				name=f"wordSeg initializer {moduleName}.{qualname}",
 				daemon=True,
 			).start()
 		except Exception:
-			log.exception(f"Failed to start initializer {module_name}.{qualname}")
+			log.exception(f"Failed to start initializer {moduleName}.{qualname}")

--- a/source/textUtils/wordSeg/wordSegStrategy.py
+++ b/source/textUtils/wordSeg/wordSegStrategy.py
@@ -5,6 +5,7 @@
 
 import os
 from ctypes import (
+	CDLL,
 	c_bool,
 	c_char_p,
 	c_int,
@@ -15,8 +16,8 @@ from ctypes import (
 )
 from abc import ABC, abstractmethod
 from functools import lru_cache
-from collections.abc import Callable
-from typing import Any
+from collections.abc import Callable, Iterator
+from typing import Any, ParamSpec, TypeVar
 import re
 import unicodedata
 
@@ -24,40 +25,32 @@ import textUtils
 from logHandler import log
 
 
-# Initializer registry (robust: saves module + qualname + original function + args/kwargs)
-# Each entry: (module_name: str, qualname: str, func_obj: Callable, args: tuple, kwargs: dict)
-initializerList: list[tuple[str, str, Callable[..., Any], tuple[Any, ...], dict[str, Any]]] = []
+_P = ParamSpec("_P")
+_R = TypeVar("_R")
+_InitializerEntry = tuple[str, str, Callable[..., Any], tuple[Any, ...], dict[str, Any]]
+_initializerList: list[_InitializerEntry] = []
 
 
-def initializerRegistry(*decorator_args, **decorator_kwargs):
+def iterInitializers() -> Iterator[_InitializerEntry]:
+	"""Iterate over registered initializer entries."""
+	return iter(_initializerList)
+
+
+def initializerRegistry(func: Callable[_P, _R]) -> Callable[_P, _R]:
 	"""
 	A decorator to register an initializer function.
-	Usage:
-		@initializerRegistry
-		def f(): ...
-	or with arguments:
-		@initializerRegistry(arg1, arg2, kw=val)
-		def f(...): ...
-	We save (func.__module__, func.__qualname__, func, args, kwargs) so that during
-	package initialize() we can dynamically resolve the callable from the module
-	(this handles classmethod/staticmethod ordering issues).
+	We save (func.__module__, func.__qualname__, func) so that during package initialize()
+	we can dynamically resolve the callable from the module.
+	This handles classmethod/staticmethod ordering issues.
 	"""
-	if decorator_args and callable(decorator_args[0]) and len(decorator_args) == 1 and not decorator_kwargs:
-		func = decorator_args[0]
-		initializerList.append((func.__module__, func.__qualname__, func, (), {}))
-		return func
-
-	def _decorator(func: Callable[..., Any]):
-		initializerList.append((func.__module__, func.__qualname__, func, decorator_args, decorator_kwargs))
-		return func
-
-	return _decorator
+	_initializerList.append((func.__module__, func.__qualname__, func, (), {}))
+	return func
 
 
 class WordSegmentationStrategy(ABC):
 	"""Abstract base class for word segmentation strategies."""
 
-	def __init__(self, text: str, encoding: str | None = None):
+	def __init__(self, text: str, encoding: str | None = None) -> None:
 		self.text: str = text
 		self.encoding: str | None = encoding
 		self.wordEnds: list[int] = []
@@ -158,12 +151,16 @@ class UniscribeWordSegmentationStrategy(WordSegmentationStrategy):
 
 
 class ChineseWordSegmentationStrategy(WordSegmentationStrategy):
-	_lib = None
-	_LANGUAGE_PATTERN = re.compile(r"^zh", re.IGNORECASE)
+	_lib: CDLL | None = None
+	_LANGUAGE_PATTERN: re.Pattern[str] = re.compile(r"^zh", re.IGNORECASE)
+	_PUNCTUATION_CATEGORY_PREFIXES: str = "pP"
+	_OTHER_PATTERN_CATEGORY: str = "So"
 
 	@classmethod
 	@initializerRegistry
-	def _initCppJieba(cls, forceInit: bool = False):  # TODO: Add a fallback when cppjieba.dll is unavailable.
+	def _initCppJieba(
+		cls, forceInit: bool = False
+	) -> None:  # TODO: Add a fallback when cppjieba.dll is unavailable.
 		"""
 		Class-level initializer: attempts to load the versioned cppjieba library and
 		set up ctypes signatures.
@@ -186,8 +183,8 @@ class ChineseWordSegmentationStrategy(WordSegmentationStrategy):
 		try:
 			from NVDAState import ReadPaths
 
-			lib_path = os.path.join(ReadPaths.coreArchLibPath, "cppjieba.dll")
-			lib = cdll.LoadLibrary(lib_path)
+			libPath = os.path.join(ReadPaths.coreArchLibPath, "cppjieba.dll")
+			lib = cdll.LoadLibrary(libPath)
 
 			# Setup function signatures
 			# bool initJieba(const char* dictDir)
@@ -217,11 +214,11 @@ class ChineseWordSegmentationStrategy(WordSegmentationStrategy):
 			# Initialize with dictionary path
 			import globalVars
 
-			DICTS_DIR = os.path.join(globalVars.appDir, "cppjieba", "dicts")
-			DICTS_DIR_BYTES = DICTS_DIR.encode("utf-8")
-			dictDir = create_string_buffer(DICTS_DIR_BYTES)
+			dictsDir = os.path.join(globalVars.appDir, "cppjieba", "dicts")
+			dictsDirBytes = dictsDir.encode("utf-8")
+			dictDir = create_string_buffer(dictsDirBytes)
 			if not lib.initJieba(dictDir):
-				log.debugWarning("Failed to initialize cppjieba library with dictionary path: %s", DICTS_DIR)
+				log.debugWarning("Failed to initialize cppjieba library with dictionary path: %s", dictsDir)
 				cls._lib = None
 				return
 			cls._lib = lib
@@ -230,7 +227,7 @@ class ChineseWordSegmentationStrategy(WordSegmentationStrategy):
 			cls._lib = None
 
 	@lru_cache(maxsize=256)
-	def _callCppjiebaCached(self, text_utf8: bytes) -> list[int]:
+	def _callCppJiebaCached(self, textUtf8: bytes) -> list[int]:
 		if self._lib is None:
 			return []
 
@@ -238,7 +235,7 @@ class ChineseWordSegmentationStrategy(WordSegmentationStrategy):
 		outLen = c_int(0)
 
 		try:
-			success: bool = self._lib.calculateWordOffsets(text_utf8, byref(charPtr), byref(outLen))
+			success: bool = self._lib.calculateWordOffsets(textUtf8, byref(charPtr), byref(outLen))
 			if not success or not bool(charPtr) or outLen.value <= 0:
 				return []
 
@@ -257,7 +254,7 @@ class ChineseWordSegmentationStrategy(WordSegmentationStrategy):
 				log.debugWarning("Failed to free cppjieba offsets after error: %s", cleanupErr)
 			return []
 
-	def _callCPPJieba(self) -> list[int]:
+	def _callCppJieba(self) -> list[int]:
 		"""
 		Instance method: encode self.text and call cppjieba.
 		Returns list[int] on success, or an empty list on failure.
@@ -266,7 +263,7 @@ class ChineseWordSegmentationStrategy(WordSegmentationStrategy):
 		data = self.text.encode("utf-8")
 
 		if getattr(self, "_lib", None) is ChineseWordSegmentationStrategy._lib:
-			return self._callCppjiebaCached(data)
+			return self._callCppJiebaCached(data)
 		else:
 			if self._lib is None:
 				return []
@@ -312,16 +309,12 @@ class ChineseWordSegmentationStrategy(WordSegmentationStrategy):
 				# separator already present at either side -> skip adding
 				continue
 
-			# Unicode categories for punctuation
-			PUNCTUATION_CATEGORIES: str = "pP"
-			# Unicode categories for other (mainly for braille) patterns
-			OTHER_PATTERN_CATEGORIES: str = "So"
 			# Determine whether any punctuation forbids a separator
 			noSep = (
-				unicodedata.category(self.text[curIndex - 1])[0] in PUNCTUATION_CATEGORIES
-				or unicodedata.category(self.text[curIndex - 1]) == OTHER_PATTERN_CATEGORIES
-				or unicodedata.category(self.text[curIndex])[0] in PUNCTUATION_CATEGORIES
-				or unicodedata.category(self.text[curIndex]) == OTHER_PATTERN_CATEGORIES
+				unicodedata.category(self.text[curIndex - 1])[0] in self._PUNCTUATION_CATEGORY_PREFIXES
+				or unicodedata.category(self.text[curIndex - 1]) == self._OTHER_PATTERN_CATEGORY
+				or unicodedata.category(self.text[curIndex])[0] in self._PUNCTUATION_CATEGORY_PREFIXES
+				or unicodedata.category(self.text[curIndex]) == self._OTHER_PATTERN_CATEGORY
 			)
 
 			if not noSep:
@@ -337,6 +330,6 @@ class ChineseWordSegmentationStrategy(WordSegmentationStrategy):
 	def getSegmentForOffset(self, offset: int) -> tuple[int, int] | None:
 		return self.getWordOffsetRange(offset)
 
-	def __init__(self, text, encoding=None):
+	def __init__(self, text: str, encoding: str | None = None) -> None:
 		super().__init__(text, encoding)
-		self.wordEnds = self._callCPPJieba()
+		self.wordEnds = self._callCppJieba()

--- a/source/textUtils/wordSeg/wordSegStrategy.py
+++ b/source/textUtils/wordSeg/wordSegStrategy.py
@@ -161,7 +161,7 @@ class ChineseWordSegmentationStrategy(WordSegmentationStrategy):
 	def _initCppJieba(
 		cls,
 		forceInit: bool = False,
-	) -> None:  # TODO: Add a fallback when cppjieba.dll is unavailable.
+	) -> None:
 		"""
 		Class-level initializer: attempts to load the versioned cppjieba library and
 		set up ctypes signatures.

--- a/source/textUtils/wordSeg/wordSegStrategy.py
+++ b/source/textUtils/wordSeg/wordSegStrategy.py
@@ -159,7 +159,8 @@ class ChineseWordSegmentationStrategy(WordSegmentationStrategy):
 	@classmethod
 	@initializerRegistry
 	def _initCppJieba(
-		cls, forceInit: bool = False
+		cls,
+		forceInit: bool = False,
 	) -> None:  # TODO: Add a fallback when cppjieba.dll is unavailable.
 		"""
 		Class-level initializer: attempts to load the versioned cppjieba library and

--- a/source/textUtils/wordSeg/wordSegUtils.py
+++ b/source/textUtils/wordSeg/wordSegUtils.py
@@ -14,10 +14,10 @@ class WordSegWithSeparatorOffsetConverter(OffsetConverter):
 	computedStrToEncodedOffsets: list[int]
 	computedEncodedToStrOffsets: list[int]
 
-	def __init__(self, text: str):
+	def __init__(self, text: str) -> None:
 		super().__init__(text)
 		self.newSepIndex: list[int] = []
-		self.encoded = WordSegmenter(text).segmentedText(sep=self.sep, newSepIndex=self.newSepIndex)
+		self.encoded: str = WordSegmenter(text).segmentedText(sep=self.sep, newSepIndex=self.newSepIndex)
 
 	@cached_property
 	def _separatorFlag(self) -> list[bool]:

--- a/tests/unit/test_braille/test_routing.py
+++ b/tests/unit/test_braille/test_routing.py
@@ -46,7 +46,7 @@ class TestBrailleOffsetConverters(unittest.TestCase):
 		config.conf["braille"]["translationTable"] = self._originalTranslationTable
 		config.conf["braille"]["unicodeNormalization"] = self._originalUnicodeNormalization
 
-	def test_chineseWordSegmentationAndUnicodeNormalizationOffsetsAreComposed(self):
+	def test_chineseWordSegmentationAndUnicodeNormalizationOffsetsAreComposed(self) -> None:
 		config.conf["braille"]["translationTable"] = "zh-chn.ctb"
 		config.conf["braille"]["unicodeNormalization"] = "enabled"
 		wordSegmenter = Mock()

--- a/tests/unit/test_textInfos.py
+++ b/tests/unit/test_textInfos.py
@@ -178,13 +178,13 @@ class TestEndpoints(unittest.TestCase):
 
 
 class TestWordExpansion(unittest.TestCase):
-	def test_expandWordDoesNotRequireFlowsToBeforeEndOfStory(self):
+	def test_expandWordDoesNotRequireFlowsToBeforeEndOfStory(self) -> None:
 		obj = BasicTextProvider(text="one two")
 		ti = obj.makeTextInfo(Offsets(0, 0))
 		ti.expand(textInfos.UNIT_WORD)
 		self.assertEqual(ti.text, "one ")
 
-	def test_expandWordAtEndOfStoryWithoutFlowsToDoesNothing(self):
+	def test_expandWordAtEndOfStoryWithoutFlowsToDoesNothing(self) -> None:
 		obj = BasicTextProvider(text="one two")
 		ti = obj.makeTextInfo(textInfos.POSITION_ALL)
 		ti.collapse(end=True)
@@ -199,7 +199,7 @@ class _UnknownWordSegConf:
 
 
 class TestWordSegFlag(unittest.TestCase):
-	def test_unknownWordSegConfigReturnsNoneAfterLogging(self):
+	def test_unknownWordSegConfigReturnsNoneAfterLogging(self) -> None:
 		obj = BasicTextProvider(text="abc")
 		ti = obj.makeTextInfo(Offsets(0, 0))
 		ti.wordSegConf = _UnknownWordSegConf()

--- a/tests/unit/test_textUtils.py
+++ b/tests/unit/test_textUtils.py
@@ -14,6 +14,7 @@ from unittest.mock import Mock, patch
 from textUtils import UnicodeNormalizationOffsetConverter, WideStringOffsetConverter, WordSegmenter
 from textUtils.uniscribe import splitAtCharacterBoundaries
 from textUtils.segFlag import WordSegFlag
+from textUtils.wordSeg.wordSegUtils import WordSegWithSeparatorOffsetConverter
 
 FACE_PALM = "\U0001f926"  # 🤦
 SMILE = "\U0001f60a"  # 😊
@@ -450,7 +451,7 @@ class TestUniscribeSplitAtCharacterBoundaries(unittest.TestCase):
 
 
 class TestChineseWordSegmentationInitialization(unittest.TestCase):
-	def _makeMockJiebaDll(self):
+	def _makeMockJiebaDll(self) -> SimpleNamespace:
 		return SimpleNamespace(
 			initJieba=Mock(return_value=True),
 			calculateWordOffsets=Mock(),
@@ -460,7 +461,7 @@ class TestChineseWordSegmentationInitialization(unittest.TestCase):
 			freeOffsets=Mock(),
 		)
 
-	def _setWordSegConfig(self, *, initForUnusedLang: bool):
+	def _setWordSegConfig(self, *, initForUnusedLang: bool) -> Callable[[], None]:
 		import config
 		from config.featureFlag import FeatureFlag
 		from config.featureFlagEnums import WordNavigationUnitFlag
@@ -473,13 +474,13 @@ class TestChineseWordSegmentationInitialization(unittest.TestCase):
 			behaviorOfDefault=WordNavigationUnitFlag.AUTO,
 		)
 
-		def restoreConfig():
+		def restoreConfig() -> None:
 			config.conf["documentNavigation"]["initWordSegForUnusedLang"] = originalInitForUnusedLang
 			config.conf["documentNavigation"]["wordSegmentationStandard"] = originalWordSegmentationStandard
 
 		return restoreConfig
 
-	def test_doesNotInitializeForUnusedLanguageByDefault(self):
+	def test_doesNotInitializeForUnusedLanguageByDefault(self) -> None:
 		from textUtils.wordSeg.wordSegStrategy import ChineseWordSegmentationStrategy
 
 		originalLib = ChineseWordSegmentationStrategy._lib
@@ -497,7 +498,7 @@ class TestChineseWordSegmentationInitialization(unittest.TestCase):
 			ChineseWordSegmentationStrategy._lib = originalLib
 			restoreConfig()
 
-	def test_initializesForUnusedLanguageWhenConfigured(self):
+	def test_initializesForUnusedLanguageWhenConfigured(self) -> None:
 		from textUtils.wordSeg.wordSegStrategy import ChineseWordSegmentationStrategy
 
 		mockDll = self._makeMockJiebaDll()
@@ -520,7 +521,7 @@ class TestChineseWordSegmentationInitialization(unittest.TestCase):
 			ChineseWordSegmentationStrategy._lib = originalLib
 			restoreConfig()
 
-	def test_forceInitStillInitializesForUnusedLanguage(self):
+	def test_forceInitStillInitializesForUnusedLanguage(self) -> None:
 		from textUtils.wordSeg.wordSegStrategy import ChineseWordSegmentationStrategy
 
 		mockDll = self._makeMockJiebaDll()
@@ -543,7 +544,7 @@ class TestChineseWordSegmentationInitialization(unittest.TestCase):
 			ChineseWordSegmentationStrategy._lib = originalLib
 			restoreConfig()
 
-	def test_initFailureDisablesCppJieba(self):
+	def test_initFailureDisablesCppJieba(self) -> None:
 		from textUtils.wordSeg.wordSegStrategy import ChineseWordSegmentationStrategy
 
 		mockDll = self._makeMockJiebaDll()
@@ -575,7 +576,7 @@ class TestChineseWordSegmentationInitialization(unittest.TestCase):
 class TestWordSegmenter(unittest.TestCase):
 	"""Tests for the WordSegmenter class."""
 
-	def test_basicLatin(self):
+	def test_basicLatin(self) -> None:
 		text = "hello world"
 		segmenter = WordSegmenter(text, wordSegFlag=WordSegFlag.UNISCRIBE)
 		self.assertEqual(segmenter.getSegmentForOffset(0), (0, 6))
@@ -583,7 +584,7 @@ class TestWordSegmenter(unittest.TestCase):
 		self.assertEqual(segmenter.getSegmentForOffset(6), (6, 11))
 		self.assertEqual(segmenter.getSegmentForOffset(11), (6, 11))
 
-	def test_chinese(self):
+	def test_chinese(self) -> None:
 		text = "你好世界"
 
 		from textUtils.wordSeg.wordSegStrategy import ChineseWordSegmentationStrategy
@@ -596,7 +597,7 @@ class TestWordSegmenter(unittest.TestCase):
 		self.assertEqual(segmenter.getSegmentForOffset(3), (2, 4))
 		self.assertEqual(segmenter.getSegmentForOffset(4), (2, 4))
 
-	def test_chineseSegmentationFailureStoresEmptyWordEnds(self):
+	def test_chineseSegmentationFailureStoresEmptyWordEnds(self) -> None:
 		from textUtils.wordSeg.wordSegStrategy import ChineseWordSegmentationStrategy
 
 		mockDll = SimpleNamespace(
@@ -614,7 +615,7 @@ class TestWordSegmenter(unittest.TestCase):
 
 
 class TestWordSegInitialize(unittest.TestCase):
-	def test_runsAllRegisteredInitializers(self):
+	def test_runsAllRegisteredInitializers(self) -> None:
 		from textUtils import wordSeg
 		from textUtils.wordSeg import wordSegStrategy
 
@@ -649,7 +650,7 @@ class TestWordSegInitialize(unittest.TestCase):
 			("missingModule", "secondInitializer", secondInitializer, (), {}),
 		]
 		with (
-			patch.object(wordSegStrategy, "initializerList", initializerList),
+			patch.object(wordSegStrategy, "_initializerList", initializerList),
 			patch("threading.Thread", ImmediateThread),
 		):
 			wordSeg.initialize()
@@ -658,10 +659,8 @@ class TestWordSegInitialize(unittest.TestCase):
 
 
 class TestWordSegWithSeparatorOffsetConverter(unittest.TestCase):
-	def _makeConverter(self):
-		from textUtils.wordSeg.wordSegUtils import WordSegWithSeparatorOffsetConverter
-
-		def segmentedText(sep, newSepIndex):
+	def _makeConverter(self) -> WordSegWithSeparatorOffsetConverter:
+		def segmentedText(sep: str, newSepIndex: list[int]) -> str:
 			newSepIndex.append(2)
 			return "ab cd"
 
@@ -671,7 +670,7 @@ class TestWordSegWithSeparatorOffsetConverter(unittest.TestCase):
 		):
 			return WordSegWithSeparatorOffsetConverter("abcd")
 
-	def test_strToEncodedOffsetsMapsEndAndClampsOutOfRange(self):
+	def test_strToEncodedOffsetsMapsEndAndClampsOutOfRange(self) -> None:
 		converter = self._makeConverter()
 
 		self.assertEqual(converter.strToEncodedOffsets(-1), 0)
@@ -679,13 +678,13 @@ class TestWordSegWithSeparatorOffsetConverter(unittest.TestCase):
 		self.assertEqual(converter.strToEncodedOffsets(4), 5)
 		self.assertEqual(converter.strToEncodedOffsets(5, 6), (5, 5))
 
-	def test_strToEncodedOffsetsRaisesOnOutOfRangeWhenRequested(self):
+	def test_strToEncodedOffsetsRaisesOnOutOfRangeWhenRequested(self) -> None:
 		converter = self._makeConverter()
 
 		with self.assertRaises(IndexError):
 			converter.strToEncodedOffsets(5, raiseOnError=True)
 
-	def test_encodedToStrOffsetsMapsEndAndClampsOutOfRange(self):
+	def test_encodedToStrOffsetsMapsEndAndClampsOutOfRange(self) -> None:
 		converter = self._makeConverter()
 
 		self.assertEqual(converter.encodedToStrOffsets(-1), 0)
@@ -694,7 +693,7 @@ class TestWordSegWithSeparatorOffsetConverter(unittest.TestCase):
 		self.assertEqual(converter.encodedToStrOffsets(5), 4)
 		self.assertEqual(converter.encodedToStrOffsets(6, 7), (4, 4))
 
-	def test_encodedToStrOffsetsRaisesOnOutOfRangeWhenRequested(self):
+	def test_encodedToStrOffsetsRaisesOnOutOfRangeWhenRequested(self) -> None:
 		converter = self._makeConverter()
 
 		with self.assertRaises(IndexError):


### PR DESCRIPTION
This PR addresses type hint and style issues found while reviewing PR #20183.

Completed:
- [x] Preserve `initializerRegistry` signatures.
- [x] Add missing type hints in word segmentation code.
- [x] Add missing type hints in related tests.
- [x] Add type hints for document navigation save hooks.
- [x] Add type hints for word segmentation labels.
- [x] Move a test import out of local scope.
- [x] Keep initializer registry state private.
- [x] Rename word segmentation locals to NVDA style.
- [x] Clean up cppjieba sconscript naming and formatting.