### PR TITLE
fix: feature: CLI argument to start after I sign in

### DIFF
--- a/source/argsParsing.py
+++ b/source/argsParsing.py
@@ -239,6 +239,14 @@ def _createNVDAArgParser() -> NoConsoleOptionParser:
 		help="When installing, enable NVDA's start on the logon screen",
 	)
 	parser.add_argument(
+		"--start-after-signin",
+		metavar="True|False",
+		type=stringToBool,
+		dest="startAfterSignin",
+		default=None,
+		help="When installing, set whether NVDA starts after the user signs in",
+	)
+	parser.add_argument(
 		"--copy-portable-config",
 		action="store_true",
 		dest="copyPortableConfig",

--- a/source/globalVars.py
+++ b/source/globalVars.py
@@ -68,6 +68,7 @@ class DefaultAppArgs(argparse.Namespace):
 	portablePath: Optional[os.PathLike] = None
 	launcher: bool = False
 	enableStartOnLogon: Optional[bool] = None
+	startAfterSignin: Optional[bool] = None
 	copyPortableConfig: bool = False
 	easeOfAccess: bool = False
 

--- a/source/gui/installerGui.py
+++ b/source/gui/installerGui.py
@@ -309,6 +309,9 @@ def doSilentInstall(
 	startOnLogon = globalVars.appArgs.enableStartOnLogon
 	if startOnLogon is None:
 		startOnLogon = config.getStartOnLogonScreen() if not freshInstall else False
+	startAfterSignin = globalVars.appArgs.startAfterSignin
+	if startAfterSignin is not None:
+		config.setStartAfterLogon(startAfterSignin)
 	# Currently, this function is only called by ``core.main`` when ``--install`` or ``--install-silent`` are provided at the command line.
 	# The only use of the ``silent`` parameter to ``doInstall`` is to surpress the post-installation restart dialog.
 	# Since that dialog should be shown unless this genuinely is a silent installation, use presence of ``--install-silent`` as the actual value of the ``silent`` argument.

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -35,6 +35,7 @@
 * It is now possible to change an existing gesture in the Input Gestures dialog. (#10983, @amirmahdifard)
 * A new "Say all reads by" speech setting lets you choose whether say all reads by sentence, paragraph or line; say all now reads by sentence by default where supported. (#13420, #9179, #13971, @LeonarddeR)
 * A new command, assigned to `NVDA+control+x`, copies the last spoken information to the clipboard. (#19385, @Cary-rowen)
+* Added the `--start-after-signin` command line parameter to configure whether NVDA starts automatically after the user signs in, for example when installing NVDA silently. Specify `True` to start after sign-in or `False` to not start after sign-in. (#20619)
 
 ### Changes
 

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -6569,6 +6569,7 @@ Following are the command line options for NVDA:
 |None |`--install` |Installs NVDA (starting the newly installed copy)|
 |None |`--install-silent` |Silently installs NVDA (does not start the newly installed copy)|
 |None |`--enable-start-on-logon=True|False` |When installing, enable NVDA's [Use NVDA during Windows sign-in](#StartAtWindowsLogon)| <!-- markdownlint-disable-line MD055 MD056 -->
+|None |`--start-after-signin=True|False` |When installing, enable NVDA's [Start NVDA after I sign in](#GeneralSettingsStartAfterLogOn)| <!-- markdownlint-disable-line MD055 MD056 -->
 |None |`--copy-portable-config` |When installing, copy the portable configuration from the provided path (`--config-path`, `-c`) to the current user account|
 |None |`--create-portable` |Creates a portable copy of NVDA (and starts the new copy). Requires `--portable-path` to be specified|
 |None |`--create-portable-silent` |Creates a portable copy of NVDA (without starting the new copy). Requires `--portable-path` to be specified. This option suppresses warnings when writing to non-empty directories and may overwrite files without warning.|


### PR DESCRIPTION
Fixes #20619

Added the `--start-after-signin=True|False` CLI argument that, during NVDA installation, configures whether NVDA starts after the user signs in by calling `config.setStartAfterLogon` (the same path as the General settings checkbox), plus docs and changelog updates.

Could not run the suite locally: . Fork CI needs a maintainer approval to run, so this branch has no test signal yet.

---
This change was prepared with AI assistance under human direction and review.