### PR TITLE
ART host boot: control stream ownership, and Windows handle duplication helpers

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -93,7 +93,10 @@ repos:
             textProvider.py |
             extensionPointTestHelpers.py |
             objectProvider.py |
-            test_art/threadHostController.py |
+            test_art/ (
+                probes/ |
+                threadHostController.py
+            ) |
             test_speechManager/speechManagerTestHarness.py
           )
         )

--- a/source/_art/__init__.py
+++ b/source/_art/__init__.py
@@ -13,6 +13,7 @@ This package defines NVDA's out-of-process, sandboxed add-on runtime.
 * :mod:`.session`: The core side of the boundary:
 	host controllers, core-side wire ends, and the root service core exposes to the host.
 * :mod:`.exceptions`: The capability failure taxonomy, shared by both sides.
+* :mod:`.winHandles`: Handle ownership helpers, shared by both sides.
 """
 
 from typing import Final

--- a/source/_art/host/entrypoint.py
+++ b/source/_art/host/entrypoint.py
@@ -136,7 +136,7 @@ def _claimControlStream() -> Stream:
 		writeHandle = claimHandleFromDescriptor(writeFd)
 		writeFd = -1
 	# Deliberately not ``except BaseException``:
-	# a signal-delivered exception can land between a successful claim and resetting the variable  to its sentinel,
+	# a signal-delivered exception can land between a successful claim and resetting the variable to its sentinel,
 	# at which point the descriptor has been closed, unbeknownst to us.
 	# Closing it again could land on a recycled descriptor,
 	# so leaking it is the safest option.

--- a/source/_art/host/entrypoint.py
+++ b/source/_art/host/entrypoint.py
@@ -30,6 +30,12 @@ from ..winHandles import claimHandleFromDescriptor
 
 #: Name of the host's end of the control connection, used in logging.
 CONTROL_CONNECTION_NAME: Final[str] = "ART host control"
+#: File descriptor of this process's standard input.
+_STDIN_FD: Final[int] = 0
+#: File descriptor of this process's standard output.
+_STDOUT_FD: Final[int] = 1
+#: File descriptor of this process's standard error.
+_STDERR_FD: Final[int] = 2
 
 
 def run(stream: Stream) -> None:
@@ -54,72 +60,92 @@ def run(stream: Stream) -> None:
 		conn.close()
 
 
+def _redirectToDevNull(targetFd: int) -> None:
+	"""Point a descriptor at the null device.
+
+	The descriptor opened to reach the null device is closed again before returning,
+	so this owns nothing once it is done.
+
+	:param targetFd: Descriptor to redirect.
+		Left open, but pointing at the null device.
+	:raises OSError: If the null device cannot be opened, or ``targetFd`` cannot be redirected.
+	"""
+	devNullFd = os.open(os.devnull, os.O_RDWR)
+	try:
+		os.dup2(devNullFd, targetFd)
+	finally:
+		os.close(devNullFd)
+
+
+def _redirectStandardStreams() -> None:
+	"""Move this process's standard input and output off the descriptors carrying the control connection.
+
+	Standard input is pointed at the null device, and standard output is folded into standard error,
+	so that anything written to either after boot cannot desynchronise rpyc's framing on the wire.
+	Both the descriptors and the :mod:`sys` objects layered over them are moved,
+	since either is enough to corrupt the connection.
+
+	Standard error is left where it is:
+	it is the host's diagnostic channel, which NVDA drains to its log.
+
+	Owns nothing on return, so a caller part way through claiming descriptors
+	has nothing extra to release if this raises.
+
+	:raises OSError: If the null device cannot be opened, or a descriptor cannot be redirected.
+	"""
+	# Make stdin point to the null device
+	_redirectToDevNull(_STDIN_FD)
+	sys.stdin = open(os.devnull)  # noqa: SIM115
+	# make stdout point to stderr
+	try:
+		os.dup2(_STDERR_FD, _STDOUT_FD)
+	except OSError:
+		# No usable standard error, so redirect to the null device instead
+		_redirectToDevNull(_STDOUT_FD)
+	sys.stdout = sys.stderr if sys.stderr is not None else open(os.devnull, "w")  # noqa: SIM115
+
+
 def _claimControlStream() -> Stream:
 	"""Take private ownership of the standard descriptors and return the control stream.
 
-	The control connection runs over stdin and stdout,  which carry framed rpyc traffic rather than text.
+	The control connection runs over stdin and stdout, which carry framed rpyc traffic rather than text.
 	Writing anything else to them will corrupt the connection.
