### PR TITLE
Prevent "OrderedDict mutated during iteration" when a handler (un)registers during extension point dispatch

### DIFF
--- a/source/extensionPoints/__init__.py
+++ b/source/extensionPoints/__init__.py
@@ -62,8 +62,7 @@ class Action(HandlerRegistrar[Callable[..., None]]):
 		Unregister handlers after calling.
 		@param kwargs: Arguments to pass to the handlers.
 		"""
-		oldHandlers = list(self.handlers)
-		for handler in oldHandlers:
+		for handler in self.handlers:
 			try:
 				callWithSupportedKwargs(handler, **kwargs)
 				self.unregister(handler)

--- a/source/extensionPoints/util.py
+++ b/source/extensionPoints/util.py
@@ -173,8 +173,11 @@ class HandlerRegistrar(Generic[HandlerT]):
 	def handlers(self) -> Generator[HandlerT, None, None]:
 		"""Generator of registered handler functions.
 		This should be used when you want to call the handlers.
+		A snapshot of the registered handlers is taken before yielding,
+		so that handlers may register or unregister handlers while being called
+		without mutating the collection that is being iterated.
 		"""
-		for weak in self._handlers.values():
+		for weak in list(self._handlers.values()):
 			handler = weak()
 			if not handler:
 				continue  # Died.

--- a/tests/unit/test_extensionPoints.py
+++ b/tests/unit/test_extensionPoints.py
@@ -584,6 +584,67 @@ class TestAction(unittest.TestCase):
 		self.action.notify(a=1)
 		self.assertEqual(calledKwargs, {"a": 1})
 
+	def test_handlerUnregistersItselfDuringNotify(self):
+		"""Test that a handler unregistering itself during notify doesn't raise.
+		Regression test for "RuntimeError: OrderedDict mutated during iteration".
+		"""
+		called = []
+
+		def handler():
+			called.append(handler)
+			self.action.unregister(handler)
+
+		self.action.register(handler)
+		self.action.notify()
+		self.assertEqual(called, [handler])
+		# The handler unregistered itself, so a second notify does not call it again.
+		self.action.notify()
+		self.assertEqual(called, [handler])
+
+	def test_handlerUnregistersOtherHandlerDuringNotify(self):
+		"""Test that a handler unregistering another handler during notify doesn't raise.
+		The handlers present when notify started are all still called (they were captured
+		before iteration), but the unregistered handler is gone on the next notify.
+		"""
+		called = []
+
+		def handler1():
+			called.append(handler1)
+			self.action.unregister(handler2)
+
+		def handler2():
+			called.append(handler2)
+
+		self.action.register(handler1)
+		self.action.register(handler2)
+		self.action.notify()
+		self.assertEqual(called, [handler1, handler2])
+		called.clear()
+		self.action.notify()
+		self.assertEqual(called, [handler1])
+
+	def test_handlerRegistersHandlerDuringNotify(self):
+		"""Test that a handler registering a new handler during notify doesn't raise.
+		The newly registered handler is not called until the next notify.
+		"""
+		called = []
+
+		def newHandler():
+			called.append(newHandler)
+
+		def handler():
+			called.append(handler)
+			self.action.register(newHandler)
+
+		# Keep newHandler alive for the duration of the test (register uses a weak reference).
+		self.addCleanup(lambda: newHandler)
+		self.action.register(handler)
+		self.action.notify()
+		self.assertEqual(called, [handler])
+		called.clear()
+		self.action.notify()
+		self.assertEqual(called, [handler, newHandler])
+
 
 class TestFilter(unittest.TestCase):
 	def setUp(self):

--- a/tests/unit/test_extensionPoints.py
+++ b/tests/unit/test_extensionPoints.py
@@ -645,6 +645,26 @@ class TestAction(unittest.TestCase):
 		self.action.notify()
 		self.assertEqual(called, [handler, newHandler])
 
+	def test_notifyOnce(self):
+		"""Test that notifyOnce calls every registered handler and unregisters them all,
+		despite unregistering each handler while iterating.
+		"""
+		called = []
+
+		def handler1():
+			called.append(handler1)
+
+		def handler2():
+			called.append(handler2)
+
+		self.action.register(handler1)
+		self.action.register(handler2)
+		self.action.notifyOnce()
+		self.assertEqual(called, [handler1, handler2])
+		# All handlers were unregistered, so a second notifyOnce calls nothing.
+		self.action.notifyOnce()
+		self.assertEqual(called, [handler1, handler2])
+
 
 class TestFilter(unittest.TestCase):
 	def setUp(self):

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -84,6 +84,8 @@ Please refer to [the developer guide](https://download.nvaccess.org/documentatio
 Built on top of [Bleak](https://bleak.readthedocs.io/) and the `_asyncioEventLoop` module. (#19838, @bramd)
 * Component updates:
   * Updated py2exe to 0.14.1.1. (#20260, @LeonarddeR)
+* Handlers registered on an `extensionPoints` registrar (`Action`, `Filter`, `Decider`, `Chain`) may now register or unregister handlers while being called, without raising `RuntimeError: OrderedDict mutated during iteration`. (#XXXXX, @LeonarddeR)
+  * `HandlerRegistrar.handlers` now iterates over a snapshot of the registered handlers taken before the first handler is yielded.
 
 #### Deprecations
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -84,7 +84,7 @@ Please refer to [the developer guide](https://download.nvaccess.org/documentatio
 Built on top of [Bleak](https://bleak.readthedocs.io/) and the `_asyncioEventLoop` module. (#19838, @bramd)
 * Component updates:
   * Updated py2exe to 0.14.1.1. (#20260, @LeonarddeR)
-* Handlers registered on an `extensionPoints` registrar (`Action`, `Filter`, `Decider`, `Chain`) may now register or unregister handlers while being called, without raising `RuntimeError: OrderedDict mutated during iteration`. (#20545, @LeonarddeR)
+* Handlers registered on an `extensionPoints` registrar (`Action`, `Filter`, `Decider`, `AccumulatingDecider`, `Chain`) may now register or unregister handlers while being called, without raising `RuntimeError: OrderedDict mutated during iteration`. (#20545, @LeonarddeR)
   * `HandlerRegistrar.handlers` now iterates over a snapshot of the registered handlers taken before the first handler is yielded.
 
 #### Deprecations

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -84,7 +84,7 @@ Please refer to [the developer guide](https://download.nvaccess.org/documentatio
 Built on top of [Bleak](https://bleak.readthedocs.io/) and the `_asyncioEventLoop` module. (#19838, @bramd)
 * Component updates:
   * Updated py2exe to 0.14.1.1. (#20260, @LeonarddeR)
-* Handlers registered on an `extensionPoints` registrar (`Action`, `Filter`, `Decider`, `Chain`) may now register or unregister handlers while being called, without raising `RuntimeError: OrderedDict mutated during iteration`. (#XXXXX, @LeonarddeR)
+* Handlers registered on an `extensionPoints` registrar (`Action`, `Filter`, `Decider`, `Chain`) may now register or unregister handlers while being called, without raising `RuntimeError: OrderedDict mutated during iteration`. (#20545, @LeonarddeR)
   * `HandlerRegistrar.handlers` now iterates over a snapshot of the registered handlers taken before the first handler is yielded.
 
 #### Deprecations


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
`extensionPoints.Action.notify` (and `Filter.apply`, `Decider.decide`, `AccumulatingDecider.decide`, `Chain.iter`) drive the `HandlerRegistrar.handlers` generator, which iterated `self._handlers.values()` directly. If a handler registered or unregistered a handler on the same extension point while being called, the underlying `OrderedDict` was mutated mid-iteration and Python raised `RuntimeError: OrderedDict mutated during iteration`, aborting the remaining handlers.

I hit this in practice during development of the RDAccess add-on: on `post_secureDesktopStateChange` / `post_sessionLockStateChanged`, a handler that tears down a braille display or synth driver (which unregisters itself) during the notify crashed `queueHandler.flushQueue` on the `_handleUserDesktop` desktop-switch path.

### Description of user facing changes:
Handlers on an extension point can now register or unregister during handler iteration without errors.

### Description of developer facing changes:
`HandlerRegistrar.handlers` now yields from a snapshot of the registered handlers rather than the live collection. Handlers present when dispatch started are all still called (a just-unregistered handler still runs in that pass); newly registered handlers are picked up on the next dispatch. This matches the existing `Action.notifyOnce` semantics.

### Description of development approach:
`HandlerRegistrar.handlers` now iterates over `list(self._handlers.values())`, taken before the first handler is yielded, instead of the live dict view. This mirrors the approach `Action.notifyOnce` already used (`list(self.handlers)`), and fixes every consumer of the generator with one change. As `handlers` now guarantees a snapshot, `Action.notifyOnce` was simplified to iterate `self.handlers` directly while unregistering each handler.

### Testing strategy:
Added unit tests to `TestAction` in `tests/unit/test_extensionPoints.py`: a handler that unregisters itself during `notify`; a handler that unregisters another handler during `notify` (this reproduced the `RuntimeError` before the fix); a handler that registers a new handler during `notify`; and a `notifyOnce` test confirming all handlers are called and unregistered. The full unit suite passes. `runcheckpot.bat`, ruff and ty are clean.

### Known issues with pull request:
`HandlerRegistrar` remains non-thread-safe; the snapshot addresses re-entrant mutation during dispatch, not concurrent mutation from another thread.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
