### PR TITLE
fix module cache cleanup in Addon._cleanupAddonImports

### DIFF
--- a/source/addonHandler/__init__.py
+++ b/source/addonHandler/__init__.py
@@ -1,8 +1,8 @@
 # A part of NonVisual Desktop Access (NVDA)
 # Copyright (C) 2012-2026 NV Access Limited, Rui Batista, Noelia Ruiz Martínez, Joseph Lee, Babbage B.V.,
 # Arnold Loubriat, Łukasz Golonka, Leonard de Ruijter, Julien Cochuyt, Cyrille Bougot
-# This file is covered by the GNU General Public License.
-# See the file COPYING for more details.
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
 
 from __future__ import annotations  # Avoids quoting of forward references
 
@@ -888,9 +888,11 @@ class Addon(AddonBase):
 			log.debug(f"removing imported add-on module {modName}")
 			del sys.modules[modName]
 		self._importedAddonModules.clear()
+		addonPathPrefix = os.path.join(os.path.normcase(self.path), "")
 		for modName in set(sys.modules.keys()) - self._modulesBeforeInstall:
 			module = sys.modules[modName]
-			if module.__name__ and module.__name__.startswith(self.path):
+			moduleFile = getattr(module, "__file__", None)
+			if moduleFile and os.path.normcase(moduleFile).startswith(addonPathPrefix):
 				log.debug(f"Removing module {module} from cache of imported modules")
 				del sys.modules[modName]
 

