### PR TITLE
addon store. Fixed the bug where actions button wasn't available for multiple selected addons

### DIFF
--- a/source/gui/addonStoreGui/controls/details.py
+++ b/source/gui/addonStoreGui/controls/details.py
@@ -129,7 +129,7 @@ class AddonDetails(
 		self.contents.Add(self.actionsButton)
 		self.actionsButton.Bind(
 			event=wx.EVT_BUTTON,
-			handler=lambda e: self._actionsContextMenu.popupContextMenuFromPosition(
+			handler=lambda e: self.Parent.addonListView._contextMenu.popupContextMenuFromPosition(
 				self,
 				self.actionsButton.Position,
 			),
@@ -213,7 +213,12 @@ class AddonDetails(
 			# SetDefaultStyle, however, this means the text control must start empty.
 			self.otherDetailsTextCtrl.SetValue("")
 			if numSelectedAddons > 1:
-				self.contentsPanel.Hide()
+				self.contentsPanel.Show()
+				self.actionsButton.Show()
+				self.descriptionLabel.Hide()
+				self.descriptionTextCtrl.Hide()
+				self.otherDetailsLabel.Hide()
+				self.otherDetailsTextCtrl.Hide()
 				self.updateAddonName(
 					npgettext(
 						"addonStore",
@@ -226,6 +231,11 @@ class AddonDetails(
 				)
 			elif not details:
 				self.contentsPanel.Hide()
+				self.actionsButton.Hide()
+				self.descriptionLabel.Hide()
+				self.descriptionTextCtrl.Hide()
+				self.otherDetailsLabel.Hide()
+				self.otherDetailsTextCtrl.Hide()
 				if self._detailsVM._listVM._isLoading:
 					self.updateAddonName(AddonDetails._loadingAddonsLabelText)
 				else:
@@ -391,6 +401,11 @@ class AddonDetails(
 						)
 
 				self.contentsPanel.Show()
+				self.actionsButton.Show()
+				self.descriptionLabel.Show()
+				self.descriptionTextCtrl.Show()
+				self.otherDetailsLabel.Show()
+				self.otherDetailsTextCtrl.Show()
 
 		self.Layout()
 		# Set caret/insertion point at the beginning so that NVDA users can more easily read from the start.

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -20,6 +20,7 @@
 
 ### Bug Fixes
 
+* When selecting multiple addons in the addon store, the actions button is no longer disabled, and pressing it on multiple addons selection will open the context menu for bulk actions for the selected addons, and if a single addon is selected, it will open the context menu related to the selected addon only, same as the application key, or right click on the addons list. (#19971, @amirmahdifard)
 * When moving to an ARIA grid cell in focus mode in web browsers, NVDA no longer reports both the row and column headers even if only the row or only the column changed. (#17750, @jcsteh)
 * In live text regions, such as terminals, NVDA no longer freezes when substantial amounts of text are dumped to the screen. (#20177)
 * When an application stops responding, NVDA no longer freezes or floods its log with errors; it stays responsive and drops UIA and MSAA events from the unresponsive application until it recovers. (#16749, @heath-toby)

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -20,7 +20,7 @@
 
 ### Bug Fixes
 
-* When selecting multiple addons in the addon store, the actions button is no longer disabled, and pressing it on multiple addons selection will open the context menu for bulk actions for the selected addons, and if a single addon is selected, it will open the context menu related to the selected addon only, same as the application key, or right click on the addons list. (#19971, @amirmahdifard)
+* The actions button can now be used when selecting multiple add-ons in the Add-on Store to perform batch actions, instead of just via the context menu in the add-ons list. (#19971, @amirmahdifard)
 * When moving to an ARIA grid cell in focus mode in web browsers, NVDA no longer reports both the row and column headers even if only the row or only the column changed. (#17750, @jcsteh)
 * In live text regions, such as terminals, NVDA no longer freezes when substantial amounts of text are dumped to the screen. (#20177)
 * When an application stops responding, NVDA no longer freezes or floods its log with errors; it stays responsive and drops UIA and MSAA events from the unresponsive application until it recovers. (#16749, @heath-toby)


### PR DESCRIPTION
### Link to issue number:
fixes https://github.com/nvaccess/nvda/issues/19971
### Summary of the issue:
When multiple addons are selected in the addons list in the addon store dialog, The application key and right click was available to open the context menu for the bulk actions for the selected addons, but the actions button, which should've been a direct remote button for triggering the same context menu was not available, and it was just explisitly opening the context menu for a single selected addon
### Description of user facing changes:
In the addon store, now when multiple addons are selected, the actions button which was not available before is now available. Only when no addon is selected this option will not be available. Otherwise, for multiple addons selected or single addon selected, actions button is available and triggers the related context menu accordingly
### Description of developer facing changes:
in the refresh method, instead of just globelly doing
self.contentsPanel.Show()
self.contentsPanel.Hide()
on statements if numSelectedAddons > 1: elif not details: else:, explisitly set each controle's visibility. Only hide the entire contents pannel in statement where no controle inside the pannel must be visible. If any of them should be visible, show the panel, and hide or show the related controle only explisitly on it 
### Description of development approach:
before this, the actions button was explisitly opening the context menu for the single selected addon, but,
on actions.binde, I treeted it as it's the right click or application on the list. The actions button is now directly a remote for the context menu of the addons list, which is expected and how as it should be.
### Testing strategy:
selected a single addon, confurmed that the actions button, discription and details text boxes are there, and doing there job as expected. Pressed the actions button, it opened the correct context menu with correct actions for the selected addon.
selected multiple addons, confurmed that the discription and details text boxes are not there and only actions button was available, pressed the actions button, made sure that it opens the correct context menu bulk actions for the selected addons
Selected no addon, and ensured the entire pannel is hidden.
### Known issues with pull request:
none
### Code Review Checklist:
I checked everything and everything is working properly as expected
- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.