### PR TITLE
Use current focus state to filter UIA focus events

### DIFF
--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -1631,7 +1631,8 @@ class UIA(Window):
 
 	def _get_shouldAllowUIAFocusEvent(self):
 		try:
-			return bool(self._getUIACacheablePropertyValue(UIAHandler.UIA_HasKeyboardFocusPropertyId))
+			# Focus may have moved since the event sender's cache was populated.
+			return bool(self.UIAElement.currentHasKeyboardFocus)
 		except COMError:
 			return True
 

--- a/tests/unit/test_NVDAObjects_UIA.py
+++ b/tests/unit/test_NVDAObjects_UIA.py
@@ -88,6 +88,16 @@ class TestMenuItemDescription(unittest.TestCase):
 				getLegacyDescription.assert_not_called()
 
 
+class TestUIAFocusEvent(unittest.TestCase):
+	def test_shouldAllowUIAFocusEventIgnoresStaleCache(self):
+		obj = object.__new__(UIA)
+		obj.UIAElement = Mock(currentHasKeyboardFocus=False)
+
+		with patch.object(UIA, "_getUIACacheablePropertyValue", return_value=True) as getCachedValue:
+			self.assertFalse(obj._get_shouldAllowUIAFocusEvent())
+			getCachedValue.assert_not_called()
+
+
 class TestMenuItemStates(unittest.TestCase):
 	def test_legacyCheckedStateFallback(self) -> None:
 		menuItem = object.__new__(MenuItem)


### PR DESCRIPTION
### Link to issue number:

Fixes #20763

### Summary of the issue:

In the current NVDA alpha snapshot, pressing Page Up or Page Down in WeChat's conversation list causes NVDA to announce the conversation-list container (会话，列表) before announcing the focused conversation item.

The issue is specific to Page Up and Page Down. Up Arrow and Down Arrow do not reproduce it.

### Description of user facing changes:

NVDA no longer announces the intermediate conversation-list container when the user presses Page Up or Page Down in WeChat. The focused conversation item is announced directly.

### Description of developer facing changes:

No public API changes.

### Description of development approach:

The regression was introduced by #20608, which expanded the UIA base cache and made event-created UIA objects use cached base properties, including `HasKeyboardFocus`.

WeChat's Qt UIA provider emits an intermediate focus event for the conversation-list container (`session_list`, `mmui::XTableView`) during Page Up/Page Down scrolling, followed by a focus event for the conversation item (`session_item_*`, `mmui::ChatSessionCell`). The cached focus state may be stale by the time NVDA validates the intermediate event, causing the container announcement.

The focus-event validation now reads the current UIA `HasKeyboardFocus` value instead of the event sender's cached value. This filters out stale intermediate events while keeping the broader UIA caching optimization unchanged.

### Testing strategy:

Manual testing was performed with WeChat:

1. In the current NVDA alpha snapshot, focus the conversation list and press Page Up and Page Down repeatedly. Confirm that the extra “会话，列表” announcement is reproduced.
2. Repeat the same steps with the PR build. Confirm that only the focused conversation item is announced.
3. With the PR build, navigate with Up Arrow and Down Arrow and confirm that conversation items continue to be announced.

### Known issues with pull request:

Focus-event validation performs one live UIA focus-property query. This may add a small cost to that validation, but the broader UIA caching optimization remains in place.

### Code Review Checklist:

- [ ] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [ ] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [ ] API is compatible with existing add-ons.
- [ ] Security precautions taken.