### PR TITLE
Prevent synth settings from leaking between configuration profiles

### DIFF
--- a/source/synthDriverHandler.py
+++ b/source/synthDriverHandler.py
@@ -112,6 +112,11 @@ class SynthDriver(driverHandler.Driver):
 	# type information for auto property _get_availableLanguages
 	# the set of languages available in the availableVoices
 	availableLanguages: set[str | None]
+	_shouldSaveSettings = True
+
+	def saveSettings(self) -> None:
+		if self._shouldSaveSettings:
+			super().saveSettings()
 
 	@classmethod
 	def LanguageSetting(cls):
@@ -502,7 +507,25 @@ def getSynthInstance(name: str, asDefault: bool = False):
 defaultSynthPriorityList = ["oneCore", "espeak", "silence"]
 
 
-def setSynth(name: str | None, isFallback: bool = False, *, _leftToTry: list[str] | None = None) -> bool:
+def _terminateSynth(synth: SynthDriver, *, saveSettings: bool) -> None:
+	if saveSettings:
+		synth.terminate()
+		return
+	shouldSaveSettings = synth._shouldSaveSettings
+	synth._shouldSaveSettings = False
+	try:
+		synth.terminate()
+	finally:
+		synth._shouldSaveSettings = shouldSaveSettings
+
+
+def setSynth(
+	name: str | None,
+	isFallback: bool = False,
+	*,
+	_leftToTry: list[str] | None = None,
+	_isConfigProfileSwitch: bool = False,
+) -> bool:
 	"""Set the currently active speech synth by name.
 
 	If the chosen synth cannot be used, this function will attempt to fall back to another synth.
@@ -512,6 +535,7 @@ def setSynth(name: str | None, isFallback: bool = False, *, _leftToTry: list[str
 	:param isFallback: Whether this synth is a fallback, i.e. it isn't the synth that the user wants. Defaults to ``False``.
 	:param _leftToTry: List of synth names to try falling back to, in reverse order of priority. Defaults to ``None``.
 		If ``None``, the list will be calculated automatically.
+	:param _isConfigProfileSwitch: Whether the synthesizer is being reloaded for a configuration profile switch.
 	:return: ``True`` if switching to the named synthesizer succeeds; ``False`` otherwise.
 	"""
 	from synthDrivers.silence import SynthDriver as SilenceSynthDriver
