### PR TITLE
winVersion: recognize build 26300 as Windows 11 Version 26H2 (2026 update)

### DIFF
--- a/source/winVersion.py
+++ b/source/winVersion.py
@@ -45,6 +45,7 @@ _BUILDS_TO_RELEASE_NAMES: dict[int, str] = {
 	22631: "Windows 11 23H2",
 	26100: "Windows 11 24H2",
 	26200: "Windows 11 25H2",
+	26300: "Windows 11 26H2",
 }
 
 
@@ -164,6 +165,7 @@ WIN11_22H2 = WinVersion(major=10, minor=0, build=22621)
 WIN11_23H2 = WinVersion(major=10, minor=0, build=22631)
 WIN11_24H2 = WinVersion(major=10, minor=0, build=26100)
 WIN11_25H2 = WinVersion(major=10, minor=0, build=26200)
+WIN11_26H2 = WinVersion(major=10, minor=0, build=26300)
 
 
 @functools.lru_cache(maxsize=1)

--- a/source/winVersion.py
+++ b/source/winVersion.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2006-2025 NV Access Limited, Bill Dengler, Joseph Lee
+# Copyright (C) 2006-2026 NV Access Limited, Bill Dengler, Joseph Lee
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 


### PR DESCRIPTION

### Link to issue number:
Closes #20559 

### Summary of the issue:
On June 19, 2026, Microsoft announced Windows 11 Version 26H2 with the build number of 26300.

### Description of user facing changes:
None

### Description of developer facing changes:
source/winVersion.py:

* Updated copyright header
* Added constants for Windows 11 26H2 including build to release names mapping

### Description of development approach:
Added winVersion.WIN11_26H2 as the constant representing Windows 11 Version 26H2. Testing (see below) requires computers running builds below, on, and above 26300. The computer used to develop this PR runs build 26300 (Insider Preview).

### Testing strategy:
Manual:

Prerequisite: prepare three computers or virtual machines: a mahcine running a build below 26300 (25H2 (26200) will do), a computer subscribed to Windows Insider Experimental channel and WinVer shows build 26300, a machine running a build above 26300 (say, 26H1 stable build (28000)).

Procedure:

1. Open Python Console.
2. Import winVersion module, then define `WIN11_26H2` as `winVersion.WinVersion(major=10, minor=0, build=26300)`.
3. Check the just defined constant against winVersion.getWinVer() function output (specifically, `winVersion.getWinVer() >= WIN11_26H2`)..

Result:

* Below 26300: winVersion.getWinVer() >= WIN11_26H2 -> False
* Builds on or above 26300: winVersion.getWinVer() >= WIN11_26H2 -> True

### Known issues with pull request:
None for most cases. Note that Windows 11 Version 26H1 has a higher build number than 26H2.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
