### PR TITLE
Report checked state for .NET Framework WinForms ToolStrip menu items using UIA

### DIFF
--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -22,6 +22,7 @@ from ctypes.wintypes import POINT
 from comtypes import COMError
 import time
 import numbers
+import oleacc
 import colors
 import languageHandler
 import NVDAState
@@ -2565,6 +2566,28 @@ class TreeviewItem(UIA):
 
 
 class MenuItem(UIA):
+	_UIAStatesPropertyIDs: set[int] = UIA._UIAStatesPropertyIDs | {
+		UIAHandler.UIA_LegacyIAccessibleStatePropertyId,
+	}
+
+	def _get_states(self) -> set[controlTypes.State]:
+		states = super()._get_states()
+		if controlTypes.State.CHECKABLE in states:
+			return states
+		# #19335: WinForms ToolStripMenuItems can expose their checked state only through LegacyIAccessible.
+		legacyState = self._getUIACacheablePropertyValue_handlesCOMErrors(
+			UIAHandler.UIA_LegacyIAccessibleStatePropertyId,
+			True,
+		)
+		if isinstance(legacyState, int) and legacyState & oleacc.STATE_SYSTEM_CHECKED:
+			states.update(
+				{
+					controlTypes.State.CHECKABLE,
+					controlTypes.State.CHECKED,
+				},
+			)
+		return states
+
 	def _get_description(self):
 		name = self.name
 		description = super(MenuItem, self)._get_description()

--- a/tests/unit/test_NVDAObjects_UIA.py
+++ b/tests/unit/test_NVDAObjects_UIA.py
@@ -1,0 +1,55 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2026 NV Access Limited, Cary-rowen
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
+
+"""Unit tests for NVDAObjects.UIA."""
+
+import unittest
+from unittest.mock import patch
+
+import controlTypes
+from NVDAObjects.UIA import MenuItem, UIA
+import oleacc
+import UIAHandler
+
+
+class TestMenuItemStates(unittest.TestCase):
+	def test_legacyCheckedStateFallback(self) -> None:
+		menuItem = object.__new__(MenuItem)
+		testCases = (
+			(
+				set(),
+				oleacc.STATE_SYSTEM_CHECKED,
+				{controlTypes.State.CHECKABLE, controlTypes.State.CHECKED},
+				True,
+			),
+			(set(), 0, set(), True),
+			(
+				{controlTypes.State.CHECKABLE},
+				oleacc.STATE_SYSTEM_CHECKED,
+				{controlTypes.State.CHECKABLE},
+				False,
+			),
+		)
+		for uiaStates, legacyState, expectedStates, shouldReadLegacyState in testCases:
+			with (
+				self.subTest(
+					uiaStates=uiaStates,
+					legacyState=legacyState,
+				),
+				patch.object(UIA, "_get_states", return_value=uiaStates.copy()),
+				patch.object(
+					MenuItem,
+					"_getUIACacheablePropertyValue_handlesCOMErrors",
+					return_value=legacyState,
+				) as getLegacyState,
+			):
+				self.assertEqual(expectedStates, menuItem._get_states())
+				if shouldReadLegacyState:
+					getLegacyState.assert_called_once_with(
+						UIAHandler.UIA_LegacyIAccessibleStatePropertyId,
+						True,
+					)
+				else:
+					getLegacyState.assert_not_called()

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -52,6 +52,7 @@
 Previously these keys had no function when pressed on their own. (#20366, @fla-rion)
 * The HID keyboard input simulation setting for ALVA braille displays is now remembered across reconnects and restarts. (#20455, @Cary-rowen)
 * Braille now follows the spoken text during say all in browse mode when braille is tethered to focus. (#3287, @LeonarddeR)
+* NVDA now reports checked ToolStrip menu items in .NET Framework Windows Forms applications using UI Automation. (#19335, @Cary-rowen)
 
 ### Changes for Developers
 


### PR DESCRIPTION
### Link to issue number:
Fixes #19335

### Summary of the issue:
Classic .NET Framework Windows Forms ToolStrip menu items exposed through the native UIA provider do not expose the TogglePattern. Their checked state is instead available through LegacyIAccessible, so NVDA does not currently report when these menu items are checked.

### Description of user facing changes:
NVDA now reports when affected ToolStrip menu items are checked.

### Description of developer facing changes:
No public API changes.

### Description of development approach:
Extend the existing UIA menu item state handling with a LegacyIAccessible fallback. Standard UIA states remain authoritative. When UIA does not identify the item as checkable, NVDA reads the cached LegacyIAccessible state and adds the checkable and checked states when `STATE_SYSTEM_CHECKED` is present.

The fallback is implemented directly in `NVDAObjects.UIA.MenuItem`, the overlay class NVDA applies to UIA menu item controls. This avoids introducing a WinForms-specific overlay or .NET Framework version detection.

### Testing strategy:
* Manual testing with a .NET Framework 4.8 Windows Forms demo containing ToolStrip menu items with `CheckOnClick = true`, verifying that checked items are announced and other items are not falsely reported as checked.
* Unit tests for the LegacyIAccessible checked-state fallback, items without the checked state, and precedence of standard UIA states.

### Known issues with pull request:
None known.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [ ] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [ ] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [ ] API is compatible with existing add-ons.
- [ ] Security precautions taken.