-	To ensure the wire has exclusive use of the original descriptors, duplicate them, then:
-
-	* point stdin (descriptor 0) at the null device; and
-	* alias stdout (descriptor 1)  to stderr (descriptor 2).
+	To give the wire exclusive use of the original descriptors, duplicate them,
+	then move the standard streams elsewhere (see :func:`_redirectStandardStreams`).
 
 	The duplicated descriptors are then converted into handles the returned stream solely owns,
 	so that nothing else closes them out from under it
 	(see :func:`_art.winHandles.claimHandleFromDescriptor`).
 
-	Standard error is the host's diagnostic channel,
-	which NVDA drains to its log.
-
 	:returns: The host's end of the control connection.
+	:raises OSError: If the descriptors cannot be duplicated, redirected, or claimed.
+		Nothing is left open in that case.
 	"""
-	# File descriptors of the standard streams.
-	STDIN_FD: Final[int] = 0
-	STDOUT_FD: Final[int] = 1
-	STDERR_FD: Final[int] = 2
-	# Duplicate the current stdin and stdout for our own use
-	readFd = os.dup(STDIN_FD)
+	readFd = -1
+	writeFd = -1
+	readHandle: int | None = None
 	try:
-		writeFd = os.dup(STDOUT_FD)
-	except:
-		os.close(readFd)
-		raise
-	try:
-		# Make stdin point to the null device
-		devNullFd = os.open(os.devnull, os.O_RDWR)
-		try:
-			os.dup2(devNullFd, STDIN_FD)
-		finally:
-			os.close(devNullFd)
-		sys.stdin = open(os.devnull)  # noqa: SIM115
-		# make stdout point to stderr
-		try:
-			os.dup2(STDERR_FD, STDOUT_FD)
-		except OSError:
-			# No usable standard error, so redirect to the null device instead
-			devNullFd = os.open(os.devnull, os.O_RDWR)
-			try:
-				os.dup2(devNullFd, STDOUT_FD)
-			finally:
-				os.close(devNullFd)
-		sys.stdout = sys.stderr if sys.stderr is not None else open(os.devnull, "w")  # noqa: SIM115
-	except:
-		os.close(readFd)
-		os.close(writeFd)
-		raise
-	# ``PipeStream`` closes the handles it is built from, so it has to be their sole owner:
-	# leaving the descriptors open would hand the C runtime a second claim on them.
-	try:
+		readFd = os.dup(_STDIN_FD)
+		writeFd = os.dup(_STDOUT_FD)
+		_redirectStandardStreams()
+		# ``PipeStream`` closes the handles it is built from, so it has to be their sole owner:
+		# leaving the descriptors open would hand the C runtime a second claim on them.
 		readHandle = claimHandleFromDescriptor(readFd)
-	except OSError:
-		os.close(readFd)
-		os.close(writeFd)
-		raise
-	try:
+		readFd = -1
 		writeHandle = claimHandleFromDescriptor(writeFd)
-	except OSError:
-		os.close(writeFd)
-		CloseHandle(readHandle)
+		writeFd = -1
+	# Deliberately not ``except BaseException``:
+	# a signal-delivered exception can land between a successful claim and resetting the variable  to its sentinel,
+	# at which point the descriptor has been closed, unbeknownst to us.
+	# Closing it again could land on a recycled descriptor,
+	# so leaking it is the safest option.
+	except Exception:
+		if readFd >= 0:
+			os.close(readFd)
+		if writeFd >= 0:
+			os.close(writeFd)
+		if readHandle is not None:
+			CloseHandle(readHandle)
 		raise
 	return PipeStream(readHandle, writeHandle)
 

--- a/source/_art/host/entrypoint.py
+++ b/source/_art/host/entrypoint.py
@@ -17,10 +17,16 @@ The work is split in two so that the same boot path can be exercised without a p
 
 from __future__ import annotations
 
+import logging
+import os
 import sys
 from typing import Final
 
-from rpyc.core.stream import Stream
+from rpyc.core.stream import PipeStream, Stream
+from winBindings.kernel32 import CloseHandle
+
+from .. import _HOST_MARKER_ENV
+from ..winHandles import claimHandleFromDescriptor
 
 #: Name of the host's end of the control connection, used in logging.
 CONTROL_CONNECTION_NAME: Final[str] = "ART host control"
@@ -48,6 +54,90 @@ def run(stream: Stream) -> None:
 		conn.close()
 
 
+def _claimControlStream() -> Stream:
+	"""Take private ownership of the standard descriptors and return the control stream.
+
+	The control connection runs over stdin and stdout,  which carry framed rpyc traffic rather than text.
+	Writing anything else to them will corrupt the connection.
+	To ensure the wire has exclusive use of the original descriptors, duplicate them, then:
+
+	* point stdin (descriptor 0) at the null device; and
+	* alias stdout (descriptor 1)  to stderr (descriptor 2).
+
+	The duplicated descriptors are then converted into handles the returned stream solely owns,
+	so that nothing else closes them out from under it
+	(see :func:`_art.winHandles.claimHandleFromDescriptor`).
+
+	Standard error is the host's diagnostic channel,
+	which NVDA drains to its log.
+
+	:returns: The host's end of the control connection.
+	"""
+	# File descriptors of the standard streams.
+	STDIN_FD: Final[int] = 0
+	STDOUT_FD: Final[int] = 1
+	STDERR_FD: Final[int] = 2
+	# Duplicate the current stdin and stdout for our own use
+	readFd = os.dup(STDIN_FD)
+	try:
+		writeFd = os.dup(STDOUT_FD)
+	except:
+		os.close(readFd)
+		raise
+	try:
+		# Make stdin point to the null device
+		devNullFd = os.open(os.devnull, os.O_RDWR)
+		try:
+			os.dup2(devNullFd, STDIN_FD)
+		finally:
+			os.close(devNullFd)
+		sys.stdin = open(os.devnull)  # noqa: SIM115
+		# make stdout point to stderr
+		try:
+			os.dup2(STDERR_FD, STDOUT_FD)
+		except OSError:
+			# No usable standard error, so redirect to the null device instead
+			devNullFd = os.open(os.devnull, os.O_RDWR)
+			try:
+				os.dup2(devNullFd, STDOUT_FD)
+			finally:
+				os.close(devNullFd)
+		sys.stdout = sys.stderr if sys.stderr is not None else open(os.devnull, "w")  # noqa: SIM115
+	except:
+		os.close(readFd)
+		os.close(writeFd)
+		raise
+	# ``PipeStream`` closes the handles it is built from, so it has to be their sole owner:
+	# leaving the descriptors open would hand the C runtime a second claim on them.
+	try:
+		readHandle = claimHandleFromDescriptor(readFd)
+	except OSError:
+		os.close(readFd)
+		os.close(writeFd)
+		raise
+	try:
+		writeHandle = claimHandleFromDescriptor(writeFd)
+	except OSError:
+		os.close(writeFd)
+		CloseHandle(readHandle)
+		raise
+	return PipeStream(readHandle, writeHandle)
+
+
+def _initializeLogging() -> None:
+	"""Send this process's log output to standard error.
+
+	Configures the ``_art`` logger tree root, which every ART logger propagates to, so all of the host's records reach the handler.
+	The level is set as low as it goes so that the host captures everything for now;
+	NVDA drains the host's standard error into its own log.
+	"""
+	artLog = logging.getLogger("_art")
+	artLog.setLevel(logging.DEBUG)
+	handler = logging.StreamHandler(sys.stderr)
+	handler.setFormatter(logging.Formatter("ART host: %(levelname)s - %(name)s - %(message)s"))
+	artLog.addHandler(handler)
+
+
 def main(argv: list[str] | None = None) -> int:
 	"""Entry point of the host process.
 
