### PR TITLE
Fix word navigation in Chromium text boxes with RTL content

### DIFF
--- a/source/NVDAObjects/IAccessible/chromium.py
+++ b/source/NVDAObjects/IAccessible/chromium.py
@@ -1,17 +1,19 @@
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-# Copyright (C) 2010-2022 NV Access Limited
+# Copyright (C) 2010-2022 NV Access Limited, 2026 Islam Benmebarek
 
 """NVDAObjects for the Chromium browser project"""
 
 import typing
+import unicodedata
 from typing import Dict, Optional
 from comtypes import COMError
 
 import config
 import controlTypes
-from NVDAObjects.IAccessible import IAccessible
+from NVDAObjects import NVDAObjectTextInfo
+from NVDAObjects.IAccessible import IAccessible, IA2TextTextInfo
 from virtualBuffers.gecko_ia2 import Gecko_ia2 as GeckoVBuf, Gecko_ia2_TextInfo as GeckoVBufTextInfo
 from . import ia2Web
 from logHandler import log
@@ -161,8 +163,62 @@ class Figure(ia2Web.Ia2Web):
 		return controlTypes.Role.FIGURE
 
 
+def _containsMultipleWhitespaceSeparatedWords(text: str) -> bool:
+	foundWordCharacter = False
+	foundWhitespaceAfterWord = False
+	for character in text:
+		if character.isalnum():
+			if foundWhitespaceAfterWord:
+				return True
+			foundWordCharacter = True
+		elif foundWordCharacter and character.isspace():
+			foundWhitespaceAfterWord = True
+	return False
+
+
+def _isWordCharacter(character: str) -> bool:
+	"""Return whether a character can occur within a word for boundary validation."""
+	category = unicodedata.category(character)
+	return category[0] in ("L", "M", "N") or category == "Pc"
+
+
+def _rangeCutsThroughWord(textInfo: IA2TextTextInfo, start: int, end: int) -> bool:
+	"""Return whether either edge of a range splits a Unicode word."""
+	if start > 0:
+		startContext = textInfo._getTextRange(start - 1, start + 1)
+		if len(startContext) == 2 and all(_isWordCharacter(character) for character in startContext):
+			return True
+	endContext = textInfo._getTextRange(max(0, end - 1), end + 1)
+	return len(endContext) == 2 and all(_isWordCharacter(character) for character in endContext)
+
+
+class ChromiumIA2TextTextInfo(IA2TextTextInfo):
+	"""Raw text information for editable text exposed by Chromium."""
+
+	def _getWordOffsets(self, offset: int) -> tuple[int, int]:
+		ia2Offsets = super()._getWordOffsets(offset)
+		wordText = self._getTextRange(*ia2Offsets)
+		if not (
+			_containsMultipleWhitespaceSeparatedWords(wordText) or _rangeCutsThroughWord(self, *ia2Offsets)
+		):
+			return ia2Offsets
+		# Chromium can expose a word boundary that overlaps another word or cuts through one
+		# for mixed-direction text.
+		# Its caret offsets are still correct, so use NVDA's configured segmentation as a fallback.
+		return super(IA2TextTextInfo, self)._getWordOffsets(offset)
+
+
+def _getRawTextInfoClass(obj) -> type[IA2TextTextInfo] | type[NVDAObjectTextInfo]:
+	if obj.TextInfo is NVDAObjectTextInfo:
+		return NVDAObjectTextInfo
+	return ChromiumIA2TextTextInfo
+
+
 class EditorTextInfo(ia2Web.MozillaCompoundTextInfo):
 	"""The TextInfo for edit areas such as edit fields and documents in Chromium."""
+
+	def _makeRawTextInfo(self, obj, position):
+		return _getRawTextInfoClass(obj)(obj, position)
 
 	def _isCaretAtEndOfLine(self, caretObj: IAccessible) -> bool:
 		# Detecting if the caret is at the end of the line in Chromium is not currently possible

