### PR TITLE
Fix broken link to pull request template in dev docs

### DIFF
--- a/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
+++ b/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
@@ -91,7 +91,7 @@ For instance, "Will not work with UIA enabled in advanced settings".
 ## Code Review Checklist
 
 Code must be reviewed (via a Pull Request on GitHub) before it can be accepted into the project.
-The [Pull Request template](.github/PULL_REQUEST_TEMPLATE.md) asks authors (and reviewers) to consider several aspects of the change.
+The [Pull Request template](../../.github/PULL_REQUEST_TEMPLATE.md) asks authors (and reviewers) to consider several aspects of the change.
 
 The aim of this checklist is to ensure each item has been considered by both the author and the reviewer.
 Hopefully it helps to prevent items being forgotten.


### PR DESCRIPTION
### Link to issue number:
N/A

### Summary of the issue:
The link "Pull Request template" in the Code Review Checklist section of `projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md` points to `.github/PULL_REQUEST_TEMPLATE.md` as a relative path. From the file's location in `projectDocs/dev/`, GitHub resolves it to `projectDocs/dev/.github/PULL_REQUEST_TEMPLATE.md`, which does not exist, resulting in a 404 when clicked.

### Description of user facing changes:
N/A

### Description of developer facing changes:
Developers reading the PR explanation document can now reach the pull request template from the Code Review Checklist section without hitting a broken link.

### Description of development approach:
Changed the relative link from `.github/PULL_REQUEST_TEMPLATE.md` to `../../.github/PULL_REQUEST_TEMPLATE.md`. Each `../` moves up one directory level; from `projectDocs/dev/`, `../../` reaches the repository root, so the link now resolves to the existing `.github/PULL_REQUEST_TEMPLATE.md`.

### Testing strategy:
Verified on the rendered GitHub page that the link now resolves to the existing `.github/PULL_REQUEST_TEMPLATE.md` at the repository root (HTTP 200).

### Known issues with pull request:
N/A

### Code Review Checklist:

- [X] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [ ] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [ ] API is compatible with existing add-ons.
- [ ] Security precautions taken.
