### PR TITLE
Resolve the typed character protected state lazily

### DIFF
--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -1453,11 +1453,14 @@ def speakTypedCharacters(ch: str) -> None:
 		return cachedTypingIsProtected
 
 	def getRealChar() -> str:
-		"""The character to buffer or speak, masked if typing is protected."""
+		"""The character to speak, masked if typing is protected."""
 		return PROTECTED_CHAR if typingIsProtected() else ch
 
 	if unicodedata.category(ch)[0] in "LMN":
-		_curWordChars.append(getRealChar())
+		# #20654: buffer the real character and mask when the word is used, so that
+		# buffering costs no protected state lookup. The word is never spoken while
+		# typing is protected, and it is masked before being logged.
+		_curWordChars.append(ch)
 	elif ch == "\b":
 		# Backspace, so remove the last character from our buffer.
 		del _curWordChars[-1:]
@@ -1468,7 +1471,8 @@ def speakTypedCharacters(ch: str) -> None:
 		typedWord = "".join(_curWordChars)
 		clearTypedWordBuffer()
 		if log.isEnabledFor(log.IO):
-			log.io("typed word: %s" % typedWord)
+			loggedWord = PROTECTED_CHAR * len(typedWord) if typingIsProtected() else typedWord
+			log.io("typed word: %s" % loggedWord)
 		typingEchoMode = config.conf["keyboard"]["speakTypedWords"]
 		if typingEchoMode != TypingEcho.OFF.value:
 			if typingEchoMode == TypingEcho.ALWAYS.value or (

--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -1439,14 +1439,25 @@ def isFocusEditable() -> bool:
 	) and controlTypes.STATE_READONLY not in obj.states
 
 
-def speakTypedCharacters(ch: str):
-	typingIsProtected = api.isTypingProtected()
-	if typingIsProtected:
-		realChar = PROTECTED_CHAR
-	else:
-		realChar = ch
+def speakTypedCharacters(ch: str) -> None:
+	# #20654: resolving the protected state requires the focus object's states, which is a
+	# blocking cross-process call. Resolve it lazily, so characters that cannot be spoken,
+	# and characters typed while the relevant echo is off, do not pay for it.
+	cachedTypingIsProtected: bool | None = None
+
+	def typingIsProtected() -> bool:
+		"""Whether the focus object hides its input. Fetched at most once per call."""
+		nonlocal cachedTypingIsProtected
+		if cachedTypingIsProtected is None:
+			cachedTypingIsProtected = api.isTypingProtected()
+		return cachedTypingIsProtected
+
+	def getRealChar() -> str:
+		"""The character to buffer or speak, masked if typing is protected."""
+		return PROTECTED_CHAR if typingIsProtected() else ch
+
 	if unicodedata.category(ch)[0] in "LMN":
-		_curWordChars.append(realChar)
+		_curWordChars.append(getRealChar())
 	elif ch == "\b":
 		# Backspace, so remove the last character from our buffer.
 		del _curWordChars[-1:]
@@ -1459,11 +1470,14 @@ def speakTypedCharacters(ch: str):
 		if log.isEnabledFor(log.IO):
 			log.io("typed word: %s" % typedWord)
 		typingEchoMode = config.conf["keyboard"]["speakTypedWords"]
-		if typingEchoMode != TypingEcho.OFF.value and not typingIsProtected:
+		if typingEchoMode != TypingEcho.OFF.value:
 			if typingEchoMode == TypingEcho.ALWAYS.value or (
 				typingEchoMode == TypingEcho.EDIT_CONTROLS.value and isFocusEditable()
 			):
-				speakText(typedWord)
+				# Checked last, so the protected state is only resolved once we know the
+				# word would otherwise be spoken.
+				if not typingIsProtected():
+					speakText(typedWord)
 	if _speechState._suppressSpeakTypedCharactersNumber > 0:
 		# We primarily suppress based on character count and still have characters to suppress.
 		# However, we time out after a short while just in case.
@@ -1481,7 +1495,7 @@ def speakTypedCharacters(ch: str):
 		if typingEchoMode == TypingEcho.ALWAYS.value or (
 			typingEchoMode == TypingEcho.EDIT_CONTROLS.value and isFocusEditable()
 		):
