### PR TITLE
Fix notepad++: Editing Chinese letters, NVDA fails to track caret movements within "uncommitted" IME

### DIFF
--- a/source/appModules/notepadPlusPlus.py
+++ b/source/appModules/notepadPlusPlus.py
@@ -47,30 +47,21 @@ def _hasActiveInputComposition(obj) -> bool:
 	return bool(getattr(obj, "compositionString", ""))
 
 
-def _shouldUseNpp83TextInfo(productVersion: str) -> bool:
-	"""Return True for Notepad++ versions which use 64-bit Scintilla positions."""
-	try:
-		appVerMajor, appVerMinor, *__ = productVersion.split(".")
-		appVerMajor = int(appVerMajor)
-		firstMinorDigit = int(appVerMinor[0])
-	except (IndexError, ValueError):
-		return False
-	# When retrieving the version, Notepad++ concatenates
-	# minor, patch, build in major.minor.patch.build to the form of major.minor
-	# https://github.com/notepad-plus-plus/npp-usermanual/blob/master/content/docs/plugin-communication.md#nppm_getnppversion
-	# e.g. '8.3' for '8.3', '8.21' for '8.2.1' and '8.192' for '8.1.9.2'.
-	# Therefore, only use the first digit of the minor version to match against version 8.3 or later.
-	return appVerMajor > 8 or (appVerMajor == 8 and firstMinorDigit >= 3)
-
-
 class NppEdit(ScintillaBase.Scintilla):
 	name = None  # The name of the editor is not useful.
 
 	def _get_TextInfo(self):
 		if _hasActiveInputComposition(self):
 			return InputCompositionTextInfo
-		if self.appModule.is64BitProcess and _shouldUseNpp83TextInfo(self.appModule.productVersion):
-			return ScintillaTextInfoNpp83
+		if self.appModule.is64BitProcess:
+			appVerMajor, appVerMinor, *__ = self.appModule.productVersion.split(".")
+			# When retrieving the version, Notepad++ concatenates
+			# minor, patch, build in major.minor.patch.build to the form of major.minor
+			# https://github.com/notepad-plus-plus/npp-usermanual/blob/master/content/docs/plugin-communication.md#nppm_getnppversion
+			# e.g. '8.3' for '8.3', '8.21' for '8.2.1' and '8.192' for '8.1.9.2'.
+			# Therefore, only use the first digit of the minor version to match against version 8.3 or later.
+			if int(appVerMajor) >= 8 and int(appVerMinor[0]) >= 3:
+				return ScintillaTextInfoNpp83
 		return super().TextInfo
 
 

--- a/source/appModules/notepadPlusPlus.py
+++ b/source/appModules/notepadPlusPlus.py
@@ -13,6 +13,7 @@ and the current name makes it possible to expose it from `nvdaBuiltin` for add-o
 import ctypes
 
 import appModuleHandler
+from NVDAObjects.inputComposition import InputCompositionTextInfo
 import NVDAObjects.window.scintilla as ScintillaBase
 
 
@@ -39,19 +40,37 @@ class ScintillaTextInfoNpp83(ScintillaBase.ScintillaTextInfo):
 		]
 
 
+def _hasActiveInputComposition(obj) -> bool:
+	"""Return True when NVDA has current IME composition text on this object."""
+	if getattr(obj, "isReading", False):
+		return bool(getattr(obj, "readingString", ""))
+	return bool(getattr(obj, "compositionString", ""))
+
+
+def _shouldUseNpp83TextInfo(productVersion: str) -> bool:
+	"""Return True for Notepad++ versions which use 64-bit Scintilla positions."""
+	try:
+		appVerMajor, appVerMinor, *__ = productVersion.split(".")
+		appVerMajor = int(appVerMajor)
+		firstMinorDigit = int(appVerMinor[0])
+	except (IndexError, ValueError):
+		return False
+	# When retrieving the version, Notepad++ concatenates
+	# minor, patch, build in major.minor.patch.build to the form of major.minor
+	# https://github.com/notepad-plus-plus/npp-usermanual/blob/master/content/docs/plugin-communication.md#nppm_getnppversion
+	# e.g. '8.3' for '8.3', '8.21' for '8.2.1' and '8.192' for '8.1.9.2'.
+	# Therefore, only use the first digit of the minor version to match against version 8.3 or later.
+	return appVerMajor > 8 or (appVerMajor == 8 and firstMinorDigit >= 3)
+
+
 class NppEdit(ScintillaBase.Scintilla):
 	name = None  # The name of the editor is not useful.
 
 	def _get_TextInfo(self):
-		if self.appModule.is64BitProcess:
-			appVerMajor, appVerMinor, *__ = self.appModule.productVersion.split(".")
-			# When retrieving the version, Notepad++ concatenates
-			# minor, patch, build in major.minor.patch.build to the form of major.minor
-			# https://github.com/notepad-plus-plus/npp-usermanual/blob/master/content/docs/plugin-communication.md#nppm_getnppversion
-			# e.g. '8.3' for '8.3', '8.21' for '8.2.1' and '8.192' for '8.1.9.2'.
-			# Therefore, only use the first digit of the minor version to match against version 8.3 or later.
-			if int(appVerMajor) >= 8 and int(appVerMinor[0]) >= 3:
-				return ScintillaTextInfoNpp83
+		if _hasActiveInputComposition(self):
+			return InputCompositionTextInfo
+		if self.appModule.is64BitProcess and _shouldUseNpp83TextInfo(self.appModule.productVersion):
+			return ScintillaTextInfoNpp83
 		return super().TextInfo
 
 

