### PR TITLE
Fix potential initialization/termination deadlock in nvdaHelperRemote.

### DIFF
--- a/nvdaHelper/remote/IA2Support.cpp
+++ b/nvdaHelper/remote/IA2Support.cpp
@@ -38,7 +38,6 @@ using namespace std;
 LONG WINAPI GetCurrentApplicationUserModelId(UINT32* pBufSize,PWSTR buf);
 
 
-UINT wm_uninstallIA2Support = 0;
 bool isIA2SupportDisabled=false;
 
 bool installIA2Support() {
@@ -48,10 +47,6 @@ bool installIA2Support() {
 map<DWORD, IA2InstallData> IA2InstallMap;
 
 pair<map<DWORD, IA2InstallData>::iterator, bool> installIA2SupportForThread(DWORD threadID) {
-	if (wm_uninstallIA2Support == 0) {
-		// Register our window message the first time we initialize IA2 support in a process
-		wm_uninstallIA2Support = RegisterWindowMessage(L"wm_uninstallIA2Support");
-	}
 	if (IA2InstallMap.find(threadID) != IA2InstallMap.end()) {
 		// Support already installed for this thread
 		return {IA2InstallMap.end(), false};
@@ -82,10 +77,6 @@ bool uninstallIA2Support() {
 }
 
 bool uninstallIA2SupportForThread(DWORD threadID) {
-	if (wm_uninstallIA2Support == 0) {
-		// IA2 support was never installed
-		return false;
-	}
 	auto it = IA2InstallMap.find(threadID);
 	if (it == IA2InstallMap.end()) {
 		return false;
@@ -113,20 +104,6 @@ void CALLBACK IA2Support_winEventProcHook(HWINEVENTHOOK hookID, DWORD eventID, H
 		auto& data = installRes.first->second;
 		data.uiThreadHandle = OpenThread(SYNCHRONIZE, false, threadID);
 	}
-}
-
-LRESULT CALLBACK IA2Support_uninstallerHook(int code, WPARAM wParam, LPARAM lParam) {
-	MSG* pmsg=(MSG*)lParam;
-	if(pmsg->message==wm_uninstallIA2Support) {
-		auto threadId = GetCurrentThreadId();
-		uninstallIA2SupportForThread(threadId);
-		auto it = IA2InstallMap.find(threadId);
-		if (it != IA2InstallMap.end()) {
-			auto& data = it->second;
-			SetEvent(data.uiThreadUninstalledEvent);
-		}
-	}
-	return 0;
 }
 
 bool isSuspendableProcess() {
@@ -194,30 +171,14 @@ void IA2Support_inProcess_terminate() {
 	if (IA2InstallMap.size()  == 0) {
 		return;
 	}
-	registerWindowsHook(WH_GETMESSAGE, IA2Support_uninstallerHook);
 	for (auto& [threadId, data] : IA2InstallMap) {
 		//Check if the UI thread is still alive, if not there's nothing for us to do
 		if (WaitForSingleObject(data.uiThreadHandle, 0) == 0) {
 			continue;
 		}
-		//Instruct the UI thread to uninstall IA2
-		data.uiThreadUninstalledEvent = CreateEvent(NULL, true, false, NULL);
-		if (data.uiThreadUninstalledEvent == 0) {
-			// unable to create the event, can't continue
-			continue;
-		}
-		PostThreadMessage(threadId, wm_uninstallIA2Support, 0, 0);
-		const UINT WAIT_HANDLE_COUNT = 2;
-		HANDLE waitHandles[WAIT_HANDLE_COUNT] = {data.uiThreadUninstalledEvent, data.uiThreadHandle};
-		const UINT MAX_WAIT_TIME = 10000; // 10 seconds
-		int res = WaitForMultipleObjects(WAIT_HANDLE_COUNT, waitHandles, false, MAX_WAIT_TIME);
-		if (res != WAIT_OBJECT_0 && res != WAIT_OBJECT_0 + 1) {
-			LOG_DEBUGWARNING(L"WaitForMultipleObjects returned "<<res);
-		}
-		CloseHandle(data.uiThreadUninstalledEvent);
+		execInThread(threadId, uninstallIA2Support);
 		CloseHandle(data.uiThreadHandle);
 	}
-	unregisterWindowsHook(WH_GETMESSAGE,IA2Support_uninstallerHook);
 }
 
 const long FINDCONTENTDESCENDANT_FIRST=0;

--- a/nvdaHelper/remote/IA2Support.h
+++ b/nvdaHelper/remote/IA2Support.h
@@ -25,7 +25,6 @@ struct IA2InstallData {
 	COMProxyRegistration_t* IA2ProxyRegistration;
 	COMProxyRegistration_t* ISimpleDOMProxyRegistration;
 	HANDLE uiThreadHandle;
-	HANDLE uiThreadUninstalledEvent;
 };
 
 bool installIA2Support();

--- a/nvdaHelper/remote/inProcess.cpp
+++ b/nvdaHelper/remote/inProcess.cpp
@@ -41,8 +41,19 @@ windowsHookRegistry_t inProcess_registeredGetMessageWindowsHooks;
 
 UINT wm_execInThread;
 
+UINT getExecInThreadMessage() {
+	// If there was a previous instance of NVDA, RegisterWindowMessage will return
+	// the same identifier. If not, this will be the identifier used hereafter.
+	if (!wm_execInThread) {
+		wm_execInThread = RegisterWindowMessage(L"nvdaHelper_execInThread");
+	}
+	return wm_execInThread;
+}
+
 void inProcess_initialize() {
-	wm_execInThread=RegisterWindowMessage(L"nvdaHelper_execInThread");
+	// This should already have been called by initInprocManagerThreadIfNeeded,
+	// but it doesn't hurt to be safe.
+	getExecInThreadMessage();
 	IA2Support_inProcess_initialize();
 	ia2LiveRegions_inProcess_initialize();
 	typedCharacter_inProcess_initialize();

--- a/nvdaHelper/remote/inProcess.h
+++ b/nvdaHelper/remote/inProcess.h
@@ -11,8 +11,8 @@ void inProcess_initialize();
 void inProcess_terminate();
 
 #include <functional>
+UINT getExecInThreadMessage();
 typedef std::function<void()> execInThread_funcType;
 bool execInThread(long threadID, execInThread_funcType func);
-
 
 #endif

--- a/nvdaHelper/remote/injection.cpp
+++ b/nvdaHelper/remote/injection.cpp
@@ -280,11 +280,15 @@ bool initInprocManagerThreadIfNeeded() {
 			}
 			if (MsgWaitForMultipleObjects(2, waitHandles, FALSE, (DWORD)remaining,
 					QS_POSTMESSAGE) == 2) {
+				// A posted window message has arrived.
 				MSG msg;
 				while(PeekMessage(&msg, nullptr, wm_execInThread, wm_execInThread, PM_REMOVE)) {
 					TranslateMessage(&msg);
 					DispatchMessage(&msg);
 				}
+			} else {
+				// Anything other than a window message means we should stop waiting.
+				break;
 			}
 		}
 	}

--- a/nvdaHelper/remote/injection.cpp
+++ b/nvdaHelper/remote/injection.cpp
@@ -264,7 +264,29 @@ bool initInprocManagerThreadIfNeeded() {
 	inprocThreadsLock.release();
 	if(threadCreated) {
 		//Wait until the event is set (the thread is past initialization) or until the thread dies.
-		WaitForMultipleObjects(2,waitHandles,FALSE,10000);
+		// If there is a manager thread from a previous instance of NVDA which is
+		// still terminating, we need to allow execInThread calls to be processed so
+		// that it can terminate. Otherwise, we might deadlock because we're waiting
+		// for the new manager thread to start, the new manager thread is waiting for
+		// the old one to exit, but the old one might be waiting on a termination
+		// call to execute in this thread.
+		UINT wm_execInThread = getExecInThreadMessage();
+		// Wait a maximum of 10 seconds.
+		const ULONGLONG latest = GetTickCount64() + 10000;
+		for (;;) {
+			LONGLONG remaining = latest - GetTickCount64();
+			if (remaining <= 0) {
+				break;
+			}
+			if (MsgWaitForMultipleObjects(2, waitHandles, FALSE, (DWORD)remaining,
+					QS_POSTMESSAGE) == 2) {
+				MSG msg;
+				while(PeekMessage(&msg, nullptr, wm_execInThread, wm_execInThread, PM_REMOVE)) {
+					TranslateMessage(&msg);
+					DispatchMessage(&msg);
+				}
+			}
+		}
 	}
 	//Close the event handle, but not the thread handle as the thread itself will do that.
 	if(waitHandles[0]) CloseHandle(waitHandles[0]);


### PR DESCRIPTION
### Link to issue number:
Re #19292.

### Summary of the issue:
1. When nvdaHelperRemote initializes in the application's UI thread, it sets up a new manager thread.
2. That thread waits on a mutex to guarantee that only one of these manager threads runs at any given time.
3. The UI thread waits until the new manager thread is initialized.
4. If an old manager thread is terminating, that thread (which still holds the mutex in (2)) might try to post a window message to the UI thread to terminate IA2 support and then waits for that termination to complete.
5. But the UI thread is blocked because of (3), which is blocked because of (2), which is blocked because of (4).
6. Deadlock!

This deadlock occurs infrequently, but I'm fairly sure it has been spotted in the wild. We have a timeout of 10 seconds for these waits, so we deadlock for a maximum of 10 seconds. This deadlock is most visible when it occurs in Explorer, since alt+tab won't be reported properly for at least 10 seconds after restarting NVDA.

Furthermore, this deadlock prevents us from enabling IA2 support in Windows Store applications, which was the workaround implemented for this deadlock in #5417. However, the inability to enable IA2 support for Windows Store applications causes problems like #19292.

### Description of user facing changes:
None, as it isn't clear when this occurs, even though there's potential for it. This is a correctness fix, as well as paving the way for a future fix for #19292.

### Description of development approach:
1. Make IA2Support_inProcess_terminate use execInThread instead of its own window message. It needs to wait for execution in the target thread, which is functionality that execInThread already provides.
2. Make it possible for injection.cpp to access wm_execInThread.
3. In initInprocManagerThreadIfNeeded, while waiting for the manager thread to initialize, dispatch wm_execInThread messages only. This ensures that a previous instance of nvdaHelperRemote can uninstall IA2 support on the UI thread without causing a deadlock.

### Testing strategy:
I ran a try build on multiple machines with fairly solid usage for multiple hours across multiple days and encountered no problems. This included using Firefox, which is a very heavy IAccessible2 app. @michaelDCurran has also run the build for several days with no problems.

### Known issues with pull request:
None known.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
