### PR TITLE
Add syllable-boundary braille text wrap using pyphen hyphenation

### DIFF
--- a/source/braille.py
+++ b/source/braille.py
@@ -553,26 +553,26 @@ class Region(object):
 	"""A region of braille to be displayed.
 	Each portion of braille to be displayed is represented by a region.
 	The region is responsible for retrieving its text and the cursor and selection positions, translating it into braille cells and handling cursor routing requests relative to its braille cells.
-	The L{BrailleBuffer} containing this region will call L{update} and expect that L{brailleCells}, L{brailleCursorPos}, L{brailleSelectionStart} and L{brailleSelectionEnd} will be set appropriately.
-	L{routeTo} will be called to handle a cursor routing request.
+	The :class:`BrailleBuffer` containing this region will call :meth:`update` and expect that :attr:`brailleCells`, :attr:`brailleCursorPos`, :attr:`brailleSelectionStart` and :attr:`brailleSelectionEnd` will be set appropriately.
+	:meth:`routeTo` will be called to handle a cursor routing request.
 	"""
 
 	rawText: str = ""
 	"""The original, raw text of this region."""
 	cursorPos: int | None = None
-	"""The position of the cursor in L{rawText}, C{None} if the cursor is not in this region."""
+	"""The position of the cursor in :attr:`rawText`, ``None`` if the cursor is not in this region."""
 	selectionStart: int | None = None
-	"""The start of the selection in L{rawText} (inclusive), C{None} if there is no selection in this region."""
+	"""The start of the selection in :attr:`rawText` (inclusive), ``None`` if there is no selection in this region."""
 	selectionEnd: int | None = None
-	"""The end of the selection in L{rawText} (exclusive), C{None} if there is no selection in this region."""
+	"""The end of the selection in :attr:`rawText` (exclusive), ``None`` if there is no selection in this region."""
 	rawTextTypeforms: list[int] | None = None
-	"""liblouis typeform flags for each character in L{rawText}, C{None} if no typeform info."""
+	"""liblouis typeform flags for each character in :attr:`rawText`, ``None`` if no typeform info."""
 	brailleCursorPos: int | None = None
-	"""The position of the cursor in L{brailleCells}, C{None} if the cursor is not in this region."""
+	"""The position of the cursor in :attr:`brailleCells`, ``None`` if the cursor is not in this region."""
 	brailleSelectionStart: int | None = None
-	"""The position of the selection start in L{brailleCells}, C{None} if there is no selection in this region."""
+	"""The position of the selection start in :attr:`brailleCells`, ``None`` if there is no selection in this region."""
 	brailleSelectionEnd: int | None = None
-	"""The position of the selection end in L{brailleCells}, C{None} if there is no selection in this region."""
+	"""The position of the selection end in :attr:`brailleCells`, ``None`` if there is no selection in this region."""
 	hidePreviousRegions: bool = False
 	"""Whether to hide all previous regions."""
 	focusToHardLeft: bool = False
@@ -580,21 +580,21 @@ class Region(object):
 
 	def __init__(self):
 		self._languageIndexes: dict[int, str] = {0: self._getDefaultRegionLanguage()}
-		"""Language indexes in L{rawText}. The last language is assumed to be the final language in the region."""
+		"""Language indexes in :attr:`rawText`. The last language is assumed to be the final language in the region."""
 		self.brailleCells: list[int] = []
 		"""The translated braille representation of this region."""
 		self.rawToBraillePos: list[int] = []
-		"""A list mapping positions in L{rawText} to positions in L{brailleCells}."""
+		"""A list mapping positions in :attr:`rawText` to positions in :attr:`brailleCells`."""
 		self.brailleToRawPos: list[int] = []
-		"""A list mapping positions in L{brailleCells} to positions in L{rawText}."""
+		"""A list mapping positions in :attr:`brailleCells` to positions in :attr:`rawText`."""
 
 	def _getDefaultRegionLanguage(self) -> str:
 		"""Get the default language for a region."""
 		return louisHelper.getTableLanguage(handler.table.fileName) or languageHandler.getLanguage()
 
 	def _getLanguageAtPos(self, pos: int) -> str:
-		"""Get the language at a given position in L{rawText} based on L{_languageIndexes}."""
-		keys = list(self._languageIndexes)
+		"""Get the language at a given position in :attr:`rawText` based on :attr:`_languageIndexes`."""
+		keys = sorted(self._languageIndexes)
 		i = bisect.bisect_right(keys, pos) - 1
 		return self._languageIndexes[keys[i]]
 

