### PR TITLE
Fix UIA text unit crash and Word sentence-nav boundary wraparound

### DIFF
--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -1,8 +1,8 @@
 # A part of NonVisual Desktop Access (NVDA)
-# This file is covered by the GNU General Public License.
-# See the file COPYING for more details.
-# Copyright (C) 2009-2025 NV Access Limited, Joseph Lee, Mohammad Suliman, Babbage B.V., Leonard de Ruijter,
+# Copyright (C) 2009-2026 NV Access Limited, Joseph Lee, Mohammad Suliman, Babbage B.V., Leonard de Ruijter,
 # Bill Dengler, Cyrille Bougot
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
 
 """Support for UI Automation (UIA) controls."""
 
@@ -1055,7 +1055,7 @@ class UIATextInfo(textInfos.TextInfo):
 		return self._getBoundingRectsFromUIARange(self._rangeObj)
 
 	def expand(self, unit: str) -> None:
-		UIAUnit = UIAHandler.NVDAUnitsToUIAUnits[unit]
+		UIAUnit = UIAHandler.getUIAUnitFromNVDAUnit(unit)
 		self._rangeObj.ExpandToEnclosingUnit(UIAUnit)
 
 	def move(
@@ -1064,7 +1064,7 @@ class UIATextInfo(textInfos.TextInfo):
 		direction: int,
 		endPoint: Optional[str] = None,
 	):
