### PR TITLE
Add type annotations to the Java Access Bridge files

### DIFF
--- a/source/JABHandler.py
+++ b/source/JABHandler.py
@@ -5,6 +5,7 @@
 
 from collections.abc import Callable
 from enum import IntEnum, IntFlag
+from typing import Any
 import os
 import queue
 from ctypes import (
@@ -55,13 +56,13 @@ A11Y_PROPS_CONTENT = (
 # Some utility functions to help with function defines
 
 
-def _errcheck(res, func, args):
+def _errcheck(res: Any, func: Callable, args: tuple) -> Any:
 	if not res:
 		raise RuntimeError("Result %s" % res)
 	return res
 
 
-def _fixBridgeFunc(restype, name, *argtypes, **kwargs):
+def _fixBridgeFunc(restype: type | None, name: str, *argtypes: type, **kwargs: bool) -> None:
 	try:
 		func = getattr(bridgeDll, name)
 	except AttributeError:
@@ -334,7 +335,7 @@ AccessBridge_PropertyActiveDescendentChangeFP = CFUNCTYPE(
 )
 
 
-def _fixBridgeFuncs():
+def _fixBridgeFuncs() -> None:
 	"""Appropriately set the return and argument types of all the access bridge dll functions"""
 	_fixBridgeFunc(None, "Windows_run")
 	_fixBridgeFunc(None, "setFocusGainedFP", c_void_p)
@@ -592,7 +593,7 @@ def internalQueueFunction(func: Callable, *args, **kwargs) -> None:
 	core.requestPump()
 
 
-def internal_getWindowHandleFromAccContext(vmID, accContext):
+def internal_getWindowHandleFromAccContext(vmID: int, accContext: int) -> int | None:
 	try:
 		topAC = bridgeDll.getTopLevelObject(vmID, accContext)
 		try:
@@ -603,7 +604,7 @@ def internal_getWindowHandleFromAccContext(vmID, accContext):
 		return None
 
 
-def getWindowHandleFromAccContext(vmID, accContext):
+def getWindowHandleFromAccContext(vmID: int, accContext: int) -> int | None:
 	hwnd = internal_getWindowHandleFromAccContext(vmID, accContext)
 	if hwnd:
 		vmIDsToWindowHandles[vmID] = hwnd
@@ -613,7 +614,12 @@ def getWindowHandleFromAccContext(vmID, accContext):
 
 
 class JABContext(object):
-	def __init__(self, hwnd=None, vmID=None, accContext=None):
+	def __init__(
+		self,
+		hwnd: int | None = None,
+		vmID: int | None = None,
+		accContext: int | None = None,
+	) -> None:
 		if hwnd and not vmID:
 			vmID = c_long()
 			accContext = JOBJECT64()
@@ -627,14 +633,14 @@ class JABContext(object):
 		self.vmID = vmID
 		self.accContext = accContext
 
-	def __del__(self):
+	def __del__(self) -> None:
 		if isRunning:
 			try:
 				bridgeDll.releaseJavaObject(self.vmID, self.accContext)
 			except:  # noqa: E722
 				log.debugWarning("Error releasing java object", exc_info=True)
 
-	def __eq__(self, jabContext):
+	def __eq__(self, jabContext: "JABContext") -> bool:
 		if self.vmID == jabContext.vmID and bridgeDll.isSameObject(
 			self.vmID,
 			self.accContext,
@@ -646,10 +652,10 @@ class JABContext(object):
 
 	# As __eq__ was defined on this class, we must provide __hash__ to remain hashable.
 	# The default hash implementation is fine for  our purposes.
-	def __hash__(self):
+	def __hash__(self) -> int:
 		return super().__hash__()
 
-	def __ne__(self, jabContext):
+	def __ne__(self, jabContext: "JABContext") -> bool:
 		if self.vmID != jabContext.vmID or not bridgeDll.isSameObject(
 			self.vmID,
 			self.accContext,
@@ -659,30 +665,30 @@ class JABContext(object):
 		else:
 			return False
 
-	def getVersionInfo(self):
+	def getVersionInfo(self) -> AccessBridgeVersionInfo:
 		info = AccessBridgeVersionInfo()
 		bridgeDll.getVersionInfo(self.vmID, byref(info))
 		return info
 
-	def getObjectDepth(self):
+	def getObjectDepth(self) -> int:
 		return bridgeDll.getObjectDepth(self.vmID, self.accContext)
 
-	def getAccessibleContextInfo(self):
+	def getAccessibleContextInfo(self) -> AccessibleContextInfo:
 		info = AccessibleContextInfo()
 		bridgeDll.getAccessibleContextInfo(self.vmID, self.accContext, byref(info))
 		return info
 
-	def getAccessibleTextInfo(self, x, y):
+	def getAccessibleTextInfo(self, x: int, y: int) -> AccessibleTextInfo:
 		textInfo = AccessibleTextInfo()
 		bridgeDll.getAccessibleTextInfo(self.vmID, self.accContext, byref(textInfo), x, y)
 		return textInfo
 
-	def getAccessibleTextItems(self, index):
+	def getAccessibleTextItems(self, index: int) -> AccessibleTextItemsInfo:
 		textItemsInfo = AccessibleTextItemsInfo()
 		bridgeDll.getAccessibleTextItems(self.vmID, self.accContext, byref(textItemsInfo), index)
 		return textItemsInfo
 
-	def getAccessibleTextSelectionInfo(self):
+	def getAccessibleTextSelectionInfo(self) -> AccessibleTextSelectionInfo:
 		textSelectionInfo = AccessibleTextSelectionInfo()
 		bridgeDll.getAccessibleTextSelectionInfo(self.vmID, self.accContext, byref(textSelectionInfo))
 		return textSelectionInfo
@@ -728,7 +734,7 @@ class JABContext(object):
 
 		return "".join(text)
 
-	def getAccessibleTextLineBounds(self, index):
+	def getAccessibleTextLineBounds(self, index: int) -> tuple[int, int]:
 		index = max(index, 0)
 		log.debug("lineBounds: index %s" % index)
 		# Java returns end as the last character, not end as past the last character
@@ -787,35 +793,35 @@ class JABContext(object):
 		log.debug("line bounds: returning %s, %s" % (start, end))
 		return (start, end)
 
-	def getAccessibleParentFromContext(self):
+	def getAccessibleParentFromContext(self) -> "JABContext | None":
 		accContext = bridgeDll.getAccessibleParentFromContext(self.vmID, self.accContext)
 		if accContext:
 			return self.__class__(self.hwnd, self.vmID, accContext)
 		else:
 			return None
 
-	def getAccessibleParentWithRole(self, role):
+	def getAccessibleParentWithRole(self, role: str) -> "JABContext | None":
 		accContext = bridgeDll.getParentWithRole(self.vmID, self.accContext, role)
 		if accContext:
 			return self.__class__(self.hwnd, self.vmID, accContext)
 		else:
 			return None
 
-	def getAccessibleChildFromContext(self, index):
+	def getAccessibleChildFromContext(self, index: int) -> "JABContext | None":
 		accContext = bridgeDll.getAccessibleChildFromContext(self.vmID, self.accContext, index)
 		if accContext:
 			return self.__class__(self.hwnd, self.vmID, accContext)
 		else:
 			return None
 
-	def getActiveDescendent(self):
+	def getActiveDescendent(self) -> "JABContext | None":
 		accContext = bridgeDll.getActiveDescendent(self.vmID, self.accContext)
 		if accContext:
 			return self.__class__(self.hwnd, self.vmID, accContext)
 		else:
 			return None
 
-	def getAccessibleContextAt(self, x, y):
+	def getAccessibleContextAt(self, x: int, y: int) -> "JABContext | None":
 		newAccContext = JOBJECT64()
 		res = bridgeDll.getAccessibleContextAt(self.vmID, self.accContext, x, y, byref(newAccContext))
 		if not res or not newAccContext:
@@ -826,7 +832,7 @@ class JABContext(object):
 			bridgeDll.releaseJavaObject(self.vmID, newAccContext)
 		return None
 
-	def getCurrentAccessibleValueFromContext(self):
+	def getCurrentAccessibleValueFromContext(self) -> str:
 		buf = create_unicode_buffer(SHORT_STRING_SIZE + 1)
 		bridgeDll.getCurrentAccessibleValueFromContext(self.vmID, self.accContext, buf, SHORT_STRING_SIZE)
 		return buf.value
@@ -834,10 +840,14 @@ class JABContext(object):
 	def selectTextRange(self, start: int, end: int) -> None:
 		bridgeDll.selectTextRange(self.vmID, self.accContext, start, end)
 
-	def setCaretPosition(self, offset):
+	def setCaretPosition(self, offset: int) -> None:
 		bridgeDll.setCaretPosition(self.vmID, self.accContext, offset)
 
-	def getTextAttributesInRange(self, startIndex, endIndex):
+	def getTextAttributesInRange(
+		self,
+		startIndex: int,
+		endIndex: int,
+	) -> tuple[AccessibleTextAttributesInfo, int]:
 		attributes = AccessibleTextAttributesInfo()
 		length = c_short()
 		bridgeDll.getTextAttributesInRange(
@@ -850,17 +860,17 @@ class JABContext(object):
 		)
 		return attributes, length.value
 
-	def getAccessibleTextRect(self, index):
+	def getAccessibleTextRect(self, index: int) -> AccessibleTextRectInfo:
 		rect = AccessibleTextRectInfo()
 		bridgeDll.getAccessibleTextRect(self.vmID, self.accContext, byref(rect), index)
 		return rect
 
-	def getAccessibleRelationSet(self):
+	def getAccessibleRelationSet(self) -> AccessibleRelationSetInfo:
 		relations = AccessibleRelationSetInfo()
 		bridgeDll.getAccessibleRelationSet(self.vmID, self.accContext, byref(relations))
 		return relations
 
-	def getAccessibleTableInfo(self):
+	def getAccessibleTableInfo(self) -> AccessibleTableInfo | None:
 		info = AccessibleTableInfo()
 		if bridgeDll.getAccessibleTableInfo(self.vmID, self.accContext, byref(info)):
 			# #6992: Querying the hwnd for table related objects can cause the app to crash.
@@ -884,7 +894,7 @@ class JABContext(object):
 			)
 			return info
 
-	def getAccessibleTableCellInfo(self, row, col):
+	def getAccessibleTableCellInfo(self, row: int, col: int) -> AccessibleTableCellInfo | None:
 		info = AccessibleTableCellInfo()
 		if bridgeDll.getAccessibleTableCellInfo(self.vmID, self.accContext, row, col, byref(info)):
 			# #6992: Querying the hwnd for table related objects can cause the app to crash.
@@ -897,13 +907,13 @@ class JABContext(object):
 			)
 			return info
 
-	def getAccessibleTableRow(self, index):
+	def getAccessibleTableRow(self, index: int) -> int:
 		return bridgeDll.getAccessibleTableRow(self.vmID, self.accContext, index)
 
-	def getAccessibleTableColumn(self, index):
+	def getAccessibleTableColumn(self, index: int) -> int:
 		return bridgeDll.getAccessibleTableColumn(self.vmID, self.accContext, index)
 
-	def getAccessibleTableRowHeader(self):
+	def getAccessibleTableRowHeader(self) -> AccessibleTableInfo | None:
 		info = AccessibleTableInfo()
 		if bridgeDll.getAccessibleTableRowHeader(self.vmID, self.accContext, byref(info)):
 			# #6992: Querying the hwnd for table related objects can cause the app to crash.
@@ -927,7 +937,7 @@ class JABContext(object):
 			)
 			return info
 
-	def getAccessibleTableRowDescription(self, row):
+	def getAccessibleTableRowDescription(self, row: int) -> "JABContext | None":
 		accContext = bridgeDll.getAccessibleTableRowDescription(self.vmID, self.accContext, row)
 		if accContext:
 			# #6992: Querying the hwnd for table related objects can cause the app to crash.
@@ -935,7 +945,7 @@ class JABContext(object):
 			# so just pass the hwnd for the querying object.
 			return JABContext(hwnd=self.hwnd, vmID=self.vmID, accContext=accContext)
 
-	def getAccessibleTableColumnHeader(self):
+	def getAccessibleTableColumnHeader(self) -> AccessibleTableInfo | None:
 		info = AccessibleTableInfo()
 		if bridgeDll.getAccessibleTableColumnHeader(self.vmID, self.accContext, byref(info)):
 			# #6992: Querying the hwnd for table related objects can cause the app to crash.
@@ -959,7 +969,7 @@ class JABContext(object):
 			)
 			return info
 
