### PR TITLE
fix xliff generation

### DIFF
--- a/source/markdownTranslate.py
+++ b/source/markdownTranslate.py
@@ -98,7 +98,7 @@ def preprocessMarkdownLines(mdLines: Iterable[str]) -> Iterable[str]:
 	"""
 	for mdLine in mdLines:
 		# #18982: Remove markdown lint comments completely - not needed for intermediate markdown or final html.
-		mdLine = re_inlineMarkdownLintComment.sub(r"\1\2", mdLine)
+		mdLine = re_inlineMarkdownLintComment.sub(r"\1\2\n", mdLine)
 		yield mdLine
 
 


### PR DESCRIPTION


### Link to issue number:
Fixes #20105

### Summary of the issue:
xliff generation was failing due to a line mismatch when processing out markdownlint comments.
The substitution was not adding a new line character when it should

### Description of user facing changes:
none
### Description of developer facing changes:
none
### Description of development approach:
add new line when substituting line for markdown comment

### Testing strategy:
tested generating xliff locally with 

`python source/markdownTranslate.py updateXliff -x user_docs/en/userGuide.xliff -m user_docs/en/userGuide.md -o $tempXliff`

### Known issues with pull request:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
