### PR TITLE
Support multi routing on Freedom Scientific displays

### DIFF
--- a/source/brailleDisplayDrivers/freedomScientific.py
+++ b/source/brailleDisplayDrivers/freedomScientific.py
@@ -22,6 +22,12 @@ from hwIo import intToByte
 from logHandler import log
 from utils._deprecate import MovedSymbol, handleDeprecations
 
+__getattr__ = handleDeprecations(
+	MovedSymbol("RoutingGesture", "brailleDisplayDrivers.freedomScientific", "KeyGesture"),
+)
+"""Module level `__getattr__` used to preserve backward compatibility."""
+
+
 BAUD_RATE = 57600
 PARITY = serial.PARITY_NONE
 
@@ -794,9 +800,3 @@ class WizWheelGesture(InputGesture):
 		direction = "Down" if isDown else "Up"
 		self.id = f"{which}WizWheel{direction}"
 		super().__init__(model)
-
-
-__getattr__ = handleDeprecations(
-	MovedSymbol("RoutingGesture", "brailleDisplayDrivers.freedomScientific", "KeyGesture"),
-)
-"""Module level `__getattr__` used to preserve backward compatibility."""

--- a/source/brailleDisplayDrivers/freedomScientific.py
+++ b/source/brailleDisplayDrivers/freedomScientific.py
@@ -100,13 +100,13 @@ DOTS_TABLE_SIZE = 8
 TRANSLATION_TABLE_SIZE = 2**DOTS_TABLE_SIZE
 
 
-def _makeTranslationTable(dotsTable):
+def _makeTranslationTable(dotsTable: list[int]) -> list[int]:
 	"""Create a translation table for braille dot combinations
 
-	@param dotsTable: The list of 8 bitmasks to use for each dot (dot 1 - 8)
+	:param dotsTable: The list of 8 bitmasks to use for each dot (dot 1 - 8)
 	"""
 
-	def isoDot(number):
+	def isoDot(number: int) -> int:
 		"""
 		Returns the ISO 11548 formatted braille dot for the given number.
 
@@ -118,8 +118,7 @@ def _makeTranslationTable(dotsTable):
 
 		Based on: https://github.com/brltty/brltty/blob/master/Headers/brl_dots.h
 
-		@param number: The dot to encode (1-8)
-		@type number: int
+		:param number: The dot to encode (1-8)
 		"""
 		return 1 << (number - 1)
 
@@ -133,21 +132,16 @@ def _makeTranslationTable(dotsTable):
 	return outputTable
 
 
-def _translate(cells, translationTable):
+def _translate(cells: list[int], translationTable: list[int]) -> list[int]:
 	"""Translate cells according to a translation table
 
 	The translation table contains the bytes to encode all the possible dot combinations.
 	See :meth:`_makeTranslationTable` as well.
 
-	@param cells: The cells to translate, given in ISO 11548 format (used by most braille displays)
-	@type cells: [int]
-	@param translationTable: A list of all possible braille dot combinations
-	@type translationTable: [int]
+	:param cells: The cells to translate, given in ISO 11548 format (used by most braille displays)
+	:param translationTable: A list of all possible braille dot combinations
 	"""
-	outCells = [0] * len(cells)
-	for i, cell in enumerate(cells):
-		outCells[i] = translationTable[cell]
-	return outCells
+	return [translationTable[cell] for cell in cells]
 
 
 #: Dots table used by first generation Focus displays
@@ -197,7 +191,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver, ScriptableObject):
 	]
 
 	@classmethod
-	def registerAutomaticDetection(cls, driverRegistrar: bdDetect.DriverRegistrar):
+	def registerAutomaticDetection(cls, driverRegistrar: bdDetect.DriverRegistrar) -> None:
 		driverRegistrar.addUsbDevices(
 			bdDetect.ProtocolType.CUSTOM,
 			{
@@ -220,7 +214,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver, ScriptableObject):
 			),
 		)
 
-	def __init__(self, port="auto"):
+	def __init__(self, port: str | bdDetect.DeviceMatch = "auto"):
 		self.numCells = 0
 		self._ackPending = False
 		self._pendingCells = []
@@ -301,7 +295,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver, ScriptableObject):
 		)
 		self._restarting = False
 
-	def terminate(self):
+	def terminate(self) -> None:
 		try:
 			super().terminate()
 		finally:
@@ -316,32 +310,23 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver, ScriptableObject):
 		arg2: bytes = FS_BYTE_NULL,
 		arg3: bytes = FS_BYTE_NULL,
 		data: bytes = FS_DATA_EMPTY,
-	):
+	) -> None:
 		"""Send a packet to the display
-		@param packetType: Type of packet (first byte), use one of the FS_PKT constants
-		@param arg1: First argument (second byte of packet)
-		@param arg2: Second argument (third byte of packet)
-		@param arg3: Third argument (fourth byte of packet)
-		@param data: Data to send if this is an extended packet, required checksum will
+		:param packetType: Type of packet (first byte), use one of the FS_PKT constants
+		:param arg1: First argument (second byte of packet)
+		:param arg2: Second argument (third byte of packet)
+		:param arg3: Third argument (fourth byte of packet)
+		:param data: Data to send if this is an extended packet, required checksum will
 			be added automatically
 		"""
 
