### PR TITLE
Preserve word segmentation compatibility and documentation

### DIFF
--- a/include/readme.md
+++ b/include/readme.md
@@ -62,7 +62,7 @@ Used in chrome system tests.
 
 Fetch latest from master.
 
-### cppjieba
+## cppjieba
 
 [cppjieba](https://github.com/yanyiwu/cppjieba).
 

--- a/nvdaHelper/cppjieba/cppjieba.hpp
+++ b/nvdaHelper/cppjieba/cppjieba.hpp
@@ -126,7 +126,7 @@ public:
     static std::once_flag initFlag;
 
 private:
-    JiebaSingleton(const char* dictDir);         ///< private ctor initializes base Jieba
+    JiebaSingleton(const char* dictDir);  ///< private ctor initializes base Jieba
 
     /// Disable copy and move
     JiebaSingleton(const JiebaSingleton&) = delete;
@@ -134,7 +134,7 @@ private:
     JiebaSingleton(JiebaSingleton&&) = delete;
     JiebaSingleton& operator = (JiebaSingleton&&) = delete;
 
-    std::mutex segMutex;      ///< guards concurrent Cut() calls
+    std::mutex segMutex;  ///< guards concurrent Cut() calls
 };
 
 #ifdef _WIN32

--- a/source/textInfos/offsets.py
+++ b/source/textInfos/offsets.py
@@ -20,17 +20,59 @@ from textUtils.segFlag import CharSegFlag, WordSegFlag
 from textUtils._wordSeg.wordSegmenter import WordSegmenter
 from dataclasses import dataclass
 from typing import (
+	Any,
 	Dict,
 	List,
 	Optional,
 	Self,
 	Tuple,
-	TYPE_CHECKING,
 )
 from logHandler import log
 
-if TYPE_CHECKING:
-	from NVDAObjects import NVDAObject
+
+def _warnUseUniscribeDeprecated() -> None:
+	log.warning(
+		"OffsetsTextInfo.useUniscribe is deprecated. "
+		"Use OffsetsTextInfo.charSegFlag and OffsetsTextInfo.wordSegFlag instead.",
+		stack_info=True,
+	)
+
+
+class _OffsetsTextInfoMeta(type(textInfos.TextInfo)):
+	def __init__(
+		cls,
+		name: str,
+		bases: tuple[type, ...],
+		namespace: dict[str, Any],
+		/,
+		**kwargs: Any,
+	) -> None:
+		super().__init__(name, bases, namespace, **kwargs)
+		legacyUseUniscribe = namespace.get("useUniscribe")
+		if not isinstance(legacyUseUniscribe, bool):
+			return
+		type.__delattr__(cls, "useUniscribe")
+		type.__setattr__(cls, "_useUniscribeOverride", legacyUseUniscribe)
+
+	def __getattribute__(cls, name: str) -> Any:
+		if name != "useUniscribe":
+			return super().__getattribute__(name)
+		if not NVDAState._allowDeprecatedAPI():
+			raise AttributeError(f"'{cls.__name__}' has no attribute 'useUniscribe'")
+		_warnUseUniscribeDeprecated()
+		override = cls._getUseUniscribeClassOverride()
+		if override is not None:
+			return override
+		return type.__getattribute__(cls, "charSegFlag") == CharSegFlag.UNISCRIBE
+
+	def __setattr__(cls, name: str, value: Any) -> None:
+		if name != "useUniscribe":
+			super().__setattr__(name, value)
+			return
+		if not NVDAState._allowDeprecatedAPI():
+			raise AttributeError(f"'{cls.__name__}' has no attribute 'useUniscribe'")
+		_warnUseUniscribeDeprecated()
+		type.__setattr__(cls, "_useUniscribeOverride", bool(value))
 
 
 @dataclass
@@ -144,7 +186,7 @@ def findEndOfWord(text, offset, lineLength=None):
 	return offset
 
 
