### PR TITLE
Make duration of indentation beeps configurable (#19353)

### DIFF
--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -3343,7 +3343,9 @@ class DocumentFormattingPanel(SettingsPanel):
 			max=2000,
 			initial=config.conf["documentFormatting"]["indentToneDuration"],
 		)
-		self.indentToneDurationSpin.Enable(reportLineIndentation in (ReportLineIndentation.TONES, ReportLineIndentation.SPEECH_AND_TONES))
+		self.indentToneDurationSpin.Enable(
+			reportLineIndentation in (ReportLineIndentation.TONES, ReportLineIndentation.SPEECH_AND_TONES)
+		)
 
 		# Translators: This message is presented in the document formatting settings panel
 		# If this option is selected, NVDA will report paragraph indentation if available.
@@ -3496,7 +3498,9 @@ class DocumentFormattingPanel(SettingsPanel):
 
 	def _onLineIndentationChange(self, evt: wx.CommandEvent) -> None:
 		self.ignoreBlankLinesRLICheckbox.Enable(evt.GetSelection() != 0)
-		self.indentToneDurationSpin.Enable(evt.GetSelection() in (ReportLineIndentation.TONES, ReportLineIndentation.SPEECH_AND_TONES))
+		self.indentToneDurationSpin.Enable(
+			evt.GetSelection() in (ReportLineIndentation.TONES, ReportLineIndentation.SPEECH_AND_TONES)
+		)
 
 	def _onLinksChange(self, evt: wx.CommandEvent):
 		self.linkTypeCheckBox.Enable(evt.IsChecked())

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -3344,7 +3344,7 @@ class DocumentFormattingPanel(SettingsPanel):
 			initial=config.conf["documentFormatting"]["indentToneDuration"],
 		)
 		self.indentToneDurationSpin.Enable(
-			reportLineIndentation in (ReportLineIndentation.TONES, ReportLineIndentation.SPEECH_AND_TONES)
+			reportLineIndentation in (ReportLineIndentation.TONES, ReportLineIndentation.SPEECH_AND_TONES),
 		)
 
 		# Translators: This message is presented in the document formatting settings panel
@@ -3499,7 +3499,7 @@ class DocumentFormattingPanel(SettingsPanel):
 	def _onLineIndentationChange(self, evt: wx.CommandEvent) -> None:
 		self.ignoreBlankLinesRLICheckbox.Enable(evt.GetSelection() != 0)
 		self.indentToneDurationSpin.Enable(
-			evt.GetSelection() in (ReportLineIndentation.TONES, ReportLineIndentation.SPEECH_AND_TONES)
+			evt.GetSelection() in (ReportLineIndentation.TONES, ReportLineIndentation.SPEECH_AND_TONES),
 		)
 
 	def _onLinksChange(self, evt: wx.CommandEvent):

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -3347,7 +3347,7 @@ class DocumentFormattingPanel(SettingsPanel):
 			reportLineIndentation in (ReportLineIndentation.TONES, ReportLineIndentation.SPEECH_AND_TONES),
 		)
 		self.bindHelpEvent(
-			"DocumentFormattingSettingsIndentToneDuration",
+			"sIndentToneDuration",
 			self.indentToneDurationSpin,
 		)
 

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -3347,7 +3347,7 @@ class DocumentFormattingPanel(SettingsPanel):
 			reportLineIndentation in (ReportLineIndentation.TONES, ReportLineIndentation.SPEECH_AND_TONES),
 		)
 		self.bindHelpEvent(
-			"sIndentToneDuration",
+			"IndentToneDuration",
 			self.indentToneDurationSpin,
 		)
 

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -3346,6 +3346,10 @@ class DocumentFormattingPanel(SettingsPanel):
 		self.indentToneDurationSpin.Enable(
 			reportLineIndentation in (ReportLineIndentation.TONES, ReportLineIndentation.SPEECH_AND_TONES),
 		)
