### PR TITLE
Add a link to Copy Settings to System-wide Configuration Dialog paragraph

### DIFF
--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -2037,8 +2037,10 @@ This option is only available for installed copies of NVDA.
 
 ##### Use currently saved settings during sign-in and on secure screens (requires administrator privileges) {#GeneralSettingsCopySettings}
 
-Pressing this button copies your currently saved NVDA user configuration to NVDA's system configuration directory, so that NVDA will use it during sign-in and when running on User Account Control (UAC) and other [secure screens](#SecureScreens).
+Pressing this button will allow you to copy your currently saved NVDA user configuration to NVDA's system configuration directory, so that NVDA will use it during sign-in and when running on User Account Control (UAC) and other [secure screens](#SecureScreens).
 To make sure that all your settings are transferred, make sure to save your configuration first with control+NVDA+c or Save configuration in the NVDA menu.
+When this button is pressed, it first opens the [Copy Settings to System-wide Configuration](#CopyAddonsToSystemProfileDialog) dialog in which you can choose the add-ons you want to be copied to system configuration.
+
 This option is only available for installed copies of NVDA.
 
 ##### Automatically check for updates to NVDA {#GeneralSettingsCheckForUpdates}


### PR DESCRIPTION
### Link to issue number:
Closes #20192

### Summary of the issue:
In User Guide, there is a "Copy Settings to System-wide Configuration Dialog" paragraph describing this dialog. But the paragraph is not linked in the paragraph describing the button which opens it.

### Description of user facing changes:
The "Use currently saved settings during sign-in and on secure screens" paragraph has been reworded matching better the new workflow to copy to copy user config to system config.

### Description of developer facing changes:
N/A
### Description of development approach:
See UG
### Testing strategy:
Check generated UG.

### Known issues with pull request:
None
### Code Review Checklist:


- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
