### PR TITLE
ci-cd: Bump GitHub Actions to latest stable versions

### DIFF
--- a/.github/workflows/add-new-language.yml
+++ b/.github/workflows/add-new-language.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         ref: beta
         fetch-depth: 1

--- a/.github/workflows/add-new-language.yml
+++ b/.github/workflows/add-new-language.yml
@@ -30,7 +30,7 @@ jobs:
         submodules: true
 
     - name: Set up python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.13'
         architecture: 'x86'

--- a/.github/workflows/add-new-language.yml
+++ b/.github/workflows/add-new-language.yml
@@ -36,7 +36,7 @@ jobs:
         architecture: 'x86'
 
     - name: setup uv
-      uses: astral-sh/setup-uv@v6
+      uses: astral-sh/setup-uv@v7
 
     - name: Download translations from Crowdin
       run: uv run source/l10nUtil.py exportTranslations -o . -l ${{ matrix.newLanguage }}

--- a/.github/workflows/assign-milestone-on-close.yml
+++ b/.github/workflows/assign-milestone-on-close.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Check if milestone is set
         id: check-milestone
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
@@ -42,7 +42,7 @@ jobs:
 
       - name: Check merged
         id: check-done
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
@@ -54,7 +54,7 @@ jobs:
 
       - name: Assign default milestone
         if: steps.check-milestone.outputs.milestoneNotSet == 'true' && steps.check-done.outputs.isDone == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -42,7 +42,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
@@ -70,6 +70,6 @@ jobs:
         exit 1
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -38,7 +38,7 @@ jobs:
           build-mode: none
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/fetch-crowdin-translations.yml
+++ b/.github/workflows/fetch-crowdin-translations.yml
@@ -35,7 +35,7 @@ jobs:
         GH_REPO: ${{ github.repository }}
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         ref: beta
         fetch-depth: 1

--- a/.github/workflows/fetch-crowdin-translations.yml
+++ b/.github/workflows/fetch-crowdin-translations.yml
@@ -83,7 +83,7 @@ jobs:
 
     - name: Notify translators of errors
       if: steps.commit.outputs.has_failures == 'true'
-      uses: dawidd6/action-send-mail@v4
+      uses: dawidd6/action-send-mail@v18
       with:
         server_address: ${{ secrets.EMAIL_SERVER_ADDRESS }}
         server_port: ${{ secrets.EMAIL_SERVER_PORT || 465 }}

--- a/.github/workflows/fetch-crowdin-translations.yml
+++ b/.github/workflows/fetch-crowdin-translations.yml
@@ -48,7 +48,7 @@ jobs:
         architecture: 'x64'
 
     - name: setup uv
-      uses: astral-sh/setup-uv@v6
+      uses: astral-sh/setup-uv@v7
 
     - name: Download translations from Crowdin
       run: uv run source/l10nUtil.py exportTranslations -o .

--- a/.github/workflows/monitor-localisation-file-changes.yml
+++ b/.github/workflows/monitor-localisation-file-changes.yml
@@ -45,7 +45,7 @@ jobs:
         echo "DOUBLE_SPACED_DIFF<<EOF"$'\n'"$DOUBLE_SPACED_DIFF"$'\n'EOF >> $GITHUB_OUTPUT
 
     - name: Send email
-      uses: dawidd6/action-send-mail@v4
+      uses: dawidd6/action-send-mail@v18
       with:
         server_address: ${{ secrets.EMAIL_SERVER_ADDRESS }}
         server_port: ${{ secrets.EMAIL_SERVER_PORT || 465 }}

--- a/.github/workflows/monitor-localisation-file-changes.yml
+++ b/.github/workflows/monitor-localisation-file-changes.yml
@@ -27,7 +27,7 @@ jobs:
         GH_REPO: ${{ github.repository }}
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         fetch-depth: 0
 

--- a/.github/workflows/regenerate_english_userDocs_translation_source.yml
+++ b/.github/workflows/regenerate_english_userDocs_translation_source.yml
@@ -34,7 +34,7 @@ jobs:
         token: ${{ secrets.NVACCESSAUTO_PUSH_PAT }}
 
     - name: Set up python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.13'
         architecture: 'x86'

--- a/.github/workflows/regenerate_english_userDocs_translation_source.yml
+++ b/.github/workflows/regenerate_english_userDocs_translation_source.yml
@@ -28,7 +28,7 @@ jobs:
         GH_REPO: ${{ github.repository }}
 
     - name: Checkout repository
-      uses: actions/checkout@v5
+      uses: actions/checkout@v7
       with:
         fetch-depth: 0
         token: ${{ secrets.NVACCESSAUTO_PUSH_PAT }}

--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -79,7 +79,7 @@ jobs:
       APIBackCompat: ${{ steps.releaseInfo.outputs.NVDA_API_COMPAT_TO }}
     steps:
     - name: Checkout NVDA
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         submodules: recursive
     - name: Install Python
@@ -180,7 +180,7 @@ jobs:
       contents: read
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         # Include gettext
         submodules: true
@@ -796,7 +796,7 @@ jobs:
       contents: read
     steps:
     - name: Checkout NVDA
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         submodules: false
 


### PR DESCRIPTION

### Link to issue number:
none
### Summary of the issue:
Upgrade referenced GitHub Actions to the latest versions to apply the latest security patches.
### Description of user facing changes:
none
### Description of developer facing changes:
* actions/checkout:
Update the actions/checkout action from v4 to v7 in the following workflow files:
add-new-language.yml
codeql.yml
fetch-crowdin-translations.yml
monitor-localisation-file-changes.yml
testAndPublish.yml

Note that regenerate_english_userDocs_translation_source.yml already references v5 of the checkout action, so it should be upgraded from v5 to v7.

* actions/setup-python:
Updated from v5 to v6 in the following workflow files:
add-new-language.yml
regenerate_english_userDocs_translation_source.yml

* actions/github-script: v7 to v9
* * github/codeql-action: v3 to v4

* dawidd6/action-send-mail: v4 to v18

* Update astral-sh/setup-uv from v7 to v8.
Note: The uses: astral-sh/setup-uv@vx format is no longer supported in v8. The new format requires pinning to a specific commit hash, like this:
astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0

### Description of development approach:
**Update GitHub Actions to the latest versions in .github/workflows/*.yml files.**
### Testing strategy:
fork link:
https://github.com/dpy013/nvda/actions/runs/28876473907
### Known issues with pull request:
none
### Code Review Checklist:


- [ ] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [ ] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [ ] API is compatible with existing add-ons.
- [ ] Security precautions taken.
