### PR TITLE
Handle ValueError in UIAControlQuicknavIterator previous and next directions

### DIFF
--- a/source/UIAHandler/browseMode.py
+++ b/source/UIAHandler/browseMode.py
@@ -371,7 +371,10 @@ def UIAControlQuicknavIterator(
 				elif not curElementMatchedCondition and isUIAElementInWalker(curElement, walker):
 					curElementMatchedCondition = True
 				if curElementMatchedCondition:
-					yield itemClass(itemType, document, curElement)
+					try:
+						yield itemClass(itemType, document, curElement)
+					except ValueError:
+						pass  # this element was not represented in the document's text content.
 			previousSibling = walker.getPreviousSiblingElement(curElement)
 			if previousSibling:
 				gonePreviousOnce = True
@@ -388,7 +391,10 @@ def UIAControlQuicknavIterator(
 				goneParent = True
 				curElementMatchedCondition = True
 				if gonePreviousOnce:
-					yield itemClass(itemType, document, curElement)
+					try:
+						yield itemClass(itemType, document, curElement)
+					except ValueError:
+						pass  # this element was not represented in the document's text content.
 				continue
 			curElement = None
 	else:  # direction is next
@@ -466,13 +472,19 @@ def UIAControlQuicknavIterator(
 		# If we are already past our position, and this is a valid child
 		# Then we can emit an item already
 		if goneNextOnce and isUIAElementInWalker(curElement, walker):
-			yield itemClass(itemType, document, curElement)
+			try:
+				yield itemClass(itemType, document, curElement)
+			except ValueError:
+				pass  # this element was not represented in the document's text content.
 		# Start traversing from this child forwards through the document, emitting items for valid elements.
 		while curElement:
 			firstChild = walker.getFirstChildElement(curElement) if goneNextOnce else None
 			if firstChild:
 				curElement = firstChild
-				yield itemClass(itemType, document, curElement)
+				try:
+					yield itemClass(itemType, document, curElement)
+				except ValueError:
+					pass  # this element was not represented in the document's text content.
 			else:
 				nextSibling = None
 				while not nextSibling:
@@ -488,7 +500,10 @@ def UIAControlQuicknavIterator(
 							return
 				curElement = nextSibling
 				goneNextOnce = True
-				yield itemClass(itemType, document, curElement)
+				try:
+					yield itemClass(itemType, document, curElement)
+				except ValueError:
+					pass  # this element was not represented in the document's text content.
 
 
 class UIABrowseModeDocumentTextInfo(

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -44,6 +44,7 @@
 * NVDA should no longer fail to navigate tables, read editable text fields or enable native app selection mode in Web browsers after a random period of time. (#16020)
 * NVDA should no longer cause File Explorer or other applications to crash when NVDA is exited or restarted. (#16207)
 * Focus is no longer silent on list items in Qt-based applications (such as Telegram Desktop) when the item exposes the UIA SelectionItem pattern without an associated action interface. (#20255, @rezabakhshilaktasaraei)
+* In Microsoft Word browse mode, navigating backwards to a previous graphic with `shift+g` no longer fails silently or produces an error sound when a UIA text range cannot be resolved for an element. (#20419, @munzzyy)
 
 ### Changes for Developers
 


### PR DESCRIPTION
### Link to issue number:

Fixes #20419

### Summary of the issue:

In Microsoft Word browse mode, pressing `shift+g` to move back to a previous graphic fails silently or plays an error sound instead of moving the cursor. The reported traceback puts the error in `UIAControlQuicknavIterator`:

```
File "UIAHandler\browseMode.pyc", line 374, in UIAControlQuicknavIterator
File "UIAHandler\browseMode.pyc", line 70, in __init__
ValueError: Could not get text range for UIA element
```

`UIATextRangeQuickNavItem.__init__` raises `ValueError` when `getNormalizedUIATextRangeFromElement` fails to resolve a text range for a UIA element. This happens when the underlying COM call fails, which shows up more on documents containing images.

### Description of user facing changes:

Moving backward or forward through quicknav items (graphics, for example) in Word browse mode no longer aborts the whole operation when one element along the way can't be turned into a text range. That element is skipped, matching the existing behaviour for the "up" direction.

### Description of developer facing changes:

None.

### Description of development approach:

`UIAControlQuicknavIterator` has three direction branches: `up`, `previous`, and `next`. The `up` branch already wraps its `yield itemClass(itemType, document, element)` call in a `try/except ValueError: pass` so an element that isn't representable in the document's text content is just skipped rather than blowing up the whole generator.

The `previous` and `next` branches don't have this guard on any of their yield points, so the same `ValueError` from `UIATextRangeQuickNavItem.__init__` propagates out of the generator and aborts quicknav navigation entirely, which is what the user sees as silence or an error sound.

This change wraps every yield in the `previous` and `next` branches with the same `try/except ValueError: pass` already used in `up`, so a single unresolvable element is skipped and iteration continues to the next candidate instead of stopping.

### Testing strategy:

Verified by code inspection: the fix mirrors an existing, working pattern in the same function (the `up` branch) rather than introducing new logic. Ran `ruff check` and `ruff format --diff` against the modified file, both clean.

I don't have a Word document in front of me that reliably triggers the underlying COM failure, so I haven't done an interactive repro of the original symptom. This is a source-level fix closing the same gap already closed for the `up` direction; a maintainer or the reporter re-testing `shift+g` over images in the original repro document would confirm it end to end.

### Known issues with pull request:

None known.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
- [ ] API is compatible with existing add-ons.
- [x] Security precautions taken.
