### PR TITLE
Fix Add-on Store freeze when navigating the list quickly

### DIFF
--- a/source/gui/addonStoreGui/controls/details.py
+++ b/source/gui/addonStoreGui/controls/details.py
@@ -14,6 +14,7 @@ from addonStore.models.addon import (
 from gui import guiHelper
 from gui.dpiScalingHelper import DpiScalingHelperMixinWithoutInit
 from logHandler import log
+from utils.debounce import debounceLimiter
 
 from ..viewModels.addonList import AddonDetailsVM, AddonListField
 
@@ -53,6 +54,14 @@ class AddonDetails(
 	_actionsLabelText: str = pgettext("addonStore", "A&ctions")
 
 	Parent: "AddonStoreDialog"
+
+	_REFRESH_DELAY_MS: int = 100
+	"""
+	Debounce delay in milliseconds before refreshing the details view after the selection changes.
+	Rebuilding the details controls emits a burst of accessibility events, so debouncing avoids
+	flooding NVDA while navigating the list quickly, for example when holding an arrow key.
+	See #17351.
+	"""
 
 	def __init__(
 		self,
@@ -160,8 +169,10 @@ class AddonDetails(
 		)
 		self._createRichTextStyles()
 		self.contents.Add(self.otherDetailsTextCtrl, flag=wx.EXPAND, proportion=1)
+		self._isBeingDestroyed: bool = False
 		self._refresh()  # ensure that the visual state matches.
 		self._detailsVM.updated.register(self._updatedListItem)
+		self.Bind(wx.EVT_WINDOW_DESTROY, self._onDestroy, source=self)
 		self.Layout()
 
 	def _createRichTextStyles(self):
@@ -202,9 +213,32 @@ class AddonDetails(
 	def _updatedListItem(self, addonDetailsVM: AddonDetailsVM):
 		log.debug(f"Setting listItem: {addonDetailsVM.listItem}")
 		assert self._detailsVM.listItem == addonDetailsVM.listItem
+		self._scheduleRefresh()
+
+	@debounceLimiter(
+		cooldownTimeMs=_REFRESH_DELAY_MS,
+		delayTimeMs=_REFRESH_DELAY_MS,
+		runImmediateFirstCall=False,
+	)
+	def _scheduleRefresh(self) -> None:
+		"""Refresh the details view once the selection settles, using the shared debouncer.
+
+		Rapid selection changes only schedule a single trailing refresh, so navigating the list
+		quickly no longer floods the main thread with the accessibility events of a full rebuild.
+		"""
 		self._refresh()
 
+	def _onDestroy(self, evt: wx.WindowDestroyEvent) -> None:
+		# The binding uses source=self, so this only runs for the panel's own destruction.
+		# Unregister from updates and mark the panel as gone, so a pending debounced refresh
+		# becomes a no-op instead of touching controls that are being destroyed.
+		self._isBeingDestroyed = True
+		self._detailsVM.updated.unregister(self._updatedListItem)
+		evt.Skip()
+
 	def _refresh(self):
+		if self._isBeingDestroyed:
+			return
 		details = None if self._detailsVM.listItem is None else self._detailsVM.listItem.model
 		numSelectedAddons = self.Parent.addonListView.GetSelectedItemCount()
 

--- a/source/gui/addonStoreGui/controls/details.py
+++ b/source/gui/addonStoreGui/controls/details.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2022-2026 NV Access Limited, Cyrille Bougot
+# Copyright (C) 2022-2026 NV Access Limited, Cyrille Bougot, Christopher Proß
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 

--- a/tests/manual/nvdaUI/addonStore.md
+++ b/tests/manual/nvdaUI/addonStore.md
@@ -46,6 +46,16 @@ Add-ons can be filtered by display name, publisher and description.
 1. Ensure that the add-ons list is sorted accordingly
 1. Change to different tabs, and repeat the previous steps.
 
+### Rapidly navigating the add-ons list
+
+1. Open the Add-on Store
+1. Change to the "Available add-ons" tab and enable the "Include incompatible add-ons" filter, to get a long list.
+1. Tab to the list of add-ons.
+1. Hold down the arrow keys to move through the list quickly, then release.
+1. Ensure NVDA stays responsive and does not freeze.
+1. After stopping, tab to the details view.
+1. Ensure the details update to show the currently selected add-on.
+
 ### Failure to fetch add-ons available for download
 
 1. Disable your internet connection

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -54,6 +54,7 @@ Previously these keys had no function when pressed on their own. (#20366, @fla-r
 * The HID keyboard input simulation setting for ALVA braille displays is now remembered across reconnects and restarts. (#20455, @Cary-rowen)
 * Braille now follows the spoken text during say all in browse mode when braille is tethered to focus. (#3287, @LeonarddeR)
 * NVDA now reports checked ToolStrip menu items in .NET Framework Windows Forms applications using UI Automation. (#19335, @Cary-rowen)
+* The Add-on Store no longer becomes unresponsive when navigating the list of add-ons quickly, such as by holding down an arrow key. (#17351, @christopherpross)
 
 ### Changes for Developers
 


### PR DESCRIPTION
### Link to issue number:

Closes #17351

### Summary of the issue:

NVDA freezes when navigating the Add-on Store list quickly, for example by holding an arrow key. The watchdog triggers and NVDA becomes unresponsive for several seconds at a time.

The cause is the details panel to the right of the list. Every time the selection changes, `AddonDetails._refresh` rebuilds that panel from scratch. Rebuilding the "Other details" rich text control appends its content in many small steps, and each append emits an `EVENT_OBJECT_VALUECHANGE` accessibility event on the control. NVDA processes every one of these events on the main thread. While navigating quickly the rebuilds pile up, the value change events flood the main thread, and the main thread saturates until the watchdog reports a freeze.

### Description of user facing changes:

The Add-on Store stays responsive when navigating the list quickly. NVDA no longer freezes when holding an arrow key to move through the add-ons.

### Description of developer facing changes:

None.

### Description of development approach:

The details refresh in `AddonDetails` is now debounced. `_updatedListItem` no longer calls `_refresh` directly. Instead it calls `_scheduleRefresh`, which is decorated with the shared `debounceLimiter` from `utils.debounce`. It is configured as a pure trailing edge debounce, `runImmediateFirstCall=False`, with the named constant `_REFRESH_DELAY_MS` of 100 milliseconds. This reuses NVDA's existing debouncing architecture, the same approach as `_scheduleFilter` in `browseMode`. Rapid selection changes keep restarting the debounce, so the expensive rebuild runs only once the user settles on an add-on.

There is deliberately no immediate flush when focus leaves the list. Human reaction time between stopping and pressing tab is well above the 100 millisecond debounce. The rebuild has therefore almost always run before the details are reached, and any remaining lag is not perceptible. A flush would also force a rebuild on every list exit, including the common case where the details are already current. That would reintroduce the accessibility event traffic this fix removes.

Teardown is handled in `_onDestroy`. Destroy events bubble up from child controls, so the handler filters on `evt.GetWindow() is self`. The debouncer offers no way to cancel a scheduled call from outside, so on the panel's own destruction `_onDestroy` sets an `_isBeingDestroyed` flag and unregisters from selection updates. `_refresh` checks that flag first and returns early, so a still scheduled refresh becomes a no-op instead of touching controls that are being destroyed.

The root cause was confirmed with debug logging. Before the fix, holding an arrow key through the list produced about 37000 value change events on the details rich text control across roughly 740 selection changes, which is about 50 events per selection, together with a single freeze of about 4.6 seconds. After the fix, a comparable run with more navigation, about 1000 selection changes, produced about 2600 value change events, which is about 2.5 events per selection, and no freeze at all.

This PR was developed with AI assistance (Claude Code) with human review and manual testing.

### Testing strategy:

Manual testing, repeated before and after the fix:

1. Open the Add-on Store.
2. Change to the "Available add-ons" tab and enable the "Include incompatible add-ons" filter, to get a long list.
3. Tab to the list of add-ons.
4. Hold down the arrow keys to move through the list quickly, then release.
5. Before the fix, the watchdog triggers and NVDA freezes for several seconds. After the fix, NVDA stays responsive.
6. After stopping, tab to the details view.
7. Confirm the details update to show the currently selected add-on.

A matching manual test case was added to `tests/manual/nvdaUI/addonStore.md`.

No automated test was added. The bug is about the timing of accessibility events under rapid input, which is not practical to reproduce in a unit test, and the Add-on Store GUI has no unit test coverage to build on. The manual test case documents the scenario instead.

### Known issues with pull request:

The details panel now updates up to 100 milliseconds after the selection settles, rather than instantly, even for a single key press. This is not perceptible and does not affect what is spoken. Feedback on the delay value is welcome.

### Code Review Checklist:

* [x] Documentation:
  * Change log entry
  * User Documentation
  * Developer / Technical Documentation
  * Context sensitive help for GUI changes
* [x] Testing:
  * Unit tests
  * System (end to end) tests
  * Manual testing
* [x] UX of all users considered:
  * Speech
  * Braille
  * Low Vision
  * Different web browsers
  * Localization in other languages / culture than English
* [x] API is compatible with existing add-ons.
* [x] Security precautions taken.
