### PR TITLE
Added edge gestures: a set of gestures that only work at the edge of the screen

### DIFF
--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -230,6 +230,7 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 [touch]
 	enabled = boolean(default=true)
 	touchTyping = boolean(default=False)
+	edgeGesturesEnabled = boolean(default=False)
 
 #Settings for document reading (such as MS Word and wordpad)
 [documentFormatting]

--- a/source/config/configSpec.py
+++ b/source/config/configSpec.py
@@ -230,7 +230,7 @@ schemaVersion = integer(min=0, default={latestSchemaVersion})
 [touch]
 	enabled = boolean(default=true)
 	touchTyping = boolean(default=False)
-	edgeGesturesEnabled = boolean(default=False)
+	edgeGestures = boolean(default=False)
 
 #Settings for document reading (such as MS Word and wordpad)
 [documentFormatting]

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -4179,10 +4179,16 @@ class TouchInteractionPanel(SettingsPanel):
 		self.touchTypingCheckBox = sHelper.addItem(wx.CheckBox(self, label=_("&Touch typing mode")))
 		self.bindHelpEvent("TouchTypingMode", self.touchTypingCheckBox)
 		self.touchTypingCheckBox.SetValue(config.conf["touch"]["touchTyping"])
+		# Translators: This is the label for a checkbox in the touch interaction settings panel.
+		self.edgeGesturesCheckBox = sHelper.addItem(wx.CheckBox(self, label=_("Enable &edge gestures")))
+		self.bindHelpEvent("TouchEdgeGesturesEnable", self.edgeGesturesCheckBox)
+		self.edgeGesturesCheckBox.SetValue(config.conf["touch"]["edgeGesturesEnabled"])
+		self.edgeGesturesCheckBox.Enable(touchHandler.touchSupported())
 
 	def onSave(self):
 		config.conf["touch"]["enabled"] = self.enableTouchSupportCheckBox.IsChecked()
 		config.conf["touch"]["touchTyping"] = self.touchTypingCheckBox.IsChecked()
+		config.conf["touch"]["edgeGesturesEnabled"] = self.edgeGesturesCheckBox.IsChecked()
 		touchHandler.setTouchSupport(config.conf["touch"]["enabled"])
 
 

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -4181,14 +4181,14 @@ class TouchInteractionPanel(SettingsPanel):
 		self.touchTypingCheckBox.SetValue(config.conf["touch"]["touchTyping"])
 		# Translators: This is the label for a checkbox in the touch interaction settings panel.
 		self.edgeGesturesCheckBox = sHelper.addItem(wx.CheckBox(self, label=_("Enable &edge gestures")))
-		self.bindHelpEvent("TouchEdgeGesturesEnable", self.edgeGesturesCheckBox)
-		self.edgeGesturesCheckBox.SetValue(config.conf["touch"]["edgeGesturesEnabled"])
+		self.bindHelpEvent("TouchEdgeGestures", self.edgeGesturesCheckBox)
+		self.edgeGesturesCheckBox.SetValue(config.conf["touch"]["edgeGestures"])
 		self.edgeGesturesCheckBox.Enable(touchHandler.touchSupported())
 
 	def onSave(self):
 		config.conf["touch"]["enabled"] = self.enableTouchSupportCheckBox.IsChecked()
 		config.conf["touch"]["touchTyping"] = self.touchTypingCheckBox.IsChecked()
-		config.conf["touch"]["edgeGesturesEnabled"] = self.edgeGesturesCheckBox.IsChecked()
+		config.conf["touch"]["edgeGestures"] = self.edgeGesturesCheckBox.IsChecked()
 		touchHandler.setTouchSupport(config.conf["touch"]["enabled"])
 
 

