### PR TITLE
Handle COMError from getChildren in UIAControlQuicknavIterator previous and next directions

### DIFF
--- a/source/UIAHandler/browseMode.py
+++ b/source/UIAHandler/browseMode.py
@@ -304,7 +304,12 @@ def UIAControlQuicknavIterator(
 		# And fetch the last child again.
 		zoomedOnce = False
 		while True:
-			children = toPosition.getChildren()
+			try:
+				children = toPosition.getChildren()
+			except COMError:
+				if zoomedOnce:
+					child = toPosition.getEnclosingElement()
+				break
 			length = children.length
 			if length == 0:
 				if zoomedOnce:
@@ -409,7 +414,12 @@ def UIAControlQuicknavIterator(
 		)
 		zoomedOnce = False
 		while True:
-			children = toPosition.getChildren()
+			try:
+				children = toPosition.getChildren()
+			except COMError:
+				if zoomedOnce:
+					child = toPosition.getEnclosingElement()
+				break
 			length = children.length
 			if length == 0:
 				if zoomedOnce:

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -46,6 +46,7 @@
 * NVDA should no longer fail to navigate tables, read editable text fields or enable native app selection mode in Web browsers after a random period of time. (#16020)
 * NVDA should no longer cause File Explorer or other applications to crash when NVDA is exited or restarted. (#16207)
 * Focus is no longer silent on list items in Qt-based applications (such as Telegram Desktop) when the item exposes the UIA SelectionItem pattern without an associated action interface. (#20255, @rezabakhshilaktasaraei)
+* In Microsoft Word (and Outlook) using UI Automation, quick navigation to the next or previous link no longer silently fails on certain documents. (#17848, @munzzyy)
 
 ### Changes for Developers
 


### PR DESCRIPTION
### Link to issue number:

Fixes #17848

### Summary of the issue:

In Word (or Outlook) browse mode using UIA, pressing `k` to jump to the next link does nothing and logs an error. The traceback in the issue points at `UIAControlQuicknavIterator`:

```
File "UIAHandler\browseMode.pyc", line 412, in UIAControlQuicknavIterator
_ctypes.COMError: (-2146233079, None, (None, None, None, 0, None))
```

Line 412 is a bare `toPosition.getChildren()` call in the `next` direction branch. It has no guard, so a `COMError` from that call propagates straight out of the generator and aborts quicknav entirely, which is what shows up as the caret not moving and an error being logged.

### Description of user facing changes:

`k` and `shift+k` (next/previous link, and other quicknav item types that go through this same code path) no longer abort with an error on documents where the underlying UIA call fails partway through. NVDA now treats that failure the same way it already treats "no more children found," so navigation stops cleanly instead of blowing up.

### Description of developer facing changes:

None.

### Description of development approach:

`UIAControlQuicknavIterator` has `up`, `previous`, and `next` branches. Both `previous` and `next` have a loop that calls `toPosition.getChildren()` and then reads `children.length`. Neither call was guarded, even though the `rangeFromChild` calls right next to them in the same function already catch `COMError`.

I wrapped `getChildren()` in `try/except COMError` in both branches (the issue is about `next`, but `previous` has the identical unguarded call and would hit the same crash on `shift+k`, so I fixed both for symmetry). On a caught `COMError`, the code does exactly what the existing `length == 0` branch already does a few lines below: if `zoomedOnce` is set, re-derive `child` via `getEnclosingElement()`; otherwise leave `child` as whatever it was already bound to before the loop. That mirrors how the function already handles "ran out of children" rather than inventing new behavior.

### Testing strategy:

Verified by code inspection: the fix reuses the exact handling the function already has for the zero-children case, and follows the same catch-and-continue shape already used for the nearby `rangeFromChild` calls in the same branches. Ran `ruff check` and `ruff format --diff` against the modified file, both clean.

I don't have a Word/UIA setup to run through the attached GoToLinkError.docx repro interactively, so I haven't confirmed the fix end to end against the actual reported symptom. The reporter's repro doc should make that quick to check.

### Known issues with pull request:

None known.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
- [ ] API is compatible with existing add-ons.
- [x] Security precautions taken.
