### PR TITLE
ART thread-backed host controller, and tests for the root services

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -93,6 +93,7 @@ repos:
             textProvider.py |
             extensionPointTestHelpers.py |
             objectProvider.py |
+            test_art/threadHostController.py |
             test_speechManager/speechManagerTestHarness.py
           )
         )

--- a/source/_art/host/entrypoint.py
+++ b/source/_art/host/entrypoint.py
@@ -33,7 +33,19 @@ def run(stream: Stream) -> None:
 
 	:param stream: The host's end of the control connection.
 	"""
-	raise NotImplementedError
+	# Import late to allow ``main`` to set the host marker first.
+	from .._log import log
+	from ..transport import Connection
+	from .rootService import HostRootService
+
+	service = HostRootService()
+	conn = Connection(stream, service, name=CONTROL_CONNECTION_NAME)
+	log.debug("ART host serving control connection")
+	try:
+		conn.eventLoop()
+	finally:
+		log.debug("ART host control connection closed")
+		conn.close()
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/source/_art/session/hostController.py
+++ b/source/_art/session/hostController.py
@@ -11,6 +11,8 @@ tears it down.
 It controls the host process, not the add-on running inside it.
 
 The abstraction is provided primarily to facilitate testing.
+
+A thread-backed version for testing is provided at ``tests/unit/test_art/threadHostController.py``.
 """
 
 from __future__ import annotations

