### PR TITLE
Actually restart rather than just logging off

### DIFF
--- a/source/gui/installerGui.py
+++ b/source/gui/installerGui.py
@@ -106,7 +106,7 @@ def _restartWindows() -> bool:
 	# Shut down the system and force all applications to close.
 	if (
 		ExitWindowsEx(
-			EWX.RESTARTAPPS,
+			EWX.REBOOT | EWX.RESTARTAPPS,
 			SHTDN_REASON.MAJOR_APPLICATION | SHTDN_REASON.MINOR_INSTALLATION | SHTDN_REASON.FLAG_PLANNED,
 		)
 		== 0

--- a/source/winBindings/user32.py
+++ b/source/winBindings/user32.py
@@ -1688,6 +1688,8 @@ class NMHDR(Structure):
 class EWX(IntFlag):
 	"""The shutdown type requested by a call to ExitWindowsEx."""
 
+	REBOOT = 0x00000002
+	"""EWX_REBOOT: Shuts down and then restarts the system."""
 	RESTARTAPPS = 0x00000040
 	"""EWX_RESTARTAPPS: Shuts down and restarts the system, as well as any applications that have been registered for restart using the RegisterApplicationRestart function."""
 


### PR DESCRIPTION
### Link to issue number:

Follow-up #20441

### Summary of the issue:

The changes in #20441 only log the user off, and do not actually restart the system.

### Description of user facing changes:

The restart button shown by the installer will actually restart the system.

### Description of developer facing changes:

Added the `winBindings.user32.EWX.REBOOT` enum variant.

### Description of development approach:

Turns out the `EWX_RESTARTAPPS` flag only indicates that apps should be restarted; it doesn't actually cause the system to restart. In order to restart the system and restart apps, it has to be used in conjunction with the `EWX_REBOOT` flag.

I'm not sure how I missed this while testing the original PR, as I'm pretty sure it worked then.

### Testing strategy:

Ran from source. Called `gui.installerGui._restartWindows` from the Python console. Visually verified that the system actually restarted.

Also did so with a draft email open in Thunderbird, and verified that the blocked shutdown screen was shown.

### Known issues with pull request:

None known.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
