### PR TITLE
Handle tree interceptors in objectBelowLockScreenAndWindowsIsLocked

### DIFF
--- a/source/utils/security.py
+++ b/source/utils/security.py
@@ -177,19 +177,19 @@ def objectBelowLockScreenAndWindowsIsLocked(
 
 	:return: True if the Windows 10/11 lockscreen is active and obj is below the lock screen.
 	"""
-	if not isLockScreenModeActive():
-		return False
-
-	import NVDAObjects
-
-	if not isinstance(obj, NVDAObjects.NVDAObject):
-		rootObj = getattr(obj, "rootNVDAObject", None)
-		if rootObj is None:
-			if shouldLog:
-				log.debug(f"Unhandled object type {type(obj)}, considering object as safe.")
-			return False
-		obj = rootObj
 	try:
+		if not isLockScreenModeActive():
+			return False
+
+		import NVDAObjects
+
+		if not isinstance(obj, NVDAObjects.NVDAObject):
+			rootObj = getattr(obj, "rootNVDAObject", None)
+			if rootObj is None:
+				if shouldLog:
+					log.debug(f"Unhandled object type {type(obj)}, considering object as safe.")
+				return False
+			obj = rootObj
 		isObjectBelowLockScreen = obj.isBelowLockScreen
 	except Exception:
 		log.exception()

--- a/source/utils/security.py
+++ b/source/utils/security.py
@@ -31,6 +31,7 @@ import winUser
 if TYPE_CHECKING:
 	import scriptHandler  # noqa: F401, use for typing
 	import NVDAObjects  # noqa: F401, use for typing
+	import treeInterceptorHandler  # noqa: F401, use for typing
 
 
 def __getattr__(attrName: str) -> Any:
@@ -155,7 +156,7 @@ def getSafeScripts() -> Set["scriptHandler._ScriptFunctionT"]:
 
 
 def objectBelowLockScreenAndWindowsIsLocked(
-	obj: "NVDAObjects.NVDAObject",
+	obj: "NVDAObjects.NVDAObject | treeInterceptorHandler.TreeInterceptor",
 	shouldLog: bool = True,
 ) -> bool:
 	"""
@@ -171,10 +172,10 @@ def objectBelowLockScreenAndWindowsIsLocked(
 
 	As such, NVDA must prevent accessing and reading objects below the lock screen when Windows is locked.
 
-	Some callers pass a L{TreeInterceptor} rather than an NVDAObject.
-	As TreeInterceptors do not implement C{isBelowLockScreen}, their root object is checked instead.
+	Some callers pass a TreeInterceptor rather than an NVDAObject.
+	As TreeInterceptors do not implement isBelowLockScreen, their root object is checked instead.
 
-	@return: C{True} if the Windows 10/11 lockscreen is active and C{obj} is below the lock screen.
+	:return: True if the Windows 10/11 lockscreen is active and obj is below the lock screen.
 	"""
 	if not isLockScreenModeActive():
 		return False
@@ -184,7 +185,8 @@ def objectBelowLockScreenAndWindowsIsLocked(
 	if not isinstance(obj, NVDAObjects.NVDAObject):
 		rootObj = getattr(obj, "rootNVDAObject", None)
 		if rootObj is None:
-			log.debug(f"Unhandled object type {type(obj)}, considering object as safe.")
+			if shouldLog:
+				log.debug(f"Unhandled object type {type(obj)}, considering object as safe.")
 			return False
 		obj = rootObj
 	try:

--- a/source/utils/security.py
+++ b/source/utils/security.py
@@ -170,10 +170,25 @@ def objectBelowLockScreenAndWindowsIsLocked(
 	as it may contain sensitive information.
 
 	As such, NVDA must prevent accessing and reading objects below the lock screen when Windows is locked.
+
+	Some callers pass a L{TreeInterceptor} rather than an NVDAObject.
+	As TreeInterceptors do not implement C{isBelowLockScreen}, their root object is checked instead.
+
 	@return: C{True} if the Windows 10/11 lockscreen is active and C{obj} is below the lock screen.
 	"""
+	if not isLockScreenModeActive():
+		return False
+
+	import NVDAObjects
+
+	if not isinstance(obj, NVDAObjects.NVDAObject):
+		rootObj = getattr(obj, "rootNVDAObject", None)
+		if rootObj is None:
+			log.debug(f"Unhandled object type {type(obj)}, considering object as safe.")
+			return False
+		obj = rootObj
 	try:
-		isObjectBelowLockScreen = isLockScreenModeActive() and obj.isBelowLockScreen
+		isObjectBelowLockScreen = obj.isBelowLockScreen
 	except Exception:
 		log.exception()
 		return False

--- a/tests/unit/test_util/test_security.py
+++ b/tests/unit/test_util/test_security.py
@@ -14,9 +14,13 @@ from typing import (
 import unittest
 from unittest.mock import patch
 
+from ..objectProvider import PlaceholderNVDAObject
+import treeInterceptorHandler
+
 from utils.security import (
 	_UnexpectedWindowCountError,
 	_isWindowBelowWindowMatchesCond,
+	objectBelowLockScreenAndWindowsIsLocked,
 )
 import winUser
 
@@ -29,6 +33,48 @@ class _MoveWindow:
 	insertBelowHWND: winUser.HWNDVal  # is moved to below this window
 	triggerHWND: winUser.HWNDVal  # when this window is reached
 	triggered = False  # If the move has been triggered
+
+
+class Test_objectBelowLockScreenAndWindowsIsLocked(unittest.TestCase):
+	"""
+	Tests for objects which are not NVDAObjects being passed to
+	objectBelowLockScreenAndWindowsIsLocked.
+
+	Several callers, e.g. braille.handler.handleUpdate and braille.handler.handleCaretMove,
+	are called with a TreeInterceptor (such as a virtual buffer) rather than an NVDAObject.
+	TreeInterceptors do not implement isBelowLockScreen (#18861).
+	"""
+
+	def setUp(self) -> None:
+		# isLockScreenModeActive is imported into both modules by name.
+		self._patches = [
+			patch("utils.security.isLockScreenModeActive", lambda: True),
+			patch("NVDAObjects.isLockScreenModeActive", lambda: True),
+			# Avoid depending on the z-order of real windows.
+			patch("NVDAObjects._isObjectBelowLockScreen", lambda obj: True),
+		]
+		for p in self._patches:
+			p.start()
+		self._rootObj = PlaceholderNVDAObject()
+		return super().setUp()
+
+	def tearDown(self) -> None:
+		for p in self._patches:
+			p.stop()
+		return super().tearDown()
+
+	def test_NVDAObject(self):
+		"""An NVDAObject below the lock screen is detected as such."""
+		self.assertTrue(objectBelowLockScreenAndWindowsIsLocked(self._rootObj))
+
+	def test_treeInterceptor(self):
+		"""A TreeInterceptor is checked via its root NVDAObject."""
+		treeInterceptor = treeInterceptorHandler.TreeInterceptor(self._rootObj)
+		self.assertTrue(objectBelowLockScreenAndWindowsIsLocked(treeInterceptor))
+
+	def test_unhandledObject(self):
+		"""An object which is neither an NVDAObject nor has a root NVDAObject is treated as safe."""
+		self.assertFalse(objectBelowLockScreenAndWindowsIsLocked(object()))
 
 
 class _Test_isWindowAboveWindowMatchesCond(unittest.TestCase):

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -84,6 +84,7 @@ Previously these keys had no function when pressed on their own. (#20366, @fla-r
 * NVDA no longer briefly disconnects and re-detects the braille display on desktop switches that do not enter the secure desktop, such as when switching between a Remote Desktop session and the local machine. (#18810, #20550, @LeonarddeR)
 * In Mozilla Firefox and Chromium based browsers with native selection mode enabled, the caret no longer gets stuck when switching to focus mode, and typing in edit fields works again. (#19075, #18028, @LeonarddeR)
 * In Windows Terminal, mouse tracking now reports the line of text under the mouse pointer. (#20448, @DataTriny)
+* NVDA no longer floods its log with errors while Windows is locked and a browse mode document keeps updating in the background, such as a playing video in Mozilla Firefox. (#18861, @bramd)
 
 ### Changes for Developers
 


### PR DESCRIPTION
### Link to issue number:

Fixes #18861

Note that #18861 was closed as "fixed / can't reproduce", but the underlying bug was never fixed.
Reproducing it reliably requires the virtual buffer to keep changing while Windows is locked, which is why it appeared to go away.

### Summary of the issue:

While Windows is locked, NVDA logs the following roughly once a second if a browse mode document keeps updating in the background, for example a Firefox tab playing a YouTube video:

```
Traceback (most recent call last):
  File "utils\security.pyc", line 176, in objectBelowLockScreenAndWindowsIsLocked
AttributeError: 'Gecko_ia2' object has no attribute 'isBelowLockScreen'
```

`Gecko_ia2` here is the virtual buffer, i.e. a `TreeInterceptor`, not an `NVDAObject`.
Whenever the document changes, `VirtualBuffer.changeNotify` queues `_handleUpdate`, which calls `braille.handler.handleUpdate(self)`, passing the tree interceptor itself.
`handleUpdate` then calls `objectBelowLockScreenAndWindowsIsLocked`, which reads `obj.isBelowLockScreen`.
That property is only implemented by `NVDAObject`, so an `AttributeError` is raised, caught, and logged.

The error only appears while Windows is locked because `isLockScreenModeActive() and obj.isBelowLockScreen` short circuits when unlocked.

`braille.handler.handleCaretMove` has the same problem, as `cursorManager` passes `self` to it.

### Description of user facing changes:

The log is no longer flooded with these errors while Windows is locked.

### Description of developer facing changes:

`utils.security.objectBelowLockScreenAndWindowsIsLocked` now accepts a `TreeInterceptor` as well as an `NVDAObject`, and checks the tree interceptor's `rootNVDAObject`.

### Description of development approach:

Tree interceptors are resolved to their root object inside `objectBelowLockScreenAndWindowsIsLocked`, rather than changing what `_handleUpdate` passes to braille.
Braille regions store the tree interceptor in `region.obj`, so passing the root object from `_handleUpdate` instead would break the `region.obj == obj` match and stop braille updates.
Fixing it in `utils.security` also covers the `handleCaretMove` path.

An object which is neither an `NVDAObject` nor has a `rootNVDAObject` is logged at debug level and treated as safe, consistent with the existing handling in `api.setReviewPosition`.

Note that this changes behaviour beyond silencing the log: previously the `AttributeError` was handled as if the object were above the lock screen, so the check did not apply to tree interceptors at all.

The `isLockScreenModeActive()` check has been moved to the top of the function, so the common unlocked case returns before the added `isinstance` check and import.
The `NVDAObjects` import is inline because `NVDAObjects` imports `utils.security` at module level, matching the existing inline import in `_isObjectBelowLockScreen`.

### Testing strategy:

Unit tests added for `objectBelowLockScreenAndWindowsIsLocked` covering an `NVDAObject`, a `TreeInterceptor`, and an unhandled object type.
The tree interceptor test fails before this change and passes after it.

Manually tested back to back with an unmodified NVDA, using the same YouTube video playing in Firefox in browse mode, locking with `Windows+L` and checking the log after unlocking.
The errors are present without this change and absent with it.

### Known issues with pull request:

None known.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
