### PR TITLE
Add Quick Navigation commands for clickable elements

### DIFF
--- a/source/UIAHandler/browseMode.py
+++ b/source/UIAHandler/browseMode.py
@@ -692,6 +692,19 @@ class UIABrowseModeDocument(UIADocumentWithTableNavigation, browseMode.BrowseMod
 				UIAHandler.UIA_SliderControlTypeId,
 			)
 			return UIAControlQuicknavIterator(nodeType, self, pos, condition, direction)
+		elif nodeType == "clickable":
+			# Match the generic control types which UIAWeb exposes with State.CLICKABLE.
+			condition = createUIAMultiPropertyCondition(
+				{
+					UIAHandler.UIA_ControlTypePropertyId: [
+						UIAHandler.UIA_TextControlTypeId,
+						UIAHandler.UIA_GroupControlTypeId,
+						UIAHandler.UIA_ImageControlTypeId,
+					],
+					UIAHandler.UIA_IsInvokePatternAvailablePropertyId: True,
+				},
+			)
+			return UIAControlQuicknavIterator(nodeType, self, pos, condition, direction)
 		elif nodeType == "nonTextContainer":
 			condition = createUIAMultiPropertyCondition(
 				{

--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -1235,6 +1235,21 @@ qn(
 	touchLabel=_("sliders"),
 )
 qn(
+	"clickable",
+	key=None,
+	# Translators: Input help message for a quick navigation command in browse mode.
+	nextDoc=_("moves to the next clickable element"),
+	# Translators: Message presented when the browse mode element is not found.
+	nextError=_("no next clickable element"),
+	# Translators: Input help message for a quick navigation command in browse mode.
+	prevDoc=_("moves to the previous clickable element"),
+	# Translators: Message presented when the browse mode element is not found.
+	prevError=_("no previous clickable element"),
+	readUnit=textInfos.UNIT_LINE,
+	# Translators: Label announced when cycling browse mode touch navigation element types in browse mode.
+	touchLabel=_("clickable elements"),
+)
+qn(
 	"article",
 	key=None,
 	# Translators: Input help message for a quick navigation command in browse mode.

--- a/source/virtualBuffers/MSHTML.py
+++ b/source/virtualBuffers/MSHTML.py
@@ -401,6 +401,12 @@ class MSHTML(VirtualBuffer):
 				{"IAccessible::role": [oleacc.ROLE_SYSTEM_SLIDER]},
 				{"HTMLAttrib::role": ["slider"]},
 			]
+		elif nodeType == "clickable":
+			attrs = [
+				{"HTMLAttrib::onclick": [VBufStorage_findMatch_notEmpty]},
+				{"HTMLAttrib::onmousedown": [VBufStorage_findMatch_notEmpty]},
+				{"HTMLAttrib::onmouseup": [VBufStorage_findMatch_notEmpty]},
+			]
 		elif nodeType == "table":
 			attrs = {"IHTMLDOMNode::nodeName": ["TABLE"]}
 			if not config.conf["documentFormatting"]["includeLayoutTables"]:

--- a/source/virtualBuffers/gecko_ia2.py
+++ b/source/virtualBuffers/gecko_ia2.py
@@ -486,6 +486,8 @@ class Gecko_ia2(VirtualBuffer):
 				{"IAccessible::role": [oleacc.ROLE_SYSTEM_SLIDER]},
 				{"IAccessible2::attribute_xml-roles": [VBufStorage_findMatch_word("slider")]},
 			]
+		elif nodeType == "clickable":
+			attrs = {"IAccessibleAction_click": [VBufStorage_findMatch_notEmpty]}
 		elif nodeType == "graphic":
 			attrs = {"IAccessible::role": [oleacc.ROLE_SYSTEM_GRAPHIC]}
 		elif nodeType == "blockQuote":

--- a/tests/system/robot/chromeTests.py
+++ b/tests/system/robot/chromeTests.py
@@ -2760,6 +2760,44 @@ def test_styleNav():
 	_asserts.strings_match(actualSpeech, "No next same style text")
 
 
+def test_clickableNavigation() -> None:
+	"""Tests that unassigned quick navigation commands move between clickable elements."""
+	spy: "NVDASpyLib" = _NvdaLib.getSpyLib()
+	spy.assignGesture(
+		"kb:z",
+		"browseMode",
+		"BrowseModeTreeInterceptor",
+		"nextClickable",
+	)
+	spy.assignGesture(
+		"kb:shift+z",
+		"browseMode",
+		"BrowseModeTreeInterceptor",
+		"previousClickable",
+	)
+	# The navigation must use the clickable metadata even when its speech reporting is disabled.
+	spy.set_configValue(["documentFormatting", "reportClickable"], False)
+	_chrome.prepareChrome("""
+		<p>Before the custom controls</p>
+		<button>Semantic button</button>
+		<div tabindex="0" onclick="void(0)">First custom control</div>
+		<p>Between the custom controls</p>
+		<div tabindex="0" onclick="void(0)">Second custom control</div>
+		<p>After the custom controls</p>
+	""")
+
+	actualSpeech = _chrome.getSpeechAfterKey("z")
+	_asserts.strings_match(actualSpeech, "First custom control")
+	actualSpeech = _chrome.getSpeechAfterKey("z")
+	_asserts.strings_match(actualSpeech, "Second custom control")
+	actualSpeech = _chrome.getSpeechAfterKey("z")
+	_asserts.strings_match(actualSpeech, "no next clickable element")
+	actualSpeech = _chrome.getSpeechAfterKey("shift+z")
+	_asserts.strings_match(actualSpeech, "First custom control")
+	actualSpeech = _chrome.getSpeechAfterKey("shift+z")
+	_asserts.strings_match(actualSpeech, "no previous clickable element")
+
+
 def test_ariaErrorMessage():
 	_chrome.prepareChrome("""
 		<h2>Native valid</h2>

--- a/tests/system/robot/chromeTests.robot
+++ b/tests/system/robot/chromeTests.robot
@@ -246,6 +246,10 @@ styleNav
 	[Documentation]	Same style navigation
 	[Tags]	chrome_misc
 	test_styleNav
+Clickable navigation
+	[Documentation]	Navigate between clickable elements using unassigned quick navigation commands
+	[Tags]	chrome_misc
+	test_clickableNavigation
 
 ## chrome_link tests
 ### Link destination reporting (NVDA+K)

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -18,6 +18,7 @@
   * All four edges are supported.
   Note that the Windows taskbar may override gestures on an edge.
   Gestures from the taskbar edge open the Start menu or Action Center, NVDA will not receive them.
+* Added an unassigned Quick Navigation Command for jumping to next/previous clickable element in browse mode. (#14429, @cary-rowen)
 * On supported braille displays, pressing multiple routing keys simultaneously can now be bound to a new "multi routing" gesture. (#20001, @LeonarddeR)
   * The "select range" command, which selects the text from the first up to the last pressed routing key, is bound to this gesture by default on supporting drivers.
   * Drivers with built-in support for multi routing: ALVA, Albatross (only when combined with `home1` or `home2`), Baum (and compatible), Freedom Scientific Focus/PAC Mate, HumanWare Brailliant BI/B series, Handy Tech, NLS eReader Zoomax, Seika Notetaker, and Standard HID Braille displays.
@@ -273,7 +274,6 @@ When resetting NVDA to factory defaults, an Undo button is now available to rest
 * After installing or updating NVDA, a dialog now offers options to restart Windows, start the installed copy, or exit the installer. (#19268, #19718, @kefaslungu)
 * Added an unassigned command to toggle keyboard layout. (#19211, @CyrilleB79)
 * Added an unassigned Quick Navigation Command for jumping to next/previous slider in browse mode. (#17005, @tareh7z)
-* Added an unassigned Quick Navigation Command for jumping to next/previous clickable element in browse mode. (#14429, @cary-rowen)
 * When resetting the configuration to factory defaults from the NVDA menu, a dialog is now shown afterwards with an Undo button to restore the previous configuration.
 The triple-press keyboard shortcut (`NVDA+control+r`) is not affected, as it is intended for recovery scenarios. (#19575, @bramd)
 * Added an unassigned command to report the current status of the Screen Curtain. (#19759)

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -273,6 +273,7 @@ When resetting NVDA to factory defaults, an Undo button is now available to rest
 * After installing or updating NVDA, a dialog now offers options to restart Windows, start the installed copy, or exit the installer. (#19268, #19718, @kefaslungu)
 * Added an unassigned command to toggle keyboard layout. (#19211, @CyrilleB79)
 * Added an unassigned Quick Navigation Command for jumping to next/previous slider in browse mode. (#17005, @tareh7z)
+* Added an unassigned Quick Navigation Command for jumping to next/previous clickable element in browse mode. (#14429, @cary-rowen)
 * When resetting the configuration to factory defaults from the NVDA menu, a dialog is now shown afterwards with an Undo button to restore the previous configuration.
 The triple-press keyboard shortcut (`NVDA+control+r`) is not affected, as it is intended for recovery scenarios. (#19575, @bramd)
 * Added an unassigned command to report the current status of the Screen Curtain. (#19759)

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -1150,6 +1150,7 @@ Here is a list of available commands:
 * Toggle button
 * Progress bar
 * Slider
+* Clickable element
 * Reference
 * Math formula
 * Vertically aligned paragraph


### PR DESCRIPTION
### Link to issue number:

Partially addresses #14429.

### Summary of the issue:

Some websites use custom interactive elements that NVDA reports as clickable rather than exposing them as semantic links or buttons. Browse mode does not currently provide Quick Navigation commands for moving between these elements.

### Description of user facing changes:

Adds unassigned Quick Navigation commands for moving to the next or previous clickable element in browse mode. Users can assign gestures to these commands in the Input Gestures dialog.

Clickable elements are also available as an optional browse mode touch navigation element type.

### Description of developer facing changes:

Adds a `clickable` Quick Navigation node type to the browse mode framework and implements native lookup conditions for IA2, MSHTML, and UIA browse mode backends.

Adds a Chrome system test covering clickable element navigation. No existing API signatures are changed.

### Description of development approach:

The implementation uses the existing `BrowseModeTreeInterceptor.addQuickNav` mechanism with no default key assigned.

Each browse mode backend uses metadata it already exposes for clickable elements:

* IA2 searches for the `click` accessible action.
* MSHTML searches for non-empty `onclick`, `onmousedown`, or `onmouseup` attributes.
* UIA searches for generic text, group, or image controls that support the Invoke pattern.

The searches use the native virtual buffer or UIA condition mechanisms. Clickable elements are reported by line to avoid reading an entire clickable container.

The Elements List was not changed.

### Testing strategy:

Manual testing:

1. Assigned gestures to the next and previous clickable element commands.
2. Opened a web page containing clickable elements in browse mode.
3. Used the assigned gestures to navigate forward and backward between the clickable elements.
4. Confirmed that both commands moved to the expected elements.

Result: Passed.

System testing:

* Ran the Chrome `Clickable navigation` system test.
* The test covers forward and backward navigation, document boundaries, skipping a semantic button, and navigation when clickable reporting is disabled.

Result: Passed.

### Known issues with pull request:

Clickable elements are not added to the Elements List. This pull request only implements Quick Navigation commands.

No other known issues.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [ ] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [ ] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [ ] API is compatible with existing add-ons.
- [ ] Security precautions taken.