-	def getAccessibleTableColumnDescription(self, column):
+	def getAccessibleTableColumnDescription(self, column: int) -> "JABContext | None":
 		accContext = bridgeDll.getAccessibleTableColumnDescription(self.vmID, self.accContext, column)
 		if accContext:
 			# #6992: Querying the hwnd for table related objects can cause the app to crash.
@@ -967,20 +977,20 @@ class JABContext(object):
 			# so just pass the hwnd for the querying object.
 			return JABContext(hwnd=self.hwnd, vmID=self.vmID, accContext=accContext)
 
-	def getAccessibleKeyBindings(self):
+	def getAccessibleKeyBindings(self) -> AccessibleKeyBindings | None:
 		bindings = AccessibleKeyBindings()
 		if bridgeDll.getAccessibleKeyBindings(self.vmID, self.accContext, byref(bindings)):
 			return bindings
 
 
 @AccessBridge_FocusGainedFP
-def internal_event_focusGained(vmID, event, source):
+def internal_event_focusGained(vmID: int, event: int, source: int) -> None:
 	hwnd = getWindowHandleFromAccContext(vmID, source)
 	internalQueueFunction(event_gainFocus, vmID, source, hwnd)
 	bridgeDll.releaseJavaObject(vmID, event)
 
 
-def event_gainFocus(vmID, accContext, hwnd):
+def event_gainFocus(vmID: int, accContext: int, hwnd: int) -> None:
 	jabContext = JABContext(hwnd=hwnd, vmID=vmID, accContext=accContext)
 	if not winUser.isDescendantWindow(winUser.getForegroundWindow(), jabContext.hwnd):
 		return
