### PR TITLE
ART host entrypoint infrastructure: root services, host controller protocol, exception taxonomy, and logging shim

### DIFF
--- a/source/_art/__init__.py
+++ b/source/_art/__init__.py
@@ -8,4 +8,17 @@
 This package defines NVDA's out-of-process, sandboxed add-on runtime.
 
 * :mod:`.transport`: Generic transport over anonymous pipes.
+* :mod:`.host`: The add-on side of the boundary:
+	the host entry point and the root service it exposes to core.
+* :mod:`.session`: The core side of the boundary:
+	host controllers, core-side wire ends, and the root service core exposes to the host.
+* :mod:`.exceptions`: The capability failure taxonomy, shared by both sides.
 """
+
+from typing import Final
+
+#: Environment variable the host entry point sets, at run time, to mark its process.
+#:
+#: Shared code, like :mod:`._log`, checks for its presence to distinguish between host and core.
+#: It should only be set from :func:`.host.entrypoint.main`.
+_HOST_MARKER_ENV: Final[str] = "ART_HOST"

--- a/source/_art/_log.py
+++ b/source/_art/_log.py
@@ -1,0 +1,57 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2026 NV Access Limited
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
+
+"""Logging indirection shared by both sides of the ART boundary.
+
+Core-side ART code must log through NVDA's ``logHandler.log``,
+but the host process is isolated from core and must not import from it.
+
+The host entry point sets :data:`._HOST_MARKER_ENV` at run time, before any shared module is imported,
+and this module reads it to tell the two sides apart.
+Using an explicit signal rather than testing if ``logHandler`` can be imported
+allows host processes to behave the same when running from source.
+
+.. warning::
+	This module must be imported lazily on the host,
+	after :func:`.host.entrypoint.main` has set the marker.
+	That includes transitive imports.
+	Practically, that means that ``host.entrypoint`` should avoid importing ART code at module-scope.
+"""
+
+import os
+from typing import Final
+
+from . import _HOST_MARKER_ENV
+
+__all__ = ["log"]
+
+#: The numeric level of NVDA's ``DEBUGWARNING`` (``logHandler.Logger.DEBUGWARNING``).
+#: Duplicated because the host must not import ``logHandler`` to read it.
+_DEBUGWARNING_LEVEL: Final[int] = 15
+
+
+if os.environ.get(_HOST_MARKER_ENV):
+	# The isolated host: log to our own stdlib logger, never NVDA's.
+	import logging
+
+	logging.addLevelName(_DEBUGWARNING_LEVEL, "DEBUGWARNING")
+
+	class _HostLogger(logging.LoggerAdapter):
+		"""A stdlib logger extended with the NVDA ``Logger`` methods ART's shared code uses.
+
+		Only ``debugWarning`` is needed today.
+		Extend this if shared code starts calling more NVDA-specific logging methods.
+		"""
+
+		def debugWarning(self, msg: object, *args: object, **kwargs: object) -> None:
+			"""Log ``msg`` at NVDA's ``DEBUGWARNING`` level."""
+			self.log(_DEBUGWARNING_LEVEL, msg, *args, **kwargs)
+
+	#: The logger shared ART code uses in the host process.
+	#: The host writes to standard error, which NVDA drains into its own log.
+	log = _HostLogger(logging.getLogger("_art"), {})
+else:
+	# Core, or an in-process test host: log through NVDA's own logger.
+	from logHandler import log

