### PR TITLE
change timer for smoother mouse follow

### DIFF
--- a/source/_magnifier/magnifier.py
+++ b/source/_magnifier/magnifier.py
@@ -15,6 +15,7 @@ import wx
 import ui
 import speech
 import screenCurtain
+from winBindings import winmm
 from winAPI import _displayTracking
 from winAPI._displayTracking import OrientationState, getPrimaryDisplayOrientation
 from .utils.types import (
@@ -38,7 +39,7 @@ from .utils.focusManager import FocusManager
 
 
 class Magnifier:
-	_TIMER_INTERVAL_MS: int = 12
+	_TIMER_INTERVAL_MS: int = 8
 	_MARGIN_BORDER: int = 50
 	_MAX_CONSECUTIVE_ERRORS: int = 3
 	_MAGNIFIED_VIEW: MagnifiedView
@@ -182,14 +183,17 @@ class Magnifier:
 			ui.message(message, speechPriority=speech.priorities.Spri.NOW)
 			return
 
+		result = winmm.timeBeginPeriod(1)
+		if result != winmm.TIMERR_NOERROR:
+			log.warning(f"timeBeginPeriod(1) failed with code {result} — timer resolution stays at ~15ms")
+
 		self._isActive = True
 		self.currentCoordinates = self._focusManager.getCurrentFocusCoordinates()
 
 	def _updateMagnifier(self) -> None:
 		"""
 		Update the magnifier position and content.
-		This method is called repeatedly by the timer.
-		On transient errors (below threshold): reschedules itself to keep running.
+		This method is called repeatedly by the repeating timer.
 		On repeated errors (at threshold): delegates rescheduling to _attemptRecovery.
 		"""
 		if not self._isActive:
@@ -225,8 +229,6 @@ class Magnifier:
 				f"Transient error updating magnifier ({self._consecutiveErrors}/{self._MAX_CONSECUTIVE_ERRORS})",
 				exc_info=True,
 			)
-		# Always reschedule the timer to keep the magnifier alive
-		self._startTimer(self._updateMagnifier)
 
 	def _doUpdate(self) -> None:
 		"""
@@ -253,6 +255,7 @@ class Magnifier:
 		if not self._isActive:
 			return
 		self._stopTimer()
+		winmm.timeEndPeriod(1)
 		self._isActive = False
 		# Unregister from display changes
 		_displayTracking.displayChanged.unregister(self._onDisplayChanged)
@@ -367,7 +370,7 @@ class Magnifier:
 		self._stopTimer()
 		self._timer = wx.Timer()
 		self._timer.Bind(wx.EVT_TIMER, lambda evt: callback())
-		self._timer.Start(self._TIMER_INTERVAL_MS, oneShot=True)
+		self._timer.Start(self._TIMER_INTERVAL_MS, oneShot=False)
 
 	def _stopTimer(self) -> None:
 		"""

