### PR TITLE
Fix the remote Python console

### DIFF
--- a/source/remotePythonConsole.py
+++ b/source/remotePythonConsole.py
@@ -1,53 +1,59 @@
-# remotePythonConsole.py
 # A part of NonVisual Desktop Access (NVDA)
-# This file is covered by the GNU General Public License.
-# See the file COPYING for more details.
-# Copyright (C) 2011 NV Access Inc
+# Copyright (C) 2011-2026 NV Access Limited, Leonard de Ruijter
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
 
 """Provides an interactive Python console run inside NVDA which can be accessed via TCP.
-To use, call L{initialize} to start the server.
-Then, connect to it using TCP port L{PORT}.
+To use, call `initialize` to start the server.
+Then, connect to it using TCP port `PORT`.
 The server will only handle one connection at a time.
 """
 
-import threading
 import socketserver
-import wx
+import threading
+
 import pythonConsole
+import wx
 from logHandler import log
 
-#: The TCP port on which the server will run.
-#: @type: int
-PORT = 6832
+PORT: int = 6832
+"""The TCP port on which the server will run."""
 
-server = None
+server: socketserver.TCPServer | None = None
 
 
 class RequestHandler(socketserver.StreamRequestHandler):
-	def setPrompt(self, prompt):
+	_keepRunning: bool
+	_execDoneEvt: threading.Event
+	console: pythonConsole.PythonConsole | None
+
+	def setPrompt(self, prompt: str) -> None:
 		if not self._keepRunning:
 			# We're about to exit, so don't output the prompt.
 			return
-		self.wfile.write(prompt + " ")
+		self._write(prompt + " ")
 
-	def exit(self):
+	def _write(self, text: str) -> None:
+		self.wfile.write(text.encode("utf-8", errors="replace"))
+
+	def exit(self) -> None:
 		self._keepRunning = False
 
-	def execute(self, line):
+	def execute(self, line: str) -> None:
 		self.console.push(line)
 		# Notify handle() that the line has finished executing.
 		self._execDoneEvt.set()
 
-	def handle(self):
+	def handle(self) -> None:
 		# #3126: Remove the default socket timeout.
 		# We can't use the class timeout attribute because None means don't set a timeout.
 		self.connection.settimeout(None)
 		self._keepRunning = True
 
 		try:
-			self.wfile.write("NVDA Remote Python Console\n")
+			self._write("NVDA Remote Python Console\n")
 			self.console = pythonConsole.PythonConsole(
-				outputFunc=self.wfile.write,
+				outputFunc=self._write,
 				setPromptFunc=self.setPrompt,
 				exitFunc=self.exit,
 			)
@@ -60,10 +66,10 @@ class RequestHandler(socketserver.StreamRequestHandler):
 
 			self._execDoneEvt = threading.Event()
 			while self._keepRunning:
-				line = self.rfile.readline()
-				if not line:
+				rawLine = self.rfile.readline()
+				if not rawLine:
 					break
-				line = line.rstrip("\r\n")
+				line = rawLine.decode("utf-8", errors="replace").rstrip("\r\n")
 				# Execute in the main thread.
 				wx.CallAfter(self.execute, line)
 				# Wait until the line has finished executing before retrieving the next.
@@ -77,7 +83,7 @@ class RequestHandler(socketserver.StreamRequestHandler):
 			self.console = None
 
 
-def initialize():
+def initialize() -> None:
 	global server
 	server = socketserver.TCPServer(("", PORT), RequestHandler)
 	server.daemon_threads = True
@@ -89,7 +95,7 @@ def initialize():
 	thread.start()
 
 
-def terminate():
+def terminate() -> None:
 	global server
 	server.shutdown()
 	server = None

--- a/source/remotePythonConsole.py
+++ b/source/remotePythonConsole.py
@@ -97,5 +97,8 @@ def initialize() -> None:
 
 def terminate() -> None:
 	global server
+	if server is None:
+		return
 	server.shutdown()
+	server.server_close()
 	server = None

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -77,6 +77,7 @@ Previously these keys had no function when pressed on their own. (#20366, @fla-r
 
 Please refer to [the developer guide](https://download.nvaccess.org/documentation/developerGuide.html#API) for information on NVDA's API deprecation and removal process.
 
+* The remote Python console, available when running NVDA from source, works again. (#20626, @LeonarddeR)
 * The UIA remote operations framework now supports cache requests. (#20621, @LeonarddeR)
   * A remote operation can create a cache request with `ra.newCacheRequest`, add properties and patterns to it, and populate the cache of a remote element with `RemoteElement.populateCache`.
   * Elements returned or yielded from the operation carry the populated cache.


### PR DESCRIPTION
### Link to issue number:

None.

### Summary of the issue:

NVDA has a remote Python console for debugging.
It is described in the developer guide.
A TCP server runs inside NVDA.
A client connects to port 6832 and types console commands.

The module predates the move to Python 3.
The socket streams of the server carry bytes.
The module writes text strings to them and reads text from them.
Writing the greeting therefore raises `TypeError` as soon as a client connects.
The server thread dies and the connection closes immediately.
The remote console has been unusable since NVDA moved to Python 3.

### Description of user facing changes:

None.
The remote console is only available in source builds and must be enabled manually.

### Description of developer facing changes:

The remote Python console works again.

### Description of development approach:

A helper method encodes text as UTF-8 before writing it to the socket (`_write`).
The greeting, the prompt and all console output now go through this helper.
Received lines are decoded from UTF-8 before the line ending is stripped and the line is executed.
Characters that cannot be encoded or decoded are replaced instead of raising.

Type hints were added throughout the module and it has been modernized further to follow NVDA coding guidelines.

### Testing strategy:

Manual testing.
The console was enabled from the local Python console as described in the developer guide.
A socket client connected on TCP port 6832.
The greeting and the prompt appear.
Statements execute and their output returns to the client.
The `snap()` helper works and the snapshot variables are usable.

There are no unit tests.
The module needs a running NVDA and a TCP client, which the unit test framework does not provide.

### Known issues with pull request:

The remote Python console is considered a security risk.
An alternative direction is therefore removing it altogether instead.
However, it turned out to be helpful for letting AI agents interact with NVDA.
An MCP server would be even better suited for that purpose.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
