### PR TITLE
Set radio box layout for speech dictionary entry to vertical

### DIFF
--- a/source/gui/speechDict.py
+++ b/source/gui/speechDict.py
@@ -65,7 +65,7 @@ class DictionaryEntryDialog(
 		typeChoices = [
 			DictionaryEntryDialog.TYPE_LABELS[i] for i in DictionaryEntryDialog.TYPE_LABELS_ORDERING
 		]
-		self.typeRadioBox = sHelper.addItem(wx.RadioBox(self, label=typeText, choices=typeChoices))
+		self.typeRadioBox = sHelper.addItem(wx.RadioBox(self, label=typeText, choices=typeChoices, style=wx.RA_SPECIFY_ROWS))
 
 		sHelper.addDialogDismissButtons(wx.OK | wx.CANCEL, separated=True)
 

--- a/source/gui/speechDict.py
+++ b/source/gui/speechDict.py
@@ -65,7 +65,9 @@ class DictionaryEntryDialog(
 		typeChoices = [
 			DictionaryEntryDialog.TYPE_LABELS[i] for i in DictionaryEntryDialog.TYPE_LABELS_ORDERING
 		]
-		self.typeRadioBox = sHelper.addItem(wx.RadioBox(self, label=typeText, choices=typeChoices, style=wx.RA_SPECIFY_ROWS))
+		self.typeRadioBox = sHelper.addItem(
+			wx.RadioBox(self, label=typeText, choices=typeChoices, style=wx.RA_SPECIFY_ROWS)
+		)
 
 		sHelper.addDialogDismissButtons(wx.OK | wx.CANCEL, separated=True)
 

--- a/source/gui/speechDict.py
+++ b/source/gui/speechDict.py
@@ -66,7 +66,7 @@ class DictionaryEntryDialog(
 			DictionaryEntryDialog.TYPE_LABELS[i] for i in DictionaryEntryDialog.TYPE_LABELS_ORDERING
 		]
 		self.typeRadioBox = sHelper.addItem(
-			wx.RadioBox(self, label=typeText, choices=typeChoices, style=wx.RA_SPECIFY_ROWS)
+			wx.RadioBox(self, label=typeText, choices=typeChoices, style=wx.RA_SPECIFY_ROWS),
 		)
 
 		sHelper.addDialogDismissButtons(wx.OK | wx.CANCEL, separated=True)


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
<!-- Use Closes/Fixes/Resolves #xxx to link this PR to the issue it is responding to. -->

Related: #19657

### Summary of the issue:

Currently, due to the large number of entry types in the speech dictionary, the add entry dialog box may extend beyond the screen area on smaller monitors.

### Description of user facing changes:

Set the layout of the entry types radio box to vertical.

### Description of developer facing changes:

### Description of development approach:

Set `style=wx.RA_SPECIFY_ROWS` for `wx.RadioBox`.

### Testing strategy:

Open the Add Entry dialog box and confirm that the radio box layout is vertical.

<img width="208" height="437" alt="The entry layout is vertical." src="https://github.com/user-attachments/assets/bd975308-f24e-457b-9e0d-9cfd5a7629c6" />

### Known issues with pull request:

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