--- a/source/winBindings/winmm.py
+++ b/source/winBindings/winmm.py
@@ -19,7 +19,7 @@ from ctypes.wintypes import (
 
 DWORD_PTR = c_size_t
 MMRESULT = c_long
-
+TIMERR_NOERROR: int = 0
 
 dll = windll.winmm
 
@@ -47,4 +47,30 @@ waveOutMessage.argtypes = (
 	UINT,  # uMsg: Message to send
 	DWORD_PTR,  # dw1: Message parameter (DWORD_PTR)
 	DWORD_PTR,  # dw2: Message parameter (DWORD_PTR)
+)
+
+timeBeginPeriod = WINFUNCTYPE(None)(("timeBeginPeriod", dll))
+"""
+Sets the minimum timer resolution for the application.
+Must be matched with a corresponding call to timeEndPeriod using the same uPeriod value.
+
+.. seealso::
+	https://learn.microsoft.com/en-us/windows/win32/api/timeapi/nf-timeapi-timebeginperiod
+"""
+timeBeginPeriod.restype = MMRESULT
+timeBeginPeriod.argtypes = (
+	UINT,  # uPeriod: Minimum timer resolution, in milliseconds
+)
+
+timeEndPeriod = WINFUNCTYPE(None)(("timeEndPeriod", dll))
+"""
+Clears a previously set minimum timer resolution.
+uPeriod must match the value passed to the corresponding timeBeginPeriod call.
+
+.. seealso::
+	https://learn.microsoft.com/en-us/windows/win32/api/timeapi/nf-timeapi-timeendperiod
+"""
+timeEndPeriod.restype = MMRESULT
+timeEndPeriod.argtypes = (
+	UINT,  # uPeriod: Minimum timer resolution to clear, in milliseconds
 )

--- a/tests/unit/test_magnifier/test_fullscreenMagnifier.py
+++ b/tests/unit/test_magnifier/test_fullscreenMagnifier.py
@@ -263,27 +263,19 @@ class TestFullscreenMagnifierEndToEnd(_TestMagnifier):
 		self.assertEqual(magnifier._consecutiveErrors, 0)
 
 	def testUpdateLoopSurvivesSingleDoUpdateError(self):
-		"""A single _doUpdate error does not kill the update loop."""
+		"""A single _doUpdate error increments the counter; a subsequent success resets it."""
 		magnifier = FullScreenMagnifier()
 		magnifier._startMagnifier()
-		magnifier._startTimer = MagicMock()
 		magnifier._focusManager.getCurrentFocusCoordinates = MagicMock(
 			return_value=(100, 200),
 		)
-
-		# First call fails, second succeeds
 		magnifier._doUpdate = MagicMock(side_effect=[OSError("Transient"), None])
 
-		# First update — error
 		magnifier._updateMagnifier()
 		self.assertEqual(magnifier._consecutiveErrors, 1)
-		magnifier._startTimer.assert_called_with(magnifier._updateMagnifier)
 
-		# Second update — success
-		magnifier._startTimer.reset_mock()
 		magnifier._updateMagnifier()
 		self.assertEqual(magnifier._consecutiveErrors, 0)
-		magnifier._startTimer.assert_called_with(magnifier._updateMagnifier)
 
 		magnifier._stopMagnifier()
 

--- a/tests/unit/test_magnifier/test_magnifier.py
+++ b/tests/unit/test_magnifier/test_magnifier.py
@@ -144,29 +144,22 @@ class TestMagnifier(_TestMagnifier):
 			2,
 		)
 		self.magnifier._doUpdate.assert_called_once()
-		self.magnifier._startTimer.assert_called_once_with(
-			self.magnifier._updateMagnifier,
-		)
+		self.magnifier._startTimer.assert_not_called()
 		self.assertEqual(self.magnifier.currentCoordinates, focusCoords)
 		# Successful update should reset error counter
 		self.assertEqual(self.magnifier._consecutiveErrors, 0)
 
 	def testUpdateMagnifierResumesAfterSingleError(self):
