### PR TITLE
Avoid duplicate cppjieba dictionary install targets

### DIFF
--- a/nvdaHelper/archBuild_sconscript
+++ b/nvdaHelper/archBuild_sconscript
@@ -199,6 +199,7 @@ else:
 
 Export("thirdPartyEnv")
 Export("env")
+Export("isNVDACoreArch")
 
 acrobatAccessRPCStubs = env.SConscript("acrobatAccess_sconscript")
 Export("acrobatAccessRPCStubs")

--- a/nvdaHelper/cppjieba/sconscript
+++ b/nvdaHelper/cppjieba/sconscript
@@ -7,6 +7,7 @@ import typing  # noqa: E402
 
 Import(
 	[
+		"isNVDACoreArch",
 		"thirdPartyEnv",
 		"sourceDir",
 	]
@@ -41,16 +42,17 @@ env.AppendUnique(
 
 cppjiebaLib = env.SharedLibrary(target="cppjieba", source=sourceFiles)
 
-env.Install(
-	outDir.Dir("dicts"),
-	[
-		env.Dir(cppjiebaDictPath).File(name)
-		for name in (
-			"jieba.dict.utf8",
-			"user.dict.utf8",
-			"hmm_model.utf8",
-		)
-	],
-)
+if isNVDACoreArch:
+	env.Install(
+		outDir.Dir("dicts"),
+		[
+			env.Dir(cppjiebaDictPath).File(name)
+			for name in (
+				"jieba.dict.utf8",
+				"user.dict.utf8",
+				"hmm_model.utf8",
+			)
+		],
+	)
 
 Return("cppjiebaLib")


### PR DESCRIPTION
### Link to issue number:

None.

### Summary of the issue:

Building NVDA could produce a SCons warning because the cppjieba dictionary files were installed from multiple architecture-specific build environments, even though the dictionary files are shared and architecture-independent.

### Description of user facing changes:

None.

### Description of developer facing changes:

The cppjieba dictionary files are now installed only once, from the core architecture build. The cppjieba DLL is still built per architecture.

### Description of development approach:

This follows the existing build pattern used for shared files under `source`: export `isNVDACoreArch` from `archBuild_sconscript`, then use it in `nvdaHelper/cppjieba/sconscript` to guard the dictionary install step.

### Testing strategy:

Ran `.\scons.bat source -j8`; the build completed and the duplicate install warning did not appear.

### Known issues with pull request:

None known.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [ ] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [ ] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [ ] API is compatible with existing add-ons.
- [ ] Security precautions taken.