### PR TITLE
Added the ability to change the existing gestures in the input gestures dialog

### DIFF
--- a/source/gui/inputGestures.py
+++ b/source/gui/inputGestures.py
@@ -64,6 +64,7 @@ class _GestureVM:
 	displayName: str  #: How the gesture should be displayed
 	normalizedGestureIdentifier: str  #: As per items in inputCore.AllGesturesScriptInfo.gestures
 	canAdd = False  #: adding children is not supported.
+	canChange = True  #: gestures can be changed
 	canRemove = True  #: gestures can be removed
 
 	def __init__(self, normalizedGestureIdentifier: str):
@@ -78,6 +79,7 @@ class _PendingGesture:
 	# Translators: The prompt to enter a gesture in the Input Gestures dialog.
 	displayName = _("Enter input gesture:")
 	canAdd = False
+	canChange = False
 	canRemove = False
 
 	def __repr__(self):
@@ -89,6 +91,7 @@ class _ScriptVM:
 	scriptInfo: inputCore.AllGesturesScriptInfo
 	gestures: List[Union[_GestureVM, _PendingGesture]]
 	canAdd = True  #: able to add gestures that trigger this script
+	canChange = False  #: Scripts can not be Changed
 	canRemove = False  #: Scripts can not be removed
 	addedGestures: List[_GestureVM]  #: These will also be in self.gestures
 	#: These will not be in self.gestures anymore. Key is the normalized Gesture Identifier.
@@ -143,6 +146,7 @@ class _CategoryVM:
 	displayName: str  #: Translated display name for the category
 	scripts: List[_ScriptVM]
 	canAdd = False  #: not able to add Scripts
+	canChange = False  #: categories can not be changed
 	canRemove = False  #: categories can not be removed
 
 	def __init__(self, displayName: str, scripts: _ScriptsModel):
@@ -178,6 +182,10 @@ class _EmulatedGestureVM(_ScriptVM):
 		super(_EmulatedGestureVM, self).__init__(displayName=emuGestureDisplayName, scriptInfo=emuGestureInfo)
 
 	@property
+	def canChange(self) -> bool:
+		return not bool(self.gestures)
+
+	@property
 	def canRemove(self) -> bool:
 		return not bool(self.gestures)
 
@@ -189,6 +197,7 @@ class _PendingEmulatedGestureVM:
 	# Translators: The prompt to enter an emulated gesture in the Input Gestures dialog.
 	displayName = _("Enter gesture to emulate:")
 	canAdd = False
+	canChange = False
 	canRemove = False
 
 	def __repr__(self):
@@ -199,6 +208,7 @@ class _EmuCategoryVM:
 	displayName = inputCore.SCRCAT_KBEMU  #: Translated display name for the gesture emulation category
 	scripts: List[Union[_ScriptVM, _EmulatedGestureVM, _PendingEmulatedGestureVM]]
 	canAdd = True  #: Can add new emulated gestures
+	canChange = False  #: categories can not be changed
 	canRemove = False  #: categories can not be removed
 	addedKbEmulation: List[_EmulatedGestureVM]  #: These will also be in self.scripts
 	#: These will not be in self.scripts anymore. Key is the scriptInfo display name.
@@ -619,6 +629,11 @@ class InputGesturesDialog(SettingsDialog):
 		self.addButton.Bind(wx.EVT_BUTTON, self.onAdd)
 		self.addButton.Disable()
 
+		# Translators: The label of a button to change a gesture in the Input Gestures dialog.
+		self.changeButton = bHelper.addButton(self, label=_("C&hange"))
+		self.changeButton.Bind(wx.EVT_BUTTON, self.onChange)
+		self.changeButton.Disable()
+
 		# Translators: The label of a button to remove a gesture in the Input Gestures dialog.
 		self.removeButton = bHelper.addButton(self, label=_("&Remove"))
 		self.removeButton.Bind(wx.EVT_BUTTON, self.onRemove)
@@ -669,6 +684,10 @@ class InputGesturesDialog(SettingsDialog):
 				# Translators: Context menu item label to add a new gesture
 				addItem = menu.Append(wx.ID_ANY, _("&Add"))
 				self.Bind(wx.EVT_MENU, self.onAdd, addItem)
+			if item.canChange:
+				# Translators: Context menu item label to change a gesture
+				changeItem = menu.Append(wx.ID_ANY, _("C&hange"))
+				self.Bind(wx.EVT_MENU, self.onChange, changeItem)
 			if item.canRemove:
 				# Translators: Context menu item label to remove a gesture
 				removeItem = menu.Append(wx.ID_ANY, _("&Remove"))
