### PR TITLE
ART boundary contract regression tests: exception taxonomy preservation and log shim isolation

### DIFF
--- a/tests/unit/test_art/probes/exceptionTaxonomy.py
+++ b/tests/unit/test_art/probes/exceptionTaxonomy.py
@@ -1,0 +1,91 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2026 NV Access Limited
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
+
+"""Child program checking that an ART exception keeps its type when it crosses into a fresh host.
+
+Run as a process by ``TestExceptionTaxonomyAcrossProcess``.
+Must run in its own process because rpyc rebuilds a remote exception as its real class
+only when that class's module is already resident,
+but ART's tests import :mod:`_art.exceptions`,
+which masks the failure.
+
+This program doesn't import :mod:`_art.exceptions` before making the boundary call.
+It boots the host as the real entry point does,
+asks core for a capability (which core refuses with a :class:`~_art.exceptions.PermissionNotGrantedError`),
+and only then inspects the exception.
+That models add-on code that catches an ART exception without having imported the taxonomy in that module,
+relying on the boot path to have made it resident.
+
+Exits ``0`` if the exception arrived as its real class,
+and non-zero with a diagnostic on standard error otherwise.
+"""
+
+import os
+import sys
+
+#: The capability the probe requests; core refuses every capability for now.
+_REQUESTED_CAPABILITY = "audio"
+
+
+def _check() -> list[str]:
+	"""Drive one refused capability request and report everything wrong with the result.
+
+	:returns: Human-readable descriptions of each failed expectation, empty if all held.
+	"""
+	# Mark this process as the host before importing any module that reaches ``_art._log``,
+	# exactly as ``entrypoint.main`` does.
+	import _art
+
+	os.environ[_art._HOST_MARKER_ENV] = "1"
+
+	from _art.host import entrypoint
+	from _art.host.rootService import HostRootService
+	from _art.transport import Connection
+
+	stream = entrypoint._claimControlStream()
+	conn = Connection(stream, HostRootService(), name="taxonomy probe host")
+	conn.bgEventLoop(daemon=True)
+	core = conn.remoteService
+	try:
+		try:
+			core.requestCapability(_REQUESTED_CAPABILITY)
+		except BaseException as caught:  # noqa: BLE001
+			return _describeFailures(caught)
+		return ["requestCapability returned instead of raising"]
+	finally:
+		conn.close()
+
+
+def _describeFailures(caught: BaseException) -> list[str]:
+	"""Compare a caught exception against what a real add-on would rely on.
+
+	Imports are deferred to here, after the exception has already been rebuilt, so that naming
+	the taxonomy for the check cannot be what makes it resident.
+
+	:param caught: The exception the host received from core.
+	:returns: A description of each broken expectation, empty if the type survived intact.
+	"""
+	from _art.exceptions import CapabilityDeniedError, CapabilityUnavailableError, PermissionNotGrantedError
+	from rpyc.core import vinegar
+
+	received = type(caught)
+	failures: list[str] = []
+	if issubclass(received, vinegar.GenericException):
+		failures.append(f"rebuilt as a GenericException ({received.__module__}.{received.__name__})")
+	if not isinstance(caught, CapabilityUnavailableError):
+		failures.append("not caught by `except CapabilityUnavailableError`")
+	if not isinstance(caught, CapabilityDeniedError):
+		failures.append("not caught by `except CapabilityDeniedError`")
+	if not isinstance(caught, PermissionNotGrantedError):
+		failures.append("not caught by `except PermissionNotGrantedError`")
+	return failures
+
+
+if __name__ == "__main__":
+	failures = _check()
+	if failures:
+		sys.stderr.write("; ".join(failures))
+		sys.exit(1)
+	sys.exit(0)

