### PR TITLE
Increase max line length limit in Browse Mode settings

### DIFF
--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -2566,7 +2566,7 @@ class BrowseModePanel(SettingsPanel):
 			nvdaControls.SelectOnFocusSpinCtrl,
 			# min and max are not enforced in the config for virtualBuffers.maxLineLength
 			min=10,
-			max=250,
+			max=500,
 			initial=config.conf["virtualBuffers"]["maxLineLength"],
 		)
 		self.bindHelpEvent("BrowseModeSettingsMaxLength", self.maxLengthEdit)

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -2565,8 +2565,8 @@ class BrowseModePanel(SettingsPanel):
 			maxLengthLabelText,
 			nvdaControls.SelectOnFocusSpinCtrl,
 			# min and max are not enforced in the config for virtualBuffers.maxLineLength
-			min=10,
-			max=500,
+			min=0,
+			max=1000,
 			initial=config.conf["virtualBuffers"]["maxLineLength"],
 		)
 		self.bindHelpEvent("BrowseModeSettingsMaxLength", self.maxLengthEdit)

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -24,6 +24,7 @@
 
 ### Changes
 
+* The maximum line length in browse mode can now be set between 0 and 1000 characters (previously 10-250). Setting it to 0 disables line wrapping. (#20478, @Mubashir78)
 * Updated Liblouis Braille translator to [3.38.0](https://github.com/liblouis/liblouis/releases/tag/v3.38.0). (#20269, @codeofdusk)
   * Added new Elfdalian and Sami tables, a Norwegian table for Spanish text, and additional Swedish 6 and 8 dot variants.
 * The dialog used to present browseable messages (such as formatting information) has been modernized. (#18878, @LeonarddeR)

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -3348,6 +3348,7 @@ This category contains the following options:
 ##### Maximum Number of Characters on One Line {#BrowseModeSettingsMaxLength}
 
 This field sets the maximum length of a line in browse mode (in characters).
+Setting it to 0 disables line wrapping, displaying the entire line without breaks.
 
 ##### Maximum Lines Per Page {#BrowseModeSettingsPageLines}
 

--- a/user_docs/en/userGuide.xliff
+++ b/user_docs/en/userGuide.xliff
@@ -25214,7 +25214,7 @@ $(ID:061d7d61-cfab-44b3-a92c-4e65cf63213b)
 <note appliesTo="source">line: 3331</note>
 </notes>
 <segment>
-<source>This field sets the maximum length of a line in browse mode (in characters).</source>
+<source>This field sets the maximum length of a line in browse mode (in characters). Setting it to 0 disables line wrapping, displaying the entire line without breaks.</source>
 </segment>
 </unit>
 <unit id="0c29f047-9435-493e-95d2-52d3b4a19405">


### PR DESCRIPTION
Fixes #20478

### Summary of the issue:
The "Maximum number of characters on one line" spin control in Browse Mode settings was limited to 10-250, but paragraphs exceeding 250 characters are frequently encountered with screen layout navigation.

### Description of user facing changes:
- The spin control range is now 0-1000 (was 10-250)
- Setting it to 0 disables line wrapping, equivalent to unbounded
- The user guide has been updated to describe the 0 value behavior

### Description of developer facing changes:
None.

### Description of development approach:
Changed \`min\` and \`max\` parameters of the spin control in \`settingsDialogs.py\` and updated the user guide and changelog.

### Testing strategy:
1. Open NVDA settings → Browse Mode category
2. Verify the "Maximum number of characters on one line" spin control accepts values from 0 to 1000 (previously 10-250)
3. Set the value to 50 and navigate a long paragraph in browse mode:  lines should wrap at ~50 characters
4. Set the value to 0 and navigate the same paragraph: the entire paragraph should be rendered as a single line (no wrapping)
5. Set the value to 1000 and verify long paragraphs (1000+ chars) can be read without wrapping
6. Confirm the default remains 100 on a fresh configuration

### Known issues with pull request:
None.
