### PR TITLE
Make braille and vision follow caret in browse mode

### DIFF
--- a/source/speech/sayAll.py
+++ b/source/speech/sayAll.py
@@ -1,8 +1,8 @@
 # A part of NonVisual Desktop Access (NVDA)
-# This file is covered by the GNU General Public License.
-# See the file COPYING for more details.
-# Copyright (C) 2006-2025 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Babbage B.V., Bill Dengler,
+# Copyright (C) 2006-2026 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Babbage B.V., Bill Dengler,
 # Julien Cochuyt, Cyrille Bougot, Leonard de Ruijter
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
 
 from abc import ABCMeta, abstractmethod
 from enum import IntEnum
@@ -414,7 +414,16 @@ class _CaretTextReader(_TextReader):
 			raise NotImplementedError("Unable to make TextInfo: ", e)
 
 	def updateCaret(self, updater: textInfos.TextInfo) -> None:
+		obj = updater.obj
 		updater.updateCaret()
+		# #3287: cursor managers move the caret without firing an OS caret event,
+		# so we need to communicate movement to handlers explicitly.
+		if api.isCursorManager(obj):
+			import braille
+			import vision
+
+			braille.handler.handleCaretMove(obj)
+			vision.handler.handleCaretMove(obj)
 		if config.conf["reviewCursor"]["followCaret"]:
 			api.setReviewPosition(updater, isCaret=True)
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -47,7 +47,7 @@
 * NVDA should no longer cause File Explorer or other applications to crash when NVDA is exited or restarted. (#16207)
 * Focus is no longer silent on list items in Qt-based applications (such as Telegram Desktop) when the item exposes the UIA SelectionItem pattern without an associated action interface. (#20255, @rezabakhshilaktasaraei)
 * The HID keyboard input simulation setting for ALVA braille displays is now remembered across reconnects and restarts. (#20455, @Cary-rowen)
-* Braille and the magnifier now follow the spoken text during say all in browse mode and other virtual buffers, not just when braille is tethered to review. (#3287, @LeonarddeR)
+* Braille now follows the spoken text during say all in browse mode when braille is tethered to focus. (#3287, @LeonarddeR)
 
 ### Changes for Developers
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -47,6 +47,7 @@
 * NVDA should no longer cause File Explorer or other applications to crash when NVDA is exited or restarted. (#16207)
 * Focus is no longer silent on list items in Qt-based applications (such as Telegram Desktop) when the item exposes the UIA SelectionItem pattern without an associated action interface. (#20255, @rezabakhshilaktasaraei)
 * The HID keyboard input simulation setting for ALVA braille displays is now remembered across reconnects and restarts. (#20455, @Cary-rowen)
+* Braille and the magnifier now follow the spoken text during say all in browse mode and other virtual buffers, not just when braille is tethered to review. (#3287, @LeonarddeR)
 
 ### Changes for Developers
 


### PR DESCRIPTION
### Link to issue number:

Closes #3287

### Summary of the issue:

During say all with the caret cursor in browse mode, braille and vision framework did not follow the spoken text. The display stayed on the line where say all started, and only moved if braille happened to be tethered to review.

This happens because `_CaretTextReader.updateCaret` moved the caret via `updater.updateCaret()`. In browse mode the caret is virtual, so this does not fire an OS caret event. Braille and the vision handlers are normally notified off that event, so they were never told the caret had moved.

### Description of user facing changes:

During say all in browse mode, braille and the magnifier now follow the spoken text line by line, regardless of the braille tether setting.

### Description of developer facing changes:

None. No public API changes.

### Description of development approach:

`_CaretTextReader.updateCaret` now detects cursor managers via `api.isCursorManager(obj)` and, for those, explicitly calls `braille.handler.handleCaretMove(obj)` and `vision.handler.handleCaretMove(obj)` after moving the caret. Objects that fire an OS caret event are left on the existing path, since that event already drives the handlers.

### Testing strategy:

Say all in browse mode (Firefox, Chrome) with a braille display tethered to focus: braille now follows the spoken line.

### Known issues with pull request:

None.

### Code Review Checklist:

- [x] Documentation:
  - [x] Change log entry
  - [ ] User Documentation
  - [ ] Developer / Technical Documentation
  - [ ] Context sensitive help for GUI changes
- [x] Testing:
  - [ ] Unit tests
  - [ ] System (end to end) tests
  - [x] Manual testing
- [x] UX of all users considered:
  - [x] Speech
  - [x] Braille
  - [x] Low Vision
  - [x] Different web browsers
  - [ ] Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
