### PR TITLE
ART transport core

### DIFF
--- a/source/_art/__init__.py
+++ b/source/_art/__init__.py
@@ -1,10 +1,11 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2026 NV Access Limited.
+# Copyright (C) 2026 NV Access Limited
 # This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
 # For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
 
-"""``_art``: NVDA's out-of-process, sandboxed add-on runtime.
+"""NVDA Add-on Runtime (ART)
 
-See ``projectDocs/design/_art-design.md`` for the architecture and migration plan.
-This package supersedes the ``art`` and ``_bridge`` prototypes.
+This package defines NVDA's out-of-process, sandboxed add-on runtime.
+
+* :mod:`.transport`: Generic transport over anonymous pipes.
 """

--- a/source/_art/__init__.py
+++ b/source/_art/__init__.py
@@ -1,0 +1,10 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2026 NV Access Limited.
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
+
+"""``_art``: NVDA's out-of-process, sandboxed add-on runtime.
+
+See ``projectDocs/design/_art-design.md`` for the architecture and migration plan.
+This package supersedes the ``art`` and ``_bridge`` prototypes.
+"""

--- a/source/_art/transport/__init__.py
+++ b/source/_art/transport/__init__.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2026 NV Access Limited.
+# Copyright (C) 2026 NV Access Limited
 # This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
 # For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
 

--- a/source/_art/transport/__init__.py
+++ b/source/_art/transport/__init__.py
@@ -1,0 +1,26 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2026 NV Access Limited.
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
+
+"""
+rpyc-over-pipes transport for the add-on runtime.
+
+This package provides the generic, feature-agnostic plumbing used by both ends of an add-on runtime connection:
+
+* Restricted rpyc protocol configuration;
+* ``Service`` base class (what NVDA and add-ons interact with);
+* ``Proxy`` base class (adapts between internal details and the ART API);
+* ``Connection`` wrapper over a bidirectional pipe stream.
+
+Importing this package applies the rpyc patches we rely on (see ``config``).
+
+Nothing here is specific to any feature (synth, braille, etc); feature contracts are built on top of this layer as "components".
+"""
+
+from .config import PROTOCOL_CONFIG
+from .connection import Connection
+from .proxy import Proxy
+from .service import Service
+
+__all__ = ["PROTOCOL_CONFIG", "Connection", "Proxy", "Service"]

--- a/source/_art/transport/config.py
+++ b/source/_art/transport/config.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2026 NV Access Limited.
+# Copyright (C) 2026 NV Access Limited
 # This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
 # For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
 

--- a/source/_art/transport/config.py
+++ b/source/_art/transport/config.py
@@ -1,0 +1,50 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2026 NV Access Limited.
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
+
+"""
+rpyc protocol configuration and global patches for the ART transport.
+
+.. note::
+	Importing this module applies patches that the transport depends on, so it must be imported before any connection is created.
+	It is imported by ``connection`` for that reason.
+"""
+
+import builtins
+
+import rpyc.core.vinegar
+
+
+#: The rpyc protocol configuration shared by every ART connection.
+#:
+#: These defaults are deliberately restrictive.
+#: Add-ons are untrusted, so they must only ever be able to invoke methods explicitly exposed on a :class:`.service.Service`.
+#: ``allow_getattr`` is intentionally left at the rpyc default (``True``) because exposed
+#: methods are reached via attribute access on the netref; with public, safe and all
+#: attribute access disabled, only the ``exposed`` allowlist remains reachable.
+#:
+#: None of the security-critical flags below should be loosened without a security review.
+PROTOCOL_CONFIG: dict[str, object] = {
+	# Only explicitly exposed methods may cross the boundary.
+	"allow_public_attrs": False,
+	"allow_safe_attrs": False,  # rpyc defaults this to True; turn it off.
+	"allow_all_attrs": False,
+	"allow_setattr": False,
+	"allow_delattr": False,
+	# pickle would permit arbitrary code execution during deserialization.
+	"allow_pickle": False,
+	# A raising handler must not tear down the whole channel.
+	"close_catchall": True,
+}
+
+
+def _applyPatches() -> None:
+	"""Apply the rpyc patches ``_art`` relies on. Idempotent."""
+	# NVDA ships its own top-level ``exceptions`` module. rpyc's vinegar imports
+	# ``exceptions`` (a Python 2 relic) in preference to ``builtins`` when present, which
+	# makes deserialization of remote exceptions fail. Force it back to ``builtins``.
+	rpyc.core.vinegar.exceptions_module = builtins
+
+
+_applyPatches()

--- a/source/_art/transport/config.py
+++ b/source/_art/transport/config.py
@@ -20,15 +20,15 @@ import rpyc.core.vinegar
 #:
 #: These defaults are deliberately restrictive.
 #: Add-ons are untrusted, so they must only ever be able to invoke methods explicitly exposed on a :class:`.service.Service`.
-#: ``allow_getattr`` is intentionally left at the rpyc default (``True``) because exposed
-#: methods are reached via attribute access on the netref; with public, safe and all
-#: attribute access disabled, only the ``exposed`` allowlist remains reachable.
+#: ``allow_getattr`` is intentionally left at the rpyc default (``True``) because exposed methods are reached via attribute access on the netref;
+#: with public, safe and all attribute access disabled, only the ``exposed`` allowlist remains reachable.
 #:
-#: None of the security-critical flags below should be loosened without a security review.
+#: .. warning::
+#: 	None of the security-critical flags below should be loosened without a security review..
 PROTOCOL_CONFIG: dict[str, object] = {
 	# Only explicitly exposed methods may cross the boundary.
 	"allow_public_attrs": False,
-	"allow_safe_attrs": False,  # rpyc defaults this to True; turn it off.
+	"allow_safe_attrs": False,
 	"allow_all_attrs": False,
 	"allow_setattr": False,
 	"allow_delattr": False,
@@ -40,10 +40,14 @@ PROTOCOL_CONFIG: dict[str, object] = {
 
 
 def _applyPatches() -> None:
-	"""Apply the rpyc patches ``_art`` relies on. Idempotent."""
-	# NVDA ships its own top-level ``exceptions`` module. rpyc's vinegar imports
-	# ``exceptions`` (a Python 2 relic) in preference to ``builtins`` when present, which
-	# makes deserialization of remote exceptions fail. Force it back to ``builtins``.
+	"""Apply the rpyc patches that ART relies on.
+
+	.. note::
+		This function is idempotent.
+	"""
+	# NVDA ships its own top-level ``exceptions`` module.
+	# rpyc's vinegar imports ``exceptions`` (a Python 2 relic) in preference to ``builtins`` when present, which makes deserialization of remote exceptions fail.
+	# Force it back to ``builtins``.
 	rpyc.core.vinegar.exceptions_module = builtins
 
 

--- a/source/_art/transport/config.py
+++ b/source/_art/transport/config.py
@@ -20,12 +20,13 @@ import rpyc.core.vinegar
 #:
 #: These defaults are deliberately restrictive.
 #: Add-ons are untrusted, so they must only ever be able to invoke methods explicitly exposed on a :class:`.service.Service`.
-#: ``allow_getattr`` is intentionally left at the rpyc default (``True``) because exposed methods are reached via attribute access on the netref;
+#: ``allow_getattr`` is intentionally set to ``True`` because exposed methods are reached via attribute access on the netref;
 #: with public, safe and all attribute access disabled, only the ``exposed`` allowlist remains reachable.
 #:
-#: .. warning::
-#: 	None of the security-critical flags below should be loosened without a security review..
+#: :warning: None of the security-critical flags below should be loosened without a security review.
 PROTOCOL_CONFIG: dict[str, bool] = {
+	# Exposed methods are reached via attribute access on the netref.
+	"allow_getattr": True,
 	# Only explicitly exposed methods may cross the boundary.
 	"allow_public_attrs": False,
 	"allow_safe_attrs": False,

--- a/source/_art/transport/config.py
+++ b/source/_art/transport/config.py
@@ -25,7 +25,7 @@ import rpyc.core.vinegar
 #:
 #: .. warning::
 #: 	None of the security-critical flags below should be loosened without a security review..
-PROTOCOL_CONFIG: dict[str, object] = {
+PROTOCOL_CONFIG: dict[str, bool] = {
 	# Only explicitly exposed methods may cross the boundary.
 	"allow_public_attrs": False,
 	"allow_safe_attrs": False,

--- a/source/_art/transport/connection.py
+++ b/source/_art/transport/connection.py
@@ -1,0 +1,128 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2026 NV Access Limited.
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
+
+"""The rpyc connection wrapper used by the ``_art`` transport."""
+
+from __future__ import annotations
+
+import threading
+import weakref
+
+import rpyc
+from rpyc.core.stream import Stream
+
+from logHandler import log
+
+from .config import PROTOCOL_CONFIG
+from .service import Service
+
+
+class Connection[LocalService_t: "Service | None", RemoteService_t: "Service"]:
+	"""A single bidirectional rpyc connection over a ``stream``.
+
+	The local service (if any) is exposed to the peer; the peer's root service is reached
+	via :attr:`remoteService`. Requests from the peer are handled by a serving loop, run
+	either in a background thread (:meth:`bgEventLoop`) or in the calling thread
+	(:meth:`eventLoop`).
+	"""
+
+	def __init__(
+		self,
+		stream: Stream,
+		localService: LocalService_t = None,
+		name: str = "unknown",
+	) -> None:
+		self._name = name
+		log.debug(f"Creating _art connection {name!r}")
+		self._localService = localService
+		self._conn: rpyc.Connection | None = rpyc.connect_stream(
+			stream,
+			service=localService or rpyc.VoidService,
+			config=PROTOCOL_CONFIG,
+		)
+
+	@property
+	def name(self) -> str:
+		return self._name
+
+	@property
+	def closed(self) -> bool:
+		return self._conn is None or self._conn._closed
+
+	@property
+	def remoteService(self) -> RemoteService_t:
+		"""The peer's root service."""
+		if self._conn is None:
+			raise RuntimeError(f"Connection {self._name!r} is closed")
+		return self._conn.root
+
+	def eventLoop(self) -> None:
+		"""Serve peer requests in the calling thread until the connection closes."""
+		conn = self._conn
+		if conn is None or conn._closed:
+			return
+		try:
+			conn.serve_all()
+		except Exception:
+			if self._conn is not None and not self._conn._closed:
+				log.debugWarning(f"Error in event loop for connection {self._name!r}", exc_info=True)
+
+	def bgEventLoop(self, daemon: bool = False) -> threading.Thread:
+		"""Serve peer requests in a background thread."""
+		thread = threading.Thread(
+			target=self._bgEventLoop,
+			args=(weakref.ref(self), self._name),
+			name=f"_art connection event loop: {self._name}",
+			daemon=daemon,
+		)
+		thread.start()
+		return thread
+
+	@staticmethod
+	def _bgEventLoop(connRef: weakref.ref[Connection], name: str) -> None:
+		# Hold only a weak reference while waiting for work, so the serving thread never
+		# keeps the Connection (and hence the child process) alive on its own.
+		conn = connRef()
+		rawConn = conn._conn if conn is not None else None
+		del conn
+		if rawConn is None or rawConn._closed:
+			return
+		try:
+			rawConn.serve_all()
+		except Exception:
+			if not rawConn._closed:
+				log.debugWarning(f"Error in event loop for connection {name!r}", exc_info=True)
+
+	def close(self) -> None:
+		if self._conn is None:
+			return
+		if isinstance(self._localService, Service) and not self._localService.terminated:
+			try:
+				self._localService.terminate()
+			except Exception:
+				log.debugWarning("Error terminating local service", exc_info=True)
+		self._localService = None
+		conn = self._conn
+		self._conn = None
+		if not conn._closed:
+			# Closing can raise; do it off-thread so a failure cannot pin this Connection
+			# in a traceback frame and leak it (and its child process).
+			threading.Thread(
+				target=self._closeRawConnection,
+				args=(conn, self._name),
+				name=f"_art connection close: {self._name}",
+				daemon=True,
+			).start()
+
+	@staticmethod
+	def _closeRawConnection(conn: rpyc.Connection, name: str) -> None:
+		try:
+			conn.close()
+		except Exception:
+			if not conn._closed:
+				log.debugWarning(f"Error closing connection {name!r}", exc_info=True)
+
+	def __del__(self):
+		self.close()

