### PR TITLE
add links to new stacked PR docs

### DIFF
--- a/projectDocs/dev/contributing.md
+++ b/projectDocs/dev/contributing.md
@@ -51,7 +51,7 @@ Avoid PRs where over 500 lines of code (LOC) is added.
 PRs over 500 LOC may be rejected at the reviewers' discretion.
 
 500-1000 line PRs can typically be broken into smaller changes such as automated tests, refactors, data-structures and core changes.
-These can be merged as stacked PRs if they depend on each other (e.g. `branchX` targets `master`, `branchY` targets `branchX`).
+These can be merged as [stacked PRs](https://github.github.com/gh-stack/) if they depend on each other (e.g. `branchX` targets `master`, `branchY` targets `branchX`).
 
 Large refactors should instead target specific symbols/files/modules per PR to minimize mass changes.
 

--- a/projectDocs/dev/proposingMajorChanges.md
+++ b/projectDocs/dev/proposingMajorChanges.md
@@ -72,7 +72,7 @@ Every ADR should include a PR integration strategy.
 In general:
 
 * Prefer PRs around 500 LOC where possible.
-* If changes are interdependent, use stacked PRs with clear ordering.
+* If changes are interdependent, use [stacked PRs](https://github.github.com/gh-stack/) with clear ordering.
 * For long-running feature work that cannot merge directly to `master`, request a `try-` branch and integrate in pieces.
 * Separate unrelated work into separate issues/PRs.
 


### PR DESCRIPTION
Encourage use of the new GitHub feature for stacked PRs: https://github.github.com/gh-stack/