### PR TITLE
Suggest changes to beta phase

### DIFF
--- a/projectDocs/community/releaseProcess.md
+++ b/projectDocs/community/releaseProcess.md
@@ -53,13 +53,15 @@ Reasons in favor of not reverting the pull request may be:
 
 ### Beta phase
 
-* A commit without any known serious issues, will be selected from the 'master' branch and merged into 'beta', this draws the line for features included in the release.
-* Documentation changes will be reviewed. A release summary will be added to the change log for the beta.
-* A tagged 'beta release' will be created for wider testing.
+* A commit without any known serious issues, will be selected from the 'master' branch and merged into 'beta'.
+* Once a beta commit is chosen, no further changes are included in the release, except for:
+  * addressing a bug introduced in the current or previous release cycle.
+  * reverting code introduced in the current release cycle.
+  * addressing a critical Operating System change out of our control.
+* Documentation changes will be reviewed.
+A release summary will be added to the change log for the beta.
+* A tagged "beta release" will be created for wider testing.
 * New pull requests may be now considered for squash merging straight to beta.
-  * If addressing regression introduced in this release.
-  * If addressing a bug in a "must have" feature for this release.
-  * If addressing a critical Operating System change out of our control.
 * As appropriate new tagged beta releases will be published once a week.
 * As necessary `beta` will be merged back into master.
   * For critical pull requests or translation merges.

--- a/projectDocs/community/releaseProcess.md
+++ b/projectDocs/community/releaseProcess.md
@@ -59,6 +59,7 @@ Reasons in favor of not reverting the pull request may be:
   * addressing a `p1` or `p2` filed in the current or previous release cycle.
   * reverting code introduced in the current release cycle.
   * updates to documentation introduced in the current or previous release cycle.
+  * updates to translations.
 * Documentation changes will be reviewed.
 A release summary will be added to the change log for the beta.
 * Once considered stable enough, a tagged "beta release" will be created for wider testing.

--- a/projectDocs/community/releaseProcess.md
+++ b/projectDocs/community/releaseProcess.md
@@ -61,7 +61,6 @@ Reasons in favor of not reverting the pull request may be:
 * Documentation changes will be reviewed.
 A release summary will be added to the change log for the beta.
 * A tagged "beta release" will be created for wider testing.
-* New pull requests may be now considered for squash merging straight to beta.
 * As appropriate new tagged beta releases will be published once a week.
 * As necessary `beta` will be merged back into master.
   * For critical pull requests or translation merges.

--- a/projectDocs/community/releaseProcess.md
+++ b/projectDocs/community/releaseProcess.md
@@ -56,7 +56,7 @@ Reasons in favor of not reverting the pull request may be:
 * A commit will be selected from the `master` branch and merged into `beta`.
 * Once a beta commit is chosen, only the following types of changes are included in the release:
   * addressing a bug introduced in the current or previous release cycle.
-  * addressing a `p1` filed in the current or previous release cycle.
+  * addressing a `p1` or `p2` filed in the current or previous release cycle.
   * reverting code introduced in the current release cycle.
   * updates to documentation introduced in this release cycle.
 * Documentation changes will be reviewed.

--- a/projectDocs/community/releaseProcess.md
+++ b/projectDocs/community/releaseProcess.md
@@ -53,14 +53,14 @@ Reasons in favor of not reverting the pull request may be:
 
 ### Beta phase
 
-* A commit without any known serious issues, will be selected from the `master` branch and merged into `beta`.
+* A commit will be selected from the `master` branch and merged into `beta`.
 * Once a beta commit is chosen, no further changes are included in the release, except the following will be considered:
   * addressing a bug introduced in the current or previous release cycle.
   * addressing a `p1` filed in the current or previous release cycle.
   * reverting code introduced in the current release cycle.
 * Documentation changes will be reviewed.
 A release summary will be added to the change log for the beta.
-* A tagged "beta release" will be created for wider testing.
+* Once considered stable enough, a tagged "beta release" will be created for wider testing.
 * New pull requests may be now considered for squash merging straight to beta.
 * As appropriate new tagged beta releases will be published once a week.
 * As necessary `beta` will be merged back into master.