--- a/tests/unit/test_art/probes/logIsolation.py
+++ b/tests/unit/test_art/probes/logIsolation.py
@@ -1,0 +1,75 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2026 NV Access Limited
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
+
+"""Child program checking that the host's logging stays isolated from NVDA core.
+
+Run as a process by ``TestHostLoggingIsolation``.
+Must run in its own process because :mod:`_art._log` chooses its logger once, at import time,
+from the host marker, and a core-side test process has already resolved that choice the other way
+(and imported ``logHandler``).
+
+It reproduces the ordering of the real host boot path:
+
+* import the entry point, which must not pull core in by itself;
+* set the host marker exactly as :func:`_art.host.entrypoint.main` does;
+* import the transport tree, which reaches :mod:`_art._log`.
+
+At each step it checks that ``logHandler`` never becomes resident,
+and finally that shared code received the host's own logger (with the NVDA methods it relies on).
+
+Exits ``0`` if the host stayed isolated, and non-zero with a diagnostic on standard error otherwise.
+"""
+
+import os
+import sys
+
+
+def _check() -> list[str]:
+	"""Boot far enough to import the transport, checking core never comes with it.
+
+	:returns: Human-readable descriptions of each failed expectation, empty if all held.
+	"""
+	import _art
+	from _art.host import (
+		entrypoint,  # noqa: F401 - Needed to assert that the entrypoint itself doesn't import logHandler
+	)
+
+	failures: list[str] = []
+	if "logHandler" in sys.modules:
+		failures.append("importing the host entry point pulled in logHandler")
+
+	# Mark this process as the host, exactly as ``entrypoint.main`` does,
+	# before importing anything that reaches ``_art._log``.
+	os.environ[_art._HOST_MARKER_ENV] = "1"
+
+	import _art.transport
+
+	artTransportBroughtLogHandler = False
+	if "logHandler" in sys.modules:
+		failures.append("importing the transport tree pulled in logHandler")
+		artTransportBroughtLogHandler = True
+
+	from _art._log import log
+
+	if not artTransportBroughtLogHandler and "logHandler" in sys.modules:
+		failures.append("importing the log shim  pulled in logHandler")
+
+	if not hasattr(log, "debugWarning"):
+		failures.append("the host logger has no debugWarning method")
+	else:
+		try:
+			log.debugWarning("host logging isolation probe")
+		except Exception as caught:  # noqa: BLE001
+			failures.append(f"log.debugWarning raised: {caught!r}")
+
+	return failures
+
+
+if __name__ == "__main__":
+	failures = _check()
+	if failures:
+		sys.stderr.write("; ".join(failures))
+		sys.exit(1)
+	sys.exit(0)

--- a/tests/unit/test_art/test_artHost.py
+++ b/tests/unit/test_art/test_artHost.py
@@ -390,6 +390,77 @@ class TestControlStreamHandleOwnership(unittest.TestCase):
 		self.assertFailedBootStrandsNothing(2)
 
 
+class TestExceptionTaxonomyAcrossProcess(unittest.TestCase):
+	"""An ART exception keeps its type when it crosses into a real, freshly booted host.
+
+	``rpyc`` rebuilds a remote exception as its real class
+	only when that class's module is resident in the receiving process.
+	A host process does not import :mod:`_art.exceptions` just by booting,
+	so unless the transport makes the taxonomy resident, a denial raised by core arrives at the host as a ``GenericException`` subclass.
+	The check runs in a child process that deliberately avoids importing the taxonomy before the boundary call.
+	"""
+
+	def test_deniedCapabilityArrivesAsItsRealClass(self):
+		"""A denial raised by core is catchable by its taxonomy classes in a fresh host."""
+		process = subprocess.Popen(
+			[sys.executable, getProbePath("exceptionTaxonomy.py")],
+			stdin=subprocess.PIPE,
+			stdout=subprocess.PIPE,
+			stderr=subprocess.PIPE,
+			cwd=globalVars.appDir,
+			creationflags=subprocess.CREATE_NO_WINDOW,
+		)
+		self.addCleanup(process.stderr.close)
+		self.addCleanup(process.kill)
+		conn = Connection(
+			claimProcessControlStream(process),
+			CoreRootService(),
+			name=f"test {CONTROL_CONNECTION_NAME}",
+		)
+		self.addCleanup(conn.close)
+		conn.bgEventLoop(daemon=True)
+		try:
+			process.wait(timeout=_PROCESS_TIMEOUT)
+		except subprocess.TimeoutExpired:
+			process.kill()
+			raise
+		# The probe writes a short diagnostic and never fills the pipe, so reading after it exits
+		# cannot deadlock.
+		diagnostic = process.stderr.read().decode(errors="replace")
+		self.assertEqual(
+			process.returncode,
+			0,
+			f"A denial raised by core reached the host as the wrong type: {diagnostic}",
+		)
+
+
+class TestHostLoggingIsolation(unittest.TestCase):
+	"""The host process logs without importing NVDA core.
+
+	Shared transport code logs through :mod:`_art._log`, which resolves to NVDA's ``log`` in core
+	but to a stdlib logger in the host, so the host never imports ``logHandler`` (and core with it).
+	The choice is made once, at import time, from the host marker,
+	so it can only be observed in a process that boots as the host does.
+	"""
+
+	def test_hostDoesNotImportLogHandler(self):
+		"""A host process reaches the transport without ``logHandler`` becoming resident."""
+		process = subprocess.run(
+			[sys.executable, getProbePath("logIsolation.py")],
+			cwd=globalVars.appDir,
+			creationflags=subprocess.CREATE_NO_WINDOW,
+			capture_output=True,
+			timeout=_PROCESS_TIMEOUT,
+			check=False,
+		)
+		diagnostic = process.stderr.decode(errors="replace")
+		self.assertEqual(
+			process.returncode,
+			0,
+			f"The host did not stay isolated from core: {diagnostic}",
+		)
+
+
 class TestHostRootServiceDisconnect(unittest.TestCase):
 	"""The host root service cleans up when core drops the control connection."""
 


