### PR TITLE
Dispatch browse mode alt+arrow gestures between collapse or expand and sentence navigation

### DIFF
--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -2036,6 +2036,65 @@ class BrowseModeDocumentTreeInterceptor(
 			self.passThrough = False
 		reportPassThrough(self)
 
+	#: States indicating that a control consumes alt+upArrow/alt+downArrow itself,
+	#: to expand/collapse or to cycle through values.
+	_EXPAND_OR_POPUP_STATES = frozenset(
+		{
+			controlTypes.State.COLLAPSED,
+			controlTypes.State.EXPANDED,
+			controlTypes.State.AUTOCOMPLETE,
+			controlTypes.State.HASPOPUP,
+		},
+	)
+
+	def _isExpandableControlAtCaret(self) -> bool:
+		"""Whether the focusable control at the caret should handle alt+up/down itself.
+
+		The object tested is the one :meth:`script_collapseOrExpandControl` acts on.  For
+		plain document content the focusable node is the root object, so this returns
+		``False``.
+
+		:return: ``True`` to collapse/expand the control, ``False`` to navigate by sentence.
+		"""
+		obj = self.currentFocusableNVDAObject
+		if obj is None or obj == self.rootNVDAObject:
+			return False
+		if obj.role in self.ALWAYS_SWITCH_TO_PASS_THROUGH_ROLES:
+			return True
+		return not obj.states.isdisjoint(self._EXPAND_OR_POPUP_STATES)
+
+	def _moveBySentence_scriptHelper(self, gesture: inputCore.InputGesture, direction: int) -> None:
+		"""Dispatch alt+up/down to either collapse/expand or sentence navigation.
+
+		Sentence navigation does nothing in documents whose TextInfo has no sentence support.
+
+		:param gesture: The triggering gesture.
+		:param direction: 1 to move to the next sentence, -1 to move to the previous one.
+		"""
+		if self._isExpandableControlAtCaret():
+			self.script_collapseOrExpandControl(gesture)
+			return
+		try:
+			self._caretMovementScriptHelper(gesture, textInfos.UNIT_SENTENCE, direction)
+		except NotImplementedError:
+			pass
+
+	@script(
+		# Translators: Input help mode message for a command in browse mode.
+		description=_("Moves the caret to the previous sentence and announces it"),
+		resumeSayAllMode=sayAll.CURSOR.CARET,
+	)
+	def script_moveBySentence_back(self, gesture):
+		self._moveBySentence_scriptHelper(gesture, -1)
+
+	@script(
+		# Translators: Input help mode message for a command in browse mode.
+		description=_("Moves the caret to the next sentence and announces it"),
+		resumeSayAllMode=sayAll.CURSOR.CARET,
+	)
+	def script_moveBySentence_forward(self, gesture):
+		self._moveBySentence_scriptHelper(gesture, 1)
+
 	def _tabOverride(self, direction):
 		"""Override the tab order if the virtual  caret is not within the currently focused node.
 		This is done because many nodes are not focusable and it is thus possible for the virtual caret to be unsynchronised with the focus.
@@ -2809,8 +2868,6 @@ class BrowseModeDocumentTreeInterceptor(
 				return
 
 	__gestures = {
-		"kb:alt+upArrow": "collapseOrExpandControl",
-		"kb:alt+downArrow": "collapseOrExpandControl",
 		"kb:tab": "tab",
 		"kb:shift+tab": "shiftTab",
 		"kb:shift+,": "moveToStartOfContainer",

--- a/source/textInfos/offsets.py
+++ b/source/textInfos/offsets.py
@@ -566,9 +566,17 @@ class OffsetsTextInfo(textInfos.TextInfo, metaclass=_OffsetsTextInfoMeta):
 
 		:param offset: The offset of the character within the sentence.
 		:return: A tuple of the start and end offsets of the sentence.
-		:raises NotImplementedError: If ICU is unavailable (Windows older than version 1703)
+		:raises NotImplementedError: If the encoding is neither UTF-16 nor one whose offsets
+		    are str indices, ICU is unavailable (Windows older than version 1703),
 		    or the ICU call fails.
 		"""
+		if not (
+			self.encoding == textUtils.WCHAR_ENCODING
+			or self.encoding is None
+			or self.encoding == "utf_32_le"
+			or self.encoding == textUtils.USER_ANSI_CODE_PAGE
+		):
+			raise NotImplementedError
 		if not ICU_AVAILABLE:
 			raise NotImplementedError
 		paragraphStart, paragraphEnd = self._getParagraphOffsets(offset)

--- a/source/textInfos/offsets.py
+++ b/source/textInfos/offsets.py
@@ -16,8 +16,10 @@ import textInfos
 import locationHelper
 from treeInterceptorHandler import TreeInterceptor
 import textUtils
+from textUtils import icu
 from textUtils.segFlag import CharSegFlag, WordSegFlag
 from textUtils._wordSeg.wordSegmenter import WordSegmenter
+from winBindings.icu import ICU_AVAILABLE
 from dataclasses import dataclass
 from typing import (
 	Any,
@@ -556,13 +558,30 @@ class OffsetsTextInfo(textInfos.TextInfo, metaclass=_OffsetsTextInfoMeta):
 		return [start, end]
 
 	def _getSentenceOffsets(self, offset: int) -> tuple[int, int]:
-		"""
-		Gets the start and end offsets of the sentence containing the given offset.
+		"""Gets the start and end offsets of the sentence containing the given offset.
+
+		Sentences are segmented over the containing paragraph (:meth:`_getParagraphOffsets`)
+		using the Windows built-in ICU BreakIterator (UAX#29), so a sentence can span
+		multiple lines.
+
 		:param offset: The offset of the character within the sentence.
 		:return: A tuple of the start and end offsets of the sentence.
-		:raise NotImplementedError: If the method is not implemented.
+		:raises NotImplementedError: If ICU is unavailable (Windows older than version 1703)
+		    or the ICU call fails.
 		"""
-		raise NotImplementedError
+		if not ICU_AVAILABLE:
+			raise NotImplementedError
+		paragraphStart, paragraphEnd = self._getParagraphOffsets(offset)
+		paragraphText = self._getTextRange(paragraphStart, paragraphEnd)
+		result = icu.calculateOffsetsForEncoding(
+			icu.calculateSentenceOffsets,
+			paragraphText,
+			offset - paragraphStart,
+			self.encoding,
+		)
+		if result is None:
+			raise NotImplementedError
+		return (result[0] + paragraphStart, result[1] + paragraphStart)
 
 	def _getParagraphOffsets(self, offset):
 		return self._getLineOffsets(offset)

--- a/source/textUtils/_wordSeg/wordSegStrategy.py
+++ b/source/textUtils/_wordSeg/wordSegStrategy.py
@@ -25,6 +25,7 @@ import config
 import languageHandler
 import NVDAHelper
 import textUtils
+from textUtils import icu
 from NVDAState import ReadPaths
 from logHandler import log
 
@@ -358,14 +359,9 @@ class IcuWordSegmentationStrategy(WordSegmentationStrategy):
 	"""
 
 	def getSegmentForOffset(self, offset: int) -> tuple[int, int] | None:
-		from textUtils import icu
-
-		if self.encoding == textUtils.WCHAR_ENCODING:
-			return icu.calculateWordOffsets(self.text, offset)
-		# Convert the str offset to a UTF-16 offset for ICU, then convert the result back.
-		offsetConverter = textUtils.WideStringOffsetConverter(self.text)
-		wideOffset = offsetConverter.strToEncodedOffsets(offset, offset)[0]
-		result = icu.calculateWordOffsets(self.text, wideOffset)
-		if result is None:
-			return None
-		return offsetConverter.encodedToStrOffsets(*result)
+		return icu.calculateOffsetsForEncoding(
+			icu.calculateWordOffsets,
+			self.text,
+			offset,
+			self.encoding,
+		)

--- a/source/textUtils/icu.py
+++ b/source/textUtils/icu.py
@@ -17,8 +17,9 @@ import winBindings.icu as icu
 from logHandler import log
 
 _ROOT_LOCALE: bytes = b""
-"""ICU root locale. Word and character segmentation are script-driven, not
-locale-driven (see calculateWordOffsets), so the root locale is always used.
+"""ICU root locale. Word, character and sentence segmentation are script-driven, not
+locale-driven (see calculateWordOffsets and calculateSentenceOffsets), so the root
+locale is always used.
 """
 
 
@@ -144,6 +145,37 @@ def calculateWordOffsets(
 			return (start, end)
 	except RuntimeError:
 		log.debugWarning("ICU word break iterator failed", exc_info=True)
+		return None
+
+
+def calculateSentenceOffsets(
+	text: str,
+	offset: int,
+) -> tuple[int, int] | None:
+	"""Calculate the UTF-16 start and end offsets of the sentence at the given offset.
+
+	Sentence boundaries follow Unicode Standard Annex #29 default rules, driven by the
+	language-neutral Sentence_Break property (STerm/ATerm terminators such as ".", "!",
+	"?" and the ideographic full stop "。"), so the root locale is used.  Abbreviation
+	tailoring, which would keep "Dr." from ending a sentence, is locale-specific and is
+	therefore not applied.  Trailing whitespace and punctuation are attached to the
+	preceding sentence.
+
+	:param text: The paragraph text as a Python str.
+	:param offset: UTF-16 code unit offset within text at which to find the boundary.
+	:return: (startOffset, endOffset) as UTF-16 code unit indices (endOffset exclusive),
+	    or None if the ICU call failed.
+	"""
+	buf = ctypes.create_unicode_buffer(text)
+	textLength = len(buf) - 1
+	if offset >= textLength:
+		return (offset, offset + 1)
+
+	try:
+		with _breakIterator(icu.UBRK.SENTENCE, _ROOT_LOCALE, buf) as bi:
+			return _containingSegment(bi, offset, textLength)
+	except RuntimeError:
+		log.debugWarning("ICU sentence break iterator failed", exc_info=True)
 		return None
 
 

--- a/source/textUtils/icu.py
+++ b/source/textUtils/icu.py
@@ -9,8 +9,10 @@ Requires Windows 10 version 1703 (Creators Update) or later.
 """
 
 import ctypes
+from collections.abc import Callable
 from contextlib import contextmanager
 
+import textUtils
 import winBindings.icu as icu
 from logHandler import log
 
@@ -42,6 +44,27 @@ def _breakIterator(kind: int, locale: bytes, buf: ctypes.Array[ctypes.c_wchar]):
 		yield bi
 	finally:
 		icu.ubrk_close(bi)
+
+
+def _containingSegment(bi: int, offset: int, textLength: int) -> tuple[int, int]:
+	"""Return the [start, end) ICU segment containing offset for an already-open iterator.
+
+	The iterator is left positioned at start, so callers can keep using it to walk
+	further boundaries.
+
+	:param bi: An open UBreakIterator handle.
+	:param offset: UTF-16 code unit offset within the analyzed text.
+	:param textLength: Number of UTF-16 code units in the analyzed text (used when the
+	    iterator reports UBRK_DONE past the end).
+	:return: (startOffset, endOffset) as UTF-16 code unit indices, endOffset exclusive.
+	"""
+	end = icu.ubrk_following(bi, offset)
+	if end == icu.UBRK_DONE:
+		end = textLength
+	start = icu.ubrk_preceding(bi, end)
+	if start == icu.UBRK_DONE:
+		start = 0
+	return (start, end)
 
 
 def calculateWordOffsets(
@@ -84,15 +107,7 @@ def calculateWordOffsets(
 	try:
 		with _breakIterator(icu.UBRK.WORD, _ROOT_LOCALE, buf) as bi:
 			# Find [start, end) — the ICU segment containing offset.
-			# ICU offsets are UTF-16 code-unit indexed, so anchor on the boundary following
-			# offset and take the boundary preceding that. (ubrk_preceding(offset + 1)
-			# would snap back for multi-unit segments.)
-			end = icu.ubrk_following(bi, offset)
-			if end == icu.UBRK_DONE:
-				end = textLength
-			start = icu.ubrk_preceding(bi, end)
-			if start == icu.UBRK_DONE:
-				start = 0
+			start, end = _containingSegment(bi, offset, textLength)
 
 			# ICU works in word boundaries, i.e. a word always starts and ends at a boundary.
 			# This means that whitespace runs also always start and end at a word boundary.
@@ -130,3 +145,31 @@ def calculateWordOffsets(
 	except RuntimeError:
 		log.debugWarning("ICU word break iterator failed", exc_info=True)
 		return None
+
+
+def calculateOffsetsForEncoding(
+	calculate: Callable[[str, int], tuple[int, int] | None],
+	text: str,
+	offset: int,
+	encoding: str | None,
+) -> tuple[int, int] | None:
+	"""Run one of this module's offset calculations against offsets in the given encoding.
+
+	The calculations are UTF-16 code unit indexed; for any other encoding the offset is
+	converted before the call and the result converted back.
+
+	:param calculate: The calculation to run, e.g. calculateWordOffsets.
+	:param text: The text to segment.
+	:param offset: Offset within text, indexed according to encoding.
+	:param encoding: The encoding offset is indexed by; textUtils.WCHAR_ENCODING for
+	    UTF-16 code units, anything else for str indices.
+	:return: (startOffset, endOffset) indexed according to encoding (endOffset
+	    exclusive), or None if the ICU call failed.
+	"""
+	if encoding == textUtils.WCHAR_ENCODING:
+		return calculate(text, offset)
+	offsetConverter = textUtils.WideStringOffsetConverter(text)
+	result = calculate(text, offsetConverter.strToEncodedOffsets(offset, offset)[0])
+	if result is None:
+		return None
+	return offsetConverter.encodedToStrOffsets(*result)

--- a/source/winBindings/icu.py
+++ b/source/winBindings/icu.py
@@ -52,6 +52,9 @@ class UBRK(IntEnum):
 	WORD = 1
 	"""Word breaks."""
 
+	SENTENCE = 3
+	"""Sentence breaks (UAX#29)."""
+
 
 def U_FAILURE(code: int) -> bool:
 	"""Return True if the given UErrorCode indicates an error."""

--- a/tests/unit/test_browseModeSentenceDispatch.py
+++ b/tests/unit/test_browseModeSentenceDispatch.py
@@ -1,0 +1,95 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2026 NV Access Limited, Leonard de Ruijter
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
+
+"""Unit tests for browse mode alt+up/down sentence-vs-collapse/expand dispatch.
+
+Covers ``BrowseModeDocumentTreeInterceptor._isExpandableControlAtCaret``, the discriminator
+that decides whether ``alt+upArrow``/``alt+downArrow`` should collapse/expand a control or
+navigate by sentence.  The method is exercised against a duck-typed ``self``, which avoids
+constructing a tree interceptor and its virtual buffer.
+"""
+
+import unittest
+
+import browseMode
+import controlTypes
+
+
+class _FakeObject:
+	"""A minimal stand-in for an NVDAObject with just a role and states."""
+
+	def __init__(self, role=controlTypes.Role.UNKNOWN, states=frozenset()):
+		self.role = role
+		self.states = states
+
+
+class _FakeInterceptor:
+	"""A duck-typed ``self`` exposing only what ``_isExpandableControlAtCaret`` reads."""
+
+	ALWAYS_SWITCH_TO_PASS_THROUGH_ROLES = (
+		browseMode.BrowseModeDocumentTreeInterceptor.ALWAYS_SWITCH_TO_PASS_THROUGH_ROLES
+	)
+	_EXPAND_OR_POPUP_STATES = browseMode.BrowseModeDocumentTreeInterceptor._EXPAND_OR_POPUP_STATES
+	_isExpandableControlAtCaret = browseMode.BrowseModeDocumentTreeInterceptor._isExpandableControlAtCaret
+
+	def __init__(self, focusable, root):
+		self.currentFocusableNVDAObject = focusable
+		self.rootNVDAObject = root
+
+
+def _check(focusable, root):
+	return _FakeInterceptor(focusable, root)._isExpandableControlAtCaret()
+
+
+class TestIsExpandableControlAtCaret(unittest.TestCase):
+	def setUp(self):
+		# Plain document content: the focusable-node lookup yields the root object.
+		self.root = _FakeObject(role=controlTypes.Role.DOCUMENT)
+
+	def test_plainContent_isRoot(self):
+		"""On plain content the focusable object is the root, so sentence nav is used."""
+		self.assertFalse(_check(self.root, self.root))
+
+	def test_none(self):
+		"""A missing focusable object falls through to sentence nav rather than erroring."""
+		self.assertFalse(_check(None, self.root))
+
+	def test_comboBoxRole(self):
+		"""A combo box keeps collapse/expand regardless of its states."""
+		obj = _FakeObject(role=controlTypes.Role.COMBOBOX)
+		self.assertTrue(_check(obj, self.root))
+
+	def test_arrowConsumingRole(self):
+		"""Other arrow-key-consuming roles (e.g. slider) keep collapse/expand."""
+		obj = _FakeObject(role=controlTypes.Role.SLIDER)
+		self.assertTrue(_check(obj, self.root))
+
+	def test_autocompleteStateWithoutCollapsed(self):
+		"""An editable/autocomplete combo box is caught by AUTOCOMPLETE even without COLLAPSED."""
+		obj = _FakeObject(
+			role=controlTypes.Role.EDITABLETEXT,
+			states={controlTypes.State.EDITABLE, controlTypes.State.AUTOCOMPLETE},
+		)
+		self.assertTrue(_check(obj, self.root))
+
+	def test_collapsedState(self):
+		"""A collapsed control keeps collapse/expand."""
+		obj = _FakeObject(role=controlTypes.Role.BUTTON, states={controlTypes.State.COLLAPSED})
+		self.assertTrue(_check(obj, self.root))
+
+	def test_hasPopupState(self):
+		"""A menu/disclosure button (HASPOPUP) keeps collapse/expand."""
+		obj = _FakeObject(role=controlTypes.Role.BUTTON, states={controlTypes.State.HASPOPUP})
+		self.assertTrue(_check(obj, self.root))
+
+	def test_plainLink_navigatesBySentence(self):
+		"""A focusable link with no relevant role/state falls through to sentence nav."""
+		obj = _FakeObject(role=controlTypes.Role.LINK)
+		self.assertFalse(_check(obj, self.root))
+
+	def test_plainButton_navigatesBySentence(self):
+		"""A plain button (no popup/expand state) falls through to sentence nav."""
+		obj = _FakeObject(role=controlTypes.Role.BUTTON)
+		self.assertFalse(_check(obj, self.root))

--- a/tests/unit/test_textUtils/test_sentenceSegIcu.py
+++ b/tests/unit/test_textUtils/test_sentenceSegIcu.py
@@ -1,0 +1,166 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2026 NV Access Limited, Leonard de Ruijter
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
+
+"""Unit tests for ICU sentence segmentation.
+
+Covers the low-level ``textUtils.icu.calculateSentenceOffsets`` primitive and the
+``OffsetsTextInfo._getSentenceOffsets`` integration, including the iteration/tiling
+invariant that ``move``/``expand`` rely on.  Tests that require ICU are skipped when
+the ICU library is not present on the system.
+"""
+
+import unittest
+from unittest.mock import patch
+
+import textInfos
+from textInfos import offsets as offsetsModule
+from textInfos.offsets import Offsets
+from textUtils import icu
+
+from ..textProvider import BasicTextInfo, BasicTextProvider
+from . import skipIfNoICU
+
+
+class _BlockParagraphTextInfo(BasicTextInfo):
+	"""A TextInfo whose paragraphs are blocks separated by a blank line ("\\n\\n").
+
+	Mimics the block-level bounds VirtualBufferTextInfo._getParagraphOffsets returns,
+	rather than the line splitting BasicTextInfo does.  Test text is ASCII, so str
+	offsets equal UTF-16 offsets.
+	"""
+
+	def _getParagraphOffsets(self, offset):
+		text = self._getStoryText()
+		start = text.rfind("\n\n", 0, offset)
+		start = 0 if start < 0 else start + 2
+		end = text.find("\n\n", offset)
+		end = len(text) if end < 0 else end + 2
+		return (start, end)
+
+
+class _BlockParagraphProvider(BasicTextProvider):
+	TextInfo = _BlockParagraphTextInfo
+
+
+@skipIfNoICU
+class TestCalculateSentenceOffsets(unittest.TestCase):
+	"""Low-level UAX#29 sentence boundary tests (UTF-16 code-unit offsets, root locale)."""
+
+	def test_english_two_sentences(self):
+		"""Trailing space after the terminator is attached to the preceding sentence (UAX#29)."""
+		text = "Hello world. Goodbye now."
+		self.assertEqual(icu.calculateSentenceOffsets(text, 0), (0, 13))
+		# Mid-sentence offsets resolve to the same sentence.
+		self.assertEqual(icu.calculateSentenceOffsets(text, 5), (0, 13))
+		self.assertEqual(icu.calculateSentenceOffsets(text, 12), (0, 13))
+		self.assertEqual(icu.calculateSentenceOffsets(text, 13), (13, 25))
+
+	def test_japanese_ideographic_full_stop(self):
+		"""U+3002 (。) is Sentence_Break=STerm, so Japanese segments without a locale."""
+		text = "これは日本語です。次の文です。"
+		self.assertEqual(icu.calculateSentenceOffsets(text, 0), (0, 9))
+		self.assertEqual(icu.calculateSentenceOffsets(text, 9), (9, 15))
+
+	def test_abbreviation_splits_under_root_locale(self):
+		"""Under the root locale, which has no abbreviation tailoring, "Dr." ends a sentence."""
+		text = "Dr. Smith went home."
+		self.assertEqual(icu.calculateSentenceOffsets(text, 0), (0, 4))
+		self.assertEqual(icu.calculateSentenceOffsets(text, 4), (4, 20))
+
+	def test_surrogate_pair_offsets(self):
+		"""Offsets are UTF-16 code-unit indexed; a surrogate pair counts as two units."""
+		# H i sp [🤦 = 2 units] sp t h e r e . sp B y e sp n o w .
+		text = "Hi \U0001f926 there. Bye now."
+		# First sentence spans the surrogate pair and ends after the space at UTF-16 offset 13.
+		self.assertEqual(icu.calculateSentenceOffsets(text, 0), (0, 13))
+		# An offset inside the surrogate pair still resolves to the containing sentence.
+		self.assertEqual(icu.calculateSentenceOffsets(text, 4), (0, 13))
+		self.assertEqual(icu.calculateSentenceOffsets(text, 13), (13, 21))
+
+	def test_offset_past_end_fast_path(self):
+		"""An offset at/past the end returns a single-unit span (matches word behaviour)."""
+		self.assertEqual(icu.calculateSentenceOffsets("abc", 5), (5, 6))
+
+	def test_offset_containment(self):
+		"""For every in-range offset, start <= offset < end (the tiling precondition)."""
+		text = "One. Two! Three? Four."
+		length = len(text.encode("utf-16-le")) // 2
+		for offset in range(length):
+			start, end = icu.calculateSentenceOffsets(text, offset)
+			self.assertTrue(
+				start <= offset < end,
+				f"offset {offset} not contained in ({start}, {end}) for {text!r}",
+			)
+
+
+@skipIfNoICU
+class TestSentenceIterationTiling(unittest.TestCase):
+	"""The iteration invariant: move(UNIT_SENTENCE) walks sentences gap-free without stalling."""
+
+	def _collectSentences(self, obj, length: int, direction: int) -> list[tuple[int, int]]:
+		"""Enumerate sentence spans by expanding then moving in ``direction`` until the walk stops.
+
+		:param obj: A text provider to navigate.
+		:param length: UTF-16 length of the story text (bounds the loop and seeds the reverse walk).
+		:param direction: 1 to walk forward from the start, -1 to walk backward from the end.
+		:return: Sentence spans in document order (the backward walk is reversed before returning).
+		"""
+		startPos = 0 if direction > 0 else max(0, length - 1)
+		info = obj.makeTextInfo(Offsets(startPos, startPos))
+		info.expand(textInfos.UNIT_SENTENCE)
+		spans = []
+		# The loop is bounded so that a stalled walk fails rather than hangs.
+		for _ in range(length + 2):
+			spans.append((info._startOffset, info._endOffset))
+			if info.move(textInfos.UNIT_SENTENCE, direction) == 0:
+				break
+			info.expand(textInfos.UNIT_SENTENCE)
+		if direction < 0:
+			spans.reverse()
+		return spans
+
+	def _assertTiles(self, spans: list[tuple[int, int]], length: int):
+		"""Assert the spans tile [0, length) gap-free, in order, with no overlaps."""
+		self.assertEqual(spans[0][0], 0, f"first sentence does not start at 0: {spans}")
+		self.assertEqual(spans[-1][1], length, f"last sentence does not reach {length}: {spans}")
+		for (_, prevEnd), (nextStart, _) in zip(spans, spans[1:]):
+			self.assertEqual(prevEnd, nextStart, f"gap/overlap between sentences: {spans}")
+
+	def test_single_paragraph_tiles_both_directions(self):
+		text = "Hello world. Goodbye now. The third one."
+		length = len(text)  # all-ASCII, so str length == UTF-16 length
+		obj = BasicTextProvider(text=text)
+		forward = self._collectSentences(obj, length, 1)
+		self._assertTiles(forward, length)
+		# Three terminators => three sentences.
+		self.assertEqual(len(forward), 3)
+		# Backward navigation (alt+upArrow) visits the same sentences in the same order.
+		backward = self._collectSentences(obj, length, -1)
+		self.assertEqual(backward, forward)
+
+	def test_crosses_block_paragraph_boundary_both_directions(self):
+		"""With block-paragraph semantics, the walk crosses the blank-line boundary."""
+		text = "One. Two.\n\nThree. Four."
+		length = len(text)
+		blockStart = text.index("\n\n") + 2  # start of the second block paragraph
+		obj = _BlockParagraphProvider(text=text)
+		forward = self._collectSentences(obj, length, 1)
+		self._assertTiles(forward, length)
+		# A sentence boundary lands exactly on the second paragraph's start (the walk crossed).
+		self.assertIn(blockStart, [start for start, _ in forward])
+		backward = self._collectSentences(obj, length, -1)
+		self.assertEqual(backward, forward)
+		self.assertIn(blockStart, [start for start, _ in backward])
+
+
+class TestSentenceOffsetsWithoutIcu(unittest.TestCase):
+	"""When ICU is unavailable, _getSentenceOffsets degrades to NotImplementedError."""
+
+	def test_not_implemented_when_icu_unavailable(self):
+		obj = BasicTextProvider(text="Hello world. Goodbye now.")
+		info = obj.makeTextInfo(Offsets(0, 0))
+		with patch.object(offsetsModule, "ICU_AVAILABLE", False):
+			with self.assertRaises(NotImplementedError):
+				info._getSentenceOffsets(0)

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -9,6 +9,7 @@
   * A Word Segmentation Standard setting was added to the "Document Navigation" panel. (#18735, @CrazySteve0605, @Cary-rowen)
   * Word segmentation can also use the Windows built-in ICU library for boundary detection, improving navigation for Japanese and emoji. (#20343, #20494, @LeonarddeR)
   * By default, ICU is preferred over the legacy Windows segmentation wherever available, while Chinese word segmentation takes precedence for Chinese text.
+* Sentence navigation (`alt+upArrow` and `alt+downArrow`) now works in browse mode and other documents, using the Windows built-in ICU library for Unicode-aware sentence boundary detection. Previously it was only supported in Microsoft Word and Outlook. (#18901, @LeonarddeR)
 * Braille output for Chinese now includes spaces between words. (#18865, @CrazySteve0605, @Cary-rowen)
 * Added sequential two-flick touch gestures that combine two flicks performed in quick succession into a single gesture, increasing the number of touch gestures that can be bound to scripts. (#19938, @kefaslungu)
   * Twelve combinations are recognised: opposite-direction pairs (e.g. flick right then flick left) and perpendicular L-shaped pairs (e.g. flick right then flick up).

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -787,8 +787,8 @@ NVDA provides the following key commands in relation to the system caret:
 |Report language |none |none |Reports text language. Pressing twice shows the information in a window|
 |Report link destination |`NVDA+k` |`NVDA+k` |Pressing once speaks the destination URL of the link at the current caret or focus position. Pressing twice shows it in a window for more careful review|
 |Report caret location |NVDA+numpadDelete |NVDA+delete |Reports information about the location of the text or object at the position of system caret. For example, this might include the percentage through the document, the distance from the edge of the page or the exact screen position. Pressing twice may provide further detail.|
-|Next sentence |alt+downArrow |alt+downArrow |Moves the caret to the next sentence and announces it. (only supported in Microsoft Word and Outlook)|
-|Previous sentence |alt+upArrow |alt+upArrow |Moves the caret to the previous sentence and announces it. (only supported in Microsoft Word and Outlook)|
+|Next sentence |alt+downArrow |alt+downArrow |Moves the caret to the next sentence and announces it. (supported in browse mode and in Microsoft Word and Outlook)|
+|Previous sentence |alt+upArrow |alt+upArrow |Moves the caret to the previous sentence and announces it. (supported in browse mode and in Microsoft Word and Outlook)|
 
 When within a table, the following key commands are also available:
 


### PR DESCRIPTION
<!-- PR title: Dispatch browse mode alt+arrow gestures between collapse or expand and sentence navigation -->
<!-- Branch: browseModeSentenceNav → sentenceSegIcu -->

### Link to issue number:

Closes #18901.
Depends on #20603.

### Summary of the issue:

NVDA binds `alt+upArrow` and `alt+downArrow` to sentence navigation commands. Browse mode inherits these commands from the cursor manager. Browse mode also bound the same keys to the command that collapses or expands the current control. Bindings from more derived classes win, so the collapse or expand binding shadowed the sentence commands. Sentence navigation was therefore unreachable in browse mode, even with the working backend from the previous PR in this stack.

### Description of user facing changes:

In browse mode, `alt+upArrow` and `alt+downArrow` now move the caret by sentence in document content. Controls that use these keys themselves keep the old behaviour: they still collapse or expand. This covers comboboxes and other controls that are collapsed, expanded, have a popup, or offer autocompletion. Input help now describes the sentence commands. The user guide no longer limits sentence navigation to Word and Outlook. A changelog entry is added.

### Description of developer facing changes:

`BrowseModeDocumentTreeInterceptor` overrides the sentence scripts with `script_moveBySentence_back` and `script_moveBySentence_forward`. A new helper, `_isExpandableControlAtCaret`, decides which behaviour applies. The two static gesture bindings to `collapseOrExpandControl` are removed.

### Description of development approach:

The keys are no longer bound to one fixed command. Instead, the sentence scripts decide per key press which action applies. The decision looks at the focusable control at the caret. That is the same object the collapse or expand script acts on. If that control takes these keys itself, the script collapses or expands it. Otherwise the caret moves by sentence. In documents without sentence support, the keys do nothing instead of raising an error. The SentenceNav add-on resolves the same conflict in the same way.

### Testing strategy:

New unit tests cover the decision helper. Controls such as comboboxes, sliders, autocomplete fields, and collapsed controls keep collapse or expand. Plain content, links, and buttons fall through to sentence navigation. The binding order was also checked to confirm the sentence scripts now receive the keys. Manual verification in Firefox and Chrome browse mode confirmed that plain text moves by sentence and that comboboxes still collapse or expand.

### Known issues with pull request:

Sentence navigation is still unavailable in documents that do not use offsets-based TextInfos, such as UIA-based browse mode documents and edit controls.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
