### PR TITLE
HandyTech: Interpret reading position packets from Active Tactile Control

### DIFF
--- a/source/brailleDisplayDrivers/handyTech.py
+++ b/source/brailleDisplayDrivers/handyTech.py
@@ -266,7 +266,7 @@ class AtcMixin(object):
 	def __init__(self, display):
 		super().__init__(display)
 		self._readingPosition: int | None = None
-		self._lastRefreshTime = 0.0
+		self._lastRefreshTime: float = 0.0
 
 	def postInit(self):
 		super().postInit()

--- a/source/brailleDisplayDrivers/handyTech.py
+++ b/source/brailleDisplayDrivers/handyTech.py
@@ -283,7 +283,7 @@ class AtcMixin(object):
 				f"Unexpected ATC reading position packet with length {len(packet)}: {packet!r}",
 			)
 			return
-		reading_position = packet[1]
+		readingPosition = packet[1]
 		elapsed_since_refresh = time.monotonic() - self._lastRefreshTime
 		is_settling_after_refresh = elapsed_since_refresh < self.READ_SUPPRESS_AFTER_REFRESH_SECONDS
 		if reading_position == self.UNKNOWN_READING_POSITION:

--- a/source/brailleDisplayDrivers/handyTech.py
+++ b/source/brailleDisplayDrivers/handyTech.py
@@ -261,6 +261,7 @@ class AtcMixin(object):
 	# after cells are refreshed. Use a short settling window before
 	# accepting changes.
 	READ_SUPPRESS_AFTER_REFRESH_SECONDS = 0.25
+	READING_POSITION_MAX_JUMP_DURING_SETTLE = 2
 
 	def __init__(self, display):
 		super().__init__(display)
@@ -268,13 +269,13 @@ class AtcMixin(object):
 		self._lastRefreshTime = 0.0
 
 	def postInit(self):
-		super(AtcMixin, self).postInit()
+		super().postInit()
 		log.debug("Enabling ATC")
 		self._display.atc = True
 
 	def display(self, cells: List[int]):
-		self._lastRefreshTime = time.monotonic()
 		super().display(cells)
+		self._lastRefreshTime = time.monotonic()
 
 	def handleReadingPosition(self, packet: bytes) -> None:
 		if len(packet) != self.READING_POSITION_PACKET_LENGTH:
@@ -300,14 +301,11 @@ class AtcMixin(object):
 		# During refresh settling, preserve confirmed state. Real touches tend
 		# to remain near the previous cell, while refresh noise often appears
 		# as a release, a new touch from nowhere, or a large jump.
-		if is_settling_after_refresh and self._readingPosition is None:
-			return
-		if (
-			is_settling_after_refresh
-			and self._readingPosition is not None
-			and abs(reading_position - self._readingPosition) > 2
-		):
-			return
+		if is_settling_after_refresh:
+			if self._readingPosition is None:
+				return
+			if abs(reading_position - self._readingPosition) > self.READING_POSITION_MAX_JUMP_DURING_SETTLE:
+				return
 		if reading_position == self._readingPosition:
 			return
 		self._readingPosition = reading_position

--- a/source/brailleDisplayDrivers/handyTech.py
+++ b/source/brailleDisplayDrivers/handyTech.py
@@ -252,7 +252,7 @@ class OldProtocolMixin(object):
 		self._display.sendPacket(HT_PKT_BRAILLE, bytes(cells))
 
 
-class AtcMixin(object):
+class AtcMixin:
 	"""Support for displays with Active Tactile Control (ATC)"""
 
 	READING_POSITION_PACKET_LENGTH = 2

--- a/source/brailleDisplayDrivers/handyTech.py
+++ b/source/brailleDisplayDrivers/handyTech.py
@@ -263,7 +263,7 @@ class AtcMixin:
 	READ_SUPPRESS_AFTER_REFRESH_SECONDS = 0.25
 	READING_POSITION_MAX_JUMP_DURING_SETTLE = 2
 
-	def __init__(self, display):
+	def __init__(self, display: "BrailleDisplayDriver"):
 		super().__init__(display)
 		self._readingPosition: int | None = None
 		self._lastRefreshTime: float = 0.0

--- a/source/brailleDisplayDrivers/handyTech.py
+++ b/source/brailleDisplayDrivers/handyTech.py
@@ -1,6 +1,6 @@
 # A part of NonVisual Desktop Access (NVDA)
 # Copyright (C) 2008-2026 NV Access Limited, Bram Duvigneau, Babbage B.V.,
