### PR TITLE
Add gestures for braille autoScroll commands

### DIFF
--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -852,7 +852,6 @@ class GlobalCommands(ScriptableObject):
 		description=_("Toggles braille automatic scroll"),
 		category=SCRCAT_BRAILLE,
 		gesture="kb:NVDA+alt+k",
-		speakOnDemand=True,
 	)
 	def script_toggleBrailleAutoScroll(self, gesture: inputCore.InputGesture):
 		shouldEnableAutoScroll = braille.handler._autoScrollCallLater is None
@@ -875,7 +874,6 @@ class GlobalCommands(ScriptableObject):
 		description=_("Increases the rate for braille automatic scroll"),
 		category=SCRCAT_BRAILLE,
 		gesture="kb:NVDA+alt+l",
-		speakOnDemand=True,
 	)
 	def script_increaseBrailleAutoScrollRate(self, gesture: inputCore.InputGesture):
 		config.conf.clampedIncrementAndUpdateConfig("braille", "autoScrollRate", step=0.5)
@@ -889,7 +887,6 @@ class GlobalCommands(ScriptableObject):
 		description=_("Decreases the rate for braille automatic scroll"),
 		category=SCRCAT_BRAILLE,
 		gesture="kb:NVDA+alt+j",
-		speakOnDemand=True,
 	)
 	def script_decreaseBrailleAutoScrollRate(self, gesture: inputCore.InputGesture):
 		config.conf.clampedIncrementAndUpdateConfig("braille", "autoScrollRate", step=-0.5)

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -851,6 +851,8 @@ class GlobalCommands(ScriptableObject):
 		# Translators: Input help mode message for command to toggle braille automatic scroll.
 		description=_("Toggles braille automatic scroll"),
 		category=SCRCAT_BRAILLE,
+		gesture="kb:NVDA+alt+k",
+		speakOnDemand=True,
 	)
 	def script_toggleBrailleAutoScroll(self, gesture: inputCore.InputGesture):
 		shouldEnableAutoScroll = braille.handler._autoScrollCallLater is None
@@ -872,6 +874,8 @@ class GlobalCommands(ScriptableObject):
 		# Translators: Input help mode message for command to increase the rate for braille automatic scroll.
 		description=_("Increases the rate for braille automatic scroll"),
 		category=SCRCAT_BRAILLE,
+		gesture="kb:NVDA+alt+l",
+		speakOnDemand=True,
 	)
 	def script_increaseBrailleAutoScrollRate(self, gesture: inputCore.InputGesture):
 		config.conf.clampedIncrementAndUpdateConfig("braille", "autoScrollRate", step=0.5)
@@ -884,6 +888,8 @@ class GlobalCommands(ScriptableObject):
 		# Translators: Input help mode message for command to decrease the rate for braille automatic scroll.
 		description=_("Decreases the rate for braille automatic scroll"),
 		category=SCRCAT_BRAILLE,
+		gesture="kb:NVDA+alt+j",
+		speakOnDemand=True,
 	)
 	def script_decreaseBrailleAutoScrollRate(self, gesture: inputCore.InputGesture):
 		config.conf.clampedIncrementAndUpdateConfig("braille", "autoScrollRate", step=-0.5)

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -16,6 +16,7 @@ A new command allows repeating the last spoken information, with the ability to 
 The default gesture to repeat the last spoken information is `NVDA+x`, which can be changed in the Input Gestures dialog.
 
 The braille display can now automatically scroll and DotPad devices support multi-button combinations.
+The default gesture to toggle automatic scroll is `NVDA+alt+k`.
 
 Liblouis has been updated with new Italian and Estonian braille tables.
 
@@ -35,6 +36,7 @@ When resetting NVDA to factory defaults, an Undo button is now available to rest
   * A new command, assigned to `NVDA+x`, has been introduced to repeat the last information spoken by NVDA; pressing it twice shows it in a browseable message. (#625, @CyrilleB79)
 * Braille:
   * Added the ability to automatically scroll the braille display. (#18573, @nvdaes)
+    * `NVDA+alt+k`, `NVDA+alt+l` and `NVDA+alt+j` gestures can be used to toggle automatic scroll, increase scroll rating and decrease scroll rating, respectively.
   * DotPad braille displays now support multi-button combination gestures. (#19565, @bramd)
     * You can now press multiple buttons simultaneously to create custom gestures (e.g., `f1+panLeft`).
 * Touch:

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -1382,9 +1382,9 @@ Where text is longer than will fit on the display, panning or other keys on the 
 
 Automatic braille scrolling can be enabled to scroll the display at a set speed.
 When using this feature, the braille display scrolls to present information which is more than will fit on the display at once.
-The feature is disabled and a gesture to start braille scrolling is undefined by default.
-To use automatic braille scrolling, a gesture needs to be set in NVDA's [Input Gestures dialog](#InputGestures) before it can be used.
-Gestures can also be set to speed up or slow down the rate of automatic scrolling.
+The feature is disabled by default.
+You can change the gestures assigned to use automatic braille scrolling in NVDA's [Input Gestures dialog](#InputGestures) before it can be used.
+Gestures are also available to speed up or slow down the rate of automatic scrolling.
 Alternatively, you can [set the automatic scroll rate in Braille Settings](#BrailleAutoScrollRate).
 
 While braille is scrolling, you can still use the scroll back and scroll forward commands without stopping scrolling.
@@ -1405,10 +1405,10 @@ While reading, automatic braille scrolling will stop when any of the following h
 | Name | Key | Description |
 |---|---|---|
 | Toggles braille mode | `NVDA+alt+t` | Allows cycling between available braille modes: "follow cursors" and "display speech output"|
-| Tether braille |`NVDA+control+t` | This option allows you to choose whether the braille display will follow the system focus / caret, the navigator object / review cursor, or both |
-| Toggle automatic scroll | None | Toggles whether NVDA periodically scrolls the braille display to present information which is too long to show at once |
-| Increase automatic scroll rate | None | Makes automatic scrolling faster (when enabled) |
-| Decrease automatic scroll rate | None | Makes automatic scrolling slower (when enabled) |
+| Tether braille | `NVDA+control+t` | This option allows you to choose whether the braille display will follow the system focus / caret, the navigator object / review cursor, or both |
+| Toggle automatic scroll | `NVDA+alt+k` | Toggles whether NVDA periodically scrolls the braille display to present information which is too long to show at once |
+| Increase automatic scroll rate | `NVDA+alt+l` | Makes automatic scrolling faster (when enabled) |
+| Decrease automatic scroll rate | `NVDA+alt+j` | Makes automatic scrolling slower (when enabled) |
 | Cycle braille cursor shapes | None | Cycle through the shape options (dot pattern) of the braille cursor |
 | Cycle move system caret when routing review cursor | None | Cycle through the braille move system caret when routing review cursor states |
 | Cycle show messages modes | None | Cycle through the braille show messages modes |


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
<!-- Use Closes/Fixes/Resolves #xxx to link this PR to the issue it is responding to. -->
Fixes #20473
### Summary of the issue:
Braille autoScroll scripts don't have associated gestures by default.
### Description of user facing changes:
Now, gestures for autoScroll braille commands are available by default:

- `NVDA+alt+k`: toggles autoScroll.
- `NVDA+alt+j`: Decreases scroll rate.
- `NVDA+alt+l`: Increases scroll rate.
### Description of developer facing changes:
None.
### Description of development approach:
N/A.
### Testing strategy:
Tested locally.
### Known issues with pull request:
None.
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
