### PR TITLE
Add cache request support to the UIA remote ops framework

### DIFF
--- a/nvdaHelper/UIARemote/lowLevel.cpp
+++ b/nvdaHelper/UIARemote/lowLevel.cpp
@@ -1,3 +1,8 @@
+// A part of NonVisual Desktop Access (NVDA)
+// Copyright (C) 2023-2026 NV Access Limited, Leonard de Ruijter
+// This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+// For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
+
 #include <uiAutomationClient.h>
 #include <winrt/windows.foundation.h>
 #include <winrt/windows.foundation.collections.h>
@@ -139,6 +144,22 @@ HRESULT IInspectableToVariant(winrt::Windows::Foundation::IInspectable result, V
 			case PropertyType::Int32:
 				arg_pVariant->vt = VT_I4;
 				arg_pVariant->lVal = propVal.GetInt32();
+				break;
+			case PropertyType::UInt32:
+				arg_pVariant->vt = VT_UI4;
+				arg_pVariant->ulVal = propVal.GetUInt32();
+				break;
+			case PropertyType::Int64:
+				arg_pVariant->vt = VT_I8;
+				arg_pVariant->llVal = propVal.GetInt64();
+				break;
+			case PropertyType::Single:
+				arg_pVariant->vt = VT_R4;
+				arg_pVariant->fltVal = propVal.GetSingle();
+				break;
+			case PropertyType::Double:
+				arg_pVariant->vt = VT_R8;
+				arg_pVariant->dblVal = propVal.GetDouble();
 				break;
 			case PropertyType::String:
 				arg_pVariant->vt = VT_BSTR;

--- a/nvdaHelper/UIARemote/lowLevel.cpp
+++ b/nvdaHelper/UIARemote/lowLevel.cpp
@@ -1,7 +1,9 @@
-// A part of NonVisual Desktop Access (NVDA)
-// Copyright (C) 2023-2026 NV Access Limited, Leonard de Ruijter
-// This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
-// For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
+/*
+A part of NonVisual Desktop Access (NVDA)
+Copyright (C) 2023-2026 NV Access Limited, Leonard de Ruijter
+This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
+*/
 
 #include <uiAutomationClient.h>
 #include <winrt/windows.foundation.h>

--- a/source/UIAHandler/_remoteOps/instructions/__init__.py
+++ b/source/UIAHandler/_remoteOps/instructions/__init__.py
@@ -41,6 +41,13 @@ from .bool import (
 	BoolAnd,
 	BoolOr,
 )
+from .cacheRequest import (
+	NewCacheRequest,
+	IsCacheRequest,
+	CacheRequestAddProperty,
+	CacheRequestAddPattern,
+	PopulateCache,
+)
 from .controlFlow import (
 	Halt,
 	Fork,
@@ -67,6 +74,7 @@ from .float import (
 )
 from .general import (
 	Set,
+	IsNotSupported,
 	Compare,
 )
 from .guid import (

--- a/source/UIAHandler/_remoteOps/instructions/cacheRequest.py
+++ b/source/UIAHandler/_remoteOps/instructions/cacheRequest.py
@@ -1,0 +1,81 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2026 NV Access Limited, Leonard de Ruijter
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
+
+"""
+This module contains the instructions that operate on UIA cache requests.
+Including to create a cache request, add properties and patterns to it,
+and populate the cache of a UI Automation element from it.
+"""
+
+from __future__ import annotations
+from typing import cast
+from dataclasses import dataclass
+from ctypes import POINTER
+import UIAHandler
+from UIAHandler import UIA
+from .. import lowLevel
+from .. import builder
+from ._base import _TypedInstruction
+
+
+@dataclass
+class NewCacheRequest(_TypedInstruction):
+	opCode = lowLevel.InstructionType.NewCacheRequest
+	result: builder.Operand
+
+	def localExecute(self, registers: dict[lowLevel.OperandId, object]):
+		if not UIAHandler.handler:
+			raise RuntimeError("UIAHandler not initialized")
+		client = cast(UIA.IUIAutomation, UIAHandler.handler.clientObject)
+		registers[self.result.operandId] = client.CreateCacheRequest()
+
+
+@dataclass
+class IsCacheRequest(_TypedInstruction):
+	opCode = lowLevel.InstructionType.IsCacheRequest
+	result: builder.Operand
+	target: builder.Operand
+
+	def localExecute(self, registers: dict[lowLevel.OperandId, object]):
+		registers[self.result.operandId] = isinstance(
+			registers[self.target.operandId],
+			POINTER(UIA.IUIAutomationCacheRequest),
+		)
+
+
+@dataclass
+class CacheRequestAddProperty(_TypedInstruction):
+	opCode = lowLevel.InstructionType.CacheRequestAddProperty
+	target: builder.Operand
+	propertyId: builder.Operand
+
+	def localExecute(self, registers: dict[lowLevel.OperandId, object]):
+		cacheRequest = cast(UIA.IUIAutomationCacheRequest, registers[self.target.operandId])
+		propertyId = cast(int, registers[self.propertyId.operandId])
+		cacheRequest.AddProperty(propertyId)
+
+
+@dataclass
+class CacheRequestAddPattern(_TypedInstruction):
+	opCode = lowLevel.InstructionType.CacheRequestAddPattern
+	target: builder.Operand
+	patternId: builder.Operand
+
+	def localExecute(self, registers: dict[lowLevel.OperandId, object]):
+		cacheRequest = cast(UIA.IUIAutomationCacheRequest, registers[self.target.operandId])
+		patternId = cast(int, registers[self.patternId.operandId])
+		cacheRequest.AddPattern(patternId)
+
+
+@dataclass
+class PopulateCache(_TypedInstruction):
+	opCode = lowLevel.InstructionType.PopulateCache
+	target: builder.Operand
+	cacheRequest: builder.Operand
+
+	def localExecute(self, registers: dict[lowLevel.OperandId, object]):
+		element = cast(UIA.IUIAutomationElement, registers[self.target.operandId])
+		cacheRequest = cast(UIA.IUIAutomationCacheRequest, registers[self.cacheRequest.operandId])
+		registers[self.target.operandId] = element.BuildUpdatedCache(cacheRequest)

--- a/source/UIAHandler/_remoteOps/instructions/general.py
+++ b/source/UIAHandler/_remoteOps/instructions/general.py
@@ -10,6 +10,7 @@ Including to set a value, or compare two values.
 
 from __future__ import annotations
 from dataclasses import dataclass
+import UIAHandler
 from .. import lowLevel
 from .. import builder
 from ._base import _TypedInstruction
@@ -24,6 +25,20 @@ class Set(_TypedInstruction):
 	def localExecute(self, registers: dict[lowLevel.OperandId, object]):
 		value = registers[self.value.operandId]
 		registers[self.target.operandId] = value
+
+
+@dataclass
+class IsNotSupported(_TypedInstruction):
+	opCode = lowLevel.InstructionType.IsNotSupported
+	result: builder.Operand
+	target: builder.Operand
+
+	def localExecute(self, registers: dict[lowLevel.OperandId, object]):
+		if not UIAHandler.handler:
+			raise RuntimeError("UIAHandler not initialized")
+		registers[self.result.operandId] = (
+			registers[self.target.operandId] == UIAHandler.handler.reservedNotSupportedValue
+		)
 
 
 @dataclass

--- a/source/UIAHandler/_remoteOps/lowLevel.py
+++ b/source/UIAHandler/_remoteOps/lowLevel.py
@@ -364,6 +364,12 @@ PropertyId = enum.IntEnum(
 )
 
 
+PatternId = enum.IntEnum(
+	"PatternId",
+	{k[4:-9]: v for k, v in vars(UIA).items() if k.endswith("PatternId")},
+)
+
+
 AttributeId = enum.IntEnum(
 	"AttributeId",
 	{k[4:-11]: v for k, v in vars(UIA).items() if k.endswith("AttributeId")},

--- a/source/UIAHandler/_remoteOps/readme.md
+++ b/source/UIAHandler/_remoteOps/readme.md
@@ -323,8 +323,7 @@ Note that a cache populated this way stores default values for properties the el
 The reserved "not supported" value that a locally built cache returns for such properties is not preserved:
 reads through `getCachedPropertyValueEx` behave as if `ignoreDefault` was not set.
 To determine whether an element supports a pattern, cache the corresponding `IsXPatternAvailable` property instead.
-Alternatively, fetch the property explicitly with `getPropertyValue` and `ignoreDefault` set,
-and test the result inside the operation with `isNotSupported` on the returned variant.
+Alternatively, fetch the property explicitly with `getPropertyValue` and `ignoreDefault` set, and test the result inside the operation with `isNotSupported` on the returned variant.
 
 ### UI Automation text ranges
 

--- a/source/UIAHandler/_remoteOps/readme.md
+++ b/source/UIAHandler/_remoteOps/readme.md
@@ -288,6 +288,44 @@ element.set(parent)
 
 This is useful when walking the element tree in a loop.
 
+### UIA cache requests
+
+#### Declaring a cache request
+
+To create a new remote cache request, call `ra.newCacheRequest`:
+
+```py
+cacheRequest = ra.newCacheRequest()
+```
+
+#### Adding properties and patterns
+
+To choose what the cache request will cache, use `addProperty` and `addPattern`:
+
+```py
+cacheRequest.addProperty(UIA_NamePropertyId)
+cacheRequest.addProperty(UIA_ControlTypePropertyId)
+cacheRequest.addPattern(UIA_TextPatternId)
+```
+
+#### Populating the cache of an element
+
+To populate the cache of a remote element from the cache request, call the element's `populateCache` method:
+
+```py
+element.populateCache(cacheRequest)
+```
+
+When such an element is later returned or yielded from the operation, the received `IUIAutomationElement` carries the populated cache.
+Its cached property and pattern getters, such as `getCachedPropertyValue`, can then be used without further cross-process calls.
+
+Note that a cache populated this way stores default values for properties the element does not support.
+The reserved "not supported" value that a locally built cache returns for such properties is not preserved:
+reads through `getCachedPropertyValueEx` behave as if `ignoreDefault` was not set.
+To determine whether an element supports a pattern, cache the corresponding `IsXPatternAvailable` property instead.
+Alternatively, fetch the property explicitly with `getPropertyValue` and `ignoreDefault` set,
+and test the result inside the operation with `isNotSupported` on the returned variant.
+
 ### UI Automation text ranges
 
 #### Declaring a text range

--- a/source/UIAHandler/_remoteOps/remoteAPI.py
+++ b/source/UIAHandler/_remoteOps/remoteAPI.py
@@ -38,6 +38,7 @@ from .remoteTypes import (
 	RemoteArray,
 	RemoteElement,
 	RemoteTextRange,
+	RemoteCacheRequest,
 )
 
 
@@ -130,6 +131,9 @@ class RemoteAPI(builder._RemoteBase):
 
 	def newVariant(self) -> RemoteVariant:
 		return RemoteVariant.createNew(self.rob)
+
+	def newCacheRequest(self) -> RemoteCacheRequest:
+		return RemoteCacheRequest.createNew(self.rob)
 
 	def newArray(self) -> RemoteArray:
 		return RemoteArray.createNew(self.rob)

--- a/source/UIAHandler/_remoteOps/remoteTypes/__init__.py
+++ b/source/UIAHandler/_remoteOps/remoteTypes/__init__.py
@@ -247,6 +247,21 @@ class RemoteVariant(RemoteBaseObject):
 	def isElement(self) -> RemoteBool:
 		return self._isType(RemoteElement)
 
+	@remoteMethod
+	def isNotSupported(self) -> RemoteBool:
+		"""Checks whether this variant holds the reserved "not supported" value,
+		such as returned by a property fetch that ignores defaults for a property
+		the element does not support.
+		"""
+		result = RemoteBool(self.rob, self.rob.requestNewOperandId())
+		self.rob.getDefaultInstructionList().addInstruction(
+			instructions.IsNotSupported(
+				result=result,
+				target=self,
+			),
+		)
+		return result
+
 	_TV_asType = TypeVar("_TV_asType", bound=RemoteBaseObject)
 
 	def asType(self, remoteClass: Type[_TV_asType]) -> _TV_asType:
@@ -726,5 +741,6 @@ def getRemoteTypeForLocalType(LocalType: Type[object]) -> Type[RemoteBaseObject]
 # flake8: noqa: E402
 from .intEnum import RemoteIntEnum
 from .extensionTarget import RemoteExtensionTarget
+from .cacheRequest import RemoteCacheRequest
 from .element import RemoteElement
 from .textRange import RemoteTextRange

--- a/source/UIAHandler/_remoteOps/remoteTypes/cacheRequest.py
+++ b/source/UIAHandler/_remoteOps/remoteTypes/cacheRequest.py
@@ -1,0 +1,50 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2026 NV Access Limited, Leonard de Ruijter
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
+
+
+from __future__ import annotations
+from typing import (
+	Iterable,
+)
+from .. import lowLevel
+from .. import instructions
+from ..remoteFuncWrapper import (
+	remoteMethod_mutable,
+)
+from . import (
+	RemoteBaseObject,
+	RemoteIntEnum,
+)
+
+
+class RemoteCacheRequest(RemoteBaseObject):
+	"""
+	Represents a remote UIA cache request.
+	Properties and patterns can be added to it,
+	after which it can populate the cache of a remote UI Automation element.
+	"""
+
+	_IsTypeInstruction = instructions.IsCacheRequest
+
+	def _generateInitInstructions(self) -> Iterable[instructions.InstructionBase]:
+		yield instructions.NewCacheRequest(result=self)
+
+	@remoteMethod_mutable
+	def addProperty(self, propertyId: RemoteIntEnum[lowLevel.PropertyId] | lowLevel.PropertyId):
+		self.rob.getDefaultInstructionList().addInstruction(
+			instructions.CacheRequestAddProperty(
+				target=self,
+				propertyId=RemoteIntEnum.ensureRemote(self.rob, propertyId),
+			),
+		)
+
+	@remoteMethod_mutable
+	def addPattern(self, patternId: RemoteIntEnum[lowLevel.PatternId] | lowLevel.PatternId):
+		self.rob.getDefaultInstructionList().addInstruction(
+			instructions.CacheRequestAddPattern(
+				target=self,
+				patternId=RemoteIntEnum.ensureRemote(self.rob, patternId),
+			),
+		)

--- a/source/UIAHandler/_remoteOps/remoteTypes/element.py
+++ b/source/UIAHandler/_remoteOps/remoteTypes/element.py
@@ -16,6 +16,7 @@ from .. import lowLevel
 from .. import instructions
 from ..remoteFuncWrapper import (
 	remoteMethod,
+	remoteMethod_mutable,
 )
 from . import (
 	RemoteExtensionTarget,
@@ -23,6 +24,7 @@ from . import (
 	RemoteBool,
 	RemoteVariant,
 )
+from .cacheRequest import RemoteCacheRequest
 
 
 class RemoteElement(RemoteExtensionTarget[POINTER(UIA.IUIAutomationElement)]):
@@ -73,6 +75,15 @@ class RemoteElement(RemoteExtensionTarget[POINTER(UIA.IUIAutomationElement)]):
 			),
 		)
 		return result
+
+	@remoteMethod_mutable
+	def populateCache(self, cacheRequest: RemoteCacheRequest):
+		self.rob.getDefaultInstructionList().addInstruction(
+			instructions.PopulateCache(
+				target=self,
+				cacheRequest=cacheRequest,
+			),
+		)
 
 	@remoteMethod
 	def getParentElement(self) -> RemoteElement:

--- a/tests/unit/test_UIARemoteOps/test_highLevel/test_cacheRequest.py
+++ b/tests/unit/test_UIARemoteOps/test_highLevel/test_cacheRequest.py
@@ -1,0 +1,138 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2026 NV Access Limited, Leonard de Ruijter
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
+
+"""
+High-level UIA remote ops unit tests for cache request support.
+"""
+
+import struct
+from unittest import TestCase
+from unittest.mock import Mock, patch
+from ctypes import POINTER
+import UIAHandler
+from UIAHandler import UIA
+from UIAHandler._remoteOps import builder
+from UIAHandler._remoteOps import instructions
+from UIAHandler._remoteOps import operation
+from UIAHandler._remoteOps import remoteAPI
+from UIAHandler._remoteOps.lowLevel import (
+	PatternId,
+	PropertyId,
+)
+
+
+class Test_isNull(TestCase):
+	def test_isNull_trueForNullElement(self):
+		op = operation.Operation(localMode=True)
+
+		@op.buildFunction
+		def code(ra: remoteAPI.RemoteAPI):
+			element = ra.newElement()
+			ra.Return(element.isNull())
+
+		self.assertTrue(op.execute())
+
+	def test_isNull_falseForImportedElement(self):
+		uiaElement = Mock(spec=POINTER(UIA.IUIAutomationElement))
+		op = operation.Operation(localMode=True)
+
+		@op.buildFunction
+		def code(ra: remoteAPI.RemoteAPI):
+			element = ra.newElement(uiaElement)
+			ra.Return(element.isNull())
+
+		self.assertFalse(op.execute())
+
+
+class Test_cacheRequest(TestCase):
+	def test_populateCache_buildsAndAppliesClientCacheRequest(self):
+		uiaElement = Mock(spec=POINTER(UIA.IUIAutomationElement))
+		cachedElement = Mock(spec=POINTER(UIA.IUIAutomationElement))
+		clientCacheRequest = Mock(spec=POINTER(UIA.IUIAutomationCacheRequest))
+		handlerMock = Mock()
+		handlerMock.clientObject.CreateCacheRequest.return_value = clientCacheRequest
+		uiaElement.BuildUpdatedCache.return_value = cachedElement
+		cachedElement.GetCurrentPropertyValueEx.return_value = "cached name"
+		op = operation.Operation(localMode=True)
+
+		@op.buildFunction
+		def code(ra: remoteAPI.RemoteAPI):
+			element = ra.newElement(uiaElement)
+			cacheRequest = ra.newCacheRequest()
+			cacheRequest.addProperty(PropertyId.Name)
+			cacheRequest.addPattern(PatternId.Text)
+			element.populateCache(cacheRequest)
+			ra.Return(element.getPropertyValue(PropertyId.Name))
+
+		with patch.object(UIAHandler, "handler", handlerMock):
+			name = op.execute()
+
+		handlerMock.clientObject.CreateCacheRequest.assert_called_once_with()
+		clientCacheRequest.AddProperty.assert_called_once_with(PropertyId.Name)
+		clientCacheRequest.AddPattern.assert_called_once_with(PatternId.Text)
+		uiaElement.BuildUpdatedCache.assert_called_once_with(clientCacheRequest)
+		cachedElement.GetCurrentPropertyValueEx.assert_called_once_with(PropertyId.Name, False)
+		uiaElement.GetCurrentPropertyValueEx.assert_not_called()
+		self.assertEqual(name, "cached name")
+
+
+class Test_isNotSupported(TestCase):
+	def test_trueForReservedValue(self):
+		uiaElement = Mock(spec=POINTER(UIA.IUIAutomationElement))
+		reservedValue = object()
+		handlerMock = Mock()
+		handlerMock.reservedNotSupportedValue = reservedValue
+		uiaElement.GetCurrentPropertyValueEx.return_value = reservedValue
+		op = operation.Operation(localMode=True)
+
+		@op.buildFunction
+		def code(ra: remoteAPI.RemoteAPI):
+			element = ra.newElement(uiaElement)
+			value = element.getPropertyValue(PropertyId.RangeValueValue, True)
+			ra.Return(value.isNotSupported())
+
+		with patch.object(UIAHandler, "handler", handlerMock):
+			self.assertTrue(op.execute())
+
+	def test_falseForSupportedValue(self):
+		uiaElement = Mock(spec=POINTER(UIA.IUIAutomationElement))
+		handlerMock = Mock()
+		handlerMock.reservedNotSupportedValue = object()
+		uiaElement.GetCurrentPropertyValueEx.return_value = 42.0
+		op = operation.Operation(localMode=True)
+
+		@op.buildFunction
+		def code(ra: remoteAPI.RemoteAPI):
+			element = ra.newElement(uiaElement)
+			value = element.getPropertyValue(PropertyId.RangeValueValue, True)
+			ra.Return(value.isNotSupported())
+
+		with patch.object(UIAHandler, "handler", handlerMock):
+			self.assertFalse(op.execute())
+
+
+class Test_instructionByteCode(TestCase):
+	def test_byteCode_layout(self):
+		"""The wire encoding of the cache request instructions:
+		a 32 bit little endian opcode followed by 32 bit little endian operand IDs,
+		in the operand order of the Microsoft remote operations instruction set.
+		"""
+		cases = (
+			(instructions.NewCacheRequest, 0x4C, 1),
+			(instructions.IsCacheRequest, 0x4D, 2),
+			(instructions.CacheRequestAddProperty, 0x4E, 2),
+			(instructions.CacheRequestAddPattern, 0x4F, 2),
+			(instructions.PopulateCache, 0x50, 2),
+			(instructions.IsNotSupported, 0x3B, 2),
+		)
+		rob = builder.RemoteOperationBuilder()
+		for instructionClass, opCode, operandCount in cases:
+			with self.subTest(instruction=instructionClass.__name__):
+				operands = [builder.Operand(rob, rob.requestNewOperandId()) for _ in range(operandCount)]
+				instruction = instructionClass(*operands)
+				expected = struct.pack("<l", opCode)
+				for operand in operands:
+					expected += struct.pack("<L", operand.operandId.value)
+				self.assertEqual(instruction.getByteCode(), expected)

--- a/tests/unit/test_UIARemoteOps/test_highLevel/test_cacheRequest.py
+++ b/tests/unit/test_UIARemoteOps/test_highLevel/test_cacheRequest.py
@@ -23,29 +23,6 @@ from UIAHandler._remoteOps.lowLevel import (
 )
 
 
-class Test_isNull(TestCase):
-	def test_isNull_trueForNullElement(self):
-		op = operation.Operation(localMode=True)
-
-		@op.buildFunction
-		def code(ra: remoteAPI.RemoteAPI):
-			element = ra.newElement()
-			ra.Return(element.isNull())
-
-		self.assertTrue(op.execute())
-
-	def test_isNull_falseForImportedElement(self):
-		uiaElement = Mock(spec=POINTER(UIA.IUIAutomationElement))
-		op = operation.Operation(localMode=True)
-
-		@op.buildFunction
-		def code(ra: remoteAPI.RemoteAPI):
-			element = ra.newElement(uiaElement)
-			ra.Return(element.isNull())
-
-		self.assertFalse(op.execute())
-
-
 class Test_cacheRequest(TestCase):
 	def test_populateCache_buildsAndAppliesClientCacheRequest(self):
 		uiaElement = Mock(spec=POINTER(UIA.IUIAutomationElement))

--- a/tests/unit/test_UIARemoteOps/test_highLevel/test_element.py
+++ b/tests/unit/test_UIARemoteOps/test_highLevel/test_element.py
@@ -1,7 +1,7 @@
 # A part of NonVisual Desktop Access (NVDA)
-# This file is covered by the GNU General Public License.
-# See the file COPYING for more details.
-# Copyright (C) 2024 NV Access Limited
+# Copyright (C) 2024-2026 NV Access Limited, Leonard de Ruijter
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
 
 """
 High-level UIA remote ops Unit tests for UIA element methods.
@@ -33,3 +33,26 @@ class Test_element(TestCase):
 		name = op.execute()
 		uiaElement.GetCurrentPropertyValueEx.assert_called_once_with(PropertyId.Name, False)
 		self.assertEqual(name, "foo")
+
+
+class Test_isNull(TestCase):
+	def test_isNull_trueForNullElement(self):
+		op = operation.Operation(localMode=True)
+
+		@op.buildFunction
+		def code(ra: remoteAPI.RemoteAPI):
+			element = ra.newElement()
+			ra.Return(element.isNull())
+
+		self.assertTrue(op.execute())
+
+	def test_isNull_falseForImportedElement(self):
+		uiaElement = Mock(spec=POINTER(UIA.IUIAutomationElement))
+		op = operation.Operation(localMode=True)
+
+		@op.buildFunction
+		def code(ra: remoteAPI.RemoteAPI):
+			element = ra.newElement(uiaElement)
+			ra.Return(element.isNull())
+
+		self.assertFalse(op.execute())

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -77,6 +77,12 @@ Previously these keys had no function when pressed on their own. (#20366, @fla-r
 
 Please refer to [the developer guide](https://download.nvaccess.org/documentation/developerGuide.html#API) for information on NVDA's API deprecation and removal process.
 
+* The UIA remote operations framework now supports cache requests. (#20621, @LeonarddeR)
+  * A remote operation can create a cache request with `ra.newCacheRequest`, add properties and patterns to it, and populate the cache of a remote element with `RemoteElement.populateCache`.
+  * Elements returned or yielded from the operation carry the populated cache.
+  * Such a cache stores default values for properties the element does not support; the reserved "not supported" value is not preserved.
+* UIA remote operations can now return `UInt32`, `Int64`, `Single` and `Double` values, as well as the reserved "not supported" value for property fetches that ignore defaults. (#20621, @LeonarddeR)
+  * A remote variant can be tested for the reserved "not supported" value inside the operation with `RemoteVariant.isNotSupported`.
 * `mathPres.interactWithMathMl` now accepts an optional `sourceObj` argument.
 Math presentation providers can override `MathPresentationProvider.interactWithMathMlFromSource` to use the source object when starting interaction.
 The default implementation forwards to `interactWithMathMl`, preserving compatibility with existing providers. (#20372, @RyanMcCleary)


### PR DESCRIPTION
### Link to issue number:

Follow-up of #16214.
Related to #20608 in a stacked effort to reduce UIA cross-process calls as much as possible.

### Summary of the issue:

The UIA remote operations framework cannot use UIA caching. Elements returned from a remote operation arrive without any cache, so consumers immediately pay live cross-process calls for every property they read. The cache request opcodes exist in the framework's instruction set enum, but nothing exposes them. In addition, the result conversion in UIARemote.dll only handles Int32, String and Boolean scalars: a remote operation cannot return any floating point value.

### Description of user facing changes:

None.
This PR only adds code that is not yet used anywhere.

### Description of developer facing changes:

- A remote operation can create a cache request, add properties and patterns to it, and populate the cache of a remote element: `ra.newCacheRequest`, `RemoteCacheRequest.addProperty`, `RemoteCacheRequest.addPattern` and `RemoteElement.populateCache`. Elements returned or yielded from the operation carry the populated cache.
- `_remoteOps.lowLevel` gains a `PatternId` enum next to the existing `PropertyId`.
- Remote operations can now return `UInt32`, `Int64`, `Single` and `Double` values.
- A remote variant can be tested for the reserved "not supported" value inside the operation: `RemoteVariant.isNotSupported`.
- The framework readme documents cache request usage.

### Description of development approach:

The five cache request opcodes get instruction dataclasses with local execution through the classic COM cache request methods, so the localMode unit test path covers them. A new `RemoteCacheRequest` remote type and `RemoteElement.populateCache` expose them in the high level API. The scalar result types are additional cases in `IInspectableToVariant` in `nvdaHelper/UIARemote/lowLevel.cpp`.

Behaviour was verified against the real remote operations VM by walking the focus ancestry with per-ancestor cache population in File Explorer and in Edge with UIA web content. A comparison of 30 properties over 33 ancestors showed remotely populated caches are value identical to classic caches, with one platform difference: they store default values for unsupported properties instead of the reserved "not supported" value. This is documented in the readme. Explicit `getPropertyValue` fetches with `ignoreDefault` set do preserve the reserved value, which now also survives result marshaling.

### Testing strategy:

Unit tests cover the local execution pipeline against mocked COM cache requests, the instruction byte layout against the Microsoft remote operations instruction set, and the element null check used by tree walking loops. On a rebuilt UIARemote.dll, console spikes verified remote execution on two providers: cache population and retrieval, float returns, and the reserved "not supported" value comparing equal client side.

### Known issues with pull request:

None.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