--- a/tests/unit/test_art/test_artHost.py
+++ b/tests/unit/test_art/test_artHost.py
@@ -1,0 +1,213 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2026 NV Access Limited
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
+
+"""Unit tests for the ART host entry point, root services, and host controllers."""
+
+import threading
+import unittest
+from unittest.mock import MagicMock
+
+from _art.exceptions import CapabilityDeniedError, CapabilityUnavailableError, PermissionNotGrantedError
+from _art.host.rootService import HostRootService
+from _art.session.hostController import (
+	HostController,
+)
+from _art.session.rootService import CoreRootService
+from _art.transport import Connection
+from rpyc.core.stream import PipeStream
+
+from .threadHostController import ThreadHostController
+
+#: Bound on anything involving a real process, in seconds.
+_PROCESS_TIMEOUT: float = 30.0
+
+
+class TestRootServices(unittest.TestCase):
+	"""Exercise both root services over an in-process pipe pair.
+
+	The transport is identical whether or not a process is involved, so the contracts themselves
+	are cheapest to test without one.
+	"""
+
+	def setUp(self):
+		coreStream, hostStream = PipeStream.create_pair()
+		self.coreService = CoreRootService()
+		self.hostService = HostRootService()
+		self.coreConn = Connection(coreStream, self.coreService, name="test core")
+		self.hostConn = Connection(hostStream, self.hostService, name="test host")
+		self.coreConn.bgEventLoop(daemon=True)
+		self.hostConn.bgEventLoop(daemon=True)
+
+	def tearDown(self):
+		self.hostConn.close()
+		self.coreConn.close()
+
+	def test_corePingsHost(self):
+		"""Core can confirm the host is serving."""
+		self.assertEqual(self.coreConn.remoteService.ping(), "pong")
+
+	def test_hostPingsCore(self):
+		"""The host can confirm core is serving, over the same connection."""
+		self.assertEqual(self.hostConn.remoteService.ping(), "pong")
+
+	def test_hostReachesCoreThroughItsRootService(self):
+		"""Host-side code reaches core via ``HostRootService.coreRoot``.
+
+		This is the route every capability request will take, so it is worth proving that the
+		connection captured in ``on_connect`` resolves to core's root.
+		"""
+		self.assertEqual(self.hostService.coreRoot.ping(), "pong")
+
+	def test_coreRootIsNotExposedAcrossTheBoundary(self):
+		"""``coreRoot`` is for host-side code only; core must not reach it back over the wire."""
+		with self.assertRaises(AttributeError):
+			_ = self.coreConn.remoteService.coreRoot
+
+	def test_loadComponentIsNotImplementedYet(self):
+		"""Component loading refuses clearly until there is a manifest to drive it."""
+		with self.assertRaises(NotImplementedError):
+			self.coreConn.remoteService.loadComponent("someFeature")
+
+	def test_requestCapabilityIsDeniedByDefault(self):
+		"""Nothing is granted until there is a broker; denial is the safe default."""
+		with self.assertRaises(PermissionNotGrantedError):
+			self.hostConn.remoteService.requestCapability("audio")
+
+	def test_capabilityErrorsKeepTheirTypeAcrossTheBoundary(self):
+		"""An add-on can catch a denial by its base class, not just its exact type.
+
+		The failure taxonomy exists to be caught across the boundary, which only works while
+		``instantiate_custom_exceptions`` is set. Without it rpyc rebuilds remote exceptions as
+		opaque stand-ins that keep the name and nothing else, and every ``except`` clause below
+		stops matching while the tests that assert on exact types keep passing.
+
+		This runs in-process, so the taxonomy is already resident and rpyc can always find the real classes.
+		:class:`TestExceptionTaxonomyAcrossProcess` ensures that the taxonomy is imported by the host entry point.
+		"""
+		with self.assertRaises(CapabilityDeniedError):
+			self.hostConn.remoteService.requestCapability("audio")
+		with self.assertRaises(CapabilityUnavailableError):
+			self.hostConn.remoteService.requestCapability("audio")
+
+
+class HostControllerConformanceMixin:
+	"""Behaviour every :class:`HostController` implementation must exhibit.
+
+	Written once and run against both implementations, because conformance to a single protocol is
+	the entire point of the seam.
+	Not a ``TestCase`` itself, so it is not collected on its own.
+	"""
+
+	def makeController(self) -> HostController:
+		"""Build the controller under test."""
+		raise NotImplementedError
+
+	def setUp(self):
+		self.controller = self.makeController()
+		self.addCleanup(self.controller.terminate)
+		self.conn: Connection | None = None
+
+	def startHost(self) -> Connection:
+		"""Start the host and return core's control connection."""
+		stream = self.controller.start()
+		self.conn = Connection(stream, CoreRootService(), name="test core control")
+		self.addCleanup(self.conn.close)
+		self.conn.bgEventLoop(daemon=True)
+		return self.conn
+
+	def test_pingRoundTrip(self):
+		"""A host started by this controller answers a ping."""
+		conn = self.startHost()
+		self.assertEqual(conn.remoteService.ping(), "pong")
+
+	def test_pollBeforeStartIsRefused(self):
+		"""Polling a host that was never started is an error, not a silent ``None``."""
+		with self.assertRaises(RuntimeError):
+			self.controller.poll()
+
+	def test_waitBeforeStartIsRefused(self):
+		"""Waiting on a host that was never started is an error, not a silent ``None``."""
+		with self.assertRaises(RuntimeError):
+			self.controller.wait(_PROCESS_TIMEOUT)
+
+	def test_pollIsNoneWhileTheHostRuns(self):
+		"""A running host has no exit status yet."""
+		conn = self.startHost()
+		# Ping first, so we know the host is genuinely up rather than merely not yet started.
+		self.assertEqual(conn.remoteService.ping(), "pong")
+		self.assertIsNone(self.controller.poll())
+
+	def test_terminateStopsTheHost(self):
+		"""After ``terminate``, the host finishes and reports an exit status."""
+		conn = self.startHost()
+		self.assertEqual(conn.remoteService.ping(), "pong")
+		self.controller.terminate()
+		self.assertIsNotNone(self.controller.wait(_PROCESS_TIMEOUT))
+		self.assertIsNotNone(self.controller.poll())
+
+	def test_terminateIsSafeOnAStoppedHost(self):
+		"""Terminating twice is not an error."""
+		self.startHost()
+		self.controller.terminate()
+		self.controller.wait(_PROCESS_TIMEOUT)
+		self.controller.terminate()
+
+	def test_startingTwiceIsRefused(self):
+		"""A controller drives one host, not a series of them."""
+		self.startHost()
+		with self.assertRaises(RuntimeError):
+			self.controller.start()
+
+
+class TestThreadHostController(HostControllerConformanceMixin, unittest.TestCase):
+	"""The thread-backed fake, which is the default substrate for tests."""
+
+	def makeController(self) -> HostController:
+		return ThreadHostController()
+
+	def test_createPipePairGivesTwoUsableEnds(self):
+		"""A dependent connection can be built over the pair, in this process."""
+		self.startHost()
+		coreEnd, hostEnd = self.controller.createPipePair()
+		self.assertIsNotNone(coreEnd)
+		self.assertIsNotNone(hostEnd)
+		coreEnd.close()
+		hostEnd.close()
+
+
+class TestHostRootServiceDisconnect(unittest.TestCase):
+	"""The host root service cleans up when core drops the control connection."""
+
+	def test_onDisconnectClearsConnectionAndTerminates(self):
+		"""After ``on_disconnect``, ``coreRoot`` is unavailable again and the service is terminated."""
+		service = HostRootService()
+		conn = MagicMock()
+		service.on_connect(conn)
+		# Sanity: while connected, coreRoot reaches core through the connection.
+		self.assertIs(service.coreRoot, conn.root)
+
+		service.on_disconnect(conn)
+
+		self.assertTrue(service.terminated)
+		with self.assertRaises(RuntimeError):
+			_ = service.coreRoot
+
+
+class TestThreadHostControllerFailureReporting(unittest.TestCase):
+	"""The thread-backed controller must not report a crashed host thread as a clean exit."""
+
+	def test_finishedThreadWithoutAStatusIsAFailure(self):
+		"""A finished host thread that recorded no status died abnormally; poll reports failure, not 0."""
+		controller = ThreadHostController()
+		finished = threading.Thread(target=lambda: None)
+		finished.start()
+		finished.join()
+		# Stand in for ``_run`` dying from a ``BaseException`` its ``except Exception`` did not catch:
+		# the thread is finished, but no exit status was recorded.
+		controller._thread = finished
+		controller._exitStatus = None
+
+		self.assertIsNotNone(controller.poll())
+		self.assertNotEqual(controller.poll(), 0)

