### PR TITLE
Fix typos in 2026.2 Changes for Developers

### DIFF
--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -117,9 +117,9 @@ Please refer to [the developer guide](https://download.nvaccess.org/documentatio
   * This is set to `False` by default for performance purposes.
   * It is encouraged to enable this when logging anything particularly sensitive e.g. clipboard content.
   * Added a `DEBUG_UNREDACTED` logging level for cases where developers explicitly need debug logging without `redactSecrets` masking.
-* NVDA libraries built by the build system are now linked with the [/SETCOMPAT](https://learn.microsoft.com/en-us/cpp/build/reference/cetcompat) flag, improving protection against certain malware attacks. (#19435, @LeonarddeR)
+* NVDA libraries built by the build system are now linked with the [/CETCOMPAT](https://learn.microsoft.com/en-us/cpp/build/reference/cetcompat) flag, improving protection against certain malware attacks. (#19435, @LeonarddeR)
 * Subclasses of `browseMode.BrowseModeDocumentTreeInterceptor` that support screen layout being on and off should override the `_toggleScreenLayout` method, rather than implementing `script_toggleScreenLayout` directly. (#19487)
-* A new method has been added to the UIA.UIA class, called `_getUIACacheablePropertyValue_handleCOMErrors`. (#19713, @Emil-18)
+* A new method has been added to the UIA.UIA class, called `_getUIACacheablePropertyValue_handlesCOMErrors`. (#19713, @Emil-18)
   * This method calls `_getUIACacheablePropertyValue`, and takes an extra argument (`onError`) that specifies the value that should be returned if a `COMError` is raised.
 * The `scons tests` build target has been removed, as it was misleadingly named.
 It only ran the translation string comment check, which is equivalent to `scons checkPot`.


### PR DESCRIPTION
### Link to issue number:

None.

### Summary of the issue:

The 2026.2 Changes for Developers section contains two typos:

- `/SETCOMPAT` should be `/CETCOMPAT`.
- `_getUIACacheablePropertyValue_handleCOMErrors` should be `_getUIACacheablePropertyValue_handlesCOMErrors`.

### Description of user facing changes:

None.

### Description of developer facing changes:

The change log now uses the correct linker flag and UIA method name.

### Description of development approach:

Corrected the two identifiers in `user_docs/en/changes.md`.

### Testing strategy:

Documentation-only change. Both identifiers were checked against the linked Microsoft documentation and the implementation in `source/NVDAObjects/UIA/__init__.py`.

### Known issues with pull request:

None.

### Code Review Checklist:

- [ ] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [ ] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [ ] API is compatible with existing add-ons.
- [ ] Security precautions taken.