-		"""Timer must always be rescheduled even when _doUpdate raises an exception."""
+		"""Transient errors below the threshold increment the error counter without triggering recovery."""
 		self.magnifier._isActive = True
 		focusCoords = Coordinates(self.screenWidth // 2, self.screenHeight // 2)
 		self.magnifier._focusManager.getCurrentFocusCoordinates = MagicMock(
 			return_value=focusCoords,
 		)
 		self.magnifier._doUpdate = MagicMock(side_effect=OSError("COM failure"))
-		self.magnifier._startTimer = MagicMock()
 
 		self.magnifier._updateMagnifier()
 
-		# Timer must still be rescheduled despite the error
-		self.magnifier._startTimer.assert_called_once_with(
-			self.magnifier._updateMagnifier,
-		)
 		self.assertEqual(self.magnifier._consecutiveErrors, 1)
 
 	def testUpdateMagnifierTriggersRecoveryAfterMaxErrors(self):
@@ -189,18 +182,16 @@ class TestMagnifier(_TestMagnifier):
 		self.magnifier._startTimer.assert_not_called()
 
 	def testUpdateMagnifierCatchesCOMError(self):
-		"""COMError from UIA must be caught and the timer rescheduled."""
+		"""COMError is caught like OSError and increments the consecutive error counter."""
 		self.magnifier._isActive = True
 		focusCoords = Coordinates(self.screenWidth // 2, self.screenHeight // 2)
 		self.magnifier._focusManager.getCurrentFocusCoordinates = MagicMock(
 			return_value=focusCoords,
 		)
 		self.magnifier._doUpdate = MagicMock(side_effect=COMError(-2147417848, "RPC_E_DISCONNECTED", None))
-		self.magnifier._startTimer = MagicMock()
 
 		self.magnifier._updateMagnifier()
 
-		self.magnifier._startTimer.assert_called_once_with(self.magnifier._updateMagnifier)
 		self.assertEqual(self.magnifier._consecutiveErrors, 1)
 
 	def testUpdateMagnifierRecoveryFailureSafelyRestartsTimer(self):
@@ -229,13 +220,11 @@ class TestMagnifier(_TestMagnifier):
 		self.magnifier._focusManager.getCurrentFocusCoordinates = MagicMock(
 			return_value=focusCoords,
 		)
-		self.magnifier._doUpdate = MagicMock()  # Success
-		self.magnifier._startTimer = MagicMock()
+		self.magnifier._doUpdate = MagicMock()
 
 		self.magnifier._updateMagnifier()
 
 		self.assertEqual(self.magnifier._consecutiveErrors, 0)
-		self.magnifier._startTimer.assert_called_once()
 
 	def testAttemptRecoveryBase(self):
 		"""Base _attemptRecovery resets errors and restarts timer."""

--- a/tests/unit/test_magnifier/test_magnifier.py
+++ b/tests/unit/test_magnifier/test_magnifier.py
@@ -7,6 +7,7 @@ from _magnifier.config import ZoomLevel
 from _magnifier.magnifier import Magnifier
 from _magnifier.utils.types import Filter, Direction, Coordinates, MagnifierAction
 from comtypes import COMError
+import time
 import unittest
 from winAPI._displayTracking import getPrimaryDisplayOrientation
 from unittest.mock import MagicMock, patch
@@ -33,9 +34,14 @@ class _TestMagnifier(unittest.TestCase):
 			mock.MagUninitialize.return_value = True
 			mock.MagSetFullscreenTransform.return_value = True
 			mock.MagSetFullscreenColorEffect.return_value = True
+		self.winmm_patcher = patch("_magnifier.magnifier.winmm")
+		self.mock_winmm = self.winmm_patcher.start()
+		self.mock_winmm.timeBeginPeriod.return_value = 0
+		self.mock_winmm.TIMERR_NOERROR = 0
 
 	def tearDown(self):
 		"""Cleanup after each test."""
+		self.winmm_patcher.stop()
 		self.mag_fs_patcher.stop()
 		self.mag_patcher.stop()
 
@@ -257,6 +263,21 @@ class TestMagnifier(_TestMagnifier):
 
 		self.magnifier._stopTimer.assert_called_once()
 		self.assertFalse(self.magnifier._isActive)
+
+	def testTimeBeginPeriodReducesTimerResolution(self):
+		"""timeBeginPeriod(1) must reduce actual sleep(1ms) duration below 5ms."""
+		from winBindings import winmm as real_winmm
+
+		real_winmm.timeBeginPeriod(1)
+		try:
+			durations_ms = []
+			for _ in range(20):
+				t0 = time.perf_counter()
+				time.sleep(0.001)
+				durations_ms.append((time.perf_counter() - t0) * 1000)
+			self.assertLess(min(durations_ms), 5.0)
+		finally:
+			real_winmm.timeEndPeriod(1)
 
 	def testZoom(self):
 		"""zoom in and out with valid values and check boundaries."""


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Partially addressing #19987

### Summary of the issue:
When following the mouse, the NVDA magnifier panned in a jerky, discontinuous way compared to the built-in Windows Magnifier. Users noticed a distinct "pause then jump" instead of smooth real-time panning.
### Description of user facing changes:
Mouse panning is now significantly smoother. The magnifier follows the mouse in real time at up to 125 Hz instead of being capped at the system's default timer resolution (~67 Hz).
### Description of developer facing changes:
timeBeginPeriod(1) / timeEndPeriod(1) are now called from winmm.dll (via the new winBindings.winmm bindings) when the magnifier starts and stops. The update timer is now a repeating wx.Timer (oneShot=False) rather than a self-rescheduling one-shot timer, removing per-tick object creation overhead. _TIMER_INTERVAL_MS is now 8 ms.
### Description of development approach:
The root cause was two-fold: Windows default timer resolution (~15 ms floor) made sub-15 ms intervals ineffective, and the self-rescheduling one-shot pattern added creation overhead at every tick. Setting the timer resolution to 1 ms removes the floor; switching to a repeating timer removes the overhead.
### Testing strategy:
updated unit, manual
### Known issues with pull request:

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [ ] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [ ] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [ ] API is compatible with existing add-ons.
- [ ] Security precautions taken.
