### PR TITLE
[WIP] Tighten type checking for the ART project

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -190,6 +190,8 @@ extraPaths = [
 	"./include/nvda-mathcat/assets",
 ]
 
+strict = ["source/_art/**", "tests/unit/test_art/**"]
+
 # General config
 analyzeUnannotatedFunctions = true
 deprecateTypingAliases = true
@@ -367,6 +369,12 @@ unused-type-ignore-comment = "ignore"  # 1 warning
 unsupported-base = "ignore"  # 1 warning
 redundant-cast = "ignore"  # 1 warning
 mismatched-type-name = "ignore"  # 1 warning
+
+[[tool.ty.overrides]]
+include = ["source/_art/**", "tests/unit/test_art/**"]
+
+[tool.ty.overrides.rules]
+all = "error"
 
 [tool.uv]
 default-groups = "all"


### PR DESCRIPTION
### Link to issue number:
None

### Summary of the issue:
NVDA's Python type checker (pyright/ty) configurations are fairly permissive. This is needed for legacy code which is gradually having type annotations added.

However, it is prefferable that the ART project have stricter type checking from the start.

### Description of user facing changes:

None

### Description of developer facing changes:

The pyright and ty configurations for ART code have been tightened.

### Description of development approach:

Overrode the ty configuration for `source/_art/` and `tests/unit/test_art` to make all diagnostics errors.

Set the same directories to use pyright's strict config.

TBD: fixed existing violations and adjust configurations further (e.g. to allow typing violations caused by legacy code imported into ART).

### Testing strategy:

Type checking; unit tests, CI.

### Known issues with pull request:

### Code Review Checklist:

- [ ] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
