### PR TITLE
German key change for magnification

### DIFF
--- a/source/locale/de/gestures.ini
+++ b/source/locale/de/gestures.ini
@@ -1,4 +1,5 @@
 ﻿[globalCommands.GlobalCommands]
+	zoomIn = kb:nvda+shift+plus
 	leftMouseClick = kb(laptop):NVDA+ü
 	toggleLeftMouseButton = kb(laptop):NVDA+control+ü
 	rightMouseClick = kb(laptop):NVDA+plus


### PR DESCRIPTION
There was a conflict with the German keyboard and the assignment of NVDA+Shift+equal sign