### PR TITLE
The "Build NVDAController client" and "Create NVDA launcher" steps now run simultaneously again

### DIFF
--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -408,12 +408,13 @@ jobs:
             PowerShell -Command "Set-ExecutionPolicy Bypass"
             PowerShell -Command "Set-PSRepository PSGallery -InstallationPolicy Trusted"
             PowerShell -Command "Install-Module -Name SignPath -Force"
-    - name: Build NVDAController client
-      shell: cmd
-      run: scons client %sconsArgs% %sconsCores%
-    - name: Create NVDA launcher
-      shell: cmd
-      run: scons %sconsLauncherOutTargets% %sconsArgs%
+    - parallel:
+        - name: Build NVDAController client
+          shell: cmd
+          run: scons client %sconsArgs% %sconsCores%
+        - name: Create NVDA launcher
+          shell: cmd
+          run: scons %sconsLauncherOutTargets% %sconsArgs%
     - name: Upload launcher
       id: uploadLauncher
       uses: actions/upload-artifact@v7

--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -411,8 +411,8 @@ jobs:
     - parallel:
         - name: Build NVDAController client
           shell: cmd
+          # To avoid potential permission errors that may occur when this runs simultaneously with "Create NVDA launcher", a wait has been added to prevent them from running at the same time
           run: |
-            # To avoid potential permission errors that may occur when this runs simultaneously with "Create NVDA launcher", a wait has been added to prevent them from running at the same time
             PowerShell -Command "Start-Sleep -Seconds 5"
             scons client %sconsArgs% %sconsCores%
         - name: Create NVDA launcher

--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -411,7 +411,9 @@ jobs:
     - parallel:
         - name: Build NVDAController client
           shell: cmd
-          run: scons client %sconsArgs% %sconsCores%
+          run: |
+            PowerShell -Command "Start-Sleep -Seconds 5"
+            scons client %sconsArgs% %sconsCores%
         - name: Create NVDA launcher
           shell: cmd
           run: scons %sconsLauncherOutTargets% %sconsArgs%

--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -412,6 +412,7 @@ jobs:
         - name: Build NVDAController client
           shell: cmd
           run: |
+            # To avoid potential permission errors that may occur when this runs simultaneously with "Create NVDA launcher", a wait has been added to prevent them from running at the same time
             PowerShell -Command "Start-Sleep -Seconds 5"
             scons client %sconsArgs% %sconsCores%
         - name: Create NVDA launcher


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
<!-- Use Closes/Fixes/Resolves #xxx to link this PR to the issue it is responding to. -->
Follow-up to #20490 and #20507
### Summary of the issue:
Running the "Build NVDAController client" and "Create NVDA launcher" steps simultaneously occasionally caused permission issues. Previously, #20507 made them run separately, but this added extra build time.
### Description of user facing changes:
None
### Description of developer facing changes:
The "Build NVDAController client" and "Create NVDA launcher" steps now run simultaneously again.
### Description of development approach:
Added a wait in the "Build NVDAController client" step.
### Testing strategy:
Stress test:
Added a runs matrix to run the createLauncher job 20 times, and all runs succeeded.
Test workflow: https://github.com/wmhn1872265132/NVDA/actions/runs/29468057234/

### Known issues with pull request:
None
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
