### PR TITLE
Fix race in nvdaController_speakSsml where speechCanceled could be missed

### DIFF
--- a/source/NVDAHelper/__init__.py
+++ b/source/NVDAHelper/__init__.py
@@ -135,7 +135,6 @@ def nvdaController_speakSsml(  # noqa: C901
 
 		def prefixCallback():
 			synthDriverHandler.synthDoneSpeaking.register(onDoneSpeaking)
-			speech.speechCanceled.register(onSpeechCanceled)
 
 		def markCallable(name: str):
 			markQueue.put_nowait(name)
@@ -147,6 +146,15 @@ def nvdaController_speakSsml(  # noqa: C901
 	except Exception:
 		log.error("Error parsing SSML", exc_info=True)
 		return SystemErrorCodes.INVALID_PARAMETER
+
+	if not asynchronous:
+		# onSpeechCanceled must be registered before speech.speak is queued.
+		# If registered inside prefixCallback (a CallbackCommand), it runs on the synth
+		# thread after the sequence starts — leaving a window where speechCanceled fires
+		# between queueFunction returning and the synth reaching the CallbackCommand.
+		# onDoneSpeaking stays in prefixCallback because synthDoneSpeaking fires per
+		# sequence: registering it here would also catch a previous sequence that is still finishing.
+		speech.speechCanceled.register(onSpeechCanceled)
 
 	queueHandler.queueFunction(
 		queueHandler.eventQueue,

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -134,6 +134,7 @@ Use the individual test commands instead: `runcheckpot.bat`, `rununittests.bat`,
     * Added a `percentageToValue` function to convert a percentage to the corresponding configuration value.
     * Added a `clampedIncrementAndUpdateConfig` function to update a configuration value by applying a step, constrained within its valid range.
 * NVDA is now built with Visual Studio 2026. (#20203, @LeonarddeR)
+* Fixed a race condition in `nvdaController_speakSsml` with `asynchronous=False` where a `speechCanceled` signal fired between `queueFunction` returning and the synth thread executing the `CallbackCommand` would not be caught, causing the call to block indefinitely. (#20220, @LeonarddeR)
 
 #### Deprecations
 


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:

When `nvdaController_speakSsml` is called with `asynchronous=False`, a race condition can cause the call to block indefinitely. `onSpeechCanceled` was registered inside `prefixCallback`, a `CallbackCommand` that runs on the synth thread only after the sequence starts. If `speechCanceled` fires in the window between `queueHandler.queueFunction` returning and the synth reaching that `CallbackCommand`, the signal is missed and `markQueue.get()` never unblocks.

### Description of user facing changes:

No change under normal operation. Fixes a hang that could occur when speech is cancelled immediately after being queued via the controller client.

### Description of developer facing changes:

`speech.speechCanceled.register(onSpeechCanceled)` is now called directly before `queueHandler.queueFunction`, ensuring the handler exists before any cancel signal can fire. `onDoneSpeaking` stays in `prefixCallback` because `synthDoneSpeaking` fires per sequence — registering it earlier would catch a previous sequence still finishing when priority is `Next`.

### Description of development approach:

Minimal repositioning of one `register` call. No logic changes.

### Testing strategy:

Call `nvdaController_speakSsml` with `asynchronous=False` and cancel speech immediately after queuing, repeatedly. Before this fix the call would occasionally hang; after it should always return promptly with `ERROR_CANCELLED`.

### Known issues with pull request:

None.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.