### PR TITLE
Speech dictionaries dialog. Added a context menu to the dicts list

### DIFF
--- a/source/gui/speechDict.py
+++ b/source/gui/speechDict.py
@@ -181,8 +181,9 @@ class DictionaryDialog(
 			wx.ListCtrl,
 			style=wx.LC_REPORT | wx.LC_SINGLE_SEL,
 		)
-		self.dictList.Bind(wx.EVT_LIST_ITEM_ACTIVATED, self.onContextMenu)
+		self.dictList.Bind(wx.EVT_LIST_ITEM_ACTIVATED, self.onEditClick)
 		self.dictList.Bind(wx.EVT_CONTEXT_MENU, self.onContextMenu)
+		self.dictList.Bind(wx.EVT_CHAR_HOOK, self.onCharHook)
 		# Translators: The label for a column in dictionary entries list used to identify comments for the entry.
 		self.dictList.AppendColumn(_("Comment"), width=150)
 		# Translators: The label for a column in dictionary entries list used to identify pattern
@@ -238,6 +239,13 @@ class DictionaryDialog(
 		).Bind(wx.EVT_BUTTON, self.onRemoveAll)
 
 		sHelper.addItem(bHelper, flag=wx.EXPAND)
+
+	def onCharHook(self, evt):
+		key = evt.GetKeyCode()
+		if key == wx.WXK_DELETE:
+			self.onRemoveClick(None)
+		else:
+			evt.Skip()
 
 	def onContextMenu(self, evt):
 		menu = wx.Menu()

