### PR TITLE
Fix Windows OCR word order for RTL languages

### DIFF
--- a/nvdaHelper/localWin10/uwpOcr.cpp
+++ b/nvdaHelper/localWin10/uwpOcr.cpp
@@ -16,11 +16,14 @@ http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 #include <winrt/Windows.Storage.Streams.h>
 #include <winrt/Windows.Media.Ocr.h>
 #include <winrt/Windows.Foundation.Collections.h>
+#include <winrt/Windows.Foundation.Metadata.h>
 #include <winrt/Windows.Globalization.h>
 #include <winrt/Windows.Graphics.Imaging.h>
 #include <winrt/Windows.Data.Json.h>
 #include <windows.h>
+#include <algorithm>
 #include <cstring>
+#include <vector>
 #include <common/log.h>
 #include "uwpOcr.h"
 
@@ -29,9 +32,29 @@ using namespace winrt;
 using namespace winrt::Windows::Storage::Streams;
 using namespace winrt::Windows::Media::Ocr;
 using namespace winrt::Windows::Foundation::Collections;
+using winrt::Windows::Foundation::Metadata::ApiInformation;
 using namespace winrt::Windows::Globalization;
 using namespace winrt::Windows::Graphics::Imaging;
 using namespace winrt::Windows::Data::Json;
+
+bool isLeftToRightWord(OcrWord const& word) {
+	auto text = word.Text();
+	vector<WORD> characterTypes(text.size());
+	if (!GetStringTypeW(CT_CTYPE2, text.c_str(), static_cast<int>(text.size()), characterTypes.data())) {
+		return false;
+	}
+	for (auto const characterType : characterTypes) {
+		if (characterType & C2_RIGHTTOLEFT) {
+			return false;
+		}
+	}
+	for (auto const characterType : characterTypes) {
+		if (characterType & (C2_LEFTTORIGHT | C2_EUROPENUMBER | C2_ARABICNUMBER)) {
+			return true;
+		}
+	}
+	return false;
+}
 
 UwpOcr::UwpOcr(OcrEngine const& engine, uwpOcr_Callback callback) : engine(engine), callback(callback) { }
 
@@ -60,12 +83,46 @@ fire_and_forget UwpOcr::recognize(SoftwareBitmap bitmap) {
 		auto result = co_await engine.RecognizeAsync(bitmap);
 		auto lines = result.Lines();
 		JsonArray jLines {};
+		auto language = engine.RecognizerLanguage();
+		const bool isLanguageLayoutDirectionSupported = ApiInformation::IsApiContractPresent(
+			hstring { L"Windows.Foundation.UniversalApiContract" },
+			6
+		);
+		const auto script = language.Script();
+		const bool isRtl = isLanguageLayoutDirectionSupported
+			? language.LayoutDirection() == LanguageLayoutDirection::Rtl
+			: (script == L"Arab" || script == L"Hebr");
 
 		for (auto const& line : lines) {
 			auto words = line.Words();
+			vector<OcrWord> wordsInReadingOrder { words.begin(), words.end() };
+			if (isRtl) {
+				// Windows OCR returns words in left-to-right coordinate order, including for RTL languages.
+				// Sort by the horizontal position so speech and review navigation follow RTL reading order.
+				stable_sort(
+					wordsInReadingOrder.begin(),
+					wordsInReadingOrder.end(),
+					[](OcrWord const& first, OcrWord const& second) {
+						return first.BoundingRect().X > second.BoundingRect().X;
+					}
+				);
+				// Preserve the logical order of embedded LTR runs after reversing the RTL line.
+				for (auto runStart = wordsInReadingOrder.begin(); runStart != wordsInReadingOrder.end();) {
+					if (!isLeftToRightWord(*runStart)) {
+						++runStart;
+						continue;
+					}
+					auto runEnd = runStart + 1;
+					while (runEnd != wordsInReadingOrder.end() && isLeftToRightWord(*runEnd)) {
+						++runEnd;
+					}
+					reverse(runStart, runEnd);
+					runStart = runEnd;
+				}
+			}
 			JsonArray jWords {};
 
-			for (auto const& word : words) {
+			for (auto const& word : wordsInReadingOrder) {
 				JsonObject jWord {};
 
 				auto rect = word.BoundingRect();

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -36,6 +36,7 @@
 
 ### Bug Fixes
 
+* Windows OCR results in right-to-left languages such as Arabic and Hebrew are now read in the correct word order. (#20475)
 * In PowerPoint and other Office applications, NVDA will now correctly read and navigate the edit fields in the insert hyperlink dialog. (#17390, @aryanchoudharypro)
 * The actions button can now be used when selecting multiple add-ons in the Add-on Store to perform batch actions, instead of just via the context menu in the add-ons list. (#19971, @amirmahdifard)
 * When moving to an ARIA grid cell in focus mode in web browsers, NVDA no longer reports both the row and column headers even if only the row or only the column changed. (#17750, @jcsteh)


### PR DESCRIPTION
### Link to issue number:

Fixes #20475

### Summary of the issue:

Windows OCR returns words in left-to-right coordinate order even when the recognizer language is right-to-left. As a result, NVDA speaks and navigates Arabic and Hebrew OCR results with the word order reversed.

### Description of user facing changes:

Windows OCR results for right-to-left languages are now spoken and navigated in reading order. Embedded left-to-right runs, such as an English phrase within an Arabic sentence, retain their internal order.

### Description of developer facing changes:

The Windows OCR bridge now determines the layout direction from `OcrEngine.RecognizerLanguage`. It sorts recognized words from right to left for RTL languages and restores the logical order of contiguous LTR word runs. A Universal API contract check preserves compatibility with Windows versions predating `Language.LayoutDirection`, falling back to the Arabic and Hebrew script identifiers.

### Description of development approach:

Each OCR line is copied to a vector before serialization. For an RTL recognizer language, the vector is stably sorted by descending horizontal coordinate. Windows character-type information is then used to identify and reverse contiguous LTR runs within the reordered line.

### Testing strategy:

- Reproduced with installed NVDA 2026.1.1 and Windows OCR `ar-SA`: `مرحبا بكم في عالم البرمجة` was returned as `البرمجة عالم في بكم مرحبا`.
- Built the full `source` target successfully with warnings treated as errors, including x64, ARM64, and ARM64EC OCR helpers.
- Tested the patched x64 helper end to end with real Windows OCR:
  - Arabic: `مرحبا بكم في عالم البرمجة` retained the expected reading order.
  - English: `Welcome to the world of programming` remained unchanged.
  - Mixed RTL/LTR: `مرحبا good morning جميعا` retained both the RTL sentence order and the internal order of the English phrase.
- Ran the 29 existing `contentRecog` unit tests successfully.
- Ran `runlint.bat` and `runcheckpot.bat` successfully.

### Known issues with pull request:

None known. An automated test was not added because the ordering is implemented in the native WinRT OCR bridge and depends on real OCR output; it was covered with manual end-to-end tests against the built DLL.

### Code Review Checklist:

- [x] Documentation:
  - [x] Change log entry
  - [x] User Documentation (not required beyond the change log)
  - [x] Developer / Technical Documentation (not required; no developer API change)
  - [x] Context sensitive help for GUI changes (not applicable)
- [x] Testing:
  - [x] Unit tests (existing `contentRecog` suite)
  - [x] System (end to end) tests (real Windows OCR helper)
  - [x] Manual testing
- [x] UX of all users considered:
  - [x] Speech
  - [x] Braille
  - [x] Low Vision
  - [x] Different web browsers (not applicable)
  - [x] Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