--- a/source/_art/transport/connection.py
+++ b/source/_art/transport/connection.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2026 NV Access Limited.
+# Copyright (C) 2026 NV Access Limited
 # This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
 # For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
 
@@ -87,7 +87,7 @@ class Connection[LocalService_t: Service | None, RemoteService_t: Service]:
 		thread = threading.Thread(
 			target=self._bgEventLoop,
 			args=(weakref.ref(self), self._name),
-			name=f"_art connection event loop: {self._name}",
+			name=f"ART connection event loop: {self._name}",
 			daemon=daemon,
 		)
 		thread.start()
@@ -126,7 +126,7 @@ class Connection[LocalService_t: Service | None, RemoteService_t: Service]:
 			threading.Thread(
 				target=self._closeRawConnection,
 				args=(conn, self._name),
-				name=f"_art connection close: {self._name}",
+				name=f"ART connection close: {self._name}",
 				daemon=True,
 			).start()
 

--- a/source/_art/transport/connection.py
+++ b/source/_art/transport/connection.py
@@ -3,7 +3,9 @@
 # This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
 # For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
 
-"""The rpyc connection wrapper used by the ``_art`` transport."""
+"""
+rpyc connection wrapper used by the Add-on Runtime transport.
+"""
 
 from __future__ import annotations
 