@@ -55,7 +145,25 @@ def main(argv: list[str] | None = None) -> int:
 		Accepted so that the build ID and the launch arguments that follow it have somewhere to go.
 	:returns: Process exit status.
 	"""
-	raise NotImplementedError
+	# Mark this process as the host before any shared module is imported,
+	# so shared code doesn't attempt to pull in core.
+	os.environ[_HOST_MARKER_ENV] = "1"
+	try:
+		stream = _claimControlStream()
+	except OSError:
+		# We don't have logging yet, so output directly to stderr.
+		print("ART host could not claim its control stream", file=sys.stderr)
+		raise
+	_initializeLogging()
+	# Import late because we needed to add the host marker first.
+	from .._log import log
+
+	try:
+		run(stream)
+	except Exception:  # noqa: BLE001
+		log.exception("Unhandled exception in ART host")
+		return 1
+	return 0
 
 
 if __name__ == "__main__":

--- a/source/_art/host/entrypoint.py
+++ b/source/_art/host/entrypoint.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import logging
 import os
 import sys
+import traceback
 from typing import Final
 
 from rpyc.core.stream import PipeStream, Stream
@@ -159,7 +160,7 @@ def _initializeLogging() -> None:
 	"""
 	artLog = logging.getLogger("_art")
 	artLog.setLevel(logging.DEBUG)
