### PR TITLE
Dedicated mouse hook 

### DIFF
--- a/source/_magnifier/magnifier.py
+++ b/source/_magnifier/magnifier.py
@@ -61,6 +61,8 @@ class Magnifier:
 		self._consecutiveErrors: int = 0
 		self._recoveryAttempts: int = 0
 		self._mouseHook: MagnifierMouseHook | None = None
+		self._pendingMouseCoordinates = Coordinates(0, 0)
+		self._mouseUpdatePending: bool = False
 		# Register for display changes
 		_displayTracking.displayChanged.register(self._onDisplayChanged)
 		self._screenCurtainIsActive: bool = False
@@ -254,16 +256,37 @@ class Magnifier:
 
 	def _onMouseMove(self, x: int, y: int) -> None:
 		"""
-		Called from the hook thread on every WM_MOUSEMOVE.
-		Updates the magnified view immediately, bypassing the wx timer loop.
+		Called from the mouse hook thread on every WM_MOUSEMOVE.
+
+		This runs synchronously inside a global WH_MOUSE_LL hook chain, so it must
+		return immediately: it only records the latest coordinates and schedules
+		the actual update on the main thread. Calling into the Magnification API
+		(via _doUpdate) from here would delay delivery of the real WM_MOUSEMOVE to
+		whatever window is under the cursor, for every mouse move on the system,
+		not just NVDA's own windows.
+
 		Only acts when mouse tracking is enabled and the magnifier is active.
 		"""
 		if not self._isActive or self._isManualPanning:
 			return
 		if not getFollowState(MagnifierTrackingType.MOUSE):
 			return
+		self._pendingMouseCoordinates = Coordinates(x, y)
+		if not self._mouseUpdatePending:
+			self._mouseUpdatePending = True
+			wx.CallAfter(self._applyPendingMousePosition)
+
+	def _applyPendingMousePosition(self) -> None:
+		"""
+		Apply the latest mouse position recorded by _onMouseMove.
+		Runs on the main thread via wx.CallAfter, so this is the only place
+		where a mouse-driven update touches the Magnification API.
+		"""
+		self._mouseUpdatePending = False
+		if not self._isActive or self._isManualPanning:
+			return
 		try:
-			self.currentCoordinates = Coordinates(x, y)
+			self.currentCoordinates = self._pendingMouseCoordinates
 			self._doUpdate()
 		except OSError:
 			pass

