### PR TITLE
API breaking changes management and feature freeze

### DIFF
--- a/projectDocs/dev/contributing.md
+++ b/projectDocs/dev/contributing.md
@@ -72,7 +72,7 @@ If NV Access does not have time or the ability to fix a serious issue with a new
 
 * API breaking changes must be proposed and accepted before the first 20XX.1 alpha is released.
 They should be added to the 20XX.1 milestone and labeled `triaged`, `api-breaking-change`, `release/blocking-beta`, `release/blocking`.
-* API breaking releases should contain bug fixes and developer facing changes only.
+* API breaking releases should contain security fixes, bug fixes and developer facing changes only.
 
 API breaking releases come with too much risk and major technical changes.
 We cannot manage the additional work of new features during them.

--- a/projectDocs/dev/contributing.md
+++ b/projectDocs/dev/contributing.md
@@ -71,6 +71,7 @@ If NV Access does not have time or the ability to fix a serious issue with a new
 ### API breaking releases
 
 * API breaking changes must be proposed and accepted before the first 20XX.1 alpha is released.
+They should be added to the 20XX.1 milestone and labeled `triaged`, `release/blocking-beta`, `release/blocking`.
 * API breaking releases should contain bug fixes and developer facing changes only.
 
 API breaking releases come with too much risk and major technical changes.

--- a/projectDocs/dev/contributing.md
+++ b/projectDocs/dev/contributing.md
@@ -58,6 +58,26 @@ Large refactors should instead target specific symbols/files/modules per PR to m
 Ongoing feature development that cannot be merged straight to `master` can occur on `try-` branches, done in pieces.
 Ask NV Access on the corresponding ADR to create a `try-` branch.
 
+### Feature development
+
+Feature development adds scope to NVDA, and with that comes risk.
+New features require planning and ongoing support from the contributor throughout the release process.
+
+New features can only be added during the alpha phase for a release.
+If an issue with a new feature is not resolved in a reasonable timeframe the feature will be reverted.
+Once a feature has reached a stable release, support from the contributor may still be required.
+If NV Access does not have time or the ability to fix a serious issue with a new feature, the feature may be removed in a subsequent release.
+
+### API breaking releases
+
+* API breaking changes must be proposed and accepted before the 20XX.1 release cycle starts, and the first 20XX.1 alpha is released.
+* API breaking releases should contain bug fixes and developer facing changes only.
+
+API breaking releases come with too much risk and major technical changes, we cannot manage the additional work of new features during them.
+
+We will only accept new features in API breaking releases if they are previously scheduled, and include unavoidable API breaking changes.
+The changes proposed in the API breaking release must be minimal, e.g. focusing on the internal changes only, to enable the feature in a subsequent release.
+
 ## Overview of contribution process:
 
 1. [Setup your development environment](./createDevEnvironment.md).

--- a/projectDocs/dev/contributing.md
+++ b/projectDocs/dev/contributing.md
@@ -72,7 +72,6 @@ If NV Access does not have time or the ability to fix a serious issue with a new
 
 * API breaking changes must be proposed and accepted before the first 20XX.1 alpha is released.
 They should be added to the 20XX.1 milestone and labeled `triaged`, `api-breaking-change`, `release/blocking-beta`, `release/blocking`.
-They should be added to the 20XX.1 milestone and labeled `triaged`, `release/blocking-beta`, `release/blocking`.
 * API breaking releases should contain bug fixes and developer facing changes only.
 
 API breaking releases come with too much risk and major technical changes.

--- a/projectDocs/dev/contributing.md
+++ b/projectDocs/dev/contributing.md
@@ -64,19 +64,20 @@ Feature development adds scope to NVDA, and with that comes risk.
 New features require planning and ongoing support from the contributor throughout the release process.
 
 New features can only be added during the alpha phase for a release.
-If an issue with a new feature is not resolved in a reasonable timeframe the feature will be reverted.
+If an issue with a new feature is not resolved in a reasonable timeframe, the feature will be reverted.
 Once a feature has reached a stable release, support from the contributor may still be required.
 If NV Access does not have time or the ability to fix a serious issue with a new feature, the feature may be removed in a subsequent release.
 
 ### API breaking releases
 
-* API breaking changes must be proposed and accepted before the 20XX.1 release cycle starts, and the first 20XX.1 alpha is released.
+* API breaking changes must be proposed and accepted before the first 20XX.1 alpha is released.
 * API breaking releases should contain bug fixes and developer facing changes only.
 
-API breaking releases come with too much risk and major technical changes, we cannot manage the additional work of new features during them.
+API breaking releases come with too much risk and major technical changes.
+We cannot manage the additional work of new features during them.
 
-We will only accept new features in API breaking releases if they are previously scheduled, and include unavoidable API breaking changes.
-The changes proposed in the API breaking release must be minimal, e.g. focusing on the internal changes only, to enable the feature in a subsequent release.
+We will only accept new features in API breaking releases if they are pre-scheduled and include unavoidable API breaking changes.
+The changes proposed in the API breaking release must be minimal, e.g., focusing on the internal changes only to enable the feature in a subsequent release.
 
 ## Overview of contribution process:
 

--- a/projectDocs/dev/contributing.md
+++ b/projectDocs/dev/contributing.md
@@ -71,6 +71,7 @@ If NV Access does not have time or the ability to fix a serious issue with a new
 ### API breaking releases
 
 * API breaking changes must be proposed and accepted before the first 20XX.1 alpha is released.
+They should be added to the 20XX.1 milestone and labeled `triaged`, `api-breaking-change`, `release/blocking-beta`, `release/blocking`.
 They should be added to the 20XX.1 milestone and labeled `triaged`, `release/blocking-beta`, `release/blocking`.
 * API breaking releases should contain bug fixes and developer facing changes only.
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Circulated to [email list](https://groups.io/g/nvda-devel/topic/feature_freeze_for_2027_1/120202205)

### Summary of the issue:
API breaking releases are slow and slow down the entire release process for the rest of the year.
To push API breaking releases out faster, and thus the rest of our yearly releases, we must cut the scope of them significantly.

This proposes:

* a feature / major changes freeze during API breaking releases, to focus on API breaking changes
* requiring all API breaking changes to be pre-scheduled
* allowing the minimal set of feature changes in an API breaking release, for accompanied unavoidable prescheduled API breaking changes

### Description of developer facing changes:

Developers must pre-schedule API breaking changes.
NVDA development goes into a feature freeze from when the first 20XX.1 alpha is released until the first 20XX.2 alpha is release. This would be roughly a 2-3 month period at the end of the year.

### Downside / cons

No features means less incentive for users to try the new release. the API breaking release basically cements itself as a "soft beta" release, really only used by early adopters. This is somewhat the case already, but this change leans into that further. Most people won't upgrade until features come out in 20XX.2