+		self.bindHelpEvent(
+			"DocumentFormattingSettingsIndentToneDuration",
+			self.indentToneDurationSpin,
+		)
 
 		# Translators: This message is presented in the document formatting settings panel
 		# If this option is selected, NVDA will report paragraph indentation if available.

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -3333,6 +3333,18 @@ class DocumentFormattingPanel(SettingsPanel):
 		self.ignoreBlankLinesRLICheckbox.SetValue(config.conf["documentFormatting"]["ignoreBlankLinesForRLI"])
 		self.ignoreBlankLinesRLICheckbox.Enable(reportLineIndentation != 0)
 
+		# Translators: This is the label of a spin control in the document formatting settings panel
+		# to adjust the duration of indentation tones in milliseconds.
+		indentToneDurationText = _("Indent tone &duration (ms):")
+		self.indentToneDurationSpin = pageAndSpaceGroup.addLabeledControl(
+			indentToneDurationText,
+			wx.SpinCtrl,
+			min=10,
+			max=2000,
+			initial=config.conf["documentFormatting"]["indentToneDuration"],
+		)
+		self.indentToneDurationSpin.Enable(reportLineIndentation in (ReportLineIndentation.TONES, ReportLineIndentation.SPEECH_AND_TONES))
+
 		# Translators: This message is presented in the document formatting settings panel
 		# If this option is selected, NVDA will report paragraph indentation if available.
 		paragraphIndentationText = _("&Paragraph indentation")
@@ -3484,6 +3496,7 @@ class DocumentFormattingPanel(SettingsPanel):
 
 	def _onLineIndentationChange(self, evt: wx.CommandEvent) -> None:
 		self.ignoreBlankLinesRLICheckbox.Enable(evt.GetSelection() != 0)
+		self.indentToneDurationSpin.Enable(evt.GetSelection() in (ReportLineIndentation.TONES, ReportLineIndentation.SPEECH_AND_TONES))
 
 	def _onLinksChange(self, evt: wx.CommandEvent):
 		self.linkTypeCheckBox.Enable(evt.IsChecked())
@@ -3514,6 +3527,7 @@ class DocumentFormattingPanel(SettingsPanel):
 		config.conf["documentFormatting"]["reportPage"] = self.pageCheckBox.IsChecked()
 		config.conf["documentFormatting"]["reportLineNumber"] = self.lineNumberCheckBox.IsChecked()
 		config.conf["documentFormatting"]["reportLineIndentation"] = self.lineIndentationCombo.GetSelection()
