### PR TITLE
Prevent NVDA freeze when brailling math with certain Unicode characters

### DIFF
--- a/source/mathPres/MathCAT/MathCAT.py
+++ b/source/mathPres/MathCAT/MathCAT.py
@@ -19,11 +19,6 @@ import config
 import gui
 import libmathcat_py as libmathcat
 
-try:
-	from pyo3_runtime import PanicException
-except ImportError:
-	PanicException = None  # type: ignore[misc, assignment]
-
 import speech
 import ui
 import winKernel
@@ -61,8 +56,8 @@ class MathCATError(Exception):
 
 
 def _isPyO3Panic(exc: BaseException) -> bool:
-	if PanicException is not None and isinstance(exc, PanicException):
-		return True
+	# libmathcat_py raises pyo3_runtime.PanicException (BaseException), but pyo3_runtime
+	# is not importable as a standalone module in NVDA's shipped layout.
 	return type(exc).__name__ == "PanicException" and type(exc).__module__ == "pyo3_runtime"
 
 

--- a/source/mathPres/MathCAT/MathCAT.py
+++ b/source/mathPres/MathCAT/MathCAT.py
@@ -18,6 +18,12 @@ import braille
 import config
 import gui
 import libmathcat_py as libmathcat
+
+try:
+	from pyo3_runtime import PanicException
+except ImportError:
+	PanicException = None  # type: ignore[misc, assignment]
+
 import speech
 import ui
 import winKernel
@@ -54,16 +60,20 @@ class MathCATError(Exception):
 	"""MathCAT failure, including Rust panics from PyO3."""
 
 
+def _isPyO3Panic(exc: BaseException) -> bool:
+	if PanicException is not None and isinstance(exc, PanicException):
+		return True
+	return type(exc).__name__ == "PanicException" and type(exc).__module__ == "pyo3_runtime"
+
+
 def _callMathCAT(func, /, *args, **kwargs):
 	"""Call libmathcat, translating PyO3 panics into MathCATError."""
 	try:
 		return func(*args, **kwargs)
-	except Exception:
-		raise
 	except BaseException as exc:
-		if isinstance(exc, (KeyboardInterrupt, SystemExit)):
+		if isinstance(exc, (KeyboardInterrupt, SystemExit, GeneratorExit)):
 			raise
-		if type(exc).__name__ == "PanicException" and type(exc).__module__ == "pyo3_runtime":
+		if _isPyO3Panic(exc):
 			raise MathCATError(str(exc)) from exc
 		raise
 

--- a/source/mathPres/MathCAT/MathCAT.py
+++ b/source/mathPres/MathCAT/MathCAT.py
@@ -18,7 +18,6 @@ import braille
 import config
 import gui
 import libmathcat_py as libmathcat
-
 import speech
 import ui
 import winKernel
@@ -55,20 +54,13 @@ class MathCATError(Exception):
 	"""MathCAT failure, including Rust panics from PyO3."""
 
 
-def _isPyO3Panic(exc: BaseException) -> bool:
-	# libmathcat_py raises pyo3_runtime.PanicException (BaseException), but pyo3_runtime
-	# is not importable as a standalone module in NVDA's shipped layout.
-	return type(exc).__name__ == "PanicException" and type(exc).__module__ == "pyo3_runtime"
-
-
 def _callMathCAT(func, /, *args, **kwargs):
 	"""Call libmathcat, translating PyO3 panics into MathCATError."""
 	try:
 		return func(*args, **kwargs)
 	except BaseException as exc:
-		if isinstance(exc, (KeyboardInterrupt, SystemExit, GeneratorExit)):
-			raise
-		if _isPyO3Panic(exc):
+		# PanicException is BaseException; pyo3_runtime is not importable in NVDA's layout.
+		if type(exc).__name__ == "PanicException" and type(exc).__module__ == "pyo3_runtime":
 			raise MathCATError(str(exc)) from exc
 		raise
 
@@ -107,7 +99,7 @@ class MathCATInteraction(mathPres.MathInteractionNVDAObject):
 		"""Calls MathCAT's ZoomIn command and speaks the resulting text."""
 		super(MathCATInteraction, self).reportFocus()
 		try:
-			text: str = _callMathCAT(libmathcat.DoNavigateCommand, "ZoomIn")
+			text: str = libmathcat.DoNavigateCommand("ZoomIn")
 			speech.speak(convertSSMLTextForNVDA(text))
 		except Exception:
 			log.exception()
