### PR TITLE
 Fix AttributeError when instantiating ITextDocumentTextInfo without a selection object

### DIFF
--- a/source/NVDAObjects/window/edit.py
+++ b/source/NVDAObjects/window/edit.py
@@ -1043,7 +1043,7 @@ class Edit(EditableTextWithAutoSelectDetection, EditBase):
 	editValueUnit = textInfos.UNIT_LINE
 
 	def _get_TextInfo(self):
-		if self.editAPIVersion != 0 and self.ITextDocumentObject:
+		if self.editAPIVersion != 0 and self.ITextDocumentObject and self.ITextSelectionObject:
 			return ITextDocumentTextInfo
 		else:
 			return EditTextInfo
@@ -1098,7 +1098,7 @@ class RichEdit(Edit):
 		# We then fall back to normal Edit support.
 		try:
 			return self.TextInfo(self, position)
-		except COMError:
+		except (COMError, AttributeError):
 			log.debugWarning("Could not instanciate ITextDocumentTextInfo", exc_info=True)
 			self.TextInfo = EditTextInfo
 			return self.TextInfo(self, position)

--- a/source/NVDAObjects/window/edit.py
+++ b/source/NVDAObjects/window/edit.py
@@ -1042,7 +1042,7 @@ class Edit(EditableTextWithAutoSelectDetection, EditBase):
 	editAPIVersion = 0
 	editValueUnit = textInfos.UNIT_LINE
 
-	def _get_TextInfo(self):
+	def _get_TextInfo(self) -> EditTextInfo | ITextDocumentTextInfo:
 		if self.editAPIVersion != 0 and self.ITextDocumentObject and self.ITextSelectionObject:
 			return ITextDocumentTextInfo
 		else:

--- a/source/NVDAObjects/window/edit.py
+++ b/source/NVDAObjects/window/edit.py
@@ -1042,7 +1042,7 @@ class Edit(EditableTextWithAutoSelectDetection, EditBase):
 	editAPIVersion = 0
 	editValueUnit = textInfos.UNIT_LINE
 
-	def _get_TextInfo(self) -> EditTextInfo | ITextDocumentTextInfo:
+	def _get_TextInfo(self) -> type[textInfos.TextInfo]:
 		if self.editAPIVersion != 0 and self.ITextDocumentObject and self.ITextSelectionObject:
 			return ITextDocumentTextInfo
 		else:

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -28,6 +28,7 @@
 
 ### Bug Fixes
 
+* In PowerPoint and other Office applications, NVDA will now correctly read and navigate the edit fields in the insert hyperlink dialog. (#17390, @aryanchoudharypro)
 * The actions button can now be used when selecting multiple add-ons in the Add-on Store to perform batch actions, instead of just via the context menu in the add-ons list. (#19971, @amirmahdifard)
 * When moving to an ARIA grid cell in focus mode in web browsers, NVDA no longer reports both the row and column headers even if only the row or only the column changed. (#17750, @jcsteh)
 * In live text regions, such as terminals, NVDA no longer freezes when substantial amounts of text are dumped to the screen. (#20177)


### PR DESCRIPTION
### Link to issue number:
closes #17390

### Summary of the issue:
In PowerPoint and other Office applications, using `F2` to edit a text shape and pressing `Ctrl+K` opens the "Insert Link" dialog. Trying to write, navigate, or re-read the text in the dialog's edit fields caused NVDA to fail silently.

In the logs, this triggered the following traceback:
```
  File "globalCommands.pyc", line 211, in script_reportCurrentLine
  File "NVDAObjects\window\edit.pyc", line 1107, in makeTextInfo
  File "NVDAObjects\window\edit.pyc", line 895, in __init__
AttributeError: 'NoneType' object has no attribute 'duplicate'
```

This occurred because `ITextDocumentTextInfo` assumed `self.obj.ITextSelectionObject` was always valid, but Office's partial/restricted TOM implementation for these dialog edit fields returns `None` for the selection object.

### Description of user facing changes:
Users can now type, navigate, and read text (using arrows and `NVDA+upArrow`) normally within the edit fields of the PowerPoint "Insert Link" dialog (and other similar Office dialog edit fields).

### Description of developer facing changes:
None.

### Description of development approach:
1. Updated `Edit._get_TextInfo` in `source/NVDAObjects/window/edit.py` to check that `self.ITextSelectionObject` is not `None` before returning `ITextDocumentTextInfo`. If it is `None`, we immediately fall back to the standard `EditTextInfo`.
2. Updated `RichEdit.makeTextInfo` in `source/NVDAObjects/window/edit.py` to catch `AttributeError` in addition to `COMError` during instantiation of `ITextDocumentTextInfo`, ensuring a safe fallback to `EditTextInfo`.
3. Standard `EditTextInfo` uses standard Windows Messages/APIs which these edit controls fully support, enabling proper reading and navigation.

### Testing strategy:
* Manual Testing: Verified that typing and navigating with arrows/`NVDA+upArrow` inside the PowerPoint link insertion dialog works as expected, and that NVDA now speaks the text correctly without traceback errors.
* Automated checks: Verified compilation (`py_compile`) and ran `ruff` style checks on `edit.py`.

### Known issues with pull request:
None.

### Code Review Checklist:

- [x] Documentation:
  - [x] Change log entry
  - [ ] User Documentation
  - [ ] Developer / Technical Documentation
  - [ ] Context sensitive help for GUI changes
- [x] Testing:
  - [ ] Unit tests
  - [ ] System (end to end) tests
  - [x] Manual testing
- [x] UX of all users considered:
  - [x] Speech
  - [ ] Braille
  - [ ] Low Vision
  - [ ] Different web browsers
  - [ ] Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