@@ -19,8 +21,8 @@ from .config import PROTOCOL_CONFIG
 from .service import Service
 
 
-class Connection[LocalService_t: "Service | None", RemoteService_t: "Service"]:
-	"""A single bidirectional rpyc connection over a ``stream``.
+class Connection[LocalService_t: Service | None, RemoteService_t: Service]:
+	"""A single bidirectional rpyc connection over a :class:`Stream`.
 
 	The local service (if any) is exposed to the peer; the peer's root service is reached
 	via :attr:`remoteService`. Requests from the peer are handled by a serving loop, run
@@ -34,6 +36,12 @@ class Connection[LocalService_t: "Service | None", RemoteService_t: "Service"]:
 		localService: LocalService_t = None,
 		name: str = "unknown",
 	) -> None:
+		"""Initializer.
+
+		:param stream: rpyc stream over which NVDA and the add-on will communicate.
+		:param localService: The service to expose to the add-on, defaults to ``None``.
+		:param name: Name of this connection, defaults to "unknown".
+		"""
 		self._name = name
 		log.debug(f"Creating _art connection {name!r}")
 		self._localService = localService
@@ -45,15 +53,20 @@ class Connection[LocalService_t: "Service | None", RemoteService_t: "Service"]:
 
 	@property
 	def name(self) -> str:
+		"""The name of the connection."""
 		return self._name
 
 	@property
 	def closed(self) -> bool:
-		return self._conn is None or self._conn._closed
+		"""Whether this connection is closed."""
+		return self._conn is None or self._conn.closed
 
 	@property
 	def remoteService(self) -> RemoteService_t:
-		"""The peer's root service."""
+		"""The service exposed by the add-on.
+
+		:raises RuntimeError: If the connection is closed.
+		"""
 		if self._conn is None:
 			raise RuntimeError(f"Connection {self._name!r} is closed")
 		return self._conn.root
@@ -61,12 +74,12 @@ class Connection[LocalService_t: "Service | None", RemoteService_t: "Service"]:
 	def eventLoop(self) -> None:
 		"""Serve peer requests in the calling thread until the connection closes."""
 		conn = self._conn
