### PR TITLE
Add-ons can be removed from the Updatable tab in the store

### DIFF
--- a/source/addonStore/models/status.py
+++ b/source/addonStore/models/status.py
@@ -289,7 +289,8 @@ def _getUpdateStatus(model: "_AddonGUIModel") -> AvailableAddonStatus | None:
 	"""
 	from ..dataManager import addonDataManager
 	from ..models.addon import AddonStoreModel
-
+	if model.isPendingRemove:
+		return None
 	if not isinstance(model, AddonStoreModel):
 		# If the listed add-on is installed from a side-load
 		# and not available on the add-on store

--- a/source/addonStore/models/status.py
+++ b/source/addonStore/models/status.py
@@ -289,6 +289,7 @@ def _getUpdateStatus(model: "_AddonGUIModel") -> AvailableAddonStatus | None:
 	"""
 	from ..dataManager import addonDataManager
 	from ..models.addon import AddonStoreModel
+
 	if model.isPendingRemove:
 		return None
 	if not isinstance(model, AddonStoreModel):

--- a/source/addonStore/models/status.py
+++ b/source/addonStore/models/status.py
@@ -287,10 +287,11 @@ def _getUpdateStatus(model: "_AddonGUIModel") -> AvailableAddonStatus | None:
 	:return: Update status of add-on for the context of the current tab.
 	None if the add-on is not installed or cannot be updated.
 	"""
-	from ..dataManager import addonDataManager
-	from ..models.addon import AddonStoreModel
 	if model.isPendingRemove:
 		return None
+
+		from ..dataManager import addonDataManager
+	from ..models.addon import AddonStoreModel
 	if not isinstance(model, AddonStoreModel):
 		# If the listed add-on is installed from a side-load
 		# and not available on the add-on store

--- a/source/addonStore/models/status.py
+++ b/source/addonStore/models/status.py
@@ -287,11 +287,10 @@ def _getUpdateStatus(model: "_AddonGUIModel") -> AvailableAddonStatus | None:
 	:return: Update status of add-on for the context of the current tab.
 	None if the add-on is not installed or cannot be updated.
 	"""
+	from ..dataManager import addonDataManager
+	from ..models.addon import AddonStoreModel
 	if model.isPendingRemove:
 		return None
-
-		from ..dataManager import addonDataManager
-	from ..models.addon import AddonStoreModel
 	if not isinstance(model, AddonStoreModel):
 		# If the listed add-on is installed from a side-load
 		# and not available on the add-on store

--- a/source/gui/addonStoreGui/controls/actions.py
+++ b/source/gui/addonStoreGui/controls/actions.py
@@ -241,11 +241,11 @@ class _BatchActionsContextMenu(_ActionsContextMenuP[BatchAddonActionVM]):
 				actionHandler=self._storeVM.removeAddons,
 				validCheck=lambda aVMs: (
 					self._storeVM._filteredStatusKey
-					in [
+					in (
 						_StatusFilterKey.UPDATE,
 						_StatusFilterKey.INSTALLED,
 						_StatusFilterKey.INCOMPATIBLE,
-					]
+					)
 					and AddonListValidator(aVMs).canUseRemoveAction()
 				),
 				actionTarget=self._selectedAddons,

--- a/source/gui/addonStoreGui/controls/actions.py
+++ b/source/gui/addonStoreGui/controls/actions.py
@@ -245,7 +245,6 @@ class _BatchActionsContextMenu(_ActionsContextMenuP[BatchAddonActionVM]):
 						_StatusFilterKey.UPDATE,
 						_StatusFilterKey.INSTALLED,
 						_StatusFilterKey.INCOMPATIBLE,
-						_
 					]
 					and AddonListValidator(aVMs).canUseRemoveAction()
 				),

--- a/source/gui/addonStoreGui/controls/actions.py
+++ b/source/gui/addonStoreGui/controls/actions.py
@@ -242,10 +242,10 @@ class _BatchActionsContextMenu(_ActionsContextMenuP[BatchAddonActionVM]):
 				validCheck=lambda aVMs: (
 					self._storeVM._filteredStatusKey
 					in [
-						# Removing add-ons in the updatable view fails,
-						# as the updated version cannot be removed.
+						_StatusFilterKey.UPDATE,
 						_StatusFilterKey.INSTALLED,
 						_StatusFilterKey.INCOMPATIBLE,
+						_
 					]
 					and AddonListValidator(aVMs).canUseRemoveAction()
 				),

--- a/source/gui/addonStoreGui/viewModels/addonList.py
+++ b/source/gui/addonStoreGui/viewModels/addonList.py
@@ -30,6 +30,7 @@ from addonStore.models.addon import (
 )
 from addonStore.models.status import (
 	_installedAddonStatuses,
+	_updatableStatuses,
 	_StatusFilterKey,
 	AvailableAddonStatus,
 )