-	handler = logging.StreamHandler(sys.stderr)
+	handler = logging.StreamHandler(sys.stderr if sys.stderr is not None else open(os.devnull))  # noqa: SIM115
 	handler.setFormatter(logging.Formatter("ART host: %(levelname)s - %(name)s - %(message)s"))
 	artLog.addHandler(handler)
 
@@ -170,16 +171,20 @@ def main(argv: list[str] | None = None) -> int:
 	:param argv: Unused for now.
 		Accepted so that the build ID and the launch arguments that follow it have somewhere to go.
 	:returns: Process exit status.
+		0 on success;
+		1 if claiming the control stream fails, or if we get an unhandled exception from ``run``.
 	"""
 	# Mark this process as the host before any shared module is imported,
 	# so shared code doesn't attempt to pull in core.
 	os.environ[_HOST_MARKER_ENV] = "1"
 	try:
 		stream = _claimControlStream()
-	except OSError:
-		# We don't have logging yet, so output directly to stderr.
-		print("ART host could not claim its control stream", file=sys.stderr)
-		raise
+	except OSError as exc:
+		# We don't have logging yet, so output directly to stderr, if it exists.
+		if sys.stderr is not None:
+			print("ART host could not claim its control stream", file=sys.stderr)
+			traceback.print_exception(exc, file=sys.stderr)
+		return 1
 	_initializeLogging()
 	# Import late because we needed to add the host marker first.
 	from .._log import log

--- a/source/_art/session/hostController.py
+++ b/source/_art/session/hostController.py
@@ -17,9 +17,13 @@ A thread-backed version for testing is provided at ``tests/unit/test_art/threadH
 
 from __future__ import annotations
 
+import msvcrt
+import subprocess
 from typing import Protocol
 
-from rpyc.core.stream import Stream
+from rpyc.core.stream import PipeStream, Stream
+
+from ..winHandles import duplicateHandleForSelf
 
 
 class HostController[HostPipeEnd](Protocol):
@@ -64,3 +68,27 @@ class HostController[HostPipeEnd](Protocol):
 		:raises RuntimeError: If the host is not running.
 		"""
 		...
+
+
+def claimProcessControlStream(process: subprocess.Popen) -> Stream:
+	"""Take sole ownership of a child's standard input and output as a control stream.
+
+	Using ``PipeStream(process.stdout, process.stdin)`` sets up a double free:
+	When closed, the file objects and the ``PipeStream`` both close the underlying handles, but neither is aware of the other's actions.
+	Since handles are reused, this may result in an entirely unrelated handle being closed.
+	Duplicating the handles for the stream and closing the file objects immediately leaves one owner of each.
+
+	:param process: The child process whose standard streams carry the control connection.
+	:returns: A stream over the child's standard input and output.
+	:raises RuntimeError: If ``process`` was created without one or both of stdin or stdout piped.
+	:raises OSError: If pipe handle duplication fails.
+	"""
+	stdout = process.stdout
+	stdin = process.stdin
+	if stdout is None or stdin is None:
+		raise RuntimeError("The host process was not created with its standard streams piped")
+	readHandle = duplicateHandleForSelf(msvcrt.get_osfhandle(stdout.fileno()))
+	writeHandle = duplicateHandleForSelf(msvcrt.get_osfhandle(stdin.fileno()))
+	stdout.close()
+	stdin.close()
+	return PipeStream(readHandle, writeHandle)