--- a/source/_art/exceptions.py
+++ b/source/_art/exceptions.py
@@ -1,0 +1,47 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2026 NV Access Limited
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
+
+"""
+Exceptions shared by both sides of the ART boundary.
+
+The hierarchy is designed to allow add-ons to determine the reason a capability is unabailable
+with varying levels of specificity according to their needs:
+
+	CapabilityUnavailableError
+		CapabilityDeniedError
+			PermissionNotGrantedError
+			PermissionRevokedError
+		CapabilityLostError
+
+.. note::
+	Catching these across the boundary requires ``instantiate_custom_exceptions``;
+	see :data:`_art.transport.config.PROTOCOL_CONFIG`.
+"""
+
+
+class CapabilityUnavailableError(Exception):
+	"""A capability cannot be used."""
+
+
+class CapabilityDeniedError(CapabilityUnavailableError):
+	"""A capability is unavailable for a policy reason."""
+
+
+class PermissionNotGrantedError(CapabilityDeniedError):
+	"""The permission has never been held.
+
+	Covers ``Denied``, ``Prompt``, and permissions absent from the add-on's manifest.
+	"""
+
+
+class PermissionRevokedError(CapabilityDeniedError):
+	"""The permission was granted earlier in this session, and has since been revoked."""
+
+
+class CapabilityLostError(CapabilityUnavailableError):
+	"""A capability became unusable for an infrastructure reason, such as a crash or teardown.
+
+	Not a policy decision; the permission may still be granted.
+	"""

--- a/source/_art/host/__init__.py
+++ b/source/_art/host/__init__.py
@@ -1,0 +1,19 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2026 NV Access Limited
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
+
+"""
+The add-on side of the ART boundary.
+
+This package is the boot code of the host process:
+the entry point that attaches to the wire ends it was launched with,
+and the root service it exposes back to core.
+
+.. warning::
+	Nothing in this package may import from core-side-only modules.
+	Everything here executes inside the host process, alongside untrusted add-on code,
+	so an add-on reading it learns nothing it did not already have.
+	Core-side machinery must only ever reach the host over the control connection,
+	never by being imported into it.
+"""

--- a/source/_art/host/entrypoint.py
+++ b/source/_art/host/entrypoint.py
@@ -1,0 +1,50 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2026 NV Access Limited
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
+
+"""
+First-launch code of the ART host process.
+
+Run as ``python -m _art.host.entrypoint``
+with the control connection wired to the process's standard input and output.
+
+The work is split in two so that the same boot path can be exercised without a process:
+
+* :func:`run` is process-agnostic and takes a ready-made stream.
+* :func:`main` is the process half, and does the standard stream manipulation that only makes sense when running in our own process.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import Final
+
+from rpyc.core.stream import Stream
+
+#: Name of the host's end of the control connection, used in logging.
+CONTROL_CONNECTION_NAME: Final[str] = "ART host control"
+
+
+def run(stream: Stream) -> None:
+	"""Serve the host root service over ``stream`` until the connection closes.
+
+	Runs the event loop in the calling thread, so this blocks for the lifetime of the host.
+
+	:param stream: The host's end of the control connection.
+	"""
+	raise NotImplementedError
+
+
+def main(argv: list[str] | None = None) -> int:
+	"""Entry point of the host process.
+
+	:param argv: Unused for now.
+		Accepted so that the build ID and the launch arguments that follow it have somewhere to go.
+	:returns: Process exit status.
+	"""
+	raise NotImplementedError
+
+
+if __name__ == "__main__":
+	sys.exit(main(sys.argv[1:]))

--- a/source/_art/host/rootService.py
+++ b/source/_art/host/rootService.py
@@ -1,0 +1,85 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2026 NV Access Limited
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
+
+"""The root service the host exposes to core over the control connection."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+import rpyc
+
+from .._log import log
+from ..transport import Service
+
+
+@rpyc.service
+class HostRootService(Service):
+	"""The host's entry point, as seen from core.
+
+	This is ART's own code, not the add-on's.
+	Add-ons implement feature components; this service is the registry that hands them out.
+	"""
+
+	def __init__(self) -> None:
+		super().__init__()
+		self._conn: rpyc.Connection | None = None
+
+	def on_connect(self, conn: rpyc.Connection) -> None:
+		"""Record the connection so :attr:`coreRoot` can reach core.
+
+		:param conn: The rpyc connection this service is being served over.
+		"""
+		super().on_connect(conn)
+		self._conn = conn
+
+	def on_disconnect(self, conn: rpyc.Connection) -> None:
+		"""Tear the service down when core drops the control connection.
+
+		Clears the recorded connection so :attr:`coreRoot` no longer hands out a dead reference,
+		and terminates the service so anything bound to its lifetime is released deterministically
+		rather than lingering until process exit or garbage collection.
+
+		:param conn: The rpyc connection that has closed.
+
+		.. note::
+			Since there should only ever be one ``HostRootService`` per add-on,
+			this method does not check the identity of ``con``,
+			as it should always be the same as that passed to ``on_connect``.
+		"""
+		super().on_disconnect(conn)
+		self._conn = None
+		self.terminate()
+
+	@property
+	def coreRoot(self) -> rpyc.Service:
+		"""Core's root service, through which capabilities are requested.
+
+		:raises RuntimeError: If the control connection has not been established.
+		"""
+		if self._conn is None:
+			raise RuntimeError("Host root service is not connected")
+		return self._conn.root
+
+	@Service.exposed
+	def ping(self) -> Literal["pong"]:
+		"""Report that the host process is serving requests.
+
+		Answered by ART itself rather than by add-on code, so it measures the health of the host's
+		transport rather than the health of whatever the add-on is doing.
+
+		:returns: "pong"
+		"""
+		return "pong"
+
+	@Service.exposed
+	def loadComponent(self, name: str) -> Service:
+		"""Instantiate one of the add-on's feature components and expose it to core.
+
+		:param name: Name of the feature component to load.
+		:raises NotImplementedError: Always, for now.
+		"""
+		log.debug(f"Component load requested before components exist: {name!r}")
+		raise NotImplementedError("Component loading arrives with the manifest and component registry")

