### PR TITLE
Update Liblouis to 3.39.0

### DIFF
--- a/projectDocs/dev/createDevEnvironment.md
+++ b/projectDocs/dev/createDevEnvironment.md
@@ -88,7 +88,7 @@ If you aren't sure, run `git submodule update` after every git pull, merge or ch
 * [eSpeak NG](https://github.com/espeak-ng/espeak-ng), commit `56f2e9c730e2438787103168c0412c80c25d014e`
 * [Sonic](https://github.com/waywardgeek/sonic), commit `b93885dcb70aae50c6f76b0fe4e0868f029a077e`
 * [IAccessible2](https://wiki.linuxfoundation.org/accessibility/iaccessible2/start), commit `c9ae003d9c85eb707716928de97e055f5b77189c`
-* [liblouis](http://www.liblouis.io/), version 3.38.0
+* [liblouis](http://www.liblouis.io/), version 3.39.0
 * [Unicode Common Locale Data Repository (CLDR)](http://cldr.unicode.org/), version 48.2
 * [Adobe Acrobat accessibility interface, version XI](https://download.macromedia.com/pub/developer/acrobat/AcrobatAccess.zip)
 * [Microsoft Detours](https://github.com/microsoft/Detours), commit `9764cebcb1a75940e68fa83d6730ffaf0f669401`

--- a/source/brailleTables/__tables.py
+++ b/source/brailleTables/__tables.py
@@ -288,7 +288,15 @@ addTable(
 )
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
-addTable("hi-in-g1.utb", _("Hindi grade 1"), inputForLangs={"hi"}, outputForLangs={"hi"})
+addTable(
+	"hi-in-g1.utb",
+	_("Hindi grade 1"),
+	# #20671: Although Hindi Braille is not contracted, later cells can change
+	# earlier output, so NVDA must use its "contracted" input buffering mode.
+	contracted=True,
+	inputForLangs={"hi"},
+	outputForLangs={"hi"},
+)
 addTable(
 	"hr-comp8.utb",
 	# Translators: The name of a braille table displayed in the

--- a/source/brailleTables/__tables.py
+++ b/source/brailleTables/__tables.py
@@ -32,13 +32,27 @@ addTable("ar-ar-g1.utb", _("Arabic grade 1"), inputForLangs={"ar"}, outputForLan
 addTable("ar-ar-g2.ctb", _("Arabic grade 2"), contracted=True)
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
-addTable("as-in-g1.utb", _("Assamese grade 1"), inputForLangs={"as"}, outputForLangs={"as"})
+addTable(
+	"as-in-g1.utb",
+	_("Assamese grade 1"),
+	# #20671: Although Assamese Braille is not contracted, later cells can change
+	# earlier output, so NVDA must use its "contracted" input buffering mode.
+	contracted=True,
+	inputForLangs={"as"},
+	outputForLangs={"as"},
+)
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("ba.utb", _("Bashkir grade 1"), input=False)
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
-addTable("be-in-g1.utb", _("Bengali grade 1"))
+addTable(
+	"be-in-g1.utb",
+	_("Bengali grade 1"),
+	# #20671: Although Bengali Braille is not contracted, later cells can change
+	# earlier output, so NVDA must use its "contracted" input buffering mode.
+	contracted=True,
+)
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("bel-comp.utb", _("Belarusian computer braille"))
@@ -256,7 +270,15 @@ addTable("ga-g1.utb", _("Irish grade 1"), inputForLangs={"ga"}, outputForLangs={
 addTable("ga-g2.ctb", _("Irish grade 2"), contracted=True)
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
-addTable("gu-in-g1.utb", _("Gujarati grade 1"), inputForLangs={"gu"}, outputForLangs={"gu"})
+addTable(
+	"gu-in-g1.utb",
+	_("Gujarati grade 1"),
+	# #20671: Although Gujarati Braille is not contracted, later cells can change
+	# earlier output, so NVDA must use its "contracted" input buffering mode.
+	contracted=True,
+	inputForLangs={"gu"},
+	outputForLangs={"gu"},
+)
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("grc-international-en.utb", _("Greek international braille (2-cell accented letters)"))
@@ -354,7 +376,15 @@ addTable(
 )
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
-addTable("ka-in-g1.utb", _("Kannada grade 1"), inputForLangs={"kn"}, outputForLangs={"kn"})
+addTable(
+	"ka-in-g1.utb",
+	_("Kannada grade 1"),
+	# #20671: Although Kannada Braille is not contracted, later cells can change
+	# earlier output, so NVDA must use its "contracted" input buffering mode.
+	contracted=True,
+	inputForLangs={"kn"},
+	outputForLangs={"kn"},
+)
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("ka.utb", _("Georgian literary braille"))
@@ -381,7 +411,13 @@ addTable("ko-g1.ctb", _("Korean grade 1"), inputForLangs={"ko"}, outputForLangs=
 addTable("ko-g2.ctb", _("Korean grade 2"), contracted=True)
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
-addTable("ks-in-g1.utb", _("Kashmiri grade 1"))
+addTable(
+	"ks-in-g1.utb",
+	_("Kashmiri grade 1"),
+	# #20671: Although Kashmiri Braille is not contracted, later cells can change
+	# earlier output, so NVDA must use its "contracted" input buffering mode.
+	contracted=True,
+)
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("lo-g1.utb", _("Lao Grade 1"))
@@ -405,10 +441,22 @@ addTable("mao-nz-g1.ctb", _("Māori Braille"))
 addTable("mk-g1.utb", _("Macedonian grade 1"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
-addTable("ml-in-g1.utb", _("Malayalam grade 1"))
+addTable(
+	"ml-in-g1.utb",
+	_("Malayalam grade 1"),
+	# #20671: Although Malayalam Braille is not contracted, later cells can change
+	# earlier output, so NVDA must use its "contracted" input buffering mode.
+	contracted=True,
+)
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
-addTable("mn-in-g1.utb", _("Manipuri grade 1"))
+addTable(
+	"mn-in-g1.utb",
+	_("Manipuri grade 1"),
+	# #20671: Although Manipuri Braille is not contracted, later cells can change
+	# earlier output, so NVDA must use its "contracted" input buffering mode.
+	contracted=True,
+)
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("ms-my-g2.ctb", _("Malay grade 2"), contracted=True)
@@ -420,7 +468,13 @@ addTable("mn-MN-g1.utb", _("Mongolian grade 1"), inputForLangs={"mn"}, outputFor
 addTable("mn-MN-g2.ctb", _("Mongolian grade 2"), contracted=True)
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
-addTable("mr-in-g1.utb", _("Marathi grade 1"))
+addTable(
+	"mr-in-g1.utb",
+	_("Marathi grade 1"),
+	# #20671: Although Marathi Braille is not contracted, later cells can change
+	# earlier output, so NVDA must use its "contracted" input buffering mode.
+	contracted=True,
+)
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("my-g1.utb", _("Burmese grade 1"), inputForLangs={"my"}, outputForLangs={"my"})
@@ -450,7 +504,15 @@ addTable("No-No-g2.ctb", _("Norwegian grade 2"), contracted=True)
 addTable("No-No-g3.ctb", _("Norwegian grade 3"), contracted=True)
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
-addTable("np-in-g1.utb", _("Nepali grade 1"), inputForLangs={"ne"}, outputForLangs={"ne"})
+addTable(
+	"np-in-g1.utb",
+	_("Nepali grade 1"),
+	# #20671: Although Nepali Braille is not contracted, later cells can change
+	# earlier output, so NVDA must use its "contracted" input buffering mode.
+	contracted=True,
+	inputForLangs={"ne"},
+	outputForLangs={"ne"},
+)
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("nso-za-g1.utb", _("Sepedi grade 1"))
@@ -462,7 +524,13 @@ addTable("nso-za-g2.ctb", _("Sepedi grade 2"), contracted=True)
 addTable("ny-mw.utb", _("Chichewa (Malawi) literary braille"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
-addTable("or-in-g1.utb", _("Oriya grade 1"))
+addTable(
+	"or-in-g1.utb",
+	_("Oriya grade 1"),
+	# #20671: Although Oriya Braille is not contracted, later cells can change
+	# earlier output, so NVDA must use its "contracted" input buffering mode.
+	contracted=True,
+)
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("ovd-6g0.utb", _("Elfdalian 6 dot"))
@@ -494,7 +562,13 @@ addTable("Pt-Pt-g1.utb", _("Portuguese grade 1"), inputForLangs={"pt"}, outputFo
 addTable("Pt-Pt-g2.ctb", _("Portuguese grade 2"), contracted=True)
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
-addTable("pu-in-g1.utb", _("Punjabi grade 1"))
+addTable(
+	"pu-in-g1.utb",
+	_("Punjabi grade 1"),
+	# #20671: Although Punjabi Braille is not contracted, later cells can change
+	# earlier output, so NVDA must use its "contracted" input buffering mode.
+	contracted=True,
+)
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("ro-g0.utb", _("Romanian 6 dot"), inputForLangs={"ro"}, outputForLangs={"ro"})
@@ -521,7 +595,13 @@ addTable("ru-ru-g1.ctb", _("Russian contracted braille"), contracted=True, input
 addTable("rw-rw-g1.utb", _("Kinyarwanda literary braille"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
-addTable("sa-in-g1.utb", _("Sanskrit grade 1"))
+addTable(
+	"sa-in-g1.utb",
+	_("Sanskrit grade 1"),
+	# #20671: Although Sanskrit Braille is not contracted, later cells can change
+	# earlier output, so NVDA must use its "contracted" input buffering mode.
+	contracted=True,
+)
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("sah.utb", _("Yakut grade 1"), input=False)
@@ -659,7 +739,13 @@ addTable("ta-ta-g1.ctb", _("Tamil grade 1"), inputForLangs={"ta"}, outputForLang
 addTable("tt.utb", _("Tatar grade 1"), input=False)
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
-addTable("te-in-g1.utb", _("Telugu grade 1"))
+addTable(
+	"te-in-g1.utb",
+	_("Telugu grade 1"),
+	# #20671: Although Telugu Braille is not contracted, later cells can change
+	# earlier output, so NVDA must use its "contracted" input buffering mode.
+	contracted=True,
+)
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("th-comp8-backward.utb", _("Thai 8 dot computer braille"), output=False)

--- a/source/brailleTables/__tables.py
+++ b/source/brailleTables/__tables.py
@@ -30,10 +30,10 @@ addTable("ar-ar-g1.utb", _("Arabic grade 1"), inputForLangs={"ar"}, outputForLan
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("ar-ar-g2.ctb", _("Arabic grade 2"), contracted=True)
-# Translators: The name of a braille table displayed in the
-# braille settings dialog.
 addTable(
 	"as-in-g1.utb",
+	# Translators: The name of a braille table displayed in the
+	# braille settings dialog.
 	_("Assamese grade 1"),
 	# #20671: Although Assamese Braille is not contracted, later cells can change
 	# earlier output, so NVDA must use its "contracted" input buffering mode.
@@ -44,10 +44,10 @@ addTable(
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("ba.utb", _("Bashkir grade 1"), input=False)
-# Translators: The name of a braille table displayed in the
-# braille settings dialog.
 addTable(
 	"be-in-g1.utb",
+	# Translators: The name of a braille table displayed in the
+	# braille settings dialog.
 	_("Bengali grade 1"),
 	# #20671: Although Bengali Braille is not contracted, later cells can change
 	# earlier output, so NVDA must use its "contracted" input buffering mode.
@@ -268,10 +268,10 @@ addTable("ga-g1.utb", _("Irish grade 1"), inputForLangs={"ga"}, outputForLangs={
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("ga-g2.ctb", _("Irish grade 2"), contracted=True)
-# Translators: The name of a braille table displayed in the
-# braille settings dialog.
 addTable(
 	"gu-in-g1.utb",
+	# Translators: The name of a braille table displayed in the
+	# braille settings dialog.
 	_("Gujarati grade 1"),
 	# #20671: Although Gujarati Braille is not contracted, later cells can change
 	# earlier output, so NVDA must use its "contracted" input buffering mode.
@@ -308,10 +308,10 @@ addTable(
 	inputForLangs={"he"},
 	outputForLangs={"he"},
 )
-# Translators: The name of a braille table displayed in the
-# braille settings dialog.
 addTable(
 	"hi-in-g1.utb",
+	# Translators: The name of a braille table displayed in the
+	# braille settings dialog.
 	_("Hindi grade 1"),
 	# #20671: Although Hindi Braille is not contracted, later cells can change
 	# earlier output, so NVDA must use its "contracted" input buffering mode.
@@ -374,10 +374,10 @@ addTable(
 	# braille settings dialog.
 	_("Japanese (Rokuten Kanji) Braille"),
 )
-# Translators: The name of a braille table displayed in the
-# braille settings dialog.
 addTable(
 	"ka-in-g1.utb",
+	# Translators: The name of a braille table displayed in the
+	# braille settings dialog.
 	_("Kannada grade 1"),
 	# #20671: Although Kannada Braille is not contracted, later cells can change
 	# earlier output, so NVDA must use its "contracted" input buffering mode.
@@ -409,10 +409,10 @@ addTable("ko-g1.ctb", _("Korean grade 1"), inputForLangs={"ko"}, outputForLangs=
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("ko-g2.ctb", _("Korean grade 2"), contracted=True)
-# Translators: The name of a braille table displayed in the
-# braille settings dialog.
 addTable(
 	"ks-in-g1.utb",
+	# Translators: The name of a braille table displayed in the
+	# braille settings dialog.
 	_("Kashmiri grade 1"),
 	# #20671: Although Kashmiri Braille is not contracted, later cells can change
 	# earlier output, so NVDA must use its "contracted" input buffering mode.
@@ -439,19 +439,19 @@ addTable("mao-nz-g1.ctb", _("Māori Braille"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("mk-g1.utb", _("Macedonian grade 1"))
-# Translators: The name of a braille table displayed in the
-# braille settings dialog.
 addTable(
 	"ml-in-g1.utb",
+	# Translators: The name of a braille table displayed in the
+	# braille settings dialog.
 	_("Malayalam grade 1"),
 	# #20671: Although Malayalam Braille is not contracted, later cells can change
 	# earlier output, so NVDA must use its "contracted" input buffering mode.
 	contracted=True,
 )
-# Translators: The name of a braille table displayed in the
-# braille settings dialog.
 addTable(
 	"mn-in-g1.utb",
+	# Translators: The name of a braille table displayed in the
+	# braille settings dialog.
 	_("Manipuri grade 1"),
 	# #20671: Although Manipuri Braille is not contracted, later cells can change
 	# earlier output, so NVDA must use its "contracted" input buffering mode.
@@ -466,10 +466,10 @@ addTable("mn-MN-g1.utb", _("Mongolian grade 1"), inputForLangs={"mn"}, outputFor
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("mn-MN-g2.ctb", _("Mongolian grade 2"), contracted=True)
-# Translators: The name of a braille table displayed in the
-# braille settings dialog.
 addTable(
 	"mr-in-g1.utb",
+	# Translators: The name of a braille table displayed in the
+	# braille settings dialog.
 	_("Marathi grade 1"),
 	# #20671: Although Marathi Braille is not contracted, later cells can change
 	# earlier output, so NVDA must use its "contracted" input buffering mode.
@@ -502,10 +502,10 @@ addTable("No-No-g2.ctb", _("Norwegian grade 2"), contracted=True)
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("No-No-g3.ctb", _("Norwegian grade 3"), contracted=True)
-# Translators: The name of a braille table displayed in the
-# braille settings dialog.
 addTable(
 	"np-in-g1.utb",
+	# Translators: The name of a braille table displayed in the
+	# braille settings dialog.
 	_("Nepali grade 1"),
 	# #20671: Although Nepali Braille is not contracted, later cells can change
 	# earlier output, so NVDA must use its "contracted" input buffering mode.
@@ -522,10 +522,10 @@ addTable("nso-za-g2.ctb", _("Sepedi grade 2"), contracted=True)
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("ny-mw.utb", _("Chichewa (Malawi) literary braille"))
-# Translators: The name of a braille table displayed in the
-# braille settings dialog.
 addTable(
 	"or-in-g1.utb",
+	# Translators: The name of a braille table displayed in the
+	# braille settings dialog.
 	_("Oriya grade 1"),
 	# #20671: Although Oriya Braille is not contracted, later cells can change
 	# earlier output, so NVDA must use its "contracted" input buffering mode.
@@ -560,10 +560,10 @@ addTable("Pt-Pt-g1.utb", _("Portuguese grade 1"), inputForLangs={"pt"}, outputFo
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("Pt-Pt-g2.ctb", _("Portuguese grade 2"), contracted=True)
-# Translators: The name of a braille table displayed in the
-# braille settings dialog.
 addTable(
 	"pu-in-g1.utb",
+	# Translators: The name of a braille table displayed in the
+	# braille settings dialog.
 	_("Punjabi grade 1"),
 	# #20671: Although Punjabi Braille is not contracted, later cells can change
 	# earlier output, so NVDA must use its "contracted" input buffering mode.
@@ -593,10 +593,10 @@ addTable("ru-ru-g1.ctb", _("Russian contracted braille"), contracted=True, input
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("rw-rw-g1.utb", _("Kinyarwanda literary braille"))
-# Translators: The name of a braille table displayed in the
-# braille settings dialog.
 addTable(
 	"sa-in-g1.utb",
+	# Translators: The name of a braille table displayed in the
+	# braille settings dialog.
 	_("Sanskrit grade 1"),
 	# #20671: Although Sanskrit Braille is not contracted, later cells can change
 	# earlier output, so NVDA must use its "contracted" input buffering mode.
@@ -737,10 +737,10 @@ addTable("ta-ta-g1.ctb", _("Tamil grade 1"), inputForLangs={"ta"}, outputForLang
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("tt.utb", _("Tatar grade 1"), input=False)
-# Translators: The name of a braille table displayed in the
-# braille settings dialog.
 addTable(
 	"te-in-g1.utb",
+	# Translators: The name of a braille table displayed in the
+	# braille settings dialog.
 	_("Telugu grade 1"),
 	# #20671: Although Telugu Braille is not contracted, later cells can change
 	# earlier output, so NVDA must use its "contracted" input buffering mode.

--- a/source/brailleTables/__tables.py
+++ b/source/brailleTables/__tables.py
@@ -163,6 +163,12 @@ addTable("en-g3.ctb", _("English grade 3"), contracted=True, input=False)
 addTable("en-nabcc.utb", _("English North American Braille Computer Code"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
+addTable("en-nz-g1.utb", _("English (New Zealand) grade 1"))
+# Translators: The name of a braille table displayed in the
+# braille settings dialog.
+addTable("en-nz-g2.ctb", _("English (New Zealand) grade 2"), contracted=True)
+# Translators: The name of a braille table displayed in the
+# braille settings dialog.
 addTable("en-ueb-g1.ctb", _("Unified English Braille Code grade 1"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
@@ -296,6 +302,9 @@ addTable(
 addTable("hr-g1.ctb", _("Croatian grade 1"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
+addTable("ht-g1.utb", _("Haitian Creole Braille"))
+# Translators: The name of a braille table displayed in the
+# braille settings dialog.
 addTable("hu-hu-comp8.ctb", _("Hungarian 8 dot computer braille"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
@@ -380,6 +389,9 @@ addTable("lt-6dot.utb", _("Lithuanian 6 dot"), inputForLangs={"lt"}, outputForLa
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("Lv-Lv-g1.utb", _("Latvian grade 1"))
+# Translators: The name of a braille table displayed in the
+# braille settings dialog.
+addTable("mao-nz-g1.ctb", _("Māori Braille"))
 # Translators: The name of a braille table displayed in the
 # braille settings dialog.
 addTable("mk-g1.utb", _("Macedonian grade 1"))

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -50,7 +50,7 @@
 ### Changes
 
 * Updated Liblouis Braille translator to [3.39.0](https://github.com/liblouis/liblouis/releases/tag/v3.39.0). (#20269, #20776, @codeofdusk)
-  * Added new Elfdalian, Sami, and Haitian Creole tables, English and Māori tables from the Braille Authority of New Zealand Aotearoa Trust, a Norwegian table for Spanish text, and additional Swedish 6 and 8 dot variants.
+  * Added new Elfdalian, Sami, Maori, New Zealand English, and Haitian Creole tables, a Norwegian table for Spanish text, and additional Swedish 6 and 8 dot variants.
 * The dialog used to present browseable messages (such as formatting information) has been modernized. (#18878, @LeonarddeR)
   * The dialog's shortcut to copy contents of the message to the clipboard was changed to `alt+c`.
   * Browseable message dialogs now better support resizing, maximizing and minimizing, with text wrapping to the dialog width. (#20429, @Cary-rowen)

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -50,7 +50,7 @@
 ### Changes
 
 * Updated Liblouis Braille translator to [3.39.0](https://github.com/liblouis/liblouis/releases/tag/v3.39.0). (#20269, #20776, @codeofdusk)
-  * Added new Elfdalian, Sami, Maori, New Zealand English, and Haitian Creole tables, a Norwegian table for Spanish text, and additional Swedish 6 and 8 dot variants.
+  * Added new Elfdalian, Sami, Maori, New Zealand Unified English Braille, and Haitian Creole tables, a Norwegian table for Spanish text, and additional Swedish 6 and 8 dot variants.
 * The dialog used to present browseable messages (such as formatting information) has been modernized. (#18878, @LeonarddeR)
   * The dialog's shortcut to copy contents of the message to the clipboard was changed to `alt+c`.
   * Browseable message dialogs now better support resizing, maximizing and minimizing, with text wrapping to the dialog width. (#20429, @Cary-rowen)

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -49,8 +49,8 @@
 
 ### Changes
 
-* Updated Liblouis Braille translator to [3.38.0](https://github.com/liblouis/liblouis/releases/tag/v3.38.0). (#20269, @codeofdusk)
-  * Added new Elfdalian and Sami tables, a Norwegian table for Spanish text, and additional Swedish 6 and 8 dot variants.
+* Updated Liblouis Braille translator to [3.39.0](https://github.com/liblouis/liblouis/releases/tag/v3.39.0). (#20269, #20776, @codeofdusk)
+  * Added new Elfdalian, Sami, and Haitian Creole tables, English and Māori tables from the Braille Authority of New Zealand Aotearoa Trust, a Norwegian table for Spanish text, and additional Swedish 6 and 8 dot variants.
 * The dialog used to present browseable messages (such as formatting information) has been modernized. (#18878, @LeonarddeR)
   * The dialog's shortcut to copy contents of the message to the clipboard was changed to `alt+c`.
   * Browseable message dialogs now better support resizing, maximizing and minimizing, with text wrapping to the dialog width. (#20429, @Cary-rowen)

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -94,7 +94,7 @@ Previously these keys had no function when pressed on their own. (#20366, @fla-r
 * HIMS Braille Sense and Braille EDGE displays connected via USB now work on systems where the older HIMS USB driver cannot be installed, such as Windows 11. (#20555, @KihunJang1981)
   * On these systems, install the [HIMS WinUSB driver](https://hims-product.s3.ap-northeast-2.amazonaws.com/Util/HIMS_Braille_Driver_V3_1.exe) instead.
 * NVDA no longer briefly disconnects and re-detects the braille display on desktop switches that do not enter the secure desktop, such as when switching between a Remote Desktop session and the local machine. (#18810, #20550, @LeonarddeR)
-* Fixed incorrect back-translation when using the Hindi grade 1 table for braille input. (#20671)
+* Fixed incorrect back-translation when using Hindi and several other Indian grade 1 tables for braille input. (#20671)
 
 #### Web browsers
 

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -94,6 +94,7 @@ Previously these keys had no function when pressed on their own. (#20366, @fla-r
 * HIMS Braille Sense and Braille EDGE displays connected via USB now work on systems where the older HIMS USB driver cannot be installed, such as Windows 11. (#20555, @KihunJang1981)
   * On these systems, install the [HIMS WinUSB driver](https://hims-product.s3.ap-northeast-2.amazonaws.com/Util/HIMS_Braille_Driver_V3_1.exe) instead.
 * NVDA no longer briefly disconnects and re-detects the braille display on desktop switches that do not enter the secure desktop, such as when switching between a Remote Desktop session and the local machine. (#18810, #20550, @LeonarddeR)
+* Fixed incorrect back-translation when using the Hindi grade 1 table for braille input. (#20671)
 
 #### Web browsers
 


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests.

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review".
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:
Part of #20103. Closes #20671.

### Summary of the issue:
Liblouis 3.39.0 was released, and NVDA's next release should be kept in sync.

### Description of how this pull request fixes the issue:
Update LibLouis.

### Testing strategy:
Verified that new LibLouis functions correctly and new tables appear.

### Known issues with pull request:
None known

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