--- a/projectDocs/community/releaseProcess.md
+++ b/projectDocs/community/releaseProcess.md
@@ -54,7 +54,7 @@ Reasons in favor of not reverting the pull request may be:
 ### Beta phase
 
 * A commit will be selected from the `master` branch and merged into `beta`.
-* Once a beta commit is chosen, no further changes are included in the release, except the following will be considered:
+* Once a beta commit is chosen, only the following types of changes are included in the release:
   * addressing a bug introduced in the current or previous release cycle.
   * addressing a `p1` filed in the current or previous release cycle.
   * reverting code introduced in the current release cycle.

--- a/projectDocs/community/releaseProcess.md
+++ b/projectDocs/community/releaseProcess.md
@@ -58,7 +58,7 @@ Reasons in favor of not reverting the pull request may be:
   * addressing a bug introduced in the current or previous release cycle.
   * addressing a `p1` or `p2` filed in the current or previous release cycle.
   * reverting code introduced in the current release cycle.
-  * updates to documentation introduced in this release cycle.
+  * updates to documentation introduced in the current or previous release cycle.
 * Documentation changes will be reviewed.
 A release summary will be added to the change log for the beta.
 * Once considered stable enough, a tagged "beta release" will be created for wider testing.

--- a/projectDocs/community/releaseProcess.md
+++ b/projectDocs/community/releaseProcess.md
@@ -53,7 +53,7 @@ Reasons in favor of not reverting the pull request may be:
 
 ### Beta phase
 
-* A commit without any known serious issues, will be selected from the 'master' branch and merged into 'beta'.
+* A commit without any known serious issues, will be selected from the `master` branch and merged into `beta`.
 * Once a beta commit is chosen, no further changes are included in the release, except the following will be considered:
   * addressing a bug introduced in the current or previous release cycle.
   * addressing a `p1` filed in the current or previous release cycle.

--- a/projectDocs/community/releaseProcess.md
+++ b/projectDocs/community/releaseProcess.md
@@ -58,6 +58,7 @@ Reasons in favor of not reverting the pull request may be:
   * addressing a bug introduced in the current or previous release cycle.
   * addressing a `p1` filed in the current or previous release cycle.
   * reverting code introduced in the current release cycle.
+  * updates to documentation introduced in this release cycle.
 * Documentation changes will be reviewed.
 A release summary will be added to the change log for the beta.
 * Once considered stable enough, a tagged "beta release" will be created for wider testing.

--- a/projectDocs/community/releaseProcess.md
+++ b/projectDocs/community/releaseProcess.md
@@ -54,10 +54,10 @@ Reasons in favor of not reverting the pull request may be:
 ### Beta phase
 
 * A commit without any known serious issues, will be selected from the 'master' branch and merged into 'beta'.
-* Once a beta commit is chosen, no further changes are included in the release, except for:
+* Once a beta commit is chosen, no further changes are included in the release, except the following will be considered:
   * addressing a bug introduced in the current or previous release cycle.
+  * addressing a `p1` filed in the current or previous release cycle.
   * reverting code introduced in the current release cycle.
-  * addressing a critical Operating System change out of our control.
 * Documentation changes will be reviewed.
 A release summary will be added to the change log for the beta.
 * A tagged "beta release" will be created for wider testing.


### PR DESCRIPTION
This changes our beta phase policy in a number of ways.
It suggests that once we pick a beta commit, we reset the milestone to include only a subset of the following:

* bug fixes for issues introduced in the current or previous release cycle.
* reverting code from the current release cycle
* addressing `p1`s filed in the current or previous release cycle

previously this was:

* If addressing regression introduced in this release.
* If addressing a bug in a "must have" feature for this release.
* If addressing a critical Operating System change out of our control.

I think this better covers what we do in practice.
I think a "must have" feature is hard to define. When handling bugs from new features we should either revert or commit to fixes.
I think we should also expand fixing regressions to include the previous release cycle, as often an issue with medium/high priority from 2026.1 will get planned to fix in 2026.2 instead of 2026.1.1.

I think with p1s there could be other critical issues like with Office or browsers we may need to fix.
We might want to widen it to consider `p2`s as well.