--- a/source/_art/session/__init__.py
+++ b/source/_art/session/__init__.py
@@ -1,0 +1,16 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2026 NV Access Limited
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
+
+"""
+Core-side ownership of add-on sessions.
+
+An add-on session is the full live unit:
+host process, loaded add-on, granted capabilities, and the control connection between them.
+This package owns launching one, watching it, and tearing it down.
+
+* :mod:`.hostController`: the seam at which ART's process dependency is injected,
+	provided to allow different strategies when testing.
+* :mod:`.rootService`: the root service core exposes to the host.
+"""

--- a/source/_art/session/hostController.py
+++ b/source/_art/session/hostController.py
@@ -1,0 +1,64 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2026 NV Access Limited
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
+
+"""
+The seam at which ART's dependency on a real process is injected.
+
+A :class:`HostController` starts a host, manufactures its wire ends, reports on its liveness, and
+tears it down.
+It controls the host process, not the add-on running inside it.
+
+The abstraction is provided primarily to facilitate testing.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from rpyc.core.stream import Stream
+
+
+class HostController[HostPipeEnd](Protocol):
+	"""Starts a host, watches it, and stops it."""
+
+	def start(self) -> Stream:
+		"""Start the host and return core's end of the control connection.
+
+		:returns: Core's end of the control connection, ready to be wrapped in a
+			:class:`~_art.transport.Connection`.
+		"""
+		...
+
+	def poll(self) -> int | None:
+		"""Check whether the host has finished, without blocking.
+
+		:returns: The exit status, or ``None`` if the host is still running.
+		:raises RuntimeError: If the host has not been started.
+		"""
+		...
+
+	def wait(self, timeout: float | None = None) -> int | None:
+		"""Wait for the host to finish.
+
+		:param timeout: Seconds to wait, or ``None`` to wait indefinitely.
+		:returns: The exit status, or ``None`` if the host was still running when ``timeout`` elapsed.
+		:raises RuntimeError: If the host has not been started.
+		"""
+		...
+
+	def terminate(self) -> None:
+		"""Stop the host.
+
+		Safe to call on a host that has already finished.
+		"""
+		...
+
+	def createPipePair(self) -> tuple[Stream, HostPipeEnd]:
+		"""Manufacture a pipe pair for a dependent connection.
+
+		:returns: Core's end as a stream, and the host's end in whatever form this host consumes.
+		:raises RuntimeError: If the host is not running.
+		"""
+		...

--- a/source/_art/session/rootService.py
+++ b/source/_art/session/rootService.py
@@ -1,0 +1,43 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2026 NV Access Limited
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
+
+"""The root service core exposes to the host over the control connection."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+import rpyc
+from logHandler import log
+
+from ..exceptions import PermissionNotGrantedError
+from ..transport import Service
+
+
+@rpyc.service
+class CoreRootService(Service):
+	"""The irreducible API core hands down to an add-on.
+
+	This is the host's entry point into core,
+	and the object through which an add-on asks for the capabilities it wants.
+	"""
+
+	@Service.exposed
+	def ping(self) -> Literal["pong"]:
+		"""Report that core is serving requests.
+
+		:returns: "pong"
+		"""
+		return "pong"
+
+	@Service.exposed
+	def requestCapability(self, name: str) -> Service:
+		"""Request a capability, returning a handle to it if the permission is granted.
+
+		:param name: Name of the capability being requested.
+		:raises PermissionNotGrantedError: Always, for now.
+		"""
+		log.debug(f"Capability requested before the broker exists: {name!r}")
+		raise PermissionNotGrantedError(f"No capability named {name!r} has been granted")