@@ -138,7 +130,7 @@ class MathCATInteraction(mathPres.MathInteractionNVDAObject):
 		:param commandName: The MathCAT command name (e.g. "MovePrevious").
 		"""
 		try:
-			text = _callMathCAT(libmathcat.DoNavigateCommand, commandName)
+			text = libmathcat.DoNavigateCommand(commandName)
 			speech.speak(convertSSMLTextForNVDA(text))
 		except Exception:
 			log.exception()
@@ -153,7 +145,7 @@ class MathCATInteraction(mathPres.MathInteractionNVDAObject):
 			return
 
 		try:
-			navNode: tuple[str, int] = _callMathCAT(libmathcat.GetNavigationMathMLId)
+			navNode: tuple[str, int] = libmathcat.GetNavigationMathMLId()
 			brailleChars = _callMathCAT(libmathcat.GetBraille, navNode[0])
 			region: braille.Region = braille.Region()
 			region.rawText = brailleChars
@@ -201,23 +193,19 @@ class MathCATInteraction(mathPres.MathInteractionNVDAObject):
 			copyAs: str = "mathml"  # value used even if "CopyAs" pref is invalid
 			textToCopy: str = ""
 			try:
-				copyAs = _callMathCAT(libmathcat.GetPreference, "CopyAs").lower()
+				copyAs = libmathcat.GetPreference("CopyAs").lower()
 			except Exception:
 				log.exception("Not able to get 'CopyAs' preference.")
 			if copyAs == "asciimath" or copyAs == "latex":
 				# save the old braille code, set the new one, get the braille, then reset the code
-				savedBrailleCode: str = _callMathCAT(libmathcat.GetPreference, "BrailleCode")
-				_callMathCAT(
-					libmathcat.SetPreference,
-					"BrailleCode",
-					"LaTeX" if copyAs == "latex" else "ASCIIMath",
-				)
+				savedBrailleCode: str = libmathcat.GetPreference("BrailleCode")
+				libmathcat.SetPreference("BrailleCode", "LaTeX" if copyAs == "latex" else "ASCIIMath")
 				textToCopy = _callMathCAT(libmathcat.GetNavigationBraille)
-				_callMathCAT(libmathcat.SetPreference, "BrailleCode", savedBrailleCode)
+				libmathcat.SetPreference("BrailleCode", savedBrailleCode)
 				if copyAs == "asciimath":
 					copyAs = "ASCIIMath"  # speaks better in at least some voices
 			else:
-				mathml: str = _callMathCAT(libmathcat.GetNavigationMathML)[0]
+				mathml: str = libmathcat.GetNavigationMathML()[0]
 				if not re.match(self._startsWithMath, mathml):
 					mathml = "<math>\n" + mathml + "</math>"  # copy will fix up name spacing
 				elif self.initMathML != "":
@@ -225,15 +213,15 @@ class MathCATInteraction(mathPres.MathInteractionNVDAObject):
 				if copyAs == "speech":
 					# save the old MathML, set the navigation MathML as MathMl, get the speech, then reset the MathML
 					savedMathML: str = self.initMathML
-					savedTTS: str = _callMathCAT(libmathcat.GetPreference, "TTS")
+					savedTTS: str = libmathcat.GetPreference("TTS")
 					if savedMathML == "":  # shouldn't happen
 						raise Exception("Internal error -- MathML not set for copy")
-					_callMathCAT(libmathcat.SetPreference, "TTS", "None")
-					_callMathCAT(libmathcat.SetMathML, mathml)
+					libmathcat.SetPreference("TTS", "None")
+					libmathcat.SetMathML(mathml)
 					# get the speech text and collapse the whitespace
-					textToCopy = " ".join(_callMathCAT(libmathcat.GetSpokenText).split())
-					_callMathCAT(libmathcat.SetPreference, "TTS", savedTTS)
-					_callMathCAT(libmathcat.SetMathML, savedMathML)
+					textToCopy = " ".join(libmathcat.GetSpokenText().split())
+					libmathcat.SetPreference("TTS", savedTTS)
+					libmathcat.SetMathML(savedMathML)
 				else:
 					textToCopy = self._wrapMathMLForClipBoard(mathml)
 
@@ -333,9 +321,9 @@ class MathCAT(mathPres.MathPresentationProvider):
 				ReadPaths.mathCATDir,
 				"Rules",
 			)
-			log.info(f"MathCAT {_callMathCAT(libmathcat.GetVersion)} installed. Using rules dir: {rulesDir}")
-			_callMathCAT(libmathcat.SetRulesDir, rulesDir)
-			_callMathCAT(libmathcat.SetPreference, "TTS", "SSML")
+			log.info(f"MathCAT {libmathcat.GetVersion()} installed. Using rules dir: {rulesDir}")
+			libmathcat.SetRulesDir(rulesDir)
+			libmathcat.SetPreference("TTS", "SSML")
 			applyUserPreferences()
 		except Exception:
 			log.exception()
@@ -357,40 +345,35 @@ class MathCAT(mathPres.MathPresentationProvider):
 			# need to set Language before the MathML for DecimalSeparator canonicalization
 			language: str = getLanguageToUse()
 			# MathCAT should probably be extended to accept "extlang" tagging, but it uses lang-region tagging at the moment
-			_callMathCAT(libmathcat.SetPreference, "Language", language)
-			_callMathCAT(libmathcat.SetMathML, mathml)
+			libmathcat.SetPreference("Language", language)
+			libmathcat.SetMathML(mathml)
 		except Exception:
-			log.exception(f"Invalid MathML: {mathml}")
+			log.exception()
+			log.exception(f"MathML is {mathml}")
 			# Translators: this message reports when invalid math is found.
 			ui.message(pgettext("math", "Invalid math formatting found"))
-			_callMathCAT(libmathcat.SetMathML, "<math></math>")
+			libmathcat.SetMathML("<math></math>")
 		try:
 			supportedCommands: set[Type["SynthCommand"]] = synth.supportedCommands
 			# Set preferences for capital letters
-			_callMathCAT(
-				libmathcat.SetPreference,
+			libmathcat.SetPreference(
 				"CapitalLetters_Beep",
 				"true" if synthConfig["beepForCapitals"] else "false",
 			)
-			_callMathCAT(
-				libmathcat.SetPreference,
+			libmathcat.SetPreference(
 				"CapitalLetters_UseWord",
 				"true" if synthConfig["sayCapForCapitals"] else "false",
 			)
 			if PitchCommand in supportedCommands:
-				_callMathCAT(
-					libmathcat.SetPreference,
-					"CapitalLetters_Pitch",
-					str(synthConfig["capPitchChange"]),
-				)
+				libmathcat.SetPreference("CapitalLetters_Pitch", str(synthConfig["capPitchChange"]))
 			if self._addSounds():
 				return (
 					[BeepCommand(800, 25)]
-					+ convertSSMLTextForNVDA(_callMathCAT(libmathcat.GetSpokenText))
+					+ convertSSMLTextForNVDA(libmathcat.GetSpokenText())
 					+ [BeepCommand(600, 15)]
 				)
 			else:
-				return convertSSMLTextForNVDA(_callMathCAT(libmathcat.GetSpokenText))
+				return convertSSMLTextForNVDA(libmathcat.GetSpokenText())
 
 		except Exception:
 			log.exception()
@@ -404,7 +387,7 @@ class MathCAT(mathPres.MathPresentationProvider):
 		:returns: True if MathCAT's `SpeechSound` preference is set, and False otherwise.
 		"""
 		try:
