### PR TITLE
brailliantB: fix dot8→Enter (bug), add dot7→Backspace, add c1–c6 single-key bindings for Brailliant BI 40X

### DIFF
--- a/source/brailleDisplayDrivers/brailliantB.py
+++ b/source/brailleDisplayDrivers/brailliantB.py
@@ -346,13 +346,13 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 	gestureMap = inputCore.GlobalGestureMap(
 		{
 			"globalCommands.GlobalCommands": {
-				"braille_scrollBack": ("br(brailliantB):left",),
-				"braille_scrollForward": ("br(brailliantB):right",),
-				"braille_previousLine": ("br(brailliantB):up",),
-				"braille_nextLine": ("br(brailliantB):down",),
+				"braille_scrollBack": ("br(brailliantB):left", "br(brailliantB):c2"),
+				"braille_scrollForward": ("br(brailliantB):right", "br(brailliantB):c5"),
+				"braille_previousLine": ("br(brailliantB):up", "br(brailliantB):c1"),
+				"braille_nextLine": ("br(brailliantB):down", "br(brailliantB):c3"),
 				"braille_routeTo": ("br(brailliantB):routing",),
 				"braille_selectRange": ("br(brailliantB):multiRouting",),
-				"braille_toggleTether": ("br(brailliantB):up+down",),
+				"braille_toggleTether": ("br(brailliantB):up+down", "br(brailliantB):c4"),
 				"kb:upArrow": ("br(brailliantB):space+dot1", "br(brailliantB):stickUp"),
 				"kb:downArrow": ("br(brailliantB):space+dot4", "br(brailliantB):stickDown"),
 				"kb:leftArrow": ("br(brailliantB):space+dot3", "br(brailliantB):stickLeft"),
@@ -360,12 +360,14 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 				"showGui": (
 					"br(brailliantB):c1+c3+c4+c5",
 					"br(brailliantB):space+dot1+dot3+dot4+dot5",
+					"br(brailliantB):c6",
 				),
 				"kb:shift+tab": ("br(brailliantB):space+dot1+dot3",),
 				"kb:tab": ("br(brailliantB):space+dot4+dot6",),
 				"kb:alt": ("br(brailliantB):space+dot1+dot3+dot4",),
 				"kb:escape": ("br(brailliantB):space+dot1+dot5",),
-				"kb:enter": ("br(brailliantB):stickAction"),
+				"kb:enter": ("br(brailliantB):dot8", "br(brailliantB):stickAction"),
+				"kb:backspace": ("br(brailliantB):dot7",),
 				"kb:windows+d": (
 					"br(brailliantB):c1+c4+c5",
 					"br(brailliantB):Space+dot1+dot4+dot5",
@@ -379,7 +381,6 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 			},
 		},
 	)
-
 
 class InputGesture(braille.BrailleDisplayGesture, brailleInput.BrailleInputGesture):
 	source = BrailleDisplayDriver.name

--- a/source/brailleDisplayDrivers/brailliantB.py
+++ b/source/brailleDisplayDrivers/brailliantB.py
@@ -382,6 +382,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver):
 		},
 	)
 
+
 class InputGesture(braille.BrailleDisplayGesture, brailleInput.BrailleInputGesture):
 	source = BrailleDisplayDriver.name
 


### PR DESCRIPTION
## Summary

Fixes issue #20366.

The `brailliantB` driver's `gestureMap` is missing key bindings that are either:
1. **Documented in the NVDA user guide** but not implemented in code (`dot8` → `kb:enter`)
2. **Physically labelled keys** on the Brailliant BI 40X with no NVDA action (`dot7` → `kb:backspace`)
3. **Documented by HumanWare** in the BI X Series user guide v2.6 as the intended function of the six command keys (`c1`–`c6`)

---

## Changes

### Bug fixes

| Gesture | Action | Reason |
|---|---|---|
| `dot8` | `kb:enter` | Physical Enter key (right little finger). **Documented in NVDA user guide 2026.1.1** ("Key assignments for All models": "Punkt8 → Eingabetaste") but missing from code. |
| `dot7` | `kb:backspace` | Physical Backspace key (left little finger). Logical complement of dot8. |

The existing `stickAction` → `kb:enter` binding (for BI 14 joystick) is **preserved**.

### C-key bindings (additive, based on HumanWare docs)

The Brailliant BI 40X (and BI 32/40/B 80) has six command keys flanking the braille display. HumanWare's BI X Series User Guide v2.6 documents the following intended functions:

| Key | Layout position | HumanWare function | NVDA binding added |
|---|---|---|---|
| `c1` | left-back | "Previous item" | `braille_previousLine` |
| `c2` | left-middle | "Pan left" | `braille_scrollBack` |
| `c3` | left-front | "Next item" | `braille_nextLine` |
| `c4` | right-back | — | `braille_toggleTether` |
| `c5` | right-middle | "Pan right" | `braille_scrollForward` |
| `c6` | right-front | — | `showGui` (NVDA menu) |

These bindings are **additive** — they do not remove or conflict with the existing multi-key combinations (`c1+c3+c4+c5`, `c1+c4+c5`, `c1+c2+c3+c4+c5+c6`).

---

## Testing

- [ ] Brailliant BI 40X via USB
- [ ] Brailliant BI 40X via Bluetooth
- [ ] Brailliant BI 14 (stickAction binding still works)
- [ ] Brailliant BI 32/40/B 80 (c-key single bindings also benefit these models)
- [ ] dot8 → Enter works in focused applications
- [ ] dot7 → Backspace works in text fields
- [ ] Individual c1–c6 presses trigger expected NVDA actions
- [ ] Existing multi-key combos (c1+c3+c4+c5 etc.) still work

---

## References

- HumanWare Brailliant BI X Series User Guide v2.6 (2025): key layout description (section 1.2.1 Top Face)
- NVDA 2026.1.1 user guide, section `HumanWareBrailliantKeyAssignmentForAllModels`: documents `dot8 → Enter` but code does not implement it
- Helen Keller Services review of Brailliant BI 40X: notes "very few keyboard commands" and c-keys not functioning in NVDA

🤖 Generated with [Claude Code](https://claude.com/claude-code)