### PR TITLE
Preserve current dialect for parent language tags

### DIFF
--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -1,7 +1,7 @@
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-# Copyright (C) 2006-2025 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Babbage B.V., Bill Dengler,
+# Copyright (C) 2006-2026 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Babbage B.V., Bill Dengler,
 # Julien Cochuyt, Derek Riemer, Cyrille Bougot, Leonard de Ruijter, Łukasz Golonka, Cary-rowen
 
 """High-level functions to speak information."""
@@ -1119,6 +1119,25 @@ def getIndentationSpeech(indentation: str, formatConfig: Dict[str, bool]) -> Spe
 	return indentSequence
 
 
+def _resolveLanguageForVoiceSwitch(
+	language: str | None,
+	defaultLanguage: str,
+	autoDialectSwitching: bool,
+) -> str:
+	"""Resolve a requested language against the current voice language.
+
+	A parent language such as ``en`` should keep the current dialect, such as
+	``en_AU``. An explicitly requested dialect can still switch when enabled.
+	"""
+	if not language:
+		return defaultLanguage
+	languageRoot, dialectSeparator, _dialect = language.partition("_")
+	defaultLanguageRoot = defaultLanguage.split("_", 1)[0]
+	if languageRoot == defaultLanguageRoot and (not autoDialectSwitching or not dialectSeparator):
+		return defaultLanguage
+	return language
+
+
 # C901 'speak' is too complex
 # Note: when working on speak, look for opportunities to simplify
 # and move logic out into smaller helper functions.
@@ -1169,7 +1188,6 @@ def speak(  # noqa: C901
 	autoDialectSwitching = config.conf["speech"]["autoDialectSwitching"]
 	curLanguage = defaultLanguage = getCurrentLanguage()
 	prevLanguage = None
-	defaultLanguageRoot = defaultLanguage.split("_")[0]
 	unicodeNormalization = initialUnicodeNormalization = config.conf["speech"]["unicodeNormalization"]
 	oldSpeechSequence = speechSequence
 	speechSequence = []
@@ -1177,11 +1195,11 @@ def speak(  # noqa: C901
 		if isinstance(item, LangChangeCommand):
 			if not languageHandling.shouldMakeLangChangeCommand():
 				continue
-			curLanguage = item.lang
-			if not curLanguage or (
-				not autoDialectSwitching and curLanguage.split("_")[0] == defaultLanguageRoot
-			):
-				curLanguage = defaultLanguage
+			curLanguage = _resolveLanguageForVoiceSwitch(
+				item.lang,
+				defaultLanguage,
+				autoDialectSwitching,
+			)
 		elif isinstance(item, SuppressUnicodeNormalizationCommand):
 			if not unicodeNormalization:
 				continue

--- a/tests/unit/test_speech.py
+++ b/tests/unit/test_speech.py
@@ -1,7 +1,7 @@
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-# Copyright (C) 2021-2024 NV Access Limited, Cyrille Bougot, Leonard de Ruijter
+# Copyright (C) 2021-2026 NV Access Limited, Cyrille Bougot, Leonard de Ruijter
 
 """Unit tests for the speech module."""
 
@@ -15,6 +15,7 @@ from speech import (
 	_getSpellingCharAddCapNotification,
 	_getSpellingSpeechAddCharMode,
 	_getSpellingSpeechWithoutCharMode,
+	_resolveLanguageForVoiceSwitch,
 	cancelSpeech,
 	pauseSpeech,
 	speechCanceled,
@@ -29,6 +30,31 @@ from speech.commands import (
 )
 
 from .extensionPointTestHelpers import actionTester
+
+
+class Test_resolveLanguageForVoiceSwitch(unittest.TestCase):
+	def test_languageResolution(self):
+		testCases = (
+			(None, "en_AU", True, "en_AU"),
+			("en", "en_AU", True, "en_AU"),
+			("en_CA", "en_AU", True, "en_CA"),
+			("en_CA", "en_AU", False, "en_AU"),
+			("fr", "en_AU", True, "fr"),
+		)
+		for language, defaultLanguage, autoDialectSwitching, expected in testCases:
+			with self.subTest(
+				language=language,
+				defaultLanguage=defaultLanguage,
+				autoDialectSwitching=autoDialectSwitching,
+			):
+				self.assertEqual(
+					expected,
+					_resolveLanguageForVoiceSwitch(
+						language,
+						defaultLanguage,
+						autoDialectSwitching,
+					),
+				)
 
 
 class Test_getSpellingSpeechAddCharMode(unittest.TestCase):

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -37,6 +37,7 @@
 
 ### Bug Fixes
 
+* NVDA now keeps the current speech dialect when content specifies only the matching parent language. (#13561, @marisombra-dev)
 * In PowerPoint and other Office applications, NVDA will now correctly read and navigate the edit fields in the insert hyperlink dialog. (#17390, @aryanchoudharypro)
 * The actions button can now be used when selecting multiple add-ons in the Add-on Store to perform batch actions, instead of just via the context menu in the add-ons list. (#19971, @amirmahdifard)
 * When moving to an ARIA grid cell in focus mode in web browsers, NVDA no longer reports both the row and column headers even if only the row or only the column changed. (#17750, @jcsteh)


### PR DESCRIPTION
### Link to issue number:

Fixes #13561

### Summary of the issue:

When the current voice uses a dialect such as `en_AU`, content tagged with only the parent language (`lang="en"`) can cause NVDA to switch to another English voice. A bare parent language should not override the user's current matching dialect.

### Description of user facing changes:

NVDA keeps the current speech dialect when content specifies only the matching parent language. Explicitly different dialects, such as `en_CA`, can still switch when automatic dialect switching is enabled.

### Description of developer facing changes:

None. No public API changes.

### Description of development approach:

A small resolver was extracted from `speech.speak` so parent-language fallback can be tested independently. It preserves the existing behavior for absent languages, explicit dialects, different languages, and disabled dialect switching.

The implementation and tests were prepared with AI assistance and reviewed against the issue requirements and NVDA contribution guidance.

### Testing strategy:

Passed locally:

- Five focused language-resolution cases executed directly from the modified source.
- `ruff check` on both changed Python files.
- `ruff format --check` on both changed Python files.
- Pyright on both changed Python files: 0 errors and 0 warnings.
- Ty on both changed Python files: all checks passed.
- `git diff --check`.

The official `test_speech.py` runner reached NVDA initialization but could not run locally because this checkout does not have the compiled `source/lib/x64/nvdaHelperLocal.dll`. The added unit test therefore needs confirmation by CI. The unit-test environment was otherwise installed using the pinned Python 3.13.13 and project dependencies, omitting only `fast-diff-match-patch`, which requires MSVC and is unrelated to speech.

### Known issues with pull request:

No known behavior issues. Full compiled NVDA unit-test execution was not available locally, as described above.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
- [ ] Testing:
  - Unit tests added; CI execution required
  - No system or manual NVDA test was performed locally
- [x] UX of all users considered:
  - Speech behavior changes only
  - Braille, low vision, browser-specific behavior, and translated UI strings are unaffected
  - Language and dialect handling is covered by focused cases
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
