### PR TITLE
configuration profiles dialog. Added context menu and shortcuts for profiles

### DIFF
--- a/source/gui/configProfiles.py
+++ b/source/gui/configProfiles.py
@@ -53,6 +53,8 @@ class ProfilesDialog(
 		)
 		self.bindHelpEvent("ProfilesBasicManagement", self.profileList)
 		item.Bind(wx.EVT_LISTBOX, self.onProfileListChoice)
+		self.profileList.Bind(wx.EVT_CONTEXT_MENU, self.onContextMenu)
+		self.profileList.Bind(wx.EVT_CHAR_HOOK, self.onCharHook)
 		item.Selection = self.profileNames.index(config.conf.profiles[-1].name)
 		changeProfilesSizer.Add(item, proportion=1)
 
@@ -165,6 +167,40 @@ class ProfilesDialog(
 		except KeyError:
 			return False
 		return profile.manual
+
+	def onCharHook(self, evt):
+		key = evt.GetKeyCode()
+		sel = self.profileList.Selection
+		if key == wx.WXK_F2 and sel > 0:
+			self.onRename(None)
+		elif key == wx.WXK_DELETE and sel > 0:
+			self.onDelete(None)
+		else:
+			evt.Skip()
+
+	def onContextMenu(self, evt):
+		menu = wx.Menu()
+		# Translators: Context menu item label to add new profile
+		newItem = menu.Append(wx.ID_ANY, _("&New"))
+		# Translators: Context menu item label to open triggers dialog
+		triggersItem = menu.Append(wx.ID_ANY, _("&Triggers..."))
+		self.Bind(wx.EVT_MENU, self.onNew, newItem)
+		self.Bind(wx.EVT_MENU, self.onTriggers, triggersItem)
+		sel = self.profileList.Selection
+		if sel > 0:
+			name = self.profileNames[sel]
+			# Translators: Context menu item label to manual activate or deactivate a profile
+			label = _("Manual deactivate") if self.isProfileManual(name) else _("Manual activate")
+			stateItem = menu.Append(wx.ID_ANY, label)
+			# Translators: Context menu item label to rename a profile
+			renameItem = menu.Append(wx.ID_ANY, _("&Rename"))
+			# Translators: Context menu item label to delete a profile
+			deleteItem = menu.Append(wx.ID_ANY, _("&Delete"))
+			self.Bind(wx.EVT_MENU, self.onChangeState, stateItem)
+			self.Bind(wx.EVT_MENU, self.onRename, renameItem)
+			self.Bind(wx.EVT_MENU, self.onDelete, deleteItem)
+		self.PopupMenu(menu)
+		menu.Destroy()
 
 	def onChangeState(self, evt):
 		sel = self.profileList.Selection

--- a/source/gui/configProfiles.py
+++ b/source/gui/configProfiles.py
@@ -190,9 +190,9 @@ class ProfilesDialog(
 		if sel > 0:
 			name = self.profileNames[sel]
 			# Translators: Context menu item label to manually deactivate a profile.
-			labelDeactivate = _("Manual deactivate")
+			labelDeactivate = _("Deactivate")
 			# Translators: Context menu item label to manually activate a profile.
-			labelActivate = _("Manual activate")
+			labelActivate = _("Activate")
 			label = labelDeactivate if self.isProfileManual(name) else labelActivate
 			stateItem = menu.Append(wx.ID_ANY, label)
 			# Translators: Context menu item label to rename a profile

--- a/source/gui/configProfiles.py
+++ b/source/gui/configProfiles.py
@@ -190,9 +190,9 @@ class ProfilesDialog(
 		if sel > 0:
 			name = self.profileNames[sel]
 			# Translators: Context menu item label to manually deactivate a profile.
-			labelDeactivate = _("Deactivate")
+			labelDeactivate = _("Manual deactivate")
 			# Translators: Context menu item label to manually activate a profile.
-			labelActivate = _("Activate")
+			labelActivate = _("Manual activate")
 			label = labelDeactivate if self.isProfileManual(name) else labelActivate
 			stateItem = menu.Append(wx.ID_ANY, label)
 			# Translators: Context menu item label to rename a profile

--- a/source/gui/configProfiles.py
+++ b/source/gui/configProfiles.py
@@ -168,7 +168,7 @@ class ProfilesDialog(
 			return False
 		return profile.manual
 
-	def onCharHook(self, evt):
+	def onCharHook(self, evt: wx.KeyEvent):
 		key = evt.GetKeyCode()
 		sel = self.profileList.Selection
 		if key == wx.WXK_F2 and sel > 0:
@@ -178,7 +178,7 @@ class ProfilesDialog(
 		else:
 			evt.Skip()
 
-	def onContextMenu(self, evt):
+	def onContextMenu(self, evt: wx.ContextMenuEvent):
 		menu = wx.Menu()
 		# Translators: Context menu item label to add new profile
 		newItem = menu.Append(wx.ID_ANY, _("&New"))
@@ -189,8 +189,11 @@ class ProfilesDialog(
 		sel = self.profileList.Selection
 		if sel > 0:
 			name = self.profileNames[sel]
-			# Translators: Context menu item label to manual activate or deactivate a profile
-			label = _("Manual deactivate") if self.isProfileManual(name) else _("Manual activate")
+			# Translators: Context menu item label to manually deactivate a profile.
+			labelDeactivate = _("Manual deactivate")
+			# Translators: Context menu item label to manually activate a profile.
+			labelActivate = _("Manual activate")
+			label = labelDeactivate if self.isProfileManual(name) else labelActivate
 			stateItem = menu.Append(wx.ID_ANY, label)
 			# Translators: Context menu item label to rename a profile
 			renameItem = menu.Append(wx.ID_ANY, _("&Rename"))

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -17,6 +17,7 @@
 * The braille "word wrap" option has been replaced with a four-valued "Text wrap" option: Off, Show mark when words are cut, At word boundaries, and At word or syllable boundaries. (#17010, @LeonarddeR)
   * In modes that show a continuation mark, when a word is cut across rows, the last cell of the row now shows a continuation mark (braille dots 7-8) so it is clear that the word continues on the next row.
   * The "At word or syllable boundaries" option uses hyphenation dictionaries to split long words at syllable boundaries when they do not fit on the display.
+* Added context menu and shortcuts to configuration profiles dialog. (#18169, @amirmahdifard)
 * Magnifier: A new unassigned command has been added to move the mouse cursor to the center of the magnified view. (#20127, @CyrilleB79)
 
 ### Changes

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -4447,8 +4447,8 @@ Additional information is also shown for active profiles, indicating whether the
 
 To rename or delete a profile, press the Rename or Delete buttons, respectively.
 
-You can also manage profiles by opening the context menu on a profile in the list to Rename or Delete it.
-Additionally, you can press F2 to rename the selected profile or Delete to remove it.
+You can also manage profiles by opening the context menu on a profile in the list to rename or delete it.
+Additionally, you can press `f2` to rename the selected profile or `delete` to remove it.
 
 Press the Close button to close the dialog.
 

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -4447,7 +4447,8 @@ Additional information is also shown for active profiles, indicating whether the
 
 To rename or delete a profile, press the Rename or Delete buttons, respectively.
 
-You can also manage profiles by opening the context menu on a profile in the list  to Rename or Delete it. Additionally, you can press F2 to rename the selected profile or Delete to remove it.
+You can also manage profiles by opening the context menu on a profile in the list to Rename or Delete it.
+Additionally, you can press F2 to rename the selected profile or Delete to remove it.
 
 Press the Close button to close the dialog.
 

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -4447,6 +4447,8 @@ Additional information is also shown for active profiles, indicating whether the
 
 To rename or delete a profile, press the Rename or Delete buttons, respectively.
 
+You can also manage profiles by opening the context menu on a profile in the list  to Rename or Delete it. Additionally, you can press F2 to rename the selected profile or Delete to remove it.
+
 Press the Close button to close the dialog.
 
 #### Creating a Profile {#ProfilesCreating}


### PR DESCRIPTION
### Link to issue number:
fixes https://github.com/nvaccess/nvda/issues/18169
### Summary of the issue:
The configuration dialog was not supporting a context menu and shortcuts. When I Opened the issue, feedback suggestions came from users regarding the shortcuts (f2 to rename), (delete to delete) useful shortcuts
### Description of user facing changes:
A context menu has been added to the profiles list of configuration profiles dialog and also shortcuts, focusing a profile, press f2 to rename the profile, and delete to delete the profile
### Description of developer facing changes:
none
### Description of development approach:
Added a on context menu method contaning actions and statements regarding taking care of profile actions are not available for normal configuration profile, and also added a charhook method, and bound them to the profiles list.
### Testing strategy:
manual testing. Tested The configuration profiles dialog with the folowing. Tested that the context menu works, the actions inside it are all correctly working and bound to the existing methods. Same for onCharhook. Made sure that shortcuts are correctly working and bound to the existing rename and delete profiles method.
### Known issues with pull request:
none
### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
