### PR TITLE
Load Log Viewer content progressively to avoid freezing NVDA when the log is large

### DIFF
--- a/source/appModules/nvda.py
+++ b/source/appModules/nvda.py
@@ -1,6 +1,6 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2008-2025 NV Access Limited, James Teh, Michael Curran, Leonard de Ruijter, Reef Turner,
-# Julien Cochuyt
+# Copyright (C) 2008-2026 NV Access Limited, James Teh, Michael Curran, Leonard de Ruijter, Reef Turner,
+# Julien Cochuyt, Andrew Johnson
 # This file may be used under the terms of the GNU General Public License, version 2 or later.
 # For more details see: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -11,6 +11,7 @@ import appModuleHandler
 import api
 import buildVersion
 import controlTypes
+from NVDAObjects import NVDAObject
 from NVDAObjects.IAccessible import IAccessible
 from baseObject import ScriptableObject
 import gui
@@ -230,20 +231,21 @@ class AppModule(appModuleHandler.AppModule):
 			return True
 		return False
 
-	def isNvdaLogViewerOutputCtrl(self, obj) -> bool:
+	def isNvdaLogViewerLoadingOutputCtrl(self, obj: NVDAObject) -> bool:
+		"""Whether obj is the log viewer's output control while log content is still loading."""
 		from gui import logViewer
 
 		viewer = logViewer.logViewer
-		if not viewer:
+		if not viewer or not viewer.isLoading:
 			return False
 		return obj.windowHandle == viewer.outputCtrl.GetHandle()
 
-	def event_valueChange(self, obj, nextHandler):
-		# The log viewer output control fires a value change for every chunk of log text
-		# progressively appended to it (#16322).
-		# Processing these is pure overhead which can make NVDA sluggish while a large log loads:
-		# the control is read only and text is only ever appended, never changing what the user is reading.
-		if self.isNvdaLogViewerOutputCtrl(obj):
+	def event_valueChange(self, obj: NVDAObject, nextHandler: typing.Callable[[], None]) -> None:
+		# While the log viewer progressively loads a large log, its output control fires a
+		# value change for every appended chunk (#16322). Processing these is pure overhead
+		# which can make NVDA sluggish: the control is read only and text is only ever
+		# appended, never changing what the user is reading.
+		if self.isNvdaLogViewerLoadingOutputCtrl(obj):
 			return
 		nextHandler()
 

--- a/source/appModules/nvda.py
+++ b/source/appModules/nvda.py
@@ -230,6 +230,23 @@ class AppModule(appModuleHandler.AppModule):
 			return True
 		return False
 
+	def isNvdaLogViewerOutputCtrl(self, obj) -> bool:
+		from gui import logViewer
+
+		viewer = logViewer.logViewer
+		if not viewer:
+			return False
+		return obj.windowHandle == viewer.outputCtrl.GetHandle()
+
+	def event_valueChange(self, obj, nextHandler):
+		# The log viewer output control fires a value change for every chunk of log text
+		# progressively appended to it (#16322).
+		# Processing these is pure overhead which can make NVDA sluggish while a large log loads:
+		# the control is read only and text is only ever appended, never changing what the user is reading.
+		if self.isNvdaLogViewerOutputCtrl(obj):
+			return
+		nextHandler()
+
 	def isNvdaPythonConsoleUIInputCtrl(self, obj):
 		from pythonConsole import consoleUI
 

--- a/source/gui/logViewer.py
+++ b/source/gui/logViewer.py
@@ -1,11 +1,12 @@
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-# Copyright (C) 2008-2024 NV Access Limited, Cyrille Bougot
+# Copyright (C) 2008-2026 NV Access Limited, Cyrille Bougot, Andrew Johnson
 
 """Provides functionality to view the NVDA log."""
 
 import collections
+import re
 import time
 
 import comtypes
@@ -34,6 +35,16 @@ _APPEND_TIME_BUDGET_SEC = 0.05
 _MIN_CHUNK_SIZE = 1_000
 _MAX_CHUNK_SIZE = 1_000_000
 
