### PR TITLE
Use Windows Graphics Capture for content recognition with Screen Curtain and Magnifier

### DIFF
--- a/source/contentRecog/__init__.py
+++ b/source/contentRecog/__init__.py
@@ -129,10 +129,10 @@ class RecogImageInfo:
 		@param screenWidth: The width of the image on the screen.
 		@param screenHeight: The height of the image on the screen.
 		@param resizeFactor: The factor by which the image must be resized for recognition.
-		@raise ValueError: If the supplied screen coordinates indicate that
-			the image is not visible; e.g. width or height of 0.
+		@raise ValueError: If the supplied image dimensions are invalid;
+			e.g. width or height of 0.
 		"""
-		if screenLeft < 0 or screenTop < 0 or screenWidth <= 0 or screenHeight <= 0:
+		if screenWidth <= 0 or screenHeight <= 0:
 			raise ValueError("Image not visible (invalid screen coordinates)")
 		self.screenLeft = screenLeft
 		self.screenTop = screenTop

--- a/source/contentRecog/__init__.py
+++ b/source/contentRecog/__init__.py
@@ -129,7 +129,7 @@ class RecogImageInfo:
 		@param screenWidth: The width of the image on the screen.
 		@param screenHeight: The height of the image on the screen.
 		@param resizeFactor: The factor by which the image must be resized for recognition.
-		@raise ValueError: If the supplied image dimensions are invalid;
+		:raises ValueError: If the supplied image dimensions are invalid;
 			e.g. width or height of 0.
 		"""
 		if screenWidth <= 0 or screenHeight <= 0:

--- a/source/contentRecog/_wgcCapture.py
+++ b/source/contentRecog/_wgcCapture.py
@@ -1,0 +1,47 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2026 NV Access Limited, Cary-rowen
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+
+"""Windows Graphics Capture support for content recognition."""
+
+import ctypes
+from ctypes import POINTER, cast
+
+from NVDAHelper.localWin10 import _wgcCapture_captureScreenRegion, _wgcCapture_isSupported
+import watchdog
+from winBindings.gdi32 import RGBQUAD
+
+from . import RecogImageInfo
+
+
+def isSupported() -> bool:
+	"""Return whether Windows Graphics Capture can be used for content recognition."""
+	return bool(_wgcCapture_isSupported())
+
+
+def _captureScreenRegion(imageInfo: RecogImageInfo, buffer: ctypes.Array) -> bool:
+	return bool(
+		_wgcCapture_captureScreenRegion(
+			imageInfo.screenLeft,
+			imageInfo.screenTop,
+			imageInfo.screenWidth,
+			imageInfo.screenHeight,
+			cast(buffer, POINTER(RGBQUAD)),
+			imageInfo.recogWidth,
+			imageInfo.recogHeight,
+		),
+	)
+
+
+def captureImage(imageInfo: RecogImageInfo) -> ctypes.Array:
+	"""Capture the specified screen region using Windows Graphics Capture."""
+	buffer = (RGBQUAD * imageInfo.recogWidth * imageInfo.recogHeight)()
+	captureSucceeded = watchdog.cancellableExecute(_captureScreenRegion, imageInfo, buffer)
+	if not captureSucceeded:
+		raise RuntimeError(
+			"Windows Graphics Capture failed for region "
+			f"{imageInfo.screenLeft}, {imageInfo.screenTop}, "
+			f"{imageInfo.screenWidth}, {imageInfo.screenHeight}",
+		)
+	return buffer