--- a/tests/unit/test_addonHandler/test_addonImports.py
+++ b/tests/unit/test_addonHandler/test_addonImports.py
@@ -1,0 +1,105 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2026 NV Access Limited, Leonard de Ruijter
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
+
+"""Unit tests for the cleanup of add-on modules imported into sys.modules."""
+
+import os
+import sys
+import tempfile
+import types
+import unittest
+
+import addonHandler
+
+MANIFEST_CONTENTS = """name = testAddon
+summary = Test add-on
+author = Test author
+version = 0.1
+"""
+
+ADDON_MODULE_CONTENTS: dict[str, str] = {
+	"__init__.py": "",
+	"sibling.py": "",
+	"mainMod.py": "from . import sibling\n",
+}
+
+
+class TestCleanupAddonImports(unittest.TestCase):
+	"""Tests for the removal of an add-on's modules from sys.modules by Addon._cleanupAddonImports."""
+
+	def setUp(self) -> None:
+		self._modulesBefore = set(sys.modules)
+		self._tempDir = tempfile.TemporaryDirectory()
+		addonPath = os.path.join(self._tempDir.name, "testAddon")
+		libPath = os.path.join(addonPath, "lib")
+		os.makedirs(libPath)
+		with open(os.path.join(addonPath, addonHandler.MANIFEST_FILENAME), "w", encoding="utf-8") as f:
+			f.write(MANIFEST_CONTENTS)
+		for fileName, contents in ADDON_MODULE_CONTENTS.items():
+			with open(os.path.join(libPath, fileName), "w", encoding="utf-8") as f:
+				f.write(contents)
+		self.addon = addonHandler.Addon(addonPath)
+		self.addon._modulesBeforeInstall = set(sys.modules)
+
+	def tearDown(self) -> None:
+		for modName in set(sys.modules) - self._modulesBefore:
+			del sys.modules[modName]
+		self._tempDir.cleanup()
+
+	def _injectModule(self, name: str) -> types.ModuleType:
+		"""Adds a synthetic module to sys.modules and returns it.
+
+		:param name: The name to register the module under.
+		:return: The registered module.
+		"""
+		module = types.ModuleType(name)
+		sys.modules[name] = module
+		return module
+
+	def test_transitivelyImportedAddonModuleRemoved(self):
+		"""A module imported by another add-on module rather than by loadModule is removed."""
+		self.addon.loadModule("lib.mainMod")
+		siblingName = "addons.testAddon.lib.sibling"
+		self.assertIn(siblingName, sys.modules)
+		self.assertNotIn(siblingName, self.addon._importedAddonModules)
+		self.addon._cleanupAddonImports()
+		self.assertNotIn(siblingName, sys.modules)
+
+	def test_addonModuleRemovedRegardlessOfPathCase(self):
+		"""A module whose file path differs from the add-on path only in case is removed."""
+		module = self._injectModule("fakeCasedAddonModule")
+		module.__file__ = os.path.join(self.addon.path.upper(), "lib", "mod.py")
+		self.addon._cleanupAddonImports()
+		self.assertNotIn("fakeCasedAddonModule", sys.modules)
+
+	def test_moduleWithoutFileAttributeKept(self):
+		"""A module without a __file__ attribute survives the cleanup."""
+		self._injectModule("fakeBuiltinModule")
+		self.addon._cleanupAddonImports()
+		self.assertIn("fakeBuiltinModule", sys.modules)
+
+	def test_moduleFromSiblingPathPrefixKept(self):
+		"""A module from a directory whose path starts with the add-on path survives the cleanup."""
+		module = self._injectModule("fakeSiblingPathModule")
+		module.__file__ = os.path.join(self.addon.path + "Extra", "mod.py")
+		self.addon._cleanupAddonImports()
+		self.assertIn("fakeSiblingPathModule", sys.modules)
+
+	def test_moduleWithNoneFileKept(self):
+		"""A module whose __file__ attribute is None survives the cleanup."""
+		module = self._injectModule("fakeNamespaceModule")
+		module.__file__ = None
+		self.addon._cleanupAddonImports()
+		self.assertIn("fakeNamespaceModule", sys.modules)
+
+	def test_recordedModulesRemovedAndListCleared(self):
+		"""Modules recorded by loadModule are removed and the record is emptied."""
+		self.addon.loadModule("lib.mainMod")
+		recordedNames = list(self.addon._importedAddonModules)
+		self.assertIn("addons.testAddon.lib.mainMod", recordedNames)
+		self.addon._cleanupAddonImports()
+		for modName in recordedNames:
+			self.assertNotIn(modName, sys.modules)
+		self.assertEqual(self.addon._importedAddonModules, [])

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -93,7 +93,8 @@ Previously these keys had no function when pressed on their own. (#20366, @fla-r
 * In Mozilla Firefox and Chromium based browsers with native selection mode enabled, the caret no longer gets stuck when switching to focus mode, and typing in edit fields works again. (#19075, #18028, @LeonarddeR)
 * In Windows Terminal, mouse tracking now reports the line of text under the mouse pointer. (#20448, @DataTriny)
 * NVDA no longer floods its log with errors while Windows is locked and a browse mode document keeps updating in the background, such as a playing video in Mozilla Firefox. (#18861, @bramd)
-* Updating an add-on no longer leaves modules of the old version loaded. This could cause errors in the updated add-on on the first start of NVDA after the update. (#18971, @LeonarddeR)
+* Updating an add-on no longer leaves modules of the old version loaded.
+This could cause errors in the updated add-on on the first start of NVDA after the update. (#18971, @LeonarddeR)
 
 ### Changes for Developers
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -93,6 +93,7 @@ Previously these keys had no function when pressed on their own. (#20366, @fla-r
 * In Mozilla Firefox and Chromium based browsers with native selection mode enabled, the caret no longer gets stuck when switching to focus mode, and typing in edit fields works again. (#19075, #18028, @LeonarddeR)
 * In Windows Terminal, mouse tracking now reports the line of text under the mouse pointer. (#20448, @DataTriny)
 * NVDA no longer floods its log with errors while Windows is locked and a browse mode document keeps updating in the background, such as a playing video in Mozilla Firefox. (#18861, @bramd)
+* Updating an add-on no longer leaves modules of the old version loaded. This could cause errors in the updated add-on on the first start of NVDA after the update. (#18971, @LeonarddeR)
 
 ### Changes for Developers
 


### PR DESCRIPTION
### Link to issue number:

Fixup for #18971.

### Summary of the issue:

Installing or removing an add-on can run install tasks. These tasks can import modules from the add-on. Python caches every import in `sys.modules`. NVDA must drop the add-on's modules from that cache afterwards. Otherwise a later import returns the cached old module instead of the file on disk.

Modules the tasks load directly are tracked in `_importedAddonModules` and dropped reliably. Modules imported indirectly, for example through a relative import inside the add-on, are not tracked. For those, `_cleanupAddonImports` scans every module imported during the task and drops each one whose file is inside the add-on directory.

That scan has been broken twice:

* #15967 introduced it reading `module.__file__` directly. Modules without a `__file__`, such as built-in modules, made it crash with `AttributeError`.
* #18971 fixed that crash by reading `module.__name__` instead. A module name is not a file path, so the scan matches nothing. Since 2026.1 it drops nothing.

Result: updating an add-on can break on the first start after the update. The old version's uninstall task runs first and leaves old modules in the cache. The new version then partly imports old code. A second restart of NVDA resolves the situation regardless.

### Description of user facing changes:

Updated add-ons that perform install tasks no longer raise intermittent errors on the first start of NVDA after the update.

### Description of developer facing changes:

None.

### Description of development approach:

The approach of #15967 was the correct one: a module belongs to the add-on when its file is inside the add-on directory. This change returns to matching on the file path and fixes the three defects of that implementation:

* The file is read with `getattr(module, "__file__", None)`. Modules without a `__file__` are skipped instead of crashing the scan, so the error fixed by #18971 stays fixed.
* The file path and the add-on directory are compared through `os.path.normcase`, so case differences match.
* The directory prefix ends with a path separator, so a sibling directory such as `myAddonExtra` no longer matches `myAddon`.

Each defect is covered by a unit test. The loop over the tracked modules is unchanged.

### Testing strategy:

New unit tests in `tests/unit/test_addonHandler/test_addonImports.py` build an add-on in a temporary directory. One of its modules imports a sibling module. Checked:

* the indirectly imported sibling module is dropped,
* matching ignores path case,
* a module without `__file__` is kept and nothing raises,
* a module with `__file__ = None` is kept,
* a module from a sibling directory with a shared path prefix is kept,
* tracked modules are dropped and the record is emptied.

Both historical scans fail this suite. The #18971 form fails the two drop checks. The #15967 form crashes on the missing `__file__` check, wrongly drops the sibling-directory module and misses the case difference.

### Known issues with pull request:

None.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
