### PR TITLE
Fix report details summary in Firefox.

### DIFF
--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -2785,6 +2785,7 @@ class GlobalCommands(ScriptableObject):
 			relation' in that range, and we don't yet have a way for the user to select which one to report.
 			For now, we minimise this risk by only reporting details at the current location.
 		"""
+		_isDebugLogCatEnabled = bool(config.conf["debugLog"]["annotations"])
 		try:
 			# Common cases use Caret Position: vbuf available or object supports text range
 			# Eg editable text, or regular web content
@@ -2792,28 +2793,26 @@ class GlobalCommands(ScriptableObject):
 			caret: textInfos.TextInfo = api.getCaretPosition()
 		except RuntimeError:
 			log.debugWarning("Unable to get the caret position.", exc_info=True)
-			return None
-		caret.expand(textInfos.UNIT_CHARACTER)
-		objAtStart: NVDAObject = caret.NVDAObjectAtStart
-		_isDebugLogCatEnabled = bool(config.conf["debugLog"]["annotations"])
-		if _isDebugLogCatEnabled:
-			log.debug(f"Trying with nvdaObject : {objAtStart}")
-
-		if objAtStart.annotations:
+		else:
+			caret.expand(textInfos.UNIT_CHARACTER)
+			objAtStart: NVDAObject = caret.NVDAObjectAtStart
 			if _isDebugLogCatEnabled:
-				log.debug("NVDAObjectAtStart of caret has details")
-			return objAtStart
-		elif api.getFocusObject():
+				log.debug(f"Trying with nvdaObject : {objAtStart}")
+			if objAtStart.annotations:
+				if _isDebugLogCatEnabled:
+					log.debug("NVDAObjectAtStart of caret has details")
+				return objAtStart
+
+		focus: NVDAObject = api.getFocusObject()
+		if focus:
 			# If fetching from the caret position fails, try via the focus object
 			# This case is to support where there is no virtual buffer or text interface and a caret position can
 			# not be fetched.
 			# There may still be an object with focus that has details.
-			# There isn't a known test case for this, however there isn't a known downside to attempt this.
-			focus = api.getFocusObject()
 			if _isDebugLogCatEnabled:
 				log.debug(f"Trying focus object: {focus}")
 
-			if objAtStart.annotations:
+			if focus.annotations:
 				if _isDebugLogCatEnabled:
 					log.debug("focus object has details, able to proceed")
 				return focus

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -16,6 +16,7 @@
 * When moving to an ARIA grid cell in focus mode in web browsers, NVDA no longer reports both the row and column headers even if only the row or only the column changed. (#17750, @jcsteh)
 * When an application stops responding, NVDA no longer freezes or floods its log with errors; it stays responsive and drops UIA and MSAA events from the unresponsive application until it recovers. (#16749, @heath-toby)
 * Reduced lag on UI Automation text change events, improving the responsiveness of controls such as combo boxes and of File Explorer, by using the cached element class name instead of a live cross-process fetch. (#16749, @heath-toby)
+* In Mozilla Firefox, reporting annotation details now works correctly in focus mode on controls which are not editable text. (#20208, @jcsteh)
 
 ### Changes for Developers
 


### PR DESCRIPTION
### Link to issue number:
None.

### Summary of the issue:
In focus mode in Mozilla Firefox, when a control which is not editable text is focused (such as a button), pressing NVDA+d to report the details summary reports "no additional details". In contrast, this works in Chromium browsers.

### Description of user facing changes:
In Mozilla Firefox, reporting annotation details now works correctly in focus mode on controls which are not editable text.

### Description of development approach:
script_reportDetailsSummary had some incorrect assumptions and contained code that was intended to execute but never did (effectively dead code). It assumed that browsers always set the caret even for non-editable controls, but that isn't always true, especially in Firefox. Even though it had code to fall back to using the focus, it returned early before that was ever executed. This change ensures that the fallback code actually runs, as well as fixing the fallback code so that it actually works.

I originally submitted this change as part of #20132, but that had to be reverted. This PR splits out just the details change.

### Testing strategy:
In both Firefox and Edge, with this test case:
`data:text/html,<button aria-details="d">btn</button><p id="d">d</p><div contenteditable role="textbox">a<span aria-details="d">b</span></div>`

1. Switched to focus mode.
2. Tabbed to the button.
3. Pressed NVDA+d to report details. Result: d
4. Tabbed to the text box.
5. Pressed home to move to start of line.
6. Pressed NVDA+d to report details. Result: no additional details
7. Pressed right arrow to move to "b".
8. Pressed NVDA+d to report details. Result: d
9. Switched to browse mode.
10. Pressed control+home to move to the top (the button).
11. Pressed NVDA+d to report details. Result: d

### Known issues with pull request:
None.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
