### PR TITLE
Speech dictionaries dialog modernize to remove the old stile buttons and ward context menu

### DIFF
--- a/source/gui/speechDict.py
+++ b/source/gui/speechDict.py
@@ -181,6 +181,7 @@ class DictionaryDialog(
 			wx.ListCtrl,
 			style=wx.LC_REPORT | wx.LC_SINGLE_SEL,
 		)
+		self.dictList.Bind(wx.EVT_CONTEXT_MENU, self.onContextMenu)
 		# Translators: The label for a column in dictionary entries list used to identify comments for the entry.
 		self.dictList.AppendColumn(_("Comment"), width=150)
 		# Translators: The label for a column in dictionary entries list used to identify pattern
@@ -215,18 +216,6 @@ class DictionaryDialog(
 			label=_("&Add"),
 		).Bind(wx.EVT_BUTTON, self.onAddClick)
 
-		bHelper.addButton(
-			parent=self,
-			# Translators: The label for a button in speech dictionaries dialog to edit existing entries.
-			label=_("&Edit"),
-		).Bind(wx.EVT_BUTTON, self.onEditClick)
-
-		bHelper.addButton(
-			parent=self,
-			# Translators: The label for a button in speech dictionaries dialog to remove existing entries.
-			label=_("&Remove"),
-		).Bind(wx.EVT_BUTTON, self.onRemoveClick)
-
 		bHelper.sizer.AddStretchSpacer()
 
 		bHelper.addButton(
@@ -236,6 +225,17 @@ class DictionaryDialog(
 		).Bind(wx.EVT_BUTTON, self.onRemoveAll)
 
 		sHelper.addItem(bHelper, flag=wx.EXPAND)
+
+	def onContextMenu(self, evt):
+		menu = wx.Menu()
+		# Translators: Context menu item label to edit an entry
+		editItem = menu.Append(wx.ID_ANY, _("&Edit"))
+		# Translators: Context menu item label to remove an entry
+		removeItem = menu.Append(wx.ID_ANY, _("&Remove"))
+		self.Bind(wx.EVT_MENU, self.onEditClick, editItem)
+		self.Bind(wx.EVT_MENU, self.onRemoveClick, removeItem)
+		self.PopupMenu(menu)
+		menu.Destroy()
 
 	def postInit(self):
 		self.dictList.SetFocus()

--- a/source/gui/speechDict.py
+++ b/source/gui/speechDict.py
@@ -181,6 +181,7 @@ class DictionaryDialog(
 			wx.ListCtrl,
 			style=wx.LC_REPORT | wx.LC_SINGLE_SEL,
 		)
+		self.dictList.Bind(wx.EVT_LIST_ITEM_ACTIVATED, self.onContextMenu)
 		self.dictList.Bind(wx.EVT_CONTEXT_MENU, self.onContextMenu)
 		# Translators: The label for a column in dictionary entries list used to identify comments for the entry.
 		self.dictList.AppendColumn(_("Comment"), width=150)

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -22,6 +22,7 @@
 
 ### Changes
 
+* The Speech Dictionaries dialog has been modernized. Edit and Remove actions for list entries are now available via a context menu, improving keyboard and screen reader accessibility. (#20036, @amirmahdifard)
 * The dialog used to present browseable messages (such as formatting information) has been modernized. (#18878, @LeonarddeR)
   * The dialog's shortcut to copy contents of the message to the clipboard was changed to `alt+c`.
 * Updated CLDR to version 48.2. (#20234, @OzancanKaratas)

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -4287,7 +4287,7 @@ The dialog also contains Add and Remove all buttons.
 
 To add a new rule to the dictionary, press the Add button, and fill in the fields in the dialog box that appears and then press Ok.
 You will then see your new rule in the list of rules.
-You can manage individual rules by opening a context menu on an entry in the list (press the Applications key on your keyboard, shift+f10, or right-click), which provides options to Edit or Remove the selected rule.
+You can manage individual rules by opening a context menu on an entry in the list (press the Applications key on your keyboard, shift+f10, space bar, or right/left click), which provides options to Edit or Remove the selected rule.
 However, to make sure your rule is actually saved, make sure to press Ok to exit the dictionary dialog completely once you have finished adding/editing rules.
 
 The rules for NVDA's speech dictionaries allow you to change one string of characters into another.

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -4283,10 +4283,11 @@ They are:
 You need to assign custom gestures using the [Input Gestures dialog](#InputGestures) if you wish to open any of these dictionary dialogs from anywhere.
 
 All dictionary dialogs contain a list of rules which will be used for processing the speech.
-The dialog also contains Add, Edit, Remove and Remove all buttons.
+The dialog also contains Add and Remove all buttons.
 
 To add a new rule to the dictionary, press the Add button, and fill in the fields in the dialog box that appears and then press Ok.
 You will then see your new rule in the list of rules.
+You can manage individual rules by opening a context menu on an entry in the list (press the Applications key on your keyboard, shift+f10, or right-click), which provides options to Edit or Remove the selected rule.
 However, to make sure your rule is actually saved, make sure to press Ok to exit the dictionary dialog completely once you have finished adding/editing rules.
 
 The rules for NVDA's speech dictionaries allow you to change one string of characters into another.


### PR DESCRIPTION
### Link to issue number:
part of https://github.com/nvaccess/nvda/issues/20036
### Summary of the issue:
The looking of the interface of the dialog i'm using, is very important to me. In the old days, dialogs were used to be have the buttons related to a list item beside that list. But that's why context menus are exist. If you are navigating a list's items with arrow keys, you would expect whatever you can do with that list item is possible by opening the  context menu for that item
### Description of user facing changes:
In the Speech dictionaries dialogs, there's no longer edit button, and remove button beside the Dictionary entries list. Instead, added a context menu to the list for the Dictionary entries
### Description of developer facing changes:
In the speechDict.py, Removed the edit button and remove button, Added a context menu method contaning those 2 items, and binde it to the list.
### Description of development approach:
no other extra touch or changes, removed the edit and remove buttons them selves but triggered the same thing they used to trigger in the context menu items
### Testing strategy:
Opened the Speech dictionaries dialogs.
Pressed the add button to add a fue entries, confurmed that it's working completely same as before.
In the entries list, opened the context menu using application key, shift+f10, and right click, confurmed that the context menu opens correctly, clicked the edit option, confurmed that it edits the correct entrie exactly like the old version, clicked the remove option, confurmed that it correctly removes the correctly selected entrie. No surprise, Because I didn't change anything extra in this pr, just moved the existing functionality from buttons to context menu, so everything is fine as before.
### Known issues with pull request:
none
### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.