-		def handleArg(arg: bytes) -> bytes:
-			if isinstance(arg, bytes):
-				return arg
-			else:
-				raise TypeError("Expected arg to be bytes")
-
-		arg1 = handleArg(arg1)
-		arg2 = handleArg(arg2)
-		arg3 = handleArg(arg3)
 		packet = b"".join([packetType, arg1, arg2, arg3, data])
 		if data:
 			checksum = BrailleDisplayDriver._calculateChecksum(packet)
 			packet += intToByte(checksum)
 		self._dev.write(packet)
 
-	def _onReceive(self, data: bytes):
+	def _onReceive(self, data: bytes) -> None:
 		"""Event handler when data from the display is received
 
 		Formats a packet of four bytes in a packet type and three arguments.
@@ -367,7 +352,9 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver, ScriptableObject):
 			calculatedChecksum = BrailleDisplayDriver._calculateChecksum(
 				packetType + arg1 + arg2 + arg3 + payload,
 			)
-			assert calculatedChecksum == checksum, f"Checksum mismatch, expected {checksum} but got {payload[-1]}"
+			assert calculatedChecksum == checksum, (
+				f"Checksum mismatch, expected {checksum} but got {payload[-1]}"
+			)
 		else:
 			payload = FS_DATA_EMPTY
 
@@ -391,7 +378,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver, ScriptableObject):
 		arg2: bytes,
 		arg3: bytes,
 		payload: bytes,
-	):
+	) -> None:
 		"""Handle a packet from the device"
 
 		The following packet types are handled:
@@ -467,11 +454,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver, ScriptableObject):
 				log.debugWarning("wheelNumber unknown")
 				return
 			for _i in range(count):
-				gesture = WizWheelGesture(self._model, isDown, isRight)
-				try:
-					inputCore.manager.executeGesture(gesture)
-				except inputCore.NoInputGestureAction:
-					pass
+				self._executeGesture(WizWheelGesture(self._model, isDown, isRight))
 		elif packetType == FS_PKT_BUTTON:
 			key = ord(arg1)
 			# the least significant bit is set when the key is pressed
@@ -488,14 +471,22 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver, ScriptableObject):
 		else:
 			log.debugWarning("Unknown packet of type: %r", packetType)
 
-	def _handleAck(self):
+	@staticmethod
+	def _executeGesture(gesture: "InputGesture") -> None:
+		"""Execute a gesture, ignoring it if no action is mapped."""
+		try:
+			inputCore.manager.executeGesture(gesture)
+		except inputCore.NoInputGestureAction:
+			pass
+
+	def _handleAck(self) -> None:
 		"Displays any queued cells after receiving an ACK"
 		super()._handleAck()
 		if self._pendingCells:
 			self.display(self._pendingCells)
 
 	@staticmethod
-	def _updateKeyBits(keyBits: int, oldKeyBits: int, keyCount: int):
+	def _updateKeyBits(keyBits: int, oldKeyBits: int, keyCount: int) -> tuple[int, bool, int, bool]:
 		"""Helper function that reports if keys have been pressed and which keys have been released
 		based on old and new keybits.
 		"""
@@ -521,7 +512,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver, ScriptableObject):
 			keyBit <<= 1
 		return oldKeyBits, isRelease, keyBitsBeforeRelease, newKeysPressed
 
-	def _handleKeys(self, keyBits: int):
+	def _handleKeys(self, keyBits: int) -> None:
 		"""Send gestures if keys are released and update self._keyBits"""
 		keyBits, isRelease, keyBitsBeforeRelease, newKeysPressed = self._updateKeyBits(
 			keyBits,
@@ -532,20 +523,18 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver, ScriptableObject):
 			self._ignoreKeyReleases = False
 		self._keyBits = keyBits
 		if isRelease and not self._ignoreKeyReleases:
-			gesture = KeyGesture(
-				self._model,
-				keyBitsBeforeRelease,
-				self._extendedKeyBits,
-				self._routingKeyBits,
-				self._topRoutingKeyBits,
+			self._executeGesture(
+				KeyGesture(
+					self._model,
+					keyBitsBeforeRelease,
+					self._extendedKeyBits,
+					self._routingKeyBits,
+					self._topRoutingKeyBits,
+				),
 			)
-			try:
-				inputCore.manager.executeGesture(gesture)
-			except inputCore.NoInputGestureAction:
-				pass
 			self._ignoreKeyReleases = True
 
-	def _handleExtendedKeys(self, keyBits: int):
+	def _handleExtendedKeys(self, keyBits: int) -> None:
 		"""Send gestures if keys are released and update self._extendedKeyBits"""
 		keyBits, isRelease, keyBitsBeforeRelease, newKeysPressed = self._updateKeyBits(
 			keyBits,
@@ -556,20 +545,18 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver, ScriptableObject):
 			self._ignoreKeyReleases = False
 		self._extendedKeyBits = keyBits
 		if isRelease and not self._ignoreKeyReleases:
-			gesture = KeyGesture(
-				self._model,
-				self._keyBits,
-				keyBitsBeforeRelease,
-				self._routingKeyBits,
-				self._topRoutingKeyBits,
+			self._executeGesture(
+				KeyGesture(
+					self._model,
+					self._keyBits,
+					keyBitsBeforeRelease,
+					self._routingKeyBits,
+					self._topRoutingKeyBits,
+				),
 			)
-			try:
-				inputCore.manager.executeGesture(gesture)
-			except inputCore.NoInputGestureAction:
-				pass
 			self._ignoreKeyReleases = True
 
-	def _handleRoutingKey(self, key: int, isPress: bool, isTopRow: bool):
+	def _handleRoutingKey(self, key: int, isPress: bool, isTopRow: bool) -> None:
 		"""Track routing key presses and fire a gesture on the first release."""
 		keyMask = 1 << key
 		if isPress:
@@ -583,17 +570,15 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver, ScriptableObject):
 		# Guard against stray release with no preceding press.
 		currentBits = self._topRoutingKeyBits if isTopRow else self._routingKeyBits
 		if currentBits & keyMask and not self._ignoreKeyReleases:
-			gesture = KeyGesture(
-				self._model,
-				self._keyBits,
-				self._extendedKeyBits,
-				self._routingKeyBits,
-				self._topRoutingKeyBits,
+			self._executeGesture(
+				KeyGesture(
+					self._model,
+					self._keyBits,
+					self._extendedKeyBits,
+					self._routingKeyBits,
+					self._topRoutingKeyBits,
+				),
 			)
-			try:
-				inputCore.manager.executeGesture(gesture)
-			except inputCore.NoInputGestureAction:
-				pass
 			self._ignoreKeyReleases = True
 		if isTopRow:
 			self._topRoutingKeyBits &= ~keyMask
@@ -603,13 +588,9 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver, ScriptableObject):
 	@staticmethod
 	def _calculateChecksum(data: bytes) -> int:
 		"""Calculate the checksum for extended packets"""
-		checksum = 0
-		for byte in data:
-			checksum -= byte
-		checksum = checksum & 0xFF
-		return checksum
+		return (-sum(data)) & 0xFF
 
-	def display(self, cells: list[int]):
+	def display(self, cells: list[int]) -> None:
 		if self.translationTable:
 			cells = _translate(cells, FOCUS_1_TRANSLATION_TABLE)
 		if not self._awaitingAck:
@@ -624,7 +605,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver, ScriptableObject):
 		else:
 			self._pendingCells = cells
 