-# Felix Grützmacher (Handy Tech Elektronik GmbH), Leonard de Ruijter
+# Felix Grützmacher (Handy Tech Elektronik GmbH), Leonard de Ruijter, Bill Dengler
 # This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
 # For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
 
@@ -255,10 +255,62 @@ class OldProtocolMixin(object):
 class AtcMixin(object):
 	"""Support for displays with Active Tactile Control (ATC)"""
 
+	READING_POSITION_PACKET_LENGTH = 2
+	UNKNOWN_READING_POSITION = 0xFF
+	# ATC can report transient false reading positions immediately
+	# after cells are refreshed. Use a short settling window before
+	# accepting changes.
+	READ_SUPPRESS_AFTER_REFRESH_SECONDS = 0.25
+
+	def __init__(self, display):
+		super().__init__(display)
+		self._readingPosition: Optional[int] = None
+		self._lastRefreshTime = 0.0
+
 	def postInit(self):
 		super(AtcMixin, self).postInit()
 		log.debug("Enabling ATC")
 		self._display.atc = True
+
+	def display(self, cells: List[int]):
+		self._lastRefreshTime = time.monotonic()
+		super().display(cells)
+
+	def handleReadingPosition(self, packet: bytes) -> None:
+		if len(packet) != self.READING_POSITION_PACKET_LENGTH:
+			log.debugWarning(
+				f"Unexpected ATC reading position packet with length {len(packet)}: {packet!r}",
+			)
+			return
+		reading_position = packet[1]
+		elapsed_since_refresh = time.monotonic() - self._lastRefreshTime
+		is_settling_after_refresh = elapsed_since_refresh < self.READ_SUPPRESS_AFTER_REFRESH_SECONDS
+		if reading_position == self.UNKNOWN_READING_POSITION:
+			if is_settling_after_refresh:
+				return
+			self._readingPosition = None
+			return
+		if reading_position >= self.numCells:
+			log.debugWarning(
+				f"Display has {self.numCells} cells but reported an ATC "
+				f"reading position of {reading_position}",
+			)
+			return
+
+		# During refresh settling, preserve confirmed state. Real touches tend
+		# to remain near the previous cell, while refresh noise often appears
+		# as a release, a new touch from nowhere, or a large jump.
+		if is_settling_after_refresh and self._readingPosition is None:
+			return
+		if (
+			is_settling_after_refresh
+			and self._readingPosition is not None
+			and abs(reading_position - self._readingPosition) > 2
+		):
+			return
+		if reading_position == self._readingPosition:
+			return
+		self._readingPosition = reading_position
 
 
 class TimeSyncFirmnessMixin(object):
@@ -1078,6 +1130,9 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver, ScriptableObject):
 			elif extPacketType == HT_EXTPKT_ATC_INFO:
 				# Ignore ATC packets for now
 				pass
+			elif extPacketType == HT_EXTPKT_READING_POSITION:
+				if isinstance(self._model, AtcMixin):
+					self._model.handleReadingPosition(packet)
 			elif extPacketType == HT_EXTPKT_GET_PROTOCOL_PROPERTIES:
 				self.numCells = packet[3]
 			elif isinstance(self._model, TimeSyncFirmnessMixin):

--- a/source/brailleDisplayDrivers/handyTech.py
+++ b/source/brailleDisplayDrivers/handyTech.py
@@ -273,7 +273,7 @@ class AtcMixin(object):
 		log.debug("Enabling ATC")
 		self._display.atc = True
 
-	def display(self, cells: List[int]):
+	def display(self, cells: list[int]):
 		super().display(cells)
 		self._lastRefreshTime = time.monotonic()
 

--- a/source/brailleDisplayDrivers/handyTech.py
+++ b/source/brailleDisplayDrivers/handyTech.py
@@ -285,30 +285,30 @@ class AtcMixin(object):
 			return
 		readingPosition = packet[1]
 		elapsedSinceRefresh = time.monotonic() - self._lastRefreshTime
-		isSettlingAfterRefresh = elapsed_since_refresh < self.READ_SUPPRESS_AFTER_REFRESH_SECONDS
-		if reading_position == self.UNKNOWN_READING_POSITION:
-			if is_settling_after_refresh:
+		isSettlingAfterRefresh = elapsedSinceRefresh < self.READ_SUPPRESS_AFTER_REFRESH_SECONDS
+		if readingPosition == self.UNKNOWN_READING_POSITION:
+			if isSettlingAfterRefresh:
 				return
 			self._readingPosition = None
 			return