--- a/source/_art/winHandles.py
+++ b/source/_art/winHandles.py
@@ -1,0 +1,55 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2026 NV Access Limited
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
+
+"""Windows handle ownership helpers shared by both sides of the ART boundary."""
+
+from __future__ import annotations
+
+import msvcrt
+import os
+from ctypes import WinError, byref
+from ctypes.wintypes import HANDLE
+
+import winKernel
+from winBindings.kernel32 import DuplicateHandle, GetCurrentProcess
+
+
+def duplicateHandleForSelf(handle: int) -> int:
+	"""Duplicate a handle within this process, with the same access as the original.
+
+	The duplicate is independent of ``handle``: closing one does not close the other.
+
+	:param handle: Handle to duplicate.
+	:returns: The value of an independent handle to the same object.
+	:raises OSError: If duplication fails.
+	"""
+	duplicate = HANDLE()
+	currentProcess = GetCurrentProcess()
+	if not DuplicateHandle(
+		currentProcess,
+		HANDLE(int(handle)),
+		currentProcess,
+		byref(duplicate),
+		0,
+		False,
+		winKernel.DUPLICATE_SAME_ACCESS,
+	):
+		raise WinError()
+	return duplicate.value
+
+
+def claimHandleFromDescriptor(fd: int) -> int:
+	"""Take sole ownership of the kernel handle behind a C runtime file descriptor.
+
+	Returns a handle that is independent of ``fd`, but which points to the same object.
+	Closes ``fd`` if successful.
+
+	:param fd: Descriptor to claim. Closed on success, and left open if duplication fails.
+	:returns: The value of a handle to the same object, owned by the caller.
+	:raises OSError: If ``fd`` is not a valid descriptor, or duplication fails.
+	"""
+	handle = duplicateHandleForSelf(msvcrt.get_osfhandle(fd))
+	os.close(fd)
+	return handle

--- a/tests/unit/test_art/probes/controlStream.py
+++ b/tests/unit/test_art/probes/controlStream.py
@@ -1,0 +1,50 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2026 NV Access Limited
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
+
+"""Child program asserting that the host boot path keeps no claim on its control descriptors.
+
+Run as a process by ``TestControlStreamHandleOwnership``, because
+:func:`_art.host.entrypoint._claimControlStream` takes over the standard streams of whichever
+process calls it, which is not something a test runner can survive.
+
+Reports the descriptors it saw on standard error, and exits non-zero if any of them outlived
+the call.
+"""
+
+import msvcrt
+import os
+import sys
+
+from _art.host import entrypoint
+
+#: Descriptors ``_claimControlStream`` duplicated for the control connection.
+duplicated: list[int] = []
+_realDup = os.dup
+
+
+def _spyDup(fd: int) -> int:
+	"""Stand in for :func:`os.dup`, recording what it hands out."""
+	duplicate = _realDup(fd)
+	duplicated.append(duplicate)
+	return duplicate
+
+
+os.dup = _spyDup
+try:
+	entrypoint._claimControlStream()
+finally:
+	os.dup = _realDup
+
+# A descriptor that still resolves to a handle is a second owner of one the stream will close.
+retained: list[int] = []
+for fd in duplicated:
+	try:
+		msvcrt.get_osfhandle(fd)
+	except OSError:
+		continue
+	retained.append(fd)
+
+sys.stderr.write(f"duplicated={duplicated} retained={retained}")
+sys.exit(1 if retained or len(duplicated) != 2 else 0)