### PR DESCRIPTION
### Link to issue number:

### Summary of the issue:

PR 1 established two contracts that the rest of ART depends on:

1. An ART exception keeps its real class when it crosses the boundary, so an add-on can catch `CapabilityDeniedError` rather than matching on a name.
2. The host logs without importing `logHandler`, and therefore without pulling NVDA core into the process that runs untrusted add-on code.

Both are already covered by in-process tests, but both of those tests would keep passing if the contract broke:

1. The test runner has already imported `_art.exceptions`, so RPyC can always find the real classes; and
2. it has also already imported `logHandler`, so nothing can observe the host's side of the choice.

Each contract is thus only falsifiable in a process that boots the way a host does.

This PR adds test-only coverage for both. There are no source changes.

### Description of user facing changes:

None.

### Description of developer facing changes:

None.

### Description of development approach:

Each contract gets a child program under `tests/unit/test_art/probes/` that reproduces the real boot ordering, checks its expectations, and reports failures on standard error with a non-zero exit status. The test cases assert on the exit status and surface the diagnostic in the failure message.

* `exceptionTaxonomy.py` boots as the host does, asks core for a capability (which core refuses), and only then imports the taxonomy to check what it caught. Deferring that import into the checking function matters: naming the taxonomy earlier is exactly what would make it resident and mask the failure. This models add-on code that catches an ART exception in a module that never imported the taxonomy, relying on the boot path to have made it available. It is the test that fails if PR 1's residency import in `transport/config.py` is removed as unused, or if `instantiate_custom_exceptions` is turned off.
* `logIsolation.py` walks the boot sequence one import at a time — entry point, then host marker, then the transport tree, then the log shim — checking after each that `logHandler` has not become resident, and distinguishing which step pulled it in if one did. It finishes by confirming shared code actually received the host's own logger, with the NVDA methods it relies on.

### Testing strategy:

The tests are the deliverable. `TestExceptionTaxonomyAcrossProcess` drives a real control connection to the probe from a `CoreRootService`, so the denial crosses a real process boundary. `TestHostLoggingIsolation` needs no connection and just runs its probe to completion.

Both probes are bounded by the existing `_PROCESS_TIMEOUT` and killed on cleanup, and both write only a short diagnostic, so reading their output after exit cannot deadlock on a full pipe.

### Known issues with pull request:

* The probes duplicate a little of the boot sequence that `entrypoint.main` performs. That is deliberate, as a probe that called `main` could not observe the intermediate states it exists to check, but it does mean that these tests need to be updated if the boot ordering changes.
* `logIsolation.py` asserts on `sys.modules` membership, which is a proxy for "core was not imported". It would not catch core being reached by some route that does not go through `logHandler`.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
