### PR TITLE
Use math navigation category for one more math script

### DIFF
--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -129,6 +129,8 @@ SCRCAT_AUDIO = _("Audio")
 #: Script category for Remote Access commands.
 # Translators: The name of a category of NVDA commands.
 SCRCAT_REMOTE = pgettext("remote", "Remote Access")
+# Translators: The name of the category of math navigation commands in the Input Gestures dialog.
+SCRCAT_MATH_NAV = _("Math navigation")
 
 # Translators: Reported when there are no settings to configure in synth settings ring
 # (example: when there is no setting for language).
@@ -4739,6 +4741,7 @@ class GlobalCommands(ScriptableObject):
 	@script(
 		# Translators: Describes a command.
 		description=_("Begins interaction with math content"),
+		category=SCRCAT_MATH_NAV,
 		gesture="kb:NVDA+alt+m",
 	)
 	def script_interactWithMath(self, gesture):

--- a/source/mathPres/MathCAT/MathCAT.py
+++ b/source/mathPres/MathCAT/MathCAT.py
@@ -24,6 +24,7 @@ import winKernel
 import winUser
 from api import getClipData
 from keyboardHandler import KeyboardInputGesture
+from globalCommands import SCRCAT_MATH_NAV
 from logHandler import log
 from scriptHandler import script
 from NVDAState import ReadPaths
@@ -45,9 +46,6 @@ from .localization import getLanguageToUse
 from .navCommands import NAV_COMMANDS
 from .preferences import applyUserPreferences
 from .speech import convertSSMLTextForNVDA
-
-# Translators: The name of the category of MathCAT navigation commands in the Input Gestures dialog.
-SCRCAT_MATHCAT_NAV = _("Math navigation")
 
 
 class MathCATInteraction(mathPres.MathInteractionNVDAObject):
@@ -154,7 +152,7 @@ class MathCATInteraction(mathPres.MathInteractionNVDAObject):
 			script = lambda self, gesture, _cmd=cmd.commandName: self._doNavigateCommand(_cmd)  # noqa: E731
 			script.__doc__ = cmd.description
 			script.__name__ = funcName
-			script.category = SCRCAT_MATHCAT_NAV
+			script.category = SCRCAT_MATH_NAV
 			script.speakOnDemand = cmd.speakOnDemand
 			setattr(cls, funcName, script)
 			for gesture in cmd.gestures:


### PR DESCRIPTION
Opened against beta to avoid deprecation when moving / renaming symbol.
### Link to issue number:
None

### Summary of the issue:

Since 2026.2beta, we have a "Math navigation" category. However the pre-existing command "Begins interaction with math content" is still in the Misc category.

### Description of user facing changes:
In input gestures dialog, "Begins interaction with math content" is now in "Math navigation" category

### Description of developer facing changes:
N/A
### Description of development approach:
* Added script category
* Moved and renamed `SCRCAT_MATHCAT_NAV` from `mathPres/MathCAT/MathCAT.py` to `SCRCAT_MATH_NAV` in `globalCommands.py`.

### Testing strategy:
Manual testing:
* Checked input gestures dialog content
### Known issues with pull request:
None
### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
