### PR TITLE
Disable brokering audio in the 32 bit synthDriver shim for at least 2026.2 as it is not stable enough yet.

### DIFF
--- a/source/_bridge/clients/synthDriverHost32/launcher.py
+++ b/source/_bridge/clients/synthDriverHost32/launcher.py
@@ -116,7 +116,7 @@ def createSynthDriver(name: str, synthDriversPath: str) -> tuple[Connection, Syn
 	conn.bgEventLoop(daemon=True)
 	log.debug("Connection to synthDriverHost32 process RPYC service established")
 
-	conn.remoteService.installProxies(service, brokerAudio=True)
+	conn.remoteService.installProxies(service, brokerAudio=False)
 	log.debug("Creating SynthDriverProxy over remote SynthDriverService")
 	conn.remoteService.registerSynthDriversPath(synthDriversPath)
 	synthDriverService = conn.remoteService.SynthDriver(name)


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
<!-- Use Closes/Fixes/Resolves #xxx to link this PR to the issue it is responding to. -->
Fixes #19667
Fixes #19819
Reverts #19672

### Summary of the issue:
Experimental code was recently added to NVDA (after 2026.1) that caused the 32 bit synthDriver shim to  send its audio back to NvDA for playing, rather than playing it directly in its own process. This was done to test / prepare for the time when add-ons would be running in an app container, and therefore probably would not have direct access to the audio device.
However, currently this code is still quite unstable, causing NVDA to freeze when rapidly changing the speech rate, or arrowing up and down in lists, when using sapi4 or 32 bit sapi5.
This instability is most likely a similar issue to what was fixed in pr #19609, where RPYC  is handoing the return of a call on the wrong thread. But in this case, it is calls to/from nvwave in NVDA's process.

### Description of user facing changes:

### Description of developer facing changes:

### Description of development approach:
* Simply instruct the synthDriver process not to install the nvwave proxy that brokers back to NvDA.
* Reverts #19672 so that 32 bit synthDrivers suspend audioDucking while they are running, as audioDucking cnanot be supported without brokering audio.

### Testing strategy:
* [x] verified freeze can no longer be reproduced  in issues #19667 and #19819.
* [x] Make a local signed copy, install and test that audio ducking is disabled when using sapi4, and reenabled when swtching back to espeak.

### Known issues with pull request:

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
