### PR TITLE
Remember ALVA HID keyboard input simulation setting

### DIFF
--- a/source/brailleDisplayDrivers/alva.py
+++ b/source/brailleDisplayDrivers/alva.py
@@ -152,7 +152,7 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver, ScriptableObject):
 	isThreadSafe = True
 	supportsAutomaticDetection = True
 	timeout = 0.2
-	supportedSettings = (braille.BrailleDisplayDriver.HIDInputSetting(useConfig=False),)
+	supportedSettings = (braille.BrailleDisplayDriver.HIDInputSetting(useConfig=True),)
 
 	@classmethod
 	def registerAutomaticDetection(cls, driverRegistrar: bdDetect.DriverRegistrar):
@@ -411,6 +411,8 @@ class BrailleDisplayDriver(braille.BrailleDisplayDriver, ScriptableObject):
 		return not self._rawKeyboardInput
 
 	def _set_hidKeyboardInput(self, state):
+		if state is self.hidKeyboardInput:
+			return
 		rawState = not state
 		if self.isHid:
 			# Make sure the device settings are up to date.

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -31,6 +31,7 @@
 
 ### Bug Fixes
 
+* The HID keyboard input simulation setting for ALVA braille displays is now remembered across reconnects and restarts. (#20455, @Cary-rowen)
 * In PowerPoint and other Office applications, NVDA will now correctly read and navigate the edit fields in the insert hyperlink dialog. (#17390, @aryanchoudharypro)
 * The actions button can now be used when selecting multiple add-ons in the Add-on Store to perform batch actions, instead of just via the context menu in the add-ons list. (#19971, @amirmahdifard)
 * When moving to an ARIA grid cell in focus mode in web browsers, NVDA no longer reports both the row and column headers even if only the row or only the column changed. (#17750, @jcsteh)

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -31,7 +31,6 @@
 
 ### Bug Fixes
 
-* The HID keyboard input simulation setting for ALVA braille displays is now remembered across reconnects and restarts. (#20455, @Cary-rowen)
 * In PowerPoint and other Office applications, NVDA will now correctly read and navigate the edit fields in the insert hyperlink dialog. (#17390, @aryanchoudharypro)
 * The actions button can now be used when selecting multiple add-ons in the Add-on Store to perform batch actions, instead of just via the context menu in the add-ons list. (#19971, @amirmahdifard)
 * When moving to an ARIA grid cell in focus mode in web browsers, NVDA no longer reports both the row and column headers even if only the row or only the column changed. (#17750, @jcsteh)
@@ -47,6 +46,7 @@
 * NVDA should no longer fail to navigate tables, read editable text fields or enable native app selection mode in Web browsers after a random period of time. (#16020)
 * NVDA should no longer cause File Explorer or other applications to crash when NVDA is exited or restarted. (#16207)
 * Focus is no longer silent on list items in Qt-based applications (such as Telegram Desktop) when the item exposes the UIA SelectionItem pattern without an associated action interface. (#20255, @rezabakhshilaktasaraei)
+* The HID keyboard input simulation setting for ALVA braille displays is now remembered across reconnects and restarts. (#20455, @Cary-rowen)
 
 ### Changes for Developers
 


### PR DESCRIPTION
### Link to issue number:

Fixes #20455

### Summary of the issue:

The ALVA HID keyboard input simulation setting only applies for the current session. After reconnecting or restarting NVDA, the setting returns to its default checked state instead of preserving the user's explicit choice.

### Description of user facing changes:

NVDA now remembers the user's ALVA HID keyboard input simulation preference across reconnects and restarts.

### Description of developer facing changes:

None.

### Description of development approach:

Use the existing AutoSettings configuration mechanism for ALVA's HID keyboard input setting by setting `HIDInputSetting(useConfig=True)`.

A no-op guard is also kept in `_set_hidKeyboardInput` so the driver avoids writing the same state back to the display when the requested state already matches the current state.

### Testing strategy:

Manually tested with an ALVA 6 series braille display.

### Known issues with pull request:

None known.

### Code Review Checklist:

- [ ] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [ ] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [ ] API is compatible with existing add-ons.
- [ ] Security precautions taken.