-	def _configureDisplay(self):
+	def _configureDisplay(self) -> None:
 		"""Enable extended keys on Focus firmware 3 and up"""
 		if not self._model or not self._firmwareVersion:
 			return
@@ -637,17 +618,13 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver, ScriptableObject):
 			)
 			self._sendPacket(FS_PKT_CONFIG, FS_CFG_EXTKEY)
 
-	def script_toggleLeftWizWheelAction(self, _gesture):
-		# Python 3: review required
-		# original: self.leftWizWheelActionCycle.next()
+	def script_toggleLeftWizWheelAction(self, _gesture: inputCore.InputGesture) -> None:
 		action = next(self.leftWizWheelActionCycle)
 		self.gestureMap.add("br(freedomScientific):leftWizWheelUp", *action[1], replace=True)
 		self.gestureMap.add("br(freedomScientific):leftWizWheelDown", *action[2], replace=True)
 		braille.handler.message(action[0])
 
-	def script_toggleRightWizWheelAction(self, _gesture):
-		# Python 3: review required
-		# original: self.rightWizWheelActionCycle.next()
+	def script_toggleRightWizWheelAction(self, _gesture: inputCore.InputGesture) -> None:
 		action = next(self.rightWizWheelActionCycle)
 		self.gestureMap.add("br(freedomScientific):rightWizWheelUp", *action[1], replace=True)
 		self.gestureMap.add("br(freedomScientific):rightWizWheelDown", *action[2], replace=True)
@@ -722,13 +699,12 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver, ScriptableObject):
 	)
 
 
-# pylint: disable=abstract-method
 class InputGesture(braille.BrailleDisplayGesture):
 	"""Base gesture for this braille display"""
 
 	source = BrailleDisplayDriver.name
 
-	def __init__(self, model: str):
+	def __init__(self, model: str) -> None:
 		self.model = model.replace(" ", "")
 		super().__init__()
 
@@ -773,29 +749,29 @@ class KeyGesture(InputGesture, brailleInput.BrailleInputGesture):
 		"rightRockerBarDown",
 	]
 
+	@staticmethod
+	def _bitmaskToIndexes(bitmask: int) -> list[int]:
+		"""Return the ascending indexes of the set bits in C{bitmask}."""
+		return [i for i in range(bitmask.bit_length()) if (bitmask >> i) & 1]
+
 	def __init__(
 		self,
-		model,
+		model: str,
 		keyBits: int,
 		extendedKeyBits: int,
 		routingKeyBits: int = 0,
 		topRoutingKeyBits: int = 0,
-	):
+	) -> None:
 		super().__init__(model)
 		keys = [self.keyLabels[num] for num in range(24) if (keyBits >> num) & 1]
 		extendedKeys = [self.extendedKeyLabels[num] for num in range(4) if (extendedKeyBits >> num) & 1]
-		# pylint: disable=invalid-name
 		idParts = keys + extendedKeys
 		if routingKeyBits:
-			routingIndexes = sorted(
-				i for i in range(routingKeyBits.bit_length()) if (routingKeyBits >> i) & 1
-			)
+			routingIndexes = self._bitmaskToIndexes(routingKeyBits)
 			self.cellIndexes = routingIndexes
 			idParts.append(self.idForCellCount(len(routingIndexes)))
 		if topRoutingKeyBits:
-			topIndexes = sorted(
-				i for i in range(topRoutingKeyBits.bit_length()) if (topRoutingKeyBits >> i) & 1
-			)
+			topIndexes = self._bitmaskToIndexes(topRoutingKeyBits)
 			if len(topIndexes) == 1:
 				idParts.append(f"topRouting{(topIndexes[0] + 1)}")
 			else:
