### PR TITLE
Show a clearer error for bare drive letters in Create Portable dialog

### DIFF
--- a/source/gui/installerGui.py
+++ b/source/gui/installerGui.py
@@ -610,6 +610,20 @@ def _warnAndConfirmIfInstallingRemotely(isUpdate: bool) -> bool:
 	return True
 
 
+def _isBareDriveLetterPath(path: str) -> bool:
+	"""
+	Check whether a path is a drive letter with no following separator, e.g. ``D:`` or ``D:subDir``.
+	Such a path is not absolute: Windows resolves it against that drive's current directory, which a user
+	has no reliable way to predict or control from the Create Portable NVDA dialog.
+	This only matches a bare letter and colon, not a UNC share (e.g. ``\\\\server\\share``), which
+	os.path.splitdrive also treats as having a "drive" but which is already absolute.
+	:param path: The path to check, after any environment variables have already been expanded.
+	:return: ``True`` if path is a bare drive letter with no root directory component, ``False`` otherwise.
+	"""
+	drive, tail = os.path.splitdrive(path)
+	return len(drive) == 2 and drive[1] == ":" and not tail.startswith(("\\", "/"))
+
+
 def _getUniqueNewPortableDirectory(basePath: str) -> str:
 	"""
 	Generate a new directory name for a portable copy of NVDA.
@@ -703,13 +717,31 @@ class PortableCreaterDialog(
 			)
 			return
 		expandedPortableDirectory = os.path.expandvars(self.portableDirectoryEdit.Value)
+		if _isBareDriveLetterPath(expandedPortableDirectory):
+			gui.messageBox(
+				_(
+					# Translators: The message displayed when the user has specified a destination directory
+					# consisting of a drive letter with no following backslash (e.g. "D:") in the Create
+					# Portable NVDA dialog.
+					"A drive letter on its own is not a complete path, as its exact location cannot be "
+					"reliably determined. "
+					"Please include a backslash after the drive letter (e.g. C:\\) to specify its root, "
+					"or a full path such as C:\\NVDA.\n"
+					"Current path: {path}. ",
+				).format(path=expandedPortableDirectory),
+				# Translators: The message title displayed when the user has not specified an absolute
+				# destination directory in the Create Portable NVDA dialog.
+				_("Error"),
+				wx.OK | wx.ICON_ERROR,
+			)
+			return
 		if not os.path.isabs(expandedPortableDirectory):
 			gui.messageBox(
 				_(
 					# Translators: The message displayed when the user has not specified an absolute destination directory
 					# in the Create Portable NVDA dialog.
 					"Please specify the absolute path where the portable copy should be created. "
-					"It must start with a drive letter (e.g. C:). "
+					"It must start with a drive letter (e.g. C:\\). "
 					"It may include system variables (e.g. %temp%, %homepath%) as placeholders for parts of the path.\n"
 					"Current path: {path}. ",
 				).format(path=expandedPortableDirectory),

--- a/tests/unit/test_installer.py
+++ b/tests/unit/test_installer.py
@@ -143,6 +143,27 @@ class testFollowerWarning(unittest.TestCase):
 					self.assertEqual(installerGui._shouldWarnBeforeUpdate(), expectedReturn)
 
 
+class Test_isBareDriveLetterPath(unittest.TestCase):
+	@parameterized.expand(
+		(
+			("D:", True),
+			("d:", True),
+			("C:", True),
+			("D:NVDA", True),
+			("D:\\", False),
+			("D:/", False),
+			("C:\\NVDA", False),
+			("C:\\Users\\NVDA", False),
+			("NVDA", False),
+			("\\\\server\\share", False),
+			("\\\\server\\share\\", False),
+			("", False),
+		),
+	)
+	def test_isBareDriveLetterPath(self, path: str, expected: bool):
+		self.assertEqual(installerGui._isBareDriveLetterPath(path), expected)
+
+
 class Test_comparePreviousInstall(unittest.TestCase):
 	def test_freshInstall_whenNoInstallDirsExist(self):
 		with (

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -44,6 +44,7 @@
 * NVDA should no longer fail to navigate tables, read editable text fields or enable native app selection mode in Web browsers after a random period of time. (#16020)
 * NVDA should no longer cause File Explorer or other applications to crash when NVDA is exited or restarted. (#16207)
 * Focus is no longer silent on list items in Qt-based applications (such as Telegram Desktop) when the item exposes the UIA SelectionItem pattern without an associated action interface. (#20255, @rezabakhshilaktasaraei)
+* In the Create Portable NVDA dialog, entering a destination path that is just a drive letter (e.g. `D:`) now shows an error explaining why such a path is not supported, instead of a generic message asking for an absolute path. (#20159, @munzzyy)
 
 ### Changes for Developers
 


### PR DESCRIPTION
### Link to issue number:

Related to #20159 (not closing it outright, see below)

### Summary of the issue:

If you type a bare drive letter with no trailing backslash (e.g. `D:`) into the Create Portable NVDA dialog, NVDA rejects it with an error saying the path must start with a drive letter, which is confusing since the path you typed already has one.

The original report expected NVDA to just accept `D:` and treat it as the root of that drive. Digging into the thread, a contributor pointed out that's not actually true on Windows: `D:` without a backslash means "the current directory on drive D," which is whatever a process last cd'd to on that drive, not the drive root. `os.path.abspath("D:")` on my machine resolved to `D:\Users\<name>`, not `D:\`. There was a previous PR that just moved `abspath()` before the `isabs()` check so `D:` would silently normalize, but a collaborator flagged that as accepting an undefined destination, and asked for a clearer error instead. That's what this PR does.

### Description of user facing changes:

Entering a bare drive letter as the portable copy destination now shows a specific error explaining that a drive letter on its own isn't a complete path and telling the user to add a backslash (or a full path). Previously this fell through to the generic "not absolute" error, which didn't explain why a path that visibly starts with a drive letter was rejected. Also fixed that generic message's own example, which said `(e.g. C:)` instead of `(e.g. C:\)` - so it was contradicting the rule it was trying to enforce.

### Description of developer facing changes:

Added a small helper, `installerGui._isBareDriveLetterPath()`, that checks whether a path is exactly a drive letter and colon with no following separator (covers `D:` and `D:someFolder`, not UNC paths like `\\server\share` which `os.path.splitdrive` also reports as having a "drive"). `onCreatePortable()` checks this before the existing `isabs()` check and shows a dedicated message if it matches.

### Description of development approach:

I didn't want to just move `abspath()` earlier like the earlier attempt did, because that changes behavior silently based on process state (current directory per drive), which isn't something the user can see or control from the dialog. Given the maintainer feedback in the issue thread already steered toward "explain why this isn't supported" rather than "make it work", I went with detecting the bad input directly and giving a targeted message, leaving the existing abspath/isabs logic alone.

I also fixed the wording of the pre-existing generic error message, since testing this made it obvious that message was telling users to do the exact thing that gets rejected.

### Testing strategy:

Added `Test_isBareDriveLetterPath` to `tests/unit/test_installer.py`, covering bare drive letters (`D:`, `d:`, `C:`), a drive letter with a relative tail (`D:NVDA`), proper absolute paths (`D:\`, `D:/`, `C:\NVDA`), a plain relative path, and UNC paths (`\\server\share`, with and without trailing backslash) to make sure those aren't misclassified as bare drive letters.

I want to be upfront about the limits of what I could verify here: I don't have NVDA's full dev environment set up (it needs Python 3.13 pinned via uv, plus wxPython/comtypes), so I couldn't run `rununittests.bat` against the real suite. I did verify the exact logic of `_isBareDriveLetterPath` in an isolated script against the same test cases, including catching a bug in my first attempt where UNC paths were wrongly flagged as bare drive letters (`os.path.splitdrive` puts the whole UNC prefix into "drive" with an empty tail, same shape as a bare `D:`). I have not been able to manually run the actual dialog in a built copy of NVDA to click through it, so I can't confirm the wx message box renders and reads correctly with a screen reader - that still needs manual/human testing before merge.

### Known issues with pull request:

* Not manually tested against a running NVDA build (see testing strategy above) - needs a human to build NVDA and click through the dialog with a screen reader running before merge.
* This only handles the drive-letter-only case flagged in the issue. It doesn't attempt to solve the broader ask from a later comment about making the general "not absolute" message clearer for every case.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
