### PR TITLE
Fix browseable message dialog window behavior after WebView migration

### DIFF
--- a/source/gui/message.py
+++ b/source/gui/message.py
@@ -1203,11 +1203,7 @@ class HtmlMessageDialog(MessageDialog):
 	_DEFAULT_WEBVIEW_SIZE: tuple[int, int] = (350, 300)
 	"""Default WebView viewport, matching the legacy MSHTML browseable message template."""
 	_DIALOG_STYLE: int = (
-		wx.DEFAULT_DIALOG_STYLE
-		| wx.RESIZE_BORDER
-		| wx.MAXIMIZE_BOX
-		| wx.MINIMIZE_BOX
-		| wx.DIALOG_NO_PARENT
+		wx.DEFAULT_DIALOG_STYLE | wx.RESIZE_BORDER | wx.MAXIMIZE_BOX | wx.MINIMIZE_BOX | wx.DIALOG_NO_PARENT
 	)
 
 	_FAIL_ON_NO_BUTTONS = False

--- a/source/gui/message.py
+++ b/source/gui/message.py
@@ -18,7 +18,7 @@ from typing import Any, Literal, NamedTuple, Optional, Self
 import core
 import extensionPoints
 import wx
-from wx.html2 import WebView
+import wx.html2
 from .contextHelp import ContextHelpMixin
 from logHandler import log
 
@@ -1249,8 +1249,8 @@ class HtmlMessageDialog(MessageDialog):
 		self._actionHandlers[action] = handler
 		return self
 
-	def _createMessageControl(self) -> WebView:
-		control = WebView.New(self, backend=self._webViewBackend)
+	def _createMessageControl(self) -> wx.html2.WebView:
+		control = wx.html2.WebView.New(self, backend=self._webViewBackend)
 		control.SetInitialSize(self.scaleSize(self._DEFAULT_WEBVIEW_SIZE))
 		control.EnableContextMenu(False)
 		control.EnableHistory(False)

--- a/source/gui/message.py
+++ b/source/gui/message.py
@@ -1202,7 +1202,7 @@ class HtmlMessageDialog(MessageDialog):
 	_ACTION_URL_PREFIX = "nvda-action://"
 	_DEFAULT_WEBVIEW_SIZE: tuple[int, int] = (350, 300)
 	"""Default WebView viewport, matching the legacy MSHTML browseable message template."""
-	_DIALOG_STYLE: int = wx.DEFAULT_DIALOG_STYLE | wx.RESIZE_BORDER | wx.MAXIMIZE_BOX
+	_DIALOG_STYLE: int = wx.DEFAULT_DIALOG_STYLE | wx.RESIZE_BORDER | wx.MAXIMIZE_BOX | wx.MINIMIZE_BOX
 
 	_FAIL_ON_NO_BUTTONS = False
 	"""HtmlMessageDialog can be shown without buttons; the HTML content handles its own close action."""
@@ -1235,6 +1235,7 @@ class HtmlMessageDialog(MessageDialog):
 				],
 			),
 		)
+		self.EnableCloseButton(self.hasFallback)
 
 	def registerAction(self, action: str, handler: Callable[[], None]) -> Self:
 		"""Register a handler for an ``nvda-action://<action>`` URL triggered from the HTML message.
@@ -1258,6 +1259,10 @@ class HtmlMessageDialog(MessageDialog):
 	def _wrapMessageControl(self) -> None:
 		# A WebView lays out its own content, so there is nothing to wrap.
 		pass
+
+	@property
+	def hasFallback(self) -> bool:
+		return super().hasFallback or self.GetEscapeId() == EscapeCode.CANCEL_OR_AFFIRMATIVE
 
 	def setMessage(self, message: str) -> Self:
 		self._messageControl.SetPage(message, "")
@@ -1286,7 +1291,7 @@ class HtmlMessageDialog(MessageDialog):
 		button must still work.
 		"""
 		action = super()._getFallbackAction()
-		if action is None and not self._commands:
+		if action is None and self.GetEscapeId() == EscapeCode.CANCEL_OR_AFFIRMATIVE:
 			return _Command(callback=None, closesDialog=True, returnCode=ReturnCode.CLOSE)
 		return action
 

