### PR TITLE
Extract shared ICU segment and encoding conversion helpers

### DIFF
--- a/source/textUtils/_wordSeg/wordSegStrategy.py
+++ b/source/textUtils/_wordSeg/wordSegStrategy.py
@@ -25,6 +25,7 @@ import config
 import languageHandler
 import NVDAHelper
 import textUtils
+from textUtils import icu
 from NVDAState import ReadPaths
 from logHandler import log
 
@@ -358,14 +359,9 @@ class IcuWordSegmentationStrategy(WordSegmentationStrategy):
 	"""
 
 	def getSegmentForOffset(self, offset: int) -> tuple[int, int] | None:
-		from textUtils import icu
-
-		if self.encoding == textUtils.WCHAR_ENCODING:
-			return icu.calculateWordOffsets(self.text, offset)
-		# Convert the str offset to a UTF-16 offset for ICU, then convert the result back.
-		offsetConverter = textUtils.WideStringOffsetConverter(self.text)
-		wideOffset = offsetConverter.strToEncodedOffsets(offset, offset)[0]
-		result = icu.calculateWordOffsets(self.text, wideOffset)
-		if result is None:
-			return None
-		return offsetConverter.encodedToStrOffsets(*result)
+		return icu.calculateOffsetsForEncoding(
+			icu.calculateWordOffsets,
+			self.text,
+			offset,
+			self.encoding,
+		)

--- a/source/textUtils/icu.py
+++ b/source/textUtils/icu.py
@@ -9,8 +9,10 @@ Requires Windows 10 version 1703 (Creators Update) or later.
 """
 
 import ctypes
+from collections.abc import Callable
 from contextlib import contextmanager
 
+import textUtils
 import winBindings.icu as icu
 from logHandler import log
 
@@ -42,6 +44,27 @@ def _breakIterator(kind: int, locale: bytes, buf: ctypes.Array[ctypes.c_wchar]):
 		yield bi
 	finally:
 		icu.ubrk_close(bi)
+
+
+def _containingSegment(bi: int, offset: int, textLength: int) -> tuple[int, int]:
+	"""Return the [start, end) ICU segment containing offset for an already-open iterator.
+
+	The iterator is left positioned at start, so callers can keep using it to walk
+	further boundaries.
+
+	:param bi: An open UBreakIterator handle.
+	:param offset: UTF-16 code unit offset within the analyzed text.
+	:param textLength: Number of UTF-16 code units in the analyzed text (used when the
+	    iterator reports UBRK_DONE past the end).
+	:return: (startOffset, endOffset) as UTF-16 code unit indices, endOffset exclusive.
+	"""
+	end = icu.ubrk_following(bi, offset)
+	if end == icu.UBRK_DONE:
+		end = textLength
+	start = icu.ubrk_preceding(bi, end)
+	if start == icu.UBRK_DONE:
+		start = 0
+	return (start, end)
 
 
 def calculateWordOffsets(
@@ -84,15 +107,7 @@ def calculateWordOffsets(
 	try:
 		with _breakIterator(icu.UBRK.WORD, _ROOT_LOCALE, buf) as bi:
 			# Find [start, end) — the ICU segment containing offset.
-			# ICU offsets are UTF-16 code-unit indexed, so anchor on the boundary following
-			# offset and take the boundary preceding that. (ubrk_preceding(offset + 1)
-			# would snap back for multi-unit segments.)
-			end = icu.ubrk_following(bi, offset)
-			if end == icu.UBRK_DONE:
-				end = textLength
-			start = icu.ubrk_preceding(bi, end)
-			if start == icu.UBRK_DONE:
-				start = 0
+			start, end = _containingSegment(bi, offset, textLength)
 
 			# ICU works in word boundaries, i.e. a word always starts and ends at a boundary.
 			# This means that whitespace runs also always start and end at a word boundary.
@@ -130,3 +145,31 @@ def calculateWordOffsets(
 	except RuntimeError:
 		log.debugWarning("ICU word break iterator failed", exc_info=True)
 		return None
+
+
+def calculateOffsetsForEncoding(
+	calculate: Callable[[str, int], tuple[int, int] | None],
+	text: str,
+	offset: int,
+	encoding: str | None,
+) -> tuple[int, int] | None:
+	"""Run one of this module's offset calculations against offsets in the given encoding.
+
+	The calculations are UTF-16 code unit indexed; for any other encoding the offset is
+	converted before the call and the result converted back.
+
+	:param calculate: The calculation to run, e.g. calculateWordOffsets.
+	:param text: The text to segment.
+	:param offset: Offset within text, indexed according to encoding.
+	:param encoding: The encoding offset is indexed by; textUtils.WCHAR_ENCODING for
+	    UTF-16 code units, anything else for str indices.
+	:return: (startOffset, endOffset) indexed according to encoding (endOffset
+	    exclusive), or None if the ICU call failed.
+	"""
+	if encoding == textUtils.WCHAR_ENCODING:
+		return calculate(text, offset)
+	offsetConverter = textUtils.WideStringOffsetConverter(text)
+	result = calculate(text, offsetConverter.strToEncodedOffsets(offset, offset)[0])
+	if result is None:
+		return None
+	return offsetConverter.encodedToStrOffsets(*result)


### PR DESCRIPTION
<!-- PR title: Extract shared ICU segment and encoding conversion helpers -->
<!-- Branch: icuSegHelpers → textUtilsTestPackage -->

### Link to issue number:

Part of #18901.
Depends on #20601.

### Summary of the issue:

ICU-based sentence segmentation is coming in the next PR of this stack. It needs two pieces of logic that already exist, but they are buried inside the word segmentation code. The first piece finds the segment that contains a given offset. The second converts offsets between Python string indices and the UTF-16 indices that ICU works with. Neither piece is specific to words.

### Description of user facing changes:

None.

### Description of developer facing changes:

`textUtils.icu` gains two helpers. `_containingSegment` returns the start and end of the segment containing a given offset. `calculateOffsetsForEncoding` runs a segmentation function and handles the offset conversion around it. `IcuWordSegmentationStrategy.getSegmentForOffset` now uses `calculateOffsetsForEncoding` instead of doing the conversion itself.

### Description of development approach:

This is a refactor without behaviour change. The body of `_containingSegment` is lifted as-is out of `calculateWordOffsets`. The conversion logic in `calculateOffsetsForEncoding` is lifted as-is out of the word segmentation strategy. Word segmentation returns the same results as before. The next PR reuses both helpers for sentences.

### Testing strategy:

Covered by the existing ICU word segmentation and backend comparison unit tests, which are unchanged.

### Known issues with pull request:

None.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
