### PR TITLE
Fix ICU word offsets for runs of tabs

### DIFF
--- a/source/textUtils/icu.py
+++ b/source/textUtils/icu.py
@@ -74,7 +74,6 @@ def calculateWordOffsets(
 	:return: (startOffset, endOffset) as UTF-16 code unit indices (endOffset exclusive),
 	    or None if the ICU call failed.
 	"""
-	log.debug(f"calculateWordOffsets({text=}, {offset=})")
 	# A c_wchar buffer is UTF-16 code-unit indexed on Windows, so buf[a:b] is exactly
 	# the segment ICU's offsets refer to (lone surrogates decode as non-space).
 	buf = ctypes.create_unicode_buffer(text)

--- a/source/textUtils/icu.py
+++ b/source/textUtils/icu.py
@@ -79,7 +79,6 @@ def calculateWordOffsets(
 	buf = ctypes.create_unicode_buffer(text)
 	textLength = len(buf) - 1
 	if offset >= textLength:
-		log.debug("Offset >= textLength; returning offset, offset+1")
 		return (offset, offset + 1)
 
 	try:

--- a/source/textUtils/icu.py
+++ b/source/textUtils/icu.py
@@ -74,11 +74,13 @@ def calculateWordOffsets(
 	:return: (startOffset, endOffset) as UTF-16 code unit indices (endOffset exclusive),
 	    or None if the ICU call failed.
 	"""
+	log.debug(f"calculateWordOffsets({text=}, {offset=})")
 	# A c_wchar buffer is UTF-16 code-unit indexed on Windows, so buf[a:b] is exactly
 	# the segment ICU's offsets refer to (lone surrogates decode as non-space).
 	buf = ctypes.create_unicode_buffer(text)
 	textLength = len(buf) - 1
 	if offset >= textLength:
+		log.debug("Offset >= textLength; returning offset, offset+1")
 		return (offset, offset + 1)
 
 	try:
@@ -94,20 +96,37 @@ def calculateWordOffsets(
 			if start == icu.UBRK_DONE:
 				start = 0
 
-			if buf[start:end].isspace():
-				# Offset is inside a whitespace run.  Attach this run to the
-				# preceding segment (mirroring the Uniscribe trailing-space rule).
-				if start > 0:
-					wordStart = icu.ubrk_preceding(bi, start)
-					if wordStart == icu.UBRK_DONE:
-						wordStart = 0
-					return (wordStart, end)
-			else:
-				# Offset is inside a word/punctuation segment.  Extend the end
-				# through any immediately following whitespace run.
+			# ICU works in word boundaries, i.e. a word always starts and ends at a boundary.
+			# This means that whitespace runs also always start and end at a word boundary.
+			# E.g. we get "|Multiple| |boundaries|".
+			# It also treats a single tab character as a word.
+			#
+			# To (somewhat) replicate Uniscribe's behaviour of including trailing spaces when navigating by word,
+			# we need to ensure that start lies at the first word-starting boundary before offset,
+			# and end lies at the first one after it.
+			#
+			# Move start backward until the most recently found segment contains non-space characters,
+			# or we hit the start of text.
+			prefixEnd = end
+			while start > 0 and buf[start:prefixEnd].isspace():
+				start, prefixEnd = icu.ubrk_preceding(bi, start), start
+				# ubrk_preceding should only ever return UBRK_DONE if given an offset less than or equal to  0,
+				# so we should never run into it.
+				# Since we haven't yet seen any non-space characters,
+				# we can safely just extend the start of the range back to 0.
+				if start == icu.UBRK_DONE:
+					start = 0
+					break
+			# Move end forward until doing so would introduce a new word,
+			# or we hit the end of text.
+			while end < textLength:
 				nextEnd = icu.ubrk_following(bi, end)
-				if nextEnd != icu.UBRK_DONE and buf[end:nextEnd].isspace():
-					return (start, nextEnd)
+				# ubrk_following should only ever return UBRK_DONE if given an offset greater than or equal to the length of the text,
+				# so we should never run into it.
+				# To be safe, treat it as being equivalent to finding a word.
+				if nextEnd == icu.UBRK_DONE or not buf[end:nextEnd].isspace():
+					break
+				end = nextEnd
 
 			return (start, end)
 	except RuntimeError:

--- a/tests/unit/test_textUtils_backendComparison.py
+++ b/tests/unit/test_textUtils_backendComparison.py
@@ -220,3 +220,70 @@ class TestWordOffsetsTrailingPunctuationDivergence(unittest.TestCase):
 		# ICU ends the word before the punctuation; Uniscribe runs through it.
 		self.assertEqual(icu_result, (0, 4))
 		self.assertEqual(uni_result, (0, 5))
+
+
+@skipIfNoICU
+class TestWordOffsetsTabs(_WordOffsetsParityTest):
+	"""Word offset comparison for runs of tabs.
+
+	ICU treats a single tab character as its own word.
+	This can cause oddities including getting stuck in runs of tabs.
+	"""
+
+	TEXT = "\t\tTest\t\t"
+
+	def test_preLeadingIndent(self):
+		"""Both backends should capture both tabs."""
+		result = self._assertSameWordOffsets(0)
+		self.assertEqual(result, (0, 2))
+
+	def test_midLeadingIndent(self):
+		"""Both backends should capture both tabs."""
+		result = self._assertSameWordOffsets(1)
+		self.assertEqual(result, (0, 2))
+
+	def test_postLeadingIndent(self):
+		"""Both backends should capture "Test" and both trailing tabs."""
+		result = self._assertSameWordOffsets(2)
+		self.assertEqual(result, (2, 8))
+
+	def test_preTrailingIndent(self):
+		"""Both backends should capture "Test" and both trailing tabs."""
+		result = self._assertSameWordOffsets(6)
+		self.assertEqual(result, (2, 8))
+
+	def test_midTrailingIndent(self):
+		"""Both backends should capture "Test" and both trailing tabs."""
+		result = self._assertSameWordOffsets(7)
+		self.assertEqual(result, (2, 8))
+
+
+@skipIfNoICU
+class TestMixedSpacesAndTabs(unittest.TestCase):
+	"""Uniscribe treats mixed spaces and tabs differently depending on order."""
+
+	def test_tabThenSpace(self):
+		"""Both backends treat tabs then spaces as a single whitespace run."""
+		text = "\t\t  "
+		expected = (0, 4)
+		for offset in range(len(text)):
+			with self.subTest(offset=offset):
+				self.assertEqual(_icuWordOffsets(text, offset), expected, "unexpected ICU offsets")
+				self.assertEqual(
+					_uniscribeWordOffsets(text, offset),
+					expected,
+					"unexpected uniscribe offsets",
+				)
+
+	def test_spacesThenTabs(self):
+		"""Uniscribe separates spaces from tabs that follow them."""
+		text = "  \t\t"
+		for offset in range(len(text)):
+			with self.subTest(offset=offset):
+				self.assertEqual(_icuWordOffsets(text, offset), (0, 4), "unexpected ICU offsets")
+				uniStart = 0 if offset < 2 else 2
+				self.assertEqual(
+					_uniscribeWordOffsets(text, offset),
+					(uniStart, uniStart + 2),
+					"unexpected uniscribe offsets",
+				)

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -7,7 +7,7 @@
 * Add-ons can be removed from the "Updatable add-ons" tab in the Add-on Store. (#15030, @nvdaes)
 * Chinese text can now be navigated by word using built-in input gestures.
   * A Word Segmentation Standard setting was added to the "Document Navigation" panel. (#18735, @CrazySteve0605, @Cary-rowen)
-  * Word segmentation can also use the Windows built-in ICU library for boundary detection, improving navigation for Japanese and emoji. (#20343, @LeonarddeR)
+  * Word segmentation can also use the Windows built-in ICU library for boundary detection, improving navigation for Japanese and emoji. (#20343, #20494, @LeonarddeR)
   * By default, ICU is preferred over the legacy Windows segmentation wherever available, while Chinese word segmentation takes precedence for Chinese text.
 * Braille output for Chinese now includes spaces between words. (#18865, @CrazySteve0605, @Cary-rowen)
 * Added sequential two-flick touch gestures that combine two flicks performed in quick succession into a single gesture, increasing the number of touch gestures that can be bound to scripts. (#19938, @kefaslungu)


### PR DESCRIPTION
### Link to issue number:

Follow-up to #20379

### Summary of the issue:

With the new ICU backend for word segmentation in virtual buffers, the browse mode caret would get stuck in runs of tabs when navigating by word.

ICU treats a single tab character as its own word. That is, it does not treat runs of tabs, or runs of mixed whitespace including tabs,  as a single unit. However, in order to reproduce the behaviour of Uniscribe (which treats runs of tabs optionally followed by spaces as a single unit), the ICU backend:

* If the region containing the given offset is whitespace, moves the start offset to the previous boundary ; or
* Moves the end offset to the next boundary if doing so would capture  only whitespace.

This causes the returned regions to be different depending on the offset within a run of tabs, which confuses cursor manager.

### Description of user facing changes:

* The browse mode caret no-longer gets stuck in runs of tabs when navigating by word.
* The ICU backend now treats runs of mixed spacing characters (spaces and tabs) as a single unit.

### Description of developer facing changes:

None.

### Description of development approach:

Changed the word navigation algorithm for the ICU backend. It now:

* Repeatedly moves the start offset to the previous word boundary until it lies at the start of a region containing non-space characters; and
* Repeatedly moves the end offset forward until doing so would capture non-space characters.

### Testing strategy:

Tested navigating by word in the following text in browse mode in Firefox:

```
No tabs
	Single tab
		Two tabs
Trailing	tab character
 	 Mixed indent
Multiple     spaces
trailing indent 	 
Mixed 	 spacing
Mixed 		 multi
			Three tabs
Two		tabs
```

Also added unit tests.

### Known issues with pull request:

The Uniscribe backend treats a space followed by a tab as being two words (the space, and the tab), but a tab followed by a space as a single word (the tab and the space). The new ICU algorithm treats them both as a single word.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
