### PR TITLE
Only restore braille on secure desktop exit, not on ordinary desktop switches

### DIFF
--- a/source/braille/brailleHandler.py
+++ b/source/braille/brailleHandler.py
@@ -221,6 +221,12 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 				self.display._suppressDisplayClear = True
 			self.setDisplayByName(NO_BRAILLE_DISPLAY_NAME, isFallback=True)
 		else:
+			# An ordinary desktop switch (e.g. in a Remote Desktop session) is also reported here.
+			# Only restore braille if the display differs from the last requested one, i.e. it was
+			# replaced by the secure desktop fallback.
+			currentDisplayName = self.display.name if self.display is not None else None
+			if currentDisplayName == self._lastRequestedDisplayName:
+				return
 			configured = config.conf["braille"]["display"]
 			if configured == AUTO_DISPLAY_NAME:
 				lastRequested = (self._lastRequestedDisplayName, self._lastRequestedDeviceMatch)

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -57,7 +57,7 @@ Previously these keys had no function when pressed on their own. (#20366, @fla-r
 * Braille now follows the spoken text during say all in browse mode when braille is tethered to focus. (#3287, @LeonarddeR)
 * NVDA now reports checked ToolStrip menu items in .NET Framework Windows Forms applications using UI Automation. (#19335, @Cary-rowen)
 * The Add-on Store no longer becomes unresponsive when navigating the list of add-ons quickly, such as by holding down an arrow key. (#17351, @christopherpross)
-* NVDA no longer briefly disconnects and re-detects the braille display on desktop switches that do not enter the secure desktop, such as when switching between a Remote Desktop session and the local machine. (#18810, @LeonarddeR)
+* NVDA no longer briefly disconnects and re-detects the braille display on desktop switches that do not enter the secure desktop, such as when switching between a Remote Desktop session and the local machine. (#18810, #20550, @LeonarddeR)
 
 ### Changes for Developers
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -57,6 +57,7 @@ Previously these keys had no function when pressed on their own. (#20366, @fla-r
 * Braille now follows the spoken text during say all in browse mode when braille is tethered to focus. (#3287, @LeonarddeR)
 * NVDA now reports checked ToolStrip menu items in .NET Framework Windows Forms applications using UI Automation. (#19335, @Cary-rowen)
 * The Add-on Store no longer becomes unresponsive when navigating the list of add-ons quickly, such as by holding down an arrow key. (#17351, @christopherpross)
+* NVDA no longer briefly disconnects and re-detects the braille display on desktop switches that do not enter the secure desktop, such as when switching between a Remote Desktop session and the local machine. (#18810, @LeonarddeR)
 
 ### Changes for Developers
 


### PR DESCRIPTION
### Link to issue number:
Fixup for #18810

### Summary of the issue:
Since #18810, NVDA frees the braille display when switching to the secure desktop and restores it
when returning to a user desktop. However, the restore branch also runs on desktop switches that
never entered the secure desktop. Moving input focus between a Remote Desktop session and the local
machine generates `EVENT_SYSTEM_DESKTOPSWITCH` in the remote session, so
`braille.handler._onSecureDesktopStateChanged` is invoked with `isSecureDesktop=False` even though
the secure desktop was never active. This re-runs braille display detection (or re-sets the
configured display), repeatedly disconnecting and re-detecting a working display. For remote braille
(e.g. RDAccess) each such switch causes a full channel teardown and re-handshake, so braille churns
on every alt+tab / focus change.

### Description of user facing changes:
The braille display is no longer briefly disconnected and re-detected on desktop switches that do not
enter the secure desktop, such as switching between a Remote Desktop session and the local machine.

### Description of developer facing changes:
None.

### Description of development approach:
In `BrailleHandler._onSecureDesktopStateChanged`, when returning to a user desktop
(`isSecureDesktop=False`), only restore the display when the current display differs from
`_lastRequestedDisplayName`. Switching to the secure desktop replaces the display with the
`noBraille` fallback via `setDisplayByName(..., isFallback=True)`, which deliberately does not update
`_lastRequestedDisplayName`. So a current display equal to `_lastRequestedDisplayName` means the
display was never freed (an ordinary desktop switch) and there is nothing to restore. This covers
both automatic detection (where `_lastRequestedDisplayName` holds the detected driver name) and a
manually configured display (where it equals the configured display). Entering the secure desktop is
unchanged, so the display is still freed there.

### Testing strategy:
Manually tested in a Remote Desktop session with a braille display, switching focus between the
session and the local machine (alt+tab / Windows+D): the display is no longer repeatedly
disconnected and re-detected. Verified a genuine secure desktop transition (UAC prompt) still frees
and then restores the display.

### Known issues with pull request:
`autoScroll` and `mainBuffer` are still cleared at the top of `_onSecureDesktopStateChanged` on every
reported desktop switch, so an ordinary switch still briefly clears the braille buffer (no reconnect).
This is unchanged behaviour and could be addressed separately.

### Code Review Checklist:
- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