-		if conn is None or conn._closed:
+		if conn is None or conn.closed:
 			return
 		try:
 			conn.serve_all()
 		except Exception:
-			if self._conn is not None and not self._conn._closed:
+			if self._conn is not None and not self._conn.closed:
 				log.debugWarning(f"Error in event loop for connection {self._name!r}", exc_info=True)
 
 	def bgEventLoop(self, daemon: bool = False) -> threading.Thread:
@@ -82,20 +95,21 @@ class Connection[LocalService_t: "Service | None", RemoteService_t: "Service"]:
 
 	@staticmethod
 	def _bgEventLoop(connRef: weakref.ref[Connection], name: str) -> None:
-		# Hold only a weak reference while waiting for work, so the serving thread never
-		# keeps the Connection (and hence the child process) alive on its own.
+		# Hold only a weak reference while waiting for work,
+		# so the serving thread never keeps the Connection (and hence the child process) alive on its own.
 		conn = connRef()
 		rawConn = conn._conn if conn is not None else None
 		del conn
-		if rawConn is None or rawConn._closed:
+		if rawConn is None or rawConn.closed:
 			return
 		try:
 			rawConn.serve_all()
 		except Exception:
-			if not rawConn._closed:
+			if not rawConn.closed:
 				log.debugWarning(f"Error in event loop for connection {name!r}", exc_info=True)
 
 	def close(self) -> None:
+		"""Close the connection."""
 		if self._conn is None:
 			return
 		if isinstance(self._localService, Service) and not self._localService.terminated:
@@ -106,9 +120,9 @@ class Connection[LocalService_t: "Service | None", RemoteService_t: "Service"]:
 		self._localService = None
 		conn = self._conn
 		self._conn = None
-		if not conn._closed:
-			# Closing can raise; do it off-thread so a failure cannot pin this Connection
-			# in a traceback frame and leak it (and its child process).
+		if not conn.closed:
+			# Closing can raise;
+			# do it off-thread so a failure cannot pin this Connection in a traceback frame and leak it (and its child process).
 			threading.Thread(
 				target=self._closeRawConnection,
 				args=(conn, self._name),
@@ -121,7 +135,7 @@ class Connection[LocalService_t: "Service | None", RemoteService_t: "Service"]:
 		try:
 			conn.close()
 		except Exception:
-			if not conn._closed:
+			if not conn.closed:
 				log.debugWarning(f"Error closing connection {name!r}", exc_info=True)
 
 	def __del__(self):

--- a/source/_art/transport/connection.py
+++ b/source/_art/transport/connection.py
@@ -10,6 +10,7 @@ rpyc connection wrapper used by the Add-on Runtime transport.
 from __future__ import annotations
 
 import threading
+from typing import Final
 import weakref
 
 import rpyc
@@ -19,6 +20,8 @@ from logHandler import log
 
 from .config import PROTOCOL_CONFIG
 from .service import Service
+
+_DEFAULT_CONNECTION_NAME: Final[str] = "connection"
 
 
 class Connection[LocalService_t: Service | None, RemoteService_t: Service]:
@@ -34,13 +37,13 @@ class Connection[LocalService_t: Service | None, RemoteService_t: Service]:
 		self,
 		stream: Stream,
 		localService: LocalService_t = None,
-		name: str = "unknown",
+		name: str = _DEFAULT_CONNECTION_NAME,
 	) -> None:
 		"""Initializer.
 
 		:param stream: rpyc stream over which NVDA and the add-on will communicate.
 		:param localService: The service to expose to the add-on, defaults to ``None``.
-		:param name: Name of this connection, defaults to "unknown".
+		:param name: Name of this connection, defaults to :const:`_DEFAULT_CONNECTION_NAME`.
 		"""
 		self._name = name
 		log.debug(f"Creating _art connection {name!r}")

--- a/source/_art/transport/proxy.py
+++ b/source/_art/transport/proxy.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2026 NV Access Limited.
+# Copyright (C) 2026 NV Access Limited
 # This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
 # For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
 
@@ -37,7 +37,7 @@ class Proxy[Service_t: Service]:
 	def _holdConnection(self, conn: Connection) -> None:
 		"""Keep ``conn`` alive for at least as long as this proxy.
 
-		:arg con: Connection to keep alive.
+		:param con: Connection to keep alive.
 		"""
 		self._heldConnections.append(conn)
 
@@ -49,9 +49,9 @@ class Proxy[Service_t: Service]:
 	) -> Service:
 		"""Connect to a side-channel service and tie it to this proxy's lifetime.
 
-		:arg stream: Stream over which the service will communicate.
-		:arg localService: The service to attach.
-		:arg name: Name of this dependency.
+		:param stream: Stream over which the service will communicate.
+		:param localService: The service to attach.
+		:param name: Name of this dependency.
 		"""
 		from .connection import Connection
 

