### PR TITLE
Update Python to 3.13.15

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -42,7 +42,7 @@ jobs:
       uses: actions/setup-python@v6
       with:
         # Keep in sync with defaultPythonVersion in testAndPublish.yml.
-        python-version: '3.13.13'
+        python-version: '3.13.14'
     - name: Install the latest version of uv
       uses: astral-sh/setup-uv@v7
       with:

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -42,7 +42,7 @@ jobs:
       uses: actions/setup-python@v6
       with:
         # Keep in sync with defaultPythonVersion in testAndPublish.yml.
-        python-version: '3.13.13'
+        python-version: '3.13.15'
     - name: Install the latest version of uv
       uses: astral-sh/setup-uv@v7
       with:

--- a/.github/workflows/fetch-crowdin-translations.yml
+++ b/.github/workflows/fetch-crowdin-translations.yml
@@ -46,7 +46,7 @@ jobs:
     - name: Set up python
       uses: actions/setup-python@v7
       with:
-        python-version: '3.13.13'
+        python-version: '3.13.15'
         architecture: 'x64'
 
     - name: setup uv

--- a/.github/workflows/fetch-crowdin-translations.yml
+++ b/.github/workflows/fetch-crowdin-translations.yml
@@ -46,7 +46,7 @@ jobs:
     - name: Set up python
       uses: actions/setup-python@v7
       with:
-        python-version: '3.13.13'
+        python-version: '3.13.14'
         architecture: 'x64'
 
     - name: setup uv

--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -35,8 +35,8 @@ env:
   supportedRunners: '["windows-2022", "windows-2025-vs2026"]'
   defaultArch: x64
   supportedArchitectures: '["x64"]'
-  defaultPythonVersion: '3.13.13'
-  supportedPythonVersions: '["3.13.13"]'
+  defaultPythonVersion: '3.13.14'
+  supportedPythonVersions: '["3.13.14"]'
 
 jobs:
   matrix:

--- a/.github/workflows/testAndPublish.yml
+++ b/.github/workflows/testAndPublish.yml
@@ -35,8 +35,8 @@ env:
   supportedRunners: '["windows-2022", "windows-2025-vs2026"]'
   defaultArch: x64
   supportedArchitectures: '["x64"]'
-  defaultPythonVersion: '3.13.13'
-  supportedPythonVersions: '["3.13.13"]'
+  defaultPythonVersion: '3.13.15'
+  supportedPythonVersions: '["3.13.15"]'
 
 jobs:
   matrix:

--- a/.python-versions
+++ b/.python-versions
@@ -1,1 +1,1 @@
-cpython-3.13.13-windows-x86_64-none
+cpython-3.13.14-windows-x86_64-none

--- a/.python-versions
+++ b/.python-versions
@@ -1,1 +1,1 @@
-cpython-3.13.13-windows-x86_64-none
+cpython-3.13.15-windows-x86_64-none

--- a/projectDocs/dev/createDevEnvironment.md
+++ b/projectDocs/dev/createDevEnvironment.md
@@ -49,7 +49,7 @@ The following dependencies need to be installed on your system:
 
 #### Python
 