--- a/source/contentRecog/recogUi.py
+++ b/source/contentRecog/recogUi.py
@@ -10,6 +10,7 @@ and present the result to the user so they can read it with cursor keys, etc.
 NVDA scripts or GUI call the L{recognizeNavigatorObject} function with the recognizer they wish to use.
 """
 
+import ctypes
 from typing import Optional, Union, TYPE_CHECKING
 import api
 import ui
@@ -55,7 +56,7 @@ def _isWgcCaptureSupported() -> bool:
 	return _wgcCapture.isSupported()
 
 
-def _captureWithGdi(imageInfo: RecogImageInfo):
+def _captureWithGdi(imageInfo: RecogImageInfo) -> ctypes.Array:
 	sb = screenBitmap.ScreenBitmap(imageInfo.recogWidth, imageInfo.recogHeight)
 	return sb.captureImage(
 		imageInfo.screenLeft,
@@ -65,13 +66,13 @@ def _captureWithGdi(imageInfo: RecogImageInfo):
 	)
 
 
-def _captureWithWgc(imageInfo: RecogImageInfo):
+def _captureWithWgc(imageInfo: RecogImageInfo) -> ctypes.Array:
 	from . import _wgcCapture
 
 	return _wgcCapture.captureImage(imageInfo)
 
 
-def shouldBlockScreenCurtainEnable(focusObj: NVDAObjects.NVDAObject) -> bool:
+def _shouldBlockScreenCurtainEnable(focusObj: NVDAObjects.NVDAObject) -> bool:
 	"""Return whether enabling Screen Curtain should be blocked for an active recognition result."""
 	return (
 		isinstance(focusObj, RefreshableRecogResultNVDAObject)
@@ -80,7 +81,7 @@ def shouldBlockScreenCurtainEnable(focusObj: NVDAObjects.NVDAObject) -> bool:
 	)
 
 
-def _captureImage(imageInfo: RecogImageInfo):
+def _captureImage(imageInfo: RecogImageInfo) -> ctypes.Array:
 	if _shouldUseWgcCapture():
 		try:
 			return _captureWithWgc(imageInfo)

--- a/source/contentRecog/recogUi.py
+++ b/source/contentRecog/recogUi.py
@@ -318,10 +318,10 @@ def recognizeNavigatorObject(recognizer: ContentRecognizer):
 		ui.message(notVisibleMsg)
 		return
 	if _isScreenCurtainActive() and not _isWgcCaptureSupported():
-		# Translators: Reported when content recognition (e.g. OCR) is attempted while Screen Curtain
-		# is enabled, but the system does not support the required screen capture API.
 		ui.message(
 			_(
+				# Translators: Reported when content recognition (e.g. OCR) is attempted while Screen Curtain
+				# is enabled, but the system does not support the required screen capture API.
 				"Content recognition is unavailable while Screen Curtain is enabled on this system. "
 				"Please disable Screen Curtain and try again.",
 			),

--- a/source/contentRecog/recogUi.py
+++ b/source/contentRecog/recogUi.py
@@ -20,6 +20,7 @@ import controlTypes
 import browseMode
 import cursorManager
 import eventHandler
+import exceptions
 import textInfos
 from logHandler import log
 from speech import sayAll
@@ -30,6 +31,64 @@ from . import RecogImageInfo, ContentRecognizer, RecognitionResult, onRecognizeR
 
 if TYPE_CHECKING:
 	import inputCore
+
+
+def _isScreenCurtainActive() -> bool:
+	from screenCurtain import screenCurtain
+
+	return screenCurtain is not None and screenCurtain.enabled
+
+
+def _isMagnifierActive() -> bool:
+	import _magnifier
+
+	return _magnifier.isActive()
+
+
+def _shouldUseWgcCapture() -> bool:
+	return _isScreenCurtainActive() or (_isMagnifierActive() and _isWgcCaptureSupported())
+
+
+def _isWgcCaptureSupported() -> bool:
+	from . import _wgcCapture
+
+	return _wgcCapture.isSupported()
+
+
+def _captureWithGdi(imageInfo: RecogImageInfo):
+	sb = screenBitmap.ScreenBitmap(imageInfo.recogWidth, imageInfo.recogHeight)
+	return sb.captureImage(
+		imageInfo.screenLeft,
+		imageInfo.screenTop,
+		imageInfo.screenWidth,
+		imageInfo.screenHeight,
+	)
+
+
+def _captureWithWgc(imageInfo: RecogImageInfo):
+	from . import _wgcCapture
+
+	return _wgcCapture.captureImage(imageInfo)
+
+
+def shouldBlockScreenCurtainEnable(focusObj: NVDAObjects.NVDAObject) -> bool:
+	"""Return whether enabling Screen Curtain should be blocked for an active recognition result."""
+	return (
+		isinstance(focusObj, RefreshableRecogResultNVDAObject)
+		and focusObj.recognizer.allowAutoRefresh
+		and not _isWgcCaptureSupported()
+	)
+
+
+def _captureImage(imageInfo: RecogImageInfo):
+	if _shouldUseWgcCapture():
+		try:
+			return _captureWithWgc(imageInfo)
+		except RuntimeError:
+			if _isScreenCurtainActive():
+				raise
+			log.debugWarning("Windows Graphics Capture failed; falling back to GDI.", exc_info=True)
+	return _captureWithGdi(imageInfo)
 
 
 class RecogResultNVDAObject(cursorManager.CursorManager, NVDAObjects.window.Window):
@@ -136,13 +195,11 @@ class RefreshableRecogResultNVDAObject(RecogResultNVDAObject, LiveText):
 			# shouldn't recognize again.
 			return
 		imgInfo = self.imageInfo
-		sb = screenBitmap.ScreenBitmap(imgInfo.recogWidth, imgInfo.recogHeight)
-		pixels = sb.captureImage(
-			imgInfo.screenLeft,
-			imgInfo.screenTop,
-			imgInfo.screenWidth,
-			imgInfo.screenHeight,
-		)
+		try:
+			pixels = _captureImage(imgInfo)
+		except (RuntimeError, exceptions.CallCancelled) as e:
+			onResult(e)
+			return
 		self.recognizer.recognize(pixels, self.imageInfo, onResult)
 
 	def _onFirstResult(self, result: Union[RecognitionResult, Exception]):
@@ -259,6 +316,16 @@ def recognizeNavigatorObject(recognizer: ContentRecognizer):
 		imgInfo = RecogImageInfo.createFromRecognizer(left, top, width, height, recognizer)
 	except ValueError:
 		ui.message(notVisibleMsg)
+		return
+	if _isScreenCurtainActive() and not _isWgcCaptureSupported():
+		# Translators: Reported when content recognition (e.g. OCR) is attempted while Screen Curtain
+		# is enabled, but the system does not support the required screen capture API.
+		ui.message(
+			_(
+				"Content recognition is unavailable while Screen Curtain is enabled on this system. "
+				"Please disable Screen Curtain and try again.",
+			),
+		)
 		return
 	if _activeRecog:
 		_activeRecog.recognizer.cancel()

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -4855,13 +4855,6 @@ class GlobalCommands(ScriptableObject):
 			# Translators: Reported when Windows OCR is not available.
 			ui.message(_("Windows OCR not available"))
 			return
-		from screenCurtain import screenCurtain
-
-		isScreenCurtainRunning = screenCurtain is not None and screenCurtain.enabled
-		if isScreenCurtainRunning:
-			# Translators: Reported when screen curtain is enabled.
-			ui.message(_("Please disable screen curtain before using Windows OCR."))
-			return
 		from contentRecog import uwpOcr, recogUi
 
 		recog = uwpOcr.UwpOcr()
@@ -5046,6 +5039,14 @@ class GlobalCommands(ScriptableObject):
 				self._waitingOnScreenCurtainWarningDialog = None
 				if not doEnable:
 					return  # exit early with no ui.message because the user has decided to abort.
+				from contentRecog import recogUi
+
+				if recogUi.shouldBlockScreenCurtainEnable(focusObj):
+					ui.message(
+						screenCurtain._screenCurtain.UNAVAILABLE_WHEN_RECOGNISING_CONTENT_MESSAGE,
+						speechPriority=speech.priorities.Spri.NOW,
+					)
+					return
 				tempEnable = GlobalCommands._tempEnableScreenCurtain
 				# Translators: Reported when the screen curtain is enabled.
 				enableMessage = _("Screen curtain enabled")
@@ -5067,6 +5068,7 @@ class GlobalCommands(ScriptableObject):
 
 			#  Show warning if necessary and do enable.
 			settingsStorage = screenCurtain.screenCurtain.settings
+			focusObj = api.getFocusObject()
 			if settingsStorage["warnOnLoad"]:
 				dlg = screenCurtain._screenCurtain.WarnOnLoadDialog(
 					screenCurtainSettingsStorage=settingsStorage,
@@ -5082,18 +5084,6 @@ class GlobalCommands(ScriptableObject):
 					),
 				)
 			else:
-				from contentRecog.recogUi import RefreshableRecogResultNVDAObject
-
-				focusObj = api.getFocusObject()
-				if (
-					isinstance(focusObj, RefreshableRecogResultNVDAObject)
-					and focusObj.recognizer.allowAutoRefresh
-				):
-					ui.message(
-						screenCurtain._screenCurtain.UNAVAILABLE_WHEN_RECOGNISING_CONTENT_MESSAGE,
-						speechPriority=speech.priorities.Spri.NOW,
-					)
-					return
 				_enableScreenCurtain()
 
 	@script(

--- a/source/globalCommands.py
+++ b/source/globalCommands.py
@@ -5041,7 +5041,7 @@ class GlobalCommands(ScriptableObject):
 					return  # exit early with no ui.message because the user has decided to abort.
 				from contentRecog import recogUi
 
-				if recogUi.shouldBlockScreenCurtainEnable(focusObj):
+				if recogUi._shouldBlockScreenCurtainEnable(focusObj):
 					ui.message(
 						screenCurtain._screenCurtain.UNAVAILABLE_WHEN_RECOGNISING_CONTENT_MESSAGE,
 						speechPriority=speech.priorities.Spri.NOW,

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -6566,7 +6566,7 @@ class PrivacyAndSecuritySettingsPanel(SettingsPanel):
 			self._cachedScreenCurtainConfigEnabled = screenCurtain.screenCurtain.settings["enabled"]
 			self._cachedScreenCurtainEnabled = screenCurtain.screenCurtain.enabled
 
-	def _ocrActive(self) -> bool:
+	def _contentRecognitionActive(self) -> bool:
 		"""
 		Outputs a message when content recognition prevents Screen Curtain from being enabled.
 
