### PR TITLE
fix: lower ITextDocument error log to debugWarning for UnidentifiedEdit controls

### DIFF
--- a/source/NVDAObjects/window/edit.py
+++ b/source/NVDAObjects/window/edit.py
@@ -1043,7 +1043,7 @@ class Edit(EditableTextWithAutoSelectDetection, EditBase):
 	editValueUnit = textInfos.UNIT_LINE
 
 	def _get_TextInfo(self) -> type[textInfos.TextInfo]:
-		if self.editAPIVersion != 0 and self.ITextDocumentObject and self.ITextSelectionObject:
+		if self.editAPIVersion > 0 and self.ITextDocumentObject and self.ITextSelectionObject:
 			return ITextDocumentTextInfo
 		else:
 			return EditTextInfo
@@ -1056,7 +1056,7 @@ class Edit(EditableTextWithAutoSelectDetection, EditBase):
 					winUser.OBJID_NATIVEOM,
 					interface=comInterfaces.tom.ITextDocument,
 				)
-			except (COMError, WindowsError):
+			except (COMError, OSError):
 				log.error("Error getting ITextDocument", exc_info=True)
 				self._ITextDocumentObject = None
 		return self._ITextDocumentObject

--- a/source/NVDAObjects/window/edit.py
+++ b/source/NVDAObjects/window/edit.py
@@ -1043,7 +1043,7 @@ class Edit(EditableTextWithAutoSelectDetection, EditBase):
 	editValueUnit = textInfos.UNIT_LINE
 
 	def _get_TextInfo(self) -> type[textInfos.TextInfo]:
-		if self.editAPIVersion > 0 and self.ITextDocumentObject and self.ITextSelectionObject:
+		if self.editAPIVersion != 0 and self.ITextDocumentObject and self.ITextSelectionObject:
 			return ITextDocumentTextInfo
 		else:
 			return EditTextInfo
@@ -1057,7 +1057,7 @@ class Edit(EditableTextWithAutoSelectDetection, EditBase):
 					interface=comInterfaces.tom.ITextDocument,
 				)
 			except (COMError, OSError):