@@ -714,9 +733,10 @@ class InputGesturesDialog(SettingsDialog):
 		# Check if an add operation is already in progress to prevent conflicts.
 		pendingAdd = self.gesturesVM.isExpectingNewEmuGesture or self.gesturesVM.isExpectingNewGesture
 		self.addButton.Enabled = bool(item and item.canAdd and not pendingAdd)
+		self.changeButton.Enabled = bool(item and item.canChange and not pendingAdd)
 		self.removeButton.Enabled = bool(item and item.canRemove and not pendingAdd)
 
-	def onAdd(self, evt):
+	def onAdd(self, evt: wx.CommandEvent):
 		if inputCore.manager._captureFunc:
 			# don't add while already in process of adding.
 			return
@@ -731,36 +751,65 @@ class InputGesturesDialog(SettingsDialog):
 			pending = catVM.createPendingEmuGesture()
 			self.tree.doRefresh(focus=(catVM, pending, None))
 			self._refreshButtonState()
-
-			def addKbEmuGestureCaptor(gesture: inputCore.InputGesture):
-				if not isinstance(gesture, keyboardHandler.KeyboardInputGesture) or gesture.isModifier:
-					return False
-				inputCore.manager._captureFunc = None
-				wx.CallAfter(self._addCapturedKbEmu, gesture, catVM)
-				return False
-
-			inputCore.manager._captureFunc = addKbEmuGestureCaptor
+			inputCore.manager._captureFunc = lambda g: self._addKbEmuGestureCaptor(g, catVM)
 		elif gestureVM is None and isinstance(scriptVM, _ScriptVM):
 			self.gesturesVM.isExpectingNewGesture = scriptVM
 			pendingGesture = scriptVM.createPendingGesture()
 			self.tree.doRefresh(focus=(catVM, scriptVM, pendingGesture))
 			self._refreshButtonState()
-
-			def addGestureCaptor(gesture: inputCore.InputGesture):
-				if gesture.isModifier:
-					return False
-				if isinstance(catVM, _EmuCategoryVM):
-					gesName = keyLabels.getKeyCombinationLabel(gesture.normalizedIdentifiers[-1][3:])
-					if gesName == scriptVM.scriptInfo.displayName:
-						# Disallow assigning an emulated gesture to itself
-						return False
-				inputCore.manager._captureFunc = None
-				wx.CallAfter(self._addCaptured, catVM, scriptVM, gesture)
-				return False
-
-			inputCore.manager._captureFunc = addGestureCaptor
+			inputCore.manager._captureFunc = lambda g: self._addGestureCaptor(g, catVM, scriptVM)
 		else:
 			log.error("unable to do 'add' action for selected item")
+
+	def onChange(self, evt: wx.CommandEvent):
+		if inputCore.manager._captureFunc:
+			# don't change while already in process of add/change.
+			return
+
+		selectedItems = self.tree.getSelectedItemData()
+		assert selectedItems is not None
+		catVM, scriptVM, gestureVM = selectedItems
+		log.debug(f"selection: {catVM}, {scriptVM}, {gestureVM}")
+
+		if isinstance(scriptVM, _EmulatedGestureVM) and isinstance(catVM, _EmuCategoryVM):
+			catVM.removeEmulation(scriptVM)
+			self.gesturesVM.isExpectingNewEmuGesture = catVM
+			pending = catVM.createPendingEmuGesture()
+			self.tree.doRefresh(focus=(catVM, pending, None))
+			self._refreshButtonState()
+			inputCore.manager._captureFunc = lambda g: self._addKbEmuGestureCaptor(g, catVM)
+		elif gestureVM is not None and isinstance(scriptVM, _ScriptVM):
+			scriptVM.removeGesture(gestureVM)
+			self.gesturesVM.isExpectingNewGesture = scriptVM
+			pendingGesture = scriptVM.createPendingGesture()
+			self.tree.doRefresh(focus=(catVM, scriptVM, pendingGesture))
+			self._refreshButtonState()
+			inputCore.manager._captureFunc = lambda g: self._addGestureCaptor(g, catVM, scriptVM)
+		else:
+			log.error(f"unable to do 'change' action for selected item: {catVM}, {scriptVM}, {gestureVM}")
+
+	def _addKbEmuGestureCaptor(self, gesture: inputCore.InputGesture, catVM: _EmuCategoryVM) -> bool:
+		if not isinstance(gesture, keyboardHandler.KeyboardInputGesture) or gesture.isModifier:
+			return False
+		inputCore.manager._captureFunc = None
+		wx.CallAfter(self._addCapturedKbEmu, gesture, catVM)
+		return False
+
+	def _addGestureCaptor(
+		self,
+		gesture: inputCore.InputGesture,
+		catVM: _CategoryVMTypes,
+		scriptVM: _ScriptVMTypes,
+	) -> bool:
+		if gesture.isModifier:
+			return False
+		if isinstance(catVM, _EmuCategoryVM):
+			gesName = keyLabels.getKeyCombinationLabel(gesture.normalizedIdentifiers[-1][3:])
+			if gesName == scriptVM.scriptInfo.displayName:
+				return False
+		inputCore.manager._captureFunc = None
+		wx.CallAfter(self._addCaptured, catVM, scriptVM, gesture)
+		return False
 
 	def _addCaptured(self, catVM: _CategoryVMTypes, scriptVM: _ScriptVMTypes, gesture):
 		gids = gesture.normalizedIdentifiers