@@ -6576,7 +6576,7 @@ class PrivacyAndSecuritySettingsPanel(SettingsPanel):
 		from contentRecog import recogUi
 
 		focusObj = api.getFocusObject()
-		if recogUi.shouldBlockScreenCurtainEnable(focusObj):
+		if recogUi._shouldBlockScreenCurtainEnable(focusObj):
 			ui.message(
 				screenCurtain._screenCurtain.UNAVAILABLE_WHEN_RECOGNISING_CONTENT_MESSAGE,
 				speechPriority=speech.priorities.Spri.NOW,
@@ -6593,7 +6593,7 @@ class PrivacyAndSecuritySettingsPanel(SettingsPanel):
 		currentlyEnabled = screenCurtain.screenCurtain.enabled
 		if shouldBeEnabled and not currentlyEnabled:
 			confirmed = self._confirmEnableScreenCurtainWithUser()
-			if not confirmed or self._ocrActive():
+			if not confirmed or self._contentRecognitionActive():
 				self._screenCurtainEnabledCheckbox.SetValue(False)
 			else:
 				try:

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -6568,15 +6568,15 @@ class PrivacyAndSecuritySettingsPanel(SettingsPanel):
 
 	def _ocrActive(self) -> bool:
 		"""
-		Outputs a message when trying to activate screen curtain when OCR is active.
+		Outputs a message when content recognition prevents Screen Curtain from being enabled.
 
-		:return: ``True`` when OCR is active, ``False`` otherwise.
+		:return: ``True`` when Screen Curtain should not be enabled, ``False`` otherwise.
 		"""
 		# Import late to avoid circular import
-		from contentRecog.recogUi import RefreshableRecogResultNVDAObject
+		from contentRecog import recogUi
 
 		focusObj = api.getFocusObject()
-		if isinstance(focusObj, RefreshableRecogResultNVDAObject) and focusObj.recognizer.allowAutoRefresh:
+		if recogUi.shouldBlockScreenCurtainEnable(focusObj):
 			ui.message(
 				screenCurtain._screenCurtain.UNAVAILABLE_WHEN_RECOGNISING_CONTENT_MESSAGE,
 				speechPriority=speech.priorities.Spri.NOW,

--- a/tests/unit/contentRecog/test_contentRecog.py
+++ b/tests/unit/contentRecog/test_contentRecog.py
@@ -31,6 +31,17 @@ class TestRecogImageInfo(unittest.TestCase):
 		self.assertEqual(info.convertWidthToScreen(100), 100)
 		self.assertEqual(info.convertHeightToScreen(200), 200)
 
+	def test_withNegativeOffset(self):
+		info = contentRecog.RecogImageInfo(-1920, -1080, 1000, 2000, 1)
+		self.assertEqual(info.convertXToScreen(100), -1820)
+		self.assertEqual(info.convertYToScreen(200), -880)
+
+	def test_nonPositiveDimensions(self):
+		for width, height in ((0, 100), (100, 0)):
+			with self.subTest(width=width, height=height):
+				with self.assertRaises(ValueError):
+					contentRecog.RecogImageInfo(0, 0, width, height, 1)
+
 	def test_noOffsetWithResize(self):
 		info = contentRecog.RecogImageInfo(0, 0, 1000, 2000, 2)
 		self.assertEqual(info.recogWidth, 2000)

--- a/tests/unit/contentRecog/test_recogUi.py
+++ b/tests/unit/contentRecog/test_recogUi.py
@@ -1,0 +1,104 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2026 NV Access Limited, Cary-rowen
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+
+"""Unit tests for the contentRecog.recogUi module."""
+
+from types import SimpleNamespace
+import unittest
+from unittest.mock import Mock, patch
+
+import contentRecog
+from contentRecog import recogUi
+import exceptions
+
+
+class _FakeRefreshableRecogResult:
+	def __init__(self, allowAutoRefresh: bool):
+		self.recognizer = SimpleNamespace(allowAutoRefresh=allowAutoRefresh)
+
+
+class TestCaptureImage(unittest.TestCase):
+	def setUp(self):
+		self.imageInfo = contentRecog.RecogImageInfo(0, 0, 100, 100, 1)
+		self.gdiPixels = object()
+
+	def test_usesGdiByDefault(self):
+		with (
+			patch.object(recogUi, "_isScreenCurtainActive", return_value=False),
+			patch.object(recogUi, "_isMagnifierActive", return_value=False),
+			patch.object(recogUi, "_captureWithWgc") as captureWithWgc,
+			patch.object(recogUi, "_captureWithGdi", return_value=self.gdiPixels) as captureWithGdi,
+		):
+			pixels = recogUi._captureImage(self.imageInfo)
+
+		self.assertIs(pixels, self.gdiPixels)
+		captureWithWgc.assert_not_called()
+		captureWithGdi.assert_called_once_with(self.imageInfo)
+
+	def test_screenCurtainWgcFailureDoesNotFallBackToGdi(self):
+		captureError = RuntimeError("capture failed")
+		with (
+			patch.object(recogUi, "_isScreenCurtainActive", return_value=True),
+			patch.object(recogUi, "_captureWithWgc", side_effect=captureError) as captureWithWgc,
+			patch.object(recogUi, "_captureWithGdi") as captureWithGdi,
+		):
+			with self.assertRaises(RuntimeError) as cm:
+				recogUi._captureImage(self.imageInfo)
+
+		self.assertIs(cm.exception, captureError)
+		captureWithWgc.assert_called_once_with(self.imageInfo)
+		captureWithGdi.assert_not_called()
+
+	def test_magnifierWgcFailureFallsBackToGdi(self):
+		with (
+			patch.object(recogUi, "_isScreenCurtainActive", return_value=False),
+			patch.object(recogUi, "_isMagnifierActive", return_value=True),
+			patch.object(recogUi, "_isWgcCaptureSupported", return_value=True),
+			patch.object(
+				recogUi, "_captureWithWgc", side_effect=RuntimeError("capture failed")
+			) as captureWithWgc,
+			patch.object(recogUi, "_captureWithGdi", return_value=self.gdiPixels) as captureWithGdi,
+		):
+			pixels = recogUi._captureImage(self.imageInfo)
+
+		self.assertIs(pixels, self.gdiPixels)
+		captureWithWgc.assert_called_once_with(self.imageInfo)
+		captureWithGdi.assert_called_once_with(self.imageInfo)
+
+
+class TestRecognize(unittest.TestCase):
+	def test_callCancelledIsReported(self):
+		cancellation = exceptions.CallCancelled()
+		recognizer = Mock()
+		result = SimpleNamespace(
+			result=None,
+			imageInfo=object(),
+			recognizer=recognizer,
+		)
+		results = []
+
+		with patch.object(recogUi, "_captureImage", side_effect=cancellation):
+			recogUi.RefreshableRecogResultNVDAObject._recognize(result, results.append)
+
+		self.assertEqual(results, [cancellation])
+		recognizer.recognize.assert_not_called()
+
+
+class TestScreenCurtainEnableBlock(unittest.TestCase):
+	def test_autoRefreshRecognitionBlocksScreenCurtainOnlyWhenWgcUnsupported(self):
+		focusObj = _FakeRefreshableRecogResult(allowAutoRefresh=True)
+
+		with (
+			patch.object(recogUi, "RefreshableRecogResultNVDAObject", _FakeRefreshableRecogResult),
+			patch.object(recogUi, "_isWgcCaptureSupported", side_effect=(False, True)),
+		):
+			self.assertTrue(recogUi.shouldBlockScreenCurtainEnable(focusObj))
+			self.assertFalse(recogUi.shouldBlockScreenCurtainEnable(focusObj))
+
+	def test_nonAutoRefreshRecognitionDoesNotBlockScreenCurtain(self):
+		focusObj = _FakeRefreshableRecogResult(allowAutoRefresh=False)
+
+		with patch.object(recogUi, "RefreshableRecogResultNVDAObject", _FakeRefreshableRecogResult):
+			self.assertFalse(recogUi.shouldBlockScreenCurtainEnable(focusObj))

--- a/tests/unit/contentRecog/test_recogUi.py
+++ b/tests/unit/contentRecog/test_recogUi.py
@@ -96,11 +96,11 @@ class TestScreenCurtainEnableBlock(unittest.TestCase):
 			patch.object(recogUi, "RefreshableRecogResultNVDAObject", _FakeRefreshableRecogResult),
 			patch.object(recogUi, "_isWgcCaptureSupported", side_effect=(False, True)),
 		):
-			self.assertTrue(recogUi.shouldBlockScreenCurtainEnable(focusObj))
-			self.assertFalse(recogUi.shouldBlockScreenCurtainEnable(focusObj))
+			self.assertTrue(recogUi._shouldBlockScreenCurtainEnable(focusObj))
+			self.assertFalse(recogUi._shouldBlockScreenCurtainEnable(focusObj))
 
 	def test_nonAutoRefreshRecognitionDoesNotBlockScreenCurtain(self):
 		focusObj = _FakeRefreshableRecogResult(allowAutoRefresh=False)
 
 		with patch.object(recogUi, "RefreshableRecogResultNVDAObject", _FakeRefreshableRecogResult):
-			self.assertFalse(recogUi.shouldBlockScreenCurtainEnable(focusObj))
+			self.assertFalse(recogUi._shouldBlockScreenCurtainEnable(focusObj))

--- a/tests/unit/contentRecog/test_recogUi.py
+++ b/tests/unit/contentRecog/test_recogUi.py
@@ -57,7 +57,9 @@ class TestCaptureImage(unittest.TestCase):
 			patch.object(recogUi, "_isMagnifierActive", return_value=True),
 			patch.object(recogUi, "_isWgcCaptureSupported", return_value=True),
 			patch.object(
-				recogUi, "_captureWithWgc", side_effect=RuntimeError("capture failed")
+				recogUi,
+				"_captureWithWgc",
+				side_effect=RuntimeError("capture failed"),
 			) as captureWithWgc,
 			patch.object(recogUi, "_captureWithGdi", return_value=self.gdiPixels) as captureWithGdi,
 		):

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -51,7 +51,7 @@ Please responsibly disclose security issues following NVDA's [security policy](h
   * Browseable message dialogs now better support resizing, maximizing and minimizing, with text wrapping to the dialog width. (#20429, @Cary-rowen)
 * Updated CLDR to version 48.2. (#20234, @OzancanKaratas)
 * Improved speech responsiveness in long text with mixed capitalization or many digits. (#20433, @codeofdusk)
-* Windows OCR can now be used while Screen Curtain or NVDA's built-in Magnifier is active on supported systems.
+* Windows OCR can now be used while Screen Curtain or NVDA's built-in Magnifier is active on supported systems. (#19164, #20630, @cary-rowen)
 * The duration of indentation beeps can now be configured via a new "Indent tone duration (ms)" spin control in the Document Formatting settings panel. (#20447, @Mubashir78)
 * Reduced the number of cross-process UI Automation calls when processing events, reporting focus changes, reporting objects under the mouse and rendering browse mode content, by caching more properties and batching focus property fetches. (#20608, @LeonarddeR)
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -51,6 +51,7 @@ Please responsibly disclose security issues following NVDA's [security policy](h
   * Browseable message dialogs now better support resizing, maximizing and minimizing, with text wrapping to the dialog width. (#20429, @Cary-rowen)
 * Updated CLDR to version 48.2. (#20234, @OzancanKaratas)
 * Improved speech responsiveness in long text with mixed capitalization or many digits. (#20433, @codeofdusk)
+* Windows OCR can now be used while Screen Curtain or NVDA's built-in Magnifier is active on supported systems.
 * The duration of indentation beeps can now be configured via a new "Indent tone duration (ms)" spin control in the Document Formatting settings panel. (#20447, @Mubashir78)
 * Reduced the number of cross-process UI Automation calls when processing events, reporting focus changes, reporting objects under the mouse and rendering browse mode content, by caching more properties and batching focus property fetches. (#20608, @LeonarddeR)
 

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -1641,9 +1641,9 @@ You can enable Screen Curtain in the [Privacy and Security category](#PrivacyAnd
 
 <!-- KC:endInclude -->
 
-When Screen Curtain is enabled, features that rely on what is literally on screen will not function.
-For example, you cannot [use OCR](#Win10Ocr).
-Some screenshot utilities also may not work.
+When Screen Curtain is enabled, some features that rely on what is literally on screen will not function.
+On supported systems, [Windows OCR](#Win10Ocr) can still be used while Screen Curtain is enabled.
+Some screenshot utilities may not work.
 
 Please note that while Windows Magnifier is running and inverted screen colors are being used, Screen Curtain cannot be enabled.
 
@@ -1765,7 +1765,9 @@ Additional languages can be installed by opening the Start menu, choosing Settin
 When you want to monitor constantly changing content, such as when watching a video with subtitles, you can optionally enable automatic refresh of the recognized content.
 This can also be done in the [Windows OCR category](#Win10OcrSettings) of the [NVDA Settings](#NVDASettings) dialog.
 
-Windows OCR may be partially or fully incompatible with [NVDA vision enhancements](#Vision) or other external visual aids. You will need to disable these aids before proceeding to a recognition.
+On supported systems, Windows OCR can still be used while [Screen Curtain](#VisionScreenCurtain) or NVDA's built-in [Magnifier](#Magnifier) is active.
+External visual aids may be partially or fully incompatible with Windows OCR.
+You may need to disable these aids before proceeding to a recognition.
 
 <!-- KC:beginInclude -->
 To recognize the text in the current navigator object using Windows OCR, press NVDA+r.


### PR DESCRIPTION
### Link to issue number:
Follow up #20630 
Part of #20480.
Fixes #19164 

### Summary of the issue:

Content recognition currently uses GDI to capture screen pixels. Screen Curtain causes this capture to return black pixels, while NVDA's built-in Magnifier can cause recognition to receive magnified, cropped or color-transformed pixels instead of the original screen content.

### Description of user facing changes:

On supported systems, Windows OCR can now be used while Screen Curtain or NVDA's built-in Magnifier is active. Existing GDI capture behavior is preserved when neither feature is active and when WGC is unavailable for Magnifier.

### Description of developer facing changes:

Added a private Python wrapper for the Windows Graphics Capture backend introduced in #20630 and centralized capture selection in `contentRecog.recogUi`. Content recognizers using the shared recognition framework receive the same capture behavior. Negative virtual-screen origins are now accepted for monitors positioned left of or above the primary display. No public API changes are introduced.

### Description of development approach:

GDI remains the default capture path. WGC is used when Screen Curtain is active, or when NVDA's built-in Magnifier is active and WGC is supported. A WGC failure while Magnifier is active falls back to GDI, preserving the previous usable behavior. No GDI fallback is allowed while Screen Curtain is active because it would return pixels from the obscured display. Capture failures and watchdog cancellation are passed through the existing recognition result lifecycle. Enabling Screen Curtain during automatically refreshed recognition is blocked only when WGC is unavailable.

### Testing strategy:

Unit tests cover default GDI selection, Screen Curtain and Magnifier failure behavior, watchdog cancellation, Screen Curtain state transitions, negative virtual-screen coordinates and invalid capture dimensions. The focused content recognition test suite and Python lint and formatting checks pass. Windows OCR with Screen Curtain has also been tested manually.

### Known issues with pull request:

Further manual testing is pending.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [ ] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [ ] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [ ] API is compatible with existing add-ons.
- [ ] Security precautions taken.