### PR TITLE
Retry copying a file while its source is briefly in use

### DIFF
--- a/source/installer.py
+++ b/source/installer.py
@@ -821,28 +821,57 @@ def tryRemoveFile(
 	raise RetriableFailure("File %s could not be removed" % path)
 
 
-def tryCopyFile(sourceFilePath: str, destFilePath: str):
+def tryCopyFile(
+	sourceFilePath: str,
+	destFilePath: str,
+	numRetries: int = 6,
+	retryInterval: float = 0.5,
+):
+	"""Copies a file, retrying while the source cannot be read.
+
+	:param sourceFilePath: Path of the file to copy.
+	:param destFilePath: Path to copy the file to.
+	:param numRetries: Number of attempts to make before giving up.
+	:param retryInterval: Time to wait between attempts, in seconds.
+	:raises OSError: If the file could not be copied.
+	:raises RetriableFailure: If an existing destination file could not be replaced.
+	"""
 	if not sourceFilePath.startswith("\\\\"):
 		sourceFilePath = "\\\\?\\" + sourceFilePath
 	if not destFilePath.startswith("\\\\"):
 		destFilePath = "\\\\?\\" + destFilePath
-	if winBindings.kernel32.CopyFile(sourceFilePath, destFilePath, False) == 0:
+	errorCode = 0
+	for count in range(numRetries):
+		if winBindings.kernel32.CopyFile(sourceFilePath, destFilePath, False) != 0:
+			return
 		errorCode = ctypes.GetLastError()
 		log.debugWarning("Unable to copy %s, error %d" % (sourceFilePath, errorCode))
-		if not os.path.exists(destFilePath):
-			raise OSError("error %d copying %s to %s" % (errorCode, sourceFilePath, destFilePath))
-		tempPath = _createEmptyTempFileForDeletingFile(dir=os.path.dirname(destFilePath))
-		try:
-			os.replace(destFilePath, tempPath)
-		except (WindowsError, OSError):
-			log.error("Failed to rename %s after failed overwrite" % destFilePath, exc_info=True)
-			raise RetriableFailure("Failed to rename %s after failed overwrite" % destFilePath)
-		winKernel.moveFileEx(tempPath, None, winKernel.MOVEFILE_DELAY_UNTIL_REBOOT)
-		if winBindings.kernel32.CopyFile(sourceFilePath, destFilePath, False) == 0:
-			errorCode = ctypes.GetLastError()
-			raise OSError(
-				"Unable to copy file %s to %s, error %d" % (sourceFilePath, destFilePath, errorCode),
+		if os.path.exists(destFilePath):
+			# The destination already exists, so the copy failed while overwriting it.
+			# Replace the existing file rather than retrying the copy.
+			break
+		# The destination was never created, so the copy failed while reading the source.
+		# Another process may hold the source open for a short time, for example NVDA
+		# still has a database open while leaving the UAC screen, so try again.
+		if count < numRetries - 1:
+			log.debugWarning(
+				f"Retrying copy of {sourceFilePath}, attempt {count + 1}/{numRetries}",
 			)
+			time.sleep(retryInterval)
+	else:
+		raise OSError("error %d copying %s to %s" % (errorCode, sourceFilePath, destFilePath))
+	tempPath = _createEmptyTempFileForDeletingFile(dir=os.path.dirname(destFilePath))
+	try:
+		os.replace(destFilePath, tempPath)
+	except (WindowsError, OSError):
+		log.error("Failed to rename %s after failed overwrite" % destFilePath, exc_info=True)
+		raise RetriableFailure("Failed to rename %s after failed overwrite" % destFilePath)
+	winKernel.moveFileEx(tempPath, None, winKernel.MOVEFILE_DELAY_UNTIL_REBOOT)
+	if winBindings.kernel32.CopyFile(sourceFilePath, destFilePath, False) == 0:
+		errorCode = ctypes.GetLastError()
+		raise OSError(
+			"Unable to copy file %s to %s, error %d" % (sourceFilePath, destFilePath, errorCode),
+		)
 
 
 _nvdaExes = {

--- a/tests/unit/test_installer.py
+++ b/tests/unit/test_installer.py
@@ -6,10 +6,11 @@
 """Unit tests for the installer module."""
 
 import pathlib
+import shutil
 import tempfile
 from typing import NamedTuple
 import unittest
-from unittest.mock import patch, PropertyMock
+from unittest.mock import call, patch, PropertyMock
 
 from parameterized import parameterized
 
@@ -480,3 +481,49 @@ class Test_comparePreviousInstall(unittest.TestCase):
 			),
 		):
 			self.assertEqual(installer._comparePreviousInstall(), installer.ComparisonState.UPGRADE)
+
+
+class Test_TryCopyFile(unittest.TestCase):
+	"""Tests for copying a single file.
+	A copy which fails because the source is briefly in use should be retried,
+	rather than aborting the whole operation it is part of.
+	"""
+
+	def setUp(self) -> None:
+		self._tempDir = tempfile.mkdtemp()
+		self._source = str(pathlib.Path(self._tempDir, "source.txt"))
+		self._dest = str(pathlib.Path(self._tempDir, "dest.txt"))
+		pathlib.Path(self._source).touch(exist_ok=False)
+
+	def tearDown(self) -> None:
+		shutil.rmtree(self._tempDir, ignore_errors=True)
+
+	def test_copySucceedsWithoutRetrying(self):
+		with patch("installer.winBindings.kernel32.CopyFile", return_value=1) as copyFile:
+			with patch("installer.time.sleep") as sleep:
+				installer.tryCopyFile(self._source, self._dest)
+		self.assertEqual(copyFile.call_count, 1)
+		sleep.assert_not_called()
+
+	def test_copyRetriedWhileSourceInUse(self):
+		"""A copy which leaves no destination file behind is retried until it succeeds."""
+		with patch("installer.winBindings.kernel32.CopyFile", side_effect=[0, 0, 1]) as copyFile:
+			with patch("installer.time.sleep") as sleep:
+				installer.tryCopyFile(self._source, self._dest)
+		self.assertEqual(copyFile.call_count, 3)
+		self.assertEqual(sleep.call_args_list, [call(0.5), call(0.5)])
+
+	def test_retryIntervalIsUsed(self):
+		"""Each retry waits for the requested interval."""
+		with patch("installer.winBindings.kernel32.CopyFile", side_effect=[0, 0, 1]):
+			with patch("installer.time.sleep") as sleep:
+				installer.tryCopyFile(self._source, self._dest, retryInterval=0.25)
+		self.assertEqual(sleep.call_args_list, [call(0.25), call(0.25)])
+
+	def test_copyFailsOnceRetriesAreExhausted(self):
+		with patch("installer.winBindings.kernel32.CopyFile", return_value=0) as copyFile:
+			with patch("installer.time.sleep") as sleep:
+				with self.assertRaises(OSError):
+					installer.tryCopyFile(self._source, self._dest, numRetries=3)
+		self.assertEqual(copyFile.call_count, 3)
+		self.assertEqual(sleep.call_count, 2)

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -77,6 +77,7 @@ Previously these keys had no function when pressed on their own. (#20366, @fla-r
 * Remote Access: NVDA now reports when connecting as the controlled computer fails, while continuing to retry the connection in the background. (#19103, @danielw97)
 * NVDA no longer briefly disconnects and re-detects the braille display on desktop switches that do not enter the secure desktop, such as when switching between a Remote Desktop session and the local machine. (#18810, #20550, @LeonarddeR)
 * In Windows Terminal, mouse tracking now reports the line of text under the mouse pointer. (#20448, @DataTriny)
+* When copying the current user configuration for use on the sign-in and other secure screens, NVDA now retries files which are briefly in use, instead of failing the whole copy. (#20118, @yasumorishima)
 
 ### Changes for Developers
 


### PR DESCRIPTION
### Link to issue number:

Fixes #20118

### Summary of the issue:

Copying the current user configuration to the system configuration, so that it is used on the sign-in and other secure screens, fails with "cannot copy NVDA user settings" while some files are copied and others are not.

`config._setSystemConfig` walks the user configuration and calls `installer.tryCopyFile` for every file. `tryCopyFile` raises as soon as `CopyFile` fails and no destination file was created, so a single source file that another process still holds open aborts the whole copy.

In the report, a database in the user configuration was still open while NVDA was leaving the UAC screen, which matches @seanbudd's reading of the cause in the issue.

### Description of user facing changes:

Copying the configuration to the system configuration no longer fails because a file was briefly in use.

### Description of developer facing changes:

`installer.tryCopyFile` takes two new optional arguments, `numRetries` (default 6) and `retryInterval` (default 0.5). Existing callers are unaffected.

### Description of development approach:

`tryRemoveFile` in the same module already retries six times at half second intervals, so `tryCopyFile` now follows that pattern rather than introducing a new one.

The retry applies only when the copy failed and no destination file exists, which is the case where the source could not be read. When the destination does exist the copy failed while overwriting it, and that path is unchanged: the existing file is still scheduled for deletion and the copy is attempted once more.

### Testing strategy:

Unit tests in `tests/unit/test_installer.py` cover four cases: success without retrying, retry until success, the configured `retryInterval` being used for each wait, and failure once the retries are exhausted. `CopyFile` and `time.sleep` are patched, so the tests assert the retry behaviour rather than filesystem timing.

CI on my fork is green, including the installer system tests, which exercise `tryCopyFile` through `copyProgramFiles` during a real installation.

I have not reproduced the original failure, since it depends on another process holding a configuration file open at the moment the copy runs. The change is therefore verified as retry behaviour rather than as a fix confirmed against the reported reproduction.

### Known issues with pull request:

@CyrilleB79 noted in the issue that it would be useful to tell the user which files could not be copied. That changes what the user is told rather than whether the copy succeeds, so it is not part of this change.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