@@ -1011,7 +1021,7 @@ def internal_event_activeDescendantChange(
 		bridgeDll.releaseJavaObject(vmID, accContext)
 
 
-def internal_hasFocus(sourceContext):
+def internal_hasFocus(sourceContext: JABContext) -> bool:
 	focus = api.getFocusObject()
 	if isinstance(focus, NVDAObjects.JAB.JAB) and focus.jabContext == sourceContext:
 		return True
@@ -1101,12 +1111,18 @@ def event_valueChange(vmID: int, accContext: int) -> None:
 
 
 @AccessBridge_PropertyStateChangeFP
-def internal_event_stateChange(vmID, event, source, oldState, newState):
+def internal_event_stateChange(
+	vmID: int,
+	event: int,
+	source: int,
+	oldState: str | None,
+	newState: str | None,
+) -> None:
 	internalQueueFunction(event_stateChange, vmID, source, oldState, newState)
 	bridgeDll.releaseJavaObject(vmID, event)
 
 
-def event_stateChange(vmID, accContext, oldState, newState):
+def event_stateChange(vmID: int, accContext: int, oldState: str | None, newState: str) -> None:
 	jabContext = JABContext(vmID=vmID, accContext=accContext)
 	if not jabContext.hwnd:
 		log.debugWarning("Unable to obtain window handle for accessible context")
@@ -1135,7 +1151,7 @@ def event_stateChange(vmID, accContext, oldState, newState):
 
 
 @AccessBridge_PropertyCaretChangeFP
-def internal_event_caretChange(vmID, event, source, oldPos, newPos):
+def internal_event_caretChange(vmID: int, event: int, source: int, oldPos: int, newPos: int) -> None:
 	hwnd = getWindowHandleFromAccContext(vmID, source)
 	if oldPos < 0 and newPos >= 0:
 		internalQueueFunction(event_gainFocus, vmID, source, hwnd)
@@ -1144,7 +1160,7 @@ def internal_event_caretChange(vmID, event, source, oldPos, newPos):
 	bridgeDll.releaseJavaObject(vmID, event)
 
 
-def event_caret(vmID, accContext, hwnd):
+def event_caret(vmID: int, accContext: int, hwnd: int) -> None:
 	jabContext = JABContext(hwnd=hwnd, vmID=vmID, accContext=accContext)
 	if jabContext.hwnd:
 		focus = api.getFocusObject()
@@ -1159,11 +1175,11 @@ def event_caret(vmID, accContext, hwnd):
 		log.debugWarning("Unable to obtain window handle for accessible context")
 
 
-def event_enterJavaWindow(hwnd):
+def event_enterJavaWindow(hwnd: int) -> None:
 	internalQueueFunction(enterJavaWindow_helper, hwnd)
 
 
-def enterJavaWindow_helper(hwnd):
+def enterJavaWindow_helper(hwnd: int) -> None:
 	vmID = c_long()
 	accContext = JOBJECT64()
 	timeout = time.time() + 0.2
@@ -1188,13 +1204,13 @@ def enterJavaWindow_helper(hwnd):
 	event_gainFocus(vmID, accContext, hwnd)
 
 
-def isJavaWindow(hwnd):
+def isJavaWindow(hwnd: int) -> bool:
 	if not bridgeDll or not isRunning:
 		return False
 	return bridgeDll.isJavaWindow(hwnd)
 
 
-def isBridgeEnabled():
+def isBridgeEnabled() -> bool:
 	try:
 		data = open(A11Y_PROPS_PATH, "rt").read()
 	except OSError:
@@ -1202,7 +1218,7 @@ def isBridgeEnabled():
 	return data == A11Y_PROPS_CONTENT
 
 
-def enableBridge():
+def enableBridge() -> None:
 	try:
 		props = open(A11Y_PROPS_PATH, "wt")
 		props.write(A11Y_PROPS_CONTENT)
@@ -1211,7 +1227,7 @@ def enableBridge():
 		log.warning("Couldn't enable Java Access Bridge for user", exc_info=True)
 
 
-def initialize():
+def initialize() -> None:
 	global bridgeDll, isRunning
 	try:
 		bridgeDll = cdll.LoadLibrary(NVDAState.ReadPaths.javaAccessBridgeDLL)
@@ -1241,12 +1257,12 @@ def initialize():
 	isRunning = True
 
 
-def pumpAll():
+def pumpAll() -> None:
 	if isRunning:
 		queueHandler.flushQueue(internalFunctionQueue)
 
 
-def terminate():
+def terminate() -> None:
 	global isRunning, bridgeDll
 	if not bridgeDll or not isRunning:
 		return
@@ -1295,7 +1311,7 @@ JABKeyModifiersToLabels = {
 }
 
 
-def _getKeyLabels(modifiers, character):
+def _getKeyLabels(modifiers: int, character: str) -> list[str]:
 	keys = [v for m, v in JABKeyModifiersToLabels.items() if modifiers & m]
 	if modifiers & AccessibleKeystroke.FKEY:
 		keys.append("F{}".format(ord(character)))

--- a/source/NVDAObjects/JAB/__init__.py
+++ b/source/NVDAObjects/JAB/__init__.py
@@ -197,7 +197,12 @@ class JABTextInfo(textInfos.offsets.OffsetsTextInfo):
 	def _getParagraphOffsets(self, offset: int) -> tuple[int, int]:
 		return super()._getLineOffsets(offset)
 
-	def _getFormatFieldAndOffsets(self, offset: int, formatConfig, calculateOffsets=True):
+	def _getFormatFieldAndOffsets(
+		self,
+		offset: int,
+		formatConfig,
+		calculateOffsets: bool = True,
+	) -> tuple[textInfos.FormatField, tuple[int, int]]:
 		attribs: JABHandler.AccessibleTextAttributesInfo
 		attribs, length = self.obj.jabContext.getTextAttributesInRange(offset, self._endOffset - 1)
 		field = textInfos.FormatField()
@@ -295,7 +300,7 @@ class JAB(Window):
 		return parent is not None and isinstance(parent, Table) and parent._jabTableInfo
 
 	@classmethod
-	def kwargsFromSuper(cls, kwargs, relation: str | None = None) -> bool:
+	def kwargsFromSuper(cls, kwargs: dict[str, Any], relation: str | None = None) -> bool:
 		jabContext = None
 		windowHandle = kwargs["windowHandle"]
 		if relation == "focus":
@@ -322,7 +327,12 @@ class JAB(Window):
 		kwargs["jabContext"] = jabContext
 		return True
 
-	def __init__(self, relation=None, windowHandle=None, jabContext=None):
+	def __init__(
+		self,
+		relation: str | None = None,
+		windowHandle: int | None = None,
+		jabContext: "JABHandler.JABContext | None" = None,
+	) -> None:
 		if not windowHandle:
 			windowHandle = jabContext.hwnd
 		self.windowHandle = windowHandle
@@ -333,10 +343,10 @@ class JAB(Window):
 		except RuntimeError:
 			raise InvalidNVDAObject("Could not get accessible context info")
 
-	def _get__JABAccContextInfo(self):
+	def _get__JABAccContextInfo(self) -> "JABHandler.AccessibleContextInfo":
 		return self.jabContext.getAccessibleContextInfo()
 
-	def _get_TextInfo(self):
+	def _get_TextInfo(self) -> type[textInfos.TextInfo]:
 		if self._JABAccContextInfo.accessibleText and self.role not in [
 			controlTypes.Role.BUTTON,
 			controlTypes.Role.MENUITEM,
@@ -379,14 +389,14 @@ class JAB(Window):
 			shortcutsList.append("+".join(keyList))
 		return ", ".join(shortcutsList)
 
-	def _get_name(self):
+	def _get_name(self) -> str:
 		name = self._JABAccContextInfo.name
 		return _processHtml(name)
 
-	def _get_JABRole(self):
+	def _get_JABRole(self) -> str:
 		return self._JABAccContextInfo.role_en_US
 
-	def _get_role(self):
+	def _get_role(self) -> controlTypes.Role:
 		role = JABRolesToNVDARoles.get(self.JABRole, controlTypes.Role.UNKNOWN)
 		if (
 			role in (controlTypes.Role.LABEL, controlTypes.Role.PANEL, controlTypes.Role.UNKNOWN)
@@ -403,10 +413,10 @@ class JAB(Window):
 			return controlTypes.Role.STATICTEXT
 		return role
 
-	def _get_JABStates(self):
+	def _get_JABStates(self) -> str:
 		return self._JABAccContextInfo.states_en_US
 
-	def _get_states(self):
+	def _get_states(self) -> set[controlTypes.State]:
 		log.debug("states: %s" % self.JABStates)
 		stateSet = set()
 		stateString = self.JABStates
@@ -429,7 +439,7 @@ class JAB(Window):
 			stateSet.add(controlTypes.State.UNAVAILABLE)
 		return stateSet
 
-	def _get_value(self):
+	def _get_value(self) -> str | None:
 		if (
 			self.role
 			not in [
@@ -445,11 +455,11 @@ class JAB(Window):
 		):
 			return self.jabContext.getCurrentAccessibleValueFromContext()
 
-	def _get_description(self):
+	def _get_description(self) -> str:
 		description = self._JABAccContextInfo.description
 		return _processHtml(description)
 
-	def _get_location(self):
+	def _get_location(self) -> RectLTWH:
 		return RectLTWH(
 			self._JABAccContextInfo.x,
 			self._JABAccContextInfo.y,
@@ -463,7 +473,7 @@ class JAB(Window):
 		else:
 			return False
 
-	def _get_positionInfo(self):
+	def _get_positionInfo(self) -> dict[str, int]:
 		info = super(JAB, self).positionInfo or {}
 
 		# If tree view item, try to retrieve the level via JAB
@@ -497,14 +507,14 @@ class JAB(Window):
 			info["similarItemsInGroup"] = childCount
 		return info
 
-	def _get_activeChild(self):
+	def _get_activeChild(self) -> "JAB | None":
 		jabContext = self.jabContext.getActiveDescendent()
 		if jabContext:
 			return JAB(jabContext=jabContext)
 		else:
 			return None
 
-	def _get_parent(self):
+	def _get_parent(self) -> NVDAObject | None:
 		if not hasattr(self, "_parent"):
 			jabContext = self.jabContext.getAccessibleParentFromContext()
 			if jabContext and self.indexInParent is not None:
@@ -513,7 +523,7 @@ class JAB(Window):
 				self._parent = super(JAB, self).parent
 		return self._parent
 
-	def _get_next(self):
+	def _get_next(self) -> NVDAObject | None:
 		parent = self.parent
 		if not isinstance(parent, JAB):
 			return super(JAB, self).next
@@ -534,7 +544,7 @@ class JAB(Window):
 			return None
 		return obj
 
-	def _get_previous(self):
+	def _get_previous(self) -> NVDAObject | None:
 		parent = self.parent
 		if not isinstance(parent, JAB):
 			return super(JAB, self).previous
@@ -555,7 +565,7 @@ class JAB(Window):
 			return None
 		return obj
 
-	def _get_firstChild(self):
+	def _get_firstChild(self) -> "JAB | None":
 		if self._JABAccContextInfo.childrenCount <= 0:
 			return None
 		jabContext = self.jabContext.getAccessibleChildFromContext(0)
@@ -569,7 +579,7 @@ class JAB(Window):
 		else:
 			return None
 
-	def _get_lastChild(self):
+	def _get_lastChild(self) -> "JAB | None":
 		if self._JABAccContextInfo.childrenCount <= 0:
 			return None
 		jabContext = self.jabContext.getAccessibleChildFromContext(self.childCount - 1)
@@ -616,17 +626,17 @@ class JAB(Window):
 					JABHandler.bridgeDll.releaseJavaObject(self.jabContext.vmID, target)
 		return targets
 
-	def _get_flowsTo(self):
+	def _get_flowsTo(self) -> "JABHandler.JABContext | None":
 		targets = self._getJABRelationTargets("flowsTo")
 		if targets:
 			return targets[0]
 
-	def _get_flowsFrom(self):
+	def _get_flowsFrom(self) -> "JABHandler.JABContext | None":
 		targets = self._getJABRelationTargets("flowsFrom")
 		if targets:
 			return targets[0]
 
-	def reportFocus(self):
+	def reportFocus(self) -> None:
 		parent = self.parent
 		if (
 			self.role in [controlTypes.Role.LIST]
@@ -636,7 +646,7 @@ class JAB(Window):
 			return
 		super(JAB, self).reportFocus()
 
-	def _get__actions(self):
+	def _get__actions(self) -> list["JABHandler.AccessibleActionInfo"]:
 		actions = JABHandler.AccessibleActions()
 		JABHandler.bridgeDll.getAccessibleActions(self.jabContext.vmID, self.jabContext.accContext, actions)
 		return actions.actionInfo[: actions.actionsCount]
@@ -644,7 +654,7 @@ class JAB(Window):
 	def _get_actionCount(self) -> int:
 		return len(self._actions)
 
-	def getActionName(self, index=None):
+	def getActionName(self, index: int | None = None) -> str:
 		if index is None:
 			index = self.defaultActionIndex
 		try:
@@ -652,7 +662,7 @@ class JAB(Window):
 		except IndexError:
 			raise NotImplementedError
 
-	def doAction(self, index=None):
+	def doAction(self, index: int | None = None) -> None:
 		if index is None:
 			index = self.defaultActionIndex
 		try:
@@ -665,7 +675,7 @@ class JAB(Window):
 		except (IndexError, RuntimeError):
 			raise NotImplementedError
 
-	def _get_activeDescendant(self):
+	def _get_activeDescendant(self) -> "JAB | None":
 		descendantFound = False
 		jabContext = self.jabContext
 		while jabContext:
@@ -686,7 +696,7 @@ class JAB(Window):
 		if descendantFound:
 			return JAB(jabContext=jabContext)
 
-	def event_gainFocus(self):
+	def event_gainFocus(self) -> None:
 		if eventHandler.isPendingEvents("gainFocus"):
 			return
 		super(JAB, self).event_gainFocus()
@@ -698,7 +708,7 @@ class JAB(Window):
 
 
 class ComboBox(JAB):
-	def _get_states(self):
+	def _get_states(self) -> set[controlTypes.State]:
 		states = super(ComboBox, self).states
 		if controlTypes.State.COLLAPSED not in states and controlTypes.State.EXPANDED not in states:
 			if (
@@ -712,12 +722,12 @@ class ComboBox(JAB):
 					states.add(controlTypes.State.EXPANDED)
 		return states
 
-	def _get_activeDescendant(self):
+	def _get_activeDescendant(self) -> "JAB | None":
 		if controlTypes.State.COLLAPSED in self.states:
 			return None
 		return super(ComboBox, self).activeDescendant
 
-	def _get_value(self):
+	def _get_value(self) -> str | None:
 		value = super(ComboBox, self).value
 		if not value and not self.activeDescendant:
 			descendant = super(ComboBox, self).activeDescendant
@@ -727,7 +737,7 @@ class ComboBox(JAB):
 
 
 class Table(JAB):
-	def _get__jabTableInfo(self):
+	def _get__jabTableInfo(self) -> "JABHandler.AccessibleTableInfo | None":
 		info = self.jabContext.getAccessibleTableInfo()
 		if info:
 			self._jabTableInfo = info
@@ -741,17 +751,17 @@ class Table(JAB):
 		if self._jabTableInfo:
 			return self._jabTableInfo.columnCount
 
-	def _get_tableID(self):
+	def _get_tableID(self) -> int:
 		return self._jabTableInfo.jabTable.accContext.value
 
 
 class TableCell(JAB):
-	def _get_table(self):
+	def _get_table(self) -> "Table | None":
 		if self.parent and isinstance(self.parent, Table):
 			self.table = self.parent
 			return self.table
 
-	def _get_tableID(self):
+	def _get_tableID(self) -> int:
 		return self.table.tableID
 
 	def _get_rowNumber(self) -> int:


### PR DESCRIPTION
### THIS IS AN UNSUPERVISED AI PR. NO HUMAN WAS INVOLVED IN REVIEWING OR TESTING THIS CODE.

### Link to issue number:

Closes #13835

### Summary of the issue:

`source/JABHandler.py` and `source/NVDAObjects/JAB/__init__.py` carry very little type information. #13835 asks for it to be added as its own effort rather than pushed onto unrelated contributions.

Measured on master before this change:

| File | Functions | Missing return annotation | Missing ≥1 parameter annotation |
| --- | ---: | ---: | ---: |
| `source/JABHandler.py` | 64 | 52 | 33 |
| `source/NVDAObjects/JAB/__init__.py` | 66 | 34 | 5 |

### Description of user facing changes:

None. Signatures only.

### Description of developer facing changes:

Both files now have a return annotation on every function. 38 parameter annotations were added, and `from typing import Any` was added to `JABHandler.py` for `_errcheck`.

Two omissions are deliberate:

- `internalQueueFunction`'s `*args`/`**kwargs` — it forwards arbitrary handler arguments, and its `func: Callable` / `-> None` annotations were added deliberately, so the gap looks intentional.
- `JABTextInfo._getFormatFieldAndOffsets`'s `formatConfig` — the base declaration in `textInfos/offsets.py` is itself unannotated, so typing only the override would assert a contract the base does not make.

### Description of development approach:

The types were read out of declarations already in the tree rather than guessed.

- `_fixBridgeFuncs`'s restype/argtypes table gives the return type of every bridge call: `getObjectDepth` is `c_int`, so the wrapper is `-> int`; `getAccessibleTableRow`/`Column` are `jint`; the `JOBJECT64`-returning calls are wrapped into `JABContext | None`.
- The `CFUNCTYPE` prototypes fix the callback parameters. `AccessBridge_PropertyStateChangeFP` declares its last two arguments as `c_wchar_p`, so `oldState`/`newState` are `str | None`; `AccessBridge_PropertyCaretChangeFP` declares `c_int`, so `oldPos`/`newPos` are `int`.
- Where an unannotated function had an annotated sibling, the sibling's convention was followed rather than a new one invented — `internal_event_nameChange` was already `(vmID: int, event: int, source: int, oldVal: str | None, newVal: str | None) -> None`, so `internal_event_stateChange` and `internal_event_caretChange` match it, including its multi-line formatting.
- In `NVDAObjects/JAB/__init__.py`, `JABHandler` references are quoted. `JABHandler` imports `NVDAObjects.JAB` at line 41, before it defines `JABContext` and the ctypes structures, and annotations in a class body are evaluated when the class is created — so an unquoted `JABHandler.X` there resolves against a partially initialised module. This is not hypothetical: an earlier revision of this branch raised `AttributeError: partially initialized module 'JABHandler' has no attribute 'JABContext'` and broke importing `NVDAObjects` at all. The pre-existing `_getJABRelationTargets` annotation is already written as `list["JABHandler.JABContext"]` for the same reason.

`controlTypes` needs no quoting — the module-level `JABRolesToNVDARoles` dict already dereferences `controlTypes.Role.*` at import. `textInfos` needs none either — `class JABTextInfo(textInfos.offsets.OffsetsTextInfo)` already resolves at import.

### Testing strategy:

Java Access Bridge needs a Java application and a running NVDA, which was not available here, so this change was confined to signatures with no behavioural edit. The verification is therefore static, and it is the CI, not an assertion of correctness by inspection:

- **`Check types with Pyright`, `Check types with ty`, `Run unit tests`, `Build NVDA (x64)` and `Autofix or fail` all pass** on a fork run of byte-identical content (both blobs hash-match this branch: `431fc4aa…` and `ad8e26cf…`).
- The audit that produced the 52/34 counts reports 0 functions missing a return annotation after the change.
- Every introduced line is within ruff-format's 110 columns at `indent-width = 4`. Note the files already contain docstrings wider than that; ruff's selected lint rules (`E4`, `E7`, `E9`, `F`) do not include `E501`.

### Known issues with pull request:

The fork's system tests are unreliable and a different suite fails on each run — `browseableMessage`, then `chrome_roleDescription`. To check whether that was caused by this change, CI was also run on the fork's unmodified `master`: it failed too, on `installer` and `startupShutdown`, with unit tests passing. So the system-test failures track the fork environment, not this diff. Each failure seen was a timing one of the form `Timed out waiting for key to be processed`.

Three judgement calls a reviewer should overrule if they disagree:

1. **`JABContext.__eq__` / `__ne__` are annotated as taking `"JABContext"`, not `object`.** `object` is the strictly correct signature, but the bodies read `jabContext.vmID` with no `isinstance` guard, so `object` would only be honest alongside a body change — outside "add type information". Annotating the real expectation at least documents that `JABContext() == "somestring"` raises `AttributeError` today.
2. **`isJavaWindow` is annotated `-> bool`.** `bridgeDll.isJavaWindow` has restype `BOOL`, so ctypes hands back an `int`; the annotation states the intent rather than the exact runtime type. Wrapping the return in `bool(...)` would make it exact but is a behaviour-adjacent edit.
3. **`accContext` is annotated `int`.** That follows the functions in `JABHandler.py` that were already annotated, but the bridge calls with a `JOBJECT64` restype hand back a `JOBJECT64` instance which is then passed straight into `JABContext(...)`. If you would rather these read `int | JOBJECT64`, that is a mechanical follow-up.