--- a/tests/unit/test_art/threadHostController.py
+++ b/tests/unit/test_art/threadHostController.py
@@ -1,0 +1,96 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2026 NV Access Limited
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
+
+"""Thread-backed ``HostController`` for testing."""
+
+import contextlib
+import threading
+
+from _art.host import entrypoint
+from rpyc.core.stream import PipeStream, Stream
+
+
+class ThreadHostController:
+	"""Runs the host entry point in a thread of this process.
+
+	The default test substrate: no process to schedule, no cold start to wait for, and failures
+	surface as ordinary exceptions.
+
+	Some things have no in-process analogue:
+	a thread cannot close a pipe by dying, be timed for cold start, or demonstrate handle inheritance.
+	Tests that rely on such behaviour should use :class:`_art.session.hostController.SubprocessHostController` instead.
+	"""
+
+	def __init__(self) -> None:
+		self._thread: threading.Thread | None = None
+		self._hostStream: Stream | None = None
+		self._exitStatus: int | None = None
+
+	def start(self) -> Stream:
+		"""Start the host thread and return core's end of the control connection."""
+		if self._thread is not None:
+			msg = "Host has already been started"
+			raise RuntimeError(msg)
+		coreStream, hostStream = PipeStream.create_pair()
+		self._hostStream = hostStream
+		self._thread = threading.Thread(
+			target=self._run,
+			args=(hostStream,),
+			name="ART host (thread-backed)",
+			# A wedged host must not be able to keep the interpreter alive.
+			daemon=True,
+		)
+		self._thread.start()
+		return coreStream
+
+	def _run(self, hostStream: Stream) -> None:
+		try:
+			entrypoint.run(hostStream)
+		except Exception:  # noqa: BLE001
+			# A host failure ends the thread with a non-zero status rather than propagating a traceback.
+			self._exitStatus = 1
+		except BaseException:
+			# SystemExit/KeyboardInterrupt: record failure before letting it unwind the thread,
+			# so a finished thread never lacks a status.
+			self._exitStatus = 1
+			raise
+		else:
+			self._exitStatus = 0
+
+	def poll(self) -> int | None:
+		"""Check whether the host thread has finished, without blocking."""
+		if self._thread is None:
+			raise RuntimeError("Cannot poll a host that has not been started")
+		if self._thread.is_alive():
+			return None
+		# ``_run`` records a status before anything else, so a finished thread always has one;
+		# fall back to a failure status rather than reporting a clean exit if somehow it does not.
+		return self._exitStatus if self._exitStatus is not None else 1
+
+	def wait(self, timeout: float | None = None) -> int | None:
+		"""Wait for the host thread to finish."""
+		if self._thread is None:
+			raise RuntimeError("Cannot wait on a host that has not been started")
+		self._thread.join(timeout)
+		return self.poll()
+
+	def terminate(self) -> None:
+		"""Stop the host by closing its end of the control connection.
+
+		The host's event loop sees the connection close and returns, which is the same thing that
+		happens to a real host when core goes away.
+		"""
+		if self._hostStream is None:
+			return
+		with contextlib.suppress(Exception):
+			self._hostStream.close()
+
+	def createPipePair(self) -> tuple[Stream, Stream]:
+		"""Manufacture a pipe pair for a dependent connection.
+
+		Both ends are streams: the host shares this process, so there are no handles to duplicate.
+		"""
+		coreStream, hostStream = PipeStream.create_pair()
+		return coreStream, hostStream


