### PR TITLE
Fix mag settings shortcut on secure screens

### DIFF
--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -413,7 +413,6 @@ class MainFrame(wx.Frame):
 	def onInputGesturesCommand(self, evt):
 		self.popupSettingsDialog(InputGesturesDialog)
 
-	@blockAction.when(blockAction.Context.SECURE_MODE)
 	def onMagnifierSettingsCommand(self, evt: wx.CommandEvent):
 		self.popupSettingsDialog(NVDASettingsDialog, MagnifierPanel)
 


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
On secure screens, e.g. UAC screen, pressing `NVDA+control+w` reports "Action unavailable in secure context" instead of opening Magnifier settings.

### Description of user facing changes:
Pressing `NVDA+control+w` on secure screens now opens Magnifier settings as expected.
### Description of developer facing changes:
N/A
### Description of development approach:
Removed the inappropriate `@blockAction.when(blockAction.Context.SECURE_MODE)` decorator.

### Testing strategy:
Manual test running NVDA in secure mode (with `-s` flag).
### Known issues with pull request:
None
### Code Review Checklist:


- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