@@ -185,7 +186,8 @@ class AddonListItemVM(Generic[_AddonModelT]):
 	def canUseRemoveAction(self) -> bool:
 		return (
 			self.model.isInstalled
-			and self.status in _installedAddonStatuses
+			and not self.model.isPendingRemove
+			and self.status in _installedAddonStatuses.union(_updatableStatuses)
 			and self.status != AvailableAddonStatus.PENDING_REMOVE
 		)
 

--- a/source/gui/addonStoreGui/viewModels/addonList.py
+++ b/source/gui/addonStoreGui/viewModels/addonList.py
@@ -186,8 +186,8 @@ class AddonListItemVM(Generic[_AddonModelT]):
 	def canUseRemoveAction(self) -> bool:
 		return (
 			self.model.isInstalled
-			and not self.model.isPendingRemove
 			and self.status in _installedAddonStatuses.union(_updatableStatuses)
+			and self.status not in (AvailableAddonStatus.DOWNLOADING, AvailableAddonStatus.DOWNLOAD_SUCCESS)
 			and self.status != AvailableAddonStatus.PENDING_REMOVE
 		)
 

--- a/source/gui/addonStoreGui/viewModels/store.py
+++ b/source/gui/addonStoreGui/viewModels/store.py
@@ -193,8 +193,7 @@ class AddonStoreVM:
 					aVM.canUseRemoveAction()
 					and self._filteredStatusKey
 					in (
-						# Removing add-ons in the updatable view fails,
-						# as the updated version cannot be removed.
+						_StatusFilterKey.UPDATE,
 						_StatusFilterKey.INSTALLED,
 						_StatusFilterKey.INCOMPATIBLE,
 					)

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -6,6 +6,7 @@
 
 ### New Features
 
+* Add-ons can be removed from the Updatable add-ons tab in the store. (#15030, @nvdaes)
 * Chinese text can now be navigated by word using built-in input gestures.
   A Word Segmentation Standard setting was added to the "Document Navigation" panel. (#18735, @CrazySteve0605, @Cary-rowen)
 * Braille output for Chinese now includes spaces between words. (#18865, @CrazySteve0605, @Cary-rowen)

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -6,7 +6,7 @@
 
 ### New Features
 
-* Add-ons can be removed from the Updatable add-ons tab in the store. (#15030, @nvdaes)
+* Add-ons can be removed from the "Updatable add-ons" tab in the Add-on Store. (#15030, @nvdaes)
 * Chinese text can now be navigated by word using built-in input gestures.
   A Word Segmentation Standard setting was added to the "Document Navigation" panel. (#18735, @CrazySteve0605, @Cary-rowen)
 * Braille output for Chinese now includes spaces between words. (#18865, @CrazySteve0605, @Cary-rowen)


### PR DESCRIPTION
- **Remove add-ons from updatable tab in the store**
- **Remove from updatable if add-on is in pending removals, and don't consider removable if installation can be cancelled**
- **Check if an add-on is not updatable due to pending removals before imports in function**
- **Revert "Check if an add-on is not updatable due to pending removals before imports in function"**
- **Restore removed blank line**
- **Remove extra underline symbol**
- **Use tuple instead of list for add-on store tabs**
- **Update changelog**

<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
<!-- Use Closes/Fixes/Resolves #xxx to link this PR to the issue it is responding to. -->

Fixes #15030
Supersedes #20338 

### Summary of the issue:
Updatable add-ons cannot be removed from the Updatable tab. Sometimes, we may find an add-on from this tab, and we may decide to remove it without switching to a different tab, like Installed or Incompatible add-ons.

### Description of user facing changes:
Updatable add-ons can be removed from the Updatable tab in the store.

### Description of developer facing changes:
None.

### Description of development approach:
* In `source/addonStore/models/status.py`, make add-ons which are marked as "pending remove" as not updatable.
* In `source/gui/addonStoreGui/controls/actions.py`, add the `StatusFilterKey` tab as allowed for the Remove action.
* In `source/gui/addonStoreGui/viewModels/addonList.py`, change the `canUseRemoveAction` function to allow updatable add-ons if installation cannot be cancelled, i.e., not marked as "downloading" or "downloaded".
* In `source/gui/addonStoreGui/viewModels/store.py`, make the Remove action available in the Updatable tab.

### Testing strategy:

Tested locally with several add-ons:
* Add-ons can be removed from the Updatable tab.
* When an add-on is removed, it's not updatable, and it's not presented in this tab anymore, similar to the behavior observed when removing from the Incompatible tab.

### Known issues with pull request:

None.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