+		config.conf["documentFormatting"]["indentToneDuration"] = self.indentToneDurationSpin.GetValue()
 		config.conf["documentFormatting"]["ignoreBlankLinesForRLI"] = (
 			self.ignoreBlankLinesRLICheckbox.IsChecked()
 		)

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -26,6 +26,7 @@
 * The dialog used to present browseable messages (such as formatting information) has been modernized. (#18878, @LeonarddeR)
   * The dialog's shortcut to copy contents of the message to the clipboard was changed to `alt+c`.
 * Updated CLDR to version 48.2. (#20234, @OzancanKaratas)
+* The duration of indentation beeps can now be configured via a new "Indent tone duration (ms)" spin control in the Document Formatting settings panel. (#20447, @Mubashir78)
 
 ### Bug Fixes
 

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -3536,9 +3536,9 @@ The tone will increase in pitch every space, and for a tab, it will increase in 
 If you tick the "Ignore blank lines for line indentation reporting" checkbox, then indentation changes won't be reported for blank lines.
 This may be useful when reading a document where blank lines are used to separate indented blocks of text, such as in programming source code.
 
-##### Indent tone duration {#DocumentFormattingSettingsIndentToneDuration}
+##### Indent tone duration {#sIndentToneDuration}
 
-This option allows you to configure the duration of indentation tones when the "Tones" or "Both Speech and Tones" option is selected in the "Report line indentation with" combo box.
+This option allows you to configure the duration of indentation tones when the "Tones" or "Both Speech and Tones" option is selected in the ["Report line indentation with"](#DocumentFormattingSettingsLineIndentation) combo box.
 The value can range from 10 ms to 2000 ms. The default is 40 ms.
 
 #### Document Navigation {#DocumentNavigation}

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -3536,7 +3536,7 @@ The tone will increase in pitch every space, and for a tab, it will increase in 
 If you tick the "Ignore blank lines for line indentation reporting" checkbox, then indentation changes won't be reported for blank lines.
 This may be useful when reading a document where blank lines are used to separate indented blocks of text, such as in programming source code.
 
-##### Indent tone duration {#sIndentToneDuration}
+##### Indent tone duration {#IndentToneDuration}
 
 This option allows you to configure the duration of indentation tones when the "Tones" or "Both Speech and Tones" option is selected in the ["Report line indentation with"](#DocumentFormattingSettingsLineIndentation) combo box.
 The value can range from 10 ms to 2000 ms.

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -3539,7 +3539,8 @@ This may be useful when reading a document where blank lines are used to separat
 ##### Indent tone duration {#sIndentToneDuration}
 
 This option allows you to configure the duration of indentation tones when the "Tones" or "Both Speech and Tones" option is selected in the ["Report line indentation with"](#DocumentFormattingSettingsLineIndentation) combo box.
-The value can range from 10 ms to 2000 ms. The default is 40 ms.
+The value can range from 10 ms to 2000 ms.
+The default is 40 ms.
 
 #### Document Navigation {#DocumentNavigation}
 

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -3456,6 +3456,7 @@ You can configure reporting of:
   * Page numbers
   * Line numbers
   * Line indentation reporting [(Off, Speech, Tones, Both Speech and Tones)](#DocumentFormattingSettingsLineIndentation)
+  * Indent tone duration (ms)
   * Ignore blank lines for line indentation reporting
   * Paragraph indentation (e.g. hanging indent, first line indent)
   * Line spacing (single, double, etc.)
@@ -3534,6 +3535,11 @@ The tone will increase in pitch every space, and for a tab, it will increase in 
 
 If you tick the "Ignore blank lines for line indentation reporting" checkbox, then indentation changes won't be reported for blank lines.
 This may be useful when reading a document where blank lines are used to separate indented blocks of text, such as in programming source code.
+
+##### Indent tone duration {#DocumentFormattingSettingsIndentToneDuration}
+
+This option allows you to configure the duration of indentation tones when the "Tones" or "Both Speech and Tones" option is selected in the "Report line indentation with" combo box.
+The value can range from 10 ms to 2000 ms. The default is 40 ms.
 
 #### Document Navigation {#DocumentNavigation}
 


### PR DESCRIPTION
Fixes #19353

### Link to issue number:
#19353

### Summary of the issue:
The duration of indentation beeps was hardcoded to 40ms, with no way for users to adjust it. Users who find the beeps too short or too long had no recourse.

### Description of user facing changes:
A new "Indent tone duration (ms)" spin control has been added to the Document Formatting settings panel, allowing users to adjust the length of indentation beeps from 10ms to 2000ms. The control is enabled only when "Tones" or "Speech and Tones" is selected in the line indentation reporting combo box.

### Description of developer facing changes:
No developer-facing changes. The `indentToneDuration` config key was already defined in `configSpec.py` with min=10, max=2000, default=40; this change only exposes it in the GUI.

### Description of development approach:
Added a spin control bound to the existing `config.conf["documentFormatting"]["indentToneDuration"]` value, gated by the line indentation reporting mode. The control enables/disables dynamically when the reporting mode combo changes.

### Testing strategy:
- Verified the spin control loads with the current config value (default 40)
- Verified the spin control enables/disables correctly when switching the line indentation reporting combo
- Verified the value is saved via onSave
- Verified F1 opens the user guide to the correct section

### Known issues with pull request:
None.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.