### PR TITLE
Clear the braille display on system shutdown

### DIFF
--- a/source/braille/brailleHandler.py
+++ b/source/braille/brailleHandler.py
@@ -219,6 +219,7 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 			if self.display:
 				# Suppress setting the display with empty cells when terminating it.
 				self.display._suppressDisplayClear = True
+			self.update()
 			self.setDisplayByName(NO_BRAILLE_DISPLAY_NAME, isFallback=True)
 		else:
 			# An ordinary desktop switch (e.g. in a Remote Desktop session) is also reported here.

--- a/source/core.py
+++ b/source/core.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 from typing import (
 	TYPE_CHECKING,
 	Any,
+	Literal,
 	Optional,
 )
 import comtypes
@@ -628,6 +629,7 @@ def _setUpWxApp() -> "wx.App":
 	import config
 	import nvwave
 	import speech
+	import braille
 
 	log.info(f"Using wx version {wx.version()}")
 
@@ -662,10 +664,16 @@ def _setUpWxApp() -> "wx.App":
 
 	app.Bind(wx.EVT_QUERY_END_SESSION, onQueryEndSession)
 
+	def returnFalse() -> Literal[False]:
+		return False
+
 	def onEndSession(evt):
 		# NVDA will be terminated as soon as this function returns, so save configuration if appropriate.
 		config.saveOnExit()
 		speech.cancelSpeech()
+		braille.extensions.decide_enabled.register(returnFalse)
+		if (brailleHandler := braille.handler) is not None:
+			brailleHandler._clearAll()
 		if not globalVars.appArgs.minimal and config.conf["general"]["playStartAndExitSounds"]:
 			try:
 				nvwave.playWaveFile(

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -6,7 +6,7 @@
 
 Please responsibly disclose security issues following NVDA's [security policy](https://github.com/nvaccess/nvda/blob/master/security.md).
 
-* Prevents showing potentially sensitive information on braille displays when the computer is shut down or restarted. ([GHSA-qhjv-3xf4-9c66](https://github.com/nvaccess/nvda/security/advisories/GHSA-qhjv-3xf4-9c66)
+* Prevents showing potentially sensitive information on braille displays when the computer is shut down or restarted. ([GHSA-qhjv-3xf4-9c66](https://github.com/nvaccess/nvda/security/advisories/GHSA-qhjv-3xf4-9c66))
 
 ### New Features
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -2,6 +2,12 @@
 
 ## 2026.3
 
+### Security fixes
+
+Please responsibly disclose security issues following NVDA's [security policy](https://github.com/nvaccess/nvda/blob/master/security.md).
+
+* Prevents showing potentially sensitive information on braille displays when the computer is shut down or restarted. ([GHSA-qhjv-3xf4-9c66](https://github.com/nvaccess/nvda/security/advisories/GHSA-qhjv-3xf4-9c66)
+
 ### New Features
 
 * Add-ons can be removed from the "Updatable add-ons" tab in the Add-on Store. (#15030, @nvdaes)


### PR DESCRIPTION
### Link to issue number:

Closes https://github.com/nvaccess/nvda/security/advisories/GHSA-qhjv-3xf4-9c66
Follow-up to #18810

### Summary of the issue:

When the machine is shut down or restarted with NVDA running and a braille display connected, the display is not reliably updated before NVDA exits. Depending on timing and braille message settings, whatever was last written to the display can remain on it until the display is refreshed or powered off.

### Description of user facing changes:

When shutting down or restarting the computer with NVDA running and a braille display connected, the braille display now either shows "Secure Desktop" or is cleared entirely.

### Description of developer facing changes:

None.

### Description of development approach:

Two changes:

1. In `braille.brailleHandler.BrailleHandler._onSecureDesktopStateChanged`, call `self.update()` after clearing the main buffer and before switching to the no-braille fallback. The "Secure Desktop" text is presented as an alert, which is not necessarily written to the display. If it isn't, clearing the buffer has no visible effect until the next display update, and by the time this function returns the display has been freed, so later code can no longer refresh it without re-acquiring it.
2. In our wx app's `WM_ENDSESSION` handler, disable braille (by registering a `braille.extensions.decide_enabled` handler that always returns `False`) and then call `braille.handler._clearAll()` if a braille handler exists.

In practice step 2 is usually a no-op for me, because the secure desktop state change handler frees the display first, but I don't believe that ordering is guaranteed. To confirm step 2 works on its own, I temporarily removed the session lock and secure desktop state change bindings in `BrailleHandler` and verified the `WM_ENDSESSION` path behaves correctly.

### Testing strategy:

* Built a portable copy (`./scons dist`).
* Connected a Hims Braille eMotion 40 via USB HID.
* Shut down the machine with the power button, with "Show messages" set to "Use timeout".
* Repeated with "Show messages" set to "Disabled".
* Commented out the registration and unregistration of `BrailleHandler`'s session lock state change and secure desktop state change handlers, rebuilt the dist, ran NVDA and shut down the machine with the power button.
* In all cases the display was either cleared completely or showed "Secure Desktop".

### Known issues with pull request:

When running from source, the display is not updated on shutdown, as we don't appear to receive `WM_ENDSESSION`. I suspect the Python interpreter consumes it and terminates in that case. I don't think this is something we need to worry about.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.