--- a/source/_magnifier/magnifier.py
+++ b/source/_magnifier/magnifier.py
@@ -21,11 +21,13 @@ from .utils.types import (
 	MagnifierParameters,
 	MagnifierAction,
 	MagnifiedView,
+	MagnifierTrackingType,
 	Direction,
 	Filter,
 	Coordinates,
 )
 from .config import (
+	getFollowState,
 	getZoomLevel,
 	getPanStep,
 	getFilter,
@@ -35,6 +37,7 @@ from .config import (
 	_isDebug,
 )
 from .utils.focusManager import FocusManager
+from .utils.mouseHook import MagnifierMouseHook
 
 
 class Magnifier:
@@ -57,6 +60,7 @@ class Magnifier:
 		self._isManualPanning: bool = False
 		self._consecutiveErrors: int = 0
 		self._recoveryAttempts: int = 0
+		self._mouseHook: MagnifierMouseHook | None = None
 		# Register for display changes
 		_displayTracking.displayChanged.register(self._onDisplayChanged)
 		self._screenCurtainIsActive: bool = False
@@ -184,6 +188,8 @@ class Magnifier:
 
 		self._isActive = True
 		self.currentCoordinates = self._focusManager.getCurrentFocusCoordinates()
+		self._mouseHook = MagnifierMouseHook(self._onMouseMove)
+		self._mouseHook.start()
 
 	def _updateMagnifier(self) -> None:
 		"""
@@ -246,12 +252,31 @@ class Magnifier:
 		self._consecutiveErrors = 0
 		self._startTimer(self._updateMagnifier)
 
+	def _onMouseMove(self, x: int, y: int) -> None:
+		"""
+		Called from the hook thread on every WM_MOUSEMOVE.
+		Updates the magnified view immediately, bypassing the wx timer loop.
+		Only acts when mouse tracking is enabled and the magnifier is active.
+		"""
+		if not self._isActive or self._isManualPanning:
+			return
+		if not getFollowState(MagnifierTrackingType.MOUSE):
+			return
+		try:
+			self.currentCoordinates = Coordinates(x, y)
+			self._doUpdate()
+		except OSError:
+			pass
+
 	def _stopMagnifier(self) -> None:
 		"""
 		Stop the magnifier
 		"""
 		if not self._isActive:
 			return
+		if self._mouseHook:
+			self._mouseHook.stop()
+			self._mouseHook = None
 		self._stopTimer()
 		self._isActive = False
 		# Unregister from display changes

--- a/source/_magnifier/utils/mouseHook.py
+++ b/source/_magnifier/utils/mouseHook.py
@@ -20,6 +20,7 @@ from winInputHook import MSLLHOOKSTRUCT, HC_ACTION, WH_MOUSE_LL
 
 WM_MOUSEMOVE: int = 0x0200
 WM_QUIT: int = 0x0012
+PM_NOREMOVE: int = 0x0000
 
 
 class MagnifierMouseHook:
@@ -38,13 +39,23 @@ class MagnifierMouseHook:
 		self._hookReady.wait(timeout=1.0)
 
 	def stop(self) -> None:
-		if self._thread:
-			user32.PostThreadMessage(self._thread.ident, WM_QUIT, 0, 0)
-			self._thread.join(timeout=1.0)
-			self._thread = None
+		thread = self._thread
+		if not thread:
+			self._cCallback = None
+			return
+		if thread.ident is None or not user32.PostThreadMessage(thread.ident, WM_QUIT, 0, 0):
+			log.error(
+				f"Failed to post WM_QUIT to magnifier mouse hook thread (error {ctypes.GetLastError()})",
+			)
+		thread.join()
+		self._thread = None
 		self._cCallback = None
 
 	def _run(self) -> None:
+		windowsMessage = MSG()
+		# Ensure the thread message queue exists so PostThreadMessage(WM_QUIT) succeeds.
+		user32.PeekMessage(byref(windowsMessage), None, 0, 0, PM_NOREMOVE)
+
 		def _onRawMouseEvent(code, eventType, mouseDataPointer):
 			if code == HC_ACTION and eventType == WM_MOUSEMOVE:
 				mouseData = MSLLHOOKSTRUCT.from_address(mouseDataPointer)
@@ -62,8 +73,15 @@ class MagnifierMouseHook:
 			log.error(f"Failed to install magnifier mouse hook (error {ctypes.GetLastError()})")
 			return
 
-		windowsMessage = MSG()
-		while user32.GetMessage(byref(windowsMessage), None, 0, 0):
-			pass
-
-		user32.UnhookWindowsHookEx(hookHandle)
+		try:
+			while True:
+				result = user32.GetMessage(byref(windowsMessage), None, 0, 0)
+				if result == 0:
+					break
+				if result == -1:
+					log.error(
+						f"GetMessage failed in magnifier mouse hook thread (error {ctypes.GetLastError()})",
+					)
+					break
+		finally:
+			user32.UnhookWindowsHookEx(hookHandle)

--- a/source/_magnifier/utils/mouseHook.py
+++ b/source/_magnifier/utils/mouseHook.py
@@ -24,7 +24,14 @@ PM_NOREMOVE: int = 0x0000
 
 
 class MagnifierMouseHook:
-	"""Installs a WH_MOUSE_LL hook in a dedicated thread. Calls onMouseMove(x, y) on every mouse move."""
+	"""Installs a WH_MOUSE_LL hook in a dedicated thread. Calls onMouseMove(x, y) on every mouse move.
+
+	WH_MOUSE_LL is a global hook: it runs for every mouse move on the system, and
+	delivery of the real WM_MOUSEMOVE to the window under the cursor waits for the
+	whole hook chain to return. onMouseMove must therefore return immediately (no
+	Magnification API calls, no blocking work) — defer any real work to another
+	thread, e.g. via wx.CallAfter.
+	"""
 
 	def __init__(self, onMouseMove):
 		self._onMouseMove = onMouseMove

--- a/source/_magnifier/utils/mouseHook.py
+++ b/source/_magnifier/utils/mouseHook.py
@@ -18,8 +18,8 @@ from logHandler import log
 from winBindings import user32
 from winInputHook import MSLLHOOKSTRUCT, HC_ACTION, WH_MOUSE_LL
 
-WM_MOUSEMOVE: int = 0x0200  # the mouse moved
-_WM_QUIT: int = 0x0012  # stop the message loop (sent by stop())
+WM_MOUSEMOVE: int = 0x0200
+WM_QUIT: int = 0x0012
 
 
 class MagnifierMouseHook:
@@ -30,16 +30,16 @@ class MagnifierMouseHook:
 		self._thread: threading.Thread | None = None
 		self._cCallback = None  # kept alive to prevent GC of the ctypes callback
 		self._hookReady = threading.Event()
+		self._hookInstalled: bool = False
 
 	def start(self) -> None:
-		self._hookReady.clear()
 		self._thread = threading.Thread(target=self._run, name="magnifierMouseHook", daemon=True)
 		self._thread.start()
 		self._hookReady.wait(timeout=1.0)
 
 	def stop(self) -> None:
 		if self._thread:
-			user32.PostThreadMessage(self._thread.ident, _WM_QUIT, 0, 0)
+			user32.PostThreadMessage(self._thread.ident, WM_QUIT, 0, 0)
 			self._thread.join(timeout=1.0)
 			self._thread = None
 		self._cCallback = None
@@ -56,13 +56,14 @@ class MagnifierMouseHook:
 
 		self._cCallback = user32.HOOKPROC(_onRawMouseEvent)
 		hookHandle = user32.SetWindowsHookEx(WH_MOUSE_LL, self._cCallback, None, 0)
+		self._hookInstalled = bool(hookHandle)
+		self._hookReady.set()
 		if not hookHandle:
 			log.error(f"Failed to install magnifier mouse hook (error {ctypes.GetLastError()})")
-		self._hookReady.set()
+			return
 
 		windowsMessage = MSG()
 		while user32.GetMessage(byref(windowsMessage), None, 0, 0):
 			pass
 
-		if hookHandle:
-			user32.UnhookWindowsHookEx(hookHandle)
+		user32.UnhookWindowsHookEx(hookHandle)

--- a/source/_magnifier/utils/mouseHook.py
+++ b/source/_magnifier/utils/mouseHook.py
@@ -12,6 +12,7 @@ the DPI-related lag compared to the built-in Windows Magnifier.
 
 import ctypes
 import threading
+from collections.abc import Callable
 from ctypes import byref
 from ctypes.wintypes import MSG
 from logHandler import log
@@ -33,7 +34,7 @@ class MagnifierMouseHook:
 	thread, e.g. via wx.CallAfter.
 	"""
 
-	def __init__(self, onMouseMove):
+	def __init__(self, onMouseMove: Callable[[int, int], None]):
 		self._onMouseMove = onMouseMove
 		self._thread: threading.Thread | None = None
 		self._cCallback = None  # kept alive to prevent GC of the ctypes callback
@@ -58,21 +59,21 @@ class MagnifierMouseHook:
 		self._thread = None
 		self._cCallback = None
 
+	def _onRawMouseEvent(self, code: int, eventType: int, mouseDataPointer: int) -> int:
+		if code == HC_ACTION and eventType == WM_MOUSEMOVE:
+			mouseData = MSLLHOOKSTRUCT.from_address(mouseDataPointer)
+			try:
+				self._onMouseMove(mouseData.pt.x, mouseData.pt.y)
+			except Exception:
+				log.exception("Error in magnifier mouse hook callback")
+		return user32.CallNextHookEx(0, code, eventType, mouseDataPointer)
+
 	def _run(self) -> None:
 		windowsMessage = MSG()
 		# Ensure the thread message queue exists so PostThreadMessage(WM_QUIT) succeeds.
 		user32.PeekMessage(byref(windowsMessage), None, 0, 0, PM_NOREMOVE)
 
-		def _onRawMouseEvent(code, eventType, mouseDataPointer):
-			if code == HC_ACTION and eventType == WM_MOUSEMOVE:
-				mouseData = MSLLHOOKSTRUCT.from_address(mouseDataPointer)
-				try:
-					self._onMouseMove(mouseData.pt.x, mouseData.pt.y)
-				except Exception:
-					log.exception("Error in magnifier mouse hook callback")
-			return user32.CallNextHookEx(0, code, eventType, mouseDataPointer)
-
-		self._cCallback = user32.HOOKPROC(_onRawMouseEvent)
+		self._cCallback = user32.HOOKPROC(self._onRawMouseEvent)
 		hookHandle = user32.SetWindowsHookEx(WH_MOUSE_LL, self._cCallback, None, 0)
 		self._hookInstalled = bool(hookHandle)
 		self._hookReady.set()

--- a/source/_magnifier/utils/mouseHook.py
+++ b/source/_magnifier/utils/mouseHook.py
@@ -7,7 +7,7 @@
 
 Runs in its own thread so it stays responsive even when the wx main thread is
 busy (e.g. at high Windows display scale factors), which is the root cause of
-the DPI-related smoothness regression compared to the built-in Windows Magnifier.
+the DPI-related lag compared to the built-in Windows Magnifier.
 """
 
 import ctypes
@@ -15,75 +15,53 @@ import threading
 from ctypes import byref
 from ctypes.wintypes import MSG
 from logHandler import log
-from winBindings import user32, kernel32
+from winBindings import user32
 from winInputHook import MSLLHOOKSTRUCT, HC_ACTION, WH_MOUSE_LL
 
-WM_MOUSEMOVE: int = 0x0200
-_WM_QUIT: int = 0x0012
+WM_MOUSEMOVE: int = 0x0200  # the mouse moved
+_WM_QUIT: int = 0x0012  # stop the message loop (sent by stop())
 
 
 class MagnifierMouseHook:
-	"""
-	Installs a WH_MOUSE_LL hook in a dedicated thread with its own message pump.
-	Calls onMouseMove(x, y) for every WM_MOUSEMOVE event.
-
-	The dedicated thread keeps mouse tracking independent of wx main-thread load.
-	"""
+	"""Installs a WH_MOUSE_LL hook in a dedicated thread. Calls onMouseMove(x, y) on every mouse move."""
 
 	def __init__(self, onMouseMove):
 		self._onMouseMove = onMouseMove
 		self._thread: threading.Thread | None = None
-		self._threadId: int | None = None
-		self._hookProc = None  # must be kept alive to prevent GC of ctypes callback
-		self._ready = threading.Event()
+		self._cCallback = None  # kept alive to prevent GC of the ctypes callback
+		self._hookReady = threading.Event()
 
 	def start(self) -> None:
-		self._ready.clear()
-		self._thread = threading.Thread(
-			target=self._run,
-			name="magnifierMouseHook",
-			daemon=True,
-		)
+		self._hookReady.clear()
+		self._thread = threading.Thread(target=self._run, name="magnifierMouseHook", daemon=True)
 		self._thread.start()
-		self._ready.wait(timeout=1.0)
+		self._hookReady.wait(timeout=1.0)
 
 	def stop(self) -> None:
-		if self._threadId:
-			user32.PostThreadMessage(self._threadId, _WM_QUIT, 0, 0)
-			self._threadId = None
 		if self._thread:
+			user32.PostThreadMessage(self._thread.ident, _WM_QUIT, 0, 0)
 			self._thread.join(timeout=1.0)
 			self._thread = None
-		self._hookProc = None
+		self._cCallback = None
 
 	def _run(self) -> None:
-		self._threadId = ctypes.windll.kernel32.GetCurrentThreadId()
-
-		def _hookFunc(code, wParam, lParam):
-			if code == HC_ACTION and wParam == WM_MOUSEMOVE:
-				msll = MSLLHOOKSTRUCT.from_address(lParam)
+		def _onRawMouseEvent(code, eventType, mouseDataPointer):
+			if code == HC_ACTION and eventType == WM_MOUSEMOVE:
+				mouseData = MSLLHOOKSTRUCT.from_address(mouseDataPointer)
 				try:
-					self._onMouseMove(msll.pt.x, msll.pt.y)
+					self._onMouseMove(mouseData.pt.x, mouseData.pt.y)
 				except Exception:
 					log.exception("Error in magnifier mouse hook callback")
-			return user32.CallNextHookEx(0, code, wParam, lParam)
+			return user32.CallNextHookEx(0, code, eventType, mouseDataPointer)
 
-		self._hookProc = user32.HOOKPROC(_hookFunc)
-
-		hookHandle = user32.SetWindowsHookEx(
-			WH_MOUSE_LL,
-			self._hookProc,
-			kernel32.GetModuleHandle(None),
-			0,
-		)
-
+		self._cCallback = user32.HOOKPROC(_onRawMouseEvent)
+		hookHandle = user32.SetWindowsHookEx(WH_MOUSE_LL, self._cCallback, None, 0)
 		if not hookHandle:
 			log.error(f"Failed to install magnifier mouse hook (error {ctypes.GetLastError()})")
+		self._hookReady.set()
 
-		self._ready.set()
-
-		msg = MSG()
-		while user32.GetMessage(byref(msg), None, 0, 0):
+		windowsMessage = MSG()
+		while user32.GetMessage(byref(windowsMessage), None, 0, 0):
 			pass
 
 		if hookHandle:

--- a/source/_magnifier/utils/mouseHook.py
+++ b/source/_magnifier/utils/mouseHook.py
@@ -1,0 +1,90 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2026 NV Access Limited, Antoine Haffreingue
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
+
+"""Dedicated low-level mouse hook for the magnifier.
+
+Runs in its own thread so it stays responsive even when the wx main thread is
+busy (e.g. at high Windows display scale factors), which is the root cause of
+the DPI-related smoothness regression compared to the built-in Windows Magnifier.
+"""
+
+import ctypes
+import threading
+from ctypes import byref
+from ctypes.wintypes import MSG
+from logHandler import log
+from winBindings import user32, kernel32
+from winInputHook import MSLLHOOKSTRUCT, HC_ACTION, WH_MOUSE_LL
+
+WM_MOUSEMOVE: int = 0x0200
+_WM_QUIT: int = 0x0012
+
+
+class MagnifierMouseHook:
+	"""
+	Installs a WH_MOUSE_LL hook in a dedicated thread with its own message pump.
+	Calls onMouseMove(x, y) for every WM_MOUSEMOVE event.
+
+	The dedicated thread keeps mouse tracking independent of wx main-thread load.
+	"""
+
+	def __init__(self, onMouseMove):
+		self._onMouseMove = onMouseMove
+		self._thread: threading.Thread | None = None
+		self._threadId: int | None = None
+		self._hookProc = None  # must be kept alive to prevent GC of ctypes callback
+		self._ready = threading.Event()
+
+	def start(self) -> None:
+		self._ready.clear()
+		self._thread = threading.Thread(
+			target=self._run,
+			name="magnifierMouseHook",
+			daemon=True,
+		)
+		self._thread.start()
+		self._ready.wait(timeout=1.0)
+
+	def stop(self) -> None:
+		if self._threadId:
+			user32.PostThreadMessage(self._threadId, _WM_QUIT, 0, 0)
+			self._threadId = None
+		if self._thread:
+			self._thread.join(timeout=1.0)
+			self._thread = None
+		self._hookProc = None
+
+	def _run(self) -> None:
+		self._threadId = ctypes.windll.kernel32.GetCurrentThreadId()
+
+		def _hookFunc(code, wParam, lParam):
+			if code == HC_ACTION and wParam == WM_MOUSEMOVE:
+				msll = MSLLHOOKSTRUCT.from_address(lParam)
+				try:
+					self._onMouseMove(msll.pt.x, msll.pt.y)
+				except Exception:
+					log.exception("Error in magnifier mouse hook callback")
+			return user32.CallNextHookEx(0, code, wParam, lParam)
+
+		self._hookProc = user32.HOOKPROC(_hookFunc)
+
+		hookHandle = user32.SetWindowsHookEx(
+			WH_MOUSE_LL,
+			self._hookProc,
+			kernel32.GetModuleHandle(None),
+			0,
+		)
+
+		if not hookHandle:
+			log.error(f"Failed to install magnifier mouse hook (error {ctypes.GetLastError()})")
+
+		self._ready.set()
+
+		msg = MSG()
+		while user32.GetMessage(byref(msg), None, 0, 0):
+			pass
+
+		if hookHandle:
+			user32.UnhookWindowsHookEx(hookHandle)

--- a/tests/unit/test_magnifier/test_magnifier.py
+++ b/tests/unit/test_magnifier/test_magnifier.py
@@ -33,9 +33,14 @@ class _TestMagnifier(unittest.TestCase):
 			mock.MagUninitialize.return_value = True
 			mock.MagSetFullscreenTransform.return_value = True
 			mock.MagSetFullscreenColorEffect.return_value = True
+		self.mouseHook_patcher = patch("_magnifier.magnifier.MagnifierMouseHook")
+		self.MockMouseHook = self.mouseHook_patcher.start()
+		self.mock_hook_instance = MagicMock()
+		self.MockMouseHook.return_value = self.mock_hook_instance
 
 	def tearDown(self):
 		"""Cleanup after each test."""
+		self.mouseHook_patcher.stop()
 		self.mag_fs_patcher.stop()
 		self.mag_patcher.stop()
 

--- a/tests/unit/test_magnifier/test_magnifier.py
+++ b/tests/unit/test_magnifier/test_magnifier.py
@@ -40,6 +40,13 @@ class _TestMagnifier(unittest.TestCase):
 
 	def tearDown(self):
 		"""Cleanup after each test."""
+		magnifier = getattr(self, "magnifier", None)
+		if magnifier is not None:
+			if getattr(magnifier, "_timer", None):
+				magnifier._timer.Stop()
+				magnifier._timer = None
+			if getattr(magnifier, "_isActive", False):
+				magnifier._isActive = False
 		self.mouseHook_patcher.stop()
 		self.mag_fs_patcher.stop()
 		self.mag_patcher.stop()
@@ -49,25 +56,21 @@ class TestMagnifier(_TestMagnifier):
 	"""Tests for the Magnifier class."""
 
 	def setUp(self):
-		"""Setup before each test."""
 		super().setUp()
-
 		self.magnifier = Magnifier()
-		self.magnifier.zoomLevel = 200  # Set a default zoom level for testing (2.0x)
-		self.magnifier.filterType = Filter.NORMAL  # Set a default filter type for testing
+		self.magnifier.zoomLevel = 200
+		self.magnifier.filterType = Filter.NORMAL
 		self.screenWidth = getPrimaryDisplayOrientation().width
 		self.screenHeight = getPrimaryDisplayOrientation().height
 
-	def tearDown(self):
-		"""Cleanup after each test."""
-		if hasattr(self.magnifier, "_timer") and self.magnifier._timer:
-			self.magnifier._timer.Stop()
-			self.magnifier._timer = None
-
-		if hasattr(self.magnifier, "_isActive") and self.magnifier._isActive:
-			self.magnifier._isActive = False
-
-		super().tearDown()
+	def _setUpUpdateError(self, side_effect=None, consecutiveErrors=0):
+		self.magnifier._isActive = True
+		self.magnifier._focusManager.getCurrentFocusCoordinates = MagicMock(
+			return_value=Coordinates(self.screenWidth // 2, self.screenHeight // 2),
+		)
+		self.magnifier._doUpdate = MagicMock(side_effect=side_effect)
+		self.magnifier._startTimer = MagicMock()
+		self.magnifier._consecutiveErrors = consecutiveErrors
 
 	def testMagnifierCreation(self):
 		"""Can we create a magnifier with valid parameters?"""
@@ -158,87 +161,38 @@ class TestMagnifier(_TestMagnifier):
 
 	def testUpdateMagnifierResumesAfterSingleError(self):
 		"""Timer must always be rescheduled even when _doUpdate raises an exception."""
-		self.magnifier._isActive = True
-		focusCoords = Coordinates(self.screenWidth // 2, self.screenHeight // 2)
-		self.magnifier._focusManager.getCurrentFocusCoordinates = MagicMock(
-			return_value=focusCoords,
-		)
-		self.magnifier._doUpdate = MagicMock(side_effect=OSError("COM failure"))
-		self.magnifier._startTimer = MagicMock()
-
+		self._setUpUpdateError(OSError("COM failure"))
 		self.magnifier._updateMagnifier()
-
-		# Timer must still be rescheduled despite the error
-		self.magnifier._startTimer.assert_called_once_with(
-			self.magnifier._updateMagnifier,
-		)
+		self.magnifier._startTimer.assert_called_once_with(self.magnifier._updateMagnifier)
 		self.assertEqual(self.magnifier._consecutiveErrors, 1)
 
 	def testUpdateMagnifierTriggersRecoveryAfterMaxErrors(self):
 		"""After _MAX_CONSECUTIVE_ERRORS failures, _attemptRecovery is called instead of restarting timer."""
-		self.magnifier._isActive = True
-		focusCoords = Coordinates(self.screenWidth // 2, self.screenHeight // 2)
-		self.magnifier._focusManager.getCurrentFocusCoordinates = MagicMock(
-			return_value=focusCoords,
-		)
-		self.magnifier._doUpdate = MagicMock(side_effect=OSError("COM failure"))
-		self.magnifier._startTimer = MagicMock()
+		self._setUpUpdateError(OSError("COM failure"), Magnifier._MAX_CONSECUTIVE_ERRORS - 1)
 		self.magnifier._attemptRecovery = MagicMock()
-
-		# Simulate reaching max errors
-		self.magnifier._consecutiveErrors = Magnifier._MAX_CONSECUTIVE_ERRORS - 1
 		self.magnifier._updateMagnifier()
-
-		# Recovery should be called, timer should NOT be rescheduled directly
 		self.magnifier._attemptRecovery.assert_called_once()
 		self.magnifier._startTimer.assert_not_called()
 
 	def testUpdateMagnifierCatchesCOMError(self):
 		"""COMError from UIA must be caught and the timer rescheduled."""
-		self.magnifier._isActive = True
-		focusCoords = Coordinates(self.screenWidth // 2, self.screenHeight // 2)
-		self.magnifier._focusManager.getCurrentFocusCoordinates = MagicMock(
-			return_value=focusCoords,
-		)
-		self.magnifier._doUpdate = MagicMock(side_effect=COMError(-2147417848, "RPC_E_DISCONNECTED", None))
-		self.magnifier._startTimer = MagicMock()
-
+		self._setUpUpdateError(COMError(-2147417848, "RPC_E_DISCONNECTED", None))
 		self.magnifier._updateMagnifier()
-
 		self.magnifier._startTimer.assert_called_once_with(self.magnifier._updateMagnifier)
 		self.assertEqual(self.magnifier._consecutiveErrors, 1)
 
 	def testUpdateMagnifierRecoveryFailureSafelyRestartsTimer(self):
 		"""If _attemptRecovery itself raises, the timer must still be restarted to prevent a freeze."""
-		self.magnifier._isActive = True
-		focusCoords = Coordinates(self.screenWidth // 2, self.screenHeight // 2)
-		self.magnifier._focusManager.getCurrentFocusCoordinates = MagicMock(
-			return_value=focusCoords,
-		)
-		self.magnifier._doUpdate = MagicMock(side_effect=OSError("API failure"))
-		self.magnifier._startTimer = MagicMock()
+		self._setUpUpdateError(OSError("API failure"), Magnifier._MAX_CONSECUTIVE_ERRORS - 1)
 		self.magnifier._attemptRecovery = MagicMock(side_effect=RuntimeError("recovery crashed"))
-
-		self.magnifier._consecutiveErrors = Magnifier._MAX_CONSECUTIVE_ERRORS - 1
 		self.magnifier._updateMagnifier()
-
-		# Timer must be restarted by the safety net even though recovery failed
 		self.magnifier._startTimer.assert_called_once_with(self.magnifier._updateMagnifier)
 		self.assertEqual(self.magnifier._consecutiveErrors, 0)
 
 	def testUpdateMagnifierResetsErrorCountOnSuccess(self):
 		"""A successful update after errors resets the consecutive error counter."""
-		self.magnifier._isActive = True
-		self.magnifier._consecutiveErrors = 2
-		focusCoords = Coordinates(self.screenWidth // 2, self.screenHeight // 2)
-		self.magnifier._focusManager.getCurrentFocusCoordinates = MagicMock(
-			return_value=focusCoords,
-		)
-		self.magnifier._doUpdate = MagicMock()  # Success
-		self.magnifier._startTimer = MagicMock()
-
+		self._setUpUpdateError(consecutiveErrors=2)
 		self.magnifier._updateMagnifier()
-
 		self.assertEqual(self.magnifier._consecutiveErrors, 0)
 		self.magnifier._startTimer.assert_called_once()
 
@@ -273,29 +227,6 @@ class TestMagnifier(_TestMagnifier):
 
 		self.magnifier._stopTimer.assert_called_once()
 		self.assertFalse(self.magnifier._isActive)
-
-	def testZoom(self):
-		"""zoom in and out with valid values and check boundaries."""
-		# Set initial zoom to 1.0 for predictable testing
-		self.magnifier.zoomLevel = 100
-
-		# Test zoom in
-		self.magnifier._zoom(Direction.IN)
-		self.assertEqual(self.magnifier.zoomLevel, 150)
-
-		# Test zoom out
-		self.magnifier._zoom(Direction.OUT)
-		self.assertEqual(self.magnifier.zoomLevel, 100)
-
-		# Test zoom in at maximum boundary
-		self.magnifier.zoomLevel = ZoomLevel.MAX_ZOOM
-		self.magnifier._zoom(Direction.IN)
-		self.assertEqual(self.magnifier.zoomLevel, ZoomLevel.MAX_ZOOM)  # Should remain at max
-
-		# Test zoom out at minimum boundary
-		self.magnifier.zoomLevel = ZoomLevel.MIN_ZOOM
-		self.magnifier._zoom(Direction.OUT)
-		self.assertEqual(self.magnifier.zoomLevel, ZoomLevel.MIN_ZOOM)  # Should remain at min
 
 	def _setupPanTest(self):
 		"""Common setup for pan tests."""

--- a/tests/unit/test_magnifier/test_magnifier.py
+++ b/tests/unit/test_magnifier/test_magnifier.py
@@ -33,21 +33,9 @@ class _TestMagnifier(unittest.TestCase):
 			mock.MagUninitialize.return_value = True
 			mock.MagSetFullscreenTransform.return_value = True
 			mock.MagSetFullscreenColorEffect.return_value = True
-		self.mouseHook_patcher = patch("_magnifier.magnifier.MagnifierMouseHook")
-		self.MockMouseHook = self.mouseHook_patcher.start()
-		self.mock_hook_instance = MagicMock()
-		self.MockMouseHook.return_value = self.mock_hook_instance
 
 	def tearDown(self):
 		"""Cleanup after each test."""
-		magnifier = getattr(self, "magnifier", None)
-		if magnifier is not None:
-			if getattr(magnifier, "_timer", None):
-				magnifier._timer.Stop()
-				magnifier._timer = None
-			if getattr(magnifier, "_isActive", False):
-				magnifier._isActive = False
-		self.mouseHook_patcher.stop()
 		self.mag_fs_patcher.stop()
 		self.mag_patcher.stop()
 
@@ -56,21 +44,25 @@ class TestMagnifier(_TestMagnifier):
 	"""Tests for the Magnifier class."""
 
 	def setUp(self):
+		"""Setup before each test."""
 		super().setUp()
+
 		self.magnifier = Magnifier()
-		self.magnifier.zoomLevel = 200
-		self.magnifier.filterType = Filter.NORMAL
+		self.magnifier.zoomLevel = 200  # Set a default zoom level for testing (2.0x)
+		self.magnifier.filterType = Filter.NORMAL  # Set a default filter type for testing
 		self.screenWidth = getPrimaryDisplayOrientation().width
 		self.screenHeight = getPrimaryDisplayOrientation().height
 
-	def _setUpUpdateError(self, side_effect=None, consecutiveErrors=0):
-		self.magnifier._isActive = True
-		self.magnifier._focusManager.getCurrentFocusCoordinates = MagicMock(
-			return_value=Coordinates(self.screenWidth // 2, self.screenHeight // 2),
-		)
-		self.magnifier._doUpdate = MagicMock(side_effect=side_effect)
-		self.magnifier._startTimer = MagicMock()
-		self.magnifier._consecutiveErrors = consecutiveErrors
+	def tearDown(self):
+		"""Cleanup after each test."""
+		if hasattr(self.magnifier, "_timer") and self.magnifier._timer:
+			self.magnifier._timer.Stop()
+			self.magnifier._timer = None
+
+		if hasattr(self.magnifier, "_isActive") and self.magnifier._isActive:
+			self.magnifier._isActive = False
+
+		super().tearDown()
 
 	def testMagnifierCreation(self):
 		"""Can we create a magnifier with valid parameters?"""
@@ -161,38 +153,87 @@ class TestMagnifier(_TestMagnifier):
 
 	def testUpdateMagnifierResumesAfterSingleError(self):
 		"""Timer must always be rescheduled even when _doUpdate raises an exception."""
-		self._setUpUpdateError(OSError("COM failure"))
+		self.magnifier._isActive = True
+		focusCoords = Coordinates(self.screenWidth // 2, self.screenHeight // 2)
+		self.magnifier._focusManager.getCurrentFocusCoordinates = MagicMock(
+			return_value=focusCoords,
+		)
+		self.magnifier._doUpdate = MagicMock(side_effect=OSError("COM failure"))
+		self.magnifier._startTimer = MagicMock()
+
 		self.magnifier._updateMagnifier()
-		self.magnifier._startTimer.assert_called_once_with(self.magnifier._updateMagnifier)
+
+		# Timer must still be rescheduled despite the error
+		self.magnifier._startTimer.assert_called_once_with(
+			self.magnifier._updateMagnifier,
+		)
 		self.assertEqual(self.magnifier._consecutiveErrors, 1)
 
 	def testUpdateMagnifierTriggersRecoveryAfterMaxErrors(self):
 		"""After _MAX_CONSECUTIVE_ERRORS failures, _attemptRecovery is called instead of restarting timer."""
-		self._setUpUpdateError(OSError("COM failure"), Magnifier._MAX_CONSECUTIVE_ERRORS - 1)
+		self.magnifier._isActive = True
+		focusCoords = Coordinates(self.screenWidth // 2, self.screenHeight // 2)
+		self.magnifier._focusManager.getCurrentFocusCoordinates = MagicMock(
+			return_value=focusCoords,
+		)
+		self.magnifier._doUpdate = MagicMock(side_effect=OSError("COM failure"))
+		self.magnifier._startTimer = MagicMock()
 		self.magnifier._attemptRecovery = MagicMock()
+
+		# Simulate reaching max errors
+		self.magnifier._consecutiveErrors = Magnifier._MAX_CONSECUTIVE_ERRORS - 1
 		self.magnifier._updateMagnifier()
+
+		# Recovery should be called, timer should NOT be rescheduled directly
 		self.magnifier._attemptRecovery.assert_called_once()
 		self.magnifier._startTimer.assert_not_called()
 
 	def testUpdateMagnifierCatchesCOMError(self):
 		"""COMError from UIA must be caught and the timer rescheduled."""
-		self._setUpUpdateError(COMError(-2147417848, "RPC_E_DISCONNECTED", None))
+		self.magnifier._isActive = True
+		focusCoords = Coordinates(self.screenWidth // 2, self.screenHeight // 2)
+		self.magnifier._focusManager.getCurrentFocusCoordinates = MagicMock(
+			return_value=focusCoords,
+		)
+		self.magnifier._doUpdate = MagicMock(side_effect=COMError(-2147417848, "RPC_E_DISCONNECTED", None))
+		self.magnifier._startTimer = MagicMock()
+
 		self.magnifier._updateMagnifier()
+
 		self.magnifier._startTimer.assert_called_once_with(self.magnifier._updateMagnifier)
 		self.assertEqual(self.magnifier._consecutiveErrors, 1)
 
 	def testUpdateMagnifierRecoveryFailureSafelyRestartsTimer(self):
 		"""If _attemptRecovery itself raises, the timer must still be restarted to prevent a freeze."""
-		self._setUpUpdateError(OSError("API failure"), Magnifier._MAX_CONSECUTIVE_ERRORS - 1)
+		self.magnifier._isActive = True
+		focusCoords = Coordinates(self.screenWidth // 2, self.screenHeight // 2)
+		self.magnifier._focusManager.getCurrentFocusCoordinates = MagicMock(
+			return_value=focusCoords,
+		)
+		self.magnifier._doUpdate = MagicMock(side_effect=OSError("API failure"))
+		self.magnifier._startTimer = MagicMock()
 		self.magnifier._attemptRecovery = MagicMock(side_effect=RuntimeError("recovery crashed"))
+
+		self.magnifier._consecutiveErrors = Magnifier._MAX_CONSECUTIVE_ERRORS - 1
 		self.magnifier._updateMagnifier()
+
+		# Timer must be restarted by the safety net even though recovery failed
 		self.magnifier._startTimer.assert_called_once_with(self.magnifier._updateMagnifier)
 		self.assertEqual(self.magnifier._consecutiveErrors, 0)
 
 	def testUpdateMagnifierResetsErrorCountOnSuccess(self):
 		"""A successful update after errors resets the consecutive error counter."""
-		self._setUpUpdateError(consecutiveErrors=2)
+		self.magnifier._isActive = True
+		self.magnifier._consecutiveErrors = 2
+		focusCoords = Coordinates(self.screenWidth // 2, self.screenHeight // 2)
+		self.magnifier._focusManager.getCurrentFocusCoordinates = MagicMock(
+			return_value=focusCoords,
+		)
+		self.magnifier._doUpdate = MagicMock()  # Success
+		self.magnifier._startTimer = MagicMock()
+
 		self.magnifier._updateMagnifier()
+
 		self.assertEqual(self.magnifier._consecutiveErrors, 0)
 		self.magnifier._startTimer.assert_called_once()
 
@@ -227,6 +268,29 @@ class TestMagnifier(_TestMagnifier):
 
 		self.magnifier._stopTimer.assert_called_once()
 		self.assertFalse(self.magnifier._isActive)
+
+	def testZoom(self):
+		"""zoom in and out with valid values and check boundaries."""
+		# Set initial zoom to 1.0 for predictable testing
+		self.magnifier.zoomLevel = 100
+
+		# Test zoom in
+		self.magnifier._zoom(Direction.IN)
+		self.assertEqual(self.magnifier.zoomLevel, 150)
+
+		# Test zoom out
+		self.magnifier._zoom(Direction.OUT)
+		self.assertEqual(self.magnifier.zoomLevel, 100)
+
+		# Test zoom in at maximum boundary
+		self.magnifier.zoomLevel = ZoomLevel.MAX_ZOOM
+		self.magnifier._zoom(Direction.IN)
+		self.assertEqual(self.magnifier.zoomLevel, ZoomLevel.MAX_ZOOM)  # Should remain at max
+
+		# Test zoom out at minimum boundary
+		self.magnifier.zoomLevel = ZoomLevel.MIN_ZOOM
+		self.magnifier._zoom(Direction.OUT)
+		self.assertEqual(self.magnifier.zoomLevel, ZoomLevel.MIN_ZOOM)  # Should remain at min
 
 	def _setupPanTest(self):
 		"""Common setup for pan tests."""

--- a/tests/unit/test_magnifier/test_mouseHook.py
+++ b/tests/unit/test_magnifier/test_mouseHook.py
@@ -33,17 +33,62 @@ class TestMouseHookLifecycle(_TestMagnifier):
 
 
 class TestOnMouseMove(_TestMagnifier):
-	"""Tests for FullScreenMagnifier._onMouseMove — the hook callback."""
+	"""Tests for FullScreenMagnifier._onMouseMove — the hook callback.
 
-	def testUpdatesMagnifier(self):
-		"""_onMouseMove updates currentCoordinates and calls _fullscreenMagnifier."""
+	_onMouseMove runs synchronously inside a global WH_MOUSE_LL hook chain (see
+	utils/mouseHook.py), so it must never call into the Magnification API directly:
+	doing so would delay delivery of the real WM_MOUSEMOVE to whatever window is
+	under the cursor, for every mouse move on the system. It should only record
+	the latest coordinates and defer the actual update to the main thread via
+	wx.CallAfter (_applyPendingMousePosition).
+	"""
+
+	def testDoesNotUpdateMagnifierSynchronously(self):
+		"""_onMouseMove must not touch the Magnification API from the hook thread."""
 		magnifier = FullScreenMagnifier()
 		magnifier._startMagnifier()
 		magnifier._fullscreenMagnifier = MagicMock()
 
-		with patch("_magnifier.magnifier.getFollowState", return_value=True):
+		with (
+			patch("_magnifier.magnifier.getFollowState", return_value=True),
+			patch("_magnifier.magnifier.wx.CallAfter"),
+		):
+			magnifier._onMouseMove(500, 400)
+
+		magnifier._fullscreenMagnifier.assert_not_called()
+		self.assertEqual(magnifier._pendingMouseCoordinates, Coordinates(500, 400))
+		magnifier._stopMagnifier()
+
+	def testSchedulesMainThreadUpdate(self):
+		"""_onMouseMove schedules exactly one wx.CallAfter, even for bursts of moves."""
+		magnifier = FullScreenMagnifier()
+		magnifier._startMagnifier()
+
+		with (
+			patch("_magnifier.magnifier.getFollowState", return_value=True),
+			patch("_magnifier.magnifier.wx.CallAfter") as mockCallAfter,
+		):
+			magnifier._onMouseMove(500, 400)
+			magnifier._onMouseMove(510, 410)
+			magnifier._onMouseMove(520, 420)
+
+		mockCallAfter.assert_called_once_with(magnifier._applyPendingMousePosition)
+		self.assertEqual(magnifier._pendingMouseCoordinates, Coordinates(520, 420))
+		magnifier._stopMagnifier()
+
+	def testApplyPendingMousePositionUpdatesMagnifier(self):
+		"""_applyPendingMousePosition (run on the main thread) performs the real update."""
+		magnifier = FullScreenMagnifier()
+		magnifier._startMagnifier()
+		magnifier._fullscreenMagnifier = MagicMock()
+
+		with (
+			patch("_magnifier.magnifier.getFollowState", return_value=True),
+			patch("_magnifier.magnifier.wx.CallAfter", side_effect=lambda func, *a, **kw: func(*a, **kw)),
+		):
 			magnifier._onMouseMove(500, 400)
 
 		magnifier._fullscreenMagnifier.assert_called_once()
 		self.assertEqual(magnifier.currentCoordinates, Coordinates(500, 400))
+		self.assertFalse(magnifier._mouseUpdatePending)
 		magnifier._stopMagnifier()

--- a/tests/unit/test_magnifier/test_mouseHook.py
+++ b/tests/unit/test_magnifier/test_mouseHook.py
@@ -5,6 +5,7 @@
 
 from unittest.mock import MagicMock, patch
 from _magnifier.fullscreenMagnifier import FullScreenMagnifier
+from _magnifier.utils.types import Coordinates
 from tests.unit.test_magnifier.test_magnifier import _TestMagnifier
 
 
@@ -45,67 +46,12 @@ class TestMouseHookLifecycle(_TestMagnifierWithHook):
 		self.mock_hook_instance.stop.assert_called_once()
 		self.assertIsNone(magnifier._mouseHook)
 
-	def testHookNotStartedIfAlreadyActive(self):
-		"""Calling _startMagnifier twice does not create a second hook."""
-		magnifier = FullScreenMagnifier()
-		magnifier._startMagnifier()
-		magnifier._startMagnifier()
-
-		self.assertEqual(self.MockMouseHook.call_count, 1)
-
-		magnifier._stopMagnifier()
-
-	def testHookNotStartedIfInitFails(self):
-		"""Hook is not left running when API initialisation fails."""
-		self.mock_mag_fs.MagInitialize.side_effect = OSError("init failed")
-
-		with patch("_magnifier.fullscreenMagnifier.ui.message"):
-			magnifier = FullScreenMagnifier()
-			magnifier._startMagnifier()
-
-		self.mock_hook_instance.stop.assert_called_once()
-		self.assertIsNone(magnifier._mouseHook)
-
 
 class TestOnMouseMove(_TestMagnifierWithHook):
 	"""Tests for FullScreenMagnifier._onMouseMove — the hook callback."""
 
-	def testIgnoredWhenInactive(self):
-		"""_onMouseMove does nothing when magnifier is not active."""
-		magnifier = FullScreenMagnifier()
-		magnifier._fullscreenMagnifier = MagicMock()
-		magnifier._isActive = False
-
-		magnifier._onMouseMove(500, 400)
-
-		magnifier._fullscreenMagnifier.assert_not_called()
-
-	def testIgnoredDuringManualPan(self):
-		"""_onMouseMove does nothing while the user is manually panning."""
-		magnifier = FullScreenMagnifier()
-		magnifier._startMagnifier()
-		magnifier._fullscreenMagnifier = MagicMock()
-		magnifier._isManualPanning = True
-
-		magnifier._onMouseMove(500, 400)
-
-		magnifier._fullscreenMagnifier.assert_not_called()
-		magnifier._stopMagnifier()
-
-	def testIgnoredWhenMouseFollowDisabled(self):
-		"""_onMouseMove does nothing when follow-mouse is off."""
-		magnifier = FullScreenMagnifier()
-		magnifier._startMagnifier()
-		magnifier._fullscreenMagnifier = MagicMock()
-
-		with patch("_magnifier.magnifier.getFollowState", return_value=False):
-			magnifier._onMouseMove(500, 400)
-
-		magnifier._fullscreenMagnifier.assert_not_called()
-		magnifier._stopMagnifier()
-
 	def testUpdatesMagnifier(self):
-		"""_onMouseMove calls _fullscreenMagnifier when all conditions are met."""
+		"""_onMouseMove updates currentCoordinates and calls _fullscreenMagnifier."""
 		magnifier = FullScreenMagnifier()
 		magnifier._startMagnifier()
 		magnifier._fullscreenMagnifier = MagicMock()
@@ -114,15 +60,5 @@ class TestOnMouseMove(_TestMagnifierWithHook):
 			magnifier._onMouseMove(500, 400)
 
 		magnifier._fullscreenMagnifier.assert_called_once()
-		magnifier._stopMagnifier()
-
-	def testSilencesOSError(self):
-		"""_onMouseMove swallows OSError from the magnification API."""
-		magnifier = FullScreenMagnifier()
-		magnifier._startMagnifier()
-		magnifier._fullscreenMagnifier = MagicMock(side_effect=OSError("API failure"))
-
-		with patch("_magnifier.magnifier.getFollowState", return_value=True):
-			magnifier._onMouseMove(500, 400)  # must not raise
-
+		self.assertEqual(magnifier.currentCoordinates, Coordinates(500, 400))
 		magnifier._stopMagnifier()

--- a/tests/unit/test_magnifier/test_mouseHook.py
+++ b/tests/unit/test_magnifier/test_mouseHook.py
@@ -9,22 +9,7 @@ from _magnifier.utils.types import Coordinates
 from tests.unit.test_magnifier.test_magnifier import _TestMagnifier
 
 
-class _TestMagnifierWithHook(_TestMagnifier):
-	"""Extends _TestMagnifier with a mock for MagnifierMouseHook."""
-
-	def setUp(self):
-		super().setUp()
-		self.mouseHook_patcher = patch("_magnifier.magnifier.MagnifierMouseHook")
-		self.MockMouseHook = self.mouseHook_patcher.start()
-		self.mock_hook_instance = MagicMock()
-		self.MockMouseHook.return_value = self.mock_hook_instance
-
-	def tearDown(self):
-		self.mouseHook_patcher.stop()
-		super().tearDown()
-
-
-class TestMouseHookLifecycle(_TestMagnifierWithHook):
+class TestMouseHookLifecycle(_TestMagnifier):
 	"""Tests for the WH_MOUSE_LL hook lifecycle managed by the base Magnifier class."""
 
 	def testHookStartedWithMagnifier(self):
@@ -47,7 +32,7 @@ class TestMouseHookLifecycle(_TestMagnifierWithHook):
 		self.assertIsNone(magnifier._mouseHook)
 
 
-class TestOnMouseMove(_TestMagnifierWithHook):
+class TestOnMouseMove(_TestMagnifier):
 	"""Tests for FullScreenMagnifier._onMouseMove — the hook callback."""
 
 	def testUpdatesMagnifier(self):

--- a/tests/unit/test_magnifier/test_mouseHook.py
+++ b/tests/unit/test_magnifier/test_mouseHook.py
@@ -1,0 +1,114 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2025-2026 NV Access Limited, Antoine Haffreingue
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
+
+from unittest.mock import MagicMock, patch
+from _magnifier.fullscreenMagnifier import FullScreenMagnifier
+from _magnifier.utils.types import Coordinates
+from tests.unit.test_magnifier.test_magnifier import _TestMagnifier
+
+
+class TestMouseHookLifecycle(_TestMagnifier):
+	"""Tests for the WH_MOUSE_LL hook lifecycle managed by the base Magnifier class."""
+
+	def testHookStartedWithMagnifier(self):
+		"""Mouse hook is started when the magnifier starts."""
+		magnifier = FullScreenMagnifier()
+		magnifier._startMagnifier()
+
+		self.MockMouseHook.assert_called_once_with(magnifier._onMouseMove)
+		self.mock_hook_instance.start.assert_called_once()
+
+		magnifier._stopMagnifier()
+
+	def testHookStoppedWithMagnifier(self):
+		"""Mouse hook is stopped and cleared when the magnifier stops."""
+		magnifier = FullScreenMagnifier()
+		magnifier._startMagnifier()
+		magnifier._stopMagnifier()
+
+		self.mock_hook_instance.stop.assert_called_once()
+		self.assertIsNone(magnifier._mouseHook)
+
+	def testHookNotStartedIfAlreadyActive(self):
+		"""Calling _startMagnifier twice does not create a second hook."""
+		magnifier = FullScreenMagnifier()
+		magnifier._startMagnifier()
+		magnifier._startMagnifier()
+
+		self.assertEqual(self.MockMouseHook.call_count, 1)
+
+		magnifier._stopMagnifier()
+
+	def testHookNotStartedIfInitFails(self):
+		"""Hook is not left running when API initialisation fails."""
+		self.mock_mag_fs.MagInitialize.side_effect = OSError("init failed")
+
+		with patch("_magnifier.fullscreenMagnifier.ui.message"):
+			magnifier = FullScreenMagnifier()
+			magnifier._startMagnifier()
+
+		self.mock_hook_instance.stop.assert_called_once()
+		self.assertIsNone(magnifier._mouseHook)
+
+
+class TestOnMouseMove(_TestMagnifier):
+	"""Tests for FullScreenMagnifier._onMouseMove — the hook callback."""
+
+	def testIgnoredWhenInactive(self):
+		"""_onMouseMove does nothing when magnifier is not active."""
+		magnifier = FullScreenMagnifier()
+		magnifier._fullscreenMagnifier = MagicMock()
+		magnifier._isActive = False
+
+		magnifier._onMouseMove(500, 400)
+
+		magnifier._fullscreenMagnifier.assert_not_called()
+
+	def testIgnoredDuringManualPan(self):
+		"""_onMouseMove does nothing while the user is manually panning."""
+		magnifier = FullScreenMagnifier()
+		magnifier._startMagnifier()
+		magnifier._fullscreenMagnifier = MagicMock()
+		magnifier._isManualPanning = True
+
+		magnifier._onMouseMove(500, 400)
+
+		magnifier._fullscreenMagnifier.assert_not_called()
+		magnifier._stopMagnifier()
+
+	def testIgnoredWhenMouseFollowDisabled(self):
+		"""_onMouseMove does nothing when follow-mouse is off."""
+		magnifier = FullScreenMagnifier()
+		magnifier._startMagnifier()
+		magnifier._fullscreenMagnifier = MagicMock()
+
+		with patch("_magnifier.magnifier.getFollowState", return_value=False):
+			magnifier._onMouseMove(500, 400)
+
+		magnifier._fullscreenMagnifier.assert_not_called()
+		magnifier._stopMagnifier()
+
+	def testUpdatesMagnifier(self):
+		"""_onMouseMove calls _fullscreenMagnifier when all conditions are met."""
+		magnifier = FullScreenMagnifier()
+		magnifier._startMagnifier()
+		magnifier._fullscreenMagnifier = MagicMock()
+
+		with patch("_magnifier.magnifier.getFollowState", return_value=True):
+			magnifier._onMouseMove(500, 400)
+
+		magnifier._fullscreenMagnifier.assert_called_once()
+		magnifier._stopMagnifier()
+
+	def testSilencesOSError(self):
+		"""_onMouseMove swallows OSError from the magnification API."""
+		magnifier = FullScreenMagnifier()
+		magnifier._startMagnifier()
+		magnifier._fullscreenMagnifier = MagicMock(side_effect=OSError("API failure"))
+
+		with patch("_magnifier.magnifier.getFollowState", return_value=True):
+			magnifier._onMouseMove(500, 400)  # must not raise
+
+		magnifier._stopMagnifier()

--- a/tests/unit/test_magnifier/test_mouseHook.py
+++ b/tests/unit/test_magnifier/test_mouseHook.py
@@ -5,11 +5,25 @@
 
 from unittest.mock import MagicMock, patch
 from _magnifier.fullscreenMagnifier import FullScreenMagnifier
-from _magnifier.utils.types import Coordinates
 from tests.unit.test_magnifier.test_magnifier import _TestMagnifier
 
 
-class TestMouseHookLifecycle(_TestMagnifier):
+class _TestMagnifierWithHook(_TestMagnifier):
+	"""Extends _TestMagnifier with a mock for MagnifierMouseHook."""
+
+	def setUp(self):
+		super().setUp()
+		self.mouseHook_patcher = patch("_magnifier.magnifier.MagnifierMouseHook")
+		self.MockMouseHook = self.mouseHook_patcher.start()
+		self.mock_hook_instance = MagicMock()
+		self.MockMouseHook.return_value = self.mock_hook_instance
+
+	def tearDown(self):
+		self.mouseHook_patcher.stop()
+		super().tearDown()
+
+
+class TestMouseHookLifecycle(_TestMagnifierWithHook):
 	"""Tests for the WH_MOUSE_LL hook lifecycle managed by the base Magnifier class."""
 
 	def testHookStartedWithMagnifier(self):
@@ -53,7 +67,7 @@ class TestMouseHookLifecycle(_TestMagnifier):
 		self.assertIsNone(magnifier._mouseHook)
 
 
-class TestOnMouseMove(_TestMagnifier):
+class TestOnMouseMove(_TestMagnifierWithHook):
 	"""Tests for FullScreenMagnifier._onMouseMove — the hook callback."""
 
 	def testIgnoredWhenInactive(self):


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
partially closes #19987

### Summary of the issue:
Fixes the lag observed when following the mouse with NVDA's magnifier at high Windows display scale factors (e.g. 225 %).
### Description of user facing changes:
When following the mouse with NVDA's magnifier at high Windows display scale factors (e.g. 225 %), the magnified view should now follows the cursor smoothly. Previously, the view was noticeably delayed compared to the actual cursor position at such scale factors.
### Description of developer facing changes:
source/_magnifier/utils/mouseHook.py installs a WH_MOUSE_LL Windows hook in a dedicated thread with its own message pump. The base Magnifier class manages its lifecycle _startMagnifier /_stopMagnifier and calls _onMouseMove(x, y) on every mouse move event, which updates MagSetFullscreenTransform directly without going through the wx main thread.

The existing wx.Timer loop is unchanged and continues to handle all other tracking modes (keyboard focus, review cursor, navigator object) as well as error recovery and manual panning.
### Description of development approach:
At high DPI, Windows increases the rendering workload of the wx main thread significantly. Since the magnifier's mouse tracking relied on a wx.Timer firing every 12 ms, delayed timer callbacks caused visible stutter even though the mouse moved smoothly.

The fix bypasses the wx thread entirely for mouse tracking by using a WH_MOUSE_LL hook in a dedicated daemon thread. This hook fires immediately on every WM_MOUSEMOVE event regardless of main-thread load. MagSetFullscreenTransform is thread-safe, so calling it from the hook thread is safe. A second WH_MOUSE_LL hook in the same process is valid and does not interfere with NVDA's existing hook in winInputHook.py. The hook is installed and uninstalled within the same thread, as required by Windows.
### Testing strategy:
unit
### Known issues with pull request:

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [ ] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [ ] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [ ] API is compatible with existing add-ons.
- [ ] Security precautions taken.