-		if reading_position >= self.numCells:
+		if readingPosition >= self.numCells:
 			log.debugWarning(
 				f"Display has {self.numCells} cells but reported an ATC "
-				f"reading position of {reading_position}",
+				f"reading position of {readingPosition}",
 			)
 			return
 
 		# During refresh settling, preserve confirmed state. Real touches tend
 		# to remain near the previous cell, while refresh noise often appears
 		# as a release, a new touch from nowhere, or a large jump.
-		if is_settling_after_refresh:
+		if isSettlingAfterRefresh:
 			if self._readingPosition is None:
 				return
-			if abs(reading_position - self._readingPosition) > self.READING_POSITION_MAX_JUMP_DURING_SETTLE:
+			if abs(readingPosition - self._readingPosition) > self.READING_POSITION_MAX_JUMP_DURING_SETTLE:
 				return
-		if reading_position == self._readingPosition:
+		if readingPosition == self._readingPosition:
 			return
-		self._readingPosition = reading_position
+		self._readingPosition = readingPosition
 
 
 class TimeSyncFirmnessMixin(object):

--- a/source/brailleDisplayDrivers/handyTech.py
+++ b/source/brailleDisplayDrivers/handyTech.py
@@ -284,7 +284,7 @@ class AtcMixin(object):
 			)
 			return
 		readingPosition = packet[1]
-		elapsed_since_refresh = time.monotonic() - self._lastRefreshTime
+		elapsedSinceRefresh = time.monotonic() - self._lastRefreshTime
 		is_settling_after_refresh = elapsed_since_refresh < self.READ_SUPPRESS_AFTER_REFRESH_SECONDS
 		if reading_position == self.UNKNOWN_READING_POSITION:
 			if is_settling_after_refresh:

--- a/source/brailleDisplayDrivers/handyTech.py
+++ b/source/brailleDisplayDrivers/handyTech.py
@@ -265,7 +265,7 @@ class AtcMixin(object):
 
 	def __init__(self, display):
 		super().__init__(display)
-		self._readingPosition: Optional[int] = None
+		self._readingPosition: int | None = None
 		self._lastRefreshTime = 0.0
 
 	def postInit(self):

--- a/source/brailleDisplayDrivers/handyTech.py
+++ b/source/brailleDisplayDrivers/handyTech.py
@@ -273,7 +273,7 @@ class AtcMixin:
 		log.debug("Enabling ATC")
 		self._display.atc = True
 
-	def display(self, cells: list[int]):
+	def display(self, cells: list[int]) -> None:
 		super().display(cells)
 		self._lastRefreshTime = time.monotonic()
 

--- a/source/brailleDisplayDrivers/handyTech.py
+++ b/source/brailleDisplayDrivers/handyTech.py
@@ -285,7 +285,7 @@ class AtcMixin(object):
 			return
 		readingPosition = packet[1]
 		elapsedSinceRefresh = time.monotonic() - self._lastRefreshTime
-		is_settling_after_refresh = elapsed_since_refresh < self.READ_SUPPRESS_AFTER_REFRESH_SECONDS
+		isSettlingAfterRefresh = elapsed_since_refresh < self.READ_SUPPRESS_AFTER_REFRESH_SECONDS
 		if reading_position == self.UNKNOWN_READING_POSITION:
 			if is_settling_after_refresh:
 				return


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Re #4775.

### Summary of the issue:
Some HandyTech Braille displays, such as the Activator, can communicate the user's reading position back to the controlling device. This allows, for instance, the display to advance when the user finishes reading a line (instead of on a timer or with a button press), to speak the current word or line (or perform some other action) if the user dwells, etc. NVDA lacks support for interpreting HandyTech control packets containing this information.

### Description of how this pull request fixes the issue:
This PR adds support for parsing reading position packets to the HandyTech driver and stores the current reading position in a private field. No user-facing behaviour changes have been made as the API will likely require some discussion (do we want to expose reading position as events, an extension point, something else?) and that work is better done in a follow-up.

### Testing strategy:
Tested with an Activator over USB-C. Reported reading positions are accurate, including in text fields with a rapidly refreshing blinking cursor.

### Known issues with pull request:
The ATC protocol is undocumented as far as I can tell. I've made a best effort and added logging in case of unexpected packet shapes. NVDA was already receiving (and throwing away) these reading position packets, so these changes have no other impact on the HandyTech driver.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.