### PR TITLE
Add --start-after-signin command line option

### DIFF
--- a/source/argsParsing.py
+++ b/source/argsParsing.py
@@ -239,6 +239,14 @@ def _createNVDAArgParser() -> NoConsoleOptionParser:
 		help="When installing, enable NVDA's start on the logon screen",
 	)
 	parser.add_argument(
+		"--start-after-signin",
+		metavar="True|False",
+		type=stringToBool,
+		dest="startAfterSignin",
+		default=None,
+		help="Set whether NVDA starts automatically after signing in to Windows",
+	)
+	parser.add_argument(
 		"--copy-portable-config",
 		action="store_true",
 		dest="copyPortableConfig",

--- a/source/core.py
+++ b/source/core.py
@@ -265,7 +265,7 @@ def restartUnsafely():
 		except ValueError:
 			pass
 	restartCLIArgs = computeRestartCLIArgs(
-		removeArgsList=["easeOfAccess"],
+		removeArgsList=["easeOfAccess", "startAfterSignin"],
 	)
 	options = []
 	if NVDAState.isRunningAsSource():
@@ -289,7 +289,7 @@ def restart(disableAddons=False, debugLogging=False):
 	import subprocess
 
 	restartCLIArgs = computeRestartCLIArgs(
-		removeArgsList=["disableAddons", "debugLogging", "language", "easeOfAccess"],
+		removeArgsList=["disableAddons", "debugLogging", "language", "easeOfAccess", "startAfterSignin"],
 	)
 	options = []
 	if NVDAState.isRunningAsSource():
@@ -726,6 +726,16 @@ def main():
 	import config
 
 	config.initialize()
+	if globalVars.appArgs.startAfterSignin is not None:
+		if globalVars.appArgs.secure or not config.isInstalledCopy():
+			log.warning(
+				"Ignoring --start-after-signin: secure mode or non-installed copy",
+			)
+		else:
+			try:
+				config.setStartAfterLogon(globalVars.appArgs.startAfterSignin)
+			except (WindowsError, FileNotFoundError):
+				log.error("Failed to set start-after-signin", exc_info=True)
 	if config.conf["development"]["enableScratchpadDir"]:
 		log.info("Developer Scratchpad mode enabled")
 	if languageHandler.isLanguageForced():

--- a/source/globalVars.py
+++ b/source/globalVars.py
@@ -68,6 +68,7 @@ class DefaultAppArgs(argparse.Namespace):
 	portablePath: Optional[os.PathLike] = None
 	launcher: bool = False
 	enableStartOnLogon: Optional[bool] = None
+	startAfterSignin: Optional[bool] = None
 	copyPortableConfig: bool = False
 	easeOfAccess: bool = False
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -35,6 +35,7 @@
 * It is now possible to change an existing gesture in the Input Gestures dialog. (#10983, @amirmahdifard)
 * A new "Say all reads by" speech setting lets you choose whether say all reads by sentence, paragraph or line; say all now reads by sentence by default where supported. (#13420, #9179, #13971, @LeonarddeR)
 * A new command, assigned to `NVDA+control+x`, copies the last spoken information to the clipboard. (#19385, @Cary-rowen)
+* A new command line option `--start-after-signin` sets whether NVDA starts automatically after signing in to Windows. (#20619, @ShlokShar)
 
 ### Changes
 

--- a/user_docs/en/userGuide.md
+++ b/user_docs/en/userGuide.md
@@ -6569,6 +6569,7 @@ Following are the command line options for NVDA:
 |None |`--install` |Installs NVDA (starting the newly installed copy)|
 |None |`--install-silent` |Silently installs NVDA (does not start the newly installed copy)|
 |None |`--enable-start-on-logon=True|False` |When installing, enable NVDA's [Use NVDA during Windows sign-in](#StartAtWindowsLogon)| <!-- markdownlint-disable-line MD055 MD056 -->
+|None |`--start-after-signin=True|False` |Set whether NVDA [starts automatically after you sign in to Windows](#GeneralSettingsStartAfterLogOn)| <!-- markdownlint-disable-line MD055 MD056 -->
 |None |`--copy-portable-config` |When installing, copy the portable configuration from the provided path (`--config-path`, `-c`) to the current user account|
 |None |`--create-portable` |Creates a portable copy of NVDA (and starts the new copy). Requires `--portable-path` to be specified|
 |None |`--create-portable-silent` |Creates a portable copy of NVDA (without starting the new copy). Requires `--portable-path` to be specified. This option suppresses warnings when writing to non-empty directories and may overwrite files without warning.|


### PR DESCRIPTION
### Link to issue number:

Closes #20619

### Summary of the issue:

NVDA has a "Start NVDA after I sign in" option in General settings, but there is no equivalent command line option. This means the setting cannot be configured from a script, an installer wrapper, or an automated deployment without going through the GUI.

### Description of user facing changes:

A new command line option, `--start-after-signin=True|False`, sets whether NVDA starts automatically after signing in to Windows. It is equivalent to the "Start NVDA after I sign in" checkbox in General settings.

The option is documented in the command line options table in the user guide, and a change log entry has been added.

### Description of developer facing changes:

`startAfterSignin: Optional[bool] = None` was added to the `DefaultAppArgs` class in `source/globalVars.py`, alongside the existing `enableStartOnLogon`.

### Description of development approach:

The option is applied in `core.main` immediately after `config.initialize()`, calling the existing `config.setStartAfterLogon()`.

This deliberately uses `setStartAfterLogon` (the Ease of Access auto-start setting) rather than `setStartOnLogonScreen`, which is the separate "Use NVDA during sign-in" secure screen feature.

Three details were handled to match existing behaviour:

* The call is skipped in secure mode and for non-installed copies, and a warning is logged instead. This matches the conditions under which the equivalent GUI checkbox is disabled in `source/gui/settingsDialogs.py`.
* `easeOfAccess.setAutoStart` is documented to raise `WindowsError` / `FileNotFoundError`. The call is therefore wrapped and failures are logged rather than propagated, so that a registry failure cannot prevent NVDA from starting.
* `startAfterSignin` is added to the `removeArgsList` passed to `computeRestartCLIArgs` in both `restartUnsafely` and `restart`. That function appends the flag but skips the value for bool arguments, and because this option requires a value, a restart would otherwise generate an invalid command line. Excluding it is also the correct behaviour, since the value is already persisted to the registry and should not be reapplied on every restart.

### Testing strategy:

I have not yet been able to test this on a Windows install, as I do not currently have an NVDA development environment set up. `ruff check` and `ruff format --check` pass against the project configuration.

I would appreciate guidance on the expected manual test for this option, and I am happy to run it and report back once I have an environment available.

### Known issues with pull request:

Not manually tested yet, as described above.

Separately, `--enable-start-on-logon` appears to be affected by the same `computeRestartCLIArgs` behaviour described above, where a bool option is emitted without its value. This PR only avoids the problem for the new option rather than changing the shared logic, since that would affect other arguments. I am happy to open a separate issue for that if it would be useful.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.