### PR TITLE
Prevent magnifier from keeping foreign objects alive

### DIFF
--- a/source/_magnifier/utils/focusManager.py
+++ b/source/_magnifier/utils/focusManager.py
@@ -232,26 +232,25 @@ class FocusManager:
 			return textInfo.pointAtStart
 		except (NotImplementedError, LookupError, AttributeError, COMError, RuntimeError) as e:
 			if _isDebug():
-				log.debug(f"pointAtStart failed for {textInfo!r}: {e}", exc_info=True)
-			originalExc = e
-
-		# Only apply the fallback for TextInfos exposing the offset-based internals
-		# we need. Otherwise, preserve the original failure.
-		if not (isinstance(textInfo, OffsetsTextInfo) and textInfo.isCollapsed and textInfo._startOffset > 0):
-			raise originalExc
-
-		prevOffset = textInfo._startOffset - 1
-		try:
-			return textInfo._getBoundingRectFromOffset(prevOffset).topRight
-		except (NotImplementedError, LookupError, AttributeError) as e:
-			if _isDebug():
-				log.debug(f"_getBoundingRectFromOffset failed: {e}", exc_info=True)
+				log.debug(f"pointAtStart failed for {textInfo!r}: {e}")
+			# Only apply the fallback for TextInfos exposing the offset-based internals we need.
+			# Otherwise, preserve the original failure.
+			if not (
+				isinstance(textInfo, OffsetsTextInfo) and textInfo.isCollapsed and textInfo._startOffset > 0
+			):
+				raise
+			prevOffset = textInfo._startOffset - 1
 			try:
-				return textInfo._getPointFromOffset(prevOffset)
+				return textInfo._getBoundingRectFromOffset(prevOffset).topRight
 			except (NotImplementedError, LookupError, AttributeError) as e:
 				if _isDebug():
-					log.debug(f"_getPointFromOffset failed: {e}", exc_info=True)
-		raise originalExc
+					log.debug(f"_getBoundingRectFromOffset failed: {e}")
+				try:
+					return textInfo._getPointFromOffset(prevOffset)
+				except (NotImplementedError, LookupError, AttributeError) as e:
+					if _isDebug():
+						log.debug(f"_getPointFromOffset failed: {e}", exc_info=True)
+			raise
 
 	def _getNavigatorObjectLocation(self) -> Coordinates | None:
 		"""


### PR DESCRIPTION
### Link to issue number:

Fixes #20317 

### Summary of the issue:

When magnifier is running, subsequent attepts to access a particular speech dictionary's dialog after an entry has been added to that dictionary fail.

### Description of user facing changes:

Speech dictionary dialogs can now be accessed reliably when Magnifier is running.

### Description of developer facing changes:

None.

### Description of development approach:

`_magnifier.utils.focusManager.FocusManager._getPointAtStart` uses several methods to try and obtain the start position of a `TextInfo`. However, in doing so, it creates an extra copy of the initial exception raised by `textInfo.pointAtStart` at function-local scope.  When any of the fallbacks raises an exception, the original exception is thus captured into the traceback of that exception.

In the case of adding or modifying a dictionary entry, this means that we have stack frames which refer to TextInfos which refer to the `DictionaryEntryDialog`, as well as `DictionaryDialog.addClicke` which also refers to the same `DictionaryEntryDialog`. Since these references ultimately point to foreign objects, the garbage collecter is unable to clean them up, as it can't know that they aren't being used elsewhere. This then means that the specific `DictionaryDialog` subclass object is kept alive, as it still has live children, and `DictionaryDialog` objects are single-instance only.

To fix this, the fallback attempts to get the start point of a `TextInfo` have been moved into the original `except` block. Since the reference to an exception captured in an `except` block is freed when the block is exited (to prevent exactly this sort of issue), when exiting `_pointAtStart`, there will never be any local references to any of the exceptions raised, and thus no indirect references to foreign objects.

### Testing strategy:

Ran from source. Started the magnifier. Repeatedly opened the default dictionary dialog, added a new entry, and safed the dictionary. Verified that I was never blocked from accessing the dialog.

### Known issues with pull request:

I haven't audited the rest of magnifier's code, so there may be other instances of this behaviour that we're unaware of.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
