### PR TITLE
Fix memory leak in _getIA2TargetsForRelationsOfType.

### DIFF
--- a/source/NVDAObjects/IAccessible/__init__.py
+++ b/source/NVDAObjects/IAccessible/__init__.py
@@ -1877,9 +1877,12 @@ class IAccessible(Window):
 		)
 		if config.conf["debugLog"]["annotations"]:
 			log.debug(f"Got {count} relations, given maxRelations: {maxRelations}")
-		if count == 0:
-			return
-		yield from (targets[i] for i in range(min(maxRelations, count)))
+		try:
+			if count == 0:
+				return
+			yield from (targets[i] for i in range(min(maxRelations, count)))
+		finally:
+			winBindings.ole32.CoTaskMemFree(targets)
 
 	def _getIA2RelationFirstTarget(
 		self,


### PR DESCRIPTION
### Link to issue number:
None.

### Summary of the issue:
`NVDAObjects.IAccessible.IAccessible._getIA2TargetsForRelationsOfType` calls IAccessible2_2::relationTargetsOfType, a COM method which returns a server-allocated array. Per COM rules and the IAccessible2 documentation, this array must be freed with CoTaskMemFree. However, comtypes doesn't have sufficient information to know that it must be freed, nor do we explicitly free it ourselves. Thus, we are leaking memory every time we call this and it returns a relation.

Note that we already call CoTaskMemFree for IAccessibleTableCell::row/columnHeaderCells, which is a similar COM method. See `NVDAObjects.IAccessible.IAccessible._tableHeaderTextHelper`.

### Description of user facing changes:
Fixes a memory leak. However, I don't think this is worth noting in the What's New, since it's probably not significant enough for most users to notice.

### Description of development approach:
Use try/finally after the COM method call. Call CoTaskMemFree in the finally block.

### Testing strategy:
1. Used this test case in Microsoft Edge:
    `data:text/html,<button aria-details="d">b</button><div id="d">d`
2. Switched to focus mode.
3. Tabbed to the button.
4. Repeatedly pressed NVDA+d. It reported "d" as expected each time.

Note that this can't currently be tested in Firefox, as NVDA details reporting is broken in focus mode in Firefox. However, that is an existing bug, not one introduced by this PR.

### Known issues with pull request:
None.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