-[Python](https://www.python.org/), version 3.13.13, 64-bit.
+[Python](https://www.python.org/), version 3.13.14, 64-bit.
 Install the python version listed in [.python-versions](../../.python-versions)
 
 #### uv

--- a/projectDocs/dev/createDevEnvironment.md
+++ b/projectDocs/dev/createDevEnvironment.md
@@ -49,7 +49,7 @@ The following dependencies need to be installed on your system:
 
 #### Python
 
-[Python](https://www.python.org/), version 3.13.13, 64-bit.
+[Python](https://www.python.org/), version 3.13.15, 64-bit.
 Install the python version listed in [.python-versions](../../.python-versions)
 
 #### uv

--- a/runtime-builders/synthDriverHost32/.python-version
+++ b/runtime-builders/synthDriverHost32/.python-version
@@ -1,1 +1,1 @@
-cpython-3.13.13-windows-x86-none
+cpython-3.13.14-windows-x86-none

--- a/runtime-builders/synthDriverHost32/.python-version
+++ b/runtime-builders/synthDriverHost32/.python-version
@@ -1,1 +1,1 @@
-cpython-3.13.13-windows-x86-none
+cpython-3.13.15-windows-x86-none

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -103,6 +103,7 @@ The default implementation forwards to `interactWithMathMl`, preserving compatib
 Built on top of [Bleak](https://bleak.readthedocs.io/) and the `_asyncioEventLoop` module. (#19838, @bramd)
 * Component updates:
   * Updated py2exe to 0.14.1.1. (#20260, @LeonarddeR)
+  * Python to 3.13.14. (#20606, @dpy013)
 * Handlers registered on an `extensionPoints` registrar (`Action`, `Filter`, `Decider`, `AccumulatingDecider`, `Chain`) may now register or unregister handlers while being called, without raising `RuntimeError: OrderedDict mutated during iteration`. (#20545, @LeonarddeR)
   * `HandlerRegistrar.handlers` now iterates over a snapshot of the registered handlers taken before the first handler is yielded.
 * `languageHandler.windowsLCIDToLocaleName` no longer consults `locale.windows_locale`, which is unmaintained, incomplete and changes between Python patch releases. (#20589, @LeonarddeR)

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -110,6 +110,7 @@ The default implementation forwards to `interactWithMathMl`, preserving compatib
 Built on top of [Bleak](https://bleak.readthedocs.io/) and the `_asyncioEventLoop` module. (#19838, @bramd)
 * Component updates:
   * Updated py2exe to 0.14.1.1. (#20260, @LeonarddeR)
+  * Python to 3.13.15. (#20606, @dpy013)
 * Handlers registered on an `extensionPoints` registrar (`Action`, `Filter`, `Decider`, `AccumulatingDecider`, `Chain`) may now register or unregister handlers while being called, without raising `RuntimeError: OrderedDict mutated during iteration`. (#20545, @LeonarddeR)
   * `HandlerRegistrar.handlers` now iterates over a snapshot of the registered handlers taken before the first handler is yielded.
 * `languageHandler.windowsLCIDToLocaleName` no longer consults `locale.windows_locale`, which is unmaintained, incomplete and changes between Python patch releases. (#20589, @LeonarddeR)


### PR DESCRIPTION
### Link to issue number:

Follow on #20589, reopen #20476.

### Summary of the issue:

NVDA is currently built and tested with Python 3.13.14. Update the supported Python patch release to Python 3.13.15.

### Description of user facing changes:

None.

### Description of developer facing changes:

- Update the Python version from 3.13.14 to 3.13.15 for local development, CI, and the 32-bit synth driver runtime builder.
- Update the development environment documentation to reference Python 3.13.15.
- Update the existing change log entry to record Python 3.13.15.

### Description of development approach:

Update every current NVDA Python version pin consistently:

- `.python-versions`
- `runtime-builders/synthDriverHost32/.python-version`
- GitHub Actions workflows
- `projectDocs/dev/createDevEnvironment.md`
- `user_docs/en/changes.md`

The separate `miscDeps` Python version was intentionally left unchanged because it belongs to its independent build environment.

### Testing strategy:

- Confirmed all current NVDA Python version pins use Python 3.13.15.
- Confirmed the CI workflow's default and supported Python versions match.
- Ran `git diff --check`.
- CI validates the build and test workflows using Python 3.13.15.

### Known issues with pull request:

None known.

### Code Review Checklist:


- [x] Documentation:
  - Change log entry
  - Developer / Technical Documentation
  - User Documentation: Not applicable; no user-facing behavior changes.
  - Context sensitive help for GUI changes: Not applicable; no GUI changes.
- [x] Testing:
  - Unit tests: Not applicable; configuration-only change.
  - System (end to end) tests: Not run locally; covered by CI.
  - Manual testing: Verified version pins and ran `git diff --check`.
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
  - No user-facing changes.
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.