-class OffsetsTextInfo(textInfos.TextInfo):
+class OffsetsTextInfo(textInfos.TextInfo, metaclass=_OffsetsTextInfoMeta):
 	"""An abstract TextInfo for text implementations which represent ranges using numeric offsets relative to the start of the text.
 	In such implementations, the start of the text is represented by 0 and the end is the length of the entire text.
 
@@ -166,6 +208,59 @@ class OffsetsTextInfo(textInfos.TextInfo):
 	detectFormattingAfterCursorMaybeSlow: bool = True
 	#: Method to calculate character and word offsets.
 	charSegFlag: CharSegFlag = CharSegFlag.UNISCRIBE
+	#: Backing value for the deprecated useUniscribe compatibility attribute.
+	_useUniscribeOverride: bool | None = None
+
+	def _getDeprecatedUseUniscribe(self) -> bool:
+		if not NVDAState._allowDeprecatedAPI():
+			raise AttributeError(f"'{type(self).__name__}' object has no attribute 'useUniscribe'")
+		_warnUseUniscribeDeprecated()
+		override = self._getUseUniscribeCompatOverride()
+		if override is not None:
+			return override
+		return self._getEffectiveCharSegFlag() == CharSegFlag.UNISCRIBE and bool(
+			self._getEffectiveWordSegFlag(),
+		)
+
+	def _setDeprecatedUseUniscribe(self, value: bool) -> None:
+		if not NVDAState._allowDeprecatedAPI():
+			raise AttributeError(f"'{type(self).__name__}' object has no attribute 'useUniscribe'")
+		_warnUseUniscribeDeprecated()
+		self._useUniscribeOverride = bool(value)
+
+	# Deprecated pending removal in the 2027.1 API breaking release.
+	# Use charSegFlag and wordSegFlag instead.
+	useUniscribe = property(_getDeprecatedUseUniscribe, _setDeprecatedUseUniscribe)
+
+	@classmethod
+	def _getUseUniscribeClassOverride(cls) -> bool | None:
+		for klass in cls.__mro__:
+			override = klass.__dict__.get("_useUniscribeOverride")
+			if override is not None:
+				return bool(override)
+		return None
+
+	def _getUseUniscribeCompatOverride(self) -> bool | None:
+		override = self.__dict__.get("_useUniscribeOverride")
+		if override is not None:
+			return bool(override)
+		return type(self)._getUseUniscribeClassOverride()
+
+	def _getEffectiveCharSegFlag(self) -> CharSegFlag:
+		useUniscribe = self._getUseUniscribeCompatOverride()
+		if useUniscribe is False:
+			return CharSegFlag.NONE
+		if useUniscribe is True:
+			return CharSegFlag.UNISCRIBE
+		return self.charSegFlag
+
+	def _getEffectiveWordSegFlag(self) -> WordSegFlag | None:
+		useUniscribe = self._getUseUniscribeCompatOverride()
+		if useUniscribe is False:
+			return WordSegFlag.NONE
+		if useUniscribe is True:
+			return WordSegFlag.UNISCRIBE
+		return self.wordSegFlag
 
 	@property
 	def wordSegFlag(self) -> WordSegFlag | None:
@@ -178,7 +273,7 @@ class OffsetsTextInfo(textInfos.TextInfo):
 				return WordSegFlag.CHINESE
 			case _:
 				log.error(f"Unknown word segmentation standard, {self.wordSegConf.calculated()!r}")
-				return None
+		return None
 
 	#: The encoding internal to the underlying text info implementation.
 	encoding: Optional[str] = textUtils.WCHAR_ENCODING
@@ -399,7 +494,7 @@ class OffsetsTextInfo(textInfos.TextInfo):
 		lineStart, lineEnd = self._getLineOffsets(offset)
 		lineText = self._getTextRange(lineStart, lineEnd)
 		relOffset = offset - lineStart
-		if self.charSegFlag == CharSegFlag.UNISCRIBE:
+		if self._getEffectiveCharSegFlag() == CharSegFlag.UNISCRIBE:
 			offsets = self._calculateUniscribeOffsets(lineText, textInfos.UNIT_CHARACTER, relOffset)
 			if offsets is not None:
 				return (offsets[0] + lineStart, offsets[1] + lineStart)
@@ -423,8 +518,9 @@ class OffsetsTextInfo(textInfos.TextInfo):
 		# Convert NULL and non-breaking space to space to make sure that words will break on them
 		lineText = lineText.translate({0: " ", 0xA0: " "})
 		relOffset = offset - lineStart
-		if self.wordSegFlag:
-			offsets = WordSegmenter(lineText, self.encoding, self.wordSegFlag).getSegmentForOffset(
+		wordSegFlag = self._getEffectiveWordSegFlag()
+		if wordSegFlag:
+			offsets = WordSegmenter(lineText, self.encoding, wordSegFlag).getSegmentForOffset(
 				relOffset,
 			)
 			if offsets is not None:
@@ -590,7 +686,7 @@ class OffsetsTextInfo(textInfos.TextInfo):
 	def expand(self, unit):
 		if unit == textInfos.UNIT_WORD and self.isCollapsed and self._startOffset == self._getStoryLength():
 			try:
-				flowsTo: "NVDAObject | None" = self.obj.flowsTo
+				flowsTo = self.obj.flowsTo
 			except (AttributeError, NotImplementedError):
 				flowsTo = None
 			if not flowsTo:

--- a/source/textUtils/__init__.py
+++ b/source/textUtils/__init__.py
@@ -1,7 +1,7 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2018-2026 NV Access Limited, Babbage B.V., Łukasz Golonka, Wang Chong
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
+# Copyright (C) 2018-2026 NV Access Limited, Babbage B.V., Łukasz Golonka
 
 """
 Classes and utilities to deal with offsets variable width encodings, particularly utf_16.