--- a/source/braille.py
+++ b/source/braille.py
@@ -1,9 +1,10 @@
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-# Copyright (C) 2008-2025 NV Access Limited, Joseph Lee, Babbage B.V., Davy Kager, Bram Duvigneau,
+# Copyright (C) 2008-2026 NV Access Limited, Joseph Lee, Babbage B.V., Davy Kager, Bram Duvigneau,
 # Leonard de Ruijter, Burman's Computer and Education Ltd., Julien Cochuyt
 
+import bisect
 from enum import StrEnum
 import dataclasses
 import itertools
@@ -35,10 +36,13 @@ import ctypes.wintypes
 import threading
 import time
 import wx
+import languageHandler
 import louisHelper
 import louis
 import gui
 from controlTypes.state import State
+import textUtils
+import textUtils.hyphenation
 import winBindings.kernel32
 import winKernel
 import keyboardHandler
@@ -553,45 +557,46 @@ class Region(object):
 	L{routeTo} will be called to handle a cursor routing request.
 	"""
 
+	rawText: str = ""
+	"""The original, raw text of this region."""
+	cursorPos: int | None = None
+	"""The position of the cursor in L{rawText}, C{None} if the cursor is not in this region."""
+	selectionStart: int | None = None
+	"""The start of the selection in L{rawText} (inclusive), C{None} if there is no selection in this region."""
+	selectionEnd: int | None = None
+	"""The end of the selection in L{rawText} (exclusive), C{None} if there is no selection in this region."""
+	rawTextTypeforms: list[int] | None = None
+	"""liblouis typeform flags for each character in L{rawText}, C{None} if no typeform info."""
+	brailleCursorPos: int | None = None
+	"""The position of the cursor in L{brailleCells}, C{None} if the cursor is not in this region."""
+	brailleSelectionStart: int | None = None
+	"""The position of the selection start in L{brailleCells}, C{None} if there is no selection in this region."""
+	brailleSelectionEnd: int | None = None
+	"""The position of the selection end in L{brailleCells}, C{None} if there is no selection in this region."""
+	hidePreviousRegions: bool = False
+	"""Whether to hide all previous regions."""
+	focusToHardLeft: bool = False
+	"""Whether this region should be positioned at the absolute left of the display when focused."""
+
 	def __init__(self):
-		#: The original, raw text of this region.
-		self.rawText = ""
-		#: The position of the cursor in L{rawText}, C{None} if the cursor is not in this region.
-		#: @type: int
-		self.cursorPos = None
-		#: The start of the selection in L{rawText} (inclusive), C{None} if there is no selection in this region.
-		#: @type: int
-		self.selectionStart = None
-		#: The end of the selection in L{rawText} (exclusive), C{None} if there is no selection in this region.
-		#: @type: int
-		self.selectionEnd = None
-		#: The translated braille representation of this region.
-		#: @type: [int, ...]
-		self.brailleCells = []
-		#: liblouis typeform flags for each character in L{rawText},
-		#: C{None} if no typeform info.
-		#: @type: [int, ...]
-		self.rawTextTypeforms = None
-		#: A list mapping positions in L{rawText} to positions in L{brailleCells}.
-		#: @type: [int, ...]
-		self.rawToBraillePos = []
-		#: A list mapping positions in L{brailleCells} to positions in L{rawText}.
-		#: @type: [int, ...]
-		self.brailleToRawPos = []
-		#: The position of the cursor in L{brailleCells}, C{None} if the cursor is not in this region.
-		self.brailleCursorPos: Optional[int] = None
-		#: The position of the selection start in L{brailleCells}, C{None} if there is no selection in this region.
-		#: @type: int
-		self.brailleSelectionStart = None
-		#: The position of the selection end in L{brailleCells}, C{None} if there is no selection in this region.
-		#: @type: int
-		self.brailleSelectionEnd = None
-		#: Whether to hide all previous regions.
-		#: @type: bool
-		self.hidePreviousRegions = False
-		#: Whether this region should be positioned at the absolute left of the display when focused.
-		#: @type: bool
-		self.focusToHardLeft = False
+		self._languageIndexes: dict[int, str] = {0: self._getDefaultRegionLanguage()}
+		"""Language indexes in L{rawText}. The last language is assumed to be the final language in the region."""
+		self.brailleCells: list[int] = []
+		"""The translated braille representation of this region."""
+		self.rawToBraillePos: list[int] = []
+		"""A list mapping positions in L{rawText} to positions in L{brailleCells}."""
+		self.brailleToRawPos: list[int] = []
+		"""A list mapping positions in L{brailleCells} to positions in L{rawText}."""
+
+	def _getDefaultRegionLanguage(self) -> str:
+		"""Get the default language for a region."""
+		return louisHelper.getTableLanguage(handler.table.fileName) or languageHandler.getLanguage()
+
+	def _getLanguageAtPos(self, pos: int) -> str:
+		"""Get the language at a given position in L{rawText} based on L{_languageIndexes}."""
+		keys = list(self._languageIndexes)
+		i = bisect.bisect_right(keys, pos) - 1
+		return self._languageIndexes[keys[i]]
 
 	def update(self):
 		"""Update this region.
