### PR TITLE
Fix generating skeleton

### DIFF
--- a/source/markdownTranslate.py
+++ b/source/markdownTranslate.py
@@ -1,10 +1,9 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2024 NV Access Limited.
-# This file is covered by the GNU General Public License.
-# See the file COPYING for more details.
+# Copyright (C) 2024-2026 NV Access Limited
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
 
-from typing import Generator
-from collections.abc import Iterable
+from collections.abc import Generator
 import tempfile
 import os
 import contextlib
@@ -30,7 +29,7 @@ re_hiddenHeaderRow = re.compile(r"^\|\s*\.\s*\{\.hideHeaderRow\}\s*(\|\s*\.\s*)*
 re_postTableHeaderLine = re.compile(r"^(\|\s*-+\s*)+\|$")
 re_tableRow = re.compile(r"^(\|)(.+)(\|)$")
 re_translationID = re.compile(r"^(.*)\$\(ID:([0-9a-f-]+)\)(.*)$")
-re_inlineMarkdownLintComment = re.compile(r"^(.*?)(?:\s*<!-- markdownlint.*-->)(\s*)$")
+re_inlineMarkdownLintComment = re.compile(r"^(.*?)(\s*<!--\s*markdownlint.*-->)(\s*)$")
 
 
 def prettyPathString(path: str) -> str:
@@ -90,21 +89,26 @@ def getRawGithubURLForPath(filePath: str) -> str:
 	return f"{RAW_GITHUB_REPO_URL}/{commitID}/{relativePath}"
 
 
-def preprocessMarkdownLines(mdLines: Iterable[str]) -> Iterable[str]:
-	"""
-	Preprocess markdown lines such as removing inline markdown lint comments.\
-	:param mdLines: The markdown lines to preprocess
-	:returns: The preprocessed markdown lines
-	"""
-	for mdLine in mdLines:
-		# #18982: Remove markdown lint comments completely - not needed for intermediate markdown or final html.
-		mdLine = re_inlineMarkdownLintComment.sub(r"\1\2", mdLine)
-		yield mdLine
+def getSkeletonContentFromXliffText(skeletonText: str | None) -> str:
+	"""Return skeleton content while preserving meaningful leading/trailing whitespace."""
+	if skeletonText is None:
+		return ""
+	# Skeleton content is written as <skeleton>\n{content}\n</skeleton>.
+	# Remove only wrapper newlines, not significant whitespace inside the skeleton itself.
+	if skeletonText.startswith("\n"):
+		skeletonText = skeletonText[1:]
+	if skeletonText.endswith("\n"):
+		skeletonText = skeletonText[:-1]
+	return skeletonText
 
 
 def skeletonizeLine(mdLine: str) -> str | None:
 	prefix = ""
 	suffix = ""
+	markdownLintComment = ""
+	if m := re_inlineMarkdownLintComment.match(mdLine):
+		mdLine, markdownLintComment, trailingWhitespace = m.groups()
+		mdLine = f"{mdLine}{trailingWhitespace}"
 	if (
 		mdLine.isspace()
 		or mdLine.strip() == "[TOC]"
@@ -127,7 +131,7 @@ def skeletonizeLine(mdLine: str) -> str | None:
 	elif re_comment.match(mdLine):
 		return None
 	ID = str(uuid.uuid4())
-	return f"{prefix}$(ID:{ID}){suffix}\n"
+	return f"{prefix}$(ID:{ID}){suffix}{markdownLintComment}\n"
 
 
 @dataclass
@@ -143,7 +147,7 @@ def generateSkeleton(mdPath: str, outputPath: str) -> Result_generateSkeleton:
 		open(mdPath, "r", encoding="utf8") as mdFile,
 		open(outputPath, "w", encoding="utf8", newline="") as outputFile,
 	):
-		for mdLine in preprocessMarkdownLines(mdFile.readlines()):
+		for mdLine in mdFile.readlines():
 			res.numTotalLines += 1
 			skelLine = skeletonizeLine(mdLine)
 			if skelLine:
@@ -179,7 +183,7 @@ def extractSkeleton(xliffPath: str, outputPath: str):
 		skeletonNode = xliffRoot.find("./xliff:file/xliff:skeleton", namespaces=namespace)
 		if skeletonNode is None:
 			raise ValueError("No skeleton found in xliff file")
-		skeletonContent = skeletonNode.text.strip()
+		skeletonContent = getSkeletonContentFromXliffText(skeletonNode.text)
 		outputFile.write(skeletonContent)
 		print(f"Extracted skeleton to {prettyPathString(outputPath)}")
 
@@ -199,8 +203,8 @@ def updateSkeleton(
 		newMdFile = stack.enter_context(open(newMdPath, "r", encoding="utf8"))
 		origSkelFile = stack.enter_context(open(origSkelPath, "r", encoding="utf8"))
 		outputFile = stack.enter_context(open(outputPath, "w", encoding="utf8", newline=""))
-		origMdLines = preprocessMarkdownLines(origMdFile.readlines())
-		newMdLines = preprocessMarkdownLines(newMdFile.readlines())
+		origMdLines = origMdFile.readlines()
+		newMdLines = newMdFile.readlines()
 		mdDiff = difflib.ndiff(list(origMdLines), list(newMdLines))
 		origSkelLines = iter(origSkelFile.readlines())
 		for mdDiffLine in mdDiff:
@@ -209,6 +213,10 @@ def updateSkeleton(
 			if mdDiffLine.startswith(" "):
 				res.numUnchangedLines += 1
 				skelLine = next(origSkelLines)
+				# Extracted skeletons may lack a trailing newline on the last line.
+				# Preserve line boundaries when this unchanged line is followed by additions.
+				if mdDiffLine[2:].endswith("\n") and not skelLine.endswith("\n"):
+					skelLine = f"{skelLine}\n"
 				if re_translationID.match(skelLine):
 					res.numUnchangedTranslationPlaceholders += 1
 				outputFile.write(skelLine)
@@ -278,7 +286,7 @@ def generateXliff(
 		res.numTranslatableStrings = 0
 		for lineNo, (mdLine, skelLine) in enumerate(
 			zip_longest(
-				preprocessMarkdownLines(mdFile.readlines()),
+				mdFile.readlines(),
 				skelContent.splitlines(keepends=True),
 			),
 			start=1,
@@ -378,11 +386,11 @@ def translateXliff(
 		skeletonNode = xliffRoot.find("./xliff:file/xliff:skeleton", namespaces=namespace)
 		if skeletonNode is None:
 			raise ValueError("No skeleton found in xliff file")
-		skeletonContent = skeletonNode.text.strip()
+		skeletonContent = getSkeletonContentFromXliffText(skeletonNode.text)
 		for lineNo, (skelLine, pretranslatedLine) in enumerate(
 			zip_longest(
 				skeletonContent.splitlines(),
-				preprocessMarkdownLines(pretranslatedMdFile.readlines()),
+				pretranslatedMdFile.readlines(),
 			),
 			start=1,
 		):
@@ -450,7 +458,7 @@ def generateMarkdown(xliffPath: str, outputPath: str, translated: bool = True) -
 		skeletonNode = xliffRoot.find("./xliff:file/xliff:skeleton", namespaces=namespace)
 		if skeletonNode is None:
 			raise ValueError("No skeleton found in xliff file")
-		skeletonContent = skeletonNode.text.strip()
+		skeletonContent = getSkeletonContentFromXliffText(skeletonNode.text)
 		for lineNum, line in enumerate(skeletonContent.splitlines(keepends=True), 1):
 			res.numTotalLines += 1
 			if m := re_translationID.match(line):
@@ -506,8 +514,8 @@ def ensureMarkdownFilesMatch(path1: str, path2: str, allowBadAnchors: bool = Fal
 		file2 = stack.enter_context(open(path2, "r", encoding="utf8"))
 		for lineNo, (line1, line2) in enumerate(
 			zip_longest(
-				preprocessMarkdownLines(file1.readlines()),
-				preprocessMarkdownLines(file2.readlines()),
+				file1.readlines(),
+				file2.readlines(),
 			),
 			start=1,
 		):

--- a/tests/markdownTranslate/markdownlint_inlineComments.md
+++ b/tests/markdownTranslate/markdownlint_inlineComments.md
@@ -1,0 +1,3 @@
+# Heading <!-- markdownlint-disable-line MD041 -->
+Regular line <!-- markdownlint-disable-line MD013 -->
+<!-- markdownlint-disable MD011 -->

--- a/tests/unit/test_markdownTranslate.py
+++ b/tests/unit/test_markdownTranslate.py
@@ -1,15 +1,19 @@
 # A part of NonVisual Desktop Access (NVDA)
-# This file is covered by the GNU General Public License.
-# See the file COPYING for more details.
-# Copyright (C) 2024 NV Access Limited
+# Copyright (C) 2024-2026 NV Access Limited
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
 
 """Unit tests for the markdownTranslate module."""
 
+import importlib.util
 import tempfile
 import unittest
+from unittest import mock
 import subprocess
 import sys
 import os
+from pathlib import Path
+import xml.etree.ElementTree as ET
 
 
 class TestMarkdownTranslate(unittest.TestCase):
@@ -137,3 +141,31 @@ class TestMarkdownTranslate(unittest.TestCase):
 				os.path.join(testDir, "fr_pretranslated_2024.3beta6_userGuide.md"),
 			],
 		)
+
+	def test_generateXliff_preservesInlineMarkdownLintCommentsInSkeleton(self):
+		outDir = self.outDir.name
+		inputMdPath = os.path.join(self.testDir, "markdownlint_inlineComments.md")
+		xliffPath = os.path.join(outDir, "markdownlint.xliff")
+		spec = importlib.util.spec_from_file_location("markdownTranslateUnderTest", self.markdownTranslateScriptPath)
+		self.assertIsNotNone(spec)
+		if spec is None or spec.loader is None:
+			self.fail("Unable to load markdownTranslate module for testing")
+		markdownTranslateModule = importlib.util.module_from_spec(spec)
+		spec.loader.exec_module(markdownTranslateModule)
+		with mock.patch.object(
+			markdownTranslateModule,
+			"getRawGithubURLForPath",
+			return_value=Path(inputMdPath).resolve().as_uri(),
+		):
+			markdownTranslateModule.generateXliff(mdPath=inputMdPath, outputPath=xliffPath)
+
+		xliff = ET.parse(xliffPath)
+		xliffRoot = xliff.getroot()
+		namespace = {"xliff": "urn:oasis:names:tc:xliff:document:2.0"}
+		skeletonNode = xliffRoot.find("./xliff:file/xliff:skeleton", namespace)
+		self.assertIsNotNone(skeletonNode)
+		skeletonContent = skeletonNode.text
+		self.assertIsNotNone(skeletonContent)
+		self.assertIn("$(ID:", skeletonContent)
+		self.assertIn("<!-- markdownlint-disable-line MD041 -->", skeletonContent)
+		self.assertIn("<!-- markdownlint-disable-line MD013 -->", skeletonContent)

--- a/tests/unit/test_markdownTranslate.py
+++ b/tests/unit/test_markdownTranslate.py
@@ -146,7 +146,9 @@ class TestMarkdownTranslate(unittest.TestCase):
 		outDir = self.outDir.name
 		inputMdPath = os.path.join(self.testDir, "markdownlint_inlineComments.md")
 		xliffPath = os.path.join(outDir, "markdownlint.xliff")
-		spec = importlib.util.spec_from_file_location("markdownTranslateUnderTest", self.markdownTranslateScriptPath)
+		spec = importlib.util.spec_from_file_location(
+			"markdownTranslateUnderTest", self.markdownTranslateScriptPath
+		)
 		self.assertIsNotNone(spec)
 		if spec is None or spec.loader is None:
 			self.fail("Unable to load markdownTranslate module for testing")

--- a/tests/unit/test_markdownTranslate.py
+++ b/tests/unit/test_markdownTranslate.py
@@ -147,7 +147,8 @@ class TestMarkdownTranslate(unittest.TestCase):
 		inputMdPath = os.path.join(self.testDir, "markdownlint_inlineComments.md")
 		xliffPath = os.path.join(outDir, "markdownlint.xliff")
 		spec = importlib.util.spec_from_file_location(
-			"markdownTranslateUnderTest", self.markdownTranslateScriptPath
+			"markdownTranslateUnderTest",
+			self.markdownTranslateScriptPath,
 		)
 		self.assertIsNotNone(spec)
 		if spec is None or spec.loader is None:

--- a/tests/unit/test_markdownTranslate.py
+++ b/tests/unit/test_markdownTranslate.py
@@ -169,3 +169,4 @@ class TestMarkdownTranslate(unittest.TestCase):
 		self.assertIn("$(ID:", skeletonContent)
 		self.assertIn("<!-- markdownlint-disable-line MD041 -->", skeletonContent)
 		self.assertIn("<!-- markdownlint-disable-line MD013 -->", skeletonContent)
+		self.assertIn("<!-- markdownlint-disable MD011 -->", skeletonContent)


### PR DESCRIPTION

<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Fixes #20105

### Summary of the issue:
markdownTranslate.py previously removed inline `markdownlint` comments during preprocessing, so those comments were not preserved in generated XLIFF skeleton content. This could break round-tripping and comment fidelity for markdown files that embed inline lint directives.

### Description of user facing changes:
No direct end-user NVDA feature change. This affects markdown/XLIFF tooling behavior used in docs workflows: inline markdownlint comments are now retained in skeleton output.

### Description of developer facing changes:
- Removed `preprocessMarkdownLines` usage across markdown/XLIFF processing paths.
- Updated inline markdownlint regex handling to capture and preserve inline markdownlint comments in `skeletonizeLine`.
- Added `getSkeletonContentFromXliffText` to avoid over-aggressive `.strip()` on skeleton text.
- Added a new fixture file:
  - markdownlint_inlineComments.md
- Added unit coverage:
  - `test_generateXliff_preservesInlineMarkdownLintCommentsInSkeleton`
  - Uses module loading + patching of `getRawGithubURLForPath` to support file URI in test context.

### Description of development approach:
This PR was heavily assisted through CoPilot.
The change removes line preprocessing that was stripping semantic inline comments and instead handles markdownlint comments at skeletonization time so comments remain in output. Skeleton text extraction was adjusted to preserve meaningful whitespace/newline boundaries. Test strategy was expanded with a dedicated fixture and targeted assertion of skeleton content.

### Testing strategy:
Manual testing with: `python source/markdownTranslate.py updateXliff -x user_docs/en/userGuide.xliff -m user_docs/en/userGuide.md -o $tempXliff`

- New targeted unit test validates that:
  - XLIFF generation succeeds for markdown containing inline markdownlint comments.
  - Skeleton contains translation placeholders and the expected inline markdownlint comments.
- Existing markdownTranslate unit test suite remains in place for round-trip/update/translate behavior.

### Known issues with pull request:
None

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