@@ -812,7 +861,7 @@ class InputGesturesDialog(SettingsDialog):
 		self.tree.doRefresh(focus=(catVM, newScript, None))
 		self._refreshButtonState()
 
-	def onRemove(self, evt):
+	def onRemove(self, evt: wx.CommandEvent):
 		selectedItems = self.tree.getSelectedItemData()
 		assert selectedItems is not None
 		catVM, scriptVM, gestureVM = selectedItems

--- a/source/gui/inputGestures.py
+++ b/source/gui/inputGestures.py
@@ -91,7 +91,7 @@ class _ScriptVM:
 	scriptInfo: inputCore.AllGesturesScriptInfo
 	gestures: List[Union[_GestureVM, _PendingGesture]]
 	canAdd = True  #: able to add gestures that trigger this script
-	canChange = False  #: Scripts can not be Changed
+	canChange = False  #: Scripts can not be changed
 	canRemove = False  #: Scripts can not be removed
 	addedGestures: List[_GestureVM]  #: These will also be in self.gestures
 	#: These will not be in self.gestures anymore. Key is the normalized Gesture Identifier.

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -23,6 +23,7 @@
 * Magnifier: A new unassigned command has been added to move the mouse cursor to the center of the magnified view. (#20127, @CyrilleB79)
 * Added context menu and shortcuts support to the Input gestures dialog. (#16816, @amirmahdifard)
 * Added context menu and shortcuts support to the Speech Dictionaries dialog. (#20420, @amirmahdifard)
+* It is now possible to change an existing gesture in the input gestures dialog. (#10983, @amirmahdifard)
 
 ### Changes
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -23,7 +23,7 @@
 * Magnifier: A new unassigned command has been added to move the mouse cursor to the center of the magnified view. (#20127, @CyrilleB79)
 * Added context menu and shortcuts support to the Input gestures dialog. (#16816, @amirmahdifard)
 * Added context menu and shortcuts support to the Speech Dictionaries dialog. (#20420, @amirmahdifard)
-* It is now possible to change an existing gesture in the input gestures dialog. (#10983, @amirmahdifard)
+* It is now possible to change an existing gesture in the Input Gestures dialog. (#10983, @amirmahdifard)
 
 ### Changes
 

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -4385,8 +4385,10 @@ Often, a gesture can be interpreted in more than one way.
 For example, if you pressed a key on the keyboard, you may wish it to be specific to the current keyboard layout (e.g. desktop or laptop) or you may wish it to apply for all layouts.
 In this case, a menu will appear allowing you to select the desired option.
 
-You can use the context menu to add or remove gestures for each command.
-To remove a gesture from a command, you can also press the `delete` key.
+You can also use the context menu to add, change, or remove gestures for each command.
+To change an input gesture of a command, select the gesture and press the change button.
+Then, perform the new input gesture you wish to associate; that will replace the old one.
+To remove a gesture from a command, you can press the `delete` key or the remove button.
 
 The Emulated system keyboard keys category contains NVDA commands that emulate keys on the system keyboard.
 These emulated system keyboard keys can be used to control a system keyboard right from your braille display.


### PR DESCRIPTION
### Link to issue number:
fixes https://github.com/nvaccess/nvda/issues/10983
### Summary of the issue:
Requested to be able to edit and change existing gestures in the input gestures dialog directly, raather than removing a gesture, go back to the script level, and add a new one.
### Description of user facing changes:
Added the ability to change currently existing gestures in the input gestures dialog press change, enter your new gesture, and done.
### Description of developer facing changes:
none
### Description of development approach:
Used the same patten as the "onAdd" method and added an "onChange" method, that safely removes the currently focused gesture, and Allow the user to enter a new one.
### Testing strategy:
manual testing. Changed an existing gesture, made sure that it properly edits. No unexpected bug, no crash, no duplication. The gesture is properly replaced.
### Known issues with pull request:
none
### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
