### PR TITLE
Fix up references to full-screen modes

### DIFF
--- a/source/_magnifier/commands.py
+++ b/source/_magnifier/commands.py
@@ -286,7 +286,7 @@ def toggleFullscreenMode() -> None:
 			currentMode = fullscreenMagnifier._fullscreenMode
 			idx = modes.index(currentMode)
 			newMode = modes[(idx + 1) % len(modes)]
-			log.debug(f"Changing tracking mode from {currentMode} to {newMode}")
+			log.debug(f"Changing full-screen tracking mode from {currentMode} to {newMode}")
 			fullscreenMagnifier._fullscreenMode = newMode
 			setFullscreenMode(newMode)
 			ui.message(

--- a/source/_magnifier/commands.py
+++ b/source/_magnifier/commands.py
@@ -286,14 +286,14 @@ def toggleFullscreenMode() -> None:
 			currentMode = fullscreenMagnifier._fullscreenMode
 			idx = modes.index(currentMode)
 			newMode = modes[(idx + 1) % len(modes)]
-			log.debug(f"Changing full-screen mode from {currentMode} to {newMode}")
+			log.debug(f"Changing tracking mode from {currentMode} to {newMode}")
 			fullscreenMagnifier._fullscreenMode = newMode
 			setFullscreenMode(newMode)
 			ui.message(
 				pgettext(
 					"magnifier",
-					# Translators: Message announced when changing the full-screen mode with {mode} being the new full-screen mode.
-					"Full-screen mode {mode}",
+					# Translators: Message announced when changing the tracking mode with {mode} being the new tracking mode.
+					"Tracking mode {mode}",
 				).format(mode=newMode.displayString),
 			)
 

--- a/source/_magnifier/fullscreenMagnifier.py
+++ b/source/_magnifier/fullscreenMagnifier.py
@@ -74,7 +74,7 @@ class FullScreenMagnifier(Magnifier):
 			return
 		if _isDebug():
 			log.debug(
-				f"Starting magnifier with zoom level {self.zoomLevel} and filter {self.filterType} and tracking mode {self._fullscreenMode}",
+				f"Starting magnifier with zoom level {self.zoomLevel} and filter {self.filterType} and full-screen tracking mode {self._fullscreenMode}",
 			)
 		try:
 			self._initializeNativeMagnification()

--- a/source/_magnifier/fullscreenMagnifier.py
+++ b/source/_magnifier/fullscreenMagnifier.py
@@ -74,7 +74,7 @@ class FullScreenMagnifier(Magnifier):
 			return
 		if _isDebug():
 			log.debug(
-				f"Starting magnifier with zoom level {self.zoomLevel} and filter {self.filterType} and full-screen mode {self._fullscreenMode}",
+				f"Starting magnifier with zoom level {self.zoomLevel} and filter {self.filterType} and tracking mode {self._fullscreenMode}",
 			)
 		try:
 			self._initializeNativeMagnification()

--- a/source/_magnifier/utils/types.py
+++ b/source/_magnifier/utils/types.py
@@ -82,7 +82,7 @@ class MagnifierAction(DisplayStringEnum):
 			self.TOGGLE_FILTER: pgettext("magnifier action", "cycle color filters"),
 			# Translators: Action description for changing magnifier view.
 			self.CHANGE_MAGNIFIER_VIEW: pgettext("magnifier action", "change magnifier view"),
-			# Translators: Action description for changing full-screen mode.
+			# Translators: Action description for changing tracking mode.
 			self.CHANGE_FULLSCREEN_MODE: pgettext("magnifier action", "change tracking mode"),
 			# Translators: Action description for showing entire screen overview.
 			self.START_SPOTLIGHT: pgettext("magnifier action", "show screen overview"),

--- a/source/_magnifier/utils/types.py
+++ b/source/_magnifier/utils/types.py
@@ -83,7 +83,7 @@ class MagnifierAction(DisplayStringEnum):
 			# Translators: Action description for changing magnifier view.
 			self.CHANGE_MAGNIFIER_VIEW: pgettext("magnifier action", "change magnifier view"),
 			# Translators: Action description for changing full-screen mode.
-			self.CHANGE_FULLSCREEN_MODE: pgettext("magnifier action", "change full-screen mode"),
+			self.CHANGE_FULLSCREEN_MODE: pgettext("magnifier action", "change tracking mode"),
 			# Translators: Action description for showing entire screen overview.
 			self.START_SPOTLIGHT: pgettext("magnifier action", "show screen overview"),
 		}

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -6212,7 +6212,7 @@ class MagnifierPanel(SettingsPanel):
 		sHelper.addItem(trackingGroup)
 
 		# Tracking MODE SETTINGS
-		# Translators: The label for a setting in magnifier settings to select the full-screen mode
+		# Translators: The label for a setting in magnifier settings to select the tracking mode
 		trackingModeLabelText = _("&Tracking mode:")
 		trackingModeChoices = [mode.displayString for mode in FullScreenMode]
 		self.trackingModeList = trackingGroup.addLabeledControl(

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -6202,15 +6202,6 @@ class MagnifierPanel(SettingsPanel):
 			checkBox.Bind(wx.EVT_CHECKBOX, self._onImmediateSettingChange)
 			self._trackingTypeCheckBoxes[trackingType] = checkBox
 
-		# Tracking GROUP
-		# Translators: This is the label for a group of tracking magnifier options in the
-		# magnifier settings panel
-		trackingGroupText = _("Tracking")
-		self.trackingGroupSizer = wx.StaticBoxSizer(wx.VERTICAL, self, label=trackingGroupText)
-		trackingGroupBox = self.trackingGroupSizer.GetStaticBox()
-		trackingGroup = guiHelper.BoxSizerHelper(trackingGroupBox, sizer=self.trackingGroupSizer)
-		sHelper.addItem(trackingGroup)
-
 		# Tracking MODE SETTINGS
 		# Translators: The label for a setting in magnifier settings to select the tracking mode
 		trackingModeLabelText = _("&Tracking mode:")


### PR DESCRIPTION
### Link to issue number:
Raised here https://groups.io/g/nvda-translations/topic/comfused_about_fullscreen/120722300

### Summary of the issue:
Translators noticed some strings still refer to tracking mode as full-screen mode

### Description of user facing changes:
Fix up strings to describing tracking mode as such
### Description of developer facing changes:

### Description of development approach:

### Testing strategy:

### Known issues with pull request:
we will need to another translation freeze
### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