@@ -11,7 +11,6 @@ import ctypes
 import encodings
 import locale
 import unicodedata
-
 from abc import ABCMeta, abstractmethod, abstractproperty
 from functools import cached_property
 from typing import Generator, Optional, Tuple, Type

--- a/tests/unit/test_textInfos.py
+++ b/tests/unit/test_textInfos.py
@@ -219,6 +219,14 @@ class _LegacyNoUniscribeProvider(BasicTextProvider):
 	TextInfo = _LegacyNoUniscribeTextInfo
 
 
+class _RuntimeLegacyNoUniscribeTextInfo(BasicTextProvider.TextInfo):
+	pass
+
+
+class _RuntimeLegacyNoUniscribeProvider(BasicTextProvider):
+	TextInfo = _RuntimeLegacyNoUniscribeTextInfo
+
+
 class TestUseUniscribeCompatibility(unittest.TestCase):
 	def test_instanceOverrideFalseDisablesWordSegmenter(self) -> None:
 		obj = BasicTextProvider(text="abc def")
@@ -242,14 +250,9 @@ class TestUseUniscribeCompatibility(unittest.TestCase):
 		self.assertEqual(ti.text, "abc ")
 
 	def test_classAssignmentFalseDisablesWordSegmenter(self) -> None:
-		class RuntimeLegacyNoUniscribeTextInfo(BasicTextProvider.TextInfo):
-			pass
-
-		class RuntimeLegacyNoUniscribeProvider(BasicTextProvider):
-			TextInfo = RuntimeLegacyNoUniscribeTextInfo
-
-		RuntimeLegacyNoUniscribeTextInfo.useUniscribe = False
-		obj = RuntimeLegacyNoUniscribeProvider(text="abc def")
+		_RuntimeLegacyNoUniscribeTextInfo.useUniscribe = False
+		self.addCleanup(type.__delattr__, _RuntimeLegacyNoUniscribeTextInfo, "_useUniscribeOverride")
+		obj = _RuntimeLegacyNoUniscribeProvider(text="abc def")
 		ti = obj.makeTextInfo(Offsets(0, 0))
 
 		with patch("textInfos.offsets.WordSegmenter") as wordSegmenter:

--- a/tests/unit/test_textInfos.py
+++ b/tests/unit/test_textInfos.py
@@ -13,6 +13,7 @@ from .textProvider import BasicTextProvider, MockBlackBoxTextInfo
 import textInfos
 from textInfos.offsets import Offsets
 import textUtils