@@ -1400,8 +1405,15 @@ class TextInfoRegion(Region):
 		if separate and self.rawText:
 			# Separate this field text from the rest of the text.
 			text = TEXT_SEPARATOR + text
-		self.rawText += text
 		textLen = len(text)
+		# Fields are reported in NVDA's language
+		fieldLanguage = languageHandler.getLanguage()
+		rawTextLen = len(self.rawText)
+		lastLanguage = self._getLanguageAtPos(rawTextLen)
+		if fieldLanguage != lastLanguage:
+			self._languageIndexes[rawTextLen] = fieldLanguage
+			self._languageIndexes[rawTextLen + textLen] = lastLanguage
+		self.rawText += text
 		self.rawTextTypeforms.extend((louis.plain_text,) * textLen)
 		self._rawToContentPos.extend((contentPos,) * textLen)
 
@@ -1454,16 +1466,21 @@ class TextInfoRegion(Region):
 				field = command.field
 				if cmd == "formatChange":
 					typeform = self._getTypeformFromFormatField(field, formatConfig)
+					language = field.get("language")
 					text = getFormatFieldBraille(
 						field,
 						formatFieldAttributesCache,
 						self._isFormatFieldAtStart,
 						formatConfig,
 					)
+					if text:
+						# Map this field text to the start of the field's content.
+						self._addFieldText(text, self._currentContentPos)
+					rawTextLen = len(self.rawText)
+					if language and self._getLanguageAtPos(rawTextLen) != language:
+						self._languageIndexes[rawTextLen] = language
 					if not text:
 						continue
-					# Map this field text to the start of the field's content.
-					self._addFieldText(text, self._currentContentPos)
 				elif cmd == "controlStart":
 					if self._skipFieldsNotAtStartOfNode and not field.get("_startOfNode"):
 						text = None
@@ -1531,6 +1548,7 @@ class TextInfoRegion(Region):
 		self.rawText = ""
 		self.rawTextTypeforms = []
 		self.cursorPos = None
+		self._languageIndexes: dict[int, str] = {0: self._getDefaultRegionLanguage()}
 		# The output includes text representing fields which isn't part of the real content in the control.
 		# Therefore, maintain a map of positions in the output to positions in the content.
 		self._rawToContentPos = []
@@ -1917,6 +1935,11 @@ class BrailleBuffer(baseObject.AutoPropertyObject):
 				return region, bufferPos - start
 		raise LookupError("No such position")
 