--- a/source/_art/transport/proxy.py
+++ b/source/_art/transport/proxy.py
@@ -1,0 +1,66 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2026 NV Access Limited.
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
+
+"""The ``Proxy`` base class: the local-side wrapper around a remote ``Service``."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from rpyc.core.stream import Stream
+
+from logHandler import log
+
+if TYPE_CHECKING:
+	from .connection import Connection
+	from .service import Service
+
+
+class Proxy[Service_t: "Service"]:
+	"""Base class for the local-side wrapper around a remote :class:`.service.Service`.
+
+	A ``Proxy`` re-presents the remote service through NVDA's normal local interface, so
+	consuming code is unaware the implementation lives in another process. It may be used
+	as a mixin (e.g. alongside ``SynthDriver``); ``__init__`` and ``__del__`` cooperate
+	with the rest of the MRO.
+
+	The proxy owns any connections it depends on and closes them when it is destroyed.
+	"""
+
+	def __init__(self, remoteService: Service_t, *args, **kwargs) -> None:
+		super().__init__(*args, **kwargs)
+		self._remoteService = remoteService
+		self._heldConnections: list[Connection] = []
+
+	def holdConnection(self, conn: Connection) -> None:
+		"""Keep ``conn`` alive for at least as long as this proxy."""
+		self._heldConnections.append(conn)
+
+	def _connectDependentService(
+		self,
+		stream: Stream,
+		localService: Service | None = None,
+		name: str = "dependent service",
+	) -> Service:
+		"""Connect to a side-channel service and tie it to this proxy's lifetime."""
+		from .connection import Connection
+
+		conn = Connection(stream, localService, name=name)
+		conn.bgEventLoop(daemon=True)
+		self.holdConnection(conn)
+		return conn.remoteService
+
+	def __del__(self):
+		for conn in self._heldConnections:
+			if not conn.closed:
+				try:
+					conn.close()
+				except Exception:
+					log.debugWarning(f"Error closing held connection {conn.name!r}", exc_info=True)
+		self._heldConnections.clear()
+		# As a mixin we may sit above another class with its own __del__; chain to it.
+		deleter = getattr(super(), "__del__", None)
+		if deleter is not None:
+			deleter()

--- a/source/_art/transport/proxy.py
+++ b/source/_art/transport/proxy.py
@@ -3,7 +3,7 @@
 # This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
 # For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
 
-"""The ``Proxy`` base class: the local-side wrapper around a remote ``Service``."""
+"""The ``Proxy`` base class, which mediates between local NVDA code and the ART."""
 
 from __future__ import annotations
 
@@ -18,15 +18,15 @@ if TYPE_CHECKING:
 	from .service import Service
 
 
-class Proxy[Service_t: "Service"]:
+class Proxy[Service_t: Service]:
 	"""Base class for the local-side wrapper around a remote :class:`.service.Service`.
 
-	A ``Proxy`` re-presents the remote service through NVDA's normal local interface, so
-	consuming code is unaware the implementation lives in another process. It may be used
-	as a mixin (e.g. alongside ``SynthDriver``); ``__init__`` and ``__del__`` cooperate
-	with the rest of the MRO.
+	A ``Proxy`` re-presents the remote service through NVDA's normal local interface,
+	so consuming code is unaware the implementation lives in another process.
+	It may be used as a mixin (e.g. alongside ``SynthDriver``);
+	``__init__`` and ``__del__`` cooperate with the rest of the MRO.
 
-	The proxy owns any connections it depends on and closes them when it is destroyed.
+	The proxy owns any connections on which it depends and closes them when it is destroyed.
 	"""
 
 	def __init__(self, remoteService: Service_t, *args, **kwargs) -> None:
@@ -34,8 +34,11 @@ class Proxy[Service_t: "Service"]:
 		self._remoteService = remoteService
 		self._heldConnections: list[Connection] = []
 
-	def holdConnection(self, conn: Connection) -> None:
-		"""Keep ``conn`` alive for at least as long as this proxy."""
+	def _holdConnection(self, conn: Connection) -> None:
+		"""Keep ``conn`` alive for at least as long as this proxy.
+
+		:arg con: Connection to keep alive.
+		"""
 		self._heldConnections.append(conn)
 
 	def _connectDependentService(
@@ -44,12 +47,17 @@ class Proxy[Service_t: "Service"]:
 		localService: Service | None = None,
 		name: str = "dependent service",
 	) -> Service:
-		"""Connect to a side-channel service and tie it to this proxy's lifetime."""
+		"""Connect to a side-channel service and tie it to this proxy's lifetime.
+
+		:arg stream: Stream over which the service will communicate.
+		:arg localService: The service to attach.
+		:arg name: Name of this dependency.
+		"""
 		from .connection import Connection
 
-		conn = Connection(stream, localService, name=name)
+		conn = Connection(stream, localService, name)
 		conn.bgEventLoop(daemon=True)
-		self.holdConnection(conn)
+		self._holdConnection(conn)
 		return conn.remoteService
 
 	def __del__(self):

--- a/source/_art/transport/proxy.py
+++ b/source/_art/transport/proxy.py
@@ -7,7 +7,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Final
 
 from rpyc.core.stream import Stream
 
@@ -16,6 +16,9 @@ from logHandler import log
 if TYPE_CHECKING:
 	from .connection import Connection
 	from .service import Service
+
+
+_DEFAULT_DEPENDENT_SERVICE_NAME: Final[str] = "dependent service"
 
 
 class Proxy[Service_t: Service]:
@@ -45,13 +48,13 @@ class Proxy[Service_t: Service]:
 		self,
 		stream: Stream,
 		localService: Service | None = None,
