### PR TITLE
changed access key so they are all unique

### DIFF
--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -6147,7 +6147,7 @@ class MagnifierPanel(SettingsPanel):
 
 		# True center tracking SETTINGS
 		# Translators: The label for a setting in magnifier settings to select whether true center tracking is used
-		trueCenterTrackingText = _("&True center tracking")
+		trueCenterTrackingText = _("T&rue center tracking")
 		self.trueCenterTrackingCheckBox = generalGroup.addItem(
 			wx.CheckBox(generalGroupBox, label=trueCenterTrackingText),
 		)
@@ -6224,7 +6224,7 @@ class MagnifierPanel(SettingsPanel):
 
 		# Tracking MODE SETTINGS
 		# Translators: The label for a setting in magnifier settings to select the full-screen mode
-		trackingModeLabelText = _("Tracking &mode:")
+		trackingModeLabelText = _("&Tracking mode:")
 		trackingModeChoices = [mode.displayString for mode in FullScreenMode] if FullScreenMode else []
 		self.trackingModeList = trackingGroup.addLabeledControl(
 			trackingModeLabelText,


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Closes #20500

### Summary of the issue:
Access keys in the magnifier settings was not unique

### Description of user facing changes:
All access keys are now unique

### Description of developer facing changes:
True center mode from T to R
Tracking mode from M to T

### Description of development approach:

### Testing strategy:

### Known issues with pull request:

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