--- a/source/gui/message.py
+++ b/source/gui/message.py
@@ -398,6 +398,8 @@ class MessageDialog(DpiScalingHelperMixinWithoutInit, ContextHelpMixin, wx.Dialo
 	"""Class default for whether to run the :meth:`._checkMainThread` test."""
 	_FAIL_ON_NO_BUTTONS = True
 	"""Class default for whether to run the :meth:`._checkHasButtons` test."""
+	_DIALOG_STYLE: int = wx.DEFAULT_DIALOG_STYLE
+	"""wx style used when creating the dialog window."""
 
 	# region Constructors
 	def __new__(cls, *args, **kwargs) -> Self:
@@ -429,7 +431,7 @@ class MessageDialog(DpiScalingHelperMixinWithoutInit, ContextHelpMixin, wx.Dialo
 		"""
 		self._checkMainThread()
 		self.helpId = helpId  # Must be set before initialising ContextHelpMixin.
-		super().__init__(parent, title=title)
+		super().__init__(parent, title=title, style=self._DIALOG_STYLE)
 		self._isLayoutFullyRealized = False
 		self._commands: dict[int, _Command] = {}
 		"""Registry of commands bound to this MessageDialog."""
@@ -450,12 +452,13 @@ class MessageDialog(DpiScalingHelperMixinWithoutInit, ContextHelpMixin, wx.Dialo
 		mainSizer = self._mainSizer = wx.BoxSizer(wx.VERTICAL)
 		contentsSizer = self._contentsSizer = guiHelper.BoxSizerHelper(parent=self, orientation=wx.VERTICAL)
 		messageControl = self._messageControl = self._createMessageControl()
-		contentsSizer.addItem(messageControl)
+		contentsSizer.addItem(messageControl, flag=wx.EXPAND, proportion=1)
 		buttonHelper = self._buttonHelper = guiHelper.ButtonHelper(wx.HORIZONTAL)
 		mainSizer.Add(
 			contentsSizer.sizer,
+			proportion=1,
 			border=guiHelper.BORDER_FOR_DIALOGS,
-			flag=wx.ALL,
+			flag=wx.ALL | wx.EXPAND,
 		)
 		self.SetSizer(mainSizer)
 
@@ -1197,6 +1200,9 @@ class HtmlMessageDialog(MessageDialog):
 	"""
 
 	_ACTION_URL_PREFIX = "nvda-action://"
+	_DEFAULT_WEBVIEW_SIZE: tuple[int, int] = (350, 300)
+	"""Default WebView viewport, matching the legacy MSHTML browseable message template."""
+	_DIALOG_STYLE: int = wx.DEFAULT_DIALOG_STYLE | wx.RESIZE_BORDER | wx.MAXIMIZE_BOX
 
 	_FAIL_ON_NO_BUTTONS = False
 	"""HtmlMessageDialog can be shown without buttons; the HTML content handles its own close action."""
@@ -1242,6 +1248,7 @@ class HtmlMessageDialog(MessageDialog):
 
 	def _createMessageControl(self) -> WebView:
 		control = WebView.New(self, backend=self._webViewBackend)
+		control.SetInitialSize(self.scaleSize(self._DEFAULT_WEBVIEW_SIZE))
 		control.EnableContextMenu(False)
 		control.EnableHistory(False)
 		# Bind before MessageDialog.__init__ sets the initial content, so the first load and navigation are observed.

--- a/source/gui/message.py
+++ b/source/gui/message.py
@@ -1202,7 +1202,13 @@ class HtmlMessageDialog(MessageDialog):
 	_ACTION_URL_PREFIX = "nvda-action://"
 	_DEFAULT_WEBVIEW_SIZE: tuple[int, int] = (350, 300)
 	"""Default WebView viewport, matching the legacy MSHTML browseable message template."""
-	_DIALOG_STYLE: int = wx.DEFAULT_DIALOG_STYLE | wx.RESIZE_BORDER | wx.MAXIMIZE_BOX | wx.MINIMIZE_BOX
+	_DIALOG_STYLE: int = (
+		wx.DEFAULT_DIALOG_STYLE
+		| wx.RESIZE_BORDER
+		| wx.MAXIMIZE_BOX
+		| wx.MINIMIZE_BOX
+		| wx.DIALOG_NO_PARENT
+	)
 
 	_FAIL_ON_NO_BUTTONS = False
 	"""HtmlMessageDialog can be shown without buttons; the HTML content handles its own close action."""

--- a/source/message.html
+++ b/source/message.html
@@ -1,7 +1,20 @@
 <!doctype html>
-<html style="width: 350px; height: 300px">
+<html>
 <head>
+	<meta http-equiv="X-UA-Compatible" content="IE=edge">
+	<meta charset="utf-8">
 	<title>{{TITLE}}</title>
+	<style>
+		body {
+			margin: 1em;
+			overflow-wrap: break-word;
+			word-wrap: break-word;
+		}
+		pre {
+			white-space: pre-wrap;
+			word-wrap: break-word;
+		}
+	</style>
 	<script>
 		document.addEventListener('keydown', function (e) {
 			if (e.key === 'Escape') {
@@ -12,7 +25,7 @@
 		});
 	</script>
 </head>
-<body style="margin: 1em">
+<body>
 	<div id="messageDiv">{{MESSAGE}}</div>
 </body>
 </html>

--- a/source/ui.py
+++ b/source/ui.py
@@ -139,7 +139,7 @@ def browseableMessage(
 		)
 
 	# --- build the dialog ---
-	dialog = HtmlMessageDialog(gui.mainFrame, templatedMessage, title, buttons=None)
+	dialog = HtmlMessageDialog(None, templatedMessage, title, buttons=None)
 
 	if copyButton:
 		dialog.addButton(

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -25,6 +25,7 @@
   * Added new Elfdalian and Sami tables, a Norwegian table for Spanish text, and additional Swedish 6 and 8 dot variants.
 * The dialog used to present browseable messages (such as formatting information) has been modernized. (#18878, @LeonarddeR)
   * The dialog's shortcut to copy contents of the message to the clipboard was changed to `alt+c`.
+  * Browseable message dialogs now better support resizing, maximizing and minimizing, with text wrapping to the dialog width. (#20429, @Cary-rowen)
 * Updated CLDR to version 48.2. (#20234, @OzancanKaratas)
 
 ### Bug Fixes


### PR DESCRIPTION
### Link to issue number:

Fixes #20429

### Summary of the issue:

After `ui.browseableMessage` was migrated from the legacy MSHTML dialog to `wx.html2.WebView`, the dialog could open at a very small size.

The old template had a fixed `350 x 300` size, and the old MSHTML dialog used that as part of its window sizing. With the wx WebView implementation, that HTML size no longer contributes to the wx control's best size, so `MessageDialog.Fit()` can size the dialog around a very small WebView.

The old dialog was also resizable. The wx message dialog used after the migration did not preserve that behavior.

The wx implementation also made browseable messages owned by NVDA's hidden main frame. When opened from another NVDA window, such as the Python console, the browseable message was not exposed as a separate window for Alt+Tab and could trap focus away from the console.

### Description of user facing changes:

Browseable message dialogs now open at a usable default size again.

The dialog can be resized, maximized, or minimized. When the window size changes, the WebView expands with it.

Plain text browseable messages wrap to the available width. This avoids the long horizontal scrolling that could happen when showing text such as the last spoken message.

Browseable message dialogs can be switched to as separate windows, including when opened from the NVDA Python console.

### Description of developer facing changes:

No public API changes.

`HtmlMessageDialog` now controls its own wx dialog style and WebView initial size. The HTML template no longer controls the initial window size.

### Description of development approach:

Set the initial WebView viewport to `350 x 300`, matching the size used by the legacy `message.html` template.

Allow the message control and its containing sizers to expand, so resizing or maximizing the dialog also resizes the WebView.

Make `HtmlMessageDialog` use a resizable dialog style with maximize and minimize buttons. This keeps the change scoped to browseable messages rather than changing every `MessageDialog`.

Create browseable message dialogs without a parent and use `wx.DIALOG_NO_PARENT`, so they behave as independent modeless windows rather than owned dialogs of NVDA's hidden main frame.

Remove the fixed `width` and `height` from `message.html`, because after the migration the wx host should own the control size. Add wrapping styles for the body and `<pre>` content so plain text can use the current viewport width.

### Testing strategy:

Manual testing, visual verification.

### Known issues with pull request:

None known.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [ ] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [ ] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [ ] API is compatible with existing add-ons.
- [ ] Security precautions taken.


