### PR TITLE
Restore documentation for move mouse to view command

### DIFF
--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -1612,6 +1612,7 @@ Once the magnifier is enabled, you can use the following keyboard commands to co
 | Pan to right edge | `NVDA+shift+alt+rightArrow` | Moves the magnified view directly to the right edge of the screen |
 | Pan to top edge | `NVDA+shift+alt+upArrow` | Moves the magnified view directly to the top edge of the screen |
 | Pan to bottom edge | `NVDA+shift+alt+downArrow` | Moves the magnified view directly to the bottom edge of the screen |
+| Move mouse to view | None | Move the mouse cursor to the center of the magnified view |
 
 <!-- KC:endInclude -->
 


### PR DESCRIPTION
### Link to issue number:
Fix-up of #20329

Addresses https://github.com/nvaccess/nvda/pull/20329#discussion_r3401814119

### Summary of the issue:
When merging beta to master, mouse to view documentation has been lost.

### Description of user facing changes:
Restored mouse to view command in documented magnified commands
### Description of developer facing changes:
N/A
### Description of development approach:
See User Guide
### Testing strategy:
Check generated user guide.
### Known issues with pull request:
None
### Code Review Checklist:


- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
