### PR TITLE
Fix Clang detection for Visual Studio 2026

### DIFF
--- a/nvdaHelper/liblouis/sconscript
+++ b/nvdaHelper/liblouis/sconscript
@@ -49,7 +49,7 @@ def getLouisVersion():
 if not env.WhereIs("clang-cl"):
 	raise RuntimeError(
 		"Could not find the Clang compiler. "
-		"Perhaps the C++ Clang tools for Windows component in visual Studio is not installed",
+		"Perhaps the C++ Clang tools for Windows component in Visual Studio is not installed?",
 	)
 env["CC"] = "clang-cl"
 env["M4"] = f'"{env.File("#miscdeps/tools/m4.exe")}"'

--- a/nvdaHelper/liblouis/sconscript
+++ b/nvdaHelper/liblouis/sconscript
@@ -6,8 +6,6 @@
 
 import os
 import re
-import glob
-from SCons.Tool.MSCommon.vc import find_vc_pdir
 import typing
 from SCons.Environment import Environment
 from SCons.Environment import Base
@@ -45,8 +43,10 @@ def getLouisVersion():
 
 
 # Liblouis is build with Clang, as Microsoft Visual C++ is unable to build C99 code.
-clangDirs = glob.glob(os.path.join(find_vc_pdir(env.get("MSVC_VERSION"), env), r"Tools\Llvm\bin"))
-if len(clangDirs) == 0:
+# The MSVC tool adds the C++ Clang tools for Windows component to the environment's PATH,
+# so locate clang-cl via PATH rather than hard-coding the Visual Studio install layout.
+# This is independent of the LLVM directory structure, which changed in Visual Studio 2026.
+if not env.WhereIs("clang-cl"):
 	raise RuntimeError(
 		"Could not find the Clang compiler. "
 		"Perhaps the C++ Clang tools for Windows component in visual Studio is not installed",


### PR DESCRIPTION
### Link to issue number:
None.

### Summary of the issue:
Building from source with `scons source` fails on Visual Studio 2026 (v18) with
"Could not find the Clang compiler. Perhaps the C++ Clang tools for Windows
component in visual Studio is not installed", even when that component is installed.

The Visual Studio 2026 June update bumped the bundled Clang to version 22 and
reorganized the LLVM layout: the legacy 32-bit `VC\Tools\Llvm\bin` directory was
dropped, shipping only arch-specific subdirectories (`VC\Tools\Llvm\x64\bin`,
`VC\Tools\Llvm\ARM64\bin`). The liblouis sconscript globbed the now-nonexistent
`Tools\Llvm\bin` path, got an empty result, and raised before compilation.

### Description of user facing changes:
None.

### Description of developer facing changes:
Building NVDA from source now works with Visual Studio 2026 (June update, Clang 22).

### Description of development approach:
Replaced the hard-coded glob of the Visual Studio LLVM install layout with
`env.WhereIs("clang-cl")`, which probes the environment PATH already populated by
the MSVC tool with the C++ Clang tools directory. This is independent of the LLVM
directory structure, so it works across Visual Studio versions. Removed the now
unused `glob` and `find_vc_pdir` imports.

### Testing strategy:
Ran `scons source --all-cores` on Visual Studio 2026 (v18) Enterprise; liblouis
compiles with clang-cl and the build completes. Confirmed the presence check still
raises when clang-cl is absent from PATH.

### Known issues with pull request:
None.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