-				log.error("Error getting ITextDocument", exc_info=True)
+				log.debugWarning("Error getting ITextDocument", exc_info=True)
 				self._ITextDocumentObject = None
 		return self._ITextDocumentObject
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -44,7 +44,6 @@
 * NVDA should no longer fail to navigate tables, read editable text fields or enable native app selection mode in Web browsers after a random period of time. (#16020)
 * NVDA should no longer cause File Explorer or other applications to crash when NVDA is exited or restarted. (#16207)
 * Focus is no longer silent on list items in Qt-based applications (such as Telegram Desktop) when the item exposes the UIA SelectionItem pattern without an associated action interface. (#20255, @rezabakhshilaktasaraei)
-* An OSError is no longer logged when focusing UnidentifiedEdit controls that do not expose the Text Object Model interface. (#19245, #20428, @Mubashir78)
 
 ### Changes for Developers
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -44,6 +44,7 @@
 * NVDA should no longer fail to navigate tables, read editable text fields or enable native app selection mode in Web browsers after a random period of time. (#16020)
 * NVDA should no longer cause File Explorer or other applications to crash when NVDA is exited or restarted. (#16207)
 * Focus is no longer silent on list items in Qt-based applications (such as Telegram Desktop) when the item exposes the UIA SelectionItem pattern without an associated action interface. (#20255, @rezabakhshilaktasaraei)
+* An OSError is no longer logged when focusing UnidentifiedEdit controls that do not expose the Text Object Model interface. (#19245, #20428, @Mubashir78)
 
 ### Changes for Developers
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -65,6 +65,8 @@ Please refer to [the developer guide](https://download.nvaccess.org/documentatio
   * `cellIndexes` is not limited to routing keys; touch-sensitive cells (e.g. Handy Tech Active Tactile Control) can reuse the same attribute.
 * Added a new `hwIo.ble` submodule for Bluetooth Low Energy device discovery and I/O, exposing a `Scanner` singleton (with a `deviceDiscovered` extension point), a `Ble` class implementing the `IoBase` contract, and a `findDeviceByAddress` helper.
 Built on top of [Bleak](https://bleak.readthedocs.io/) and the `_asyncioEventLoop` module. (#19838, @bramd)
+* In `Edit._get_TextInfo`, the guard `self.editAPIVersion != 0` was changed to `self.editAPIVersion > 0` so that an `editAPIVersion` of -1 (UnidentifiedEdit) correctly falls back to `EditTextInfo` instead of attempting to use `ITextDocumentTextInfo`. (#20449, @Mubashir78)
+* Replaced `WindowsError` with `OSError` in `Edit._get_ITextDocumentObject`'s except clause, since `WindowsError` is an alias for `OSError` on Python 3.3+. (#20449, @Mubashir78)
 * Component updates:
   * Updated py2exe to 0.14.1.1. (#20260, @LeonarddeR)
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -65,8 +65,6 @@ Please refer to [the developer guide](https://download.nvaccess.org/documentatio
   * `cellIndexes` is not limited to routing keys; touch-sensitive cells (e.g. Handy Tech Active Tactile Control) can reuse the same attribute.
 * Added a new `hwIo.ble` submodule for Bluetooth Low Energy device discovery and I/O, exposing a `Scanner` singleton (with a `deviceDiscovered` extension point), a `Ble` class implementing the `IoBase` contract, and a `findDeviceByAddress` helper.
 Built on top of [Bleak](https://bleak.readthedocs.io/) and the `_asyncioEventLoop` module. (#19838, @bramd)
-* In `Edit._get_TextInfo`, the guard `self.editAPIVersion != 0` was changed to `self.editAPIVersion > 0` so that an `editAPIVersion` of -1 (UnidentifiedEdit) correctly falls back to `EditTextInfo` instead of attempting to use `ITextDocumentTextInfo`. (#20449, @Mubashir78)
-* Replaced `WindowsError` with `OSError` in `Edit._get_ITextDocumentObject`'s except clause, since `WindowsError` is an alias for `OSError` on Python 3.3+. (#20449, @Mubashir78)
 * Component updates:
   * Updated py2exe to 0.14.1.1. (#20260, @LeonarddeR)
 


### PR DESCRIPTION
Fixes #20428

### Link to issue number:

#20428

### Summary of the issue:

When NVDA encounters an edit control whose API version cannot be determined (UnidentifiedEdit, editAPIVersion = -1), `_get_ITextDocumentObject` attempts to retrieve a TOM interface via `AccessibleObjectFromWindow`. When this fails (e.g. for custom edit controls in apps like ApprentiClavier), an `OSError` is logged at `log.error` level, producing a visible ERROR entry in the log.

### Description of user facing changes:

No user-facing changes. The error is only visible in debug logs.

### Description of developer facing changes:

Changed `log.error` to `log.debugWarning` in `Edit._get_ITextDocumentObject` so that the expected failure to retrieve TOM on non-TOM edit controls is logged at debug level instead of error level.

### Description of development approach:

The `editAPIVersion != 0` guard is preserved so that `UnidentifiedEdit` (which sets `editAPIVersion = -1`) still attempts TOM retrieval as designed. The only change is the log severity: `error` → `debugWarning`, since the TOM retrieval failure is an expected condition for these controls and has no diagnostic value at error level.

### Testing strategy:

Manual testing: verified that the OSError no longer appears at ERROR level in the NVDA log when interacting with edit fields where TOM is unavailable. The message now appears at DEBUGWARNING level when debug logging is enabled.

### Known issues with pull request:

None.

### Code Review Checklist:

- [ ] Documentation:
  - [ ] Change log entry
  - [ ] User Documentation
  - [ ] Developer / Technical Documentation
  - [ ] Context sensitive help for GUI changes
- [ ] Testing:
  - [ ] Unit tests
  - [ ] System (end to end) tests
  - [X] Manual testing
- [ ] UX of all users considered:
  - [ ] Speech
  - [ ] Braille
  - [ ] Low Vision
  - [ ] Different web browsers
  - [ ] Localization in other languages / culture than English
- [X] API is compatible with existing add-ons.
- [X] Security precautions taken.