### PR TITLE
Document gui.message.DisplayableError in the  Developer Guide

### DIFF
--- a/projectDocs/dev/developerGuide/developerGuide.md
+++ b/projectDocs/dev/developerGuide/developerGuide.md
@@ -1532,6 +1532,16 @@ For examples of how to define and use new extension points, please see the code 
 | --- | --- | --- |
 | `Action` | `postNvdaStartup` | Notifies after NVDA has finished starting up. |
 
+### gui.message {#guiMessageExtPts}
+
+Unlike the other modules listed in this chapter, `gui.message` does not define a shared extension point instance.
+Instead, `DisplayableError.OnDisplayableErrorT` is an `Action` type: each component that needs to route user-visible errors out of non-GUI code creates its own instance.
+See [Displaying errors to the user](#DisplayableError) for a full description and examples.
+
+| Type | Extension Point | Description |
+| --- | --- | --- |
+| `Action` | `DisplayableError.OnDisplayableErrorT` (instantiated per component) | Notifies a registered handler (usually a GUI component) that a `DisplayableError` has occurred, allowing the handler to decide how to present the error to the user. |
+
 ### inputCore {#inputCoreExtPts}
 
 | Type | Extension Point | Description |
@@ -1865,3 +1875,75 @@ The following convenience class methods are provided (keyword arguments for over
 | `alert` | OK (`okLabel`) | `None` |
 | `confirm` | OK (`okLabel`) and Cancel (`cancelLabel`) | `ReturnCode.OK` or `ReturnCode.CANCEL` |
 | `ask` | Yes (`yesLabel`), No (`noLabel`) and Cancel (`cancelLabel`) | `ReturnCode.YES`, `ReturnCode.NO` or `ReturnCode.CANCEL` |
+
+### Displaying errors to the user: DisplayableError {#DisplayableError}
+
+`gui.message.DisplayableError` is an exception class for failures which the user should be told about via a message box, rather than only logged.
+It carries a translated message (`displayMessage`) and an optional translated title (`titleMessage`, which defaults to "Error"), and can present itself with its `displayError` method, which safely schedules a `gui.message.messageBox` call on the GUI thread using `wx.CallAfter`.
+
+Use `DisplayableError` when code outside the GUI layer (e.g. network or data-processing code, possibly running on a background thread) encounters an error the user needs to know about, but where that code should not decide how, or even whether, the error is presented.
+This keeps user-facing error presentation out of business logic, and involves three roles:
+
+* The code detecting the failure raises `DisplayableError` with a translated message.
+* A component that coordinates the work owns an instance of `DisplayableError.OnDisplayableErrorT` (an `extensionPoints.Action`), catches the exception, and notifies the action.
+Where the exception may be raised on a background thread, notify via `core.callLater` (or `wx.CallAfter`) so that handlers run on the main thread.
+* A GUI component registers a handler with that action and decides how to present the error.
+Typically the handler calls the error's `displayError` method, but it may equally decide to only log the error.
+For example, NVDA's automatic add-on update check fails silently, as the user did not initiate that work.
+
+For example, code performing a background task may raise a `DisplayableError`:
+
+```py
+from gui.message import DisplayableError
+
+def fetchWidgetData() -> WidgetData:
+	try:
+		...
+	except requests.exceptions.RequestException:
+		raise DisplayableError(
+			# Translators: Message shown when widget data cannot be fetched from the server.
+			displayMessage=_("Unable to fetch the latest widget data."),
+		)
+```
+
+The component coordinating the work owns the extension point, and notifies it on the main thread when the exception is caught:
+
+```py
+import core
+from gui.message import DisplayableError
+
+class WidgetDataUpdater:
+	onDisplayableError = DisplayableError.OnDisplayableErrorT()
+
+	def _updateInBackground(self):
+		try:
+			data = fetchWidgetData()
+		except DisplayableError as displayableError:
+			# Handlers may interact with the GUI, so ensure they are called on the main thread.
+			core.callLater(
+				delay=0,
+				callable=self.onDisplayableError.notify,
+				displayableError=displayableError,
+			)
+			return
+		...
+```
+
+Note that the keyword argument passed to `notify` must be named `displayableError`, as handlers receive it by that name.
+
+Finally, the GUI component responsible for presentation registers a handler:
+
+```py
+import gui
+from gui.message import DisplayableError
+
+class WidgetDialog(wx.Dialog):
+	def __init__(self, parent: wx.Window, updater: WidgetDataUpdater):
+		updater.onDisplayableError.register(self.handleDisplayableError)
+		...
+
+	def handleDisplayableError(self, displayableError: DisplayableError):
+		displayableError.displayError(gui.mainFrame)
+```
+
+For real-world usage, see the Add-on Store: `DisplayableError` is raised in `addonStore.install` and `addonStore.network`, routed through `gui.addonStoreGui.viewModels.store.AddonStoreVM.onDisplayableError`, and handled by `gui.addonStoreGui.controls.storeDialog.AddonStoreDialog`.

--- a/projectDocs/dev/developerGuide/developerGuide.md
+++ b/projectDocs/dev/developerGuide/developerGuide.md
@@ -1879,9 +1879,14 @@ The following convenience class methods are provided (keyword arguments for over
 ### Displaying errors to the user: DisplayableError {#DisplayableError}
 
 `gui.message.DisplayableError` is an exception class for failures which the user should be told about via a message box, rather than only logged.
-It carries a translated message (`displayMessage`) and an optional translated title (`titleMessage`, which defaults to "Error"), and can present itself with its `displayError` method, which safely schedules a `gui.message.messageBox` call on the GUI thread using `wx.CallAfter`.
+It carries a translated message (`displayMessage`) and an optional translated title (`titleMessage`).
+If no title is given, "Error" is used.
+The error can also present itself, using its `displayError` method.
+This method safely schedules a `gui.message.messageBox` call on the GUI thread, using `wx.CallAfter`.
 
-Use `DisplayableError` when code outside the GUI layer (e.g. network or data-processing code, possibly running on a background thread) encounters an error the user needs to know about, but where that code should not decide how, or even whether, the error is presented.
+Use `DisplayableError` when code outside the GUI layer encounters an error the user needs to know about.
+Such code might be network or data-processing code, possibly running on a background thread.
+That code should not decide how, or even whether, the error is presented.
 This keeps user-facing error presentation out of business logic, and involves three roles:
 
 * The code detecting the failure raises `DisplayableError` with a translated message.

--- a/source/gui/message.py
+++ b/source/gui/message.py
@@ -150,7 +150,15 @@ class DisplayableError(Exception):
 	"""
 
 	def __init__(self, displayMessage: str, titleMessage: Optional[str] = None):
-		"""
+		"""An error with a message that should be presented to the user via a message box.
+
+		Code outside the GUI layer may raise DisplayableError to report a failure with a
+		translated, user friendly message, without deciding how the error is presented.
+		A component coordinating the work catches the exception and notifies an instance of
+		OnDisplayableErrorT, and a handler registered to that action decides how to display
+		the error, typically by calling L{displayError}.
+		See the "Communicating with the user" chapter of the Developer Guide for examples.
+
 		@param displayMessage: A translated message, to be displayed to the user.
 		@param titleMessage: A translated message, to be used as a title for the display message.
 		If left None, "Error" is presented as the title by default.

--- a/source/gui/message.py
+++ b/source/gui/message.py
@@ -156,12 +156,12 @@ class DisplayableError(Exception):
 		translated, user friendly message, without deciding how the error is presented.
 		A component coordinating the work catches the exception and notifies an instance of
 		OnDisplayableErrorT, and a handler registered to that action decides how to display
-		the error, typically by calling L{displayError}.
+		the error, typically by calling ``displayError``.
 		See the "Communicating with the user" chapter of the Developer Guide for examples.
 
-		@param displayMessage: A translated message, to be displayed to the user.
-		@param titleMessage: A translated message, to be used as a title for the display message.
-		If left None, "Error" is presented as the title by default.
+		:param displayMessage: A translated message, to be displayed to the user.
+		:param titleMessage: A translated message, to be used as a title for the display message.
+			If left None, "Error" is presented as the title by default.
 		"""
 		self.displayMessage = displayMessage
 		if titleMessage is None:

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -78,6 +78,7 @@ Please refer to [the developer guide](https://download.nvaccess.org/documentatio
   * `cellIndexes` is not limited to routing keys; touch-sensitive cells (e.g. Handy Tech Active Tactile Control) can reuse the same attribute.
 * Added a new `hwIo.ble` submodule for Bluetooth Low Energy device discovery and I/O, exposing a `Scanner` singleton (with a `deviceDiscovered` extension point), a `Ble` class implementing the `IoBase` contract, and a `findDeviceByAddress` helper.
 Built on top of [Bleak](https://bleak.readthedocs.io/) and the `_asyncioEventLoop` module. (#19838, @bramd)
+* The Developer Guide now documents `gui.message.DisplayableError` and its associated extension point, covering when to use it and example usage. (#16984, @danielw97)
 * Component updates:
   * Updated py2exe to 0.14.1.1. (#20260, @LeonarddeR)
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -78,7 +78,6 @@ Please refer to [the developer guide](https://download.nvaccess.org/documentatio
   * `cellIndexes` is not limited to routing keys; touch-sensitive cells (e.g. Handy Tech Active Tactile Control) can reuse the same attribute.
 * Added a new `hwIo.ble` submodule for Bluetooth Low Energy device discovery and I/O, exposing a `Scanner` singleton (with a `deviceDiscovered` extension point), a `Ble` class implementing the `IoBase` contract, and a `findDeviceByAddress` helper.
 Built on top of [Bleak](https://bleak.readthedocs.io/) and the `_asyncioEventLoop` module. (#19838, @bramd)
-* The Developer Guide now documents `gui.message.DisplayableError` and its associated extension point, covering when to use it and example usage. (#16984, @danielw97)
 * Component updates:
   * Updated py2exe to 0.14.1.1. (#20260, @LeonarddeR)
 


### PR DESCRIPTION
### Link to issue number:

Closes #16984

### Summary of the issue:

`gui.message.DisplayableError` is an exception class that pairs with an `extensionPoints.Action` to present user-friendly errors via a message box, letting non-GUI code report a failure without deciding how it is displayed. It was undocumented: it had no entry in the Extension Points chapter of the Developer Guide, no explanation of when it should (and shouldn't) be used, and no usage examples. Its only docstring was attached to the `OnDisplayableErrorT` alias, leaving the class itself effectively undocumented.

### Description of user facing changes:

None. This is a documentation and developer-facing change only.

### Description of developer facing changes:

- The Developer Guide now has a "Displaying errors to the user" section under "Communicating with the user", describing what `DisplayableError` is for, when to use it and when not to, and the raise / route / handle pattern, with short examples based on the Add-on Store's real usage.
- The Extension Points chapter now has a `gui.message` entry noting that `DisplayableError.OnDisplayableErrorT` is an `Action` type that components instantiate per-use, cross-referencing the new section.
- `DisplayableError.__init__` now carries a docstring describing the class and its intended usage, so the class is documented at the point developers are most likely to look.

### Description of development approach:

Following the discussion on the issue, the prose lives under "Communicating with the user" (which already documents the rest of `gui.message`) rather than only in the Extension Points chapter, so the explanation and examples sit alongside the related message dialog API. Per @seanbudd's suggestion on the issue, the class documentation was added to the existing `__init__` docstring rather than as a separate class-level docstring.

The examples were derived from examining the existing Add-on Store usage: `DisplayableError` is raised in `addonStore.install` and `addonStore.network`, routed through `gui.addonStoreGui.viewModels.store.AddonStoreVM.onDisplayableError`, and handled by `gui.addonStoreGui.controls.storeDialog.AddonStoreDialog`. The documented pattern reflects that flow, including the `core.callLater` hop used to ensure handlers run on the main thread when the error may be raised on a background thread, and the option for a handler to only log (as `UpdatableAddonsDialog` does for the automatic add-on update check).

### Testing strategy:

- Built the Developer Guide HTML locally and confirmed the new section and Extension Points entry render correctly, including the cross-reference anchor.
- Ran `ruff check` and `ruff format` on the changed `source/gui/message.py`; both pass. Ran `pyright` on the file: 0 errors, 0 warnings.
- No unit or system tests were added: the change is documentation plus a docstring, with no behaviour change to test.

### Known issues with pull request:

None.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.


---

This change was developed with the assistance of AI (Claude), with the approach, scope, and all content reviewed and understood by me.
