### PR TITLE
Update catalan, spanish and galician gestures.ini

### DIFF
--- a/source/locale/ca/gestures.ini
+++ b/source/locale/ca/gestures.ini
@@ -5,7 +5,7 @@
 	toggleRightMouseButton = kb(laptop):NVDA+control+plus
 	navigatorObject_previousInFlow = kb(laptop):NVDA+shift+AGUDO
 	navigatorObject_nextInFlow = kb(laptop):NVDA+shift+plus
-	zoomIn = kb:NVDA+plus+shift
+	zoomIn = kb:NVDA+-
 [NVDAObjects.window.winword.WordDocument]
 	None = kb:control+a, kb:control+b, kb:control+i, kb:control+u, kb:control+l, kb:control+r, kb:control+shift+n, "kb:control+shift+,", kb:control+alt+1, kb:control+alt+2, kb:control+alt+3
 	increaseDecreaseFontSize = kb:control+<, kb:control+shift+<

--- a/source/locale/es/gestures.ini
+++ b/source/locale/es/gestures.ini
@@ -5,7 +5,7 @@
 	toggleRightMouseButton = kb(laptop):NVDA+control+plus
 	navigatorObject_previousInFlow = kb(laptop):NVDA+shift+AGUDO
 	navigatorObject_nextInFlow = kb(laptop):NVDA+shift+plus
-	zoomIn = kb:NVDA+plus+shift
+	zoomIn = kb:NVDA+-
 [NVDAObjects.window.winword.WordDocument]
 	None = kb:control+a, kb:control+b, kb:control+i, kb:control+u, kb:control+l, kb:control+r, kb:control+shift+n, "kb:control+shift+,", kb:control+alt+1, kb:control+alt+2, kb:control+alt+3
 	increaseDecreaseFontSize = kb:control+<, kb:control+shift+<

--- a/source/locale/gl/gestures.ini
+++ b/source/locale/gl/gestures.ini
@@ -5,7 +5,7 @@
 	toggleRightMouseButton = kb(laptop):NVDA+control+plus
 	navigatorObject_previousInFlow = kb(laptop):NVDA+shift+AGUDO
 	navigatorObject_nextInFlow = kb(laptop):NVDA+shift+plus
-	zoomIn = kb:NVDA+plus+shift
+	zoomIn = kb:NVDA+-
 [NVDAObjects.window.winword.WordDocument]
 	None = kb:control+a, kb:control+b, kb:control+i, kb:control+u, kb:control+l, kb:control+r, kb:control+shift+n, "kb:control+shift+,", kb:control+alt+1, kb:control+alt+2, kb:control+alt+3
 	increaseDecreaseFontSize = kb:control+<, kb:control+shift+<


### PR DESCRIPTION
This pull request fixes a gesture conflict in laptop layout when spanish, catalan or galician are used. It changes again the zoom in gesture from `NVDA+shift+plus` to `NVDA+-`. As a result, `NVDA+-` is used to zoom in and `NVDA+shift+-` to zoom out.
CC: @quetzatl @ericdq