### PR TITLE
Normalize bare drive letters in portable copy directory (#20159)

### DIFF
--- a/source/gui/installerGui.py
+++ b/source/gui/installerGui.py
@@ -761,11 +761,22 @@ class PortableCreaterDialog(
 			)
 			return
 		expandedPortableDirectory = os.path.expandvars(self.portableDirectoryEdit.Value)
-		# Normalize bare drive letters (e.g. "c:" -> "c:\") so they are
-		# recognised as absolute paths. (#20159)
 		drive, tail = os.path.splitdrive(expandedPortableDirectory)
 		if drive and not tail:
-			expandedPortableDirectory = drive + os.sep
+			# Bare drive letter (e.g. "c:") is not an absolute path.
+			# On Windows "c:" refers to the current directory on drive C, not its root.
+			gui.messageBox(
+				_(
+					# Translators: The message displayed when the user enters a bare drive letter
+					# in the Create Portable NVDA dialog.
+					"A drive letter without a trailing backslash (e.g. \"{path}\") is not a valid "
+					"destination directory.\n"
+					"Please use \"{suggested}\" instead.",
+				).format(path=drive, suggested=drive + os.sep),
+				_("Error"),
+				wx.OK | wx.ICON_ERROR,
+			)
+			return
 		if not os.path.isabs(expandedPortableDirectory):
 			gui.messageBox(
 				_(

--- a/source/gui/installerGui.py
+++ b/source/gui/installerGui.py
@@ -761,6 +761,11 @@ class PortableCreaterDialog(
 			)
 			return
 		expandedPortableDirectory = os.path.expandvars(self.portableDirectoryEdit.Value)
+		# Normalize bare drive letters (e.g. "c:" -> "c:\") so they are
+		# recognised as absolute paths. (#20159)
+		drive, tail = os.path.splitdrive(expandedPortableDirectory)
+		if drive and not tail:
+			expandedPortableDirectory = drive + os.sep
 		if not os.path.isabs(expandedPortableDirectory):
 			gui.messageBox(
 				_(

--- a/source/gui/installerGui.py
+++ b/source/gui/installerGui.py
@@ -34,6 +34,7 @@ from installer import ComparisonState
 from logHandler import log
 import gui
 from gui import guiHelper
+from gui.message import DisplayableError
 import gui.contextHelp
 from gui.dpiScalingHelper import DpiScalingHelperMixinWithoutInit
 import systemUtils
@@ -682,28 +683,22 @@ def _getUniqueNewPortableDirectory(basePath: str) -> str:
 	return newPortableDirectory
 
 
-def _validatePortableDirectory(portableDirectory: str) -> str | None:
+def _validatePortableDirectory(portableDirectory: str) -> str:
 	"""Validate and normalize a portable directory path.
 
-	Returns the expanded absolute path if valid, or None if invalid
-	(the error is shown to the user via a message box).
+	Returns the expanded absolute path if valid.
+	Raises DisplayableError if the path is invalid.
 	"""
 	if not portableDirectory:
-		gui.messageBox(
-			# Translators: The message displayed when the user has not specified a destination directory
-			# in the Create Portable NVDA dialog.
+		raise DisplayableError(
 			_("Please specify a directory in which to create the portable copy."),
-			# Translators: the title of an error dialog.
-			_("Error"),
-			wx.OK | wx.ICON_ERROR,
 		)
-		return None
 	expandedPortableDirectory = os.path.expandvars(portableDirectory)
 	if not os.path.isabs(expandedPortableDirectory):
 		mount, root, _ = os.path.splitroot(expandedPortableDirectory)
 		if mount and not root:
 			# Has a drive letter but no root separator (e.g. "c:", "c:foo").
-			gui.messageBox(
+			raise DisplayableError(
 				_(
 					# Translators: The message displayed when the user enters a bare drive letter
 					# in the Create Portable NVDA dialog.
@@ -711,12 +706,9 @@ def _validatePortableDirectory(portableDirectory: str) -> str | None:
 					"destination directory.\n"
 					'Please use "{suggested}" instead.',
 				).format(path=mount, suggested=mount + os.sep),
-				_("Error"),
-				wx.OK | wx.ICON_ERROR,
 			)
-			return None
 		# No drive letter (e.g. "foo", "foo\bar").
-		gui.messageBox(
+		raise DisplayableError(
 			_(
 				# Translators: The message displayed when the user has not specified an absolute destination directory
 				# in the Create Portable NVDA dialog.
@@ -725,12 +717,7 @@ def _validatePortableDirectory(portableDirectory: str) -> str | None:
 				"It may include system variables (e.g. %temp%, %homepath%) as placeholders for parts of the path.\n"
 				"Current path: {path}. ",
 			).format(path=expandedPortableDirectory),
-			# Translators: The message title displayed when the user has not specified an absolute
-			# destination directory in the Create Portable NVDA dialog.
-			_("Error"),
-			wx.OK | wx.ICON_ERROR,
 		)
-		return None
 	# isabs determines if the path is absolute, with or without a drive letter. abspath adds any missing initial
 	# components to that path to make it absolute from other contexts, by adding a drive letter/share path if
 	# needed. The OS's idea of the current drive is used, as in os.getcwd(). (#14681)
@@ -805,8 +792,10 @@ class PortableCreaterDialog(
 		self.CentreOnScreen()
 
 	def onCreatePortable(self, evt):
-		expandedPortableDirectory = _validatePortableDirectory(self.portableDirectoryEdit.Value)
-		if not expandedPortableDirectory:
+		try:
+			expandedPortableDirectory = _validatePortableDirectory(self.portableDirectoryEdit.Value)
+		except DisplayableError as e:
+			e.displayError(self)
 			return
 		if self.newFolderCheckBox.Value:
 			expandedPortableDirectory = _getUniqueNewPortableDirectory(expandedPortableDirectory)

--- a/source/gui/installerGui.py
+++ b/source/gui/installerGui.py
@@ -769,9 +769,9 @@ class PortableCreaterDialog(
 				_(
 					# Translators: The message displayed when the user enters a bare drive letter
 					# in the Create Portable NVDA dialog.
-					"A drive letter without a trailing backslash (e.g. \"{path}\") is not a valid "
+					'A drive letter without a trailing backslash (e.g. "{path}") is not a valid '
 					"destination directory.\n"
-					"Please use \"{suggested}\" instead.",
+					'Please use "{suggested}" instead.',
 				).format(path=drive, suggested=drive + os.sep),
 				_("Error"),
 				wx.OK | wx.ICON_ERROR,

--- a/source/gui/installerGui.py
+++ b/source/gui/installerGui.py
@@ -682,6 +682,61 @@ def _getUniqueNewPortableDirectory(basePath: str) -> str:
 	return newPortableDirectory
 
 
+def _validatePortableDirectory(portableDirectory: str) -> str | None:
+	"""Validate and normalize a portable directory path.
+
+	Returns the expanded absolute path if valid, or None if invalid
+	(the error is shown to the user via a message box).
+	"""
+	if not portableDirectory:
+		gui.messageBox(
+			# Translators: The message displayed when the user has not specified a destination directory
+			# in the Create Portable NVDA dialog.
+			_("Please specify a directory in which to create the portable copy."),
+			# Translators: the title of an error dialog.
+			_("Error"),
+			wx.OK | wx.ICON_ERROR,
+		)
+		return None
+	expandedPortableDirectory = os.path.expandvars(portableDirectory)
+	if not os.path.isabs(expandedPortableDirectory):
+		mount, root, _ = os.path.splitroot(expandedPortableDirectory)
+		if mount and not root:
+			# Has a drive letter but no root separator (e.g. "c:", "c:foo").
+			gui.messageBox(
+				_(
+					# Translators: The message displayed when the user enters a bare drive letter
+					# in the Create Portable NVDA dialog.
+					'A drive letter without a trailing backslash (e.g. "{path}") is not a valid '
+					"destination directory.\n"
+					'Please use "{suggested}" instead.',
+				).format(path=mount, suggested=mount + os.sep),
+				_("Error"),
+				wx.OK | wx.ICON_ERROR,
+			)
+			return None
+		# No drive letter (e.g. "foo", "foo\bar").
+		gui.messageBox(
+			_(
+				# Translators: The message displayed when the user has not specified an absolute destination directory
+				# in the Create Portable NVDA dialog.
+				"Please specify the absolute path where the portable copy should be created. "
+				"It must start with a drive letter (e.g. C:). "
+				"It may include system variables (e.g. %temp%, %homepath%) as placeholders for parts of the path.\n"
+				"Current path: {path}. ",
+			).format(path=expandedPortableDirectory),
+			# Translators: The message title displayed when the user has not specified an absolute
+			# destination directory in the Create Portable NVDA dialog.
+			_("Error"),
+			wx.OK | wx.ICON_ERROR,
+		)
+		return None
+	# isabs determines if the path is absolute, with or without a drive letter. abspath adds any missing initial
+	# components to that path to make it absolute from other contexts, by adding a drive letter/share path if
+	# needed. The OS's idea of the current drive is used, as in os.getcwd(). (#14681)
+	return os.path.abspath(expandedPortableDirectory)
+
+
 class PortableCreaterDialog(
 	gui.contextHelp.ContextHelpMixin,
 	wx.Dialog,  # wxPython does not seem to call base class initializer, put last in MRO
@@ -750,53 +805,9 @@ class PortableCreaterDialog(
 		self.CentreOnScreen()
 
 	def onCreatePortable(self, evt):
-		if not self.portableDirectoryEdit.Value:
-			gui.messageBox(
-				# Translators: The message displayed when the user has not specified a destination directory
-				# in the Create Portable NVDA dialog.
-				_("Please specify a directory in which to create the portable copy."),
-				# Translators: the title of an error dialog.
-				_("Error"),
-				wx.OK | wx.ICON_ERROR,
-			)
+		expandedPortableDirectory = _validatePortableDirectory(self.portableDirectoryEdit.Value)
+		if not expandedPortableDirectory:
 			return
-		expandedPortableDirectory = os.path.expandvars(self.portableDirectoryEdit.Value)
-		drive, tail = os.path.splitdrive(expandedPortableDirectory)
-		if drive and not tail:
-			# Bare drive letter (e.g. "c:") is not an absolute path.
-			# On Windows "c:" refers to the current directory on drive C, not its root.
-			gui.messageBox(
-				_(
-					# Translators: The message displayed when the user enters a bare drive letter
-					# in the Create Portable NVDA dialog.
-					'A drive letter without a trailing backslash (e.g. "{path}") is not a valid '
-					"destination directory.\n"
-					'Please use "{suggested}" instead.',
-				).format(path=drive, suggested=drive + os.sep),
-				_("Error"),
-				wx.OK | wx.ICON_ERROR,
-			)
-			return
-		if not os.path.isabs(expandedPortableDirectory):
-			gui.messageBox(
-				_(
-					# Translators: The message displayed when the user has not specified an absolute destination directory
-					# in the Create Portable NVDA dialog.
-					"Please specify the absolute path where the portable copy should be created. "
-					"It must start with a drive letter (e.g. C:). "
-					"It may include system variables (e.g. %temp%, %homepath%) as placeholders for parts of the path.\n"
-					"Current path: {path}. ",
-				).format(path=expandedPortableDirectory),
-				# Translators: The message title displayed when the user has not specified an absolute
-				# destination directory in the Create Portable NVDA dialog.
-				_("Error"),
-				wx.OK | wx.ICON_ERROR,
-			)
-			return
-		# isabs determines if the path is absolute, with or without a drive letter. abspath adds any missing initial
-		# components to that path to make it absolute from other contexts, by adding a drive letter/share path if
-		# needed. The OS's idea of the current drive is used, as in os.getcwd(). (#14681)
-		expandedPortableDirectory = os.path.abspath(expandedPortableDirectory)
 		if self.newFolderCheckBox.Value:
 			expandedPortableDirectory = _getUniqueNewPortableDirectory(expandedPortableDirectory)
 

--- a/tests/unit/test_installer.py
+++ b/tests/unit/test_installer.py
@@ -482,60 +482,49 @@ class Test_comparePreviousInstall(unittest.TestCase):
 			self.assertEqual(installer._comparePreviousInstall(), installer.ComparisonState.UPGRADE)
 
 
-def _mockSplitdrive(p: str) -> tuple:
-	if len(p) >= 2 and p[1] == ":":
-		return (p[:2], p[2:])
-	return ("", p)
-
-
-def _mockIsabs(p: str) -> bool:
-	if len(p) >= 2 and p[1] == ":":
-		return len(p) > 2
-	return False
-
-
 class Test_CreatePortableDirectoryNormalization(unittest.TestCase):
 	"""Tests for path handling in onCreatePortable (#20159)."""
 
-	def _runCreatePortable(self, path: str) -> list:
-		"""Call onCreatePortable with the given path and return messageBox calls."""
+	def _validate(self, path: str) -> tuple[str | None, list[str]]:
+		"""Call _validatePortableDirectory with the given path.
+		Returns (result, messageBox calls).
+		"""
 		msgBoxCalls = []
-		mockCheckBox = PropertyMock()
-		mockCheckBox.Value = False
-
+		import ntpath
 		with (
-			patch.object(
-				installerGui.CreatePortableDialog,
-				"portableDirectoryEdit",
-				new_callable=PropertyMock,
-			) as mockEdit,
 			patch("gui.installerGui.gui.messageBox", side_effect=lambda msg, title, style=0: msgBoxCalls.append(msg)),
-			patch("gui.installerGui.os.path.splitdrive", side_effect=_mockSplitdrive),
-			patch("gui.installerGui.os.path.isabs", side_effect=_mockIsabs),
+			patch("gui.installerGui.os.path.isabs", side_effect=ntpath.isabs),
+			patch("gui.installerGui.os.path.splitroot", side_effect=ntpath.splitroot),
+			patch("gui.installerGui.os.path.expandvars", side_effect=lambda p: p),
 			patch("gui.installerGui.os.path.abspath", return_value="C:\\NVDA"),
-			patch("gui.installerGui._warnAndConfirmForNonEmptyDirectory", return_value=False),
-			patch("gui.installerGui.doCreatePortable"),
 		):
-			mockEdit.Value = path
-			dialog = installerGui.CreatePortableDialog.__new__(installerGui.CreatePortableDialog)
-			dialog.portableDirectoryEdit = mockEdit
-			dialog.newFolderCheckBox = mockCheckBox
-			dialog.copyUserConfigCheckbox = mockCheckBox
-			dialog.startAfterCreateCheckbox = mockCheckBox
-			dialog.Hide = lambda: None
-			dialog.Destroy = lambda: None
-			dialog.onCreatePortable(None)
+			result = installerGui._validatePortableDirectory(path)
+		return result, msgBoxCalls
 
-		return msgBoxCalls
+	def test_emptyPath_showsError(self):
+		result, calls = self._validate("")
+		self.assertIsNone(result)
+		self.assertTrue(
+			any("Please specify a directory" in msg for msg in calls),
+		)
 
 	def test_bareDriveLetter_showsSpecificError(self):
-		calls = self._runCreatePortable("c:")
+		result, calls = self._validate("c:")
+		self.assertIsNone(result)
+		self.assertTrue(
+			any("c:\\" in msg for msg in calls),
+		)
+
+	def test_driveWithRelativePath_showsBareDriveError(self):
+		result, calls = self._validate("c:foo")
+		self.assertIsNone(result)
 		self.assertTrue(
 			any("c:\\" in msg for msg in calls),
 		)
 
 	def test_relativePath_showsError(self):
-		calls = self._runCreatePortable("foo")
+		result, calls = self._validate("foo")
+		self.assertIsNone(result)
 		errorText = _(
 			"Please specify the absolute path where the portable copy should be created. "
 			"It must start with a drive letter (e.g. C:). "
@@ -544,22 +533,12 @@ class Test_CreatePortableDirectoryNormalization(unittest.TestCase):
 		).format(path="foo")
 		self.assertIn(errorText, calls)
 
-	def test_driveLetterWithBackslash_isAccepted(self):
-		calls = self._runCreatePortable("c:\\")
-		errorText = _(
-			"Please specify the absolute path where the portable copy should be created. "
-			"It must start with a drive letter (e.g. C:). "
-			"It may include system variables (e.g. %temp%, %homepath%) as placeholders for parts of the path.\n"
-			"Current path: {path}. ",
-		).format(path="c:\\")
-		self.assertNotIn(errorText, calls)
+	def test_absolutePath_isAccepted(self):
+		result, calls = self._validate("c:\\")
+		self.assertEqual(result, "C:\\NVDA")
+		self.assertEqual(calls, [])
 
-	def test_driveLetterWithPath_isAccepted(self):
-		calls = self._runCreatePortable("d:\\NVDA")
-		errorText = _(
-			"Please specify the absolute path where the portable copy should be created. "
-			"It must start with a drive letter (e.g. C:). "
-			"It may include system variables (e.g. %temp%, %homepath%) as placeholders for parts of the path.\n"
-			"Current path: {path}. ",
-		).format(path="d:\\NVDA")
-		self.assertNotIn(errorText, calls)
+	def test_absolutePathWithDrive_isAccepted(self):
+		result, calls = self._validate("d:\\NVDA")
+		self.assertEqual(result, "C:\\NVDA")
+		self.assertEqual(calls, [])

--- a/tests/unit/test_installer.py
+++ b/tests/unit/test_installer.py
@@ -482,35 +482,26 @@ class Test_comparePreviousInstall(unittest.TestCase):
 			self.assertEqual(installer._comparePreviousInstall(), installer.ComparisonState.UPGRADE)
 
 
-class Test_CreatePortableDirectoryNormalization(unittest.TestCase):
-	"""Tests for path handling in onCreatePortable (#20159).
+def _mockSplitdrive(p: str) -> tuple:
+	if len(p) >= 2 and p[1] == ":":
+		return (p[:2], p[2:])
+	return ("", p)
 
-	Bare drive letters (e.g. "c:") should show a specific error message
-	suggesting the user use "c:\\" instead.
-	"""
+
+def _mockIsabs(p: str) -> bool:
+	if len(p) >= 2 and p[1] == ":":
+		return len(p) > 2
+	return False
+
+
+class Test_CreatePortableDirectoryNormalization(unittest.TestCase):
+	"""Tests for path handling in onCreatePortable (#20159)."""
 
 	def _runCreatePortable(self, path: str) -> list:
 		"""Call onCreatePortable with the given path and return messageBox calls."""
 		msgBoxCalls = []
-
-		def _msgBox(msg: str, title: str, style: int = 0):
-			msgBoxCalls.append(msg)
-
 		mockCheckBox = PropertyMock()
 		mockCheckBox.Value = False
-
-		# On non-Windows platforms, os.path.splitdrive and os.path.isabs
-		# don't understand drive letters, so mock them to behave like Windows.
-		def _mockSplitdrive(p: str) -> tuple:
-			if len(p) >= 2 and p[1] == ":":
-				return (p[:2], p[2:])
-			return ("", p)
-
-		def _mockIsabs(p: str) -> bool:
-			# On Windows, "c:" is not absolute; "c:\\" and "c:\\foo" are.
-			if len(p) >= 2 and p[1] == ":":
-				return len(p) > 2
-			return False
 
 		with (
 			patch.object(
@@ -518,7 +509,7 @@ class Test_CreatePortableDirectoryNormalization(unittest.TestCase):
 				"portableDirectoryEdit",
 				new_callable=PropertyMock,
 			) as mockEdit,
-			patch("gui.installerGui.gui.messageBox", side_effect=_msgBox),
+			patch("gui.installerGui.gui.messageBox", side_effect=lambda msg, title, style=0: msgBoxCalls.append(msg)),
 			patch("gui.installerGui.os.path.splitdrive", side_effect=_mockSplitdrive),
 			patch("gui.installerGui.os.path.isabs", side_effect=_mockIsabs),
 			patch("gui.installerGui.os.path.abspath", return_value="C:\\NVDA"),
@@ -538,15 +529,12 @@ class Test_CreatePortableDirectoryNormalization(unittest.TestCase):
 		return msgBoxCalls
 
 	def test_bareDriveLetter_showsSpecificError(self):
-		"""Entering 'c:' should show a specific error suggesting 'c:\\'."""
 		calls = self._runCreatePortable("c:")
 		self.assertTrue(
 			any("c:\\" in msg for msg in calls),
-			"Expected the error message to suggest 'c:\\'",
 		)
 
 	def test_relativePath_showsError(self):
-		"""Entering 'foo' should still show the "not absolute" error."""
 		calls = self._runCreatePortable("foo")
 		errorText = _(
 			"Please specify the absolute path where the portable copy should be created. "
@@ -557,7 +545,6 @@ class Test_CreatePortableDirectoryNormalization(unittest.TestCase):
 		self.assertIn(errorText, calls)
 
 	def test_driveLetterWithBackslash_isAccepted(self):
-		"""Entering 'c:\\' should be accepted as-is (no regression)."""
 		calls = self._runCreatePortable("c:\\")
 		errorText = _(
 			"Please specify the absolute path where the portable copy should be created. "
@@ -568,7 +555,6 @@ class Test_CreatePortableDirectoryNormalization(unittest.TestCase):
 		self.assertNotIn(errorText, calls)
 
 	def test_driveLetterWithPath_isAccepted(self):
-		"""Entering 'd:\\NVDA' should be accepted as-is (no regression)."""
 		calls = self._runCreatePortable("d:\\NVDA")
 		errorText = _(
 			"Please specify the absolute path where the portable copy should be created. "

--- a/tests/unit/test_installer.py
+++ b/tests/unit/test_installer.py
@@ -491,8 +491,12 @@ class Test_CreatePortableDirectoryNormalization(unittest.TestCase):
 		"""
 		msgBoxCalls = []
 		import ntpath
+
 		with (
-			patch("gui.installerGui.gui.messageBox", side_effect=lambda msg, title, style=0: msgBoxCalls.append(msg)),
+			patch(
+				"gui.installerGui.gui.messageBox",
+				side_effect=lambda msg, title, style=0: msgBoxCalls.append(msg),
+			),
 			patch("gui.installerGui.os.path.isabs", side_effect=ntpath.isabs),
 			patch("gui.installerGui.os.path.splitroot", side_effect=ntpath.splitroot),
 			patch("gui.installerGui.os.path.expandvars", side_effect=lambda p: p),

--- a/tests/unit/test_installer.py
+++ b/tests/unit/test_installer.py
@@ -14,6 +14,7 @@ from unittest.mock import patch, PropertyMock
 from parameterized import parameterized
 
 from gui import installerGui
+from gui.message import DisplayableError
 import installer
 
 
@@ -485,49 +486,44 @@ class Test_comparePreviousInstall(unittest.TestCase):
 class Test_CreatePortableDirectoryNormalization(unittest.TestCase):
 	"""Tests for path handling in onCreatePortable (#20159)."""
 
-	def _validate(self, path: str) -> tuple[str | None, list[str]]:
+	def _validate(self, path: str) -> tuple[str | None, str | None]:
 		"""Call _validatePortableDirectory with the given path.
-		Returns (result, messageBox calls).
+		Returns (result, error_message).
 		"""
-		msgBoxCalls = []
 		import ntpath
 
 		with (
-			patch(
-				"gui.installerGui.gui.messageBox",
-				side_effect=lambda msg, title, style=0: msgBoxCalls.append(msg),
-			),
 			patch("gui.installerGui.os.path.isabs", side_effect=ntpath.isabs),
 			patch("gui.installerGui.os.path.splitroot", side_effect=ntpath.splitroot),
 			patch("gui.installerGui.os.path.expandvars", side_effect=lambda p: p),
 			patch("gui.installerGui.os.path.abspath", return_value="C:\\NVDA"),
 		):
-			result = installerGui._validatePortableDirectory(path)
-		return result, msgBoxCalls
+			try:
+				result = installerGui._validatePortableDirectory(path)
+			except DisplayableError as e:
+				result = None
+				errorMsg = e.displayMessage
+			else:
+				errorMsg = None
+		return result, errorMsg
 
 	def test_emptyPath_showsError(self):
-		result, calls = self._validate("")
+		result, errorMsg = self._validate("")
 		self.assertIsNone(result)
-		self.assertTrue(
-			any("Please specify a directory" in msg for msg in calls),
-		)
+		self.assertIn("Please specify a directory", errorMsg)
 
 	def test_bareDriveLetter_showsSpecificError(self):
-		result, calls = self._validate("c:")
+		result, errorMsg = self._validate("c:")
 		self.assertIsNone(result)
-		self.assertTrue(
-			any("c:\\" in msg for msg in calls),
-		)
+		self.assertIn("c:\\", errorMsg)
 
 	def test_driveWithRelativePath_showsBareDriveError(self):
-		result, calls = self._validate("c:foo")
+		result, errorMsg = self._validate("c:foo")
 		self.assertIsNone(result)
-		self.assertTrue(
-			any("c:\\" in msg for msg in calls),
-		)
+		self.assertIn("c:\\", errorMsg)
 
 	def test_relativePath_showsError(self):
-		result, calls = self._validate("foo")
+		result, errorMsg = self._validate("foo")
 		self.assertIsNone(result)
 		errorText = _(
 			"Please specify the absolute path where the portable copy should be created. "
@@ -535,14 +531,14 @@ class Test_CreatePortableDirectoryNormalization(unittest.TestCase):
 			"It may include system variables (e.g. %temp%, %homepath%) as placeholders for parts of the path.\n"
 			"Current path: {path}. ",
 		).format(path="foo")
-		self.assertIn(errorText, calls)
+		self.assertEqual(errorMsg, errorText)
 
 	def test_absolutePath_isAccepted(self):
-		result, calls = self._validate("c:\\")
+		result, errorMsg = self._validate("c:\\")
 		self.assertEqual(result, "C:\\NVDA")
-		self.assertEqual(calls, [])
+		self.assertIsNone(errorMsg)
 
 	def test_absolutePathWithDrive_isAccepted(self):
-		result, calls = self._validate("d:\\NVDA")
+		result, errorMsg = self._validate("d:\\NVDA")
 		self.assertEqual(result, "C:\\NVDA")
-		self.assertEqual(calls, [])
+		self.assertIsNone(errorMsg)

--- a/tests/unit/test_installer.py
+++ b/tests/unit/test_installer.py
@@ -483,10 +483,10 @@ class Test_comparePreviousInstall(unittest.TestCase):
 
 
 class Test_CreatePortableDirectoryNormalization(unittest.TestCase):
-	"""Tests for path normalization in onCreatePortable (#20159).
+	"""Tests for path handling in onCreatePortable (#20159).
 
-	Bare drive letters (e.g. "c:") should be normalized to "c:\\" so that
-	os.path.isabs recognises them as absolute paths on Windows.
+	Bare drive letters (e.g. "c:") should show a specific error message
+	suggesting the user use "c:\\" instead.
 	"""
 
 	def _runCreatePortable(self, path: str) -> list:
@@ -507,7 +507,10 @@ class Test_CreatePortableDirectoryNormalization(unittest.TestCase):
 			return ("", p)
 
 		def _mockIsabs(p: str) -> bool:
-			return len(p) >= 2 and p[1] == ":"
+			# On Windows, "c:" is not absolute; "c:\\" and "c:\\foo" are.
+			if len(p) >= 2 and p[1] == ":":
+				return len(p) > 2
+			return False
 
 		with (
 			patch.object(
@@ -534,16 +537,13 @@ class Test_CreatePortableDirectoryNormalization(unittest.TestCase):
 
 		return msgBoxCalls
 
-	def test_bareDriveLetter_isAccepted(self):
-		"""Entering 'c:' should NOT show the "not absolute" error."""
+	def test_bareDriveLetter_showsSpecificError(self):
+		"""Entering 'c:' should show a specific error suggesting 'c:\\'."""
 		calls = self._runCreatePortable("c:")
-		errorText = _(
-			"Please specify the absolute path where the portable copy should be created. "
-			"It must start with a drive letter (e.g. C:). "
-			"It may include system variables (e.g. %temp%, %homepath%) as placeholders for parts of the path.\n"
-			"Current path: {path}. ",
-		).format(path="c:\\")
-		self.assertNotIn(errorText, calls)
+		self.assertTrue(
+			any("c:\\" in msg for msg in calls),
+			"Expected the error message to suggest 'c:\\'",
+		)
 
 	def test_relativePath_showsError(self):
 		"""Entering 'foo' should still show the "not absolute" error."""

--- a/tests/unit/test_installer.py
+++ b/tests/unit/test_installer.py
@@ -480,3 +480,100 @@ class Test_comparePreviousInstall(unittest.TestCase):
 			),
 		):
 			self.assertEqual(installer._comparePreviousInstall(), installer.ComparisonState.UPGRADE)
+
+
+class Test_CreatePortableDirectoryNormalization(unittest.TestCase):
+	"""Tests for path normalization in onCreatePortable (#20159).
+
+	Bare drive letters (e.g. "c:") should be normalized to "c:\\" so that
+	os.path.isabs recognises them as absolute paths on Windows.
+	"""
+
+	def _runCreatePortable(self, path: str) -> list:
+		"""Call onCreatePortable with the given path and return messageBox calls."""
+		msgBoxCalls = []
+
+		def _msgBox(msg: str, title: str, style: int = 0):
+			msgBoxCalls.append(msg)
+
+		mockCheckBox = PropertyMock()
+		mockCheckBox.Value = False
+
+		# On non-Windows platforms, os.path.splitdrive and os.path.isabs
+		# don't understand drive letters, so mock them to behave like Windows.
+		def _mockSplitdrive(p: str) -> tuple:
+			if len(p) >= 2 and p[1] == ":":
+				return (p[:2], p[2:])
+			return ("", p)
+
+		def _mockIsabs(p: str) -> bool:
+			return len(p) >= 2 and p[1] == ":"
+
+		with (
+			patch.object(
+				installerGui.CreatePortableDialog,
+				"portableDirectoryEdit",
+				new_callable=PropertyMock,
+			) as mockEdit,
+			patch("gui.installerGui.gui.messageBox", side_effect=_msgBox),
+			patch("gui.installerGui.os.path.splitdrive", side_effect=_mockSplitdrive),
+			patch("gui.installerGui.os.path.isabs", side_effect=_mockIsabs),
+			patch("gui.installerGui.os.path.abspath", return_value="C:\\NVDA"),
+			patch("gui.installerGui._warnAndConfirmForNonEmptyDirectory", return_value=False),
+			patch("gui.installerGui.doCreatePortable"),
+		):
+			mockEdit.Value = path
+			dialog = installerGui.CreatePortableDialog.__new__(installerGui.CreatePortableDialog)
+			dialog.portableDirectoryEdit = mockEdit
+			dialog.newFolderCheckBox = mockCheckBox
+			dialog.copyUserConfigCheckbox = mockCheckBox
+			dialog.startAfterCreateCheckbox = mockCheckBox
+			dialog.Hide = lambda: None
+			dialog.Destroy = lambda: None
+			dialog.onCreatePortable(None)
+
+		return msgBoxCalls
+
+	def test_bareDriveLetter_isAccepted(self):
+		"""Entering 'c:' should NOT show the "not absolute" error."""
+		calls = self._runCreatePortable("c:")
+		errorText = _(
+			"Please specify the absolute path where the portable copy should be created. "
+			"It must start with a drive letter (e.g. C:). "
+			"It may include system variables (e.g. %temp%, %homepath%) as placeholders for parts of the path.\n"
+			"Current path: {path}. ",
+		).format(path="c:\\")
+		self.assertNotIn(errorText, calls)
+
+	def test_relativePath_showsError(self):
+		"""Entering 'foo' should still show the "not absolute" error."""
+		calls = self._runCreatePortable("foo")
+		errorText = _(
+			"Please specify the absolute path where the portable copy should be created. "
+			"It must start with a drive letter (e.g. C:). "
+			"It may include system variables (e.g. %temp%, %homepath%) as placeholders for parts of the path.\n"
+			"Current path: {path}. ",
+		).format(path="foo")
+		self.assertIn(errorText, calls)
+
+	def test_driveLetterWithBackslash_isAccepted(self):
+		"""Entering 'c:\\' should be accepted as-is (no regression)."""
+		calls = self._runCreatePortable("c:\\")
+		errorText = _(
+			"Please specify the absolute path where the portable copy should be created. "
+			"It must start with a drive letter (e.g. C:). "
+			"It may include system variables (e.g. %temp%, %homepath%) as placeholders for parts of the path.\n"
+			"Current path: {path}. ",
+		).format(path="c:\\")
+		self.assertNotIn(errorText, calls)
+
+	def test_driveLetterWithPath_isAccepted(self):
+		"""Entering 'd:\\NVDA' should be accepted as-is (no regression)."""
+		calls = self._runCreatePortable("d:\\NVDA")
+		errorText = _(
+			"Please specify the absolute path where the portable copy should be created. "
+			"It must start with a drive letter (e.g. C:). "
+			"It may include system variables (e.g. %temp%, %homepath%) as placeholders for parts of the path.\n"
+			"Current path: {path}. ",
+		).format(path="d:\\NVDA")
+		self.assertNotIn(errorText, calls)

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -53,6 +53,7 @@
 Previously these keys had no function when pressed on their own. (#20366, @fla-rion)
 * The HID keyboard input simulation setting for ALVA braille displays is now remembered across reconnects and restarts. (#20455, @Cary-rowen)
 * Braille now follows the spoken text during say all in browse mode when braille is tethered to focus. (#3287, @LeonarddeR)
+* When creating a portable copy, entering a bare drive letter (e.g. `c:`) now shows a helpful error message suggesting the user use `c:\` instead. (#20446, @Mubashir78)
 
 ### Changes for Developers
 


### PR DESCRIPTION
Fixes #20159

### Link to issue number:
#20159

### Summary of the issue:
When entering a bare drive letter (e.g. `c:`) as the destination directory in the Create Portable NVDA dialog, the error message is confusing -- it says the path must start with a drive letter even though the user did provide one.

### Description of user facing changes:
Instead of the generic "not absolute" error, the dialog now shows a specific message: "A drive letter without a trailing backslash (e.g. "c:") is not a valid destination directory. Please use "c:\" instead." This makes it clear to the user why `c:` is not accepted and what they should type instead.

### Description of developer facing changes:
No developer-facing changes.

### Description of development approach:
Detect bare drive letters using os.path.splitdrive (when a drive letter is found with no trailing path), and show a targeted error message explaining that `c:` refers to the current directory on drive C, not its root, and suggesting `c:\` instead.

### Testing strategy:
Unit tests:
- test_bareDriveLetter_showsSpecificError -- verifies the specific error mentioning `c:\` is shown
- test_relativePath_showsError -- verifies the generic error is still shown for non-drive relative paths
- test_driveLetterWithBackslash_isAccepted -- no regression
- test_driveLetterWithPath_isAccepted -- no regression

Manual testing:
- Typed "c:" in the portable copy dialog -> confirmed the specific error message appears
- Typed "c:\" and "c:\folder" -> confirmed they are accepted
- Typed "d:" -> confirmed same specific error message appears

### Known issues with pull request:
None.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.