### PR TITLE
miscdeps submodule is enough for checkpot CI step

### DIFF
--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -174,9 +174,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v6
-      with:
-        # Include gettext
-        submodules: true
+    - name: Init miscDeps submodule
+      run: git submodule update --init miscDeps
     - name: Set up python
       uses: actions/setup-python@v6
       with:


### PR DESCRIPTION
### Link to issue number:

None.

### Summary of the issue:

Revealed by failing job https://github.com/nvaccess/nvda/actions/runs/26326719413/job/77505713553?pr=20203 — `checkpot` initialized all submodules via `submodules: true`, but only `miscDeps` is needed to generate `.po` files.

### Description of user facing changes:

None.

### Description of developer facing changes:

`checkpot` job in `testAndPublish.yml` no longer initializes all submodules. Only `miscDeps` is initialized explicitly via `git submodule update --init miscDeps`.

### Description of development approach:

Replace `submodules: true` on the checkout action with a dedicated step: `git submodule update --init miscDeps`.

### Testing strategy:

CI `checkpot` job itself validates the change.

### Known issues with pull request:

None.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.