### PR TITLE
Use windows-2025-vs2026 runner image ahead of GitHub's VS2026 migration

### DIFF
--- a/.github/workflows/add-new-language.yml
+++ b/.github/workflows/add-new-language.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   add-new-languages:
-    runs-on: windows-2025
+    runs-on: windows-2025-vs2026
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
-    runs-on: windows-2025
+    runs-on: windows-2025-vs2026
     permissions:
       # required for all workflows
       security-events: write

--- a/.github/workflows/fetch-crowdin-translations.yml
+++ b/.github/workflows/fetch-crowdin-translations.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   download-from-crowdin:
-    runs-on: windows-2025
+    runs-on: windows-2025-vs2026
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/regenerate_english_userDocs_translation_source.yml
+++ b/.github/workflows/regenerate_english_userDocs_translation_source.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   rebuild-translation-source:
-    runs-on: windows-2025
+    runs-on: windows-2025-vs2026
 
     steps:
     - name: Early exit

--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -31,8 +31,8 @@ env:
   VSCMD_SKIP_SENDTELEMETRY: 1
   # Cache details about available MSVC tooling for subsequent SCons invocations to the provided file.
   SCONS_CACHE_MSVC_CONFIG: ".scons_msvc_cache.json"
-  defaultRunner: 'windows-2025'
-  supportedRunners: '["windows-2022", "windows-2025"]'
+  defaultRunner: 'windows-2025-vs2026'
+  supportedRunners: '["windows-2022", "windows-2025-vs2026"]'
   defaultArch: x64
   supportedArchitectures: '["x64"]'
   defaultPythonVersion: '3.13.12'

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -105,6 +105,7 @@ The setting is disabled by default. (#20013, @LeonarddeR)
 
 Please refer to [the developer guide](https://download.nvaccess.org/documentation/developerGuide.html#API) for information on NVDA's API deprecation and removal process.
 
+* NVDA is now built with Visual Studio 2026. (#20203, @LeonarddeR)
 * Clarified NV Access's policy on API breaking changes in the [Developer Guide](https://download.nvaccess.org/documentation/developerGuide.html#API). (#19599)
 * Updated components:
   * Ruff to 0.15.9. (#19736, #19908)

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -105,7 +105,6 @@ The setting is disabled by default. (#20013, @LeonarddeR)
 
 Please refer to [the developer guide](https://download.nvaccess.org/documentation/developerGuide.html#API) for information on NVDA's API deprecation and removal process.
 
-* NVDA is now built with Visual Studio 2026. (#20203, @LeonarddeR)
 * Clarified NV Access's policy on API breaking changes in the [Developer Guide](https://download.nvaccess.org/documentation/developerGuide.html#API). (#19599)
 * Updated components:
   * Ruff to 0.15.9. (#19736, #19908)
@@ -134,6 +133,7 @@ Use the individual test commands instead: `runcheckpot.bat`, `rununittests.bat`,
     * Added a `valueToPercentage` function to calculate the percentage representation of a configuration value within its range.
     * Added a `percentageToValue` function to convert a percentage to the corresponding configuration value.
     * Added a `clampedIncrementAndUpdateConfig` function to update a configuration value by applying a step, constrained within its valid range.
+* NVDA is now built with Visual Studio 2026. (#20203, @LeonarddeR)
 
 #### Deprecations
 


### PR DESCRIPTION
### Link to issue number:
See https://github.com/actions/runner-images/issues/14017

### Summary of the issue:
GitHub Actions will migrate the `windows-2025` (and `windows-latest`) image label to default to Visual Studio 2026 instead of VS2022. The rollout begins **June 8, 2026** and completes **June 15, 2026** ([actions/runner-images#14017](https://github.com/actions/runner-images/issues/14017)). Any workflow still using `windows-2025` after that date will silently switch to VS2026 without prior testing.

### Description of user facing changes:
None.

### Description of developer facing changes:
NVDA is now built with Visual Studio 2026. All CI workflows use the `windows-2025-vs2026` runner image label instead of `windows-2025`, opting in ahead of GitHub's forced migration (June 8–15, 2026) to catch any VS2026 incompatibilities early.

**Note: this PR can be reverted once GitHub completes the migration (expected June 15, 2026), at which point `windows-2025` and `windows-2025-vs2026` will be equivalent and the explicit label is no longer needed. It is possible that GitHub eventually deprecates this label. ON revert, the changelog should stay as is, though.**

### Description of development approach:
Runner label changed in 5 workflow files: `testAndPublish.yml`, `codeql.yml`, `fetch-crowdin-translations.yml`, `add-new-language.yml`, `regenerate_english_userDocs_translation_source.yml`.

### Testing strategy:
- [ ] CI passes on this PR with the new image label

### Known issues with pull request:
None — surfacing VS2026 breakage early is the point.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.