### PR TITLE
Fix XLIFF generation and improve line mismatch handling

### DIFF
--- a/source/markdownTranslate.py
+++ b/source/markdownTranslate.py
@@ -283,10 +283,14 @@ def generateXliff(
 			start=1,
 		):
 			if mdLine is None:
-				print(f"Warning: {prettyPathString(mdPath)} has fewer lines than {prettyPathString(skelPath)}")
+				print(
+					f"Warning: {prettyPathString(mdPath)} has fewer lines than {prettyPathString(skelPath)}"
+				)
 				mdLine = ""
 			if skelLine is None:
-				print(f"Warning: {prettyPathString(skelPath)} has fewer lines than {prettyPathString(mdPath)}")
+				print(
+					f"Warning: {prettyPathString(skelPath)} has fewer lines than {prettyPathString(mdPath)}"
+				)
 				skelLine = ""
 			mdLine = mdLine.rstrip()
 			skelLine = skelLine.rstrip()
@@ -392,10 +396,14 @@ def translateXliff(
 			start=1,
 		):
 			if skelLine is None:
-				print(f"Warning: {prettyPathString(xliffPath)} has fewer lines than {prettyPathString(pretranslatedMdPath)}")
+				print(
+					f"Warning: {prettyPathString(xliffPath)} has fewer lines than {prettyPathString(pretranslatedMdPath)}"
+				)
 				skelLine = ""
 			if pretranslatedLine is None:
-				print(f"Warning: {prettyPathString(pretranslatedMdPath)} has fewer lines than {prettyPathString(xliffPath)}")
+				print(
+					f"Warning: {prettyPathString(pretranslatedMdPath)} has fewer lines than {prettyPathString(xliffPath)}"
+				)
 				pretranslatedLine = ""
 			skelLine = skelLine.rstrip()
 			pretranslatedLine = pretranslatedLine.rstrip()

--- a/source/markdownTranslate.py
+++ b/source/markdownTranslate.py
@@ -1,10 +1,9 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2024 NV Access Limited.
+# Copyright (C) 2024-2026 NV Access Limited.
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
-from typing import Generator
-from collections.abc import Iterable
+from collections.abc import Iterable, Generator
 import tempfile
 import os
 import contextlib
@@ -277,7 +276,7 @@ def generateXliff(
 		outputFile.write(f"<skeleton>\n{xmlEscape(skelContent)}\n</skeleton>\n")
 		res.numTranslatableStrings = 0
 		for lineNo, (mdLine, skelLine) in enumerate(
-			zip_longest(
+			zip(
 				preprocessMarkdownLines(mdFile.readlines()),
 				skelContent.splitlines(keepends=True),
 			),

--- a/source/markdownTranslate.py
+++ b/source/markdownTranslate.py
@@ -89,7 +89,7 @@ def getRawGithubURLForPath(filePath: str) -> str:
 	return f"{RAW_GITHUB_REPO_URL}/{commitID}/{relativePath}"
 
 
-def preprocessMarkdownLines(mdLines: Iterable[str]) -> Iterable[str]:
+def preprocessMarkdownLines(mdLines: Iterable[str]) -> Generator[str, None, None]:
 	"""
 	Preprocess markdown lines such as removing inline markdown lint comments.\
 	:param mdLines: The markdown lines to preprocess
@@ -276,12 +276,18 @@ def generateXliff(
 		outputFile.write(f"<skeleton>\n{xmlEscape(skelContent)}\n</skeleton>\n")
 		res.numTranslatableStrings = 0
 		for lineNo, (mdLine, skelLine) in enumerate(
-			zip(
+			zip_longest(
 				preprocessMarkdownLines(mdFile.readlines()),
 				skelContent.splitlines(keepends=True),
 			),
 			start=1,
 		):
+			if mdLine is None:
+				print(f"Warning: {prettyPathString(mdPath)} has fewer lines than {prettyPathString(skelPath)}")
+				mdLine = ""
+			if skelLine is None:
+				print(f"Warning: {prettyPathString(skelPath)} has fewer lines than {prettyPathString(mdPath)}")
+				skelLine = ""
 			mdLine = mdLine.rstrip()
 			skelLine = skelLine.rstrip()
 			if m := re_translationID.match(skelLine):
@@ -380,11 +386,17 @@ def translateXliff(
 		skeletonContent = skeletonNode.text.strip()
 		for lineNo, (skelLine, pretranslatedLine) in enumerate(
 			zip_longest(
-				skeletonContent.splitlines(),
+				skeletonContent.splitlines(keepends=True),
 				preprocessMarkdownLines(pretranslatedMdFile.readlines()),
 			),
 			start=1,
 		):
+			if skelLine is None:
+				print(f"Warning: {prettyPathString(skelLine)} has fewer lines than {prettyPathString(pretranslatedMdPath)}")
+				skelLine = ""
+			if pretranslatedLine is None:
+				print(f"Warning: {prettyPathString(pretranslatedMdPath)} has fewer lines than {prettyPathString(skelLine)}")
+				pretranslatedLine = ""
 			skelLine = skelLine.rstrip()
 			pretranslatedLine = pretranslatedLine.rstrip()
 			if m := re_translationID.match(skelLine):
@@ -510,6 +522,12 @@ def ensureMarkdownFilesMatch(path1: str, path2: str, allowBadAnchors: bool = Fal
 			),
 			start=1,
 		):
+			if line1 is None:
+				print(f"Warning: {prettyPathString(path1)} has fewer lines than {prettyPathString(path2)}")
+				line1 = ""
+			if line2 is None:
+				print(f"Warning: {prettyPathString(path2)} has fewer lines than {prettyPathString(path1)}")
+				line2 = ""
 			line1 = line1.rstrip()
 			line2 = line2.rstrip()
 			if line1 != line2:

--- a/source/markdownTranslate.py
+++ b/source/markdownTranslate.py
@@ -392,10 +392,10 @@ def translateXliff(
 			start=1,
 		):
 			if skelLine is None:
-				print(f"Warning: {prettyPathString(skelLine)} has fewer lines than {prettyPathString(pretranslatedMdPath)}")
+				print(f"Warning: {prettyPathString(xliffPath)} has fewer lines than {prettyPathString(pretranslatedMdPath)}")
 				skelLine = ""
 			if pretranslatedLine is None:
-				print(f"Warning: {prettyPathString(pretranslatedMdPath)} has fewer lines than {prettyPathString(skelLine)}")
+				print(f"Warning: {prettyPathString(pretranslatedMdPath)} has fewer lines than {prettyPathString(xliffPath)}")
 				pretranslatedLine = ""
 			skelLine = skelLine.rstrip()
 			pretranslatedLine = pretranslatedLine.rstrip()


### PR DESCRIPTION


### Link to issue number:
Fixes #20105

### Summary of the issue:
xliff generation was failing due to a line mismatch when processing out markdownlint comments
### Description of user facing changes:
none
### Description of developer facing changes:
This pull request to `source/markdownTranslate.py` improves robustness and error handling when processing markdown files, particularly when files have mismatched line counts. The changes ensure that the script does not fail when one file is shorter than another by providing warnings and substituting empty strings as needed. A

### Description of development approach:
Added checks in `generateXliff`, `translateXliff`, and `ensureMarkdownFilesMatch` to handle cases where one file has fewer lines than the other. The code now prints a warning and substitutes an empty string when a line is missing, preventing exceptions during processing. 


### Testing strategy:
tested generating xliff locally with 

`python source/markdownTranslate.py updateXliff -x user_docs/en/userGuide.xliff -m user_docs/en/userGuide.md -o $tempXliff`

### Known issues with pull request:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