--- a/source/_art/transport/config.py
+++ b/source/_art/transport/config.py
@@ -15,6 +15,11 @@ import builtins
 
 import rpyc.core.vinegar
 
+# ``instantiate_custom_exceptions`` only rebuilds an exception as its real class when that class's module is already resident.
+# Importing the taxonomy here makes it resident on both sides as soon as the transport is,
+# regardless of whether the code that catches an ART exception has imported it first.
+from .. import exceptions  # noqa: F401
+
 #: The rpyc protocol configuration shared by every ART connection.
 #:
 #: These defaults are deliberately restrictive.
@@ -34,6 +39,12 @@ PROTOCOL_CONFIG: dict[str, bool] = {
 	"allow_delattr": False,
 	# pickle would permit arbitrary code execution during deserialization.
 	"allow_pickle": False,
+	# Rebuild remote exceptions as their real classes.
+	# Without this, vinegar substitutes a ``GenericException`` subclass,
+	# which elides ART's exception taxonomy.
+	"instantiate_custom_exceptions": True,
+	# Importing a module named by the peer is arbitrary code execution. Never enable this.
+	"import_custom_exceptions": False,
 	# A raising handler must not tear down the whole channel.
 	"close_catchall": True,
 }

--- a/source/_art/transport/connection.py
+++ b/source/_art/transport/connection.py
@@ -14,9 +14,9 @@ import weakref
 from typing import Final
 
 import rpyc
-from logHandler import log
 from rpyc.core.stream import Stream
 
+from .._log import log
 from .config import PROTOCOL_CONFIG
 from .service import Service
 

--- a/source/_art/transport/proxy.py
+++ b/source/_art/transport/proxy.py
@@ -9,8 +9,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Final
 
-from logHandler import log
 from rpyc.core.stream import Stream
+
+from .._log import log
 
 if TYPE_CHECKING:
 	from .connection import Connection

--- a/source/_art/transport/service.py
+++ b/source/_art/transport/service.py
@@ -13,8 +13,9 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 import rpyc
-from logHandler import log
 from rpyc.core.stream import Stream
+
+from .._log import log
 
 if TYPE_CHECKING:
 	from .connection import Connection