-		UIAUnit = UIAHandler.NVDAUnitsToUIAUnits[unit]
+		UIAUnit = UIAHandler.getUIAUnitFromNVDAUnit(unit)
 		if endPoint == "start":
 			res = self._rangeObj.MoveEndpointByUnit(
 				UIAHandler.TextPatternRangeEndpoint_Start,

--- a/source/NVDAObjects/UIA/wordDocument.py
+++ b/source/NVDAObjects/UIA/wordDocument.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2016-2025 NV Access Limited, Joseph Lee, Jakub Lukowicz, Cyrille Bougot, Leonard de Ruijter
+# Copyright (C) 2016-2026 NV Access Limited, Joseph Lee, Jakub Lukowicz, Cyrille Bougot, Leonard de Ruijter
 # This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
 # For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
 
@@ -353,7 +353,65 @@ class WordDocumentTextInfo(UIATextInfo):
 		info.expand(textInfos.UNIT_CHARACTER)
 		return info._rangeObj.getText(-1) == "\u0007"
 
+	def _moveBySentenceRemote(self, unitCount: int) -> int:
+		"""Move this range by sentence via Word's native UIA remote ops extension.
+		On success, mutates :attr:`_rangeObj` to the moved range.
+		:raises NotImplementedError: if the extension isn't available.
+		:return: the actual number of sentences moved, which may be less than unitCount
+			if a document boundary was hit.
+		"""
+		if not UIARemote.isSupported():
+			raise NotImplementedError("UIA remote operations are not supported")
+		result = UIARemote.msWord_textRange_moveBySentence(self.obj.UIAElement, self._rangeObj, unitCount)
+		if result is None:
+			raise NotImplementedError("Word does not support sentence navigation in this document")
+		newRange, actualMoved = result
+		self._rangeObj = newRange
+		return actualMoved
+
+	def _expandToSentenceRemote(self) -> None:
+		"""Expand this range to its enclosing sentence via Word's native UIA remote ops extension.
+		On success, mutates :attr:`_rangeObj` to the expanded range.
+		:raises NotImplementedError: if the extension isn't available.
+		"""
+		if not UIARemote.isSupported():
+			raise NotImplementedError("UIA remote operations are not supported")
+		newRange = UIARemote.msWord_textRange_expandToEnclosingSentence(self.obj.UIAElement, self._rangeObj)
+		if newRange is None:
+			raise NotImplementedError("Word does not support sentence navigation in this document")
+		self._rangeObj = newRange
+
+	def _moveEndpointBySentenceRemote(self, endPoint: str, unitCount: int) -> int:
+		"""Move one endpoint of this range by sentence via Word's native UIA remote ops extension.
+		On success, mutates :attr:`_rangeObj` to the range with the endpoint moved.
+		:raises NotImplementedError: if the extension isn't available.
+		:return: the actual number of sentences moved, which may be less than unitCount
+			if a document boundary was hit.
+		"""
+		if not UIARemote.isSupported():
+			raise NotImplementedError("UIA remote operations are not supported")
+		uiaEndpoint = (
+			UIAHandler.TextPatternRangeEndpoint_Start
+			if endPoint == "start"
+			else UIAHandler.TextPatternRangeEndpoint_End
+		)
+		result = UIARemote.msWord_textRange_moveEndpointBySentence(
+			self.obj.UIAElement,
+			self._rangeObj,
+			uiaEndpoint,
+			unitCount,
+		)
+		if result is None:
+			raise NotImplementedError("Word does not support sentence navigation in this document")
+		newRange, actualMoved = result
+		self._rangeObj = newRange
+		return actualMoved
+
 	def move(self, unit, direction, endPoint=None):
+		if unit == textInfos.UNIT_SENTENCE:
+			if endPoint is None:
+				return self._moveBySentenceRemote(direction)
+			return self._moveEndpointBySentenceRemote(endPoint, direction)
 		if endPoint is None:
 			res = super(WordDocumentTextInfo, self).move(unit, direction)
 			if res == 0:
@@ -366,12 +424,18 @@ class WordDocumentTextInfo(UIATextInfo):
 		return super(WordDocumentTextInfo, self).move(unit, direction, endPoint)
 
 	def expand(self, unit):
-		if unit == textInfos.UNIT_CELL:
-			cell = self.obj._getTableCellCoordsCached(self, axis=None)
-			info = self.obj._getTableCellAt(cell.tableID, self, cell.row, cell.col)
-			self.start = info.start
-			self.end = info.end
-			return
+		match unit:
+			case textInfos.UNIT_CELL:
+				cell = self.obj._getTableCellCoordsCached(self, axis=None)
+				info = self.obj._getTableCellAt(cell.tableID, self, cell.row, cell.col)
+				self.start = info.start
+				self.end = info.end
+				return
+			case textInfos.UNIT_SENTENCE:
+				self._expandToSentenceRemote()
+				return
+			case _:
+				pass
 		super(WordDocumentTextInfo, self).expand(unit)
 		# #7970: MS Word refuses to expand to line when on the final line and it is blank.
 		# This among other things causes a newly inserted bullet not to be spoken or brailled.
@@ -774,36 +838,32 @@ class WordDocument(UIADocumentWithTableNavigation, WordDocumentNode, WordDocumen
 		if isScriptWaiting():
 			return
 
-		info = None
-
 		# Prefer UIA remote sentence navigation when available.
-		if UIARemote.isSupported():
-			try:
-				caretInfo = self.makeTextInfo(textInfos.POSITION_CARET)
-				sentenceRange = UIARemote.msWord_moveTextRangeBySentence(
-					self.UIAElement,
-					caretInfo._rangeObj,
-					direction,
-				)
-			except Exception:
-				log.debugWarning(
-					"Failed to fetch caret text range for remote sentence navigation",
-					exc_info=True,
-				)
-			else:
-				if sentenceRange is not None:
-					info = WordDocumentTextInfo(self, textInfos.POSITION_CARET, _rangeObj=sentenceRange)
-					info.updateCaret()
+		caretInfo = self.makeTextInfo(textInfos.POSITION_CARET)
+		info = None
+		try:
+			caretInfo.move(textInfos.UNIT_SENTENCE, direction)
+			caretInfo.updateCaret()
+		except NotImplementedError:
+			pass
+		except Exception:
+			log.debugWarning(
+				"Failed to move caret by sentence via remote sentence navigation",
+				exc_info=True,
+			)
+		else:
+			info = caretInfo
+			info.expand(textInfos.UNIT_SENTENCE)
 
 		if info is None:
-			if not self.WinwordSelectionObject:
+			if self.WinwordSelectionObject:
+				info = self._moveBySentenceWithObjectModel(direction)
+			else:
 				# Legacy object model not available.
 				# Translators: a message when navigating by sentence is unavailable in MS Word
 				ui.message(_("Navigating by sentence not supported in this document"))
 				gesture.send()
 				return
-			else:
-				info = self._moveBySentenceWithObjectModel(direction)
 
 		# Speak the sentence moved to
 		speech.speakTextInfo(

--- a/source/UIAHandler/__init__.py
+++ b/source/UIAHandler/__init__.py
@@ -1,7 +1,7 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2008-2025 NV Access Limited, Joseph Lee, Babbage B.V., Leonard de Ruijter, Bill Dengler
-# This file is covered by the GNU General Public License.
-# See the file COPYING for more details.
+# Copyright (C) 2008-2026 NV Access Limited, Joseph Lee, Babbage B.V., Leonard de Ruijter, Bill Dengler
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
 
 import ctypes
 import ctypes.wintypes
@@ -151,6 +151,16 @@ NVDAUnitsToUIAUnits: Dict[str, int] = {
 	textInfos.UNIT_STORY: UIA.TextUnit_Document,
 	textInfos.UNIT_FORMATFIELD: UIA.TextUnit_Format,
 }
+
+
+def getUIAUnitFromNVDAUnit(unit: str) -> int:
+	"""Translate an NVDA text unit constant to its UIA ``TextUnit`` equivalent.
+	:raises NotImplementedError: if UIA has no equivalent unit.
+	"""
+	if (UIAUnit := NVDAUnitsToUIAUnits.get(unit)) is None:
+		raise NotImplementedError(f"UIA does not support the {unit!r} text unit")
+	return UIAUnit
+
 
 UIAControlTypesToNVDARoles = {
 	UIA_ButtonControlTypeId: controlTypes.Role.BUTTON,  # noqa: F405

--- a/source/UIAHandler/remote.py
+++ b/source/UIAHandler/remote.py
@@ -1,7 +1,7 @@
 # A part of NonVisual Desktop Access (NVDA)
-# This file is covered by the GNU General Public License.
-# See the file COPYING for more details.
-# Copyright (C) 2021-2024 NV Access Limited
+# Copyright (C) 2021-2026 NV Access Limited, Leonard de Ruijter
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
 
 
 from typing import (
@@ -23,6 +23,7 @@ from ._remoteOps import operation
 from ._remoteOps import remoteAPI
 from ._remoteOps.lowLevel import (
 	TextUnit,
+	TextPatternRangeEndpoint,
 	AttributeId,
 	StyleId,
 )
@@ -122,21 +123,24 @@ def msWord_getCustomAttributeValue(
 	return customAttribValue
 
 
-def msWord_moveTextRangeBySentence(
+def msWord_textRange_moveBySentence(
 	docElement: UIA.IUIAutomationElement,
 	textRange: UIA.IUIAutomationTextRange,
 	unitCount: int,
-) -> UIA.IUIAutomationTextRange | None:
+) -> tuple[UIA.IUIAutomationTextRange, int] | None:
 	"""
-	Move a UI Automation text range by sentence using the Word-specific UIA
+	Move a UI Automation text range by unitCount sentences using the Word-specific UIA
 	extended text range pattern, if available.
-	Returns None if the operation fails or the extensions are not supported.
+	A degenerate range stays degenerate on success, matching the ITextRangeProvider::Move contract.
+	On par with ITextRangeProvider::Move, hitting a document boundary is not a failure: the range
+	is moved as far as possible and the actual number of sentences moved is returned, which may be
+	less than requested, or 0.
+	Returns None only if the operation fails or the extension is not supported.
 	"""
 	if not isSupported():
 		return None
 
 	guid_msWord_moveBySentence = GUID("{F39655AC-133A-435B-A318-C197F0D3D203}")
-	guid_msWord_expandToEnclosingSentence = GUID("{98FE8B34-F317-459A-9627-21123EA95BEA}")
 	op = operation.Operation()
 
 	@op.buildFunction
@@ -155,14 +159,6 @@ def msWord_moveTextRangeBySentence(
 		with ra.ifBlock(moveBySentenceSupported.inverse()):
 			ra.logRuntimeMessage("extendedTextRangePattern does not support MoveBySentence")
 			ra.Return(None)
-		expandSupported = remoteExtendedTextRangePattern.isExtensionSupported(
-			guid_msWord_expandToEnclosingSentence,
-		)
-		with ra.ifBlock(expandSupported.inverse()):
-			ra.logRuntimeMessage(
-				"extendedTextRangePattern does not support ExpandToEnclosingSentence",
-			)
-			ra.Return(None)
 
 		moveCount = ra.newInt(unitCount)
 		actualMoved = ra.newInt(0)
@@ -173,12 +169,132 @@ def msWord_moveTextRangeBySentence(
 			moveCount,
 			actualMoved,
 		)
+		ra.Return(remoteTextRange, actualMoved)
+
+	return op.execute()
+
+
+def msWord_textRange_moveEndpointBySentence(
+	docElement: UIA.IUIAutomationElement,
+	textRange: UIA.IUIAutomationTextRange,
+	endpoint: int,
+	unitCount: int,
+) -> tuple[UIA.IUIAutomationTextRange, int] | None:
+	"""
+	Move one endpoint of a UI Automation text range by unitCount sentences using the
+	Word-specific UIA extended text range pattern, if available.
+	:param endpoint: a TextPatternRangeEndpoint value indicating which endpoint to move.
+	On par with ITextRangeProvider::MoveEndpointByUnit, hitting a document boundary is not a
+	failure: the endpoint is moved as far as possible and the actual number of sentences moved
+	is returned, which may be less than requested, or 0.
+	Returns None only if the operation fails or the extension is not supported.
+	"""
+	if not isSupported():
+		return None
+
+	guid_msWord_moveEndpointBySentence = GUID("{368E89A2-1BC2-4402-8C58-33C63ECFFA3B}")
+	remoteEndpointConst = TextPatternRangeEndpoint(endpoint)
+	op = operation.Operation()
+
+	@op.buildFunction
+	def code(ra: remoteAPI.RemoteAPI):
+		remoteDocElement = ra.newElement(docElement)
+		remoteTextRange = ra.newTextRange(textRange)
+
+		remoteExtendedTextRangePattern = _msWord_remote_getExtendedTextRangePattern(
+			ra,
+			remoteDocElement,
+		)
+
+		moveEndpointBySentenceSupported = remoteExtendedTextRangePattern.isExtensionSupported(
+			guid_msWord_moveEndpointBySentence,
+		)
+		with ra.ifBlock(moveEndpointBySentenceSupported.inverse()):
+			ra.logRuntimeMessage(
+				"extendedTextRangePattern does not support MoveEndpointBySentence",
+			)
+			ra.Return(None)
+
+		remoteEndpoint = ra.newInt(remoteEndpointConst)
+		moveCount = ra.newInt(unitCount)
+		actualMoved = ra.newInt(0)
+		ra.logRuntimeMessage("doing callExtension for MoveEndpointBySentence")
+		remoteExtendedTextRangePattern.callExtension(
+			guid_msWord_moveEndpointBySentence,
+			remoteTextRange,
+			remoteEndpoint,
+			moveCount,
+			actualMoved,
+		)
+		ra.Return(remoteTextRange, actualMoved)
+
+	return op.execute()
+
+
+def msWord_textRange_expandToEnclosingSentence(
+	docElement: UIA.IUIAutomationElement,
+	textRange: UIA.IUIAutomationTextRange,
+) -> UIA.IUIAutomationTextRange | None:
+	"""
+	Expand a UI Automation text range to its enclosing sentence using the Word-specific UIA
+	extended text range pattern, if available.
+	If the range is collapsed at the very end of the document, it is returned unchanged:
+	Word's ExpandToEnclosingSentence extension otherwise wraps around and expands the first
+	sentence in the document instead of leaving the range where it is.
+	Returns None if the operation fails or the extension is not supported.
+	"""
+	if not isSupported():
+		return None
+
+	guid_msWord_expandToEnclosingSentence = GUID("{98FE8B34-F317-459A-9627-21123EA95BEA}")
+	op = operation.Operation()
+
+	@op.buildFunction
+	def code(ra: remoteAPI.RemoteAPI):
+		remoteDocElement = ra.newElement(docElement)
+		remoteTextRange = ra.newTextRange(textRange)
+
+		isCollapsed = (
+			remoteTextRange.compareEndpoints(
+				TextPatternRangeEndpoint.End,
+				remoteTextRange,
+				TextPatternRangeEndpoint.Start,
+			)
+			== 0
+		)
+		with ra.ifBlock(isCollapsed):
+			endTestRange = remoteTextRange.clone()
+			charsAvailable = endTestRange.moveEndpointByUnit(
+				TextPatternRangeEndpoint.End,
+				TextUnit.Character,
+				1,
+			)
+			with ra.ifBlock(charsAvailable == 0):
+				ra.logRuntimeMessage(
+					"Collapsed range is at the end of the document; "
+					"not expanding to sentence to avoid wraparound",
+				)
+				ra.Return(remoteTextRange)
+
+		remoteExtendedTextRangePattern = _msWord_remote_getExtendedTextRangePattern(
+			ra,
+			remoteDocElement,
+		)
+
+		expandSupported = remoteExtendedTextRangePattern.isExtensionSupported(
+			guid_msWord_expandToEnclosingSentence,
+		)
+		with ra.ifBlock(expandSupported.inverse()):
+			ra.logRuntimeMessage(
+				"extendedTextRangePattern does not support ExpandToEnclosingSentence",
+			)
+			ra.Return(None)
+
 		ra.logRuntimeMessage("doing callExtension for ExpandToEnclosingSentence")
 		remoteExtendedTextRangePattern.callExtension(
 			guid_msWord_expandToEnclosingSentence,
 			remoteTextRange,
 		)
-
 		ra.Return(remoteTextRange)
 
 	return op.execute()

--- a/tests/unit/test_UIAHandler.py
+++ b/tests/unit/test_UIAHandler.py
@@ -1,0 +1,22 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2026 NV Access Limited, Leonard de Ruijter
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file:
+# https://github.com/nvaccess/nvda/blob/master/copying.txt
+
+from unittest import TestCase
+
+import textInfos
+from UIAHandler import NVDAUnitsToUIAUnits, getUIAUnitFromNVDAUnit
+
+
+class Test_getUIAUnitFromNVDAUnit(TestCase):
+	def test_mappedUnitReturnsUIAUnit(self):
+		self.assertEqual(
+			getUIAUnitFromNVDAUnit(textInfos.UNIT_WORD),
+			NVDAUnitsToUIAUnits[textInfos.UNIT_WORD],
+		)
+
+	def test_unmappedUnitRaisesNotImplementedError(self):
+		with self.assertRaises(NotImplementedError):
+			getUIAUnitFromNVDAUnit(textInfos.UNIT_SENTENCE)


### PR DESCRIPTION
### Link to issue number:

Follow-up to #19367.
based on `beta` because it fixes a feature introduced in said branch that has not yet been released.

### Summary of the issue:

While wiring native Word sentence navigation into `WordDocumentTextInfo.expand()`/`move()` for `UNIT_SENTENCE` (related to #20467), two issues surfaced:

1. `UIATextInfo.expand()`/`move()` raise an uncaught `KeyError` for any NVDA text unit UIA has no mapping for, instead of a `NotImplementedError`, which is the contract `TextInfo.expand()`/`move()` callers rely on for a graceful no-op. `UNIT_SENTENCE` is one such unmapped unit, so calling `expand()`/`move()` with it on a UIA `TextInfo` crashed instead of raising cleanly.
2. Word's native `MoveBySentence`/`ExpandToEnclosingSentence` UIA extensions silently wrap around at document boundaries instead of stopping. Moving forward from the last sentence (or expanding a collapsed range at the very end of the document) teleports the range to the start of the document rather than staying put.

### Description of user facing changes:

* Moving by sentence in Word (`alt+downArrow`/`alt+upArrow`) at the start/end of a document now stops there instead of wrapping around to the opposite end.
* No new user-facing feature: this is a fix to code introduced in #19367, which itself has no changes.md entry as it was an internal backend swap.

### Description of developer facing changes:

* Added `UIAHandler.getUIAUnitFromNVDAUnit()`, which raises `NotImplementedError` instead of letting a `KeyError` escape `NVDAUnitsToUIAUnits` lookups. `UIATextInfo.expand()`/`move()` now use it. This is a general robustness fix for the UIA `TextInfo` API, strictly spoken independent of sentence navigation but definitely a show stopper for #20467. It feels more appropriate to fix this in the current PR instead of in #20467.
* `UIAHandler.remote.msWord_moveTextRangeBySentence()` is split into `msWord_textRange_moveBySentence()`, `msWord_textRange_moveEndpointBySentence()`, and `msWord_textRange_expandToEnclosingSentence()`.
* As `msWord_moveTextRangeBySentence` is UIA-remote-ops-internal API that has only ever shipped in 2026.2 betas (no stable release), and this branch targets beta, the rename drops the function outright rather than keeping a deprecated back-compat shim.

### Description of development approach:

* Wired native Word sentence support directly into `WordDocumentTextInfo.expand()`/`move()` for `UNIT_SENTENCE`. The sentence-navigation script now goes through this `TextInfo` API instead of calling the remote op directly.
* Added a boundary guard in `UIAHandler.remote.msWord_textRange_expandToEnclosingSentence()`: a collapsed range at the very end of the document is returned unchanged instead of being expanded to the first sentence in the document.

### Testing strategy:

* Added unit tests for `getUIAUnitFromNVDAUnit()` (mapped and unmapped units).
* Manually verified in Word: moving by sentence (`alt+downArrow`/`alt+upArrow`) at the start/end of a document stops instead of wrapping.

### Known issues with pull request:

- Need to decide whether `UIAHandler.getUIAUnitFromNVDAUnit()` belongs in this pr, in #20467 or in a separate one against master. Note that NotImplementedError is a well-established exception raised by TextInfo.move and TextInfo.expand whereas KeyError is a strange outlier.
- Need to decide whether it is safe to rename msWord_moveTextRangeBySentence in this stage of development.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
