### PR TITLE
Add-on Store: relabel update actions to "Update (and enable)"

### DIFF
--- a/source/gui/addonStoreGui/controls/actions.py
+++ b/source/gui/addonStoreGui/controls/actions.py
@@ -215,8 +215,9 @@ class _BatchActionsContextMenu(_ActionsContextMenuP[BatchAddonActionVM]):
 				actionTarget=self._selectedAddons,
 			),
 			BatchAddonActionVM(
-				# Translators: Label for an action that updates the selected add-ons
-				displayName=pgettext("addonStore", "&Update selected add-ons"),
+				# Translators: Label for an action that updates the selected add-ons,
+				# which also re-enables any that are disabled.
+				displayName=pgettext("addonStore", "&Update (and enable) selected add-ons"),
 				actionHandler=self._storeVM.getAddons,
 				validCheck=lambda aVMs: AddonListValidator(aVMs).canUseUpdateAction(),
 				actionTarget=self._selectedAddons,

--- a/source/gui/addonStoreGui/controls/actions.py
+++ b/source/gui/addonStoreGui/controls/actions.py
@@ -215,11 +215,24 @@ class _BatchActionsContextMenu(_ActionsContextMenuP[BatchAddonActionVM]):
 				actionTarget=self._selectedAddons,
 			),
 			BatchAddonActionVM(
+				# Translators: Label for an action that updates the selected add-ons
+				displayName=pgettext("addonStore", "&Update selected add-ons"),
+				actionHandler=self._storeVM.getAddons,
+				validCheck=lambda aVMs: (
+					AddonListValidator(aVMs).canUseUpdateAction()
+					and not AddonListValidator(aVMs).hasDisabledAddons()
+				),
+				actionTarget=self._selectedAddons,
+			),
+			BatchAddonActionVM(
 				# Translators: Label for an action that updates the selected add-ons,
-				# which also re-enables any that are disabled.
+				# shown when the selection includes disabled add-ons, which updating re-enables.
 				displayName=pgettext("addonStore", "&Update (and enable) selected add-ons"),
 				actionHandler=self._storeVM.getAddons,
-				validCheck=lambda aVMs: AddonListValidator(aVMs).canUseUpdateAction(),
+				validCheck=lambda aVMs: (
+					AddonListValidator(aVMs).canUseUpdateAction()
+					and AddonListValidator(aVMs).hasDisabledAddons()
+				),
 				actionTarget=self._selectedAddons,
 			),
 			BatchAddonActionVM(
@@ -291,6 +304,10 @@ class AddonListValidator:
 			if aVM.canUseInstallAction() or aVM.canUseInstallOverrideIncompatibilityAction():
 				hasInstallable = True
 		return hasUpdatable and not hasInstallable
+
+	def hasDisabledAddons(self) -> bool:
+		"""Whether any add-on in the list is disabled or blocked, and would therefore be re-enabled by an update."""
+		return any(aVM.model.isDisabled or aVM.model.isBlocked for aVM in self.addonsList)
 
 	def canUseRetryAction(self) -> bool:
 		return any(aVM.canUseRetryAction() for aVM in self.addonsList)

--- a/source/gui/addonStoreGui/controls/messageDialogs.py
+++ b/source/gui/addonStoreGui/controls/messageDialogs.py
@@ -443,12 +443,17 @@ class UpdatableAddonsDialog(
 		self.openStoreButton = bHelper.addButton(self, wx.ID_CLOSE, label=openStoreLabel)
 		self.openStoreButton.Bind(wx.EVT_BUTTON, self.onOpenStoreButton)
 
+		if any(addon.isDisabled or addon.isBlocked for addon in self.addonsPendingUpdate):
+			# Translators: The label of a button in a dialog that updates all add-ons,
+			# shown when the add-ons to update include disabled add-ons, which updating re-enables.
+			updateAllLabel = pgettext("addonStore", "&Update (and enable) all")
+		else:
+			# Translators: The label of a button in a dialog
+			updateAllLabel = pgettext("addonStore", "&Update all")
 		self.updateAllButton = bHelper.addButton(
 			self,
 			wx.ID_CLOSE,
-			# Translators: The label of a button in a dialog that updates all add-ons,
-			# which also re-enables any that are disabled.
-			label=pgettext("addonStore", "&Update (and enable) all"),
+			label=updateAllLabel,
 		)
 		self.updateAllButton.Bind(wx.EVT_BUTTON, self.onUpdateAllButton)
 

--- a/source/gui/addonStoreGui/controls/messageDialogs.py
+++ b/source/gui/addonStoreGui/controls/messageDialogs.py
@@ -446,8 +446,9 @@ class UpdatableAddonsDialog(
 		self.updateAllButton = bHelper.addButton(
 			self,
 			wx.ID_CLOSE,
-			# Translators: The label of a button in a dialog
-			label=pgettext("addonStore", "&Update all"),
+			# Translators: The label of a button in a dialog that updates all add-ons,
+			# which also re-enables any that are disabled.
+			label=pgettext("addonStore", "&Update (and enable) all"),
 		)
 		self.updateAllButton.Bind(wx.EVT_BUTTON, self.onUpdateAllButton)
 

--- a/source/gui/addonStoreGui/viewModels/store.py
+++ b/source/gui/addonStoreGui/viewModels/store.py
@@ -132,14 +132,36 @@ class AddonStoreVM:
 				# Translators: Label for an action that updates the selected addon
 				displayName=pgettext("addonStore", "&Update"),
 				actionHandler=self.getAddon,
-				validCheck=lambda aVM: aVM.canUseUpdateAction(),
+				validCheck=lambda aVM: aVM.canUseUpdateAction() and not aVM.model.isDisabled,
+				actionTarget=selectedListItem,
+			),
+			AddonActionVM(
+				# Translators: Label for an action that updates the selected disabled addon,
+				# which also re-enables it.
+				displayName=pgettext("addonStore", "&Update (and enable)"),
+				actionHandler=self.getAddon,
+				validCheck=lambda aVM: aVM.canUseUpdateAction() and aVM.model.isDisabled,
 				actionTarget=selectedListItem,
 			),
 			AddonActionVM(
 				# Translators: Label for an action that installs the selected addon
 				displayName=pgettext("addonStore", "&Update (override incompatibility)"),
 				actionHandler=self.installOverrideIncompatibilityForAddon,
-				validCheck=lambda aVM: aVM.canUseUpdateOverrideIncompatibilityAction(),
+				validCheck=lambda aVM: (
+					aVM.canUseUpdateOverrideIncompatibilityAction()
+					and not (aVM.model.isDisabled or aVM.model.isBlocked)
+				),
+				actionTarget=selectedListItem,
+			),
+			AddonActionVM(
+				# Translators: Label for an action that updates the selected disabled or blocked addon,
+				# which also re-enables it.
+				displayName=pgettext("addonStore", "&Update (and enable, override incompatibility)"),
+				actionHandler=self.installOverrideIncompatibilityForAddon,
+				validCheck=lambda aVM: (
+					aVM.canUseUpdateOverrideIncompatibilityAction()
+					and (aVM.model.isDisabled or aVM.model.isBlocked)
+				),
 				actionTarget=selectedListItem,
 			),
 			AddonActionVM(

--- a/source/gui/addonStoreGui/viewModels/store.py
+++ b/source/gui/addonStoreGui/viewModels/store.py
@@ -132,15 +132,19 @@ class AddonStoreVM:
 				# Translators: Label for an action that updates the selected addon
 				displayName=pgettext("addonStore", "&Update"),
 				actionHandler=self.getAddon,
-				validCheck=lambda aVM: aVM.canUseUpdateAction() and not aVM.model.isDisabled,
+				validCheck=lambda aVM: (
+					aVM.canUseUpdateAction() and not (aVM.model.isDisabled or aVM.model.isBlocked)
+				),
 				actionTarget=selectedListItem,
 			),
 			AddonActionVM(
-				# Translators: Label for an action that updates the selected disabled addon,
+				# Translators: Label for an action that updates the selected disabled or blocked addon,
 				# which also re-enables it.
 				displayName=pgettext("addonStore", "&Update (and enable)"),
 				actionHandler=self.getAddon,
-				validCheck=lambda aVM: aVM.canUseUpdateAction() and aVM.model.isDisabled,
+				validCheck=lambda aVM: (
+					aVM.canUseUpdateAction() and (aVM.model.isDisabled or aVM.model.isBlocked)
+				),
 				actionTarget=selectedListItem,
 			),
 			AddonActionVM(

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -32,7 +32,7 @@
 * Updated CLDR to version 48.2. (#20234, @OzancanKaratas)
 * The duration of indentation beeps can now be configured via a new "Indent tone duration (ms)" spin control in the Document Formatting settings panel. (#20447, @Mubashir78)
 * In the Add-on Store, the update action for a disabled add-on is now labelled "Update (and enable)", to make it clear that updating an add-on also re-enables it. (#17624, @danielw97)
-  * The bulk update actions have been relabelled "Update (and enable) selected add-ons" and "Update (and enable) all" for the same reason.
+  * Similarly, the bulk update actions are labelled "Update (and enable) selected add-ons" and "Update (and enable) all" when the add-ons to update include disabled add-ons.
 
 ### Bug Fixes
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -31,8 +31,6 @@
   * Browseable message dialogs now better support resizing, maximizing and minimizing, with text wrapping to the dialog width. (#20429, @Cary-rowen)
 * Updated CLDR to version 48.2. (#20234, @OzancanKaratas)
 * The duration of indentation beeps can now be configured via a new "Indent tone duration (ms)" spin control in the Document Formatting settings panel. (#20447, @Mubashir78)
-* In the Add-on Store, the update action for a disabled add-on is now labelled "Update (and enable)", to make it clear that updating an add-on also re-enables it. (#17624, @danielw97)
-  * Similarly, the bulk update actions are labelled "Update (and enable) selected add-ons" and "Update (and enable) all" when the add-ons to update include disabled add-ons.
 
 ### Bug Fixes
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -31,6 +31,8 @@
   * Browseable message dialogs now better support resizing, maximizing and minimizing, with text wrapping to the dialog width. (#20429, @Cary-rowen)
 * Updated CLDR to version 48.2. (#20234, @OzancanKaratas)
 * The duration of indentation beeps can now be configured via a new "Indent tone duration (ms)" spin control in the Document Formatting settings panel. (#20447, @Mubashir78)
+* In the Add-on Store, the update action for a disabled add-on is now labelled "Update (and enable)", to make it clear that updating an add-on also re-enables it. (#17624, @danielw97)
+  * The bulk update actions have been relabelled "Update (and enable) selected add-ons" and "Update (and enable) all" for the same reason.
 
 ### Bug Fixes
 

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -372,6 +372,7 @@ Press `control+tab` to get to this tab from anywhere in the Add-on Store.
 The status of the add-on will be listed as "Update available".
 The list will display the currently installed version and the available version.
 Press `enter` on the add-on to open the actions list; choose "Update".
+If the add-on is disabled, the action will instead be labelled "Update (and enable)", as add-ons must be enabled to be installed; updating a disabled add-on re-enables it.
 
 By default, after NVDA startup, you will be notified if any add-on updates are available.
 To learn more about and configure this behaviour, refer to ["Update Notifications"](#AutomaticAddonUpdates).


### PR DESCRIPTION
### Link to issue number:

Fixes #17624

### Summary of the issue:

Updating a disabled add-on from the Add-on Store silently re-enables it after restart. This is intended behavior (add-ons must be enabled to be installed), but the action is labelled simply "Update", so nothing tells the user their disabled add-on is about to be enabled. As requested by @seanbudd in the issue, the update actions should be re-labelled to make this clear, including for the bulk update cases.

### Description of user facing changes:

In the Add-on Store:

* When the selected add-on with an available update is disabled — or blocked due to incompatibility — the update action is now labelled "Update (and enable)" instead of "Update".
* Likewise, "Update (override incompatibility)" becomes "Update (and enable, override incompatibility)" when the installed add-on is disabled or blocked due to incompatibility.
* Enabled add-ons continue to show the existing "Update" / "Update (override incompatibility)" labels.
* The bulk actions show "Update (and enable) selected add-ons" (multi-selection context menu) and "Update (and enable) all" (add-on updates notification dialog) when the add-ons to update include disabled or blocked add-ons, and keep their original labels otherwise.

The wording places "Update" first, per the review feedback from @CyrilleB79 and @SaschaCowley on the earlier attempt (#19755) and @seanbudd's suggested bulk wording in #17624: updating is the primary action, enabling is a side-effect.

### Description of developer facing changes:

None. No API changes; a small helper (`AddonListValidator.hasDisabledAddons`) was added for the bulk label predicates.

### Description of development approach:

The single add-on re-labelling is implemented as paired `AddonActionVM` entries in `AddonStoreVM._makeActionsList` with complementary `validCheck` predicates (`aVM.canUseUpdateAction() and [not] (aVM.model.isDisabled or aVM.model.isBlocked)`), following the existing pattern where mutually exclusive actions (e.g. Install vs Update) are separate entries. This avoids making `_AddonAction.displayName` support callables for dynamic labels, which the previous attempt (#19755) required.

`AddonListItemVM.canUseUpdateAction()` itself is deliberately unchanged: it is used by the batch update machinery (`AddonStoreVM.getAddons` and `AddonListValidator`) to decide which add-ons actually get updated, so narrowing it would have silently excluded disabled add-ons from bulk updates.

Both update variants check `isDisabled or isBlocked`, because `Addon.completeRemove` clears both the disabled and blocked state categories when the old version is removed during an update — so updating re-enables a blocked add-on too, including when the new version is compatible and the update takes the plain (non-override) path.

The bulk labels follow the selection, per review feedback: "(and enable)" only appears when the add-ons being updated include disabled or blocked ones (`AddonListValidator.hasDisabledAddons`), and the add-on updates notification dialog chooses its button label the same way when it is built.

### Testing strategy:

* `runlint.bat` (ruff + pyright): passes on all changed files.
* Manual testing with an installed add-on that has an available update:
  * Disabled add-on: actions menu in the "Updatable add-ons" tab shows "Update (and enable)"; activating it updates the add-on and it is enabled after restart.
  * Enabled add-on: actions menu still shows "Update".
  * Multiple add-ons selected: context menu shows "Update (and enable) selected add-ons" and updates all selected add-ons, including disabled ones.
  * The add-on updates notification dialog shows "Update (and enable) all".
* No unit tests added: this view model layer (`AddonStoreVM._makeActionsList` and the actions context menus) has no existing unit test coverage, and the change adds no new logic beyond label selection.
* The conditional-label revisions made during review (89e6f38, 06eed10) pass ruff and pyright; the manual pass above covers the original behaviour, and a manual re-test of the conditional bulk labels is still pending.

### Known issues with pull request:

An add-on in the "pending disable" state (currently enabled, disabled after restart) shows the plain "Update" label, but `Addon.completeRemove` does not clear `PENDING_DISABLE`, so after updating and restarting it will be disabled. The plain "Update" label makes no promise about enabling, so this is not misleading, but the interaction of updates with pending state changes may be worth a follow-up issue.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

---

This change was developed with the assistance of AI (Claude), with the approach, scope, and all code reviewed and understood by me.

