### PR TITLE
Add references to AddonTemplate localization guides

### DIFF
--- a/projectDocs/dev/addons.md
+++ b/projectDocs/dev/addons.md
@@ -17,6 +17,8 @@
 * [NVDA Developer Guide](https://download.nvaccess.org/documentation/developerGuide.html)
 * [Technical design overview](../design/technicalDesignOverview.md)
 * [NVDA Add-on Development Community Guide](https://github.com/nvdaaddons/DevGuide/wiki/NVDA-Add-on-Development-Guide)
+* [Addon localization guide for add-on authors](https://github.com/nvaccess/AddonTemplate/blob/master/docs/l10n/addonAuthors.md)
+* [Addon localization guide for translators](https://github.com/nvaccess/AddonTemplate/blob/master/docs/l10n/addonTranslators.md)
 * [NVDA ControllerClient manual (NVDA API for external applications to directly speak or braille messages, etc.)](../../extras/controllerClient)
 
 ## Communication channels

--- a/projectDocs/translating/readme.md
+++ b/projectDocs/translating/readme.md
@@ -52,4 +52,5 @@ If your language is no longer maintained, you can request to be the new maintain
 * gestures.ini: remapping of gestures for your language, see [Translating Gestures](https://download.nvaccess.org/documentation/developerGuide.html#TranslatingGestures) for more information.
 * userGuide.md: the User Guide, see [Translating using Crowdin](./crowdin.md) for more information.
 * changes.md (optional): a list of changes between releases, see [Translating using Crowdin](./crowdin.md) for more information.
-* Add-ons (optional): a set of optional features that users can install. See the localization guides for [add-on authors](https://github.com/nvaccess/AddonTemplate/blob/master/docs/l10n/addonAuthors.md) and [add-on translators](https://github.com/nvaccess/AddonTemplate/blob/master/docs/l10n/addonTranslators.md).
+* Add-ons (optional): a set of optional features that users can install.
+See the localization guides for [add-on authors](https://github.com/nvaccess/AddonTemplate/blob/master/docs/l10n/addonAuthors.md) and [add-on translators](https://github.com/nvaccess/AddonTemplate/blob/master/docs/l10n/addonTranslators.md).

--- a/projectDocs/translating/readme.md
+++ b/projectDocs/translating/readme.md
@@ -52,4 +52,4 @@ If your language is no longer maintained, you can request to be the new maintain
 * gestures.ini: remapping of gestures for your language, see [Translating Gestures](https://download.nvaccess.org/documentation/developerGuide.html#TranslatingGestures) for more information.
 * userGuide.md: the User Guide, see [Translating using Crowdin](./crowdin.md) for more information.
 * changes.md (optional): a list of changes between releases, see [Translating using Crowdin](./crowdin.md) for more information.
-* Add-ons (optional, out of date): a set of optional features that users can install, see [Translating Addons](https://github.com/nvaccess/nvda/wiki/TranslatingAddons) for more information.
+* Add-ons (optional): a set of optional features that users can install. See the localization guides for [add-on authors](https://github.com/nvaccess/AddonTemplate/blob/master/docs/l10n/addonAuthors.md) and [add-on translators](https://github.com/nvaccess/AddonTemplate/blob/master/docs/l10n/addonTranslators.md).


### PR DESCRIPTION
### Link to issue number

None

### Summary of the issue

Documentation about add-on localization was recently added to the AddonTemplate repository. Relevant NVDA documentation pages did not yet reference these new resources.

### Description of user facing changes

Added references to the AddonTemplate localization documentation for add-on authors and translators.

### Description of developer facing changes

Developers and translators can now discover the add-on localization documentation directly from the NVDA documentation.

### Description of development approach

Updated the following documentation pages to reference the localization guides recently added to the AddonTemplate repository:

* `projectDocs/dev/addons.md`
* `projectDocs/translating/readme.md`

This work follows feedback provided during the review of [nvaccess/addon-dataStore#9671](https://github.com/nvaccess/addon-dataStore/pull/9671).

As part of that discussion, it was suggested that the NVDA documentation should reference the new add-on localization guides hosted in the AddonTemplate repository, replacing outdated references to the old TranslatingAddons wiki page.

### Testing strategy

Verified that all added links point to the correct AddonTemplate documentation and that the modified Markdown renders correctly.

### Known issues with pull request

None

### Checklist

* [x] This change only affects documentation.
* [x] Documentation has been updated accordingly.
* [x] All added links have been verified.
* [x] Markdown formatting has been reviewed.
* [x] No code changes are included in this pull request.
