### PR TITLE
Keep review copy marker across equivalent review object instances

### DIFF
--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -8,10 +8,12 @@
 
 import itertools
 from typing import (
+	TYPE_CHECKING,
 	Optional,
 	Tuple,
 	Union,
 )
+from comtypes import COMError
 from annotation import (
 	_AnnotationNavigation,
 	_AnnotationNavigationNode,
@@ -73,6 +75,9 @@ import audio
 import synthDriverHandler
 from utils.displayString import DisplayStringEnum
 import _remoteClient
+
+if TYPE_CHECKING:
+	import documentBase
 
 #: Script category for text review commands.
 # Translators: The name of a category of NVDA commands.
@@ -183,6 +188,41 @@ def toggleIntegerValue(
 
 class GlobalCommands(ScriptableObject):
 	"""Commands that are available at all times, regardless of the current focus."""
+
+	def __init__(self) -> None:
+		super().__init__()
+		self._reviewCopyStartMarker: textInfos.TextInfo | None = None
+		self._reviewCopyStartMarkerObj: "documentBase.TextContainerObject | None" = None
+		self._reviewSelectThenCopyRange: textInfos.TextInfo | None = None
+
+	def _clearReviewCopyStartMarker(self) -> None:
+		self._reviewCopyStartMarker = None
+		self._reviewCopyStartMarkerObj = None
+		self._reviewSelectThenCopyRange = None
+
+	def _getReviewCopyStartMarker(self, pos: textInfos.TextInfo) -> textInfos.TextInfo | None:
+		"""Return the review copy start marker if it is valid for ``pos``.
+
+		The marker is only valid when ``pos`` uses the same TextInfo implementation
+		and an equivalent text container. A comparison dry-run rejects stale native
+		ranges that cannot be used together.
+		"""
+		startMarker = self._reviewCopyStartMarker
+		if startMarker is None:
+			return None
+		startMarkerObj = self._reviewCopyStartMarkerObj
+		if startMarkerObj is None:
+			self._clearReviewCopyStartMarker()
+			return None
+		posObj = pos.obj
+		if pos.__class__ is not startMarker.__class__ or posObj != startMarkerObj:
+			return None
+		try:
+			pos.compareEndPoints(startMarker, "startToStart")
+		except (COMError, LookupError, NotImplementedError, RuntimeError) as e:
+			log.debug(f"Error comparing review position with marked text: {e}")
+			return None
+		return startMarker
 
 	@script(
 		description=_(
@@ -4080,13 +4120,12 @@ class GlobalCommands(ScriptableObject):
 		category=SCRCAT_TEXTREVIEW,
 		gesture="kb:NVDA+f9",
 	)
-	def script_review_markStartForCopy(self, gesture):
+	def script_review_markStartForCopy(self, gesture: inputCore.InputGesture) -> None:
 		reviewPos = api.getReviewPosition()
-		# attach the marker to obj so that the marker is cleaned up when obj is cleaned up.
-		reviewPos.obj._copyStartMarker = reviewPos.copy()  # represents the start location
-		reviewPos.obj._selectThenCopyRange = (
-			None  # we may be part way through a select, reset the copy range.
-		)
+		self._reviewCopyStartMarker = reviewPos.copy()
+		self._reviewCopyStartMarkerObj = reviewPos.obj
+		# We may be part way through a select, reset the copy range.
+		self._reviewSelectThenCopyRange = None
 		# Translators: Indicates start of review cursor text to be copied to clipboard.
 		ui.message(_("Start marked"))
 
@@ -4099,13 +4138,13 @@ class GlobalCommands(ScriptableObject):
 		category=SCRCAT_TEXTREVIEW,
 		gesture="kb:NVDA+shift+F9",
 	)
-	def script_review_moveToStartMarkedForCopy(self, gesture: inputCore.InputGesture):
-		pos = api.getReviewPosition()
-		if not getattr(pos.obj, "_copyStartMarker", None):
+	def script_review_moveToStartMarkedForCopy(self, gesture: inputCore.InputGesture) -> None:
+		startMarker = self._getReviewCopyStartMarker(api.getReviewPosition())
+		if not startMarker:
 			# Translators: Presented when attempting to move to the start marker for copy but none has been set.
 			ui.reviewMessage(_("No start marker set"))
 			return
-		startMarker = pos.obj._copyStartMarker.copy()
+		startMarker = startMarker.copy()
 		# This script is available on the lock screen via getSafeScripts,
 		# as such observe the setReviewPosition result to ensure
 		# the review position does not contain secure information
@@ -4132,16 +4171,16 @@ class GlobalCommands(ScriptableObject):
 		category=SCRCAT_TEXTREVIEW,
 		gesture="kb:NVDA+f10",
 	)
-	def script_review_copy(self, gesture):
+	def script_review_copy(self, gesture: inputCore.InputGesture) -> None:
 		pos = api.getReviewPosition().copy()
-		if not getattr(pos.obj, "_copyStartMarker", None):
+		startMarker = self._getReviewCopyStartMarker(pos)
+		if not startMarker:
 			# Translators: Presented when attempting to copy some review cursor text but there is no start marker.
 			ui.message(_("No start marker set"))
 			return
-		startMarker = api.getReviewPosition().obj._copyStartMarker
 		# first call, try to set the selection.
 		if getLastScriptRepeatCount() == 0:
-			if getattr(pos.obj, "_selectThenCopyRange", None):
+			if self._reviewSelectThenCopyRange:
 				# we have already tried selecting the text, dont try again. For now selections can not be ammended.
 				# Translators: Presented when text has already been marked for selection, but not yet copied.
 				ui.message(_("Press twice to copy or reset the start marker"))
@@ -4164,9 +4203,9 @@ class GlobalCommands(ScriptableObject):
 			if copyMarker.compareEndPoints(copyMarker, "startToEnd") == 0:
 				# Translators: Presented when there is no text selection to copy from review cursor.
 				ui.message(_("No text to copy"))
-				api.getReviewPosition().obj._copyStartMarker = None
+				self._clearReviewCopyStartMarker()
 				return
-			api.getReviewPosition().obj._selectThenCopyRange = copyMarker
+			self._reviewSelectThenCopyRange = copyMarker
 			# for applications such as word, where the selected text is not automatically spoken we must monitor it ourself
 			try:
 				# old selection info must be saved so that its possible to report on the changes to the selection.
@@ -4189,11 +4228,14 @@ class GlobalCommands(ScriptableObject):
 				log.debug("Error trying to update selection: %s" % e)
 				return
 		elif getLastScriptRepeatCount() == 1:  # the second call, try to copy the text
-			copyMarker = pos.obj._selectThenCopyRange
+			copyMarker = self._reviewSelectThenCopyRange
+			if copyMarker is None:
+				# Translators: Presented when attempting to copy some review cursor text but there is no start marker.
+				ui.message(_("No start marker set"))
+				return
 			copyMarker.copyToClipboard(notify=True)
 			# on the second call always clean up the start marker
-			api.getReviewPosition().obj._selectThenCopyRange = None
-			api.getReviewPosition().obj._copyStartMarker = None
+			self._clearReviewCopyStartMarker()
 		return
 
 	@script(

--- a/tests/unit/test_globalCommands.py
+++ b/tests/unit/test_globalCommands.py
@@ -6,19 +6,115 @@
 """Set of unit tests veryfying behavior of scripts defined in ``globalCommands``."""
 
 import unittest
+from unittest.mock import patch
 
 import config
 import globalCommands
 import inputCore
 import speech
+import textInfos
+
+from .textProvider import BasicTextProvider
 
 
 class _FakeInputGesture(inputCore.InputGesture):
 	"""An input gesture which does nothing, but can be passed to scripts."""
 
-	def _get_identifiers(self):
+	def _get_identifiers(self) -> list[str] | tuple[str, ...]:
 		"""Implemented just to satisfy base class requirements, where this is defined as abstract."""
 		raise RuntimeError("Should not be required in tests.")
+
+
+class _ReviewCopyTextProvider(BasicTextProvider):
+	def __init__(
+		self,
+		identity: str,
+		text: str = "",
+		selection: tuple[int, int] = (0, 0),
+	) -> None:
+		self._identity = identity
+		super().__init__(text=text, selection=selection)
+
+	def _isEqual(self, other: object) -> bool:
+		return isinstance(other, _ReviewCopyTextProvider) and self._identity == other._identity
+
+
+class ReviewCopyMarker(unittest.TestCase):
+	"""Tests review cursor select-then-copy marker handling."""
+
+	def setUp(self) -> None:
+		self.commands = globalCommands.GlobalCommands()
+		self.gesture = _FakeInputGesture()
+
+	def test_startMarkerSurvivesEquivalentReviewObjectChange(self) -> None:
+		startObj = _ReviewCopyTextProvider(identity="doc", text="hello world", selection=(0, 0))
+		endObj = _ReviewCopyTextProvider(identity="doc", text="hello world", selection=(5, 5))
+		startPosition = startObj.makeTextInfo(textInfos.POSITION_CARET)
+		endPosition = endObj.makeTextInfo(textInfos.POSITION_CARET)
+
+		with (
+			patch.object(globalCommands.api, "getReviewPosition", side_effect=[startPosition, endPosition]),
+			patch.object(globalCommands.ui, "message"),
+		):
+			self.commands.script_review_markStartForCopy(self.gesture)
+			with patch.object(globalCommands, "getLastScriptRepeatCount", return_value=0):
+				self.commands.script_review_copy(self.gesture)
+
+		self.assertEqual(startObj.selectionOffsets, (0, 6))
+
+	def test_moveToStartMarkerSurvivesEquivalentReviewObjectChange(self) -> None:
+		startObj = _ReviewCopyTextProvider(identity="doc", text="hello world", selection=(0, 0))
+		endObj = _ReviewCopyTextProvider(identity="doc", text="hello world", selection=(5, 5))
+		startPosition = startObj.makeTextInfo(textInfos.POSITION_CARET)
+		endPosition = endObj.makeTextInfo(textInfos.POSITION_CARET)
+
+		with (
+			patch.object(globalCommands.api, "getReviewPosition", side_effect=[startPosition, endPosition]),
+			patch.object(globalCommands.api, "setReviewPosition", return_value=True) as setReviewPosition,
+			patch.object(globalCommands.speech, "speakTextInfo"),
+			patch.object(globalCommands.ui, "message"),
+			patch.object(globalCommands.ui, "reviewMessage") as reviewMessage,
+		):
+			self.commands.script_review_markStartForCopy(self.gesture)
+			self.commands.script_review_moveToStartMarkedForCopy(self.gesture)
+
+		setReviewPosition.assert_called_once()
+		reviewMessage.assert_not_called()
+
+	def test_startMarkerIsNotUsedForDifferentReviewObject(self) -> None:
+		startObj = _ReviewCopyTextProvider(identity="sourceDoc", text="hello world", selection=(0, 0))
+		endObj = _ReviewCopyTextProvider(identity="otherDoc", text="hello world", selection=(5, 5))
+		startPosition = startObj.makeTextInfo(textInfos.POSITION_CARET)
+		endPosition = endObj.makeTextInfo(textInfos.POSITION_CARET)
+
+		with (
+			patch.object(globalCommands.api, "getReviewPosition", side_effect=[startPosition, endPosition]),
+			patch.object(globalCommands.ui, "message") as message,
+		):
+			self.commands.script_review_markStartForCopy(self.gesture)
+			with patch.object(globalCommands, "getLastScriptRepeatCount", return_value=0):
+				self.commands.script_review_copy(self.gesture)
+
+		self.assertEqual(startObj.selectionOffsets, (0, 0))
+		message.assert_called_with("No start marker set")
+
+	def test_moveToStartMarkerIsNotUsedForDifferentReviewObject(self) -> None:
+		startObj = _ReviewCopyTextProvider(identity="sourceDoc", text="hello world", selection=(0, 0))
+		endObj = _ReviewCopyTextProvider(identity="otherDoc", text="hello world", selection=(5, 5))
+		startPosition = startObj.makeTextInfo(textInfos.POSITION_CARET)
+		endPosition = endObj.makeTextInfo(textInfos.POSITION_CARET)
+
+		with (
+			patch.object(globalCommands.api, "getReviewPosition", side_effect=[startPosition, endPosition]),
+			patch.object(globalCommands.api, "setReviewPosition") as setReviewPosition,
+			patch.object(globalCommands.ui, "message"),
+			patch.object(globalCommands.ui, "reviewMessage") as reviewMessage,
+		):
+			self.commands.script_review_markStartForCopy(self.gesture)
+			self.commands.script_review_moveToStartMarkedForCopy(self.gesture)
+
+		setReviewPosition.assert_not_called()
+		reviewMessage.assert_called_with("No start marker set")
 
 
 class SpeechModeSwitching(unittest.TestCase):

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -28,6 +28,7 @@
 * NVDA recovers more quickly when an application stops responding; in particular, switching away from a hung application returns NVDA to responsiveness immediately. (#20169, @heath-toby)
 * In Mozilla Firefox, reporting annotation details now works correctly in focus mode on controls which are not editable text. (#20208, @jcsteh)
 * NVDA now announces heading, paragraph, list, and list item children inside webpage alerts (`role="alert"`). (#14990, @mehm8128)
+* After marking the start of text for review cursor copy with `NVDA+f9`, moving with Find or Go To no longer causes `NVDA+f10` to report that no start marker is set. (#13864, @Cary-rowen)
 
 ### Changes for Developers
 


### PR DESCRIPTION
### Link to issue number:
Closes #13864

### Summary of the issue:
Review copy markers are stored on the current review object. Some actions, such as find or go to, can move the review position to an equivalent text container represented by a different object instance. When this happens, NVDA+F10 reports that no start marker is set.

### Description of user facing changes:
After marking the start of text with NVDA+F9, users can move with find or go to and still use NVDA+F10 to select and copy the marked range.

### Description of developer facing changes:
Review copy marker state is now stored on the global commands instance instead of the review object. The marker is only reused when the current TextInfo implementation matches and the text container is equivalent.

### Description of development approach:
This keeps the change limited to the review copy commands. It continues to use the existing TextInfo APIs for comparing ranges, updating selection, and copying text. It does not change review cursor routing or TextInfo backends.

### Testing strategy:
Added unit tests covering review copy markers when the review object instance changes but still represents the same text container, and when it represents a different text container.

Manual testing:
1. Open a multiline edit control such as Notepad.
2. Move the review cursor to the start of the text to copy.
3. Press NVDA+F9.
4. Use find or go to to move to the end position.
5. Press NVDA+F10 once and confirm the marked range is selected.
6. Press NVDA+F10 again and confirm the selected text is copied.
7. Move to a different edit control and confirm NVDA+F10 does not reuse the previous marker.

### Known issues with pull request:
None known.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [ ] API is compatible with existing add-ons.
- [ ] Security precautions taken.