--- a/tests/unit/test_art/probes/controlStreamCleanup.py
+++ b/tests/unit/test_art/probes/controlStreamCleanup.py
@@ -1,0 +1,95 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2026 NV Access Limited
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
+
+"""Child program asserting that a failed host boot strands neither a descriptor nor a handle.
+
+Run as a process by ``TestControlStreamHandleOwnership``, for the same reason as
+``controlStream.py``: :func:`_art.host.entrypoint._claimControlStream` takes over the standard
+streams of whichever process calls it, which is not something a test runner can survive.
+
+``controlStream.py`` covers the success path; this covers the unwind. Takes the one-based index of
+the claim to fail as its only argument, because the two claims strand different things:
+
+* failing the first leaves two descriptors to close; and
+* failing the second leaves one descriptor and one handle, which need different calls to release.
+
+Reports what it saw on standard error, and exits non-zero if the unwind was incomplete.
+"""
+
+import msvcrt
+import os
+import sys
+from typing import Any, Final
+
+from _art.host import entrypoint
+
+#: One-based index of the claim to fail.
+FAILING_CLAIM: Final[int] = int(sys.argv[1])
+
+#: Descriptors ``_claimControlStream`` duplicated for the control connection.
+duplicated: list[int] = []
+#: Handles it claimed before the induced failure.
+claimed: list[int] = []
+#: Handles it released while unwinding.
+released: list[int] = []
+
+_realDup = os.dup
+_realClaim = entrypoint.claimHandleFromDescriptor
+_realCloseHandle = entrypoint.CloseHandle
+
+
+def _spyDup(fd: int) -> int:
+	"""Stand in for :func:`os.dup`, recording what it hands out."""
+	duplicate = _realDup(fd)
+	duplicated.append(duplicate)
+	return duplicate
+
+
+def _failNthClaim(fd: int) -> int:
+	"""Claim for real until ``FAILING_CLAIM``, then fail the way an unclaimable descriptor would.
+
+	``claimHandleFromDescriptor`` leaves its descriptor open when it fails, so the caller is still
+	the owner of ``fd``, along with anything claimed before it.
+	"""
+	if len(claimed) + 1 == FAILING_CLAIM:
+		raise OSError("Induced claim failure")
+	handle = _realClaim(fd)
+	claimed.append(handle)
+	return handle
+
+
+def _spyCloseHandle(handle: int) -> Any:
+	"""Stand in for ``CloseHandle``, recording what the unwind releases before releasing it."""
+	released.append(handle)
+	return _realCloseHandle(handle)
+
+
+os.dup = _spyDup
+entrypoint.claimHandleFromDescriptor = _failNthClaim
+entrypoint.CloseHandle = _spyCloseHandle
+try:
+	entrypoint._claimControlStream()
+except OSError:
+	propagated = True
+else:
+	propagated = False
+finally:
+	os.dup = _realDup
+	entrypoint.claimHandleFromDescriptor = _realClaim
+	entrypoint.CloseHandle = _realCloseHandle
+
+# Checked before anything is written, so that nothing of ours can reuse a descriptor number first.
+# A descriptor that still resolves to a handle is a second owner of one the unwind should have closed.
+retained: list[int] = []
+for fd in duplicated:
+	try:
+		msvcrt.get_osfhandle(fd)
+	except OSError:
+		continue
+	retained.append(fd)
+
+sys.stderr.write(f"{propagated=} {duplicated=} {retained=} {claimed=} {released=}")
+# Every handle claimed before the failure must have been released, and no descriptor kept back.
+sys.exit(0 if propagated and len(duplicated) == 2 and not retained and released == claimed else 1)

--- a/tests/unit/test_art/test_artHost.py
+++ b/tests/unit/test_art/test_artHost.py
@@ -5,23 +5,36 @@
 
 """Unit tests for the ART host entry point, root services, and host controllers."""
 
+import msvcrt
+import os
+import pathlib
+import subprocess
+import sys
 import threading
 import unittest
 from unittest.mock import MagicMock
 
+import globalVars
 from _art.exceptions import CapabilityDeniedError, CapabilityUnavailableError, PermissionNotGrantedError
+from _art.host.entrypoint import CONTROL_CONNECTION_NAME
 from _art.host.rootService import HostRootService
 from _art.session.hostController import (
 	HostController,
+	claimProcessControlStream,
 )
 from _art.session.rootService import CoreRootService
 from _art.transport import Connection
+from _art.winHandles import claimHandleFromDescriptor
 from rpyc.core.stream import PipeStream
 
 from .threadHostController import ThreadHostController
 
 #: Bound on anything involving a real process, in seconds.
 _PROCESS_TIMEOUT: float = 30.0
+
+
+def getProbePath(filename: str) -> str:
+	return str(pathlib.Path(__file__).parent / "probes" / filename)
 
 
 class TestRootServices(unittest.TestCase):