--- a/tests/unit/test_art/test_artLog.py
+++ b/tests/unit/test_art/test_artLog.py
@@ -1,0 +1,22 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2026 NV Access Limited
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
+
+"""Tests for the ART logging indirection, :mod:`_art._log`."""
+
+import unittest
+
+from _art import _log
+from logHandler import Logger
+
+
+class TestWarningLevels(unittest.TestCase):
+	"""
+	``_art._log`` duplicates NVDA's ``DEBUGWARNING`` because the host cannot import it.
+	This test is the coupling that catches the copy drifting from NVDA's own.
+	If further levels are copied, cases should be added for them, too.
+	"""
+
+	def test_debugWarningMatchesNVDA(self):
+		self.assertEqual(_log._DEBUGWARNING_LEVEL, Logger.DEBUGWARNING)


### PR DESCRIPTION
### Link to issue number:

### Summary of the issue:

#20386 landed ART's generic transport over anonymous pipes, but nothing that uses it. Before a host process can exist there needs to be:

* something for each side to talk to when a connection comes up;
* a way for shared transport code to log from a process that must not import NVDA core;
* a vocabulary for telling an add-on why a capability is unavailable, which survives the boundary.

This PR adds that groundwork. It is deliberately inert: it defines the shapes, and the following PRs in the stack make them run.

### Description of user facing changes:

None. `_art` is private, and nothing in NVDA constructs a host yet.

### Description of developer facing changes:

* `_art.exceptions`: the capability failure taxonomy shared by both sides.
* `_art.host.rootService.HostRootService` and `_art.session.rootService.CoreRootService`: the two root services exchanged over the control connection.
* `_art.session.hostController.HostController`: the `Protocol` describing how core starts, watches, and stops a host.
* `_art._log`: a logging indirection that resolves to NVDA's `log` in core and to a stdlib logger in the host.
* `_art._HOST_MARKER_ENV`: the environment variable the host entry point sets to mark its own process.
* `_art.transport.config`: `instantiate_custom_exceptions` enabled, `import_custom_exceptions` explicitly disabled.
* `_art.host.entrypoint`: the module skeleton, with `run` and `main` raising `NotImplementedError`.

### Description of development approach:

The exception taxonomy is a tree rather than a flat set so an add-on can choose its own specificity: catch `CapabilityUnavailableError` to handle any failure, `CapabilityDeniedError` to distinguish policy from infrastructure, or `PermissionRevokedError` to react to exactly one cause. Denial is the default: `requestCapability` refuses everything until there is a broker.

Catching these across the boundary only works with rpyc's `instantiate_custom_exceptions`. Without it vinegar substitutes a `GenericException` subclass that keeps the name and nothing else, so every `except` clause silently stops matching while tests asserting on names keep passing. `import_custom_exceptions` stays off deliberately: it lets the peer name a module to import, which is arbitrary code execution.

That setting only rebuilds an exception as its real class when that class's module is already resident, so `transport/config.py` imports `_art.exceptions` for its side effect. Making the taxonomy resident wherever the transport is means add-on code does not have to have imported it first.

The logging shim exists because the host must never import `logHandler` — that would pull core into the process that runs untrusted add-on code. `_art._log` picks its logger once, at import time, from the host marker. An explicit marker is used rather than testing whether `logHandler` imports, so that a host launched from a source checkout behaves the same as one launched from a build, where the import would succeed by accident. The host's adapter re-implements `debugWarning` because shared transport code calls it.

### Testing strategy:

`tests/unit/test_art/test_artLog.py` asserts the host's copy of NVDA's `DEBUGWARNING` level matches `logHandler.Logger.DEBUGWARNING`. The value has to be duplicated (the host cannot import it), so this test is the coupling that catches the copy drifting.

The rest of this PR is declarations with no behaviour to exercise on their own. The root services are tested in PR 2 of the stack, once there is a controller to run a host with; the taxonomy's survival across a real process boundary is tested in PR 5.

### Known issues with pull request:

* `entrypoint.run` and `entrypoint.main` raise `NotImplementedError`; they are implemented in PRs 2 and 3.
* `HostRootService.loadComponent` and `CoreRootService.requestCapability` are deliberate stubs. Neither can do anything real until the manifest, component registry, and permission broker exist.
* `HostController` has no implementations in this PR.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