--- a/source/gui/speechDict.py
+++ b/source/gui/speechDict.py
@@ -249,12 +249,18 @@ class DictionaryDialog(
 
 	def onContextMenu(self, evt):
 		menu = wx.Menu()
-		# Translators: Context menu item label to edit an entry
+		# Translators: Context menu item label to add a new entri
+		addItem = menu.Append(wx.ID_ANY, _("&Add"))
+		# Translators: Context menu item label to edit an entri
 		editItem = menu.Append(wx.ID_ANY, _("&Edit"))
-		# Translators: Context menu item label to remove an entry
+		# Translators: Context menu item label to remove an entri
 		removeItem = menu.Append(wx.ID_ANY, _("&Remove"))
+		# Translators: Context menu item label to remove all entries
+		removeallItem = menu.Append(wx.ID_ANY, _("Remove all"))
+		self.Bind(wx.EVT_MENU, self.onAddClick, addItem)
 		self.Bind(wx.EVT_MENU, self.onEditClick, editItem)
 		self.Bind(wx.EVT_MENU, self.onRemoveClick, removeItem)
+		self.Bind(wx.EVT_MENU, self.onRemoveAll, removeallItem)
 		self.PopupMenu(menu)
 		menu.Destroy()
 

--- a/source/gui/speechDict.py
+++ b/source/gui/speechDict.py
@@ -249,7 +249,7 @@ class DictionaryDialog(
 
 	def onContextMenu(self, evt: wx.ContextMenuEvent):
 		menu = wx.Menu()
-		# Translators: Context menu item label to edit an entri
+		# Translators: Context menu item label to edit an entry
 		editItem = menu.Append(wx.ID_ANY, _("&Edit"))
 		# Translators: Context menu item label to remove an entri
 		removeItem = menu.Append(wx.ID_ANY, _("&Remove"))

--- a/source/gui/speechDict.py
+++ b/source/gui/speechDict.py
@@ -240,27 +240,21 @@ class DictionaryDialog(
 
 		sHelper.addItem(bHelper, flag=wx.EXPAND)
 
-	def onCharHook(self, evt):
+	def onCharHook(self, evt: wx.KeyEvent):
 		key = evt.GetKeyCode()
 		if key == wx.WXK_DELETE:
 			self.onRemoveClick(None)
 		else:
 			evt.Skip()
 
-	def onContextMenu(self, evt):
+	def onContextMenu(self, evt: wx.ContextMenuEvent):
 		menu = wx.Menu()
-		# Translators: Context menu item label to add a new entri
-		addItem = menu.Append(wx.ID_ANY, _("&Add"))
 		# Translators: Context menu item label to edit an entri
 		editItem = menu.Append(wx.ID_ANY, _("&Edit"))
 		# Translators: Context menu item label to remove an entri
 		removeItem = menu.Append(wx.ID_ANY, _("&Remove"))
-		# Translators: Context menu item label to remove all entries
-		removeallItem = menu.Append(wx.ID_ANY, _("Remove all"))
-		self.Bind(wx.EVT_MENU, self.onAddClick, addItem)
 		self.Bind(wx.EVT_MENU, self.onEditClick, editItem)
 		self.Bind(wx.EVT_MENU, self.onRemoveClick, removeItem)
-		self.Bind(wx.EVT_MENU, self.onRemoveAll, removeallItem)
 		self.PopupMenu(menu)
 		menu.Destroy()
 

--- a/source/gui/speechDict.py
+++ b/source/gui/speechDict.py
@@ -251,7 +251,7 @@ class DictionaryDialog(
 		menu = wx.Menu()
 		# Translators: Context menu item label to edit an entry
 		editItem = menu.Append(wx.ID_ANY, _("&Edit"))
-		# Translators: Context menu item label to remove an entri
+		# Translators: Context menu item label to remove an entry
 		removeItem = menu.Append(wx.ID_ANY, _("&Remove"))
 		self.Bind(wx.EVT_MENU, self.onEditClick, editItem)
 		self.Bind(wx.EVT_MENU, self.onRemoveClick, removeItem)

--- a/source/gui/speechDict.py
+++ b/source/gui/speechDict.py
@@ -181,6 +181,8 @@ class DictionaryDialog(
 			wx.ListCtrl,
 			style=wx.LC_REPORT | wx.LC_SINGLE_SEL,
 		)
+		self.dictList.Bind(wx.EVT_LIST_ITEM_ACTIVATED, self.onContextMenu)
+		self.dictList.Bind(wx.EVT_CONTEXT_MENU, self.onContextMenu)
 		# Translators: The label for a column in dictionary entries list used to identify comments for the entry.
 		self.dictList.AppendColumn(_("Comment"), width=150)
 		# Translators: The label for a column in dictionary entries list used to identify pattern
@@ -236,6 +238,17 @@ class DictionaryDialog(
 		).Bind(wx.EVT_BUTTON, self.onRemoveAll)
 
 		sHelper.addItem(bHelper, flag=wx.EXPAND)
+
+	def onContextMenu(self, evt):
+		menu = wx.Menu()
+		# Translators: Context menu item label to edit an entry
+		editItem = menu.Append(wx.ID_ANY, _("&Edit"))
+		# Translators: Context menu item label to remove an entry
+		removeItem = menu.Append(wx.ID_ANY, _("&Remove"))
+		self.Bind(wx.EVT_MENU, self.onEditClick, editItem)
+		self.Bind(wx.EVT_MENU, self.onRemoveClick, removeItem)
+		self.PopupMenu(menu)
+		menu.Destroy()
 
 	def postInit(self):
 		self.dictList.SetFocus()

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -18,6 +18,7 @@
   * In modes that show a continuation mark, when a word is cut across rows, the last cell of the row now shows a continuation mark (braille dots 7-8) so it is clear that the word continues on the next row.
   * The "At word or syllable boundaries" option uses hyphenation dictionaries to split long words at syllable boundaries when they do not fit on the display.
 * Magnifier: A new unassigned command has been added to move the mouse cursor to the center of the magnified view. (#20127, @CyrilleB79)
+* Added context menu to the list entries of the Speech Dictionaries dialog, Maximizing eas of access to the list entries actions. (#20420, @amirmahdifard)
 
 ### Changes
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -18,7 +18,7 @@
   * In modes that show a continuation mark, when a word is cut across rows, the last cell of the row now shows a continuation mark (braille dots 7-8) so it is clear that the word continues on the next row.
   * The "At word or syllable boundaries" option uses hyphenation dictionaries to split long words at syllable boundaries when they do not fit on the display.
 * Magnifier: A new unassigned command has been added to move the mouse cursor to the center of the magnified view. (#20127, @CyrilleB79)
-* Added a context menu to the list entries of the Speech Dictionaries dialog, providing an alternative way to edit or remove a rule. (#20420, @amirmahdifard)
+* Added context menu and shortcuts support to the Speech Dictionaries dialog. (#20420, @amirmahdifard)
 
 ### Changes
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -18,7 +18,7 @@
   * In modes that show a continuation mark, when a word is cut across rows, the last cell of the row now shows a continuation mark (braille dots 7-8) so it is clear that the word continues on the next row.
   * The "At word or syllable boundaries" option uses hyphenation dictionaries to split long words at syllable boundaries when they do not fit on the display.
 * Magnifier: A new unassigned command has been added to move the mouse cursor to the center of the magnified view. (#20127, @CyrilleB79)
-* Added context menu to the list entries of the Speech Dictionaries dialog, Maximizing eas of access to the list entries actions. (#20420, @amirmahdifard)
+* Added a context menu to the list entries of the Speech Dictionaries dialog, providing an alternative way to edit or remove a rule. (#20420, @amirmahdifard)
 
 ### Changes
 

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -4283,6 +4283,7 @@ The dialog also contains Add, Edit, Remove and Remove all buttons.
 
 To add a new rule to the dictionary, press the Add button, and fill in the fields in the dialog box that appears and then press Ok.
 You will then see your new rule in the list of rules.
+As well as the edit and remove buttons, you can also manage individual rules by opening a context menu on an entry in the list (press the Applications key on your keyboard, shift+f10, space bar, or right/left-click), which provides options to Edit or Remove the selected rule.
 However, to make sure your rule is actually saved, make sure to press Ok to exit the dictionary dialog completely once you have finished adding/editing rules.
 
 The rules for NVDA's speech dictionaries allow you to change one string of characters into another.

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -4283,7 +4283,8 @@ The dialog also contains Add, Edit, Remove and Remove all buttons.
 
 To add a new rule to the dictionary, press the Add button, and fill in the fields in the dialog box that appears and then press Ok.
 You will then see your new rule in the list of rules.
-Alternatively, a context menu to perform actions on single rules (Edit and Remove) is also available.
+
+You can use a context menu to edit or remove rules.
 You can also use the `delete` key to remove a selected rule
 However, to make sure your rule is actually saved, make sure to press Ok to exit the dictionary dialog completely once you have finished adding/editing rules.
 

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -4285,7 +4285,7 @@ To add a new rule to the dictionary, press the Add button, and fill in the field
 You will then see your new rule in the list of rules.
 
 You can use a context menu to edit or remove rules.
-You can also use the `delete` key to remove a selected rule
+You can also use the `delete` key to remove a selected rule.
 However, to make sure your rule is actually saved, make sure to press Ok to exit the dictionary dialog completely once you have finished adding/editing rules.
 
 The rules for NVDA's speech dictionaries allow you to change one string of characters into another.

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -4283,12 +4283,8 @@ The dialog also contains Add, Edit, Remove and Remove all buttons.
 
 To add a new rule to the dictionary, press the Add button, and fill in the fields in the dialog box that appears and then press Ok.
 You will then see your new rule in the list of rules.
-All dictionary dialogs contain a list of rules which will be used for processing the speech.
-The dialog also contains Add, Edit, Remove and Remove all buttons.
 Alternatively, a context menu to perform actions on single rules (Edit and Remove) is also available.
-
-To add a new rule to the dictionary, press the Add button, and fill in the fields in the dialog box that appears and then press Ok.
-You will then see your new rule in the list of rules.
+You can also use delete key to remove a selected rule
 However, to make sure your rule is actually saved, make sure to press Ok to exit the dictionary dialog completely once you have finished adding/editing rules.
 
 The rules for NVDA's speech dictionaries allow you to change one string of characters into another.

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -4283,7 +4283,12 @@ The dialog also contains Add, Edit, Remove and Remove all buttons.
 
 To add a new rule to the dictionary, press the Add button, and fill in the fields in the dialog box that appears and then press Ok.
 You will then see your new rule in the list of rules.
-As well as the edit and remove buttons, you can also manage individual rules by opening a context menu on an entry in the list (press the Applications key on your keyboard, shift+f10, space bar, or right/left-click), which provides options to Edit or Remove the selected rule.
+All dictionary dialogs contain a list of rules which will be used for processing the speech.
+The dialog also contains Add, Edit, Remove and Remove all buttons.
+Alternatively, a context menu to perform actions on single rules (Edit and Remove) is also available.
+
+To add a new rule to the dictionary, press the Add button, and fill in the fields in the dialog box that appears and then press Ok.
+You will then see your new rule in the list of rules.
 However, to make sure your rule is actually saved, make sure to press Ok to exit the dictionary dialog completely once you have finished adding/editing rules.
 
 The rules for NVDA's speech dictionaries allow you to change one string of characters into another.

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -4284,7 +4284,7 @@ The dialog also contains Add, Edit, Remove and Remove all buttons.
 To add a new rule to the dictionary, press the Add button, and fill in the fields in the dialog box that appears and then press Ok.
 You will then see your new rule in the list of rules.
 Alternatively, a context menu to perform actions on single rules (Edit and Remove) is also available.
-You can also use delete key to remove a selected rule
+You can also use the `delete` key to remove a selected rule
 However, to make sure your rule is actually saved, make sure to press Ok to exit the dictionary dialog completely once you have finished adding/editing rules.
 
 The rules for NVDA's speech dictionaries allow you to change one string of characters into another.


### PR DESCRIPTION
### Link to issue number:
fixes https://github.com/nvaccess/nvda/issues/20420
### Summary of the issue:
the Speech dictionaries list item actions could only be managed by the buttons. Like many other windows dialogs, Also added context menu to this list, so users can use both, whatever they are comftable with
### Description of user facing changes:
A context menu has been added to the entries list of the Speech dictionaries dialog and can be opened that has edit, and remove options in it. No other interface changes.
### Description of developer facing changes:
none
### Description of development approach:
Added a context menu method, Added translater comments, and bound the context menu evt to dict list
### Testing strategy:
opened Speech dictionaries dialog, Added edited and removed entries, made sure that both buttons and context menu are functional as before, And also made sure other used keys will continue to act as before and nothing extra is touched and changed
### Known issues with pull request:
none
### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