-		name: str = "dependent service",
+		name: str = _DEFAULT_DEPENDENT_SERVICE_NAME,
 	) -> Service:
 		"""Connect to a side-channel service and tie it to this proxy's lifetime.
 
 		:param stream: Stream over which the service will communicate.
 		:param localService: The service to attach.
-		:param name: Name of this dependency.
+		:param name: Name of this dependency, defaults to :const:`_DEFAULT_DEPENDENT_SERVICE_NAME`.
 		"""
 		from .connection import Connection
 

--- a/source/_art/transport/service.py
+++ b/source/_art/transport/service.py
@@ -3,7 +3,7 @@
 # This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
 # For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
 
-"""The ``Service`` base class for objects exposed across the ``_art`` transport."""
+"""The base class for services exposed across the ART transport."""
 
 from __future__ import annotations
 
@@ -23,15 +23,13 @@ if TYPE_CHECKING:
 
 @rpyc.service
 class Service(rpyc.Service):
-	"""Base class for objects exposed across the ``_art`` transport boundary.
+	"""Base class for objects exposed across the ART transport boundary.
 
-	A ``Service`` wraps a real object and exposes a curated set of methods, each decorated
-	with :meth:`exposed`, to the remote peer. Concrete subclasses must also be decorated
-	with ``@rpyc.service``.
+	A ``Service`` wraps a real object and exposes a curated set of methods, each decorated with :meth:`exposed`, to the remote peer.
+	Concrete subclasses must also be decorated with ``@rpyc.service``.
 
-	A service owns the lifecycle of anything it hands out: dependent connections it opens
-	and dependant services it returns over the boundary are all torn down when it is
-	:meth:`terminate`\\ d.
+	A service owns the lifecycle of anything it hands out.
+	Dependent connections it opens and dependant services it returns over the boundary are all torn down when it is terminated.
 	"""
 
 	_terminated: bool = False
@@ -46,8 +44,7 @@ class Service(rpyc.Service):
 		"""Expose a method across the boundary.
 
 		Wraps :func:`rpyc.exposed`, additionally refusing calls on a terminated service
-		and registering any returned ``Service`` as a dependant so it shares this
-		service's lifetime.
+		and registering any returned ``Service`` as a dependant so it shares this service's lifetime.
 		"""
 		exposedFunc = rpyc.exposed(func)
 
@@ -72,8 +69,13 @@ class Service(rpyc.Service):
 	) -> Connection:
 		"""Open a connection bound to this service's lifetime.
 
-		The connection is closed automatically when this service is terminated. Used for
-		side channels such as audio streaming.
+		The connection is closed automatically when this service is terminated.
+		Used for side channels such as audio streaming.
+
+		:arg stream: Stream over which channel communications will take place.
+		:arg localService: Service to attach, defaults to ``None``.
+		:arg name: The name of this dependency, defaults to ``None``.
+			If ``None`` is given, a default name will be computed.
 		"""
 		from .connection import Connection
 
@@ -86,6 +88,7 @@ class Service(rpyc.Service):
 
 	@property
 	def terminated(self) -> bool:
+		"""Whether this service has been terminated."""
 		return self._terminated
 
 	def terminate(self) -> None:

--- a/source/_art/transport/service.py
+++ b/source/_art/transport/service.py
@@ -1,0 +1,115 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2026 NV Access Limited.
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
+
+"""The ``Service`` base class for objects exposed across the ``_art`` transport."""
+
+from __future__ import annotations
+
+import functools
+import weakref
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+
+import rpyc
+from rpyc.core.stream import Stream
+
+from logHandler import log
+
+if TYPE_CHECKING:
+	from .connection import Connection
+
+
+@rpyc.service
+class Service(rpyc.Service):
+	"""Base class for objects exposed across the ``_art`` transport boundary.
+
+	A ``Service`` wraps a real object and exposes a curated set of methods, each decorated
+	with :meth:`exposed`, to the remote peer. Concrete subclasses must also be decorated
+	with ``@rpyc.service``.
+
+	A service owns the lifecycle of anything it hands out: dependent connections it opens
+	and dependant services it returns over the boundary are all torn down when it is
+	:meth:`terminate`\\ d.
+	"""
+
+	_terminated: bool = False
+
+	def __init__(self) -> None:
+		super().__init__()
+		self._dependentConnections: list[Connection] = []
+		self._dependantServices: list[weakref.ref[Service]] = []
+
+	@classmethod
+	def exposed[R](cls, func: Callable[..., R]) -> Callable[..., R]:
+		"""Expose a method across the boundary.
+
+		Wraps :func:`rpyc.exposed`, additionally refusing calls on a terminated service
+		and registering any returned ``Service`` as a dependant so it shares this
+		service's lifetime.
+		"""
+		exposedFunc = rpyc.exposed(func)
+
+		@functools.wraps(func)
+		def wrapper(*args, **kwargs):
+			self = args[0] if args else None
+			assert isinstance(self, Service), f"{func.__qualname__} is not a Service method"
+			if self._terminated:
+				raise RuntimeError(f"Cannot call {func.__qualname__} on terminated service {self!r}")
+			result = exposedFunc(*args, **kwargs)
+			if isinstance(result, Service):
+				self._dependantServices.append(weakref.ref(result))
+			return result
+
+		return wrapper
+
+	def _addDependentConnection(
+		self,
+		stream: Stream,
+		localService: Service | None = None,
+		name: str | None = None,
+	) -> Connection:
+		"""Open a connection bound to this service's lifetime.
+
+		The connection is closed automatically when this service is terminated. Used for
+		side channels such as audio streaming.
+		"""
+		from .connection import Connection
+
+		if name is None:
+			name = f"dependent connection of {type(self).__name__}"
+		conn = Connection(stream, localService, name=name)
+		self._dependentConnections.append(conn)
+		conn.bgEventLoop(daemon=True)
+		return conn
+
+	@property
+	def terminated(self) -> bool:
+		return self._terminated
+
+	def terminate(self) -> None:
+		"""Tear down this service and everything bound to its lifetime."""
+		if self._terminated:
+			return
+		# Set first so in-flight exposed calls are refused while we tear down.
+		self._terminated = True
+		for conn in self._dependentConnections:
+			if not conn.closed:
+				try:
+					conn.close()
+				except Exception:
+					log.debugWarning(f"Error closing dependent connection {conn.name!r}", exc_info=True)
+		self._dependentConnections.clear()
+		for serviceRef in self._dependantServices:
+			service = serviceRef()
+			if service is not None and not service.terminated:
+				try:
+					service.terminate()
+				except Exception:
+					log.debugWarning("Error terminating dependant service", exc_info=True)
+		self._dependantServices.clear()
+
+	def __del__(self):
+		if not self._terminated:
+			self.terminate()

--- a/source/_art/transport/service.py
+++ b/source/_art/transport/service.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2026 NV Access Limited.
+# Copyright (C) 2026 NV Access Limited
 # This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
 # For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
 
@@ -72,9 +72,9 @@ class Service(rpyc.Service):
 		The connection is closed automatically when this service is terminated.
 		Used for side channels such as audio streaming.
 
-		:arg stream: Stream over which channel communications will take place.
-		:arg localService: Service to attach, defaults to ``None``.
-		:arg name: The name of this dependency, defaults to ``None``.
+		:param stream: Stream over which channel communications will take place.
+		:param localService: Service to attach, defaults to ``None``.
+		:param name: The name of this dependency, defaults to ``None``.
 			If ``None`` is given, a default name will be computed.
 		"""
 		from .connection import Connection

