### PR TITLE
sapi4 32 bit: support voices that don't support pitch or rate

### DIFF
--- a/source/_bridge/components/services/synthDriver.py
+++ b/source/_bridge/components/services/synthDriver.py
@@ -46,12 +46,6 @@ class SynthDriverService(Service):
 		self._synth = synthDriver
 		self._synthIndexReachedCallback = None
 		self._synthDoneSpeakingCallback = None
-		# Ensure default pitch, rate, and volume settings exist in config
-		speechConf = config.conf["speech"]
-		if self._synth.name not in speechConf:
-			synthConf = speechConf[self._synth.name] = {}
-		else:
-			synthConf = speechConf[self._synth.name]
 
 	@Service.exposed
 	def registerSynthIndexReachedNotification(self, callback: Callable[[int], Any]):
@@ -203,7 +197,10 @@ class SynthDriverService(Service):
 		setattr(self._synth, param, val)
 		# Update local config
 		# So synthCommands can use current defaults.
-		synthConf = config.conf["speech"][self._synth.name]
+		speechConf = config.conf["speech"]
+		if self._synth.name not in speechConf:
+			synthConf = speechConf[self._synth.name] = {}
+		synthConf = speechConf[self._synth.name]
 		if param == "voice":
 			for setting in self._synth.supportedSettings:
 				synthConf[setting.id] = getattr(self._synth, setting.id)

--- a/source/_bridge/components/services/synthDriver.py
+++ b/source/_bridge/components/services/synthDriver.py
@@ -52,12 +52,6 @@ class SynthDriverService(Service):
 			synthConf = speechConf[self._synth.name] = {}
 		else:
 			synthConf = speechConf[self._synth.name]
-		if "pitch" not in synthConf:
-			synthConf["pitch"] = self._synth.pitch
-		if "rate" not in synthConf:
-			synthConf["rate"] = self._synth.rate
-		if "volume" not in synthConf:
-			synthConf["volume"] = self._synth.volume
 
 	@Service.exposed
 	def registerSynthIndexReachedNotification(self, callback: Callable[[int], Any]):
@@ -210,7 +204,11 @@ class SynthDriverService(Service):
 		# Update local config
 		# So synthCommands can use current defaults.
 		synthConf = config.conf["speech"][self._synth.name]
-		synthConf[param] = val
+		if param == "voice":
+			for setting in self._synth.supportedSettings:
+				synthConf[setting.id] = getattr(self._synth, setting.id)
+		else:
+			synthConf[param] = val
 
 	def terminate(self):
 		if self._synthIndexReachedCallback:

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -101,6 +101,7 @@ The setting is disabled by default. (#20013, @LeonarddeR)
 * Speech dictionary entries of type Whole word now correctly handle words containing Unicode combining marks (e.g. Hebrew niqqud, Arabic harakat). (#20013, @LeonarddeR)
   * In particular, Whole word entries no longer incorrectly match inside larger words when those words contain combining marks.
 * Fixed a case which could cause NVDA to freeze while reading math in braille. (#20319, @AAClause)
+* NVDA no longer fails to load sapi4 voices that do not support pitch, rate or volume. (#20302)
 
 ### Changes for Developers
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
<!-- Use Closes/Fixes/Resolves #xxx to link this PR to the issue it is responding to. -->
Fixes #20302

### Summary of the issue:
Some SAPI4 voices cannot be loaded by NvDA's 32 bit synthDriver host if they don't support pitch, rate or volume.

### Description of user facing changes:
NvDA no longer fails to load sapi4 voices that do not support pitch, rate or volume.

### Description of developer facing changes:

### Description of development approach:
* _bridge's synthDriver service: no longer specifically fetch and store config for pitch, rate and volume when initializing. Rather, do this in setParam. If the voice is being set, then store all supported params after the param is set.

### Testing strategy:
* Locally tested  a sapi4 voice that did not support pitch.
* [x] Verify issue author can use their particular sapi4 voice.

### Known issues with pull request:
None known.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