-			speakSpelling(realChar)
+			speakSpelling(getRealChar())
 
 
 class SpeakTextInfoState(object):

--- a/tests/unit/test_speechTypedCharacters.py
+++ b/tests/unit/test_speechTypedCharacters.py
@@ -59,6 +59,23 @@ class _SpeakTypedCharactersTestCase(unittest.TestCase):
 			speech.speakTypedCharacters(ch)
 			return protected, speakText, speakSpelling
 
+	def speakWithIOLogging(self, ch: str, isProtected: bool = False):
+		"""Call speakTypedCharacters with input/output logging enabled.
+
+		:return: the text passed to log.io, or None if nothing was logged.
+		"""
+		logged = []
+		with (
+			patch.object(speechModule.api, "isTypingProtected", return_value=isProtected),
+			patch.object(speechModule, "speakText"),
+			patch.object(speechModule, "speakSpelling"),
+			patch.object(speechModule, "isFocusEditable", return_value=True),
+			patch.object(speechModule.log, "isEnabledFor", return_value=True),
+			patch.object(speechModule.log, "io", side_effect=lambda msg: logged.append(msg)),
+		):
+			speech.speakTypedCharacters(ch)
+		return logged[0] if logged else None
+
 
 class TestProtectedStateNotResolvedUnnecessarily(_SpeakTypedCharactersTestCase):
 	"""The cross-process fetch must be skipped when it cannot affect the outcome."""
@@ -94,19 +111,19 @@ class TestProtectedStateNotResolvedUnnecessarily(_SpeakTypedCharactersTestCase):
 		speakText.assert_not_called()
 
 	def test_characterEchoOffForANonControlCharacter(self):
-		"""A letter still needs the protected state, for the word buffer only."""
+		"""With both echoes off, buffering a letter needs no lookup at all."""
 		protected, _speakText, speakSpelling = self.speak("a")
-		# Buffering a letter requires knowing whether to store the real character.
-		protected.assert_called_once()
+		protected.assert_not_called()
 		speakSpelling.assert_not_called()
 
 
 class TestProtectedStateStillHonoured(_SpeakTypedCharactersTestCase):
 	"""Laziness must not weaken the protection of typed passwords."""
 
-	def test_protectedLetterIsBufferedAsProtectedChar(self):
+	def test_protectedLetterIsBufferedVerbatimAndMaskedLater(self):
+		"""The mask now happens when the word is used, not when it is buffered."""
 		self.speak("a", isProtected=True)
-		self.assertEqual(speechModule._curWordChars, [speechModule.PROTECTED_CHAR])
+		self.assertEqual(speechModule._curWordChars, ["a"])
 
 	def test_unprotectedLetterIsBufferedVerbatim(self):
 		self.speak("a", isProtected=False)
@@ -140,7 +157,7 @@ class TestProtectedStateResolvedAtMostOnce(_SpeakTypedCharactersTestCase):
 	"""The caching must hold, so one character costs at most one fetch."""
 
 	def test_letterWithBothEchoesOn(self):
-		"""Buffering and speaking the same character must share one lookup."""
+		"""Speaking the character resolves the state once, for the echo only."""
 		self.setEcho(chars=TypingEcho.ALWAYS, words=TypingEcho.ALWAYS)
 		protected, _speakText, speakSpelling = self.speak("a", isProtected=True)
 		protected.assert_called_once()
@@ -171,6 +188,56 @@ class TestBufferHandlingUnchanged(_SpeakTypedCharactersTestCase):
 		protected.assert_not_called()
 		speakText.assert_not_called()
 		speakSpelling.assert_not_called()