@@ -175,6 +188,95 @@ class TestThreadHostController(HostControllerConformanceMixin, unittest.TestCase
 		self.assertIsNotNone(hostEnd)
 		coreEnd.close()
 		hostEnd.close()
+
+
+class TestHostStandardStreams(unittest.TestCase):
+	"""The entry point's defence of the control connection, and its diagnostic channel."""
+
+	def test_strayStdoutDoesNotCorruptTheControlStream(self):
+		"""Output written to standard output after boot must not reach the wire.
+
+		The control connection is carried on the host's standard output, so a stray ``print`` is
+		enough to desynchronise rpyc's framing. The entry point folds standard output into
+		standard error to prevent exactly this, and this is the test that says so.
+		"""
+		script = (
+			"import _art.host.entrypoint as entrypoint\n"
+			"stream = entrypoint._claimControlStream()\n"
+			"print('stray stdout that would otherwise corrupt the wire')\n"
+			"entrypoint.run(stream)\n"
+		)
+		process = subprocess.Popen(
+			[sys.executable, "-c", script],
+			stdin=subprocess.PIPE,
+			stdout=subprocess.PIPE,
+			stderr=subprocess.DEVNULL,  # We don't care, and a pipe buffer could fill and block
+			cwd=globalVars.appDir,
+			creationflags=subprocess.CREATE_NO_WINDOW,
+		)
+		self.addCleanup(process.wait)
+		self.addCleanup(process.kill)
+		conn = Connection(
+			claimProcessControlStream(process),
+			CoreRootService(),
+			name=f"test {CONTROL_CONNECTION_NAME}",
+		)
+		self.addCleanup(conn.close)
+		conn.bgEventLoop(daemon=True)
+		# If the print had reached the wire, this would fail to deserialize rather than answer.
+		self.assertEqual(conn.remoteService.ping(), "pong")
+
+
+class TestControlStreamHandleOwnership(unittest.TestCase):
+	"""Exactly one owner of each handle carrying the control connection.
+
+	``PipeStream`` closes the handles it is built from.
+	Anything that owns them as well -- a C runtime descriptor, or a Python file object over one --
+	closes them a second time.
+	Since Windows recycles handle values, that second close may land on an unrelated object rather
+	than failing, so these tests assert on ownership rather than on an error.
+	"""
+
+	def test_claimingADescriptorLeavesOneOwner(self):
+		"""The descriptor is released, and its handle survives for the caller to use."""
+		readFd, writeFd = os.pipe()
+		self.addCleanup(os.close, writeFd)
+		handle = claimHandleFromDescriptor(readFd)
+		with self.assertRaises(OSError):
+			# The descriptor is gone, so it cannot close the handle a second time.
+			os.fstat(readFd)
+		# Ownership moved, rather than the object dying with the descriptor.
+		message = b"still open"
+		os.write(writeFd, message)
+		claimed = msvcrt.open_osfhandle(handle, os.O_RDONLY)
+		self.addCleanup(os.close, claimed)
+		self.assertEqual(os.read(claimed, len(message)), message)
+
+	def test_bootReleasesTheDescriptorsItDuplicates(self):
+		"""``_claimControlStream`` gives its descriptors to the stream and keeps none back.
+
+		Reading a handle out of a descriptor does not transfer ownership.
+		A descriptor left behind holds a second claim, which the system closes at process
+		teardown, long after the stream has closed the handle.
+
+		The check runs in a child process, since ``_claimControlStream`` takes over the standard
+		streams of whichever process calls it.
+		"""
+		process = subprocess.Popen(
+			[sys.executable, getProbePath("controlStream.py")],
+			stdin=subprocess.PIPE,
+			stdout=subprocess.PIPE,
+			stderr=subprocess.PIPE,
+			cwd=globalVars.appDir,
+			creationflags=subprocess.CREATE_NO_WINDOW,
+		)
+		self.addCleanup(process.kill)
+		_stdout, stderr = process.communicate(timeout=_PROCESS_TIMEOUT)
+		self.assertEqual(
+			process.returncode,
+			0,
+			f"Host boot kept a claim on its control descriptors: {stderr.decode(errors='replace')}",
+		)
 
 
 class TestHostRootServiceDisconnect(unittest.TestCase):

--- a/tests/unit/test_art/test_artHost.py
+++ b/tests/unit/test_art/test_artHost.py
@@ -278,6 +278,45 @@ class TestControlStreamHandleOwnership(unittest.TestCase):
 			f"Host boot kept a claim on its control descriptors: {stderr.decode(errors='replace')}",
 		)
 
+	def assertFailedBootStrandsNothing(self, failingClaim: int):
+		"""Fail the ``failingClaim``-th descriptor claim during boot, and assert the unwind is complete.
+
+		Runs in a child process for the same reason as
+		:meth:`test_bootReleasesTheDescriptorsItDuplicates`.
+
+		:param failingClaim: One-based index of the claim to fail.
+		"""
+		process = subprocess.Popen(
+			[sys.executable, getProbePath("controlStreamCleanup.py"), str(failingClaim)],
+			stdin=subprocess.PIPE,
+			stdout=subprocess.PIPE,
+			stderr=subprocess.PIPE,
+			cwd=globalVars.appDir,
+			creationflags=subprocess.CREATE_NO_WINDOW,
+		)
+		self.addCleanup(process.kill)
+		_stdout, stderr = process.communicate(timeout=_PROCESS_TIMEOUT)
+		self.assertEqual(
+			process.returncode,
+			0,
+			f"Failed host boot did not unwind cleanly: {stderr.decode(errors='replace')}",
+		)
+
+	def test_failingTheFirstClaimClosesBothDescriptors(self):
+		"""A boot that fails before claiming anything still owns both descriptors, and closes both.
+
+		Nothing has become a handle yet, so this is the case that says the descriptor half of the unwind runs.
+		"""
+		self.assertFailedBootStrandsNothing(1)
+
+	def test_failingTheSecondClaimReleasesTheDescriptorAndTheHandle(self):
+		"""A boot that fails after one claim owns a descriptor and a handle, and releases both.
+
+		This is the only point where the boot path holds a descriptor and a handle,
+		which are closed in different ways.
+		"""
+		self.assertFailedBootStrandsNothing(2)
+
 
 class TestHostRootServiceDisconnect(unittest.TestCase):
 	"""The host root service cleans up when core drops the control connection."""