--- a/source/touchHandler.py
+++ b/source/touchHandler.py
@@ -41,6 +41,7 @@ from ctypes.wintypes import (
 import re
 from winAPI.winUser.constants import SystemMetrics
 import winBindings.kernel32
+import winBindings.gdi32
 from winBindings import user32
 import gui
 import config
@@ -198,6 +199,36 @@ touchWindow = None
 touchThread = None
 blockTouchInput: bool = False
 
+_LOGPIXELSX = 88
+"""Device capability index for horizontal screen DPI, used to convert mm to pixels."""
+
+
+def _getEdge(x: int, y: int) -> str | None:
+	"""Determine if coordinates fall within an edge margin of the screen.
+
+	The margin width is defined in millimetres by :data:`touchTracker._EDGE_MARGIN_MM`
+	and converted to pixels using the screen DPI at call time.
+
+	:param x: The x screen coordinate to test.
+	:param y: The y screen coordinate to test.
+	:return: An edge constant from :mod:`touchTracker` (e.g. :data:`touchTracker.EDGE_LEFT`),
+		or ``None`` if not near any tracked edge or edge gestures are disabled.
+	"""
+	if not config.conf["touch"]["edgeGesturesEnabled"]:
+		return None
+	screenWidth = user32.GetSystemMetrics(SystemMetrics.CX_SCREEN)
+	dc = user32.GetDC(0)
+	dpi = winBindings.gdi32.GetDeviceCaps(dc, _LOGPIXELSX) or 96
+	user32.ReleaseDC(0, dc)
+	margin = int(touchTracker._EDGE_MARGIN_MM / 25.4 * dpi)
+	if x <= margin:
+		return touchTracker.EDGE_LEFT
+	if x >= screenWidth - margin:
+		return touchTracker.EDGE_RIGHT
+	if y <= margin:
+		return touchTracker.EDGE_TOP
+	return None
+
 
 _flickActions: frozenset[TouchAction] = frozenset(
 	{
@@ -324,6 +355,9 @@ class TouchInputGesture(inputCore.InputGesture):
 				ID += "%dfinger_" % self.tracker.numFingers
 			if self.tracker.actionCount > 1:
 				ID += "%s_" % self.counterNames[min(self.tracker.actionCount, 4) - 1]
+			edge = _getEdge(self.tracker.x, self.tracker.y)
+			if edge:
+				ID += "%s_" % edge
 			ID += self.tracker.action
 			# "ts" is the gesture identifier source prefix for "touch screen".
 			IDs.append("ts(%s):%s" % (self.mode, ID))
@@ -350,6 +384,12 @@ class TouchInputGesture(inputCore.InputGesture):
 						action = pluralActionLabel.format(action=action)
 						foundPlural = True
 						continue
+				edgeLabel = touchTracker.edgeLabels.get(subID)
+				if edgeLabel:
+					# Translators: a touch screen action that started from a screen edge,
+					# e.g. "left edge flick right"
+					action = _("{edgeLabel} {action}").format(edgeLabel=edgeLabel, action=action)
+					continue
 				if subID.endswith("finger"):
 					numFingers = int(subID[: 0 - len("finger")])
 					if numFingers > 1:

--- a/source/touchHandler.py
+++ b/source/touchHandler.py
@@ -51,7 +51,7 @@ import inputCore
 import screenExplorer
 from logHandler import log
 import touchTracker
-from touchTracker import TouchAction
+from touchTracker import TouchAction, TouchEdge
 import core
 import systemUtils
 from utils import _deprecate
@@ -203,7 +203,7 @@ _LOGPIXELSX = 88
 """Device capability index for horizontal screen DPI, used to convert mm to pixels."""
 
 
-def _getEdge(x: int, y: int) -> str | None:
+def _getEdge(x: int, y: int) -> TouchEdge | None:
 	"""Determine if coordinates fall within an edge margin of the screen.
 
 	The margin width is defined in millimetres by :data:`touchTracker._EDGE_MARGIN_MM`
@@ -211,7 +211,7 @@ def _getEdge(x: int, y: int) -> str | None:
 
 	:param x: The x screen coordinate to test.
 	:param y: The y screen coordinate to test.
-	:return: An edge constant from :mod:`touchTracker` (e.g. :data:`touchTracker.EDGE_LEFT`),
+	:return: A :class:`touchTracker.TouchEdge` member,
 		or ``None`` if not near any tracked edge or edge gestures are disabled.
 	"""
 	if not config.conf["touch"]["edgeGesturesEnabled"]:
@@ -222,11 +222,11 @@ def _getEdge(x: int, y: int) -> str | None:
 	user32.ReleaseDC(0, dc)
 	margin = int(touchTracker._EDGE_MARGIN_MM / 25.4 * dpi)
 	if x <= margin:
-		return touchTracker.EDGE_LEFT
+		return TouchEdge.LEFT
 	if x >= screenWidth - margin:
-		return touchTracker.EDGE_RIGHT
+		return TouchEdge.RIGHT
 	if y <= margin:
-		return touchTracker.EDGE_TOP
+		return TouchEdge.TOP
 	return None
 
 
@@ -384,12 +384,14 @@ class TouchInputGesture(inputCore.InputGesture):
 						action = pluralActionLabel.format(action=action)
 						foundPlural = True
 						continue
-				edgeLabel = touchTracker.edgeLabels.get(subID)
-				if edgeLabel:
+				try:
+					edgeLabel = TouchEdge(subID).displayString
 					# Translators: a touch screen action that started from a screen edge,
 					# e.g. "left edge flick right"
 					action = _("{edgeLabel} {action}").format(edgeLabel=edgeLabel, action=action)
 					continue
+				except ValueError:
+					pass
 				if subID.endswith("finger"):
 					numFingers = int(subID[: 0 - len("finger")])
 					if numFingers > 1:

--- a/source/touchHandler.py
+++ b/source/touchHandler.py
@@ -209,6 +209,10 @@ def _getEdge(x: int, y: int) -> TouchEdge | None:
 	The margin width is defined in millimetres by :data:`touchTracker._EDGE_MARGIN_MM`
 	and converted to pixels using the screen DPI at call time.
 
+	All four edges are checked.
+	Note that Windows or the taskbar may intercept gestures on certain edges
+	before they reach NVDA, in which case this function will never be called for those touches.
+
 	:param x: The x screen coordinate to test.
 	:param y: The y screen coordinate to test.
 	:return: A :class:`touchTracker.TouchEdge` member,
@@ -217,6 +221,7 @@ def _getEdge(x: int, y: int) -> TouchEdge | None:
 	if not config.conf["touch"]["edgeGestures"]:
 		return None
 	screenWidth = user32.GetSystemMetrics(SystemMetrics.CX_SCREEN)
+	screenHeight = user32.GetSystemMetrics(SystemMetrics.CY_SCREEN)
 	dc = user32.GetDC(0)
 	dpi = winBindings.gdi32.GetDeviceCaps(dc, _LOGPIXELSX) or 96
 	user32.ReleaseDC(0, dc)
@@ -227,6 +232,8 @@ def _getEdge(x: int, y: int) -> TouchEdge | None:
 		return TouchEdge.RIGHT
 	if y <= margin:
 		return TouchEdge.TOP
+	if y >= screenHeight - margin:
+		return TouchEdge.BOTTOM
 	return None
 
 
@@ -357,7 +364,7 @@ class TouchInputGesture(inputCore.InputGesture):
 				ID += "%s_" % self.counterNames[min(self.tracker.actionCount, 4) - 1]
 			edge = _getEdge(self.tracker.x, self.tracker.y)
 			if edge:
-				ID += "%s_" % edge
+				ID += edge + "_"
 			ID += self.tracker.action
 			# "ts" is the gesture identifier source prefix for "touch screen".
 			IDs.append("ts(%s):%s" % (self.mode, ID))

--- a/source/touchHandler.py
+++ b/source/touchHandler.py
@@ -214,7 +214,7 @@ def _getEdge(x: int, y: int) -> TouchEdge | None:
 	:return: A :class:`touchTracker.TouchEdge` member,
 		or ``None`` if not near any tracked edge or edge gestures are disabled.
 	"""
-	if not config.conf["touch"]["edgeGesturesEnabled"]:
+	if not config.conf["touch"]["edgeGestures"]:
 		return None
 	screenWidth = user32.GetSystemMetrics(SystemMetrics.CX_SCREEN)
 	dc = user32.GetDC(0)

--- a/source/touchTracker.py
+++ b/source/touchTracker.py
@@ -103,6 +103,29 @@ class TouchAction(DisplayStringStrEnum):
 
 hoverActions = (TouchAction.HOVER_DOWN, TouchAction.HOVER, TouchAction.HOVER_UP)
 
+_EDGE_MARGIN_MM: float = 15.0
+"""Width of the screen edge margin in millimetres within which a touch is considered an edge gesture.
+This is an internal constant; if a single value cannot satisfy all devices it may become configurable in future.
+"""
+
+EDGE_LEFT: str = "leftedge"
+"""Gesture identifier prefix for touches starting at the left screen edge."""
+
+EDGE_RIGHT: str = "rightedge"
+"""Gesture identifier prefix for touches starting at the right screen edge."""
+
+EDGE_TOP: str = "topedge"
+"""Gesture identifier prefix for touches starting at the top screen edge."""
+
+edgeLabels: dict[str, str] = {
+	# Translators: describes a touch gesture that started from the left edge of the screen
+	EDGE_LEFT: pgettext("touch edge", "left edge"),
+	# Translators: describes a touch gesture that started from the right edge of the screen
+	EDGE_RIGHT: pgettext("touch edge", "right edge"),
+	# Translators: describes a touch gesture that started from the top edge of the screen
+	EDGE_TOP: pgettext("touch edge", "top edge"),
+}
+
 __getattr__ = handleDeprecations(
 	MovedSymbol("action_tap", "touchTracker", "TouchAction", "TAP"),
 	MovedSymbol("action_hold", "touchTracker", "TouchAction", "HOLD"),

--- a/source/touchTracker.py
+++ b/source/touchTracker.py
@@ -112,9 +112,9 @@ This is an internal constant; if a single value cannot satisfy all devices it ma
 class TouchEdge(DisplayStringStrEnum):
 	"""Screen edges from which a touch gesture can originate."""
 
-	LEFT = "leftedge"
-	RIGHT = "rightedge"
-	TOP = "topedge"
+	LEFT = "left"
+	RIGHT = "right"
+	TOP = "top"
 
 	@cached_property
 	def _displayStringLabels(self) -> dict[Self, str]:

--- a/source/touchTracker.py
+++ b/source/touchTracker.py
@@ -108,23 +108,25 @@ _EDGE_MARGIN_MM: float = 15.0
 This is an internal constant; if a single value cannot satisfy all devices it may become configurable in future.
 """
 
-EDGE_LEFT: str = "leftedge"
-"""Gesture identifier prefix for touches starting at the left screen edge."""
 
-EDGE_RIGHT: str = "rightedge"
-"""Gesture identifier prefix for touches starting at the right screen edge."""
+class TouchEdge(DisplayStringStrEnum):
+	"""Screen edges from which a touch gesture can originate."""
 
-EDGE_TOP: str = "topedge"
-"""Gesture identifier prefix for touches starting at the top screen edge."""
+	LEFT = "leftedge"
+	RIGHT = "rightedge"
+	TOP = "topedge"
 
-edgeLabels: dict[str, str] = {
-	# Translators: describes a touch gesture that started from the left edge of the screen
-	EDGE_LEFT: pgettext("touch edge", "left edge"),
-	# Translators: describes a touch gesture that started from the right edge of the screen
-	EDGE_RIGHT: pgettext("touch edge", "right edge"),
-	# Translators: describes a touch gesture that started from the top edge of the screen
-	EDGE_TOP: pgettext("touch edge", "top edge"),
-}
+	@cached_property
+	def _displayStringLabels(self) -> dict[Self, str]:
+		return {
+			# Translators: describes a touch gesture that started from the left edge of the screen
+			TouchEdge.LEFT: pgettext("touch edge", "left edge"),
+			# Translators: describes a touch gesture that started from the right edge of the screen
+			TouchEdge.RIGHT: pgettext("touch edge", "right edge"),
+			# Translators: describes a touch gesture that started from the top edge of the screen
+			TouchEdge.TOP: pgettext("touch edge", "top edge"),
+		}
+
 
 __getattr__ = handleDeprecations(
 	MovedSymbol("action_tap", "touchTracker", "TouchAction", "TAP"),

--- a/source/touchTracker.py
+++ b/source/touchTracker.py
@@ -115,6 +115,7 @@ class TouchEdge(DisplayStringStrEnum):
 	LEFT = "left"
 	RIGHT = "right"
 	TOP = "top"
+	BOTTOM = "bottom"
 
 	@cached_property
 	def _displayStringLabels(self) -> dict[Self, str]:
@@ -125,6 +126,8 @@ class TouchEdge(DisplayStringStrEnum):
 			TouchEdge.RIGHT: pgettext("touch edge", "right edge"),
 			# Translators: describes a touch gesture that started from the top edge of the screen
 			TouchEdge.TOP: pgettext("touch edge", "top edge"),
+			# Translators: describes a touch gesture that started from the bottom edge of the screen
+			TouchEdge.BOTTOM: pgettext("touch edge", "bottom edge"),
 		}
 
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -13,6 +13,9 @@
 * Added sequential two-flick touch gestures that combine two flicks performed in quick succession into a single gesture, increasing the number of touch gestures that can be bound to scripts. (#19938, @kefaslungu)
   * Twelve combinations are recognised: opposite-direction pairs (e.g. flick right then flick left) and perpendicular L-shaped pairs (e.g. flick right then flick up).
   * The two flicks can be performed either by lifting the finger between strokes or as a single continuous swipe with a sharp change in direction.
+* Added edge gesture support for touch screens, allowing gestures that begin within 15 mm of the left, right, or top screen edge to be bound independently from the same gesture performed in the centre of the screen. (#19938, @kefaslungu)
+  * Edge gestures are disabled by default and can be enabled in the Touch Interaction settings panel.
+  * The bottom edge is intentionally excluded as Windows and the taskbar intercept touches there.
 * On supported braille displays, pressing multiple routing keys simultaneously can now be bound to a new "multi routing" gesture. (#20001, @LeonarddeR)
   * The "select range" command, which selects the text from the first up to the last pressed routing key, is bound to this gesture by default on supporting drivers.
   * Drivers with built-in support for multi routing: ALVA, Albatross (only when combined with `home1` or `home2`), Baum (and compatible), Freedom Scientific Focus/PAC Mate, HumanWare Brailliant BI/B series, Handy Tech, NLS eReader Zoomax, Seika Notetaker, and Standard HID Braille displays.

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -15,7 +15,9 @@
   * The two flicks can be performed either by lifting the finger between strokes or as a single continuous swipe with a sharp change in direction.
 * Added edge gesture support for touch screens, allowing gestures that begin within 15 mm of any screen edge to be bound independently from the same gesture performed in the centre of the screen. (#19938, @kefaslungu)
   * Edge gestures are disabled by default and can be enabled in the Touch Interaction settings panel.
-  * All four edges are supported. Note that Windows or the taskbar may intercept gestures on some edges (e.g. the bottom edge opens the Start menu or Action Center); if an edge is intercepted, NVDA will not receive those gestures.
+  * All four edges are supported.
+  Note that the Windows taskbar may override gestures on an edge.
+  Gestures from the taskbar edge open the Start menu or Action Center, NVDA will not receive them.
 * On supported braille displays, pressing multiple routing keys simultaneously can now be bound to a new "multi routing" gesture. (#20001, @LeonarddeR)
   * The "select range" command, which selects the text from the first up to the last pressed routing key, is bound to this gesture by default on supporting drivers.
   * Drivers with built-in support for multi routing: ALVA, Albatross (only when combined with `home1` or `home2`), Baum (and compatible), Freedom Scientific Focus/PAC Mate, HumanWare Brailliant BI/B series, Handy Tech, NLS eReader Zoomax, Seika Notetaker, and Standard HID Braille displays.

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -15,7 +15,7 @@
   * The two flicks can be performed either by lifting the finger between strokes or as a single continuous swipe with a sharp change in direction.
 * Added edge gesture support for touch screens, allowing gestures that begin within 15 mm of the left, right, or top screen edge to be bound independently from the same gesture performed in the centre of the screen. (#19938, @kefaslungu)
   * Edge gestures are disabled by default and can be enabled in the Touch Interaction settings panel.
-  * The bottom edge is intentionally excluded as Windows and the taskbar intercept touches there.
+  * The bottom edge is not supported; Windows intercepts swipe-from-bottom gestures, and the taskbar (which may be on any edge) will also intercept touches on whichever edge it occupies.
 * On supported braille displays, pressing multiple routing keys simultaneously can now be bound to a new "multi routing" gesture. (#20001, @LeonarddeR)
   * The "select range" command, which selects the text from the first up to the last pressed routing key, is bound to this gesture by default on supporting drivers.
   * Drivers with built-in support for multi routing: ALVA, Albatross (only when combined with `home1` or `home2`), Baum (and compatible), Freedom Scientific Focus/PAC Mate, HumanWare Brailliant BI/B series, Handy Tech, NLS eReader Zoomax, Seika Notetaker, and Standard HID Braille displays.

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -13,9 +13,9 @@
 * Added sequential two-flick touch gestures that combine two flicks performed in quick succession into a single gesture, increasing the number of touch gestures that can be bound to scripts. (#19938, @kefaslungu)
   * Twelve combinations are recognised: opposite-direction pairs (e.g. flick right then flick left) and perpendicular L-shaped pairs (e.g. flick right then flick up).
   * The two flicks can be performed either by lifting the finger between strokes or as a single continuous swipe with a sharp change in direction.
-* Added edge gesture support for touch screens, allowing gestures that begin within 15 mm of the left, right, or top screen edge to be bound independently from the same gesture performed in the centre of the screen. (#19938, @kefaslungu)
+* Added edge gesture support for touch screens, allowing gestures that begin within 15 mm of any screen edge to be bound independently from the same gesture performed in the centre of the screen. (#19938, @kefaslungu)
   * Edge gestures are disabled by default and can be enabled in the Touch Interaction settings panel.
-  * The bottom edge is not supported; Windows intercepts swipe-from-bottom gestures, and the taskbar (which may be on any edge) will also intercept touches on whichever edge it occupies.
+  * All four edges are supported. Note that Windows or the taskbar may intercept gestures on some edges (e.g. the bottom edge opens the Start menu or Action Center); if an edge is intercepted, NVDA will not receive those gestures.
 * On supported braille displays, pressing multiple routing keys simultaneously can now be bound to a new "multi routing" gesture. (#20001, @LeonarddeR)
   * The "select range" command, which selects the text from the first up to the last pressed routing key, is bound to this gesture by default on supporting drivers.
   * Drivers with built-in support for multi routing: ALVA, Albatross (only when combined with `home1` or `home2`), Baum (and compatible), Freedom Scientific Focus/PAC Mate, HumanWare Brailliant BI/B series, Handy Tech, NLS eReader Zoomax, Seika Notetaker, and Standard HID Braille displays.

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -3265,6 +3265,14 @@ This checkbox allows you to specify the method you wish to use when entering tex
 If this checkbox is checked, when you locate a key on the touch keyboard, you can lift your finger and the selected key will be pressed.
 If this is unchecked, you need to double-tap on the key of the touch keyboard to press the key.
 
+##### Enable edge gestures {#TouchEdgeGesturesEnable}
+
+This checkbox enables edge gesture support.
+When enabled, gestures that begin within 15 mm of the left, right, or top screen edge are treated as distinct gestures and can be bound independently in the Input Gestures dialog.
+For example, a flick right that starts from the left edge of the screen can be bound to a different command from a flick right performed in the centre of the screen.
+If edge gestures are disabled after bindings have been set, those bindings will remain but will never be triggered.
+Note: the bottom edge is not supported, as Windows and the taskbar intercept touches there.
+
 #### Review Cursor {#ReviewCursorSettings}
 
 The Review Cursor category in the NVDA Settings dialog is used to configure NVDA's review cursor behaviour.

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -3271,7 +3271,9 @@ This checkbox enables edge gesture support.
 When enabled, gestures that begin within 15 mm of the left, right, or top screen edge are treated as distinct gestures and can be bound independently in the Input Gestures dialog.
 For example, a flick right that starts from the left edge of the screen can be bound to a different command from a flick right performed in the centre of the screen.
 If edge gestures are disabled after bindings have been set, those bindings will remain but will never be triggered.
-Note: the bottom edge is not supported, as Windows and the taskbar intercept touches there.
+Note: the bottom edge is not supported, as Windows intercepts swipe-from-bottom gestures system-wide.
+On Windows 10, if the taskbar is moved to another edge, touches on that edge will also be intercepted by Windows before reaching NVDA, making that edge unavailable.
+On Windows 11, the taskbar is locked to the bottom and cannot be moved.
 
 #### Review Cursor {#ReviewCursorSettings}
 

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -3268,7 +3268,7 @@ If this is unchecked, you need to double-tap on the key of the touch keyboard to
 ##### Enable edge gestures {#TouchEdgeGestures}
 
 This checkbox enables edge gesture support.
-When enabled, gestures that begin within 15 mm of any screen edge are treated as distinct gestures and can be bound independently in the Input Gestures dialog.
+When enabled, gestures that begin within 15 mm of any screen edge are treated as distinct gestures and can be bound independently in the [Input Gestures dialog](#InputGestures).
 For example, a flick right that starts from the left edge of the screen can be bound to a different command from a flick right performed in the centre of the screen.
 If edge gestures are disabled after bindings have been set, those bindings will remain but will never be triggered.
 Note: Windows or the taskbar may intercept gestures on certain edges before they reach NVDA.

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -3268,12 +3268,12 @@ If this is unchecked, you need to double-tap on the key of the touch keyboard to
 ##### Enable edge gestures {#TouchEdgeGestures}
 
 This checkbox enables edge gesture support.
-When enabled, gestures that begin within 15 mm of the left, right, or top screen edge are treated as distinct gestures and can be bound independently in the Input Gestures dialog.
+When enabled, gestures that begin within 15 mm of any screen edge are treated as distinct gestures and can be bound independently in the Input Gestures dialog.
 For example, a flick right that starts from the left edge of the screen can be bound to a different command from a flick right performed in the centre of the screen.
 If edge gestures are disabled after bindings have been set, those bindings will remain but will never be triggered.
-Note: the bottom edge is not supported, as Windows intercepts swipe-from-bottom gestures system-wide.
-On Windows 10, if the taskbar is moved to another edge, touches on that edge will also be intercepted by Windows before reaching NVDA, making that edge unavailable.
-On Windows 11, the taskbar is locked to the bottom and cannot be moved.
+Note: Windows or the taskbar may intercept gestures on certain edges before they reach NVDA.
+For example, swiping from the bottom edge typically opens the Start menu or Action Center, and if the taskbar is positioned on another edge, touches on that edge will similarly be intercepted.
+If a gesture on a particular edge does not work, check whether Windows is intercepting it, and consider leaving that edge unbound.
 
 #### Review Cursor {#ReviewCursorSettings}
 

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -3265,7 +3265,7 @@ This checkbox allows you to specify the method you wish to use when entering tex
 If this checkbox is checked, when you locate a key on the touch keyboard, you can lift your finger and the selected key will be pressed.
 If this is unchecked, you need to double-tap on the key of the touch keyboard to press the key.
 
-##### Enable edge gestures {#TouchEdgeGesturesEnable}
+##### Enable edge gestures {#TouchEdgeGestures}
 
 This checkbox enables edge gesture support.
 When enabled, gestures that begin within 15 mm of the left, right, or top screen edge are treated as distinct gestures and can be bound independently in the Input Gestures dialog.


### PR DESCRIPTION
### Link to issue number:
closes #19938 
### Summary of the issue:
As discussed in #19938, NVDA needs more gestures. This is the 3rd and final PR in that issue to address that gap. For this PR, we've created a way to distinguish gestures that begin near the screen edge, so those edge regions can serve as additional gesture space.
### Description of user facing changes:
* A new "Enable edge gestures" checkbox has been added to the Touch Interaction settings panel (disabled by default).
* When enabled, gestures that begin within 15 mm of any screen edge are recognized as distinct gestures (e.g. "left edge flick right") and can be bound independently in the Input Gestures dialog.
  * I wanted to use 5 mm as suggested by @SaschaCowley but it was too small, I couldn't use more than one finger.
* All four edges are supported. Note that the Windows taskbar may override gestures on an edge; gestures from the taskbar edge open the Start menu or Action Center and NVDA will not receive them.
### Description of developer facing changes:
* Added `TouchEdge` DisplayStringStrEnum to touchTracker for identifying and labelling edge regions (values: left, right, top, bottom).
* Added `_EDGE_MARGIN_MM = 15.0` constant to touchTracker; the pixel margin is computed at call time using GetDeviceCaps(LOGPIXELSX) for DPI awareness.
* Added `_getEdge(x, y)` helper in touchHandler that returns the edge identifier or None, and respects the `edgeGestures` config key.
* TouchInputGesture._get_identifiers() now inserts the edge prefix (e.g. `left_`) before the action name when the touch origin falls within an edge region.
* TouchInputGesture.getDisplayTextForIdentifier() resolves edge labels from the TouchEdge enum for display in the Input Gestures dialog.
* New config key: `[touch] edgeGestures = boolean(default=False)`.
### Description of development approach:
Edge detection runs at gesture-identifier generation time using the tracker's starting x/y coordinates. The margin is converted from millimetres to pixels at call time using the screen DPI retrieved via GetDeviceCaps(LOGPIXELSX), ensuring the physical margin is consistent across displays of different resolutions and pixel densities. When an edge is detected, the edge name is prepended to the action in the gesture identifier (e.g. `ts(object):left_flickright`), keeping the format compatible with the existing gesture binding infrastructure and requiring no changes to the gesture map lookup logic.
### Testing strategy:
* Enabled edge gestures in the Touch Interaction settings panel and performed flicks starting from all four edges; verified that distinct identifiers (e.g. "left edge flick right") appear in the Input Gestures dialog.
* Verified that the same flick performed in the centre of the screen retains its original identifier and is unaffected.
* Verified that with edge gestures disabled, all touch behaviour is identical to before.
* Verified that the "Enable edge gestures" checkbox is greyed out on systems where touch is not supported.
* Bound a script to a left-edge flick and confirmed it fires correctly when triggered from the edge but not from anywhere else.
### Known issues with pull request:
None
### Code Review Checklist:
- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.