### PR TITLE
Fix Writer braille updates with POSITION_FIRST TextInfo

### DIFF
--- a/source/appModules/soffice.py
+++ b/source/appModules/soffice.py
@@ -461,6 +461,89 @@ class SymphonyDocument(CompoundDocument):
 	formattingGestureObjectIds: list[str] = []
 	lastFormattingGestureEventTime: float = 0
 
+	# Helpers for Writer's document-level POSITION_FIRST TextInfo.
+	# Some Writer structures can break the default compound document path,
+	# so these helpers find a usable first content object and wrap it as
+	# a document-level SymphonyDocumentTextInfo.
+	def _getNextSibling(self, obj: NVDAObject) -> NVDAObject | None:
+		for attr in ("next", "nextSibling"):
+			try:
+				nextObj = getattr(obj, attr)
+			except Exception:
+				continue
+			if nextObj is not None:
+				return nextObj
+		return None
+
+	def _iterDescendantsInTreeOrder(self, startObj: NVDAObject | None, maxObjects: int = 500):
+		stack = [startObj]
+		seen = set()
+		visitedCount = 0
+		while stack and visitedCount < maxObjects:
+			obj = stack.pop()
+			if obj is None:
+				continue
+			objId = id(obj)
+			if objId in seen:
+				continue
+			seen.add(objId)
+			visitedCount += 1
+			yield obj
+
+			children = []
+			try:
+				child = obj.firstChild
+			except Exception:
+				child = None
+			while child is not None:
+				if id(child) not in seen:
+					children.append(child)
+				child = self._getNextSibling(child)
+			for child in reversed(children):
+				stack.append(child)
+
+	def _tryMakeFirstRawTextInfo(self, obj: NVDAObject) -> textInfos.TextInfo | None:
+		try:
+			role = obj.role
+		except Exception:
+			role = None
+		if role in (controlTypes.Role.FRAME, controlTypes.Role.DOCUMENT):
+			return None
+		try:
+			return obj.makeTextInfo(textInfos.POSITION_FIRST)
+		except (NotImplementedError, RuntimeError, COMError, AttributeError):
+			return None
+
+	def _makeDocumentTextInfoFromRaw(self, obj: NVDAObject, rawInfo: textInfos.TextInfo) -> SymphonyDocumentTextInfo:
+		# rawInfo belongs to a Writer content descendant. POSITION_FIRST was requested
+		# from the document, so wrap the raw leaf TextInfo as a document-level
+		# SymphonyDocumentTextInfo owned by this SymphonyDocument.
+		info = self.TextInfo.__new__(self.TextInfo)
+		textInfos.TextInfo.__init__(info, self, textInfos.POSITION_FIRST)
+		info._startObj = obj
+		info._endObj = obj
+		info._start = rawInfo
+		info._end = rawInfo
+		return info
+
+	def _makePositionFirstTextInfo(self) -> SymphonyDocumentTextInfo:
+		try:
+			startObj = self.rootNVDAObject.firstChild
+		except Exception:
+			startObj = None
+		for obj in self._iterDescendantsInTreeOrder(startObj):
+			rawInfo = self._tryMakeFirstRawTextInfo(obj)
+			if rawInfo is not None:
+				return self._makeDocumentTextInfoFromRaw(obj, rawInfo)
+		raise LookupError("No content descendant found for Writer POSITION_FIRST")
+
+	def makeTextInfo(self, position):
+		# Writer needs a document-level POSITION_FIRST TextInfo for braille region updates.
+		# Normal caret and selection TextInfo requests continue to use the existing path.
+		if position == textInfos.POSITION_FIRST:
+			return self._makePositionFirstTextInfo()
+		return super().makeTextInfo(position)
+
 	@staticmethod
 	def isFormattingChangeAnnouncementEnabled(obj: NVDAObject) -> bool:
 		if not SymphonyDocument.announceFormattingGestureChange:

--- a/source/appModules/soffice.py
+++ b/source/appModules/soffice.py
@@ -514,7 +514,11 @@ class SymphonyDocument(CompoundDocument):
 		except (NotImplementedError, RuntimeError, COMError, AttributeError):
 			return None
 
-	def _makeDocumentTextInfoFromRaw(self, obj: NVDAObject, rawInfo: textInfos.TextInfo) -> SymphonyDocumentTextInfo:
+	def _makeDocumentTextInfoFromRaw(
+		self,
+		obj: NVDAObject,
+		rawInfo: textInfos.TextInfo,
+	) -> SymphonyDocumentTextInfo:
 		# rawInfo belongs to a Writer content descendant. POSITION_FIRST was requested
 		# from the document, so wrap the raw leaf TextInfo as a document-level
 		# SymphonyDocumentTextInfo owned by this SymphonyDocument.

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -93,6 +93,7 @@ Previously these keys had no function when pressed on their own. (#20366, @fla-r
 * In Mozilla Firefox and Chromium based browsers with native selection mode enabled, the caret no longer gets stuck when switching to focus mode, and typing in edit fields works again. (#19075, #18028, @LeonarddeR)
 * In Windows Terminal, mouse tracking now reports the line of text under the mouse pointer. (#20448, @DataTriny)
 * NVDA no longer floods its log with errors while Windows is locked and a browse mode document keeps updating in the background, such as a playing video in Mozilla Firefox. (#18861, @bramd)
+* In LibreOffice Writer, braille no longer stops following the caret in some long table documents. (#20625)
 
 ### Changes for Developers
 


### PR DESCRIPTION
### Link to issue number:

Fixes #20625

### Summary of the issue:

In LibreOffice Writer, braille can stop following the current Writer focus in some long table documents.

### Description of user facing changes:

Braille now follows the current Writer focus instead of remaining on stale content in affected LibreOffice Writer documents.

### Description of developer facing changes:

`TextInfoRegion.update` can request `POSITION_FIRST` from the Writer document TextInfo object during braille updates.

For Writer's `SymphonyDocument`, this could fail in the reported document structure and leave braille on stale content.

This change adds Writer-specific support for `SymphonyDocument.makeTextInfo(POSITION_FIRST)` by finding the first usable content descendant and wrapping it as a document-level `SymphonyDocumentTextInfo`.

This fixes the Writer TextInfo problem instead of adding a workaround in braille update code.

### Description of development approach:

This change only customizes `POSITION_FIRST` for Writer's `SymphonyDocument`.

It leaves `POSITION_CARET`, `POSITION_SELECTION`, and braille update handling unchanged.

The new path finds the first usable content descendant from the Writer document root, with guards to avoid looping through broken accessibility trees.

### Testing strategy:

Tested manually with the public CJK reproduction document from #20625.

| Case | Result |
| --- | --- |
| Before this change | Speech moved to the current Writer position, but braille remained stale. The failing log did not show a successful braille region update for the new content. |
| After this change | Speech moved to the current Writer position, and braille updated to the text region containing the current caret. The log showed the corresponding braille region content. |


### Known issues with pull request:

No known issues.

### Code Review Checklist:

- [x] Documentation:
  - [x] Change log entry
  - [ ] User Documentation
  - [ ] Developer / Technical Documentation
  - [ ] Context sensitive help for GUI changes
- [x] Testing:
  - [ ] Unit tests
  - [ ] System (end to end) tests
  - [x] Manual testing
- [x] UX of all users considered:
  - [x] Speech
  - [x] Braille
  - [ ] Low Vision
  - [ ] Different web browsers
  - [ ] Localization in other languages / culture than English
- [ ] API is compatible with existing add-ons.
- [ ] Security precautions taken.