@@ -521,7 +545,7 @@ def setSynth(name: str | None, isFallback: bool = False, *, _leftToTry: list[str
 	if name is None:
 		if _curSynth is not None:
 			_curSynth.cancel()
-			_curSynth.terminate()
+			_terminateSynth(_curSynth, saveSettings=not _isConfigProfileSwitch)
 			_curSynth = None
 		return True
 	if name == "auto":
@@ -529,7 +553,7 @@ def setSynth(name: str | None, isFallback: bool = False, *, _leftToTry: list[str
 		name = defaultSynthPriorityList[0]
 	if _curSynth is not None:
 		_curSynth.cancel()
-		_curSynth.terminate()
+		_terminateSynth(_curSynth, saveSettings=not _isConfigProfileSwitch)
 		prevSynthName = _curSynth.name
 		_curSynth = None
 	else:
@@ -541,7 +565,7 @@ def setSynth(name: str | None, isFallback: bool = False, *, _leftToTry: list[str
 
 	if _curSynth is not None:
 		_audioOutputDevice = config.conf["audio"]["outputDevice"]
-		if not isFallback:
+		if not isFallback and not _isConfigProfileSwitch:
 			config.conf["speech"]["synth"] = name
 		log.info(f"Loaded synthDriver {_curSynth.name}")
 		synthChanged.notify(synth=_curSynth, audioOutputDevice=_audioOutputDevice, isFallback=isFallback)
@@ -596,7 +620,7 @@ def handlePostConfigProfileSwitch(resetSpeechIfNeeded=True):
 			import speech
 
 			speech.cancelSpeech()
-		setSynth(conf["synth"])
+		setSynth(conf["synth"], _isConfigProfileSwitch=True)
 		return
 	_curSynth.loadSettings(onlyChanged=True)
 

--- a/tests/unit/test_synthDriverHandler.py
+++ b/tests/unit/test_synthDriverHandler.py
@@ -1,7 +1,7 @@
 # A part of NonVisual Desktop Access (NVDA)
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
-# Copyright (C) 2021-2024 NV Access Limited, Leonard de Ruijter, Cyrille Bougot
+# Copyright (C) 2021-2026 NV Access Limited, Leonard de Ruijter, Cyrille Bougot
 
 """Unit tests for the synthDriverHandler"""
 
@@ -17,18 +17,29 @@ FAKE_DEFAULT_LANG = "fakeDefault"
 FAKE_DEFAULT_SYNTH_NAME = "defaultSynth"
 
 
-class MockSynth:
+class MockSynth(synthDriverHandler.SynthDriver):
 	def __init__(self, name: str):
 		self.name = name
+		self.settingsSaved = False
 		self.availableVoices = {
 			"fooId": synthDriverHandler.VoiceInfo("fooId", "foo language", FAKE_DEFAULT_LANG),
 		}
+
+	def _get_supportedSettings(self):
+		return []
+
+	def speak(self, speechSequence):
+		pass
 
 	def cancel(self):
 		pass
 
 	def terminate(self):
-		pass
+		super().terminate()
+
+	@classmethod
+	def _saveSpecificSettings(cls, clsOrInst, settings):
+		clsOrInst.settingsSaved = True
 
 	def initSettings(self):
 		pass
@@ -43,6 +54,7 @@ class test_synthDriverHandler(unittest.TestCase):
 		self._oldLang = languageHandler.getLanguage()
 		self._oldSynthConfig = config.conf["speech"]["synth"]
 		self._originalSynth = synthDriverHandler._curSynth
+		self._originalAudioOutputDevice = synthDriverHandler._audioOutputDevice
 		self._originalGetSynthDriver = synthDriverHandler._getSynthDriver
 		config.conf["speech"]["synth"] = FAKE_DEFAULT_LANG
 		synthDriverHandler._curSynth = MockSynth(FAKE_DEFAULT_SYNTH_NAME)
@@ -56,6 +68,7 @@ class test_synthDriverHandler(unittest.TestCase):
 	def tearDown(self) -> None:
 		config.conf["speech"]["synth"] = self._oldSynthConfig
 		synthDriverHandler._curSynth = self._originalSynth
+		synthDriverHandler._audioOutputDevice = self._originalAudioOutputDevice
 		synthDriverHandler._getSynthDriver = self._originalGetSynthDriver
 		languageHandler._language = self._oldLang
 
@@ -77,6 +90,30 @@ class test_synthDriverHandler(unittest.TestCase):
 			synthDriverHandler.setSynth(synthName)
 			self.assertEqual(synthName, synthDriverHandler.getSynth().name)
 			self.assertEqual(synthName, config.conf["speech"]["synth"])
+
+	def test_setSynth_savesCurrentSettings(self):
+		oldSynth = synthDriverHandler.getSynth()
+		synthDriverHandler.setSynth("espeak")
+		self.assertTrue(oldSynth.settingsSaved)
+
+	def test_profileSwitchDoesNotSaveCurrentSettingsOrResolveAutoSynthInConfig(self):
+		oldSynth = synthDriverHandler.getSynth()
+		config.conf["speech"]["synth"] = "auto"
+
+		synthDriverHandler.handlePostConfigProfileSwitch(resetSpeechIfNeeded=False)
+
+		self.assertFalse(oldSynth.settingsSaved)
+		self.assertEqual("auto", config.conf["speech"]["synth"])
+		self.assertEqual("oneCore", synthDriverHandler.getSynth().name)
+
+	def test_profileSwitchPreservesSynthFallback(self):
+		languageHandler._language = "bar"
+		config.conf["speech"]["synth"] = "auto"
+
+		synthDriverHandler.handlePostConfigProfileSwitch(resetSpeechIfNeeded=False)
+
+		self.assertEqual("auto", config.conf["speech"]["synth"])
+		self.assertEqual(FAKE_DEFAULT_SYNTH_NAME, synthDriverHandler.getSynth().name)
 
 	def test_setSynth_auto_fallbackMode(self):
 		"""

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -92,6 +92,7 @@ Previously these keys had no function when pressed on their own. (#20366, @fla-r
 * In Mozilla Firefox and Chromium based browsers with native selection mode enabled, the caret no longer gets stuck when switching to focus mode, and typing in edit fields works again. (#19075, #18028, @LeonarddeR)
 * In Windows Terminal, mouse tracking now reports the line of text under the mouse pointer. (#20448, @DataTriny)
 * NVDA no longer floods its log with errors while Windows is locked and a browse mode document keeps updating in the background, such as a playing video in Mozilla Firefox. (#18861, @bramd)
+* Synthesizer settings no longer leak between configuration profiles when profiles use different audio output devices. (#20717, @cary-rowen)
 
 ### Changes for Developers
 


### PR DESCRIPTION
### Link to issue number:
<!-- Use Closes/Fixes/Resolves #xxx to link this PR to the issue it is responding to. -->

Fixes #20292

### Summary of the issue:

When a configuration profile changes the audio output device, NVDA reloads the synthesizer after the new profile becomes active. Terminating the old synthesizer saves its runtime settings into the newly active profile, causing speech settings such as rate to leak between profiles.

### Description of user facing changes:

Speech settings remain isolated between configuration profiles when switching profiles reloads the synthesizer due to a different audio output device.

### Description of developer facing changes:

No public API changes.

Synthesizer reloads initiated by a configuration profile switch no longer save the old synthesizer settings or replace an `auto` synthesizer setting with the resolved synthesizer name.

### Description of development approach:

A private flag identifies calls to `setSynth` made while applying a configuration profile switch.

For these calls, synthesizer termination and cleanup still occur, but saving the old synthesizer settings is temporarily suppressed. Updating the active profile's synthesizer setting is also skipped. Normal synthesizer changes continue to save settings, and existing fallback and `synthChanged` behavior is preserved.

The suppression is limited to `SynthDriver` rather than changing the behavior of the shared `AutoSettings` base class.

### Testing strategy:

Focused unit coverage verifies that normal synthesizer changes still save settings, while profile-triggered reloads do not modify the newly active profile. Automatic synthesizer selection and fallback behavior are also covered.

Manual test:

1. Select OneCore as the synthesizer.
2. Set the speech rate in the default profile to 85.
3. Create an application-specific profile and set its speech rate to 55.
4. Configure a different audio output device in the application-specific profile.
5. Switch focus between the application and another application several times.
6. Verify that the default profile retains rate 85 and the application-specific profile retains rate 55.
7. Switch synthesizers manually and verify that normal synthesizer settings continue to be retained.

### Known issues with pull request:

None known.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [ ] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [ ] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [ ] API is compatible with existing add-ons.
- [ ] Security precautions taken.