--- a/source/appModules/notepadPlusPlus.py
+++ b/source/appModules/notepadPlusPlus.py
@@ -13,8 +13,10 @@ and the current name makes it possible to expose it from `nvdaBuiltin` for add-o
 import ctypes
 
 import appModuleHandler
+from NVDAObjects import NVDAObject
 from NVDAObjects.inputComposition import InputCompositionTextInfo
 import NVDAObjects.window.scintilla as ScintillaBase
+import textInfos
 
 
 class CharacterRangeStructLongLong(ctypes.Structure):
@@ -40,7 +42,7 @@ class ScintillaTextInfoNpp83(ScintillaBase.ScintillaTextInfo):
 		]
 
 
-def _hasActiveInputComposition(obj) -> bool:
+def _hasActiveInputComposition(obj: NVDAObject) -> bool:
 	"""Return True when NVDA has current IME composition text on this object."""
 	if getattr(obj, "isReading", False):
 		return bool(getattr(obj, "readingString", ""))
@@ -50,7 +52,7 @@ def _hasActiveInputComposition(obj) -> bool:
 class NppEdit(ScintillaBase.Scintilla):
 	name = None  # The name of the editor is not useful.
 
-	def _get_TextInfo(self):
+	def _get_TextInfo(self) -> type[textInfos.TextInfo]:
 		if _hasActiveInputComposition(self):
 			return InputCompositionTextInfo
 		if self.appModule.is64BitProcess:

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -31,6 +31,7 @@
 * In live text regions, such as terminals, NVDA no longer freezes when substantial amounts of text are dumped to the screen. (#20177)
 * When an application stops responding, NVDA no longer freezes or floods its log with errors; it stays responsive and drops UIA and MSAA events from the unresponsive application until it recovers. (#16749, @heath-toby)
 * Reduced lag on UI Automation text change events, improving the responsiveness of controls such as combo boxes and of File Explorer, by using the cached element class name instead of a live cross-process fetch. (#16749, @heath-toby)
+* In Notepad++, NVDA now continues to report IME composition text in speech and braille while selecting Chinese characters. (#14140, #14152, @keyang556)
 * Fixed UAC slider not being read when changing values with arrow keys in UI Automation. (#9356, @tareh7z)
 * NVDA recovers more quickly when an application stops responding; in particular, switching away from a hung application returns NVDA to responsiveness immediately. (#20169, @heath-toby)
 * In Mozilla Firefox, reporting annotation details now works correctly in focus mode on controls which are not editable text. (#20208, @jcsteh)

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -31,7 +31,7 @@
 * In live text regions, such as terminals, NVDA no longer freezes when substantial amounts of text are dumped to the screen. (#20177)
 * When an application stops responding, NVDA no longer freezes or floods its log with errors; it stays responsive and drops UIA and MSAA events from the unresponsive application until it recovers. (#16749, @heath-toby)
 * Reduced lag on UI Automation text change events, improving the responsiveness of controls such as combo boxes and of File Explorer, by using the cached element class name instead of a live cross-process fetch. (#16749, @heath-toby)
-* In Notepad++, NVDA now continues to report IME composition text in speech and braille while selecting Chinese characters. (#14140, #14152, @keyang556)
+* In Notepad++, NVDA now continues to report IME composition text in speech and braille while selecting or navigating within Chinese IME composition. (#14140, #14152, @keyang556)
 * Fixed UAC slider not being read when changing values with arrow keys in UI Automation. (#9356, @tareh7z)
 * NVDA recovers more quickly when an application stops responding; in particular, switching away from a hung application returns NVDA to responsiveness immediately. (#20169, @heath-toby)
 * In Mozilla Firefox, reporting annotation details now works correctly in focus mode on controls which are not editable text. (#20208, @jcsteh)


### PR DESCRIPTION
### Link to issue number:
Fixes #14140 and Fixes #14152

### Summary of the issue:
In Notepad++ 64-bit 8.3 and later, NVDA may fail to report or track active Chinese IME composition text correctly while the user is selecting or navigating characters during composition.
This affects speech and braille feedback during IME candidate/composition.

### Description of user facing changes:
When entering Chinese text with an IME in Notepad++, NVDA now continues to report active composition text in speech and braille while characters are being selected or navigated.
This brings the Notepad++ IME experience closer to other text editors such as Notepad and Microsoft Word.

### Description of developer facing changes:
For the Notepad++ app module, active input composition now uses `InputCompositionTextInfo`.
No public API changes are introduced.

### Description of development approach:
When the focused Notepad++ editor has an active IME composition string or reading string, `NppEdit._get_TextInfo` returns `InputCompositionTextInfo`. Otherwise, the existing Notepad++ Scintilla text info behavior is preserved.
The existing handling for 64-bit Notepad++ 8.3+ is left unchanged.

### Testing strategy:
Ran lint
Ran unit tests
Built a test launcher
Manual testing verified Chinese IME composition in Notepad++ 64-bit 8.3 or later, including:
Typing Chinese characters with an active IME composition.
Moving within the composition text.
Selecting/changing candidate characters.
- Confirmed speech output.
Confirmed braille output.

### Known issues with pull request:
No known issues.

### Code Review Checklist:


- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