@@ -815,10 +791,9 @@ class KeyGesture(InputGesture, brailleInput.BrailleInputGesture):
 class WizWheelGesture(InputGesture):
 	"""Gesture to handle wiz wheels movements"""
 
-	def __init__(self, model: str, isDown: bool, isRight: bool):
+	def __init__(self, model: str, isDown: bool, isRight: bool) -> None:
 		which = "right" if isRight else "left"
 		direction = "Down" if isDown else "Up"
-		# pylint: disable=invalid-name
 		self.id = f"{which}WizWheel{direction}"
 		super().__init__(model)
 

--- a/source/brailleDisplayDrivers/freedomScientific.py
+++ b/source/brailleDisplayDrivers/freedomScientific.py
@@ -765,18 +765,18 @@ class KeyGesture(InputGesture, brailleInput.BrailleInputGesture):
 		keys = [self.keyLabels[num] for num in range(24) if (keyBits >> num) & 1]
 		extendedKeys = [self.extendedKeyLabels[num] for num in range(4) if (extendedKeyBits >> num) & 1]
 		idParts = keys + extendedKeys
-		if routingKeyBits:
-			routingIndexes = self._bitmaskToIndexes(routingKeyBits)
-			self.cellIndexes = routingIndexes
-			idParts.append(self.idForCellCount(len(routingIndexes)))
-		if topRoutingKeyBits:
-			topIndexes = self._bitmaskToIndexes(topRoutingKeyBits)
-			if len(topIndexes) == 1:
-				idParts.append(f"topRouting{(topIndexes[0] + 1)}")
-			else:
-				# Simultaneous main-row + top-row presses are implausible; top-row wins for cellIndexes.
-				self.cellIndexes = topIndexes
-				idParts.append(self.idForCellCount(len(topIndexes), "topRouting"))
+		# Merge the cells addressed by every routing range into a single cellIndexes list,
+		# mirroring other multi-range drivers (e.g. ALVA, Standard HID Braille).
+		# Each pressed range contributes its own id part via idForCellCount.
+		cellIndexes: list[int] = []
+		for rangeName, rangeBits in (("routing", routingKeyBits), ("topRouting", topRoutingKeyBits)):
+			if not rangeBits:
+				continue
+			rangeIndexes = self._bitmaskToIndexes(rangeBits)
+			cellIndexes.extend(rangeIndexes)
+			idParts.append(self.idForCellCount(len(rangeIndexes), rangeName))
+		if cellIndexes:
+			self.cellIndexes = sorted(cellIndexes)
 		self.id = "+".join(idParts)
 		# Don't say is this a dots gesture if some keys either from dots and space are pressed.
 		# Guard keyBits != 0 to avoid treating a pure-routing release as a zero-dots braille input.

--- a/source/brailleDisplayDrivers/freedomScientific.py
+++ b/source/brailleDisplayDrivers/freedomScientific.py
@@ -352,7 +352,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver, ScriptableObject):
 				packetType + arg1 + arg2 + arg3 + payload,
 			)
 			assert calculatedChecksum == checksum, (
-				f"Checksum mismatch, expected {checksum} but got {payload[-1]}"
+				f"Checksum mismatch, expected {calculatedChecksum} but got {checksum}"
 			)
 		else:
 			payload = FS_DATA_EMPTY
@@ -378,7 +378,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver, ScriptableObject):
 		arg3: bytes,
 		payload: bytes,
 	) -> None:
-		"""Handle a packet from the device"
+		"""Handle a packet from the device.
 
 		The following packet types are handled:
 
@@ -750,7 +750,7 @@ class KeyGesture(InputGesture, brailleInput.BrailleInputGesture):
 
 	@staticmethod
 	def _bitmaskToIndexes(bitmask: int) -> list[int]:
-		"""Return the ascending indexes of the set bits in C{bitmask}."""
+		"""Return the ascending indexes of the set bits in `bitmask`."""
 		return [i for i in range(bitmask.bit_length()) if (bitmask >> i) & 1]
 
 	def __init__(

--- a/source/brailleDisplayDrivers/freedomScientific.py
+++ b/source/brailleDisplayDrivers/freedomScientific.py
@@ -779,8 +779,7 @@ class KeyGesture(InputGesture, brailleInput.BrailleInputGesture):
 			self.cellIndexes = cellIndexes
 		self.id = "+".join(idParts)
 		# Don't say is this a dots gesture if some keys either from dots and space are pressed.
-		# Guard keyBits != 0 to avoid treating a pure-routing release as a zero-dots braille input.
-		if keyBits and not extendedKeyBits and not keyBits & ~(0xFF | (1 << 0xF)):
+		if not extendedKeyBits and not keyBits & ~(0xFF | (1 << 0xF)):
 			self.dots = keyBits & 0xFF
 			# Is space?
 			if keyBits & (1 << 0xF):

--- a/source/brailleDisplayDrivers/freedomScientific.py
+++ b/source/brailleDisplayDrivers/freedomScientific.py
@@ -776,7 +776,7 @@ class KeyGesture(InputGesture, brailleInput.BrailleInputGesture):
 			cellIndexes.extend(rangeIndexes)
 			idParts.append(self.idForCellCount(len(rangeIndexes), rangeName))
 		if cellIndexes:
-			self.cellIndexes = sorted(cellIndexes)
+			self.cellIndexes = cellIndexes
 		self.id = "+".join(idParts)
 		# Don't say is this a dots gesture if some keys either from dots and space are pressed.
 		# Guard keyBits != 0 to avoid treating a pure-routing release as a zero-dots braille input.

--- a/source/brailleDisplayDrivers/freedomScientific.py
+++ b/source/brailleDisplayDrivers/freedomScientific.py
@@ -8,20 +8,19 @@ Braille display driver for Freedom Scientific braille displays.
 A c(lang) reference implementation is available in brltty.
 """
 
-from io import BytesIO
 import itertools
+from io import BytesIO
 
-import braille
-import inputCore
-from baseObject import ScriptableObject
-from logHandler import log
 import bdDetect
+import braille
 import brailleInput
 import hwIo
-from hwIo import intToByte
+import inputCore
 import serial
-from utils._deprecate import handleDeprecations, MovedSymbol
-
+from baseObject import ScriptableObject
+from hwIo import intToByte
+from logHandler import log
+from utils._deprecate import MovedSymbol, handleDeprecations
 
 BAUD_RATE = 57600
 PARITY = serial.PARITY_NONE

--- a/source/brailleDisplayDrivers/freedomScientific.py
+++ b/source/brailleDisplayDrivers/freedomScientific.py
@@ -10,7 +10,6 @@ A c(lang) reference implementation is available in brltty.
 
 from io import BytesIO
 import itertools
-from typing import List, Optional
 
 import braille
 import inputCore
@@ -21,6 +20,7 @@ import brailleInput
 import hwIo
 from hwIo import intToByte
 import serial
+from utils._deprecate import handleDeprecations, MovedSymbol
 
 
 BAUD_RATE = 57600
@@ -41,7 +41,7 @@ MODELS = {
 #: Number of cells of Focus first generation displays
 #  The assumption is that any displays with the following cell counts are due to three cells at the
 #  beginning/end of the display are used as status cells, and an extra blank cell to separate status
-#  from normal cells. These devices require a special translation table: L{FOCUS_1_TRANSLATION_TABLE}
+#  from normal cells. These devices require a special translation table: :data:`FOCUS_1_TRANSLATION_TABLE`
 #  This line of displays is known as the first generation Focus displays.
 FOCUS_1_CELL_COUNTS = (44, 70, 84)
 
@@ -137,7 +137,7 @@ def _translate(cells, translationTable):
 	"""Translate cells according to a translation table
 
 	The translation table contains the bytes to encode all the possible dot combinations.
-	See L{_makeTranslationTable} as well.
+	See :meth:`_makeTranslationTable` as well.
 
 	@param cells: The cells to translate, given in ISO 11548 format (used by most braille displays)
 	@type cells: [int]
@@ -226,10 +226,12 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver, ScriptableObject):
 		self._pendingCells = []
 		self._keyBits = 0
 		self._extendedKeyBits = 0
+		self._routingKeyBits = 0
+		self._topRoutingKeyBits = 0
 		self._ignoreKeyReleases = False
-		self._model: Optional[str] = None
-		self._manufacturer: Optional[str] = None
-		self._firmwareVersion: Optional[str] = None
+		self._model: str | None = None
+		self._manufacturer: str | None = None
+		self._firmwareVersion: str | None = None
 		self.translationTable = None
 		self.leftWizWheelActionCycle = itertools.cycle(self.wizWheelActions)
 		action = next(self.leftWizWheelActionCycle)
@@ -239,7 +241,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver, ScriptableObject):
 		action = next(self.rightWizWheelActionCycle)
 		self.gestureMap.add("br(freedomScientific):rightWizWheelUp", *action[1])
 		self.gestureMap.add("br(freedomScientific):rightWizWheelDown", *action[2])
-		super(BrailleDisplayDriver, self).__init__()
+		super().__init__()
 		for portType, portId, port, portInfo in self._getTryPorts(port):
 			self.isUsb = portType == bdDetect.ProtocolType.CUSTOM
 			# Try talking to the display.
@@ -262,7 +264,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver, ScriptableObject):
 						writeTimeout=self.timeout,
 						onReceive=self._onReceive,
 					)
-			except EnvironmentError:
+			except OSError:
 				log.debugWarning("", exc_info=True)
 				continue
 
@@ -276,11 +278,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver, ScriptableObject):
 			if self.numCells and self._model:
 				# A display responded.
 				log.info(
-					"Found {device} connected via {type} ({port})".format(
-						device=self._model,
-						type=portType,
-						port=port,
-					),
+					f"Found {self._model} connected via {portType} ({port})",
 				)
 				break
 			self._dev.close()
@@ -296,7 +294,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver, ScriptableObject):
 			"braille_scrollBack",
 		)
 		self.gestureMap.add(
-			"br(freedomScientific):topRouting%d" % self.numCells,
+			f"br(freedomScientific):topRouting{self.numCells}",
 			"globalCommands",
 			"GlobalCommands",
 			"braille_scrollForward",
@@ -305,7 +303,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver, ScriptableObject):
 
 	def terminate(self):
 		try:
-			super(BrailleDisplayDriver, self).terminate()
+			super().terminate()
 		finally:
 			# Make sure the device gets closed.
 			# If it doesn't, we may not be able to re-open it later.
@@ -348,7 +346,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver, ScriptableObject):
 
 		Formats a packet of four bytes in a packet type and three arguments.
 		If the packet is known to have a payload, this is also fetched and the checksum is verified.
