### PR TITLE
Update monitor-localisation-file-changes.yml in line with fetch-crowdin-translations.yml

### DIFF
--- a/.github/workflows/monitor-localisation-file-changes.yml
+++ b/.github/workflows/monitor-localisation-file-changes.yml
@@ -27,7 +27,7 @@ jobs:
         GH_REPO: ${{ github.repository }}
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         fetch-depth: 0
 
@@ -45,15 +45,16 @@ jobs:
         echo "DOUBLE_SPACED_DIFF<<EOF"$'\n'"$DOUBLE_SPACED_DIFF"$'\n'EOF >> $GITHUB_OUTPUT
 
     - name: Send email
-      uses: dawidd6/action-send-mail@v4
+      uses: dawidd6/action-send-mail@v18
       with:
         server_address: ${{ secrets.EMAIL_SERVER_ADDRESS }}
         server_port: ${{ secrets.EMAIL_SERVER_PORT || 465 }}
         username: ${{ secrets.EMAIL_USERNAME }}
         password: ${{ secrets.EMAIL_PASSWORD }}
         subject: "Changes detected in localisation files"
-        to: nvda-l10n@nvaccess.org
-        from: '"NVDA localisations" <nvda-l10n@nvaccess.org>'
+        to: ${{ vars.L10N_EMAIL_TO }}
+        from: ${{ vars.L10N_EMAIL_FROM }}
+        envelope_from: ${{ vars.EMAIL_BOUNCE_ADDRESS }}
         convert_markdown: true
         body: |
           The following changes have been detected in the English symbols or character descriptions dictionaries:

--- a/ci/README.md
+++ b/ci/README.md
@@ -126,6 +126,9 @@ To enable, set:
 * `EMAIL_PASSWORD` as a secret.
 * `EMAIL_SERVER_ADDRESS` as a secret.
 * `EMAIL_SERVER_PORT` optionally, as a secret, with 465 being the default if unset.
+* `L10N_EMAIL_TO` as a variable. This is the address to which localization emails should be sent.
+* `L10N_EMAIL_FROM` as a variable. This is the address that localization emails will show as coming from.
+* `EMAIL_BOUNCE_ADDRESS` as a variable.  This is the SMTP envelope sender address, which is where emails from the SMTP server, such as bounce notifications, will be sent.
 
 ### Automatically assign milestone on PR merge
 

--- a/ci/README.md
+++ b/ci/README.md
@@ -126,9 +126,12 @@ To enable, set:
 * `EMAIL_PASSWORD` as a secret.
 * `EMAIL_SERVER_ADDRESS` as a secret.
 * `EMAIL_SERVER_PORT` optionally, as a secret, with 465 being the default if unset.
-* `L10N_EMAIL_TO` as a variable. This is the address to which localization emails should be sent.
-* `L10N_EMAIL_FROM` as a variable. This is the address that localization emails will show as coming from.
-* `EMAIL_BOUNCE_ADDRESS` as a variable.  This is the SMTP envelope sender address, which is where emails from the SMTP server, such as bounce notifications, will be sent.
+* `L10N_EMAIL_TO` as a variable.
+This is the address to which localization emails should be sent.
+* `L10N_EMAIL_FROM` as a variable.
+This is the address that localization emails will show as coming from.
+* `EMAIL_BOUNCE_ADDRESS` as a variable.
+This is the SMTP envelope sender address, which is where emails from the SMTP server, such as bounce notifications, will be sent.
 
 ### Automatically assign milestone on PR merge
 


### PR DESCRIPTION
### Link to issue number:

Follow-up to #20536
Related to #20524

### Summary of the issue:

The `monitor-localisation-file-changes` used the same sender and recipient addresses as `fetch-crowdin-translations.yml`, so it would have been subject to the same problem as #20524.

### Description of user facing changes:

None. This only affects the CI workflow that notifies the localisation team.

### Description of developer facing changes:

None to the NVDA API.

The `L10N_EMAIL_TO`, `L10N_EMAIL_FROM`, and `EMAIL_BOUNCE_ADDRESS` repository variables introduced in #20536 are documented in `ci/README.md`.

### Description of development approach:

Migrated changes from #20536:

* Bumped `actions/checkout` from `v4` to `v7` and `dawidd6/action-send-mail` from `v4` to `v18`.
* Replaced the hardcoded `to` and `from` addresses with the `L10N_EMAIL_TO` and `L10N_EMAIL_FROM` repository variables.
* Added an `envelope_from` set to the `EMAIL_BOUNCE_ADDRESS` repository variable so bounces are routed correctly.

Additionally, since I forgot to do it in the previous PR, documented the three new repository variables in `ci/README.md`. These repository variables must be configured in the repository settings for the workflow to send mail.

### Testing strategy:

Not tested, but the changes are exactly the same as in #20536, so the tests from that PR cover this one too.

### Known issues with pull request:

Requires the `L10N_EMAIL_TO`, `L10N_EMAIL_FROM`, and `EMAIL_BOUNCE_ADDRESS` repository variables to be defined; the workflow will not send correct emails until they are set.

### Code Review Checklist:

* [x] Documentation:
  * Change log entry
  * User Documentation
  * Developer / Technical Documentation
  * Context sensitive help for GUI changes
* [x] Testing:
  * Unit tests
  * System (end to end) tests
  * Manual testing
* [x] UX of all users considered:
  * Speech
  * Braille
  * Low Vision
  * Different web browsers
  * Localization in other languages / culture than English
* [x] API is compatible with existing add-ons.
* [x] Security precautions taken.