--- a/tests/unit/test_art/__init__.py
+++ b/tests/unit/test_art/__init__.py
@@ -1,0 +1,4 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2026 NV Access Limited
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt

--- a/tests/unit/test_art/test_artTransport.py
+++ b/tests/unit/test_art/test_artTransport.py
@@ -1,7 +1,7 @@
 # A part of NonVisual Desktop Access (NVDA)
-# This file is covered by the GNU General Public License.
-# See the file COPYING for more details.
 # Copyright (C) 2026 NV Access Limited
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
 
 """Unit tests for the ``_art.transport`` package (the rpyc-over-pipes transport core)."""
 

--- a/tests/unit/test_art/test_artTransport.py
+++ b/tests/unit/test_art/test_artTransport.py
@@ -94,7 +94,3 @@ class TestArtTransport(unittest.TestCase):
 		self.assertFalse(child.terminated)
 		self.serverService.terminate()
 		self.assertTrue(child.terminated)
-
-
-if __name__ == "__main__":
-	unittest.main()

--- a/tests/unit/test_art/test_artTransport.py
+++ b/tests/unit/test_art/test_artTransport.py
@@ -16,7 +16,7 @@ from _art.transport import Connection, Service
 @rpyc.service
 class _ChildService(Service):
 	@Service.exposed
-	def ping(self):
+	def ping(self) -> str:
 		return "pong"
 
 
@@ -42,7 +42,7 @@ class _EchoService(Service):
 		self.children.append(child)
 		return child
 
-	def notExposedMethod(self):
+	def notExposedMethod(self) -> str:
 		return "should not be reachable"
 
 

--- a/tests/unit/test_art/test_artTransport.py
+++ b/tests/unit/test_art/test_artTransport.py
@@ -83,7 +83,7 @@ class TestArtTransport(unittest.TestCase):
 		"""Calls on a terminated service raise (and the exception deserializes)."""
 		self.assertEqual(self.remote.echo("alive"), "alive")
 		self.serverService.terminate()
-		with self.assertRaises(Exception):
+		with self.assertRaises(RuntimeError):
 			self.remote.echo("dead")
 
 	def test_dependantServiceSharesLifetime(self):

