### PR TITLE
Set the Type radiobuttons in the Add Dictionary Entry dialog to be arranged vertically rather than horizontally

### DIFF
--- a/source/gui/speechDict.py
+++ b/source/gui/speechDict.py
@@ -65,13 +65,16 @@ class DictionaryEntryDialog(
 		typeChoices = [
 			DictionaryEntryDialog.TYPE_LABELS[i] for i in DictionaryEntryDialog.TYPE_LABELS_ORDERING
 		]
-		self.typeRadioBox = sHelper.addItem(wx.RadioBox(self, label=typeText, choices=typeChoices))
+		self.typeRadioBox = sHelper.addItem(
+			wx.RadioBox(self, label=typeText, choices=typeChoices, style=wx.RA_SPECIFY_ROWS),
+		)
 
 		sHelper.addDialogDismissButtons(wx.OK | wx.CANCEL, separated=True)
 
 		mainSizer.Add(sHelper.sizer, border=guiHelper.BORDER_FOR_DIALOGS, flag=wx.ALL)
 		mainSizer.Fit(self)
 		self.SetSizer(mainSizer)
+		self.CentreOnParent()
 		self.setType(EntryType.ANYWHERE)
 		self.patternTextCtrl.SetFocus()
 		self.Bind(wx.EVT_BUTTON, self.onOk, id=wx.ID_OK)

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -79,6 +79,7 @@ This is more noticeable for Windows releases which are enablement packages on to
 * Added an advanced setting to opt regular expression speech dictionary entries into a more modern [`regex`](https://pypi.org/project/regex/) engine.
 This provides Unicode-aware `\w` and `\b` and additional regex features.
 The setting is disabled by default. (#20013, @LeonarddeR)
+* The "Type" radio buttons in the "Add Dictionary Entry" dialog are now arranged vertically rather than horizontally. (#19657)
 
 ### Bug Fixes
 


### PR DESCRIPTION
### Link to issue number:

Temporary fix for #19657 

### Summary of the issue:

The "Type" radio buttons in the "Add Dictionary Entry" dialog were displayed on a single line, causing the dialog to stretch off screen.

### Description of user facing changes:

These radio buttons are now displayed in a single column rather than a single row.

### Description of developer facing changes:

None

### Description of development approach:

Set the `radiobox`'s style to `wx.RA_SPECIFY_ROWS`. Also added a call to `self.CentreOnParent` to properly centre the dialog on its parent.

### Testing strategy:

Ran from source and checked that the radio buttons were arranged vertically and the dialog was centred on the speech dictionary dialog.

### Known issues with pull request:

This is a temporary fix, with the desired long-term fix being to convert to a combobox.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
