### PR TITLE
Move script move mouse to view from vision to Magnifier category

### DIFF
--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -5266,7 +5266,7 @@ class GlobalCommands(ScriptableObject):
 			# Translators: Describes a command.
 			"Moves the mouse cursor to the center of the magnified view",
 		),
-		category=SCRCAT_VISION,
+		category=SCRCAT_MAGNIFIER,
 	)
 	def script_moveMouseToView(
 		self,


### PR DESCRIPTION
### Link to issue number:
Follow-up of #20261

### Summary of the issue:
with #20261, magnifier scripts have been put in the "Magnifier" category in the beta branch. However, the command "Move mouse to view" (which was only in master branch) has remained in Vision category
### Description of user facing changes:
N/A
### Description of development approach:
Changed script category
### Testing strategy:
Checked input gesture dialog
### Known issues with pull request:
None
### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
