### PR TITLE
Add Japanese locale gestures for magnifier zoomIn

### DIFF
--- a/source/locale/ja/gestures.ini
+++ b/source/locale/ja/gestures.ini
@@ -1,0 +1,2 @@
+[globalCommands.GlobalCommands]
+	zoomIn = kb:NVDA+shift+;


### PR DESCRIPTION
### Link to issue number:
Not applicable.

### Summary of the issue:
On Japanese (JIS) keyboard layouts, the default magnifier zoom in gesture (`NVDA+shift+=`) does not work. NVDA identifies keys by physical key name; on JIS, the `+` character is entered with Shift+semicolon (`;`), not with the key that produces `=` on US layouts.

### Description of user facing changes:
Japanese locale users can zoom in with the magnifier using `NVDA+shift+;`, matching the physical key used for `+` on JIS keyboards (similar to the Windows Magnifier Win+Plus shortcut on Japanese Windows).

### Description of developer facing changes:
Added `source/locale/ja/gestures.ini` with a locale-specific `zoomIn` binding.

### Description of development approach:
Added `zoomIn = kb:NVDA+shift+;` under `[globalCommands.GlobalCommands]`, following the same pattern as other locales (e.g. `fi`, `it`, `ca`) that remap magnifier zoom in while keeping Shift. The default `NVDA+shift+=` binding is left unchanged for users on non-JIS keyboard layouts.

### Testing strategy:
Manually tested on Japanese Windows with a JIS keyboard layout: `NVDA+shift+;` triggers magnifier zoom in. Verified the key name in input help mode (`NVDA+1`).

### Known issues with pull request:
None known

### Code Review Checklist:

- [ ] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.