--- a/tests/unit/test_chromium.py
+++ b/tests/unit/test_chromium.py
@@ -1,0 +1,80 @@
+# A part of NonVisual Desktop Access (NVDA)
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+# Copyright (C) 2026 Islam Benmebarek
+
+"""Unit tests for Chromium accessibility support."""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+from NVDAObjects import NVDAObjectTextInfo
+from NVDAObjects.IAccessible import chromium, IA2TextTextInfo
+from textInfos.offsets import OffsetsTextInfo
+
+
+class TestChromiumIA2TextTextInfo(unittest.TestCase):
+	def _makeTextInfo(self, storyText: str) -> chromium.ChromiumIA2TextTextInfo:
+		textInfo = object.__new__(chromium.ChromiumIA2TextTextInfo)
+		textInfo._getTextRange = Mock(side_effect=lambda start, end: storyText[start:end])
+		return textInfo
+
+	def test_malformedWordOffsetsUseNvdaSegmentation(self) -> None:
+		textInfo = self._makeTextInfo("the message after")
+		with (
+			patch.object(IA2TextTextInfo, "_getWordOffsets", return_value=(4, 13)) as getIa2WordOffsets,
+			patch.object(OffsetsTextInfo, "_getWordOffsets", return_value=(4, 12)) as getNvdaWordOffsets,
+		):
+			result = textInfo._getWordOffsets(6)
+
+		self.assertEqual(result, (4, 12))
+		getIa2WordOffsets.assert_called_once_with(6)
+		getNvdaWordOffsets.assert_called_once_with(6)
+
+	def test_wordOffsetsEndingMidWordUseNvdaSegmentation(self) -> None:
+		textInfo = self._makeTextInfo("ناقشنا خطة")
+		with (
+			patch.object(IA2TextTextInfo, "_getWordOffsets", return_value=(0, 4)),
+			patch.object(OffsetsTextInfo, "_getWordOffsets", return_value=(0, 7)) as getNvdaWordOffsets,
+		):
+			result = textInfo._getWordOffsets(2)
+
+		self.assertEqual(result, (0, 7))
+		getNvdaWordOffsets.assert_called_once_with(2)
+
+	def test_wordOffsetsStartingMidWordUseNvdaSegmentation(self) -> None:
+		textInfo = self._makeTextInfo("Finally, this")
+		with (
+			patch.object(IA2TextTextInfo, "_getWordOffsets", return_value=(1, 8)),
+			patch.object(OffsetsTextInfo, "_getWordOffsets", return_value=(0, 8)) as getNvdaWordOffsets,
+		):
+			result = textInfo._getWordOffsets(3)
+
+		self.assertEqual(result, (0, 8))
+		getNvdaWordOffsets.assert_called_once_with(3)
+
+	def test_validWordOffsetsKeepIa2Segmentation(self) -> None:
+		textInfo = self._makeTextInfo("the message after")
+		with patch.object(IA2TextTextInfo, "_getWordOffsets", return_value=(4, 12)) as getIa2WordOffsets:
+			result = textInfo._getWordOffsets(6)
+
+		self.assertEqual(result, (4, 12))
+		getIa2WordOffsets.assert_called_once_with(6)
+
+	def test_validWordOffsetsWithPunctuationKeepIa2Segmentation(self) -> None:
+		textInfo = self._makeTextInfo("Finally, this")
+		with patch.object(IA2TextTextInfo, "_getWordOffsets", return_value=(0, 8)):
+			result = textInfo._getWordOffsets(3)
+
+		self.assertEqual(result, (0, 8))
+
+	def test_ia2TextUsesChromiumTextInfo(self) -> None:
+		obj = SimpleNamespace(TextInfo=IA2TextTextInfo)
+
+		self.assertIs(chromium._getRawTextInfoClass(obj), chromium.ChromiumIA2TextTextInfo)
+
+	def test_nonIa2TextKeepsObjectTextInfo(self) -> None:
+		obj = SimpleNamespace(TextInfo=NVDAObjectTextInfo)
+
+		self.assertIs(chromium._getRawTextInfoClass(obj), NVDAObjectTextInfo)