+
+
+class TestWordBufferHoldsRealCharacters(_SpeakTypedCharactersTestCase):
+	"""Buffering must not resolve the protected state, and must not leak the word."""
+
+	def test_letterDoesNotResolveProtectedState(self):
+		"""Buffering a letter is the case that used to freeze while typing."""
+		protected, _speakText, _speakSpelling = self.speak("a")
+		protected.assert_not_called()
+
+	def test_bufferHoldsTheRealCharacter(self):
+		self.speak("a", isProtected=True)
+		self.assertEqual(speechModule._curWordChars, ["a"])
+
+	def test_bufferLengthIsUnchangedByProtection(self):
+		"""NVDAObjects.behaviors reads len(_curWordChars), so it must still count."""
+		for ch in "hi":
+			self.speak(ch, isProtected=True)
+		self.assertEqual(len(speechModule._curWordChars), 2)
+
+	def test_protectedWordIsNeverSpoken(self):
+		self.setEcho(chars=TypingEcho.OFF, words=TypingEcho.ALWAYS)
+		speechModule._curWordChars.extend("secret")
+		_protected, speakText, _speakSpelling = self.speak(" ", isProtected=True)
+		speakText.assert_not_called()
+
+	def test_unprotectedWordIsStillSpokenInFull(self):
+		self.setEcho(chars=TypingEcho.OFF, words=TypingEcho.ALWAYS)
+		speechModule._curWordChars.extend("hi")
+		_protected, speakText, _speakSpelling = self.speak(" ", isProtected=False)
+		speakText.assert_called_once_with("hi")
+
+	def test_protectedWordIsMaskedBeforeLogging(self):
+		"""The buffer now holds real characters, so the log must mask them."""
+		speechModule._curWordChars.extend("secret")
+		logged = self.speakWithIOLogging(" ", isProtected=True)
+		self.assertIsNotNone(logged)
+		self.assertNotIn("secret", logged)
+		self.assertIn(speechModule.PROTECTED_CHAR * len("secret"), logged)
+
+	def test_unprotectedWordIsLoggedVerbatim(self):
+		speechModule._curWordChars.extend("hi")
+		logged = self.speakWithIOLogging(" ", isProtected=False)
+		self.assertIn("hi", logged)
+
+	def test_characterEchoStillMasks(self):
+		"""Per character masking is unaffected by how the word buffer is stored."""
+		self.setEcho(chars=TypingEcho.ALWAYS, words=TypingEcho.OFF)
+		_protected, _speakText, speakSpelling = self.speak("a", isProtected=True)
+		speakSpelling.assert_called_once_with(speechModule.PROTECTED_CHAR)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_speechTypedCharacters.py
+++ b/tests/unit/test_speechTypedCharacters.py
@@ -1,0 +1,177 @@
+# A part of NonVisual Desktop Access (NVDA)
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+# Copyright (C) 2026 NV Access Limited
+
+"""Unit tests for speech.speakTypedCharacters.
+
+These cover the lazy resolution of the focus object's protected state. Resolving it
+requires a blocking cross-process accessibility call, so it must not happen for
+characters which cannot lead to speech (#20654).
+"""
+
+import unittest
+from unittest.mock import patch
+
+import config
+import speech
+from config.configFlags import TypingEcho
+from speech import speech as speechModule
+
+
+CTRL_C = "\x03"
+"""The character produced by control+c, as delivered to speakTypedCharacters."""
+
+ENTER = "\r"
+"""The character produced by the enter key."""
+
+DELETE = chr(0x7F)
+"""The delete character produced in some apps by control+backspace."""
+
+
+class _SpeakTypedCharactersTestCase(unittest.TestCase):
+	"""Provides a clean typed word buffer and echo configuration for each test."""
+
+	def setUp(self):
+		speechModule.clearTypedWordBuffer()
+		speechModule._speechState._suppressSpeakTypedCharactersNumber = 0
+		speechModule._speechState._suppressSpeakTypedCharactersTime = None
+		self.setEcho(chars=TypingEcho.OFF, words=TypingEcho.OFF)
+
+	def tearDown(self):
+		speechModule.clearTypedWordBuffer()
+
+	def setEcho(self, chars: TypingEcho, words: TypingEcho) -> None:
+		config.conf["keyboard"]["speakTypedCharacters"] = chars.value
+		config.conf["keyboard"]["speakTypedWords"] = words.value
+
+	def speak(self, ch: str, isProtected: bool = False):
+		"""Call speakTypedCharacters with the accessibility and speech layers mocked.
+
+		:return: a tuple of (isTypingProtected mock, speakText mock, speakSpelling mock).
+		"""
+		with (
+			patch.object(speechModule.api, "isTypingProtected", return_value=isProtected) as protected,
+			patch.object(speechModule, "speakText") as speakText,
+			patch.object(speechModule, "speakSpelling") as speakSpelling,
+			patch.object(speechModule, "isFocusEditable", return_value=True),
+		):
+			speech.speakTypedCharacters(ch)
+			return protected, speakText, speakSpelling
+
+
+class TestProtectedStateNotResolvedUnnecessarily(_SpeakTypedCharactersTestCase):
+	"""The cross-process fetch must be skipped when it cannot affect the outcome."""
+
+	def test_controlCharacterWithEmptyBuffer(self):
+		"""Control+c with nothing buffered cannot produce speech."""
+		protected, _speakText, _speakSpelling = self.speak(CTRL_C)
+		protected.assert_not_called()
+
+	def test_enterWithEmptyBuffer(self):
+		"""Enter is reported the same way as any other control character."""
+		protected, _speakText, _speakSpelling = self.speak(ENTER)
+		protected.assert_not_called()
+
+	def test_controlCharacterFlushingBufferWithWordEchoOff(self):
+		"""A buffered word is discarded without being spoken, so no fetch is needed."""
+		speechModule._curWordChars.extend("hi")
+		protected, speakText, _speakSpelling = self.speak(CTRL_C)
+		protected.assert_not_called()
+		speakText.assert_not_called()
+
+	def test_wordEchoLimitedToEditControlsOutsideAnEditControl(self):
+		"""If the word will not be spoken, the protected state is never consulted."""
+		self.setEcho(chars=TypingEcho.OFF, words=TypingEcho.EDIT_CONTROLS)
+		speechModule._curWordChars.extend("hi")
+		with (
+			patch.object(speechModule.api, "isTypingProtected", return_value=False) as protected,
+			patch.object(speechModule, "speakText") as speakText,
+			patch.object(speechModule, "isFocusEditable", return_value=False),
+		):
+			speech.speakTypedCharacters(CTRL_C)
+		protected.assert_not_called()
+		speakText.assert_not_called()
+
+	def test_characterEchoOffForANonControlCharacter(self):
+		"""A letter still needs the protected state, for the word buffer only."""
+		protected, _speakText, speakSpelling = self.speak("a")
+		# Buffering a letter requires knowing whether to store the real character.
+		protected.assert_called_once()
+		speakSpelling.assert_not_called()
+
+
+class TestProtectedStateStillHonoured(_SpeakTypedCharactersTestCase):
+	"""Laziness must not weaken the protection of typed passwords."""
+
+	def test_protectedLetterIsBufferedAsProtectedChar(self):
+		self.speak("a", isProtected=True)
+		self.assertEqual(speechModule._curWordChars, [speechModule.PROTECTED_CHAR])
+
+	def test_unprotectedLetterIsBufferedVerbatim(self):
+		self.speak("a", isProtected=False)
+		self.assertEqual(speechModule._curWordChars, ["a"])
+
+	def test_protectedWordIsNotSpoken(self):
+		self.setEcho(chars=TypingEcho.OFF, words=TypingEcho.ALWAYS)
+		speechModule._curWordChars.extend("hi")
+		protected, speakText, _speakSpelling = self.speak(" ", isProtected=True)
+		protected.assert_called_once()
+		speakText.assert_not_called()
+
+	def test_unprotectedWordIsSpoken(self):
+		self.setEcho(chars=TypingEcho.OFF, words=TypingEcho.ALWAYS)
+		speechModule._curWordChars.extend("hi")
+		_protected, speakText, _speakSpelling = self.speak(" ", isProtected=False)
+		speakText.assert_called_once_with("hi")
+
+	def test_protectedCharacterIsSpokenAsProtectedChar(self):
+		self.setEcho(chars=TypingEcho.ALWAYS, words=TypingEcho.OFF)
+		_protected, _speakText, speakSpelling = self.speak("a", isProtected=True)
+		speakSpelling.assert_called_once_with(speechModule.PROTECTED_CHAR)
+
+	def test_unprotectedCharacterIsSpokenVerbatim(self):
+		self.setEcho(chars=TypingEcho.ALWAYS, words=TypingEcho.OFF)
+		_protected, _speakText, speakSpelling = self.speak("a", isProtected=False)
+		speakSpelling.assert_called_once_with("a")
+
+
+class TestProtectedStateResolvedAtMostOnce(_SpeakTypedCharactersTestCase):
+	"""The caching must hold, so one character costs at most one fetch."""
+
+	def test_letterWithBothEchoesOn(self):
+		"""Buffering and speaking the same character must share one lookup."""
+		self.setEcho(chars=TypingEcho.ALWAYS, words=TypingEcho.ALWAYS)
+		protected, _speakText, speakSpelling = self.speak("a", isProtected=True)
+		protected.assert_called_once()
+		speakSpelling.assert_called_once_with(speechModule.PROTECTED_CHAR)
+
+	def test_wordFlushAndCharacterEcho(self):
+		"""Flushing a word and echoing the character must share one lookup."""
+		self.setEcho(chars=TypingEcho.ALWAYS, words=TypingEcho.ALWAYS)
+		speechModule._curWordChars.extend("hi")
+		protected, speakText, speakSpelling = self.speak("!", isProtected=False)
+		protected.assert_called_once()
+		speakText.assert_called_once_with("hi")
+		speakSpelling.assert_called_once_with("!")
+
+
+class TestBufferHandlingUnchanged(_SpeakTypedCharactersTestCase):
+	"""Behavior unrelated to the protected state must be preserved."""
+
+	def test_backspaceRemovesLastBufferedCharacter(self):
+		speechModule._curWordChars.extend("hi")
+		self.speak("\b")
+		self.assertEqual(speechModule._curWordChars, ["h"])
+
+	def test_deleteCharacterReturnsEarly(self):
+		speechModule._curWordChars.extend("hi")
+		protected, speakText, speakSpelling = self.speak(DELETE)
+		self.assertEqual(speechModule._curWordChars, ["h", "i"])
+		protected.assert_not_called()
+		speakText.assert_not_called()
+		speakSpelling.assert_not_called()
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -59,7 +59,8 @@ By default, when lines are skipped in a large text flood, NVDA emits a beep prop
 This can be disabled in the Advanced settings panel.
 * In Windows Terminal, NVDA is less likely to report stale characters when moving the caret in delayed remote sessions such as SSH. (#19503, @sheldon-im)
 * When an application stops responding, NVDA no longer freezes or floods its log with errors; it stays responsive and drops UIA and MSAA events from the unresponsive application until it recovers. (#16749, @heath-toby)
-* With typing echo off, NVDA no longer freezes for around five seconds while typing, or when pressing keys such as `control+c` or `enter`, in applications whose accessibility provider is slow to respond, such as Chromium menus, Qt applications and XAML applications. (#20654, @Khalil220)
+* NVDA now resolves whether typing is protected only when it needs the answer.
+This removes the freeze of around five seconds when pressing keys such as `control+c` or `enter` on default settings, and while typing when typing echo is off, in applications whose accessibility provider is slow to respond, such as Chromium menus, Qt applications and XAML applications. (#20654, @Khalil220)
 * Reduced lag on UI Automation text change events, improving the responsiveness of controls such as combo boxes and of File Explorer, by using the cached element class name instead of a live cross-process fetch. (#16749, @heath-toby)
 * In Notepad++, NVDA now continues to report IME composition text in speech and braille while selecting or navigating within Chinese IME composition. (#14140, #14152, @keyang556)
 * Fixed UAC slider not being read when changing values with arrow keys in UI Automation. (#9356, @tareh7z)

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -59,6 +59,7 @@ By default, when lines are skipped in a large text flood, NVDA emits a beep prop
 This can be disabled in the Advanced settings panel.
 * In Windows Terminal, NVDA is less likely to report stale characters when moving the caret in delayed remote sessions such as SSH. (#19503, @sheldon-im)
 * When an application stops responding, NVDA no longer freezes or floods its log with errors; it stays responsive and drops UIA and MSAA events from the unresponsive application until it recovers. (#16749, @heath-toby)
+* NVDA no longer freezes for around five seconds when pressing keys such as `control+c` or `enter` in applications whose accessibility provider is slow to respond, such as Chromium menus, Qt applications and XAML applications. (#20654, @Khalil220)
 * Reduced lag on UI Automation text change events, improving the responsiveness of controls such as combo boxes and of File Explorer, by using the cached element class name instead of a live cross-process fetch. (#16749, @heath-toby)
 * In Notepad++, NVDA now continues to report IME composition text in speech and braille while selecting or navigating within Chinese IME composition. (#14140, #14152, @keyang556)
 * Fixed UAC slider not being read when changing values with arrow keys in UI Automation. (#9356, @tareh7z)

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -59,8 +59,7 @@ By default, when lines are skipped in a large text flood, NVDA emits a beep prop
 This can be disabled in the Advanced settings panel.
 * In Windows Terminal, NVDA is less likely to report stale characters when moving the caret in delayed remote sessions such as SSH. (#19503, @sheldon-im)
 * When an application stops responding, NVDA no longer freezes or floods its log with errors; it stays responsive and drops UIA and MSAA events from the unresponsive application until it recovers. (#16749, @heath-toby)
-* NVDA no longer freezes for around five seconds when pressing keys such as `control+c` or `enter` in applications whose accessibility provider is slow to respond, such as Chromium menus, Qt applications and XAML applications. (#20654, @Khalil220)
-* The same freeze no longer happens while typing ordinary characters in those applications. (#20654, @Khalil220)
+* With typing echo off, NVDA no longer freezes for around five seconds while typing, or when pressing keys such as `control+c` or `enter`, in applications whose accessibility provider is slow to respond, such as Chromium menus, Qt applications and XAML applications. (#20654, @Khalil220)
 * Reduced lag on UI Automation text change events, improving the responsiveness of controls such as combo boxes and of File Explorer, by using the cached element class name instead of a live cross-process fetch. (#16749, @heath-toby)
 * In Notepad++, NVDA now continues to report IME composition text in speech and braille while selecting or navigating within Chinese IME composition. (#14140, #14152, @keyang556)
 * Fixed UAC slider not being read when changing values with arrow keys in UI Automation. (#9356, @tareh7z)

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -60,6 +60,7 @@ This can be disabled in the Advanced settings panel.
 * In Windows Terminal, NVDA is less likely to report stale characters when moving the caret in delayed remote sessions such as SSH. (#19503, @sheldon-im)
 * When an application stops responding, NVDA no longer freezes or floods its log with errors; it stays responsive and drops UIA and MSAA events from the unresponsive application until it recovers. (#16749, @heath-toby)
 * NVDA no longer freezes for around five seconds when pressing keys such as `control+c` or `enter` in applications whose accessibility provider is slow to respond, such as Chromium menus, Qt applications and XAML applications. (#20654, @Khalil220)
+* The same freeze no longer happens while typing ordinary characters in those applications. (#20654, @Khalil220)
 * Reduced lag on UI Automation text change events, improving the responsiveness of controls such as combo boxes and of File Explorer, by using the cached element class name instead of a live cross-process fetch. (#16749, @heath-toby)
 * In Notepad++, NVDA now continues to report IME composition text in speech and braille while selecting or navigating within Chinese IME composition. (#14140, #14152, @keyang556)
 * Fixed UAC slider not being read when changing values with arrow keys in UI Automation. (#9356, @tareh7z)


### PR DESCRIPTION
### Link to issue number:

Part of #20654. @seanbudd asked for the fixes there to be split, and this is the first of the two. I've since built and tested the second, and it doesn't fix the freeze it was meant to fix, so I'm not opening it. What I found is written down in a comment on #20654 instead.

### Summary of the issue:

`speech.speakTypedCharacters()` calls `api.isTypingProtected()` as its first statement, for every typed character, before any configuration is read. Resolving it needs `focusObject.isProtected`, which needs `self.states`, and on every `NVDAObject` implementation that means synchronous cross-process calls: `IUIAutomationElement.buildUpdatedCache` for UIA objects, `accState` and `accRole` for IAccessible ones.

The call happens even with both "Speak typed characters" and "Speak typed words" off, and for control characters such as `control+c` (0x03) and `enter` (0x0D) that are never spoken, since character echo is gated on `ch >= FIRST_NONCONTROL_CHAR`. When the provider is slow to answer, the core thread blocks until it does. That was 5.035 s in the freeze captured on #20654. Timing the call directly in a later capture showed it returning a valid value after 5.022 s, so it completes rather than timing out.

### Description of user facing changes:

NVDA no longer freezes when pressing keys such as `control+c` or `enter` on default settings, and no longer freezes while typing when typing echo is off, in applications whose accessibility provider is slow to answer. Reported in Chromium context menus, Qt applications and XAML applications.

### Description of developer facing changes:

None. `speakTypedCharacters` keeps its signature and behavior, and gains the `-> None` annotation `codingStandards.md` asks for.

### Description of development approach:

Two changes, both aimed at not resolving the protected state until something is about to use it.

The state is now resolved on demand through a nested helper that caches the result, instead of eagerly at the top of the function. It is needed when gating word echo and when producing `realChar` for character echo. Moving the lookup into those branches drops it for control characters, and for every character when the relevant echo is off.

Buffering a character used to need it as well, because the character was masked on the way into `_curWordChars`. That was the one remaining path where an ordinary printable character performed a blocking call, and it ran whatever the echo settings were. The character is now buffered as typed and masked where the word is used. The word is already never spoken while typing is protected.

Buffering as typed keeps the buffer the same length as before, which matters because `NVDAObjects.behaviors` reads `len(_curWordChars)` when filtering typed characters out of new line reporting. The trade-off is that the buffer holds the characters as typed until the word ends or the buffer is cleared, where previously it held only the mask. Nothing speaks or logs them in that state, and per character echo still masks independently.

Protection semantics are otherwise unchanged, and `_get_isProtected` stays sticky-once-true per #7908.

In the word echo branch the check now sits inside the mode test instead of being ANDed with it, so the protected state is resolved only once we know the word would be spoken. The reordering does not change which words get spoken.

### Testing strategy:

23 unit tests in `tests/unit/test_speechTypedCharacters.py`:

* the lookup is skipped for control characters, with either echo off, and with word echo limited to edit controls while focus is not editable
* buffering a character resolves nothing, and the buffer holds the character as typed
* the buffer length is unchanged by protection, which `NVDAObjects.behaviors` depends on
* protected words are never spoken, and are masked before being logged
* per character echo still speaks `PROTECTED_CHAR`
* the cache holds, so one character costs at most one lookup

Full unit suite: 1397 tests on `master`, 1420 on this branch, the difference being the 23 new tests. No failures or errors either side, 6 skipped, against a `release=1` build. `ruff check` passes, `ruff format --check` reports no changes, `pyright` exits 0.

I also checked the change deterministically, by extracting the real `speakTypedCharacters` source from this branch and from `master` and running each against stubs that count anything reaching `obj.states`. Across every combination of character type, word buffer state and the two echo settings, `master` performs the lookup in all 54 cases. This branch skips 30 of them, and needs the answer in each of the rest.

To test the control key cases, leave both echo settings at their defaults. In Chrome, open the context menu on a link, arrow to "Copy link address" and press `enter`. Try `control+c` in a Qt application and in Unigram. To test typing, set "Speak typed characters" and "Speak typed words" to off, then type into an edit control in each. Before the change these froze NVDA for about five seconds, intermittently; afterwards they do not.

For the masking, use a password field. With character echo on, confirm the masked character is spoken rather than the real one. With word echo on, confirm the word is not spoken when it ends.

Since the freeze needs the provider to be slow at that moment, no single session proves much, and the deterministic check is the stronger evidence. I have not added system tests for the same reason: the harness cannot make a provider unresponsive on demand.

### Known issues with pull request:

With character echo on, a printable character still performs the lookup, and can still freeze. `speakSpelling(getRealChar())` has to know whether to speak the mask or the character, and speaking is the last thing that happens, so there is no later point at which to decide. `isFocusEditable()` reads states for the "Only in edit controls" mode as well. Since that mode is the default for typed characters, a default configuration gets no benefit from this PR while typing in an edit control. Addressing that needs a change to the blocking call itself rather than to when it is made. See the discussion on #20654.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.

The implementation was AI-assisted, written with Claude. I reviewed the approach and the code, and tested the behavior myself.


