### PR TITLE
Migrate remaining internal consumers off the deprecated brailleInput module

### DIFF
--- a/source/_remoteClient/input.py
+++ b/source/_remoteClient/input.py
@@ -11,7 +11,7 @@ import api
 import baseObject
 import braille
 import braille.display.gesture
-import brailleInput
+import braille.input.gesture
 import globalPluginHandler
 import scriptHandler
 import vision
@@ -29,7 +29,10 @@ class VKMapType(IntEnum):
 	"""Maps a virtual key code to a scan code."""
 
 
-class BrailleInputGesture(braille.display.gesture.BrailleDisplayGesture, brailleInput.BrailleInputGesture):
+class BrailleInputGesture(
+	braille.display.gesture.BrailleDisplayGesture,
+	braille.input.gesture.BrailleInputGesture,
+):
 	def __init__(self, **kwargs):
 		super().__init__()
 		# Normalize legacy routingIndex field into cellIndexes before assignment

--- a/source/brailleDisplayDrivers/baum.py
+++ b/source/brailleDisplayDrivers/baum.py
@@ -13,7 +13,7 @@ import braille.display.gesture
 from hwIo import intToByte, boolToByte
 import inputCore
 from logHandler import log
-import brailleInput
+import braille.input.gesture
 import bdDetect
 import hwIo
 
@@ -395,7 +395,7 @@ class BrailleDisplayDriver(braille.display.driver.BrailleDisplayDriver):
 	)
 
 
-class InputGesture(braille.display.gesture.BrailleDisplayGesture, brailleInput.BrailleInputGesture):
+class InputGesture(braille.display.gesture.BrailleDisplayGesture, braille.input.gesture.BrailleInputGesture):
 	source = BrailleDisplayDriver.name
 
 	def __init__(self, model, keysDown):

--- a/source/brailleDisplayDrivers/brailleNote.py
+++ b/source/brailleDisplayDrivers/brailleNote.py
@@ -1,7 +1,7 @@
 # A part of NonVisual Desktop Access (NVDA)
