### PR TITLE
Fix NVDA restart failure after add-on installation

### DIFF
--- a/source/gui/message.py
+++ b/source/gui/message.py
@@ -90,12 +90,14 @@ def displayDialogAsModal(dialog: wx.Dialog) -> int:
 	Because an answer is required to continue after a modal messageBox is opened,
 	some actions such as shutting down are prevented while NVDA is in a possibly uncertain state.
 	"""
+	# The dialog may be destroyed before ShowModal returns, so cache this state before showing it.
+	hasParent: bool = bool(dialog.GetParent())
 	try:
-		if not dialog.GetParent():
+		if not hasParent:
 			gui.mainFrame.prePopup()
 		res = dialog.ShowModal()
 	finally:
-		if not dialog.GetParent():
+		if not hasParent:
 			gui.mainFrame.postPopup()
 
 	return res

--- a/tests/unit/test_messageDialog.py
+++ b/tests/unit/test_messageDialog.py
@@ -18,7 +18,7 @@ from parameterized import parameterized
 from typing import Any, Iterable, NamedTuple
 from concurrent.futures import ThreadPoolExecutor
 
-from gui.message import Button
+from gui.message import Button, displayDialogAsModal
 from gui.message import MessageDialog
 
 
@@ -618,6 +618,22 @@ class Test_MessageDialog_ShowModal(MDTestBase):
 			mocked_showModal.assert_called_once()
 			mocked_messageBoxCounter.__iadd__.assert_called_once()
 			mocked_messageBoxCounter.__isub__.assert_called_once()
+
+
+@patch("gui.mainFrame")
+class Test_DisplayDialogAsModal(unittest.TestCase):
+	def test_dialogDeletedDuringShowModal(self, mocked_mainFrame: MagicMock) -> None:
+		"""The dialog must not be accessed after ShowModal returns."""
+		dialog = MagicMock(spec_set=wx.Dialog)
+		dialog.GetParent.side_effect = (None, RuntimeError("wrapped C/C++ object has been deleted"))
+		dialog.ShowModal.return_value = wx.ID_YES
+
+		self.assertEqual(wx.ID_YES, displayDialogAsModal(dialog))
+
+		dialog.GetParent.assert_called_once()
+		dialog.ShowModal.assert_called_once()
+		mocked_mainFrame.prePopup.assert_called_once()
+		mocked_mainFrame.postPopup.assert_called_once()
 
 
 class Test_MessageDialog_EventHandlers(MDTestBase):

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -51,6 +51,7 @@
 
 ### Bug Fixes
 
+* NVDA now restarts reliably when requested after installing an add-on package from File Explorer. (#17925, @cary-rowen)
 * In PowerPoint and other Office applications, NVDA will now correctly read and navigate the edit fields in the insert hyperlink dialog. (#17390, @aryanchoudharypro)
 * The actions button can now be used when selecting multiple add-ons in the Add-on Store to perform batch actions, instead of just via the context menu in the add-ons list. (#19971, @amirmahdifard)
 * When moving to an ARIA grid cell in focus mode in web browsers, NVDA no longer reports both the row and column headers even if only the row or only the column changed. (#17750, @jcsteh)


### PR DESCRIPTION
### Link to issue number:

Closes #17925.

### Summary of the issue:

After installing or updating an add-on package from File Explorer, rapidly confirming the dialogs could cause NVDA to access a `MessageDialog` after its underlying wx object had been deleted. This raised a `RuntimeError` and prevented the requested NVDA restart.

### Description of user facing changes:

NVDA now restarts reliably when requested after installing or updating an add-on package from File Explorer.

### Description of developer facing changes:

No public API changes.

### Description of development approach:

`displayDialogAsModal` previously called `GetParent` both before and after `ShowModal`. A modal dialog may be destroyed before `ShowModal` returns, making the second access unsafe.

The dialog's parent state is now cached before it is shown. This preserves the existing `prePopup` and `postPopup` behavior without accessing the dialog after `ShowModal` returns.

A regression test simulates the dialog becoming invalid while it is shown and verifies that it is not accessed afterward.

### Testing strategy:

Unit tests:

* Added a regression test covering a dialog that is deleted before `ShowModal` returns.
* Verified that the message dialog unit test suite passes.
* Verified that the regression test fails with the previous implementation.

Manual testing:

1. Install an already-installed add-on package from File Explorer.
2. Rapidly press Y through the installation and update confirmation dialogs.
3. Choose Yes when prompted to restart NVDA.
4. Confirm that NVDA restarts without logging a deleted `MessageDialog` exception.

### Known issues with pull request:

None known.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [ ] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [ ] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [ ] API is compatible with existing add-ons.
- [ ] Security precautions taken.