### PR TITLE
addon store's settings now resets to default up on resetting nvda's configuration to factory defaults

### DIFF
--- a/source/addonStore/settings.py
+++ b/source/addonStore/settings.py
@@ -132,6 +132,12 @@ class _AddonStoreSettings:
 		"""
 		return self._addonSettings.get(addonId, _AddonSettings())
 
+	def reset(self):
+		"""Reset settings to factory defaults."""
+		self._showWarning = True
+		self._addonSettings = {}
+		self.save()
+
 	@property
 	def showWarning(self) -> bool:
 		return self._showWarning

--- a/source/core.py
+++ b/source/core.py
@@ -357,6 +357,8 @@ def resetConfiguration(factoryDefaults=False):
 	from addonStore import dataManager
 
 	log.debug("terminating addon dataManager")
+	if factoryDefaults and dataManager.addonDataManager is not None:
+		dataManager.addonDataManager.storeSettings.reset()
 	dataManager.terminate()
 	log.debug("Reloading config")
 	config.conf.reset(factoryDefaults=factoryDefaults)

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -26,6 +26,7 @@
 
 ### Bug Fixes
 
+* Resetting NVDA's configuration to factory defaults now also resets Add-on Store's settings. (#19866, @amirmahdifard)
 * The actions button can now be used when selecting multiple add-ons in the Add-on Store to perform batch actions, instead of just via the context menu in the add-ons list. (#19971, @amirmahdifard)
 * When moving to an ARIA grid cell in focus mode in web browsers, NVDA no longer reports both the row and column headers even if only the row or only the column changed. (#17750, @jcsteh)
 * In live text regions, such as terminals, NVDA no longer freezes when substantial amounts of text are dumped to the screen. (#20177)


### PR DESCRIPTION
### Link to issue number:
fixes https://github.com/nvaccess/nvda/issues/19866
### Summary of the issue:
Since addon store's settings was stored and retreaved diffrently than the nvda's settings, I think during the development, the resetting its settings was forgotan to be implemented, thus it didn't reset up on resetting nvda's settings back to defaults
### Description of user facing changes:
When nvda's configuration reset to factory defaults, addon stores settings will also be reset to defaults, For now it only has addon store warning up on opening the addon store, which is mentioned on the linked issue
### Description of developer facing changes:
Added a standard reset method to addon store's settings and called it on the factory default reset function in core.
### Description of development approach:
Now the reset method and the call on the core resets the existing settings of the addon store both in memory and in the settings file, so the changes are instant. If later new settings introduced to this section, its support must also be added to the reset method to support the resetting the newly introduced settings as well later
### Testing strategy:
Started nvda, opened addon store, checked the don't show again checkbox, closed it, reset settings to factory defaults, made sure the show warning was back to true in the file, and both with restart and without restart of nvda, the changes took effect, both in the live memory and the permanent settings file.
### Known issues with pull request:
none
### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.