### PR TITLE
Fix clearCaches workflow failing on forks without CACHE_EXPIRATION_HOUR variable

### DIFF
--- a/.github/workflows/clearCaches.yml
+++ b/.github/workflows/clearCaches.yml
@@ -12,7 +12,7 @@ on:
         required: false
 
 env:
-  CACHE_EXPIRATION_HOUR: ${{ inputs.cache_expiration || fromJSON(vars.CACHE_EXPIRATION_HOUR) || 6 }}
+  CACHE_EXPIRATION_HOUR: ${{ inputs.cache_expiration || fromJSON(vars.CACHE_EXPIRATION_HOUR || '6') }}
 
 jobs:
   cleanupCache:


### PR DESCRIPTION
### Link to issue number:

No issue filed — minor/trivial CI workflow fix.

### Summary of the issue:

Since #20058 (commit 25b57b850), the `clearCaches` scheduled workflow fails on every fork that does not have the `CACHE_EXPIRATION_HOUR` repository variable set. The workflow runs every 3 hours and consistently fails with:

> Error reading JToken from JsonReader. Path '', line 0, position 0.

This is a regression: before #20058 the expression was `inputs.cache_expiration || 6`, which worked fine on forks.

### Description of user facing changes:

None.

### Description of developer facing changes:

The `clearCaches` scheduled workflow now works on forks out of the box, as described in `ci/README.md` ("Builds from PRs and pushes to master/beta/rc should work out of the box for forks").

### Description of development approach:

`#20058` changed the env var expression to:

```yaml
CACHE_EXPIRATION_HOUR: ${{ inputs.cache_expiration || fromJSON(vars.CACHE_EXPIRATION_HOUR) || 6 }}
```

When `CACHE_EXPIRATION_HOUR` is not set as a repository variable, GitHub Actions evaluates `vars.CACHE_EXPIRATION_HOUR` as an empty string. `fromJSON("")` throws a hard parse error rather than returning a falsy value, so the intended `|| 6` fallback is never reached.

Fix: move the default inside `fromJSON` so the empty string is handled before parsing:

```yaml
CACHE_EXPIRATION_HOUR: ${{ inputs.cache_expiration || fromJSON(vars.CACHE_EXPIRATION_HOUR || '6') }}
```

This preserves the existing behaviour for repos that have the variable set, and correctly falls back to 6 hours for forks that do not.

### Testing strategy:

Manually triggered the fixed workflow on the `bramd/nvda` fork (which does not have `CACHE_EXPIRATION_HOUR` set) — run [26745038474](https://github.com/bramd/nvda/actions/runs/26745038474) succeeded in 4 s, compared to consistent failures on the same fork before the fix.

Before the fix, scheduled run [26735057185](https://github.com/bramd/nvda/actions/runs/26735057185) failed with the JSON parse error on line 15.

### Known issues with pull request:

None.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry — not required, no user-facing change
  - User Documentation — N/A
  - Developer / Technical Documentation — N/A (`ci/README.md` already states this workflow works out of the box for forks)
  - Context sensitive help for GUI changes — N/A
- [x] Testing:
  - Unit tests — N/A (workflow file)
  - System (end to end) tests — N/A
  - Manual testing — manually triggered on a fork without the variable set; passed
- [x] UX of all users considered — N/A (CI workflow only)
- [x] API is compatible with existing add-ons — N/A
- [x] Security precautions taken — N/A