### PR TITLE
Speech dictionaries dialog. Only added the context menu

### DIFF
--- a/source/gui/speechDict.py
+++ b/source/gui/speechDict.py
@@ -181,6 +181,8 @@ class DictionaryDialog(
 			wx.ListCtrl,
 			style=wx.LC_REPORT | wx.LC_SINGLE_SEL,
 		)
+		self.dictList.Bind(wx.EVT_LIST_ITEM_ACTIVATED, self.onContextMenu)
+		self.dictList.Bind(wx.EVT_CONTEXT_MENU, self.onContextMenu)
 		# Translators: The label for a column in dictionary entries list used to identify comments for the entry.
 		self.dictList.AppendColumn(_("Comment"), width=150)
 		# Translators: The label for a column in dictionary entries list used to identify pattern
@@ -236,6 +238,17 @@ class DictionaryDialog(
 		).Bind(wx.EVT_BUTTON, self.onRemoveAll)
 
 		sHelper.addItem(bHelper, flag=wx.EXPAND)
+
+	def onContextMenu(self, evt):
+		menu = wx.Menu()
+		# Translators: Context menu item label to edit an entry
+		editItem = menu.Append(wx.ID_ANY, _("&Edit"))
+		# Translators: Context menu item label to remove an entry
+		removeItem = menu.Append(wx.ID_ANY, _("&Remove"))
+		self.Bind(wx.EVT_MENU, self.onEditClick, editItem)
+		self.Bind(wx.EVT_MENU, self.onRemoveClick, removeItem)
+		self.PopupMenu(menu)
+		menu.Destroy()
 
 	def postInit(self):
 		self.dictList.SetFocus()

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -6,6 +6,7 @@
 
 ### New Features
 
+* Added context menu to the list entries of the Speech Dictionaries dialog, Maximizing eas of access to the list entries actions. (#20036, @amirmahdifard)
 * Add-ons can be removed from the "Updatable add-ons" tab in the Add-on Store. (#15030, @nvdaes)
 * Chinese text can now be navigated by word using built-in input gestures.
   A Word Segmentation Standard setting was added to the "Document Navigation" panel. (#18735, @CrazySteve0605, @Cary-rowen)

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -4281,6 +4281,7 @@ The dialog also contains Add, Edit, Remove and Remove all buttons.
 
 To add a new rule to the dictionary, press the Add button, and fill in the fields in the dialog box that appears and then press Ok.
 You will then see your new rule in the list of rules.
+As well as the edit and remove buttons, you can also manage individual rules by opening a context menu on an entry in the list (press the Applications key on your keyboard, shift+f10, space bar, or right/left-click), which provides options to Edit or Remove the selected rule.
 However, to make sure your rule is actually saved, make sure to press Ok to exit the dictionary dialog completely once you have finished adding/editing rules.
 
 The rules for NVDA's speech dictionaries allow you to change one string of characters into another.


### PR DESCRIPTION
### Link to issue number:
regarding the conversations and comment https://github.com/nvaccess/nvda/issues/20036#issuecomment-4788355575
### Summary of the issue:
After having conversation with NVAccess, I understood that regarding the feedback they have receaved from add-on store users, and also low skil users, removing the buttons and replacing them with only context menu actions, will force usage change for all users and the feedback will not be welcome. So, considering this, and considering that NVDA is known to be accessible and comftable for all users, The buttons have not been touched, the dialog's usage is exactly same as before, Just Added a context menu to the entries list. Now, Users who likes to work with context menus in dialogs, can press application on the list entries, and other users who doesn't want it, they can simply skip it and they don't even need to bother knowing about it. They can continue their usage as before.
### Description of user facing changes:
no dialog facing changes, Just added a context menu contaning edit and remove actions to the entries list. Who ever likes context menus can use it, the others can simply skip it. Win Win for every user
### Description of developer facing changes:
none
### Description of development approach:
Added a context menu Contaning edit and remove items, bound the items to the existing Remove and edit trigger functions, and bound the context menu to the dict list.
### Testing strategy:
Opened the Speech dictionaries dialogs, made sure that no dialog facing changes, everything, buttons are working as before, And also opened the context menu on the list items and made sure they are also working exactly the same as the buttons. A full garantee that every nvda user would be happy with this. Users who are not fan of context menus won't even notice a context menu exist here.
### Known issues with pull request:
none
### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.