-# This file is covered by the GNU General Public License.
-# See the file COPYING for more details.
-# Copyright (C) 2011-2018 NV access Limited, Rui Batista, Joseph Lee
+# Copyright (C) 2011-2026 NV Access Limited, Rui Batista, Joseph Lee, Leonard de Ruijter
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
 
 """Braille Display driver for the BrailleNote notetakers in terminal mode.
 USB, serial and bluetooth communications are supported.
@@ -17,7 +17,7 @@ import braille
 import braille.display
 import braille.display.driver
 import braille.display.gesture
-import brailleInput
+import braille.input.gesture
 import inputCore
 from logHandler import log
 import hwIo
@@ -311,7 +311,7 @@ class BrailleDisplayDriver(braille.display.driver.BrailleDisplayDriver):
 	)
 
 
-class InputGesture(braille.display.gesture.BrailleDisplayGesture, brailleInput.BrailleInputGesture):
+class InputGesture(braille.display.gesture.BrailleDisplayGesture, braille.input.gesture.BrailleInputGesture):
 	source = BrailleDisplayDriver.name
 
 	def __init__(

--- a/source/brailleDisplayDrivers/brailliantB.py
+++ b/source/brailleDisplayDrivers/brailliantB.py
@@ -13,7 +13,7 @@ import braille.display.driver
 import braille.display.gesture
 import inputCore
 from logHandler import log
-import brailleInput
+import braille.input.gesture
 import bdDetect
 import hwIo
 from hwIo import intToByte, boolToByte
@@ -384,7 +384,7 @@ class BrailleDisplayDriver(braille.display.driver.BrailleDisplayDriver):
 	)
 
 
-class InputGesture(braille.display.gesture.BrailleDisplayGesture, brailleInput.BrailleInputGesture):
+class InputGesture(braille.display.gesture.BrailleDisplayGesture, braille.input.gesture.BrailleInputGesture):
 	source = BrailleDisplayDriver.name
 
 	def __init__(self, keys):

--- a/source/brailleDisplayDrivers/eurobraille/gestures.py
+++ b/source/brailleDisplayDrivers/eurobraille/gestures.py
@@ -1,12 +1,12 @@
 # A part of NonVisual Desktop Access (NVDA)
-# This file is covered by the GNU General Public License.
-# See the file COPYING for more details.
-# Copyright (C) 2017-2023 NV Access Limited, Babbage B.V., Eurobraille, Cyrille Bougot
+# Copyright (C) 2017-2026 NV Access Limited, Babbage B.V., Eurobraille, Cyrille Bougot, Leonard de Ruijter
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
 
 from typing import TYPE_CHECKING
 import braille
 import braille.display.gesture
-import brailleInput
+import braille.input.gesture
 import inputCore
 from . import constants
 
@@ -158,7 +158,7 @@ GestureMapEntries = {
 _gestureMap = inputCore.GlobalGestureMap(GestureMapEntries)
 
 
-class InputGesture(braille.display.gesture.BrailleDisplayGesture, brailleInput.BrailleInputGesture):
+class InputGesture(braille.display.gesture.BrailleDisplayGesture, braille.input.gesture.BrailleInputGesture):
 	source = constants.name
 
 	def __init__(self, display: "BrailleDisplayDriver"):

--- a/source/brailleDisplayDrivers/freedomScientific.py
+++ b/source/brailleDisplayDrivers/freedomScientific.py
@@ -15,7 +15,7 @@ import bdDetect
 import braille
 import braille.display.driver
 import braille.display.gesture
-import brailleInput
+import braille.input.gesture
 import hwIo
 import inputCore
 import serial
@@ -716,7 +716,7 @@ class InputGesture(braille.display.gesture.BrailleDisplayGesture):
 		super().__init__()
 
 
-class KeyGesture(InputGesture, brailleInput.BrailleInputGesture):
+class KeyGesture(InputGesture, braille.input.gesture.BrailleInputGesture):
 	"""Handle keys and braille input for Freedom Scientific braille displays"""
 
 	keyLabels = [

--- a/source/brailleDisplayDrivers/handyTech.py
+++ b/source/brailleDisplayDrivers/handyTech.py
@@ -25,7 +25,7 @@ import braille
 import braille.display
 import braille.display.driver
 import braille.display.gesture
-import brailleInput
+import braille.input.gesture
 import inputCore
 import ui
 from baseObject import ScriptableObject, AutoPropertyObject
@@ -1313,7 +1313,7 @@ class BrailleDisplayDriver(braille.display.driver.BrailleDisplayDriver, Scriptab
 	)
 
 
-class InputGesture(braille.display.gesture.BrailleDisplayGesture, brailleInput.BrailleInputGesture):
+class InputGesture(braille.display.gesture.BrailleDisplayGesture, braille.input.gesture.BrailleInputGesture):
 	source = BrailleDisplayDriver.name
 
 	def __init__(self, model, keys, isBrailleInput=False):

--- a/source/brailleDisplayDrivers/hidBrailleStandard.py
+++ b/source/brailleDisplayDrivers/hidBrailleStandard.py
@@ -12,7 +12,7 @@ import braille.display.driver
 import braille.display.gesture
 import inputCore
 from logHandler import log
-import brailleInput
+import braille.input.gesture
 import bdDetect
 import hidpi
 import hwIo.hid
@@ -313,7 +313,7 @@ class HidBrailleDriver(braille.display.driver.BrailleDisplayDriver):
 	)
 
 
-class InputGesture(braille.display.gesture.BrailleDisplayGesture, brailleInput.BrailleInputGesture):
+class InputGesture(braille.display.gesture.BrailleDisplayGesture, braille.input.gesture.BrailleInputGesture):
 	source = HidBrailleDriver.name
 
 	def __init__(self, driver, dataIndices):

--- a/source/brailleDisplayDrivers/hims.py
+++ b/source/brailleDisplayDrivers/hims.py
@@ -16,7 +16,7 @@ import braille.display.gesture
 from logHandler import log
 from collections import OrderedDict
 import inputCore
-import brailleInput
+import braille.input.gesture
 from baseObject import AutoPropertyObject
 import time
 import bdDetect
@@ -797,7 +797,10 @@ class BrailleDisplayDriver(braille.display.driver.BrailleDisplayDriver):
 	)
 
 
-class KeyInputGesture(braille.display.gesture.BrailleDisplayGesture, brailleInput.BrailleInputGesture):
+class KeyInputGesture(
+	braille.display.gesture.BrailleDisplayGesture,
+	braille.input.gesture.BrailleInputGesture,
+):
 	source = BrailleDisplayDriver.name
 
 	def __init__(self, model, keys, isHid: bool = False):

--- a/source/brailleDisplayDrivers/nlseReaderZoomax.py
+++ b/source/brailleDisplayDrivers/nlseReaderZoomax.py
@@ -9,7 +9,7 @@ import bdDetect
 import braille
 import braille.display.driver
 import braille.display.gesture
-import brailleInput
+import braille.input.gesture
 import hwIo
 import inputCore
 import serial
@@ -248,7 +248,7 @@ class BrailleDisplayDriver(braille.display.driver.BrailleDisplayDriver):
 	)
 
 
-class InputGesture(braille.display.gesture.BrailleDisplayGesture, brailleInput.BrailleInputGesture):
+class InputGesture(braille.display.gesture.BrailleDisplayGesture, braille.input.gesture.BrailleInputGesture):
 	source = BrailleDisplayDriver.name
 
 	def __init__(self, keysDown: dict[bytes, bytes]):

--- a/source/brailleDisplayDrivers/papenmeier.py
+++ b/source/brailleDisplayDrivers/papenmeier.py
@@ -1,10 +1,8 @@
-# brailleDisplayDrivers/papenmeier.py
 # A part of NonVisual Desktop Access (NVDA)
-# This file is covered by the GNU General Public License.
-# See the file COPYING for more details.
-# Copyright (C) 2012-2017 Tobias Platen, Halim Sahin, Ali-Riza Ciftcioglu, NV Access Limited, Davy Kager
-# Author: Tobias Platen (nvda@lists.thm.de)
-# minor changes by Halim Sahin (nvda@lists.thm.de), Ali-Riza Ciftcioglu <aliminator83@googlemail.com>, James Teh and Davy Kager
+# Copyright (C) 2012-2026 Tobias Platen, Halim Sahin, Ali-Riza Ciftcioglu, NV Access Limited, Davy Kager,
+# Leonard de Ruijter
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
 
 import time
 from typing import List, Union, Optional
@@ -16,7 +14,7 @@ import braille.display.gesture
 from logHandler import log
 
 import inputCore
-import brailleInput
+import braille.input.gesture
 import keyboardHandler
 
 try:
@@ -623,7 +621,7 @@ def brl_join_keys(dec: List[str]) -> str:
 		return ""
 
 
-class InputGesture(braille.display.gesture.BrailleDisplayGesture, brailleInput.BrailleInputGesture):
+class InputGesture(braille.display.gesture.BrailleDisplayGesture, braille.input.gesture.BrailleInputGesture):
 	"""Input gesture for papenmeier displays"""
 
 	source = BrailleDisplayDriver.name

--- a/source/brailleDisplayDrivers/seikantk.py
+++ b/source/brailleDisplayDrivers/seikantk.py
@@ -20,7 +20,7 @@ import braille.display
 import braille.display.driver
 import braille.display.gesture
 from bdDetect import DeviceMatch, DriverRegistrar
-import brailleInput
+import braille.input.gesture
 import inputCore
 import bdDetect
 import hwIo
@@ -396,7 +396,7 @@ def _getRoutingIndexes(routingKeyBytes: bytes) -> Set[int]:
 	return {i for i in range(numRoutingKeys) if (1 << i) & combinedRoutingKeysBitSet}
 
 
-class InputGesture(braille.display.gesture.BrailleDisplayGesture, brailleInput.BrailleInputGesture):
+class InputGesture(braille.display.gesture.BrailleDisplayGesture, braille.input.gesture.BrailleInputGesture):
 	source = BrailleDisplayDriver.name
 
 	def __init__(self, keys=None, dots=None, space=0, routing=None):

--- a/source/core.py
+++ b/source/core.py
@@ -1,8 +1,9 @@
 # A part of NonVisual Desktop Access (NVDA)
 # Copyright (C) 2006-2026 NV Access Limited, Aleksey Sadovoy, Christopher Toth, Joseph Lee, Peter Vágner,
-# Derek Riemer, Babbage B.V., Zahari Yurukov, Łukasz Golonka, Cyrille Bougot, Julien Cochuyt, Wang Chong
-# This file is covered by the GNU General Public License.
-# See the file COPYING for more details.
+# Derek Riemer, Babbage B.V., Zahari Yurukov, Łukasz Golonka, Cyrille Bougot, Julien Cochuyt, Wang Chong,
+# Leonard de Ruijter
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
 
 """NVDA core"""
 
@@ -311,7 +312,7 @@ def resetConfiguration(factoryDefaults=False):
 	"""Loads the configuration, installs the correct language support and initialises audio so that it will use the configured synth and speech settings."""
 	import config
 	import braille
-	import brailleInput
+	import braille.input
 	import brailleTables
 	import speech
 	import characterProcessing
@@ -335,8 +336,8 @@ def resetConfiguration(factoryDefaults=False):
 	mathPres.terminate()
 	log.debug("Terminating braille")
 	braille.terminate()
-	log.debug("Terminating brailleInput")
-	brailleInput.terminate()
+	log.debug("Terminating braille input")
+	braille.input.terminate()
 	log.debug("Terminating brailleTables")
 	brailleTables.terminate()
 	log.debug("terminating speech")
@@ -389,8 +390,8 @@ def resetConfiguration(factoryDefaults=False):
 	# braille
 	log.debug("Initializing brailleTables")
 	brailleTables.initialize()
-	log.debug("Initializing brailleInput")
-	brailleInput.initialize()
+	log.debug("Initializing braille input")
+	braille.input.initialize()
 	log.debug("Initializing braille")
 	braille.initialize()
 	log.debug("Initializing word segmentation")
@@ -820,10 +821,9 @@ def main():
 
 	brailleTables.initialize()
 	log.debug("Initializing braille input")
-	import brailleInput
+	import braille.input
 
-	brailleInput.initialize()
-	import braille
+	braille.input.initialize()
 
 	log.debug("Initializing braille")
 	braille.initialize()
@@ -1122,7 +1122,7 @@ def main():
 	_terminate(inputCore)
 	_terminate(screenCurtain)
 	_terminate(vision)
-	_terminate(brailleInput)
+	_terminate(braille.input)
 	_terminate(braille)
 	_terminate(brailleTables)
 	_terminate(speech)

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -31,7 +31,7 @@ import audioDucking
 import braille
 import braille.constants
 import braille.display
-import brailleInput
+import braille.input
 import brailleTables
 import characterProcessing
 import config
@@ -5264,7 +5264,7 @@ class BrailleSettingsSubPanel(AutoSettingsMixin, SettingsPanel):
 			if config.conf["braille"]["inputTable"] == "auto":
 				selection = 0
 			else:
-				selection = self.inTables.index(brailleInput.handler.table) + 1
+				selection = self.inTables.index(braille.input.handler.table) + 1
 			self.inTableList.SetSelection(selection)
 		except:  # noqa: E722
 			log.exception()
@@ -5604,9 +5604,9 @@ class BrailleSettingsSubPanel(AutoSettingsMixin, SettingsPanel):
 			braille.handler.table = self.outTableForCurLang
 			config.conf["braille"]["translationTable"] = "auto"
 		if self.inTableList.GetSelection():
-			brailleInput.handler.table = self.inTables[self.inTableList.GetSelection() - 1]
+			braille.input.handler.table = self.inTables[self.inTableList.GetSelection() - 1]
 		else:
-			brailleInput.handler.table = self.inTableForCurLang
+			braille.input.handler.table = self.inTableForCurLang
 			config.conf["braille"]["inputTable"] = "auto"
 		mode = list(BrailleMode)[self.brailleModes.GetSelection()]
 		config.conf["braille"]["mode"] = mode.value

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,7 +1,7 @@
 # A part of NonVisual Desktop Access (NVDA)
-# This file is covered by the GNU General Public License.
-# See the file COPYING for more details.
-# Copyright (C) 2017-2025 NV Access Limited, Babbage B.V., Cyrille Bougot, Leonard de Ruijter
+# Copyright (C) 2017-2026 NV Access Limited, Babbage B.V., Cyrille Bougot, Leonard de Ruijter
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
 
 """NVDA unit testing.
 All unit tests should reside within this package and should be
