### PR TITLE
Compile NVDAHelper sources as UTF-8

### DIFF
--- a/nvdaHelper/archBuild_sconscript
+++ b/nvdaHelper/archBuild_sconscript
@@ -155,6 +155,7 @@ env.Append(
 	CCFLAGS=[
 		"/std:c++20",
 		"/permissive-",
+		"/utf-8",
 		# '/showIncludes': Useful to understand which file causes some other file to be included.
 		# It will output a list of the include files.
 		# The option also displays nested include files, that is, the files

--- a/nvdaHelper/readme.md
+++ b/nvdaHelper/readme.md
@@ -87,7 +87,7 @@ You should still build on the command line to verify errors.
   * In the project menu, select Properties
   * Select "Configuration:" `All Configurations`
   * Under "Configuration Properties" select NMake
-  * Set additional Options -> `/std:c++20`
+  * Set additional Options -> `/std:c++20 /utf-8`
 
 ### To confirm these settings
 
@@ -97,7 +97,7 @@ You should still build on the command line to verify errors.
 
   ```
   cl /Fobuild\x86\vbufBackends\gecko_ia2\gecko_ia2.obj /c build\x86\vbufBackends\gecko_ia2\gecko_ia2.cpp
-  /TP /EHsc /nologo /std:c++20 /permissive- /Od /MT /W3 /WX
+  /TP /EHsc /nologo /std:c++20 /permissive- /utf-8 /Od /MT /W3 /WX
   /DUNICODE /D_CRT_SECURE_NO_DEPRECATE /DLOGLEVEL=15 /D_WIN32_WINNT=_WIN32_WINNT_WIN10 /DNOMINMAX /DNDEBUG
   /Iinclude /Imiscdeps\include /Ibuild\x86
   /Z7
@@ -106,7 +106,7 @@ You should still build on the command line to verify errors.
 * This shows the:
   * defines beginning with `/D`
   * includes directories beginning with `/I`
-  * Additional options like `/std:c++20`
+  * Additional options like `/std:c++20` and `/utf-8`
 
 ## Compiling NVDAHelper with Debugging Options
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -76,6 +76,7 @@ Previously these keys had no function when pressed on their own. (#20366, @fla-r
 
 Please refer to [the developer guide](https://download.nvaccess.org/documentation/developerGuide.html#API) for information on NVDA's API deprecation and removal process.
 
+* NVDAHelper sources are now compiled with MSVC's `/utf-8` option, ensuring source files are interpreted consistently across Windows locales. (#20584, @noor-ahmadi)
 * `mathPres.interactWithMathMl` now accepts an optional `sourceObj` argument.
 Math presentation providers can override `MathPresentationProvider.interactWithMathMlFromSource` to use the source object when starting interaction.
 The default implementation forwards to `interactWithMathMl`, preserving compatibility with existing providers. (#20372, @RyanMcCleary)


### PR DESCRIPTION
### Link to issue number:
Closes #20584

### Summary of the issue:
MSVC can read NVDAHelper's UTF-8 sources using the active ANSI code page. On systems where that code page is not UTF-8, cppjieba headers can produce C++ syntax errors.

### Description of user facing changes:
No user-facing changes.

### Description of developer facing changes:
NVDAHelper and its third-party sources are now interpreted as UTF-8 consistently across Windows locales.

### Description of development approach:
Added `/utf-8` to the common NVDAHelper `CCFLAGS` before `thirdPartyEnv` is cloned. Updated the NVDAHelper build instructions and developer changelog to match.

### Testing strategy:
- `prek run check-ast --files nvdaHelper/archBuild_sconscript`
- `prek run ruff --files nvdaHelper/archBuild_sconscript`
- `prek run ruff-format --files nvdaHelper/archBuild_sconscript`
- `prek run markdownlint-cli2 --files nvdaHelper/readme.md user_docs/en/changes.md`
- Confirmed `/utf-8` appears once in the shared flags before `thirdPartyEnv` is cloned.

The NVDAHelper build and full unit suite were not run locally because Microsoft C++ Build Tools are unavailable in this environment. No unit test was added because this change only affects the compiler invocation.

### Known issues with pull request:
None known.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.