+from textUtils.segFlag import WordSegFlag
 
 
 class TestCharacterOffsets(unittest.TestCase):
@@ -208,6 +209,66 @@ class TestWordSegFlag(unittest.TestCase):
 			self.assertIsNone(ti.wordSegFlag)
 
 		mockLogError.assert_called_once_with("Unknown word segmentation standard, 'unexpected'")
+
+
+class _LegacyNoUniscribeTextInfo(BasicTextProvider.TextInfo):
+	useUniscribe = False
+
+
+class _LegacyNoUniscribeProvider(BasicTextProvider):
+	TextInfo = _LegacyNoUniscribeTextInfo
+
+
+class TestUseUniscribeCompatibility(unittest.TestCase):
+	def test_instanceOverrideFalseDisablesWordSegmenter(self) -> None:
+		obj = BasicTextProvider(text="abc def")
+		ti = obj.makeTextInfo(Offsets(0, 0))
+		ti.useUniscribe = False
+
+		with patch("textInfos.offsets.WordSegmenter") as wordSegmenter:
+			ti.expand(textInfos.UNIT_WORD)
+
+		wordSegmenter.assert_not_called()
+		self.assertEqual(ti.text, "abc ")
+
+	def test_classOverrideFalseDisablesWordSegmenter(self) -> None:
+		obj = _LegacyNoUniscribeProvider(text="abc def")
+		ti = obj.makeTextInfo(Offsets(0, 0))
+
+		with patch("textInfos.offsets.WordSegmenter") as wordSegmenter:
+			ti.expand(textInfos.UNIT_WORD)
+
+		wordSegmenter.assert_not_called()
+		self.assertEqual(ti.text, "abc ")
+
+	def test_classAssignmentFalseDisablesWordSegmenter(self) -> None:
+		class RuntimeLegacyNoUniscribeTextInfo(BasicTextProvider.TextInfo):
+			pass
+
+		class RuntimeLegacyNoUniscribeProvider(BasicTextProvider):
+			TextInfo = RuntimeLegacyNoUniscribeTextInfo
+
+		RuntimeLegacyNoUniscribeTextInfo.useUniscribe = False
+		obj = RuntimeLegacyNoUniscribeProvider(text="abc def")
+		ti = obj.makeTextInfo(Offsets(0, 0))
+
+		with patch("textInfos.offsets.WordSegmenter") as wordSegmenter:
+			ti.expand(textInfos.UNIT_WORD)
+
+		wordSegmenter.assert_not_called()
+		self.assertEqual(ti.text, "abc ")
+
+	def test_instanceOverrideTrueForcesUniscribeWordSegmentation(self) -> None:
+		obj = BasicTextProvider(text="abc def")
+		ti = obj.makeTextInfo(Offsets(0, 0))
+		ti.useUniscribe = True
+
+		with patch("textInfos.offsets.WordSegmenter") as wordSegmenter:
+			wordSegmenter.return_value.getSegmentForOffset.return_value = (0, 3)
+			ti.expand(textInfos.UNIT_WORD)
+
+		wordSegmenter.assert_called_once_with("abc def", textUtils.WCHAR_ENCODING, WordSegFlag.UNISCRIBE)
+		self.assertEqual(ti.text, "abc")
 
 
 class TestMoveToCodepointOffsetInBlackBoxTextInfo(unittest.TestCase):

--- a/tests/unit/test_textUtils.py
+++ b/tests/unit/test_textUtils.py
@@ -1,7 +1,7 @@
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-# Copyright (C) 2019-2025 NV Access Limited, Babbage B.V., Leonard de Ruijter, Wang Chong
+# Copyright (C) 2019-2025 NV Access Limited, Babbage B.V., Leonard de Ruijter
 
 """Unit tests for the textUtils module."""
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -7,8 +7,8 @@
 ### New Features
 
 * Chinese text can now be navigated by word using built-in input gestures.
