### PR TITLE
Fix ValueError when displaying touch gestures with addon-registered plain string modes

### DIFF
--- a/source/touchHandler.py
+++ b/source/touchHandler.py
@@ -297,7 +297,11 @@ class TouchInputGesture(inputCore.InputGesture):
 		# Translators: a touch screen gesture
 		source = _("Touch screen")
 		if mode:
-			source = "{source}, {mode}".format(source=source, mode=TouchMode(mode).displayString)
+			try:
+				modeLabel = TouchMode(mode).displayString
+			except ValueError:
+				modeLabel = mode
+			source = "{source}, {mode}".format(source=source, mode=modeLabel)
 		return source, " + ".join(actions)
 
 	def _get__immediate(self):


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
<!-- Use Closes/Fixes/Resolves #xxx to link this PR to the issue it is responding to. -->
closes #20561
### Summary of the issue:
When availableTouchModes was changed from list[str] to list[TouchMode] in 2026.2, TouchInputGesture.getDisplayTextForIdentifier() was left calling TouchMode(mode) unconditionally to resolve the display label for the gesture source. This raises ValueError for any plain string mode registered by an add-on, crashing the Input Gestures dialog whenever such an add-on is installed.
### Description of user facing changes:

### Description of developer facing changes:
TouchInputGesture.getDisplayTextForIdentifier() now falls back to the plain string value when TouchMode(mode) raises ValueError, allowing add-ons that append plain strings to availableTouchModes to coexist with the TouchMode enum without crashing the Input Gestures dialog.
### Description of development approach:
A try/except ValueError block wraps the TouchMode(mode) call. If the lookup succeeds the enum member's displayString is used as before; if it fails the plain string is used directly as the mode label.
### Testing strategy:

### Known issues with pull request:

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