-		The constructed packet is handed off to L{_handlePacket}.
+		The constructed packet is handed off to :meth:`_handlePacket`.
 		"""
 		if self.isUsb:
 			data = BytesIO(data)
@@ -369,10 +367,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver, ScriptableObject):
 			calculatedChecksum = BrailleDisplayDriver._calculateChecksum(
 				packetType + arg1 + arg2 + arg3 + payload,
 			)
-			assert calculatedChecksum == checksum, "Checksum mismatch, expected %s but got %s" % (
-				checksum,
-				payload[-1],
-			)
+			assert calculatedChecksum == checksum, f"Checksum mismatch, expected {checksum} but got {payload[-1]}"
 		else:
 			payload = FS_DATA_EMPTY
 
@@ -401,25 +396,25 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver, ScriptableObject):
 
 		The following packet types are handled:
 
-			* FS_PKT_ACK: See L{_handleAck}
+			* FS_PKT_ACK: See :meth:`_handleAck`
 			* FS_PKT_NAK: Logged and handled as an ACK
 			* FS_PKT_INFO: Manufacturer, model and firmware version are extracted and set as
-				properties on the object. Cell count is determined based on L{MODELS}.
+				properties on the object. Cell count is determined based on :data:`MODELS`.
 				* arg1: length of payload
 				* payload: manufacturer, model, firmware version in a fixed width field string
-			* FS_PKT_WHEEL: The corresponding L{WheelGesture}s are sent for the wheel events.
+			* FS_PKT_WHEEL: The corresponding :class:`WheelGesture`s are sent for the wheel events.
 				* arg1: movement direction (up/down) and number of clicks moved
 					Bits: BBBAAA (least significant)
 					* A: (bits 1-3) number of clicks the wheel has moved
 					* B: (bits 4-6) which wheel (left/right) and what direction (up/down)
-			* FS_PKT_BUTTON: the corresponding L{RoutingGesture} is sent
+			* FS_PKT_BUTTON: the corresponding :class:`KeyGesture` is sent
 				* arg1: number of routing button
 				* arg2: key press/release
 				* arg3: if this is a button on the second row of routing buttons
 			* FS_PKT_KEY: a key or button on the display is pressed/released (including the braille keyboard)
 				* arg 1, 2, 3, 4:
 					These bytes form the value indicating which of the 8 keys are pressed on the device.
-					Key releases can be detected by comparing to the previous state, this work is done in L{_handleKeys}.
+					Key releases can be detected by comparing to the previous state, this work is done in :meth:`_handleKeys`.
 			* FS_PKT_EXT_KEY: ??
 				* payload: The 4 most significant bits from a single byte are used.
 					More investigation is required.
@@ -483,14 +478,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver, ScriptableObject):
 			leastSigBitMask = 0x01
 			isPress = bool(ord(arg2) & leastSigBitMask)
 			isTopRow = bool(ord(arg3))
-			if isPress:
-				# Ignore keypresses
-				return
-			gesture = RoutingGesture(self._model, key, isTopRow)
-			try:
-				inputCore.manager.executeGesture(gesture)
-			except inputCore.NoInputGestureAction:
-				pass
+			self._handleRoutingKey(key, isPress, isTopRow)
 		elif packetType == FS_PKT_KEY:
 			keyBits = ord(arg1) | (ord(arg2) << 8) | (ord(arg3) << 16)
 			self._handleKeys(keyBits)
@@ -502,7 +490,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver, ScriptableObject):
 
 	def _handleAck(self):
 		"Displays any queued cells after receiving an ACK"
-		super(BrailleDisplayDriver, self)._handleAck()
+		super()._handleAck()
 		if self._pendingCells:
 			self.display(self._pendingCells)
 
@@ -544,7 +532,13 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver, ScriptableObject):
 			self._ignoreKeyReleases = False
 		self._keyBits = keyBits
 		if isRelease and not self._ignoreKeyReleases:
-			gesture = KeyGesture(self._model, keyBitsBeforeRelease, self._extendedKeyBits)
+			gesture = KeyGesture(
+				self._model,
+				keyBitsBeforeRelease,
+				self._extendedKeyBits,
+				self._routingKeyBits,
+				self._topRoutingKeyBits,
+			)
 			try:
 				inputCore.manager.executeGesture(gesture)
 			except inputCore.NoInputGestureAction:
@@ -562,12 +556,49 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver, ScriptableObject):
 			self._ignoreKeyReleases = False
 		self._extendedKeyBits = keyBits
 		if isRelease and not self._ignoreKeyReleases:
-			gesture = KeyGesture(self._model, self._keyBits, keyBitsBeforeRelease)
+			gesture = KeyGesture(
+				self._model,
+				self._keyBits,
+				keyBitsBeforeRelease,
+				self._routingKeyBits,
+				self._topRoutingKeyBits,
+			)
 			try:
 				inputCore.manager.executeGesture(gesture)
 			except inputCore.NoInputGestureAction:
 				pass
 			self._ignoreKeyReleases = True
+
+	def _handleRoutingKey(self, key: int, isPress: bool, isTopRow: bool):
+		"""Track routing key presses and fire a gesture on the first release."""
+		keyMask = 1 << key
+		if isPress:
+			if isTopRow:
+				self._topRoutingKeyBits |= keyMask
+			else:
+				self._routingKeyBits |= keyMask
+			self._ignoreKeyReleases = False
+			return
+		# On release: fire gesture while key is still tracked as pressed, then clear bit.
+		# Guard against stray release with no preceding press.
+		currentBits = self._topRoutingKeyBits if isTopRow else self._routingKeyBits
+		if currentBits & keyMask and not self._ignoreKeyReleases:
+			gesture = KeyGesture(
+				self._model,
+				self._keyBits,
+				self._extendedKeyBits,
+				self._routingKeyBits,
+				self._topRoutingKeyBits,
+			)
+			try:
+				inputCore.manager.executeGesture(gesture)
+			except inputCore.NoInputGestureAction:
+				pass
+			self._ignoreKeyReleases = True
+		if isTopRow:
+			self._topRoutingKeyBits &= ~keyMask
+		else:
+			self._routingKeyBits &= ~keyMask
 
 	@staticmethod
 	def _calculateChecksum(data: bytes) -> int:
@@ -578,7 +609,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver, ScriptableObject):
 		checksum = checksum & 0xFF
 		return checksum
 
-	def display(self, cells: List[int]):
+	def display(self, cells: list[int]):
 		if self.translationTable:
 			cells = _translate(cells, FOCUS_1_TRANSLATION_TABLE)
 		if not self._awaitingAck:
@@ -631,6 +662,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver, ScriptableObject):
 		{
 			"globalCommands.GlobalCommands": {
 				"braille_routeTo": ("br(freedomScientific):routing",),
+				"braille_selectRange": ("br(freedomScientific):multiRouting",),
 				"braille_scrollBack": (
 					"br(freedomScientific):leftAdvanceBar",
 					"br(freedomScientific):leftBumperBarUp",
@@ -698,7 +730,7 @@ class InputGesture(braille.BrailleDisplayGesture):
 
 	def __init__(self, model: str):
 		self.model = model.replace(" ", "")
-		super(InputGesture, self).__init__()
+		super().__init__()
 
 
 class KeyGesture(InputGesture, brailleInput.BrailleInputGesture):
@@ -741,27 +773,43 @@ class KeyGesture(InputGesture, brailleInput.BrailleInputGesture):
 		"rightRockerBarDown",
 	]
 
-	def __init__(self, model, keyBits: int, extendedKeyBits: int):
-		super(KeyGesture, self).__init__(model)
+	def __init__(
+		self,
+		model,
+		keyBits: int,
+		extendedKeyBits: int,
+		routingKeyBits: int = 0,
+		topRoutingKeyBits: int = 0,
+	):
+		super().__init__(model)
 		keys = [self.keyLabels[num] for num in range(24) if (keyBits >> num) & 1]
 		extendedKeys = [self.extendedKeyLabels[num] for num in range(4) if (extendedKeyBits >> num) & 1]
 		# pylint: disable=invalid-name
-		self.id = "+".join(keys + extendedKeys)
+		idParts = keys + extendedKeys
+		if routingKeyBits:
+			routingIndexes = sorted(
+				i for i in range(routingKeyBits.bit_length()) if (routingKeyBits >> i) & 1
+			)
+			self.cellIndexes = routingIndexes
+			idParts.append(self.idForCellCount(len(routingIndexes)))
+		if topRoutingKeyBits:
+			topIndexes = sorted(
+				i for i in range(topRoutingKeyBits.bit_length()) if (topRoutingKeyBits >> i) & 1
+			)
+			if len(topIndexes) == 1:
+				idParts.append(f"topRouting{(topIndexes[0] + 1)}")
+			else:
+				# Simultaneous main-row + top-row presses are implausible; top-row wins for cellIndexes.
+				self.cellIndexes = topIndexes
+				idParts.append(self.idForCellCount(len(topIndexes), "topRouting"))
+		self.id = "+".join(idParts)
 		# Don't say is this a dots gesture if some keys either from dots and space are pressed.
-		if not extendedKeyBits and not keyBits & ~(0xFF | (1 << 0xF)):
+		# Guard keyBits != 0 to avoid treating a pure-routing release as a zero-dots braille input.
+		if keyBits and not extendedKeyBits and not keyBits & ~(0xFF | (1 << 0xF)):
 			self.dots = keyBits & 0xFF
 			# Is space?
 			if keyBits & (1 << 0xF):
 				self.space = True
-
-
-class RoutingGesture(InputGesture):
-	"""Gesture to handle cursor routing and second row of routing keys on older models"""
-
-	def __init__(self, model: str, routingIndex: int, topRow: bool = False):
-		self.id = "topRouting" if topRow else "routing"
-		self.cellIndexes = [routingIndex]
-		super(RoutingGesture, self).__init__(model)
 
 
 class WizWheelGesture(InputGesture):
@@ -771,5 +819,11 @@ class WizWheelGesture(InputGesture):
 		which = "right" if isRight else "left"
 		direction = "Down" if isDown else "Up"
 		# pylint: disable=invalid-name
-		self.id = "%sWizWheel%s" % (which, direction)
-		super(WizWheelGesture, self).__init__(model)
+		self.id = f"{which}WizWheel{direction}"
+		super().__init__(model)
+
+
+__getattr__ = handleDeprecations(
+	MovedSymbol("RoutingGesture", "brailleDisplayDrivers.freedomScientific", "KeyGesture"),
+)
+"""Module level `__getattr__` used to preserve backward compatibility."""

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -8,7 +8,7 @@
 
 * On supported braille displays, pressing multiple routing keys simultaneously can now be bound to a new "multi routing" gesture. (#20001, @LeonarddeR)
   * The "select range" command, which selects the text from the first up to the last pressed routing key, is bound to this gesture by default on supporting drivers.
-  * Drivers with built-in support for multi routing: ALVA, Albatross (only when combined with `home1` or `home2`), Baum (and compatible), HumanWare Brailliant BI/B series, Handy Tech, NLS eReader Zoomax, Seika Notetaker, and Standard HID Braille displays.
+  * Drivers with built-in support for multi routing: ALVA, Albatross (only when combined with `home1` or `home2`), Baum (and compatible), Freedom Scientific Focus/PAC Mate, HumanWare Brailliant BI/B series, Handy Tech, NLS eReader Zoomax, Seika Notetaker, and Standard HID Braille displays.
 * The braille "word wrap" option has been replaced with a four-valued "Text wrap" option: Off, Show mark when words are cut, At word boundaries, and At word or syllable boundaries. (#17010, @LeonarddeR)
   * In modes that show a continuation mark, when a word is cut across rows, the last cell of the row now shows a continuation mark (braille dots 7-8) so it is clear that the word continues on the next row.
   * The "At word or syllable boundaries" option uses hyphenation dictionaries to split long words at syllable boundaries when they do not fit on the display.
@@ -36,8 +36,11 @@ Please refer to [the developer guide](https://download.nvaccess.org/documentatio
 
 #### Deprecations
 
+<<<<<<< HEAD
 * The `braille.BrailleDisplayGesture.routingIndex` attribute is deprecated.
-  Use the `cellIndexes` attribute instead. (#20001, @LeonarddeR)
+Use the `cellIndexes` attribute instead. (#20001, @LeonarddeR)
+* `brailleDisplayDrivers.freedomScientific.RoutingGesture` is deprecated.
+Use `KeyGesture` instead. (#20077, @LeonarddeR)
 * The `braille.wordWrap` configuration key is deprecated and bridged to `braille.textWrap`. (#17010, @LeonarddeR)
 
 <!-- Beyond this point, Markdown should not be automatically linted, as we don't modify old change log sections and lint rules may change over time. -->

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -36,7 +36,6 @@ Please refer to [the developer guide](https://download.nvaccess.org/documentatio
 
 #### Deprecations
 
-<<<<<<< HEAD
 * The `braille.BrailleDisplayGesture.routingIndex` attribute is deprecated.
 Use the `cellIndexes` attribute instead. (#20001, @LeonarddeR)
 * `brailleDisplayDrivers.freedomScientific.RoutingGesture` is deprecated.

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -5068,7 +5068,7 @@ Please see the display's documentation for descriptions of where these keys can 
 |Move back using right wiz wheel action |rightWizWheelUp|
 |Move forward using right wiz wheel action |rightWizWheelDown|
 |Route to braille cell |routing|
-|Select range from first up to last braille cell |multiRouting|
+| Select range from first up to last braille cell | `multiRouting` |
 |shift+tab key |brailleSpaceBar+dot1+dot2|
 |tab key |brailleSpaceBar+dot4+dot5|
 |upArrow key |brailleSpaceBar+dot1|

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -5068,6 +5068,7 @@ Please see the display's documentation for descriptions of where these keys can 
 |Move back using right wiz wheel action |rightWizWheelUp|
 |Move forward using right wiz wheel action |rightWizWheelDown|
 |Route to braille cell |routing|
+|Select range from first up to last braille cell |multiRouting|
 |shift+tab key |brailleSpaceBar+dot1+dot2|
 |tab key |brailleSpaceBar+dot4+dot5|
 |upArrow key |brailleSpaceBar+dot1|


### PR DESCRIPTION
### Link to issue number:

Fixes #20077. Follow-up of #20028.

### Summary of the issue:

The Freedom Scientific driver ignored routing button presses entirely (`if isPress: return`) and fired a single-cell `RoutingGesture` on each release. It could not signal *which* routing keys were held together, so the "multi routing" / "select range" infrastructure added in #20028 had no effect on Focus/PAC Mate displays.

### Description of user facing changes:

- Pressing multiple routing keys simultaneously on Freedom Scientific Focus/PAC Mate displays is now a single "multi routing" gesture, bound to "select range" by default.
- Single routing presses (route to cell) and the top routing row (scroll) keep working as before.

### Description of developer facing changes:

- `brailleDisplayDrivers.freedomScientific.RoutingGesture` is deprecated; use `KeyGesture`, which now carries routing state. Backward compatibility is preserved via a module-level `__getattr__` / `MovedSymbol`.
- `KeyGesture` gains `routingKeyBits` / `topRoutingKeyBits` parameters, sets `cellIndexes`, and builds its id via `idForCellCount`.

### Description of development approach:

- Routing presses are now tracked as bitmasks (`_routingKeyBits`, `_topRoutingKeyBits`) in `_handleRoutingKey`; one combined `KeyGesture` fires on the first release, then the bits clear. This mirrors the existing `_handleKeys` / `_updateKeyBits` release model instead of firing per key.
- `KeyGesture` merges the cells addressed by every routing range into one sorted `cellIndexes` list and emits an `idForCellCount` part per range, mirroring the ALVA and Standard HID Braille drivers.
- Alongside the fix, the driver was modernized/simplified with no behavior change: Python 3 idioms (`super()`, f-strings, `OSError`, `list[int]` / `X | None`), full type hints, Sphinx-style docstrings, list-comprehension `_translate`, `sum`-based checksum, extracted `_executeGesture` and `_bitmaskToIndexes` helpers, and removal of dead code, stale Python 2 comments and pylint pragmas.

### Testing strategy:

Manual testing on a Focus display: single routing routes to a cell; two routing keys select a range; the top row scrolls.

### Known issues with pull request:

None.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
