### PR TITLE
Use Windows date preferences in Add-on Store

### DIFF
--- a/source/addonStore/models/addon.py
+++ b/source/addonStore/models/addon.py
@@ -19,6 +19,7 @@ from requests.structures import CaseInsensitiveDict
 
 import addonAPIVersion
 from NVDAState import WritePaths
+from utils.localisation import formatDateForSystemLocale
 
 from .channel import Channel
 from .scanResults import VirusTotalScanResults
@@ -194,7 +195,7 @@ class _AddonStoreModel(_AddonGUIModel):
 		if self.submissionTime is None:
 			return None
 		# Convert `self.submissionTime` to seconds.
-		return datetime.strftime(datetime.fromtimestamp(self.submissionTime // 1000), "%x")
+		return formatDateForSystemLocale(datetime.fromtimestamp(self.submissionTime // 1000))
 
 
 class _AddonManifestModel(_AddonGUIModel):

--- a/source/gui/addonStoreGui/controls/details.py
+++ b/source/gui/addonStoreGui/controls/details.py
@@ -15,6 +15,7 @@ from gui import guiHelper
 from gui.dpiScalingHelper import DpiScalingHelperMixinWithoutInit
 from logHandler import log
 from utils.debounce import debounceLimiter
+from utils.localisation import formatDateForSystemLocale
 
 from ..viewModels.addonList import AddonDetailsVM, AddonListField
 
@@ -397,7 +398,7 @@ class AddonDetails(
 						self._appendDetailsLabelValue(
 							# Translators: Label for an extra detail field for the selected add-on in the add-on store dialog.
 							pgettext("addonStore", "Install date:"),
-							details.installDate.strftime("%x"),
+							formatDateForSystemLocale(details.installDate),
 						)
 
 				if isinstance(details, _AddonStoreModel):

--- a/source/gui/addonStoreGui/viewModels/addonList.py
+++ b/source/gui/addonStoreGui/viewModels/addonList.py
@@ -38,6 +38,7 @@ import core
 import extensionPoints
 from buildVersion import formatVersionForGUI
 from logHandler import log
+from utils.localisation import formatDateForSystemLocale
 
 
 if TYPE_CHECKING:
@@ -381,7 +382,7 @@ class AddonListVM:
 			if listItemVM.model.installDate is None:
 				return ""
 			else:
-				return listItemVM.model.installDate.strftime("%x")
+				return formatDateForSystemLocale(listItemVM.model.installDate)
 		if field is AddonListField.minimumNVDAVersion:
 			return formatVersionForGUI(*listItemVM.model.minimumNVDAVersion)
 		if field is AddonListField.lastTestedVersion:

--- a/source/utils/localisation.py
+++ b/source/utils/localisation.py
@@ -3,7 +3,7 @@
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
-from datetime import timedelta
+from datetime import datetime, timedelta
 from enum import (
 	auto,
 	unique,
@@ -12,7 +12,18 @@ from typing import (
 	Dict,
 )
 
+import winKernel
 from utils.displayString import DisplayStringEnum
+
+
+def formatDateForSystemLocale(date: datetime) -> str:
+	"""Format a date using the Windows user's regional and calendar settings."""
+	return winKernel.GetDateFormatEx(
+		winKernel.LOCALE_NAME_USER_DEFAULT,
+		0,
+		date,
+		None,
+	)
 
 
 @unique

--- a/tests/unit/test_util/test_localisation.py
+++ b/tests/unit/test_util/test_localisation.py
@@ -5,10 +5,12 @@
 
 """Unit tests for the localisation submodule."""
 
-from datetime import timedelta
+from datetime import datetime, timedelta
 import unittest
+from unittest.mock import patch
 
 from utils.localisation import (
+	formatDateForSystemLocale,
 	TimeOutputFormat,
 )
 
@@ -66,4 +68,17 @@ class Test_TimeOutputFormat(unittest.TestCase):
 			exampleTimeDelta=timedelta(seconds=33),
 			expectedTimeOutputFormat=TimeOutputFormat.SECONDS,
 			expectedOutputStr="33",
+		)
+
+
+class TestFormatDateForSystemLocale(unittest.TestCase):
+	@patch("utils.localisation.winKernel.GetDateFormatEx", return_value="21/07/2026")
+	def test_usesWindowsUserSettings(self, mockGetDateFormatEx):
+		date = datetime(2026, 7, 21)
+		self.assertEqual("21/07/2026", formatDateForSystemLocale(date))
+		mockGetDateFormatEx.assert_called_once_with(
+			None,
+			0,
+			date,
+			None,
 		)

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -37,6 +37,7 @@
 ### Bug Fixes
 
 * In PowerPoint and other Office applications, NVDA will now correctly read and navigate the edit fields in the insert hyperlink dialog. (#17390, @aryanchoudharypro)
+* Dates in the Add-on Store now follow the user's Windows regional and calendar settings. (#19681)
 * The actions button can now be used when selecting multiple add-ons in the Add-on Store to perform batch actions, instead of just via the context menu in the add-ons list. (#19971, @amirmahdifard)
 * When moving to an ARIA grid cell in focus mode in web browsers, NVDA no longer reports both the row and column headers even if only the row or only the column changed. (#17750, @jcsteh)
 * In live text regions, such as terminals, NVDA no longer freezes when substantial amounts of text are dumped to the screen. (#20177)


### PR DESCRIPTION
### Link to issue number:

Fixes #19681

### Summary of the issue:

The Add-on Store formats publication and installation dates with Python's `%x`. NVDA sets the process locale to its interface language, so the Arabic interface selects the Saudi Arabic calendar and displays Hijri dates even when the user configured Windows to use Gregorian dates.

### Description of user facing changes:

Publication and installation dates in the Add-on Store now follow the user's Windows regional and calendar settings instead of the NVDA interface language.

### Description of developer facing changes:

A reusable `formatDateForSystemLocale` helper formats dates through the existing `winKernel.GetDateFormatEx` wrapper with `LOCALE_NAME_USER_DEFAULT`. All Add-on Store date display paths use this helper.

### Description of development approach:

The change replaces `%x` in the Add-on Store model, list view model, and details control. This retains localized short-date formatting while allowing Windows—not NVDA's UI locale—to select the user's preferred locale and calendar.

### Testing strategy:

- Reproduced with NVDA's process locale set to `Arabic_Saudi Arabia`: 21 July 2026 formatted through `%x` as `07/02/1448`.
- With the same Arabic process locale, the new helper formats the date as `21/07/2026`, matching this Windows user's configured regional and Gregorian calendar settings.
- Added a unit test confirming that the helper delegates to Windows with `LOCALE_NAME_USER_DEFAULT` and the supplied date.
- Ran 20 matching localization and Add-on Store unit tests successfully.
- Ran `runlint.bat` and `runcheckpot.bat` successfully.

### Known issues with pull request:

None known.

### Code Review Checklist:

- [x] Documentation:
  - [x] Change log entry
  - [x] User Documentation (not required beyond the change log)
  - [x] Developer / Technical Documentation (helper has a docstring; no public API change)
  - [x] Context sensitive help for GUI changes (not applicable)
- [x] Testing:
  - [x] Unit tests
  - [x] System (end to end) tests
  - [x] Manual testing
- [x] UX of all users considered:
  - [x] Speech
  - [x] Braille
  - [x] Low Vision
  - [x] Different web browsers (not applicable)
  - [x] Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