--- a/tests/unit/test_chromiumRtlWordNavigation.py
+++ b/tests/unit/test_chromiumRtlWordNavigation.py
@@ -1,0 +1,33 @@
+# A part of NonVisual Desktop Access (NVDA)
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+# Copyright (C) 2026 Islam Benmebarek
+
+"""Regression tests for word expansion in mixed-direction Chromium editors."""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+from config.featureFlagEnums import WordNavigationUnitFlag
+from NVDAObjects.IAccessible import chromium, IA2TextTextInfo
+
+
+class TestChromiumRtlWordNavigation(unittest.TestCase):
+	def _getWord(self, line: str, offset: int) -> str:
+		textInfo = object.__new__(chromium.ChromiumIA2TextTextInfo)
+		textInfo.wordSegConf = SimpleNamespace(calculated=lambda: WordNavigationUnitFlag.UNISCRIBE)
+		textInfo._getLineOffsets = Mock(return_value=(0, len(line)))
+		textInfo._getTextRange = Mock(return_value=line)
+
+		with patch.object(IA2TextTextInfo, "_getWordOffsets", return_value=(0, len(line))):
+			start, end = textInfo._getWordOffsets(offset)
+		return line[start:end]
+
+	def test_mixedArabicEnglishLine(self) -> None:
+		line = "هذه رسالة طويلة لاختبار NVDA project داخل فقرة عربية mixed text."
+
+		self.assertEqual(self._getWord(line, line.index("رسالة")), "رسالة ")
+		self.assertEqual(self._getWord(line, line.index("NVDA")), "NVDA ")
+		self.assertEqual(self._getWord(line, line.index("project")), "project ")
+		self.assertEqual(self._getWord(line, line.index("داخل")), "داخل ")


### PR DESCRIPTION
### Link to issue number:

Closes #20121

### Summary of the issue:

Chromium can expose malformed IAccessible2 word boundaries in editable text containing mixed RTL and LTR content. A returned boundary may span parts of two whitespace-separated words, start in the middle of a word, or end in the middle of a word. Consequently, NVDA announces truncated or overlapping fragments when moving with Control+Left/Right Arrow, especially across Arabic/English direction changes and line boundaries.

### Description of user facing changes:

NVDA now announces complete words when navigating by word in affected Chromium-based multiline editors containing mixed RTL and LTR text. This covers Chromium applications such as WhatsApp as well as browser textareas and contenteditable controls.

### Description of developer facing changes:

A Chromium-specific IA2 text info class validates the word range returned by Chromium. Valid IA2 boundaries are preserved. When a range contains parts of multiple whitespace-separated words or cuts through a Unicode letter, mark, number, or connector sequence, NVDA falls back to its configured word segmentation.

### Description of development approach:

The fallback is limited to Chromium IA2 editable text and is selected only for malformed boundaries. This avoids changing valid Chromium segmentation or non-IA2 text implementations. Unicode categories are used so the validation handles Arabic letters and combining marks as well as Latin text.

### Testing strategy:

- Added unit coverage for a boundary spanning parts of two words.
- Added unit coverage for boundaries starting and ending inside a word, including Arabic and English examples.
- Added regression coverage for mixed Arabic/English text.
- All 8 targeted Chromium tests pass.
- Ruff formatting/linting and Pyright pass with no errors.
- Manually tested an experimental NVDA build with three multiline fields: textarea `dir=auto`, contenteditable `dir=auto`, and contenteditable `dir=rtl`.
- Correlated 334 Control+Left/Right Arrow gestures with NVDA speech output. Every gesture produced speech and none reproduced the previously observed fragments. Words including `ناقشنا`, `الجديدة`, `Finally`, and `team` were announced intact.
- A previous full local unit-test run completed 1327 tests with one unrelated environment-dependent keyboard-layout error in `test_inputCore.TestInputManagerExtensionPoints.test_decide_executeGesture` (`VkKeyScanEx(T)`).

### Known issues with pull request:

None known.

### Code Review Checklist:

- [ ] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [ ] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [ ] API is compatible with existing add-ons.
- [ ] Security precautions taken.