+#: Matches characters which are likely to need font fallback (e.g. CJK, emoji, braille patterns),
+#: and therefore append orders of magnitude slower.
+#: Characters up to Latin Extended-B were measured to append at full speed.
+_FALLBACK_CHARS_RE = re.compile(r"[^\x00-\u024f]")
+
+#: Maximum chunk size when the chunk contains characters needing font fallback, in characters.
+#: This bounds the cost of a single append when fast content has grown the adaptive chunk size
+#: and slow content follows.
+_FALLBACK_CHUNK_SIZE = 8_000
+
 #: How long to pause appending after the user presses a key in the output control, in seconds.
 #: This lets user interaction (e.g. caret navigation) win over background loading.
 _USER_INPUT_PAUSE_SEC = 0.5
@@ -41,8 +52,6 @@ _USER_INPUT_PAUSE_SEC = 0.5
 #: Passing this as both ends of a TOM range yields a collapsed range at the end of the document,
 #: as RichEdit clamps out of range character positions.
 _TOM_END_OF_DOC = 0x7FFFFFFF
-
-EM_SETREADONLY = 0x00CF
 
 
 class LogViewer(
@@ -94,6 +103,8 @@ class LogViewer(
 		#: Log text read from the file but not yet appended to the output control.
 		#: A C{None} entry is a marker queued by L{moveInsertionPointToEndOfLog}.
 		self._pendingText: collections.deque[str | None] = collections.deque()
+		#: How much of the head item of L{_pendingText} has already been appended.
+		self._headItemOffset = 0
 		self._isPumpScheduled = False
 		self._chunkSize = _MIN_CHUNK_SIZE
 		self._lastUserInputTime = 0.0
@@ -128,6 +139,11 @@ class LogViewer(
 		if text:
 			self._pendingText.append(text)
 			self._schedulePump()
+
+	@property
+	def isLoading(self) -> bool:
+		"""Whether log text is still queued for display."""
+		return bool(self._pendingText)
 
 	def moveInsertionPointToEndOfLog(self) -> None:
 		"""Move the insertion point to the end of the log text queued for display so far.
@@ -167,23 +183,29 @@ class LogViewer(
 			# The user is interacting with the viewer; let their input win over loading.
 			self._schedulePump(delayMs=int(_USER_INPUT_PAUSE_SEC * 1000))
 			return
-		chunk = ""
-		while self._pendingText and len(chunk) < self._chunkSize:
-			item = self._pendingText.popleft()
-			if item is None:
-				# Marker queued by moveInsertionPointToEndOfLog.
-				# Flush the chunk first so that the end of the control is the end of the queued text.
-				if chunk:
-					self._appendText(chunk)
-					chunk = ""
-				self.outputCtrl.SetInsertionPointEnd()
-				continue
-			maxLen = self._chunkSize - len(chunk)
-			if len(item) > maxLen:
-				self._pendingText.appendleft(item[maxLen:])
-				item = item[:maxLen]
-			chunk += item
-		if chunk:
+		# Process any markers at the head of the queue, then at most one chunk of text.
+		while self._pendingText and self._pendingText[0] is None:
+			# Marker queued by moveInsertionPointToEndOfLog.
+			# Any text queued before it has already been appended, so the end of the control
+			# is the end of the log at the time the marker was queued.
+			self._pendingText.popleft()
+			self.outputCtrl.SetInsertionPointEnd()
+		if self._pendingText:
+			# Slice the next chunk from the head item, tracking how much of it has been consumed.
+			# Slicing out only the chunk keeps queue consumption linear:
+			# re-queueing the remainder instead would copy almost the whole log every pump.
+			item = self._pendingText[0]
+			chunk = item[self._headItemOffset : self._headItemOffset + self._chunkSize]
+			if match := _FALLBACK_CHARS_RE.search(chunk):
+				# Text needing font fallback appends orders of magnitude slower than the
+				# adaptive chunk size may currently assume, so take at most a small bite of it.
+				# Splitting at the boundary leaves preceding fast text unaffected.
+				capLen = max(match.start(), _FALLBACK_CHUNK_SIZE)
+				chunk = chunk[:capLen]
+			self._headItemOffset += len(chunk)
+			if self._headItemOffset >= len(item):
+				self._pendingText.popleft()
+				self._headItemOffset = 0
 			self._appendText(chunk)
 		if self._pendingText:
 			self._schedulePump()
@@ -202,8 +224,7 @@ class LogViewer(
 			# and causes visible scroll flapping.
 			# A TOM range insert leaves the caret and scroll position untouched.
 			# TOM refuses to modify a read only control, so read only is lifted for the insert.
-			handle = self.outputCtrl.GetHandle()
-			winUser.sendMessage(handle, EM_SETREADONLY, False, 0)
+			self.outputCtrl.SetEditable(True)
 			try:
 				textRange = self._tomDoc.range(_TOM_END_OF_DOC, _TOM_END_OF_DOC)
 				textRange.text = text
@@ -214,7 +235,7 @@ class LogViewer(
 				)
 				self._tomDoc = None
 			finally:
-				winUser.sendMessage(handle, EM_SETREADONLY, True, 0)
+				self.outputCtrl.SetEditable(False)
 		if not self._tomDoc:
 			# Fallback if TOM is unavailable: append and restore the caret.
 			pos = self.outputCtrl.GetInsertionPoint()
@@ -236,6 +257,12 @@ class LogViewer(
 		evt.Skip()
 
 	def onClose(self, evt):
+		# Release any log text still queued for display: the module level singleton keeps
+		# this instance referenced after destruction, and a large queue would otherwise
+		# stay allocated until the viewer is reopened.
+		self._pendingText.clear()
+		self._headItemOffset = 0
+		self._tomDoc = None
 		self.Destroy()
 
 	def onSaveAsCommand(self, evt):

--- a/source/gui/logViewer.py
+++ b/source/gui/logViewer.py
@@ -34,6 +34,10 @@ _APPEND_TIME_BUDGET_SEC = 0.05
 _MIN_CHUNK_SIZE = 1_000
 _MAX_CHUNK_SIZE = 1_000_000
 
+#: How long to pause appending after the user presses a key in the output control, in seconds.
+#: This lets user interaction (e.g. caret navigation) win over background loading.
+_USER_INPUT_PAUSE_SEC = 0.5
+
 #: Passing this as both ends of a TOM range yields a collapsed range at the end of the document,
 #: as RichEdit clamps out of range character positions.
 _TOM_END_OF_DOC = 0x7FFFFFFF
@@ -92,6 +96,8 @@ class LogViewer(
 		self._pendingText: collections.deque[str | None] = collections.deque()
 		self._isPumpScheduled = False
 		self._chunkSize = _MIN_CHUNK_SIZE
+		self._lastUserInputTime = 0.0
+		self._isShowingLoadingTitle = False
 		try:
 			self._tomDoc = oleacc.AccessibleObjectFromWindow(
 				self.outputCtrl.GetHandle(),
@@ -131,18 +137,35 @@ class LogViewer(
 		self._pendingText.append(None)
 		self._schedulePump()
 
-	def _schedulePump(self) -> None:
+	def _schedulePump(self, delayMs: int = 1) -> None:
 		if not self._isPumpScheduled:
 			self._isPumpScheduled = True
 			# Chain with CallLater rather than CallAfter.
 			# Posted events starve WM_TIMER, so a CallAfter chain would block timers,
 			# including NVDA's core pump, just like a synchronous append.
-			wx.CallLater(1, self._pumpPendingText)
+			wx.CallLater(delayMs, self._pumpPendingText)
+		self._updateTitle()
+
+	def _updateTitle(self) -> None:
+		"""Reflect in the window title whether log content is still loading."""
+		isLoading = bool(self._pendingText)
+		if isLoading != self._isShowingLoadingTitle:
+			self._isShowingLoadingTitle = isLoading
+			if isLoading:
+				# Translators: The title of the NVDA log viewer window while log content is still loading.
+				self.SetTitle(_("NVDA Log Viewer (loading)"))
+			else:
+				# Translators: The title of the NVDA log viewer window.
+				self.SetTitle(_("NVDA Log Viewer"))
 
 	def _pumpPendingText(self) -> None:
 		self._isPumpScheduled = False
-		if not self:
+		if not self or self.IsBeingDeleted():
 			# The window was destroyed while a pump was scheduled.
+			return
+		if time.monotonic() - self._lastUserInputTime < _USER_INPUT_PAUSE_SEC:
+			# The user is interacting with the viewer; let their input win over loading.
+			self._schedulePump(delayMs=int(_USER_INPUT_PAUSE_SEC * 1000))
 			return
 		chunk = ""
 		while self._pendingText and len(chunk) < self._chunkSize:
@@ -164,6 +187,7 @@ class LogViewer(
 			self._appendText(chunk)
 		if self._pendingText:
 			self._schedulePump()
+		self._updateTitle()
 
 	def _appendText(self, text: str) -> None:
 		"""Append text to the output control without disturbing the caret or scroll position.
@@ -183,9 +207,15 @@ class LogViewer(
 			try:
 				textRange = self._tomDoc.range(_TOM_END_OF_DOC, _TOM_END_OF_DOC)
 				textRange.text = text
+			except comtypes.COMError:
+				log.debugWarning(
+					"TOM append failed; falling back to AppendText for this and future appends",
+					exc_info=True,
+				)
+				self._tomDoc = None
 			finally:
 				winUser.sendMessage(handle, EM_SETREADONLY, True, 0)
-		else:
+		if not self._tomDoc:
 			# Fallback if TOM is unavailable: append and restore the caret.
 			pos = self.outputCtrl.GetInsertionPoint()
 			self.outputCtrl.Freeze()
@@ -223,7 +253,9 @@ class LogViewer(
 			with open(filename, "w", encoding="UTF-8") as f:
 				f.write(self.outputCtrl.GetValue())
 				# Include any log text queued for display but not yet appended to the output control.
-				f.write("".join(item for item in self._pendingText if item is not None))
+				for item in self._pendingText:
+					if item is not None:
+						f.write(item)
 		except (IOError, OSError) as e:
 			gui.messageBox(
 				# Translators: Dialog text presented when NVDA cannot save a log file.
@@ -235,6 +267,8 @@ class LogViewer(
 			)
 
 	def onOutputKeyDown(self, evt):
+		# Pause background loading briefly so user interaction stays responsive.
+		self._lastUserInputTime = time.monotonic()
 		key = evt.GetKeyCode()
 		# #3763: WX 3 no longer passes escape via evt_char in richEdit controls. Therefore evt_key_down must be used.
 		if key == wx.WXK_ESCAPE:

--- a/source/gui/logViewer.py
+++ b/source/gui/logViewer.py
@@ -6,21 +6,39 @@
 """Provides functionality to view the NVDA log."""
 
 import collections
+import time
 
+import comtypes
 import wx
+import comInterfaces.tom
 import globalVars
 import gui
 import gui.contextHelp
+import oleacc
+import winUser
 from gui import blockAction
+from logHandler import log
 
 
 #: The singleton instance of the log viewer UI.
 logViewer = None
 
-#: Maximum number of characters appended to the output control in one event loop iteration.
-#: Larger amounts of log text are appended in chunks of this size, yielding to the event loop in
-#: between, so that displaying a very large log does not block NVDA's core. (#16322)
-_APPEND_CHUNK_SIZE = 1_000_000
+#: Target upper bound on how long one append may block the event loop, in seconds.
+#: Log text is appended to the output control in chunks sized to this budget, yielding to the
+#: event loop in between, so that displaying a large log does not block NVDA's core. (#16322)
+_APPEND_TIME_BUDGET_SEC = 0.05
+#: Bounds for the adaptive append chunk size, in characters.
+#: RichEdit append throughput varies by orders of magnitude with content: text requiring font
+#: fallback (e.g. CJK, emoji, braille patterns) appends at roughly 0.03 MB/s, plain ASCII at
+#: roughly 12 MB/s. The chunk size is therefore adapted to the measured throughput.
+_MIN_CHUNK_SIZE = 1_000
+_MAX_CHUNK_SIZE = 1_000_000
+
+#: Passing this as both ends of a TOM range yields a collapsed range at the end of the document,
+#: as RichEdit clamps out of range character positions.
+_TOM_END_OF_DOC = 0x7FFFFFFF
+
+EM_SETREADONLY = 0x00CF
 
 
 class LogViewer(
@@ -73,6 +91,16 @@ class LogViewer(
 		#: A C{None} entry is a marker queued by L{moveInsertionPointToEndOfLog}.
 		self._pendingText: collections.deque[str | None] = collections.deque()
 		self._isPumpScheduled = False
+		self._chunkSize = _MIN_CHUNK_SIZE
+		try:
+			self._tomDoc = oleacc.AccessibleObjectFromWindow(
+				self.outputCtrl.GetHandle(),
+				winUser.OBJID_NATIVEOM,
+				interface=comInterfaces.tom.ITextDocument,
+			)
+		except (comtypes.COMError, OSError):
+			log.debugWarning("Error getting ITextDocument for the log viewer output control", exc_info=True)
+			self._tomDoc = None
 
 		self.refresh()
 		self.outputCtrl.SetFocus()
@@ -117,7 +145,7 @@ class LogViewer(
 			# The window was destroyed while a pump was scheduled.
 			return
 		chunk = ""
-		while self._pendingText and len(chunk) < _APPEND_CHUNK_SIZE:
+		while self._pendingText and len(chunk) < self._chunkSize:
 			item = self._pendingText.popleft()
 			if item is None:
 				# Marker queued by moveInsertionPointToEndOfLog.
@@ -127,7 +155,7 @@ class LogViewer(
 					chunk = ""
 				self.outputCtrl.SetInsertionPointEnd()
 				continue
-			maxLen = _APPEND_CHUNK_SIZE - len(chunk)
+			maxLen = self._chunkSize - len(chunk)
 			if len(item) > maxLen:
 				self._pendingText.appendleft(item[maxLen:])
 				item = item[:maxLen]
@@ -138,14 +166,39 @@ class LogViewer(
 			self._schedulePump()
 
 	def _appendText(self, text: str) -> None:
-		"""Append text to the output control, preserving the insertion point and scroll position."""
-		pos = self.outputCtrl.GetInsertionPoint()
-		self.outputCtrl.Freeze()
-		try:
-			self.outputCtrl.AppendText(text)
-			self.outputCtrl.SetInsertionPoint(pos)
-		finally:
-			self.outputCtrl.Thaw()
+		"""Append text to the output control without disturbing the caret or scroll position.
+		Also adapts the chunk size for the next append so that appends stay within the time budget.
+		"""
+		startTime = time.perf_counter()
+		if self._tomDoc:
+			# Insert with TOM rather than wx.TextCtrl.AppendText.
+			# AppendText moves the caret to the end of the document and back,
+			# which costs RichEdit layout work proportional to the total document size
+			# (tens of ms per append on a multi MB document, however small the appended text),
+			# and causes visible scroll flapping.
+			# A TOM range insert leaves the caret and scroll position untouched.
+			# TOM refuses to modify a read only control, so read only is lifted for the insert.
+			handle = self.outputCtrl.GetHandle()
+			winUser.sendMessage(handle, EM_SETREADONLY, False, 0)
+			try:
+				textRange = self._tomDoc.range(_TOM_END_OF_DOC, _TOM_END_OF_DOC)
+				textRange.text = text
+			finally:
+				winUser.sendMessage(handle, EM_SETREADONLY, True, 0)
+		else:
+			# Fallback if TOM is unavailable: append and restore the caret.
+			pos = self.outputCtrl.GetInsertionPoint()
+			self.outputCtrl.Freeze()
+			try:
+				self.outputCtrl.AppendText(text)
+				self.outputCtrl.SetInsertionPoint(pos)
+			finally:
+				self.outputCtrl.Thaw()
+		elapsed = time.perf_counter() - startTime
+		if elapsed > 0:
+			target = int(len(text) * _APPEND_TIME_BUDGET_SEC / elapsed)
+			# Grow at most 4x per append so one unrepresentatively fast append can't overshoot.
+			self._chunkSize = max(_MIN_CHUNK_SIZE, min(_MAX_CHUNK_SIZE, target, self._chunkSize * 4))
 
 	def onActivate(self, evt):
 		if evt.GetActive():

--- a/source/gui/logViewer.py
+++ b/source/gui/logViewer.py
@@ -5,6 +5,8 @@
 
 """Provides functionality to view the NVDA log."""
 
+import collections
+
 import wx
 import globalVars
 import gui
@@ -14,6 +16,11 @@ from gui import blockAction
 
 #: The singleton instance of the log viewer UI.
 logViewer = None
+
+#: Maximum number of characters appended to the output control in one event loop iteration.
+#: Larger amounts of log text are appended in chunks of this size, yielding to the event loop in
+#: between, so that displaying a very large log does not block NVDA's core. (#16322)
+_APPEND_CHUNK_SIZE = 1_000_000
 
 
 class LogViewer(
@@ -62,6 +69,10 @@ class LogViewer(
 		self.SetMenuBar(menuBar)
 
 		self._lastFilePos = 0
+		#: Log text read from the file but not yet appended to the output control.
+		#: A C{None} entry is a marker queued by L{moveInsertionPointToEndOfLog}.
+		self._pendingText: collections.deque[str | None] = collections.deque()
+		self._isPumpScheduled = False
 
 		self.refresh()
 		self.outputCtrl.SetFocus()
@@ -70,17 +81,71 @@ class LogViewer(
 		# Ignore if log is not initialized
 		if globalVars.appArgs.logFileName is None:
 			return
-		pos = self.outputCtrl.GetInsertionPoint()
-		# Append new text to the output control which has been written to the log file since the last refresh.
+		# Queue text which has been written to the log file since the last refresh for display.
+		# It is appended to the output control in chunks by L{_pumpPendingText},
+		# as appending a large amount of text in one go blocks NVDA's core for its duration. (#16322)
 		try:
-			f = open(globalVars.appArgs.logFileName, "r", encoding="UTF-8")
-			f.seek(self._lastFilePos)
-			self.outputCtrl.AppendText(f.read())
-			self._lastFilePos = f.tell()
-			self.outputCtrl.SetInsertionPoint(pos)
-			f.close()
+			with open(globalVars.appArgs.logFileName, "r", encoding="UTF-8") as f:
+				f.seek(self._lastFilePos)
+				text = f.read()
+				self._lastFilePos = f.tell()
 		except IOError:
-			pass
+			return
+		if text:
+			self._pendingText.append(text)
+			self._schedulePump()
+
+	def moveInsertionPointToEndOfLog(self) -> None:
+		"""Move the insertion point to the end of the log text queued for display so far.
+		Text queued after this call will appear after the insertion point,
+		thus leaving the user positioned at the start of that new text.
+		"""
+		self._pendingText.append(None)
+		self._schedulePump()
+
+	def _schedulePump(self) -> None:
+		if not self._isPumpScheduled:
+			self._isPumpScheduled = True
+			# Chain with CallLater rather than CallAfter.
+			# Posted events starve WM_TIMER, so a CallAfter chain would block timers,
+			# including NVDA's core pump, just like a synchronous append.
+			wx.CallLater(1, self._pumpPendingText)
+
+	def _pumpPendingText(self) -> None:
+		self._isPumpScheduled = False
+		if not self:
+			# The window was destroyed while a pump was scheduled.
+			return
+		chunk = ""
+		while self._pendingText and len(chunk) < _APPEND_CHUNK_SIZE:
+			item = self._pendingText.popleft()
+			if item is None:
+				# Marker queued by moveInsertionPointToEndOfLog.
+				# Flush the chunk first so that the end of the control is the end of the queued text.
+				if chunk:
+					self._appendText(chunk)
+					chunk = ""
+				self.outputCtrl.SetInsertionPointEnd()
+				continue
+			maxLen = _APPEND_CHUNK_SIZE - len(chunk)
+			if len(item) > maxLen:
+				self._pendingText.appendleft(item[maxLen:])
+				item = item[:maxLen]
+			chunk += item
+		if chunk:
+			self._appendText(chunk)
+		if self._pendingText:
+			self._schedulePump()
+
+	def _appendText(self, text: str) -> None:
+		"""Append text to the output control, preserving the insertion point and scroll position."""
+		pos = self.outputCtrl.GetInsertionPoint()
+		self.outputCtrl.Freeze()
+		try:
+			self.outputCtrl.AppendText(text)
+			self.outputCtrl.SetInsertionPoint(pos)
+		finally:
+			self.outputCtrl.Thaw()
 
 	def onActivate(self, evt):
 		if evt.GetActive():
@@ -104,6 +169,8 @@ class LogViewer(
 			# #9038: work with UTF-8 from the start.
 			with open(filename, "w", encoding="UTF-8") as f:
 				f.write(self.outputCtrl.GetValue())
+				# Include any log text queued for display but not yet appended to the output control.
+				f.write("".join(item for item in self._pendingText if item is not None))
 		except (IOError, OSError) as e:
 			gui.messageBox(
 				# Translators: Dialog text presented when NVDA cannot save a log file.

--- a/source/logHandler.py
+++ b/source/logHandler.py
@@ -282,7 +282,7 @@ class Logger(logging.Logger):
 			# Move to the end of the current log text. The new text will be written at this position.
 			# This means that the user will be positioned at the start of the new log text.
 			# This is why we activate the log viewer before writing to the log.
-			logViewer.logViewer.outputCtrl.SetInsertionPointEnd()
+			logViewer.logViewer.moveInsertionPointToEndOfLog()
 
 		if stack_info:
 			if stack_info is True:

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -48,6 +48,8 @@
 
 ### Bug Fixes
 
+* NVDA no longer freezes when opening the Log Viewer while the log is very large.
+  The log is now displayed progressively, keeping NVDA responsive while it loads. (#16322, @akj)
 * In PowerPoint and other Office applications, NVDA will now correctly read and navigate the edit fields in the insert hyperlink dialog. (#17390, @aryanchoudharypro)
 * The actions button can now be used when selecting multiple add-ons in the Add-on Store to perform batch actions, instead of just via the context menu in the add-ons list. (#19971, @amirmahdifard)
 * When moving to an ARIA grid cell in focus mode in web browsers, NVDA no longer reports both the row and column headers even if only the row or only the column changed. (#17750, @jcsteh)


### PR DESCRIPTION
### Link to issue number:
Fixes #16322

### Summary of the issue:
Opening the Log Viewer after a long session (particularly with debug logging) could freeze NVDA for tens of seconds — 15 to 87 seconds in reports on the issue and on this PR.

`LogViewer.refresh()` is incremental (it tracks `_lastFilePos`), which is why F5 and re-activating an already open viewer were always fast. But on first open it read the entire log file and handed it to a single `AppendText()` call on the RichEdit control, blocking NVDA's main thread for the duration.

Benchmarking showed RichEdit append throughput is **content dependent across several orders of magnitude**: plain ASCII (any line lengths) appends at ~12 MB/s, but text requiring font fallback — CJK (~0.03 MB/s), emoji and symbols (~0.12 MB/s), including the braille pattern characters NVDA logs when braille is in use — is hundreds of times slower, because RichEdit's font binding runs per text run. This matches all field reports: a >10 MB real-world debug log froze for 87 s (@tareh7z on this PR), while synthetic ASCII logs of 100+ MB looked comparatively fine. `TE_RICH2` and disabling word wrap make no difference. Disabling font binding (`IMF_AUTOFONT`) is ~70× faster but renders emoji and some scripts as boxes, so it was rejected (though it is a possible future option for maintainers to weigh).

This also means the previously proposed truncation to the last 1000 lines is not needed: the full log can be shown, just never in one blocking call.

### Description of user facing changes:
The Log Viewer now opens immediately regardless of log size or content. The log streams in progressively while NVDA continues to speak and respond to input; the longest single UI block measured is under 100 ms. Final caret placement is unchanged: top of the log on a plain open, or the start of the freshly written developer info for NVDA+f1. As a side effect of the new append mechanism, there is no scroll/caret churn while content loads.

### Description of developer facing changes:
`logHandler` no longer reaches into the viewer's `outputCtrl` to call `SetInsertionPointEnd()`; it calls a new `LogViewer.moveInsertionPointToEndOfLog()` method, which preserves the same "position the user at the start of the new log text" behaviour now that rendering is asynchronous.

### Description of development approach:
`refresh()` only reads newly written log text and queues it. A pump appends one chunk per event loop iteration, chaining iterations via `wx.CallLater` (not `wx.CallAfter`: posted events starve `WM_TIMER`, so a `CallAfter` chain would block timers, including NVDA's core pump, just like a synchronous append).

Chunks are sized adaptively to a 50 ms time budget based on the measured duration of the previous append (1 KB floor, 1 MB cap, growing at most 4× per iteration). Pathological content therefore simply means smaller chunks, never a blocked core.

Text is inserted via a TOM `ITextDocument` range at the end of the document rather than `wx.TextCtrl.AppendText`. `AppendText` moves the caret to the end and back, costing RichEdit layout work proportional to the total document size (~35 ms per append on a 25 MB document, however small the appended text), which defeats any time-budget controller; the TOM insert costs ~2 ms and leaves the caret and scroll position untouched. TOM is already a core NVDA dependency (`comInterfaces.tom`, used by `NVDAObjects.window.edit`). `AppendText` (with caret save/restore) remains as a fallback if `ITextDocument` is unavailable for the control.

The NVDA+f1 positioning contract is preserved with an in-queue marker: `moveInsertionPointToEndOfLog()` queues a marker between the existing log text and the dev info text that follows, and the pump moves the insertion point when it reaches the marker, so ordering is correct even while a large initial load is still draining. Save As includes queued but not yet rendered text so nothing is lost mid-load.

The implementation was AI-assisted (written with Claude); the approach, code and behaviour were reviewed and manually tested by me.

### Testing strategy:
* Manual testing: with debug logging and a large log, the viewer opens instantly, NVDA stays responsive while content streams in, NVDA+f1 lands on the developer info, F5 and Save As behave as before.
* A standalone functional test importing the real `logViewer` module (NVDA-specific imports stubbed) verified: construction over a 28 MB log takes ~0.1 s; a 28 MB ASCII log fully renders in ~4 s and 1 M characters of CJK/emoji in ~8 s, in both cases with no single event-loop block over 100 ms; content renders completely; the insertion point lands exactly at the start of the dev info text in the NVDA+f1 flow; F5 preserves the caret; destroying the window mid-load does not raise.
* Benchmark matrix isolating the content-dependence of RichEdit append throughput (results summarised above and in the PR comments).
* `runlint` passes.

### Known issues with pull request:
* Loading is oldest-first, so for very large fallback-heavy logs the most recent entries arrive last (up to a minute or two of background streaming in the worst case, with NVDA fully responsive throughout). If this matters in practice, loading the tail first is a possible follow-up.
* In the NVDA+f1 flow, if the user moves the caret while a large log is still loading, the caret will still jump to the start of the developer info once it renders. The final position matches the old behaviour (previously the user could not move at all, as NVDA was frozen).

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

Notes on the checklist: change log entry added; no user guide changes needed (no UI or behaviour change beyond removing the freeze). No unit tests added, as the existing test infrastructure does not cover wx GUI code; a standalone functional test was used instead (described above). `outputCtrl` and `refresh()` keep their existing public behaviour for add-ons such as NVDA Dev & Test Toolbox. Secure mode handling is unchanged.