@@ -126,9 +126,9 @@ import bdDetect  # noqa: E402
 bdDetect.deviceInfoFetcher = bdDetect._DeviceInfoFetcher()
 
 # Braille unit tests also need braille input to be initialized.
-import brailleInput  # noqa: E402
+import braille.input  # noqa: E402
 
-brailleInput.initialize()
+braille.input.initialize()
 
 # Make sure there's no blinking cursor as that relies on wx
 config.conf["braille"]["cursorBlink"] = False

--- a/tests/unit/test_braille/test_publicSurface.py
+++ b/tests/unit/test_braille/test_publicSurface.py
@@ -9,6 +9,7 @@ Splitting braille.py into a package must not drop or hide any symbol that extern
 code (add-ons, drivers, other NVDA modules, tests) reaches as ``braille.X``.
 After the facade rewrite, resident names are directly on the module, deprecated names
 are served via ``__getattr__`` with a log warning.
+The same applies to the ``brailleInput`` module, which became the ``braille.input`` package.
 """
 
 import unittest
@@ -23,12 +24,17 @@ import braille.display.driver
 import braille.display.gesture
 import braille.extensions
 import braille.formatting
+import braille.input
+import braille.input.constants
+import braille.input.gesture
+import braille.input.inputHandler
 import braille.labels
 import braille.regions.base
 import braille.regions.NVDAObject
 import braille.regions.focus
 import braille.regions.properties
 import braille.regions.textInfo
+import brailleInput
 import config.configFlags
 
 
@@ -136,5 +142,56 @@ class TestBraillePublicSurface(unittest.TestCase):
 						actual,
 						expected,
 						f"braille.{name} returned wrong object",
+					)
+					mockLog.warning.assert_called_once()
+
+
+#: Names that live directly on ``braille.input`` and must NOT emit a deprecation warning.
+INPUT_RESIDENT = {"handler", "initialize", "terminate"}
+
+#: Mapping of deprecated ``brailleInput`` name -> the object it should resolve to.
+INPUT_DEPRECATED = {
+	# braille.input
+	"handler": braille.input.handler,
+	"initialize": braille.input.initialize,
+	"terminate": braille.input.terminate,
+	# constants
+	"FALLBACK_TABLE": braille.input.constants.FALLBACK_TABLE,
+	"DOT7": braille.input.constants.DOT7,
+	"DOT8": braille.input.constants.DOT8,
+	"LOUIS_DOTS_IO_START": braille.input.constants.LOUIS_DOTS_IO_START,
+	"UNICODE_BRAILLE_START": braille.input.constants.UNICODE_BRAILLE_START,
+	"UNICODE_BRAILLE_PROTECTED": braille.input.constants.UNICODE_BRAILLE_PROTECTED,
+	# gesture
+	"formatDotNumbers": braille.input.gesture.formatDotNumbers,
+	"BrailleInputGesture": braille.input.gesture.BrailleInputGesture,
+	# inputHandler
+	"BrailleInputHandler": braille.input.inputHandler.BrailleInputHandler,
+	"speakDots": braille.input.inputHandler.speakDots,
+}
+
+
+class TestBrailleInputPublicSurface(unittest.TestCase):
+	def test_residentNamesAccessibleWithoutWarning(self):
+		"""INPUT_RESIDENT names must be reachable via getattr without any deprecation warning."""
+		with patch("logHandler.log") as mockLog:
+			for name in INPUT_RESIDENT:
+				with self.subTest(name=name):
+					self.assertTrue(
+						hasattr(braille.input, name),
+						f"braille.input.{name} missing",
+					)
+			mockLog.warning.assert_not_called()
+
+	def test_deprecatedNamesReturnCorrectObject(self):
+		"""Each deprecated name must resolve to the same object as the new-home import."""
+		for name, expected in INPUT_DEPRECATED.items():
+			with self.subTest(name=name):
+				with patch("logHandler.log") as mockLog:
+					actual = getattr(brailleInput, name)
+					self.assertIs(
+						actual,
+						expected,
+						f"brailleInput.{name} returned wrong object",
 					)
 					mockLog.warning.assert_called_once()


### PR DESCRIPTION
### Link to issue number:

Follow-up of #20509.
Together with #20594 this completes the internal migration off the deprecated `brailleInput` module.

### Summary of the issue:

#20509 moved braille input handling into the `braille.input` package.
The old `brailleInput` module became a backwards compatibility shim that logs a deprecation warning on attribute access.
#20594 migrates the call sites that hit the shim on every event.
The remaining internal consumers touch the shim once per session.
Most braille display drivers reference `brailleInput.BrailleInputGesture` in a class definition, evaluated once at driver import.
`core` calls `brailleInput.initialize` and `terminate` at start, shutdown and configuration reset.
The braille settings panel accesses `brailleInput.handler.table` when opened or saved.
These accesses still log deprecation warnings and keep internal code on a deprecated path.

### Description of user facing changes:

None.

### Description of developer facing changes:

None.
The deprecated `brailleInput` shim is unchanged and keeps serving add-ons.
Unit tests now cover the shim surface.

### Description of development approach:

Migrated the remaining internal consumers to the new import locations.
Braille display drivers now use `braille.input.gesture.BrailleInputGesture` directly.
`core`, `gui.settingsDialogs`, `_remoteClient.input` and the unit test bootstrap import `braille.input`.
Added regression tests to `tests/unit/test_braille/test_publicSurface.py`.
They assert that resident names on `braille.input` do not warn.
They also assert that every deprecated `brailleInput` name warns and resolves to the correct object.

### Testing strategy:

A manual smoke test of NVDA from source with a braille display. Note that this touches several drivers we can't test ourselves, so this needs some Alpha testing too, though the risk is minimal.

### Known issues with pull request:

None.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