--- a/tests/unit/test_artTransport.py
+++ b/tests/unit/test_artTransport.py
@@ -1,0 +1,100 @@
+# A part of NonVisual Desktop Access (NVDA)
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+# Copyright (C) 2026 NV Access Limited
+
+"""Unit tests for the ``_art.transport`` package (the rpyc-over-pipes transport core)."""
+
+import unittest
+
+import rpyc
+from rpyc.core.stream import PipeStream
+
+from _art.transport import Connection, Service
+
+
+@rpyc.service
+class _ChildService(Service):
+	@Service.exposed
+	def ping(self):
+		return "pong"
+
+
+@rpyc.service
+class _EchoService(Service):
+	def __init__(self):
+		super().__init__()
+		self.children: list[_ChildService] = []
+		self.notExposedValue = "secret"
+
+	@Service.exposed
+	def echo(self, value):
+		return value
+
+	@Service.exposed
+	def applyCallback(self, callback, value):
+		# The callback lives in the peer; invoking it round-trips back over the connection.
+		return callback(value)
+
+	@Service.exposed
+	def makeChild(self):
+		child = _ChildService()
+		self.children.append(child)
+		return child
+
+	def notExposedMethod(self):
+		return "should not be reachable"
+
+
+class TestArtTransport(unittest.TestCase):
+	"""Exercise the transport over an in-process duplex pipe pair."""
+
+	def setUp(self):
+		serverStream, clientStream = PipeStream.create_pair()
+		self.serverService = _EchoService()
+		self.serverConn = Connection(serverStream, self.serverService, name="test server")
+		self.clientConn = Connection(clientStream, None, name="test client")
+		self.serverConn.bgEventLoop(daemon=True)
+		self.clientConn.bgEventLoop(daemon=True)
+		self.remote = self.clientConn.remoteService
+
+	def tearDown(self):
+		self.clientConn.close()
+		self.serverConn.close()
+
+	def test_roundTrip(self):
+		"""An exposed method called across the boundary returns its result."""
+		self.assertEqual(self.remote.echo("hello"), "hello")
+		self.assertEqual(self.remote.echo(42), 42)
+
+	def test_bidirectionalCallback(self):
+		"""A callable passed to the peer can be invoked back across the connection."""
+		result = self.remote.applyCallback(lambda x: x * 2, 21)
+		self.assertEqual(result, 42)
+
+	def test_nonExposedAttributesAreBlocked(self):
+		"""Only ``@Service.exposed`` members are reachable from the peer."""
+		with self.assertRaises(AttributeError):
+			self.remote.notExposedMethod()
+		with self.assertRaises(AttributeError):
+			_ = self.remote.notExposedValue
+
+	def test_terminatedServiceRefusesCalls(self):
+		"""Calls on a terminated service raise (and the exception deserializes)."""
+		self.assertEqual(self.remote.echo("alive"), "alive")
+		self.serverService.terminate()
+		with self.assertRaises(Exception):
+			self.remote.echo("dead")
+
+	def test_dependantServiceSharesLifetime(self):
+		"""A service returned over the boundary is terminated with its parent."""
+		childRef = self.remote.makeChild()
+		self.assertEqual(childRef.ping(), "pong")
+		child = self.serverService.children[0]
+		self.assertFalse(child.terminated)
+		self.serverService.terminate()
+		self.assertTrue(child.terminated)
+
+
+if __name__ == "__main__":
+	unittest.main()


### PR DESCRIPTION
### Link to issue number:

None

### Summary of the issue:

NVDA needs an out-of-process, sandboxed add-on runtime (ART) to help protect against malicious and/or buggy add-ons. Before any feature work can be built, ART needs a generic, feature-agnostic transport layer to carry calls across the NVDA—add-on process boundary.

### Description of user facing changes:

None, just plumbing/architecture at this point.

### Description of developer facing changes:

New `_art` package and `_art.transport` subpackage, which provide the rpyc-over-pipes core that ART will use for IPC:

* `Connection`: wraps a single bidirectional rpyc connection over a `Stream`. Exposes a local `Service` to the peer and reaches the peer's root service via `remoteService`. Serves peer requests either in the calling thread (`eventLoop`) or a background thread (`bgEventLoop`).
* `Service`: base class for objects exposed across the boundary. Methods are opted-in with `@Service.exposed`. Owns the lifecycle of dependent connections it opens and dependant services it returns; `terminate()` cascades teardown to both.
* `Proxy`: base class for the local-side wrapper that re-presents a remote service through NVDA's normal interface. Usable as a mixin; closes any held connections on destruction.
* `PROTOCOL_CONFIG`: the shared, deliberately restrictive rpyc protocol config.

### Description of development approach:

Harvested the rpyc-over-pipes transport and Service/Proxy model from the synth driver host (`_bridge`), but rebuilt it feature-generic from the start (nothing synth-specific) and added the explicit lifecycle/teardown discipline from the pyro5-based ART prototype.

#### Notes:

* `_art.transport.config.PROTOCOL_CONFIG` sets `allow_public_attrs`, `allow_safe_attrs`, `allow_all_attrs`, `allow_setattr`, `allow_delattr` and `allow_pickle` to `False`, so only explicitly exposed attributes/methods are available to add-ons, and remote code execution via deserialization is prevented. `allow_getattr` is `True` because exposed methods are themselves reached via attribute access; with everything else locked down the `exposed` allowlist is all that remains reachable. Changing these settings affects the security of ART.
* Importing `_art.transport` sets `rpyc.core.vinegar.exceptions_module = builtins`. This is necessary because NVDA has its own level `exceptions` module, which rpyc would otherwise pick up over `builtins`, breaking remote exception deserialization. `_bridge` patches this on the host side, but it's done globally here so it applies to both sides of the connection. The patch is idempotent.

### Testing strategy:

`tests/unit/test_art/test_artTransport.py` exercises the transport over an in-process `PipeStream` duplex pair:

* round-trip of an exposed method;
* bidirectional callback (a callable passed to the peer invoked back across the connection);
* non-exposed attributes/methods are blocked (`AttributeError`);
* a terminated service refuses further calls and the exception deserializes correctly (covers the `vinegar` patch);
* a dependant service returned over the boundary is terminated together with its parent.

### Known issues with pull request:

* No real cross-process test yet. Actual IPC is coming in a future PR.
* No NVDA-core integration; nothing is wired up or user-reachable.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
