### PR TITLE
Migrate hot code paths off the deprecated brailleInput module

### DIFF
--- a/source/NVDAObjects/__init__.py
+++ b/source/NVDAObjects/__init__.py
@@ -42,7 +42,7 @@ import braille.regions.properties
 from utils.security import _isObjectBelowLockScreen
 import vision
 import globalPluginHandler
-import brailleInput
+import braille.input
 import locationHelper
 import aria
 from winAPI.sessionTracking import isLockScreenModeActive
@@ -1373,7 +1373,7 @@ class NVDAObject(
 		"""
 		self.reportFocus()
 		braille.handler.handleGainFocus(self)
-		brailleInput.handler.handleGainFocus(self)
+		braille.input.handler.handleGainFocus(self)
 		vision.handler.handleGainFocus(self)
 
 	def event_loseFocus(self):
@@ -1429,7 +1429,7 @@ class NVDAObject(
 	def event_caret(self):
 		if self is api.getFocusObject() and not eventHandler.isPendingEvents("gainFocus"):
 			braille.handler.handleCaretMove(self)
-			brailleInput.handler.handleCaretMove(self)
+			braille.input.handler.handleCaretMove(self)
 			vision.handler.handleCaretMove(self)
 			review.handleCaretMove(self)
 

--- a/source/_remoteClient/session.py
+++ b/source/_remoteClient/session.py
@@ -73,7 +73,7 @@ import braille.display
 import braille.display.driver
 import braille.display.gesture
 import braille.extensions
-import brailleInput
+import braille.input.gesture
 import gui
 import inputCore
 import scriptHandler
@@ -611,7 +611,7 @@ class LeaderSession(RemoteSession):
 
 	def handleDecideExecuteGesture(
 		self,
-		gesture: braille.display.gesture.BrailleDisplayGesture | brailleInput.BrailleInputGesture,
+		gesture: braille.display.gesture.BrailleDisplayGesture | braille.input.gesture.BrailleInputGesture,
 	) -> bool:
 		"""Handle and forward braille gestures to remote client.
 
@@ -624,7 +624,7 @@ class LeaderSession(RemoteSession):
 
 		if isinstance(
 			gesture,
-			(braille.display.gesture.BrailleDisplayGesture, brailleInput.BrailleInputGesture),
+			(braille.display.gesture.BrailleDisplayGesture, braille.input.gesture.BrailleInputGesture),
 		):
 			if self.localMachine._showingLocalUiMessage and gesture.script in (
 				commands.script_braille_routeTo,

--- a/source/braille/display/gesture.py
+++ b/source/braille/display/gesture.py
@@ -26,7 +26,7 @@ class BrailleDisplayGesture(inputCore.InputGesture):
 	Optionally, :attr:`model` can be provided to facilitate model specific gestures.
 	:attr:`cellIndexes` should be provided for gestures addressed to specific braille cells,
 	such as routing keys or touch-sensitive cells (e.g. Handy Tech Active Tactile Control).
-	Subclasses can also inherit from :class:`brailleInput.BrailleInputGesture` if the display has a braille keyboard.
+	Subclasses can also inherit from :class:`braille.input.gesture.BrailleInputGesture` if the display has a braille keyboard.
 	If the braille display driver is a :class:`baseObject.ScriptableObject`, it can provide scripts specific to input gestures from this display.
 	"""
 
@@ -119,17 +119,17 @@ class BrailleDisplayGesture(inputCore.InputGesture):
 			if self._cellIndexesStr:
 				ids.insert(0, f"br({self.source}.{self.model}):{self.id}{self._cellIndexesStr}")
 			ids.insert(1, f"br({self.source}.{self.model}):{self.id}")
-		import brailleInput
+		from ..input.gesture import BrailleInputGesture
 
-		if isinstance(self, brailleInput.BrailleInputGesture):
-			ids.extend(brailleInput.BrailleInputGesture._get_identifiers(self))
+		if isinstance(self, BrailleInputGesture):
+			ids.extend(BrailleInputGesture._get_identifiers(self))
 		return ids
 
 	def _get_displayName(self):
-		import brailleInput
+		from ..input.gesture import BrailleInputGesture
 
-		if isinstance(self, brailleInput.BrailleInputGesture):
-			name = brailleInput.BrailleInputGesture._get_displayName(self)
+		if isinstance(self, BrailleInputGesture):
+			name = BrailleInputGesture._get_displayName(self)
 			if name:
 				return name
 		if self._cellIndexesStr:
@@ -146,10 +146,10 @@ class BrailleDisplayGesture(inputCore.InputGesture):
 		# Overrides L{inputCore.InputGesture._get_script} to support modifier keys.
 		# Also processes modifiers held by braille input.
 		# Import late to avoid circular import.
-		import brailleInput
+		from ..input import handler as brailleInputHandler
 
 		gestureKeys = set(self.keyNames)
-		gestureModifiers = brailleInput.handler.currentModifiers.copy()
+		gestureModifiers = brailleInputHandler.currentModifiers.copy()
 		script = scriptHandler.findScript(self)
 		if script:
 			scriptName = script.__name__
@@ -203,7 +203,7 @@ class BrailleDisplayGesture(inputCore.InputGesture):
 		else:
 			return None
 		self.script = scriptHandler._makeKbEmulateScript(combinedScriptName)
-		brailleInput.handler.currentModifiers.clear()
+		brailleInputHandler.currentModifiers.clear()
 		return self.script
 
 	def _get_keyNames(self):

--- a/source/braille/regions/textInfo.py
+++ b/source/braille/regions/textInfo.py
@@ -292,9 +292,9 @@ class TextInfoRegion(Region):
 		self._addTextWithFields(chunk, formatConfig)
 		# If the user is entering braille, place any untranslated braille before the selection.
 		# Import late to avoid circular import.
-		import brailleInput
+		from ..input import handler as brailleInputHandler
 
-		text = brailleInput.handler.untranslatedBraille
+		text = brailleInputHandler.untranslatedBraille
 		if text:
 			rawInputIndStart = len(self.rawText)
 			# _addFieldText adds text to self.rawText and updates other state accordingly.
@@ -351,7 +351,7 @@ class TextInfoRegion(Region):
 			# These are the start and end of the actual untranslated input, excluding indicators.
 			self._brailleInputStart = self._brailleInputIndStart + len(INPUT_START_IND)
 			self._brailleInputEnd = self._brailleInputIndEnd - len(INPUT_END_IND)
-			self.brailleCursorPos = self._brailleInputStart + brailleInput.handler.untranslatedCursorPos
+			self.brailleCursorPos = self._brailleInputStart + brailleInputHandler.untranslatedCursorPos
 		else:
 			self._brailleInputIndStart = None
 
@@ -404,11 +404,11 @@ class TextInfoRegion(Region):
 				# The user routed to the end indicator. Route to the end of the input.
 				braillePos = self._brailleInputEnd
 			# Import late to avoid circular import.
-			import brailleInput
+			from ..input import handler as brailleInputHandler
 
-			brailleInput.handler.untranslatedCursorPos = braillePos - self._brailleInputStart
-			self.brailleCursorPos = self._brailleInputStart + brailleInput.handler.untranslatedCursorPos
-			brailleInput.handler.updateDisplay()
+			brailleInputHandler.untranslatedCursorPos = braillePos - self._brailleInputStart
+			self.brailleCursorPos = self._brailleInputStart + brailleInputHandler.untranslatedCursorPos
+			brailleInputHandler.updateDisplay()
 			return
 
 		dest = self.getTextInfoForBraillePos(braillePos)

--- a/source/brailleDisplayDrivers/alva.py
+++ b/source/brailleDisplayDrivers/alva.py
@@ -12,7 +12,7 @@ import braille.display.driver
 import braille.display.gesture
 from logHandler import log
 import inputCore
-import brailleInput
+import braille.input.gesture
 import hwIo
 from hwIo import intToByte, boolToByte
 from globalCommands import SCRCAT_BRAILLE
@@ -513,7 +513,7 @@ class BrailleDisplayDriver(braille.display.driver.BrailleDisplayDriver, Scriptab
 	)
 
 
-class InputGesture(braille.display.gesture.BrailleDisplayGesture, brailleInput.BrailleInputGesture):
+class InputGesture(braille.display.gesture.BrailleDisplayGesture, braille.input.gesture.BrailleInputGesture):
 	source = BrailleDisplayDriver.name
 
 	def __init__(self, model, keys, brailleInput=False):
@@ -583,5 +583,5 @@ class InputGesture(braille.display.gesture.BrailleDisplayGesture, brailleInput.B
 			"br({source}.{model}):{id}".format(source=self.source, model=self.model, id=self.secondaryId),
 			"br({source}):{id}".format(source=self.source, id=self.id),
 		]
-		ids.extend(brailleInput.BrailleInputGesture._get_identifiers(self))
+		ids.extend(braille.input.gesture.BrailleInputGesture._get_identifiers(self))
 		return ids

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -66,7 +66,7 @@ import braille
 import braille.constants
 import braille.display.gesture
 import braille.regions.focus
-import brailleInput
+import braille.input
 import inputCore
 import characterProcessing
 from baseObject import ScriptableObject
@@ -4341,7 +4341,7 @@ class GlobalCommands(ScriptableObject):
 		gesture="bk:dots",
 	)
 	def script_braille_dots(self, gesture):
-		brailleInput.handler.input(gesture.dots)
+		braille.input.handler.input(gesture.dots)
 
 	@script(
 		# Translators: Input help mode message for a braille command.
@@ -4372,7 +4372,7 @@ class GlobalCommands(ScriptableObject):
 		gesture="bk:dot7",
 	)
 	def script_braille_eraseLastCell(self, gesture):
-		brailleInput.handler.eraseLastCell()
+		braille.input.handler.eraseLastCell()
 
 	@script(
 		# Translators: Input help mode message for a braille command.
@@ -4381,7 +4381,7 @@ class GlobalCommands(ScriptableObject):
 		gesture="bk:dot8",
 	)
 	def script_braille_enter(self, gesture):
-		brailleInput.handler.enter()
+		braille.input.handler.enter()
 
 	@script(
 		# Translators: Input help mode message for a braille command.
@@ -4390,7 +4390,7 @@ class GlobalCommands(ScriptableObject):
 		gesture="bk:dot7+dot8",
 	)
 	def script_braille_translate(self, gesture):
-		brailleInput.handler.translate()
+		braille.input.handler.translate()
 
 	@script(
 		# Translators: Input help mode message for a braille command.
@@ -4399,7 +4399,7 @@ class GlobalCommands(ScriptableObject):
 		bypassInputHelp=True,
 	)
 	def script_braille_toggleShift(self, gesture):
-		brailleInput.handler.toggleModifier("shift")
+		braille.input.handler.toggleModifier("shift")
 
 	@script(
 		# Translators: Input help mode message for a braille command.
@@ -4408,7 +4408,7 @@ class GlobalCommands(ScriptableObject):
 		bypassInputHelp=True,
 	)
 	def script_braille_toggleControl(self, gesture):
-		brailleInput.handler.toggleModifier("control")
+		braille.input.handler.toggleModifier("control")
 
 	@script(
 		# Translators: Input help mode message for a braille command.
@@ -4417,7 +4417,7 @@ class GlobalCommands(ScriptableObject):
 		bypassInputHelp=True,
 	)
 	def script_braille_toggleAlt(self, gesture):
-		brailleInput.handler.toggleModifier("alt")
+		braille.input.handler.toggleModifier("alt")
 
 	@script(
 		description=_(
@@ -4428,7 +4428,7 @@ class GlobalCommands(ScriptableObject):
 		bypassInputHelp=True,
 	)
 	def script_braille_toggleWindows(self, gesture):
-		brailleInput.handler.toggleModifier("leftWindows")
+		braille.input.handler.toggleModifier("leftWindows")
 
 	@script(
 		# Translators: Input help mode message for a braille command.
@@ -4437,7 +4437,7 @@ class GlobalCommands(ScriptableObject):
 		bypassInputHelp=True,
 	)
 	def script_braille_toggleNVDAKey(self, gesture):
-		brailleInput.handler.toggleModifier("NVDA")
+		braille.input.handler.toggleModifier("NVDA")
 
 	@script(
 		description=_(
@@ -4448,7 +4448,7 @@ class GlobalCommands(ScriptableObject):
 		bypassInputHelp=True,
 	)
 	def script_braille_toggleControlShift(self, gesture):
-		brailleInput.handler.toggleModifiers(["control", "shift"])
+		braille.input.handler.toggleModifiers(["control", "shift"])
 
 	@script(
 		description=_(
@@ -4459,7 +4459,7 @@ class GlobalCommands(ScriptableObject):
 		bypassInputHelp=True,
 	)
 	def script_braille_toggleAltShift(self, gesture):
-		brailleInput.handler.toggleModifiers(["alt", "shift"])
+		braille.input.handler.toggleModifiers(["alt", "shift"])
 
 	@script(
 		description=_(
@@ -4471,7 +4471,7 @@ class GlobalCommands(ScriptableObject):
 		bypassInputHelp=True,
 	)
 	def script_braille_toggleWindowsShift(self, gesture):
-		brailleInput.handler.toggleModifiers(["leftWindows", "shift"])
+		braille.input.handler.toggleModifiers(["leftWindows", "shift"])
 
 	@script(
 		description=_(
@@ -4482,7 +4482,7 @@ class GlobalCommands(ScriptableObject):
 		bypassInputHelp=True,
 	)
 	def script_braille_toggleNVDAKeyShift(self, gesture):
-		brailleInput.handler.toggleModifiers(["NVDA", "shift"])
+		braille.input.handler.toggleModifiers(["NVDA", "shift"])
 
 	@script(
 		description=_(
@@ -4493,7 +4493,7 @@ class GlobalCommands(ScriptableObject):
 		bypassInputHelp=True,
 	)
 	def script_braille_toggleControlAlt(self, gesture):
-		brailleInput.handler.toggleModifiers(["control", "alt"])
+		braille.input.handler.toggleModifiers(["control", "alt"])
 
 	@script(
 		description=_(
@@ -4505,7 +4505,7 @@ class GlobalCommands(ScriptableObject):
 		bypassInputHelp=True,
 	)
 	def script_braille_toggleControlAltShift(self, gesture):
-		brailleInput.handler.toggleModifiers(["control", "alt", "shift"])
+		braille.input.handler.toggleModifiers(["control", "alt", "shift"])
 
 	@script(
 		description=_(


### PR DESCRIPTION
### Link to issue number:

Follow-up of #20509.

### Summary of the issue:

#20509 moved braille input handling into the `braille.input` package.
The old `brailleInput` module became a backwards compatibility shim.
The shim logs a deprecation warning on every attribute access via its module level `__getattr__`.
Several internal call sites still access the shim on hot paths.
`NVDAObjects` accesses `brailleInput.handler` on every focus and caret change.
`braille.regions.textInfo` reads `brailleInput.handler.untranslatedBraille` on every braille region update.
`braille.display.gesture` and `globalCommands` reach the shim for every braille keyboard gesture.
The `alva` driver and `_remoteClient.session` access it per gesture as well.
This floods the log with deprecation warnings during normal usage.

### Description of user facing changes:

None.

### Description of developer facing changes:

None.
The deprecated `brailleInput` shim is unchanged and keeps serving add-ons.

### Description of development approach:

Migrated the six hot path modules to the new import locations.
`NVDAObjects`, `globalCommands`, `_remoteClient.session` and the `alva` driver now import `braille.input` or `braille.input.gesture` directly.
Modules inside the `braille` package use relative imports, e.g. `from ..input import handler`.
Late imports that avoid circular imports are kept late.
The remaining call sites only touch the shim once per session, e.g. at driver import or NVDA start.
They will be migrated in a separate PR to keep this change small.

### Testing strategy:

A manual smoke test of NVDA from source with braille input.

### Known issues with pull request:

None.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
