### PR TITLE
Pressing Apply button in mag settings panel should keep params in memory even if Discard button is then pressed

### DIFF
--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -6234,7 +6234,26 @@ class MagnifierPanel(SettingsPanel):
 	def onSave(self):
 		"""Save the current selections to config."""
 		magnifierConfig.setEnabled(self.enableMagnifierCheckBox.GetValue())
+		self._magnifierEnabledInitially = self.enableMagnifierCheckBox.GetValue()
 		self._applyCurrentSettingsToConfigAndRuntime()
+
+		selectedZoom = self.zoomCtrl.GetValue()
+		selectedPanStep = self.panSpinCtrl.GetValue()
+		selectedFilter = list(Filter)[self.filterList.GetSelection()]
+		selectedMode = list(FullScreenMode)[self.fullscreenModeList.GetSelection()]
+		isTrueCentered = self.trueCenterCheckBox.GetValue()
+		keepMouseCentered = self.keepMouseCenteredCheckBox.GetValue()
+
+		roundedZoom = magnifierConfig.roundZoomLevel(selectedZoom)
+		self._zoomInitially = roundedZoom
+		self._panStepInitially = selectedPanStep
+		self._filterInitially = selectedFilter
+		self._fullscreenModeInitially = selectedMode
+		self._trueCenterInitially = isTrueCentered
+		for focusType, checkBox in self._followFocusCheckBoxes.items():
+			shouldFollow = checkBox.GetValue()
+			self._followFocusInitially[focusType] = shouldFollow
+		self._keepMouseCenteredInitially = keepMouseCentered
 
 	def onDiscard(self):
 		"""Restore magnifier state from original settings from config."""


### PR DESCRIPTION
### Link to issue number:
Fixes #20235

Fix-up of #20050 
### Summary of the issue:
When pressing apply in Magnifier settings panel, the values were not kept in memory. Thus, if dialog was then discarded, the initial values memorized when the dialog was opened were restored instead of the ones after Aply has been pressed.
### Description of user facing changes:
When Mag settings dialog is discarded, the values of parameters present in the dialog when Apply was pressed are now restored as expected.

### Description of developer facing changes:
N/A
### Description of development approach:
Updated the *initially variables when settings panel is saved, i.e. when Apply or OK are pressed.
For OK, this has no impact since the dialog is closed.

### Testing strategy:
Manual tests: STR of #20235
### Known issues with pull request:
None
### Code Review Checklist:


- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