### PR DESCRIPTION
### Link to issue number:

### Summary of the issue:

PR 1 defined two root services and a `HostController` protocol, but nothing implements the protocol and nothing exercises the services. Most of what needs testing has nothing to do with processes: the transport behaves identically whether or not one is involved, so real subprocesses are not yet necessary.

This PR implements the process-agnostic half of the host entry point and a thread-backed controller to drive it, which makes the root services testable now and gives every later PR a cheap substrate.

### Description of user facing changes:

None.

### Description of developer facing changes:

* `_art.host.entrypoint.run` is implemented: it serves `HostRootService` over a supplied stream until the connection closes.
* `tests/unit/test_art/threadHostController.py`: `ThreadHostController`, a `HostController` implementation that runs the entry point in a thread of the current process.
* `tests/unit/test_art/test_artHost.py`: tests for both root services, and a conformance mixin for `HostController` implementations.

### Description of development approach:

`run` takes a ready-made stream rather than making one. That split is what lets the same boot path be exercised without a process: PR 3 adds `main`, which does the standard-stream manipulation that only makes sense in a process of one's own, and hands the result to `run`.

`run` imports `_art._log`, the transport, and the root service inside the function rather than at module scope. `_art._log` chooses its logger at import time from the host marker (PR 1), and `main` cannot set that marker before the module it lives in has been imported. Deferring the imports into `run` keeps the entry point importable without committing the process to one side of the boundary.

`ThreadHostController` is the default test substrate: nothing to schedule, no cold start, and a failure surfaces as an ordinary exception rather than an exit status. It terminates the host by closing the host's end of the control connection, which is what a real host sees when core goes away. Its thread is a daemon so a wedged host cannot keep the interpreter alive.

`HostControllerConformanceMixin` is written once and run against every implementation, because conformance to a single protocol is the entire reason the seam exists. PR 4 adds `SubprocessHostController` and inherits the same mixin unchanged, which is the real test of whether the abstraction holds.

### Testing strategy:

* `TestRootServices` drives both root services over an in-process pipe pair: pings in both directions, host-side code reaching core through `HostRootService.coreRoot`, `coreRoot` *not* being reachable back over the wire, and the two stubs refusing clearly.
* `test_capabilityErrorsKeepTheirTypeAcrossTheBoundary` asserts a denial is catchable by its base classes, not just its exact type. This runs in-process, so the taxonomy is already resident and rpyc can always find the real classes; PR 5 covers the case where it is not.
* `HostControllerConformanceMixin` covers the protocol: ping round trip, `poll`/`wait` refusing before start, `poll` returning `None` while running, `terminate` producing an exit status, `terminate` being safe twice, and `start` refusing a second call.
* `TestHostRootServiceDisconnect` checks `on_disconnect` clears the connection and terminates the service, so nothing hands out a dead reference.
* `TestThreadHostControllerFailureReporting` covers the one place the fake could lie: a host thread that finished without recording a status died abnormally, and must not be reported as a clean exit.

### Known issues with pull request:

* `entrypoint.main` still raises `NotImplementedError`; PR 3 implements it.
* A thread cannot close a pipe by dying, be timed for cold start, or demonstrate handle inheritance. Those tests need a real process and arrive in PR 4.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