### PR DESCRIPTION
### Link to issue number:

### Summary of the issue:

PR 2 implemented `entrypoint.run`, which serves a control connection over a stream it is handed, but `entrypoint.main` — the half that has to produce that stream from the process it finds itself in — was still a stub.

Carrying the control connection on the host's standard input and output creates two hazards, both of which fail quietly:

1. Stray output corrupts the wire: standard output carries framed rpyc traffic, not text. One `print` anywhere in the host, or in any library it loads, desynchronises the protocol.
2. Two owners of one handle: `PipeStream` closes the handles it is built from. A C runtime descriptor or a Python file object over the same handle closes it a second time. Windows recycles handle values, so the second close can land on an unrelated, still-live object rather than failing, causing an error arbitrarily far from the cause.

### Description of user facing changes:

None.

### Description of developer facing changes:

* `_art.winHandles`: `duplicateHandleForSelf` and `claimHandleFromDescriptor`, handle ownership helpers shared by both sides of the boundary.
* `_art.host.entrypoint._claimControlStream`: takes private ownership of the standard descriptors and returns the control stream.
* `_art.session.hostController.claimProcessControlStream`: the core-side counterpart, for building a stream over a child's piped standard streams.
* `_art.host.entrypoint._initializeLogging`: points the `_art` logger tree at standard error.
* `_art.host.entrypoint.main` is implemented.
* `tests/unit/test_art/probes/`: child programs for tests that cannot run in the test runner's own process.

### Description of development approach:

`_claimControlStream` duplicates the original descriptors for the wire's exclusive use, then makes the originals harmless by pointing stdin at the null device, and aliasing stdout to stderr. Anything that later writes to `sys.stdout` lands in the host's diagnostic channel instead of on the wire. Standard error is left as the diagnostic channel so NVDA can drain it to its own log (PR 4).

The duplicated descriptors are then converted into handles that the stream solely owns. Reading a handle out of a descriptor with `msvcrt.get_osfhandle` does *not* transfer ownership, so leaving the descriptor open would hand the C runtime a second claim that it settles at process teardown, long after `PipeStream` has closed the handle. `claimHandleFromDescriptor` duplicates and then closes the descriptor, leaving exactly one owner.

`claimProcessControlStream` solves the same problem from core's side. `PipeStream(process.stdout, process.stdin)` is a double free for the same reason, so the handles are duplicated for the stream and the file objects closed immediately.

`main` sets the host marker before importing anything that reaches `_art._log`, then imports the log shim late (the ordering constraint PR 1 introduced). Its one pre-logging failure path writes to standard error directly, because there is no logger yet to fail into.

### Testing strategy:

* `test_claimingADescriptorLeavesOneOwner`: after `claimHandleFromDescriptor`, the descriptor is gone but the object behind it is still readable through the returned handle. Asserts that this transfers ownership moved rather than killing the object with the descriptor.
* `test_bootReleasesTheDescriptorsItDuplicates`: runs `probes/controlStream.py`, which spies on `os.dup` to record what `_claimControlStream` hands out, then checks none of those descriptors still resolves. It needs its own process because `_claimControlStream` takes over the standard streams of whoever calls it, which would bork the test runner.
* `test_strayStdoutDoesNotCorruptTheControlStream`: boots a child that deliberately prints after claiming its stream, then pings it from core. If the print reached the wire, the ping will fail to deserialise rather than answering.

These assert on ownership rather than on an error, because the failure mode being guarded against is a successful close of the wrong object.

### Known issues with pull request:

* `_initializeLogging` pins the host to `DEBUG` unconditionally. Fine now, but it should be made configurable at some point.
* `_claimControlStream` uses bare `except:` clauses on its unwinding paths, to catch and clean up after anything at all before re-raising. In this case I think this is actually the correct approach to take.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