+	def _getLanguageAtBufferPos(self, pos: int) -> str:
+		"""Gets the language at the given braille buffer position."""
+		region, regionPos = self.bufferPosToRegionPos(pos)
+		return region._getLanguageAtPos(regionPos)
+
 	def regionPosToBufferPos(self, region: Region, pos: int, allowNearest: bool = False) -> int:
 		"""Converts a position relative to a region to a position relative to the braille buffer.
 		:param region: The region the position is relative to.
@@ -2029,13 +2052,32 @@ class BrailleBuffer(baseObject.AutoPropertyObject):
 			elif textWrap == BrailleTextWrapFlag.MARK_WORD_CUTS and self._isMidWordCut(end, bufferEnd):
 				end -= 1
 				showContinuationMark = True
-			elif textWrap == BrailleTextWrapFlag.AT_WORD_BOUNDARIES:
+			elif textWrap in (
+				BrailleTextWrapFlag.AT_WORD_BOUNDARIES,
+				BrailleTextWrapFlag.AT_WORD_OR_SYLLABLE_BOUNDARIES,
+			):
 				try:
 					lastSpaceIndex = rindex(self.brailleCells, 0, start, end + 1)
 					if lastSpaceIndex < end:
 						# lastSpaceIndex < end proves brailleCells[end] is non-zero,
 						# so searching [start, end) yields the same lastSpaceIndex.
+						oldEnd = end
 						end = lastSpaceIndex + 1
+						if end < oldEnd and textWrap == BrailleTextWrapFlag.AT_WORD_OR_SYLLABLE_BOUNDARIES:
+							# Prefer splitting the word at a syllable boundary closer to the display edge.
+							# Note that, when the below index call fails, it is appropriately handled by the except block,
+							# which means that we won't split at a syllable boundary in this case.
+							nextSpace = self.brailleCells.index(0, oldEnd, bufferEnd)
+							word = self.bufferPositionsToRawText(end, nextSpace - 1)
+							if word:
+								language = self._getLanguageAtBufferPos(end)
+								rawPos = self.brailleToRawPos[end]
+								positions = textUtils.hyphenation.getHyphenPositions(word, language)
+								for posInWord in reversed(positions):
+									if (newEnd := self.rawToBraillePos[posInWord + rawPos]) < oldEnd:
+										end = newEnd
+										showContinuationMark = True
+										break
 				except (ValueError, IndexError):
 					# No space on line - fall back to display-edge cut.
 					if self._isMidWordCut(end, bufferEnd):

--- a/source/config/featureFlagEnums.py
+++ b/source/config/featureFlagEnums.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2022 NV Access Limited, Bill Dengler, Rob Meredith
+# Copyright (C) 2022-2026 NV Access Limited, Bill Dengler, Rob Meredith, Leonard de Ruijter
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
@@ -150,6 +150,7 @@ class BrailleTextWrapFlag(DisplayStringEnum):
 	NONE = enum.auto()
 	MARK_WORD_CUTS = enum.auto()
 	AT_WORD_BOUNDARIES = enum.auto()
+	AT_WORD_OR_SYLLABLE_BOUNDARIES = enum.auto()
 
 	@property
 	def _displayStringLabels(self):
@@ -160,6 +161,11 @@ class BrailleTextWrapFlag(DisplayStringEnum):
 			self.MARK_WORD_CUTS: pgettext("braille text wrap", "Show mark when words are cut"),
 			# Translators: A choice in a combo box in the braille settings panel to configure text wrapping.
 			self.AT_WORD_BOUNDARIES: pgettext("braille text wrap", "At word boundaries"),
+			self.AT_WORD_OR_SYLLABLE_BOUNDARIES: pgettext(
+				"braille text wrap",
+				# Translators: A choice in a combo box in the braille settings panel to configure text wrapping.
+				"At word or syllable boundaries",
+			),
 		}
 
 

--- a/source/louisHelper.py
+++ b/source/louisHelper.py
@@ -1,7 +1,7 @@
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-# Copyright (C) 2018-2025 NV Access Limited, Babbage B.V., Julien Cochuyt, Leonard de Ruijter
+# Copyright (C) 2018-2026 NV Access Limited, Babbage B.V., Julien Cochuyt, Leonard de Ruijter
 
 """Helper module to ease communication to and from liblouis."""
 
@@ -17,6 +17,7 @@ from typing import Generator
 import brailleTables
 import config
 import globalVars
+import languageHandler
 from logHandler import log
 
 with os.add_dll_directory(globalVars.appDir):
@@ -176,3 +177,9 @@ def translate(
 	if cursorPos is None:
 		brailleCursorPos = None
 	return braille, brailleToRawPos, rawToBraillePos, brailleCursorPos
+
+
+def getTableLanguage(table: str) -> str | None:
+	"""Get the language of a braille table, if specified in the table file."""
+	lang = louis.getTableInfo(table, "language")
+	return languageHandler.normalizeLanguage(lang) if lang else None

--- a/source/setup.py
+++ b/source/setup.py
@@ -383,7 +383,6 @@ freeze(
 			"brailleDisplayDrivers.eurobraille",
 			"brailleDisplayDrivers.dotPad",
 			"synthDrivers",
-			"textUtils",
 			"visionEnhancementProviders",
 			# Required for markdown, markdown implicitly imports this so it isn't picked up
 			"html.parser",

--- a/tests/unit/test_braille/test_calculateWindowRowBufferOffsets.py
+++ b/tests/unit/test_braille/test_calculateWindowRowBufferOffsets.py
@@ -6,6 +6,7 @@
 """Unit tests for the _calculateWindowRowBufferOffsets function in the braille module."""
 
 import unittest
+from unittest.mock import patch
 
 import braille
 import config
@@ -42,6 +43,9 @@ class TestCalculate(unittest.TestCase):
 	def tearDown(self):
 		braille.filter_displayDimensions.unregister(_getDisplayDimensions)
 		_setTextWrap(BrailleTextWrapFlag.NONE)
+		# Remove instance-level overrides of auto-properties set by syllable-boundary tests.
+		for attr in ("rawToBraillePos", "brailleToRawPos"):
+			braille.handler.buffer.__dict__.pop(attr, None)
 
 	def test_noCells(self):
 		"""Check that, if list of braille cells is empty, offsets will be (0, 0, False)."""
@@ -144,3 +148,112 @@ class TestCalculate(unittest.TestCase):
 			braille._WindowRowPositions(0, 19, True),
 		)
 		self.assertTrue(braille.handler.buffer._windowRowBufferOffsets[0].showContinuationMark)
+
+	def test_atWordOrSyllableBoundaries_success(self):
+		"""AT_WORD_OR_SYLLABLE_BOUNDARIES splits at a syllable boundary and marks the row."""
+		_setTextWrap(BrailleTextWrapFlag.AT_WORD_OR_SYLLABLE_BOUNDARIES)
+		# Layout:
+		#   cells 0..9     -> short word
+		#   cell  10       -> space
+		#   cells 11..29   -> 19-cell long word that crosses the 20-cell display edge
+		#   cell  30       -> space
+		#   cells 31..35   -> tail
+		cells = [1] * 10 + [0] + [1] * 19 + [0] + [1] * 5
+		braille.handler.buffer.brailleCells = cells
+		# rawToBraillePos/brailleToRawPos are Getter (non-data) descriptors via
+		# AutoPropertyObject, so setting them on the instance shadows the descriptor.
+		# Cleanup happens in tearDown.
+		braille.handler.buffer.rawToBraillePos = list(range(len(cells)))
+		braille.handler.buffer.brailleToRawPos = list(range(len(cells)))
+		with (
+			patch.object(
+				braille.handler.buffer,
+				"bufferPositionsToRawText",
+				return_value="abcdefghijklmnopqrs",
+			),
+			patch.object(braille.handler.buffer, "_getLanguageAtBufferPos", return_value="en_US"),
+			patch(
+				"braille.textUtils.hyphenation.getHyphenPositions",
+				return_value=(3,),
+			),
+		):
+			braille.handler.buffer._calculateWindowRowBufferOffsets(0)
+		# Syllable split at rawPos 3 + brailleStart 11 = 14.
+		self.assertEqual(
+			braille.handler.buffer._windowRowBufferOffsets[0],
+			braille._WindowRowPositions(0, 14, True),
+		)
+		self.assertTrue(braille.handler.buffer._windowRowBufferOffsets[0].showContinuationMark)
+
+	def test_atWordOrSyllableBoundaries_emptyPositions(self):
+		"""AT_WORD_OR_SYLLABLE_BOUNDARIES with no hyphen positions falls back to a word boundary with no marker."""
+		_setTextWrap(BrailleTextWrapFlag.AT_WORD_OR_SYLLABLE_BOUNDARIES)
+		# Provide a real space so `rindex(... end+1)` / `rindex(... end)` succeeds.
+		cells = [1] * 15 + [0] + [1] * 9 + [0] + [1] * 10
+		braille.handler.buffer.brailleCells = cells
+		# See test_atWordOrSyllableBoundaries_success for why direct assignment works here.
+		braille.handler.buffer.rawToBraillePos = list(range(len(cells)))
+		braille.handler.buffer.brailleToRawPos = list(range(len(cells)))
+		with (
+			patch.object(braille.handler.buffer, "bufferPositionsToRawText", return_value="word"),
+			patch.object(braille.handler.buffer, "_getLanguageAtBufferPos", return_value="en_US"),
+			patch(
+				"braille.textUtils.hyphenation.getHyphenPositions",
+				return_value=(),
+			),
+		):
+			braille.handler.buffer._calculateWindowRowBufferOffsets(0)
+		# End should be just after the last space in row 0 (index 15 -> end = 16).
+		self.assertEqual(
+			braille.handler.buffer._windowRowBufferOffsets[0],
+			braille._WindowRowPositions(0, 16, False),
+		)
+		self.assertFalse(braille.handler.buffer._windowRowBufferOffsets[0].showContinuationMark)
+
+	def test_atWordOrSyllableBoundaries_positionPastEdge(self):
+		"""AT_WORD_OR_SYLLABLE_BOUNDARIES with newEnd >= oldEnd falls back to word boundary."""
+		_setTextWrap(BrailleTextWrapFlag.AT_WORD_OR_SYLLABLE_BOUNDARIES)
+		cells = [1] * 15 + [0] + [1] * 9 + [0] + [1] * 10
+		braille.handler.buffer.brailleCells = cells
+		# See test_atWordOrSyllableBoundaries_success for why direct assignment works here.
+		braille.handler.buffer.rawToBraillePos = list(range(len(cells)))
+		braille.handler.buffer.brailleToRawPos = list(range(len(cells)))
+		with (
+			patch.object(braille.handler.buffer, "bufferPositionsToRawText", return_value="word"),
+			patch.object(braille.handler.buffer, "_getLanguageAtBufferPos", return_value="en_US"),
+			# Position that maps past the display edge.
+			patch(
+				"braille.textUtils.hyphenation.getHyphenPositions",
+				return_value=(22,),
+			),
+		):
+			braille.handler.buffer._calculateWindowRowBufferOffsets(0)
+		# Falls back to word boundary at position 16.
+		self.assertEqual(
+			braille.handler.buffer._windowRowBufferOffsets[0],
+			braille._WindowRowPositions(0, 16, False),
+		)
+		self.assertFalse(braille.handler.buffer._windowRowBufferOffsets[0].showContinuationMark)
+
+	def test_atWordOrSyllableBoundaries_unknownLanguage(self):
+		"""AT_WORD_OR_SYLLABLE_BOUNDARIES with an unknown language behaves like empty positions."""
+		_setTextWrap(BrailleTextWrapFlag.AT_WORD_OR_SYLLABLE_BOUNDARIES)
+		cells = [1] * 15 + [0] + [1] * 9 + [0] + [1] * 10
+		braille.handler.buffer.brailleCells = cells
+		# See test_atWordOrSyllableBoundaries_success for why direct assignment works here.
+		braille.handler.buffer.rawToBraillePos = list(range(len(cells)))
+		braille.handler.buffer.brailleToRawPos = list(range(len(cells)))
+		with (
+			patch.object(braille.handler.buffer, "bufferPositionsToRawText", return_value="word"),
+			patch.object(braille.handler.buffer, "_getLanguageAtBufferPos", return_value="zz_ZZ"),
+			patch(
+				"braille.textUtils.hyphenation.getHyphenPositions",
+				return_value=(),
+			),
+		):
+			braille.handler.buffer._calculateWindowRowBufferOffsets(0)
+		self.assertEqual(
+			braille.handler.buffer._windowRowBufferOffsets[0],
+			braille._WindowRowPositions(0, 16, False),
+		)
+		self.assertFalse(braille.handler.buffer._windowRowBufferOffsets[0].showContinuationMark)

--- a/tests/unit/test_braille/test_regionLanguageIndexes.py
+++ b/tests/unit/test_braille/test_regionLanguageIndexes.py
@@ -20,10 +20,10 @@ class _FakeInfo:
 	isCollapsed = False
 	obj = _FakeObj()
 
-	def __init__(self, commands):
+	def __init__(self, commands: textInfos.TextInfo.TextWithFieldsT):
 		self._commands = commands
 
-	def getTextWithFields(self, formatConfig=None):
+	def getTextWithFields(self, formatConfig: dict | None = None):
 		return self._commands
 
 

--- a/tests/unit/test_braille/test_regionLanguageIndexes.py
+++ b/tests/unit/test_braille/test_regionLanguageIndexes.py
@@ -1,0 +1,126 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2026 NV Access Limited, Leonard de Ruijter
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
+
+"""Unit tests for Region language index tracking in the braille module."""
+
+import unittest
+from unittest.mock import patch
+
+import braille
+import textInfos
+
+
+def _makeTextInfoRegion() -> braille.TextInfoRegion:
+	"""Build a TextInfoRegion without going through __init__ (which requires an NVDAObject)."""
+	region = braille.TextInfoRegion.__new__(braille.TextInfoRegion)
+	braille.Region.__init__(region)
+	# Force a deterministic default language so we don't depend on NVDA's configured locale.
+	region._languageIndexes = {0: "en"}
+	return region
+
+
+class TestLanguageIndexes(unittest.TestCase):
+	def test_freshRegion_defaultLanguageAtAnyPos(self):
+		"""A region returns the default language for any non-negative pos."""
+		# Stub default language so Region.__init__ doesn't depend on NVDA's configured locale.
+		with patch.object(braille.Region, "_getDefaultRegionLanguage", return_value="en"):
+			region = braille.Region()
+		self.assertEqual(region._getLanguageAtPos(0), "en")
+		self.assertEqual(region._getLanguageAtPos(5), "en")
+		self.assertEqual(region._getLanguageAtPos(100), "en")
+
+	def test_addFieldText_insertsSwitchAndRestore(self):
+		"""_addFieldText inserts a switch entry at len(rawText) and a restore entry at len+textLen when the field language differs."""
+		region = _makeTextInfoRegion()
+		# Pre-existing raw text to make `len(rawText)` non-zero and exercise the separator logic.
+		region.rawText = "hello"
+		region.rawTextTypeforms = []
+		region._rawToContentPos = list(range(5))
+		rawTextLenBefore = len(region.rawText)
+		text = "field"
+		with patch("braille.languageHandler.getLanguage", return_value="fr"):
+			region._addFieldText(text, contentPos=0)
+		# `_addFieldText` prepends TEXT_SEPARATOR when `separate=True` and there is pre-existing text.
+		addedLen = len(braille.TEXT_SEPARATOR) + len(text)
+		self.assertIn(rawTextLenBefore, region._languageIndexes)
+		self.assertEqual(region._languageIndexes[rawTextLenBefore], "fr")
+		self.assertIn(rawTextLenBefore + addedLen, region._languageIndexes)
+		self.assertEqual(region._languageIndexes[rawTextLenBefore + addedLen], "en")
+
+	def test_addTextWithFields_formatChangeInsertsLanguageIndex(self):
+		"""Processing a formatChange command whose field has a `language` attribute inserts an index entry."""
+		region = _makeTextInfoRegion()
+		region.rawText = ""
+		region.rawTextTypeforms = []
+		region._rawToContentPos = []
+		region._currentContentPos = 0
+		region._endsWithField = False
+		region._isFormatFieldAtStart = True
+		region._skipFieldsNotAtStartOfNode = False
+		region.cursorPos = None
+		region.selectionStart = region.selectionEnd = None
+
+		# Build a minimal list of commands: text, then a formatChange with language=de, then more text.
+		field = textInfos.FormatField()
+		field["language"] = "de"
+		commands = [
+			"pre ",
+			textInfos.FieldCommand(command="formatChange", field=field),
+			"post",
+		]
+
+		class FakeObj:
+			_brailleFormatFieldAttributesCache: dict = {}
+
+		class FakeInfo:
+			isCollapsed = False
+			obj = FakeObj()
+
+			def getTextWithFields(self, formatConfig=None):
+				return commands
+
+		formatConfig = {
+			"reportClickable": False,
+		}
+		# Stub helpers that would otherwise require a real NVDA environment.
+		with (
+			patch("braille.getFormatFieldBraille", return_value=""),
+			patch.object(
+				braille.TextInfoRegion,
+				"_getTypeformFromFormatField",
+				return_value=0,
+			),
+		):
+			region._addTextWithFields(FakeInfo(), formatConfig)
+		# The language switch should have been recorded at len("pre ") == 4.
+		self.assertIn(4, region._languageIndexes)
+		self.assertEqual(region._languageIndexes[4], "de")
+
+	def test_textInfoRegion_update_resetsLanguageIndexes(self):
+		"""TextInfoRegion.update resets _languageIndexes to {0: default} — no stale indexes carry across updates."""
+		region = _makeTextInfoRegion()
+		# Pollute _languageIndexes with stale entries.
+		region._languageIndexes = {0: "en", 10: "de", 30: "en"}
+
+		# Run only the resetting portion of `update` by making `_getSelection` raise immediately,
+		# then inspect state. The reset happens before `_getSelection` is called.
+		# Using side_effect to halt execution mid-method avoids needing the full NVDA environment
+		# that the rest of update() requires.
+		with (
+			patch.object(braille.TextInfoRegion, "_getDefaultRegionLanguage", return_value="en"),
+			patch.object(
+				braille.TextInfoRegion,
+				"_getReadingUnit",
+				return_value=textInfos.UNIT_LINE,
+			),
+			patch.object(
+				braille.TextInfoRegion,
+				"_getSelection",
+				side_effect=RuntimeError("stop-after-reset"),
+			),
+		):
+			with self.assertRaises(RuntimeError):
+				region.update()
+		self.assertEqual(region._languageIndexes, {0: "en"})

--- a/tests/unit/test_braille/test_regionLanguageIndexes.py
+++ b/tests/unit/test_braille/test_regionLanguageIndexes.py
@@ -12,6 +12,21 @@ import braille
 import textInfos
 
 
+class _FakeObj:
+	_brailleFormatFieldAttributesCache: dict = {}
+
+
+class _FakeInfo:
+	isCollapsed = False
+	obj = _FakeObj()
+
+	def __init__(self, commands):
+		self._commands = commands
+
+	def getTextWithFields(self, formatConfig=None):
+		return self._commands
+
+
 def _makeTextInfoRegion() -> braille.TextInfoRegion:
 	"""Build a TextInfoRegion without going through __init__ (which requires an NVDAObject)."""
 	region = braille.TextInfoRegion.__new__(braille.TextInfoRegion)
@@ -71,16 +86,6 @@ class TestLanguageIndexes(unittest.TestCase):
 			"post",
 		]
 
-		class FakeObj:
-			_brailleFormatFieldAttributesCache: dict = {}
-
-		class FakeInfo:
-			isCollapsed = False
-			obj = FakeObj()
-
-			def getTextWithFields(self, formatConfig=None):
-				return commands
-
 		formatConfig = {
 			"reportClickable": False,
 		}
@@ -93,7 +98,7 @@ class TestLanguageIndexes(unittest.TestCase):
 				return_value=0,
 			),
 		):
-			region._addTextWithFields(FakeInfo(), formatConfig)
+			region._addTextWithFields(_FakeInfo(commands), formatConfig)
 		# The language switch should have been recorded at len("pre ") == 4.
 		self.assertIn(4, region._languageIndexes)
 		self.assertEqual(region._languageIndexes[4], "de")

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -6,8 +6,9 @@
 
 ### New Features
 
-* The braille "word wrap" option has been replaced with a three-valued "Text wrap" option: Off, Show mark when words are cut, and At word boundaries. (#17010, @LeonarddeR)
+* The braille "word wrap" option has been replaced with a four-valued "Text wrap" option: Off, Show mark when words are cut, At word boundaries, and At word or syllable boundaries. (#17010, @LeonarddeR)
   * In modes that show a continuation mark, when a word is cut across rows, the last cell of the row now shows a continuation mark (braille dots 7-8) so it is clear that the word continues on the next row.
+  * The "At word or syllable boundaries" option uses hyphenation dictionaries to split long words at syllable boundaries when they do not fit on the display.
 
 ### Changes
 

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -2600,6 +2600,9 @@ Instead, there will be some blank space at the end of the display.
 When you scroll the display, you will be able to read the entire word.
 Note that if the word is too large to fit on the display even by itself, the word must still be split; the continuation mark is then shown.
 This option may allow for more fluent reading, but generally requires you to scroll the display more.
+* At word or syllable boundaries: Like "At word boundaries", but long words that don't fit are split at a syllable boundary when possible, using the language of the word if known.
+For example, the word `behave` may be split between `be` and `have`.
+The continuation mark is shown whenever a word is split.
 
 ##### Unicode normalization {#BrailleUnicodeNormalization}
 


### PR DESCRIPTION
### Link to issue number:
Closes #17010
Follow-up for #20146 and #20145. This is the last of three PRs replacing #19916.

### Summary of the issue:
Word wrap is sometimes pretty aggressive, especially on shorter braille displays. The previous two PRs added the text wrap infrastructure and continuation marks; this PR adds the final mode that splits long words at syllable boundaries using hyphenation dictionaries.

### Description of user facing changes:
A fourth option, **At word or syllable boundaries**, is added to the **Text wrap** combo box in braille settings. Like "At word boundaries", it avoids splitting words mid-way, but when a word is too long to fit on the display it additionally tries to split at a syllable boundary (using hyphenation dictionaries from the `pyphen` library) so less of the word spills onto the next row. NVDA marks the split with the continuation mark (braille dots 7-8).

For locales without a pyphen dictionary, the mode falls back cleanly to word-boundary behaviour without any error.

### Description of developer facing changes:
* `BrailleTextWrapFlag.AT_WORD_OR_SYLLABLE_BOUNDARIES` member added to `config.featureFlagEnums`.
* `Region._languageIndexes` (`dict[int, str]`) tracks language-span boundaries within a braille region. Populated during `_addFieldText` and `_addTextWithFields` when format fields carry a `language` attribute or when field text is in a different language than the surrounding content.
* `Region._getLanguageAtPos(pos)` looks up the language at a raw-text offset using a bisect on the (always-ascending) keys of `_languageIndexes`.
* `BrailleBuffer._getLanguageAtBufferPos(pos)` delegates to the region that owns that braille cell.
* `louisHelper.getTableLanguage(table)` queries `louis.getTableInfo` for the `"language"` key and normalises the result, providing the default language for a region when no format-field language is known.

### Description of development approach:
When `AT_WORD_OR_SYLLABLE_BOUNDARIES` is selected and a word straddles a row boundary, `_calculateWindowRowBufferOffsets` already finds the last space before the display edge. This PR adds a second pass: it looks up the full word (from that space to the next space), retrieves the language at the word's braille position, and calls `textUtils.hyphenation.getHyphenPositions` (introduced in #20145) to obtain candidate hyphen offsets. It then iterates the candidates from the end (closest to the display edge) and picks the first that falls within the current row, updating `end` accordingly and setting `showContinuationMark`.

Language tracking in `Region` ensures that the correct pyphen dictionary is selected even when a braille region contains multilingual content (e.g. a paragraph with inline foreign phrases).

### Testing strategy:
New unit tests in `test_calculateWindowRowBufferOffsets` cover:

* Successful syllable split: correct `end` and `showContinuationMark = True`.
* Empty hyphen positions: falls back to word boundary, no continuation mark.
* All hyphen positions past the display edge: falls back to word boundary.
* Unknown language: `getHyphenPositions` returns `()`, falls back to word boundary.

New unit tests in `test_regionLanguageIndexes` cover:

* Fresh region returns the default language for any position.
* `_addFieldText` inserts a switch/restore pair when field language differs.
* `_addTextWithFields` records a language index for a `formatChange` command carrying a `language` attribute.
* `TextInfoRegion.update` resets `_languageIndexes` to `{0: default}`, discarding stale entries from the previous update cycle.

Manual testing: confirmed the new option appears in the braille settings panel with the correct label, that long words are split at syllable boundaries on a 20-cell display, and that the continuation mark is shown at the split point.

### Known issues with pull request:
None.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.