-			return _callMathCAT(libmathcat.GetPreference, "SpeechSound") != "None"
+			return libmathcat.GetPreference("SpeechSound") != "None"
 		except Exception:
 			log.exception()
 			return False
@@ -416,12 +399,12 @@ class MathCAT(mathPres.MathPresentationProvider):
 		:returns: A braille string representing the input MathML.
 		"""
 		try:
-			_callMathCAT(libmathcat.SetMathML, mathml)
+			libmathcat.SetMathML(mathml)
 		except Exception:
-			log.exception(f"Illegal MathML: {mathml}")
+			log.exception(f"MathML is {mathml}")
 			# Translators: this message reports illegal MathML.
 			ui.message(pgettext("math", "Illegal MathML found."))
-			_callMathCAT(libmathcat.SetMathML, "<math></math>")
+			libmathcat.SetMathML("<math></math>")
 		try:
 			return _callMathCAT(libmathcat.GetBraille, "")
 		except Exception:

--- a/source/mathPres/MathCAT/MathCAT.py
+++ b/source/mathPres/MathCAT/MathCAT.py
@@ -203,7 +203,9 @@ class MathCATInteraction(mathPres.MathInteractionNVDAObject):
 				# save the old braille code, set the new one, get the braille, then reset the code
 				savedBrailleCode: str = _callMathCAT(libmathcat.GetPreference, "BrailleCode")
 				_callMathCAT(
-					libmathcat.SetPreference, "BrailleCode", "LaTeX" if copyAs == "latex" else "ASCIIMath"
+					libmathcat.SetPreference,
+					"BrailleCode",
+					"LaTeX" if copyAs == "latex" else "ASCIIMath",
 				)
 				textToCopy = _callMathCAT(libmathcat.GetNavigationBraille)
 				_callMathCAT(libmathcat.SetPreference, "BrailleCode", savedBrailleCode)
@@ -372,7 +374,9 @@ class MathCAT(mathPres.MathPresentationProvider):
 			)
 			if PitchCommand in supportedCommands:
 				_callMathCAT(
-					libmathcat.SetPreference, "CapitalLetters_Pitch", str(synthConfig["capPitchChange"])
+					libmathcat.SetPreference,
+					"CapitalLetters_Pitch",
+					str(synthConfig["capPitchChange"]),
 				)
 			if self._addSounds():
 				return (

--- a/source/mathPres/MathCAT/MathCAT.py
+++ b/source/mathPres/MathCAT/MathCAT.py
@@ -50,6 +50,24 @@ from .speech import convertSSMLTextForNVDA
 SCRCAT_MATHCAT_NAV = _("MathCat navigation")
 
 
+class MathCATError(Exception):
+	"""MathCAT failure, including Rust panics from PyO3."""
+
+
+def _callMathCAT(func, /, *args, **kwargs):
+	"""Call libmathcat, translating PyO3 panics into MathCATError."""
+	try:
+		return func(*args, **kwargs)
+	except Exception:
+		raise
+	except BaseException as exc:
+		if isinstance(exc, (KeyboardInterrupt, SystemExit)):
+			raise
+		if type(exc).__name__ == "PanicException" and type(exc).__module__ == "pyo3_runtime":
+			raise MathCATError(str(exc)) from exc
+		raise
+
+
 class MathCATInteraction(mathPres.MathInteractionNVDAObject):
 	"""An NVDA object used to interact with MathML."""
 
@@ -84,7 +102,7 @@ class MathCATInteraction(mathPres.MathInteractionNVDAObject):
 		"""Calls MathCAT's ZoomIn command and speaks the resulting text."""
 		super(MathCATInteraction, self).reportFocus()
 		try:
-			text: str = libmathcat.DoNavigateCommand("ZoomIn")
+			text: str = _callMathCAT(libmathcat.DoNavigateCommand, "ZoomIn")
 			speech.speak(convertSSMLTextForNVDA(text))
 		except Exception:
 			log.exception()
@@ -100,7 +118,7 @@ class MathCATInteraction(mathPres.MathInteractionNVDAObject):
 		region: braille.Region = braille.Region()
 		region.focusToHardLeft = True
 		try:
-			region.rawText = libmathcat.GetBraille("")
+			region.rawText = _callMathCAT(libmathcat.GetBraille, "")
 		except Exception:
 			log.exception()
 			# Translators: this message alerts users to an error in brailling math.
@@ -115,7 +133,7 @@ class MathCATInteraction(mathPres.MathInteractionNVDAObject):
 		:param commandName: The MathCAT command name (e.g. "MovePrevious").
 		"""
 		try:
-			text = libmathcat.DoNavigateCommand(commandName)
+			text = _callMathCAT(libmathcat.DoNavigateCommand, commandName)
 			speech.speak(convertSSMLTextForNVDA(text))
 		except Exception:
 			log.exception()
@@ -130,8 +148,8 @@ class MathCATInteraction(mathPres.MathInteractionNVDAObject):
 			return
 
 		try:
-			navNode: tuple[str, int] = libmathcat.GetNavigationMathMLId()
-			brailleChars = libmathcat.GetBraille(navNode[0])
+			navNode: tuple[str, int] = _callMathCAT(libmathcat.GetNavigationMathMLId)
+			brailleChars = _callMathCAT(libmathcat.GetBraille, navNode[0])
 			region: braille.Region = braille.Region()
 			region.rawText = brailleChars
 			region.focusToHardLeft = True
@@ -178,19 +196,21 @@ class MathCATInteraction(mathPres.MathInteractionNVDAObject):
 			copyAs: str = "mathml"  # value used even if "CopyAs" pref is invalid
 			textToCopy: str = ""
 			try:
-				copyAs = libmathcat.GetPreference("CopyAs").lower()
+				copyAs = _callMathCAT(libmathcat.GetPreference, "CopyAs").lower()
 			except Exception:
 				log.exception("Not able to get 'CopyAs' preference.")
 			if copyAs == "asciimath" or copyAs == "latex":
 				# save the old braille code, set the new one, get the braille, then reset the code
-				savedBrailleCode: str = libmathcat.GetPreference("BrailleCode")
-				libmathcat.SetPreference("BrailleCode", "LaTeX" if copyAs == "latex" else "ASCIIMath")
-				textToCopy = libmathcat.GetNavigationBraille()
-				libmathcat.SetPreference("BrailleCode", savedBrailleCode)
+				savedBrailleCode: str = _callMathCAT(libmathcat.GetPreference, "BrailleCode")
+				_callMathCAT(
+					libmathcat.SetPreference, "BrailleCode", "LaTeX" if copyAs == "latex" else "ASCIIMath"
+				)
+				textToCopy = _callMathCAT(libmathcat.GetNavigationBraille)
+				_callMathCAT(libmathcat.SetPreference, "BrailleCode", savedBrailleCode)
 				if copyAs == "asciimath":
 					copyAs = "ASCIIMath"  # speaks better in at least some voices
 			else:
-				mathml: str = libmathcat.GetNavigationMathML()[0]
+				mathml: str = _callMathCAT(libmathcat.GetNavigationMathML)[0]
 				if not re.match(self._startsWithMath, mathml):
 					mathml = "<math>\n" + mathml + "</math>"  # copy will fix up name spacing
 				elif self.initMathML != "":
@@ -198,15 +218,15 @@ class MathCATInteraction(mathPres.MathInteractionNVDAObject):
 				if copyAs == "speech":
 					# save the old MathML, set the navigation MathML as MathMl, get the speech, then reset the MathML
 					savedMathML: str = self.initMathML
-					savedTTS: str = libmathcat.GetPreference("TTS")
+					savedTTS: str = _callMathCAT(libmathcat.GetPreference, "TTS")
 					if savedMathML == "":  # shouldn't happen
 						raise Exception("Internal error -- MathML not set for copy")
-					libmathcat.SetPreference("TTS", "None")
-					libmathcat.SetMathML(mathml)
+					_callMathCAT(libmathcat.SetPreference, "TTS", "None")
+					_callMathCAT(libmathcat.SetMathML, mathml)
 					# get the speech text and collapse the whitespace
-					textToCopy = " ".join(libmathcat.GetSpokenText().split())
-					libmathcat.SetPreference("TTS", savedTTS)
-					libmathcat.SetMathML(savedMathML)
+					textToCopy = " ".join(_callMathCAT(libmathcat.GetSpokenText).split())
+					_callMathCAT(libmathcat.SetPreference, "TTS", savedTTS)
+					_callMathCAT(libmathcat.SetMathML, savedMathML)
 				else:
 					textToCopy = self._wrapMathMLForClipBoard(mathml)
 
@@ -306,9 +326,9 @@ class MathCAT(mathPres.MathPresentationProvider):
 				ReadPaths.mathCATDir,
 				"Rules",
 			)
-			log.info(f"MathCAT {libmathcat.GetVersion()} installed. Using rules dir: {rulesDir}")
-			libmathcat.SetRulesDir(rulesDir)
-			libmathcat.SetPreference("TTS", "SSML")
+			log.info(f"MathCAT {_callMathCAT(libmathcat.GetVersion)} installed. Using rules dir: {rulesDir}")
+			_callMathCAT(libmathcat.SetRulesDir, rulesDir)
+			_callMathCAT(libmathcat.SetPreference, "TTS", "SSML")
 			applyUserPreferences()
 		except Exception:
 			log.exception()
@@ -330,35 +350,38 @@ class MathCAT(mathPres.MathPresentationProvider):
 			# need to set Language before the MathML for DecimalSeparator canonicalization
 			language: str = getLanguageToUse()
 			# MathCAT should probably be extended to accept "extlang" tagging, but it uses lang-region tagging at the moment
-			libmathcat.SetPreference("Language", language)
-			libmathcat.SetMathML(mathml)
+			_callMathCAT(libmathcat.SetPreference, "Language", language)
+			_callMathCAT(libmathcat.SetMathML, mathml)
 		except Exception:
-			log.exception()
-			log.exception(f"MathML is {mathml}")
+			log.exception(f"Invalid MathML: {mathml}")
 			# Translators: this message reports when invalid math is found.
 			ui.message(pgettext("math", "Invalid math formatting found"))
-			libmathcat.SetMathML("<math></math>")
+			_callMathCAT(libmathcat.SetMathML, "<math></math>")
 		try:
 			supportedCommands: set[Type["SynthCommand"]] = synth.supportedCommands
 			# Set preferences for capital letters
-			libmathcat.SetPreference(
+			_callMathCAT(
+				libmathcat.SetPreference,
 				"CapitalLetters_Beep",
 				"true" if synthConfig["beepForCapitals"] else "false",
 			)
-			libmathcat.SetPreference(
+			_callMathCAT(
+				libmathcat.SetPreference,
 				"CapitalLetters_UseWord",
 				"true" if synthConfig["sayCapForCapitals"] else "false",
 			)
 			if PitchCommand in supportedCommands:
-				libmathcat.SetPreference("CapitalLetters_Pitch", str(synthConfig["capPitchChange"]))
+				_callMathCAT(
+					libmathcat.SetPreference, "CapitalLetters_Pitch", str(synthConfig["capPitchChange"])
+				)
 			if self._addSounds():
 				return (
 					[BeepCommand(800, 25)]
-					+ convertSSMLTextForNVDA(libmathcat.GetSpokenText())
+					+ convertSSMLTextForNVDA(_callMathCAT(libmathcat.GetSpokenText))
 					+ [BeepCommand(600, 15)]
 				)
 			else:
-				return convertSSMLTextForNVDA(libmathcat.GetSpokenText())
+				return convertSSMLTextForNVDA(_callMathCAT(libmathcat.GetSpokenText))
 
 		except Exception:
 			log.exception()
@@ -372,7 +395,7 @@ class MathCAT(mathPres.MathPresentationProvider):
 		:returns: True if MathCAT's `SpeechSound` preference is set, and False otherwise.
 		"""
 		try:
-			return libmathcat.GetPreference("SpeechSound") != "None"
+			return _callMathCAT(libmathcat.GetPreference, "SpeechSound") != "None"
 		except Exception:
 			log.exception()
 			return False
@@ -384,14 +407,14 @@ class MathCAT(mathPres.MathPresentationProvider):
 		:returns: A braille string representing the input MathML.
 		"""
 		try:
-			libmathcat.SetMathML(mathml)
+			_callMathCAT(libmathcat.SetMathML, mathml)
 		except Exception:
-			log.exception(f"MathML is {mathml}")
+			log.exception(f"Illegal MathML: {mathml}")
 			# Translators: this message reports illegal MathML.
 			ui.message(pgettext("math", "Illegal MathML found."))
-			libmathcat.SetMathML("<math></math>")
+			_callMathCAT(libmathcat.SetMathML, "<math></math>")
 		try:
-			return libmathcat.GetBraille("")
+			return _callMathCAT(libmathcat.GetBraille, "")
 		except Exception:
 			log.exception()
 			# Translators: this message reports an error in brailling math.

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -102,6 +102,7 @@ The setting is disabled by default. (#20013, @LeonarddeR)
 * Fixed NVDA freezing when navigating in JetBrains IDEs. (#16741, @christopherpross)
 * Speech dictionary entries of type Whole word now correctly handle words containing Unicode combining marks (e.g. Hebrew niqqud, Arabic harakat). (#20013, @LeonarddeR)
   * In particular, Whole word entries no longer incorrectly match inside larger words when those words contain combining marks.
+* Fixed NVDA freezing when MathCAT panics on MathML containing certain Unicode math characters. (#20319, @AAClause)
 
 ### Changes for Developers
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -102,7 +102,7 @@ The setting is disabled by default. (#20013, @LeonarddeR)
 * Fixed NVDA freezing when navigating in JetBrains IDEs. (#16741, @christopherpross)
 * Speech dictionary entries of type Whole word now correctly handle words containing Unicode combining marks (e.g. Hebrew niqqud, Arabic harakat). (#20013, @LeonarddeR)
   * In particular, Whole word entries no longer incorrectly match inside larger words when those words contain combining marks.
-* Fixed NVDA freezing when MathCAT panics while brailling MathML containing certain Unicode math characters. (#20319, @AAClause)
+* Fixed a case which could cause NVDA to freeze while reading math in braille. (#20319, @AAClause)
 
 ### Changes for Developers
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -102,7 +102,7 @@ The setting is disabled by default. (#20013, @LeonarddeR)
 * Fixed NVDA freezing when navigating in JetBrains IDEs. (#16741, @christopherpross)
 * Speech dictionary entries of type Whole word now correctly handle words containing Unicode combining marks (e.g. Hebrew niqqud, Arabic harakat). (#20013, @LeonarddeR)
   * In particular, Whole word entries no longer incorrectly match inside larger words when those words contain combining marks.
-* Fixed NVDA freezing when MathCAT panics on MathML containing certain Unicode math characters. (#20319, @AAClause)
+* Fixed NVDA freezing when MathCAT panics while brailling MathML containing certain Unicode math characters. (#20319, @AAClause)
 
 ### Changes for Developers
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
<!-- Use Closes/Fixes/Resolves #xxx to link this PR to the issue it is responding to. -->
Fixes #20319

### Summary of the issue:
NVDA can freeze when MathCAT panics while processing MathML that contains certain Unicode characters (commonly mathematical alphanumeric symbols such as 𝑎 U+1D44E and 𝑏 U+1D44F in <mtext>, <mi>, etc.).
MathCAT's Nemeth braille post-processing can panic on invalid UTF-8 string slicing when real math characters collide with internal placeholder characters. PyO3 exposes this Rust panic as pyo3_runtime.PanicException, which does not inherit from Exception. NVDA's existing except Exception handlers in mathPres/MathCAT/MathCAT.py therefore do not catch it, leaving an unhandled exception on the main thread and triggering watchdog freeze recovery.

### Description of user facing changes:
When MathCAT panics on problematic MathML, NVDA no longer becomes unresponsive. The failure is handled like other MathCAT errors: it is logged, the user is notified (e.g. "Error in brailling math."), and NVDA remains usable.
Speech/braille for the affected formula may still be missing or incorrect until MathCAT itself is fixed upstream; this PR only ensures NVDA fails gracefully.

### Description of developer facing changes:
- Adds MathCATError, a normal Exception subclass used to represent MathCAT failures including PyO3 panics.
- Adds _callMathCAT(), a thin wrapper around all libmathcat calls that converts pyo3_runtime.PanicException into MathCATError, so existing except Exception blocks continue to work without importing PyO3 types (which are not reliably importable at module load time).
- Adds unit tests in tests/unit/test_mathPres/test_callMathCAT.py.

### Description of development approach:
All direct libmathcat.* calls in MathCAT.py are routed through _callMathCAT(). The wrapper:

1. Re-raises normal Exception subclasses unchanged.
2. Re-raises KeyboardInterrupt and SystemExit unchanged.
3. Detects PyO3 panics by type name and module (PanicException from pyo3_runtime) and raises MathCATError with the panic message, preserving the original as __cause__.
4. Re-raises any other BaseException unchanged.

This approach was chosen because:
- Importing PanicException from pyo3_runtime is unreliable outside an active panic context, so isinstance() checks against an imported class do not work.
- Broad except BaseException at every call site is noisy and easy to get wrong.
- Rewriting MathML content (e.g. normalizing mathematical alphanumeric symbols) would mask upstream MathCAT bugs and risk altering legitimate math notation.
The underlying MathCAT panic (unsafe UTF-8 slicing / placeholder collision in Nemeth braille code) remains an upstream issue in MathCAT.

### Testing strategy:
Performed manual testing using problematic math formulas.

Before: NVDA freezes; log shows unhandled pyo3_runtime.PanicException during libmathcat.GetBraille().
After: NVDA stays responsive; log shows handled MathCATError; user hears/sees the existing MathCAT error notification.

### Known issues with pull request:
- This does not fix MathCAT's internal panic or produce correct braille/speech for MathML that triggers it. That requires an upstream MathCAT fix.
- Panic detection relies on PyO3's current convention (PanicException in module pyo3_runtime). A future PyO3 change could require updating the check.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