-  A Word Segmentation Standard setting was added to the "Document Navigation" panel. (#18735, @CrazySteve0605)
-* Braille output for Chinese now includes spaces between words. (#18865, @CrazySteve0605)
+  A Word Segmentation Standard setting was added to the "Document Navigation" panel. (#18735, @CrazySteve0605, @Cary-rowen)
+* Braille output for Chinese now includes spaces between words. (#18865, @CrazySteve0605, @Cary-rowen)
 * The braille "word wrap" option has been replaced with a three-valued "Text wrap" option: Off, Show mark when words are cut, and At word boundaries. (#17010, @LeonarddeR)
   * In modes that show a continuation mark, when a word is cut across rows, the last cell of the row now shows a continuation mark (braille dots 7-8) so it is clear that the word continues on the next row.
 
@@ -27,7 +27,8 @@ Please refer to [the developer guide](https://download.nvaccess.org/documentatio
 #### Deprecations
 
 * The `braille.wordWrap` configuration key is deprecated and bridged to `braille.textWrap`. (#17010, @LeonarddeR)
-* The `useUniscribe` attribute of `textInfos.offsets.OffsetsTextInfo` and its subclasses is deprecated.
+* The `useUniscribe` attribute of `textInfos.offsets.OffsetsTextInfo` and its subclasses is deprecated,
+  but remains available for backwards compatibility.
   Use `charSegFlag` and `wordSegFlag` instead. (#18735)
 
 <!-- Beyond this point, Markdown should not be automatically linted, as we don't modify old change log sections and lint rules may change over time. -->
@@ -149,6 +150,7 @@ Use the individual test commands instead: `runcheckpot.bat`, `rununittests.bat`,
 * The `speechDictHandler.ENTRY_TYPE_*` constants are deprecated.
 Use the `speechDictHandler.types.EntryType` enumeration instead. (#19430, @LeonarddeR)
 * `speechDictHandler.SpeechDictEntry` and `speechDictHandler.SpeechDict` have been moved to `speechDictHandler.types`. (#19430, @LeonarddeR)
+
 ## 2026.1.1
 
 This is a patch release to fix security issues.

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -27,9 +27,7 @@ Please refer to [the developer guide](https://download.nvaccess.org/documentatio
 #### Deprecations
 
 * The `braille.wordWrap` configuration key is deprecated and bridged to `braille.textWrap`. (#17010, @LeonarddeR)
-* The `useUniscribe` attribute of `textInfos.offsets.OffsetsTextInfo` and its subclasses is deprecated,
-  but remains available for backwards compatibility.
-  Use `charSegFlag` and `wordSegFlag` instead. (#18735)
+* The `useUniscribe` attribute of `textInfos.offsets.OffsetsTextInfo` and its subclasses is deprecated, use `charSegFlag` and `wordSegFlag` instead. (#18735)
 
 <!-- Beyond this point, Markdown should not be automatically linted, as we don't modify old change log sections and lint rules may change over time. -->
 <!-- markdownlint-disable -->

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -3579,27 +3579,20 @@ You may toggle through the available paragraph styles from anywhere by assigning
 
 ##### Word Segmentation Standard {#WordSegmentationStandard}
 
-This combo box allows you to select how NVDA determines word boundaries when navigating by word.
-
-NVDA's Chinese word segmentation support is also used for braille.
-When a Chinese braille output table is in use, NVDA can insert spaces between Chinese words in braille, making braille output easier to read.
+This setting controls how NVDA determines word boundaries when navigating by word.
+Chinese word segmentation is also used for braille.
+When a Chinese braille output table is in use, NVDA can insert spaces between Chinese words in braille.
 
 | . {.hideHeaderRow} |.|
 |---|---|
 |Options |Default (Auto), Auto, Standard, Chinese|
 |Default |Auto|
 
-The Word Segmentation Standard combo box has three options:
-
-* Auto: NVDA will use Chinese word segmentation for Chinese text when available.
-For other text, NVDA will use standard word segmentation.
-This is the default option.
-* Standard: NVDA will use the standard Windows word segmentation.
-This option works well for most languages and matches NVDA's previous behaviour.
-* Chinese: NVDA will use Chinese word segmentation for word navigation.
-If Chinese word segmentation is not available, NVDA will fall back to standard word segmentation.
-
-For most users, the Auto option is recommended.
+|Option |Behaviour |
+|---|---|
+|Auto |Use Chinese word segmentation for Chinese text when available. For other text, use standard word segmentation. |
+|Standard |Use standard Windows word segmentation. |
+|Chinese |Use Chinese word segmentation. If Chinese word segmentation is not available, NVDA falls back to standard word segmentation. |
 
 #### Math Settings {#MathSettings}
 

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -3585,14 +3585,14 @@ When a Chinese braille output table is in use, NVDA can insert spaces between Ch
 
 | . {.hideHeaderRow} |.|
 |---|---|
-|Options |Default (Auto), Auto, Standard, Chinese|
-|Default |Auto|
+| Options | Default (Auto), Auto, Standard, Chinese |
+| Default | Auto |
 
-|Option |Behaviour |
+| Option | Behaviour |
 |---|---|
-|Auto |Use Chinese word segmentation for Chinese text when available. For other text, use standard word segmentation. |
-|Standard |Use standard Windows word segmentation. |
-|Chinese |Use Chinese word segmentation. If Chinese word segmentation is not available, NVDA falls back to standard word segmentation. |
+| Auto | Use Chinese word segmentation for Chinese text when available. For other text, use standard word segmentation. |
+| Standard | Use standard Windows word segmentation. |
+| Chinese | Use Chinese word segmentation. If Chinese word segmentation is not available, NVDA falls back to standard word segmentation. |
 
 #### Math Settings {#MathSettings}
 

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -3579,6 +3579,28 @@ You may toggle through the available paragraph styles from anywhere by assigning
 
 ##### Word Segmentation Standard {#WordSegmentationStandard}
 
+This combo box allows you to select how NVDA determines word boundaries when navigating by word.
+
+NVDA's Chinese word segmentation support is also used for braille.
+When a Chinese braille output table is in use, NVDA can insert spaces between Chinese words in braille, making braille output easier to read.
+
+| . {.hideHeaderRow} |.|
+|---|---|
+|Options |Default (Auto), Auto, Standard, Chinese|
+|Default |Auto|
+
+The Word Segmentation Standard combo box has three options:
+
+* Auto: NVDA will use Chinese word segmentation for Chinese text when available.
+For other text, NVDA will use standard word segmentation.
+This is the default option.
+* Standard: NVDA will use the standard Windows word segmentation.
+This option works well for most languages and matches NVDA's previous behaviour.
+* Chinese: NVDA will use Chinese word segmentation for word navigation.
+If Chinese word segmentation is not available, NVDA will fall back to standard word segmentation.
+
+For most users, the Auto option is recommended.
+
 #### Math Settings {#MathSettings}
 
 This category allows you to adjust how NVDA reads mathematical content.


### PR DESCRIPTION
This PR follows up on #20183 with the compatibility and documentation changes that are still useful to keep together.

The private `_wordSeg` rename has already been split out and merged in #20233. The cppjieba loader / `ReadPaths` / exception-boundary cleanup is handled separately in #20242.

## Summary

- Keep `OffsetsTextInfo.useUniscribe` available as a deprecated compatibility API, instead of removing it in this release.
- Preserve existing `useUniscribe` behaviour for subclasses and instances that already override it.
- Keep the new `charSegFlag` / `wordSegFlag` behaviour for code that does not use the deprecated API.
- Add focused coverage for the compatibility path.
- Document the Word Segmentation Standard setting, including its effect on Chinese braille output.

## Compatibility note

#20183 replaced `OffsetsTextInfo.useUniscribe` with `charSegFlag` and `wordSegFlag`.

- `useUniscribe = False` disables the Uniscribe / `WordSegmenter` path and falls back to the older offset detection.
- `useUniscribe = True` forces Uniscribe character segmentation and Uniscribe word segmentation.
- When `useUniscribe` is not explicitly set, the new `charSegFlag` and `wordSegFlag` values are used.