### PR TITLE
Back off between attempts to enable Screen Curtain

### DIFF
--- a/source/screenCurtain/_screenCurtain.py
+++ b/source/screenCurtain/_screenCurtain.py
@@ -4,6 +4,7 @@
 # For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
 
 import os
+import time
 from typing import Final, TypedDict, cast
 
 import config
@@ -159,6 +160,12 @@ class ScreenCurtain:
 	_MAX_ENABLE_RETRIES: Final[int] = 3
 	"""Maximum number of times to try enabling Screen Curtain."""
 
+	_INITIAL_ENABLE_RETRY_DELAY: Final[float] = 0.01
+	"""Delay in seconds before the second attempt at enabling Screen Curtain.
+
+	The delay doubles for each subsequent attempt.
+	"""
+
 	def __init__(self):
 		"""Initializer."""
 		super().__init__()
@@ -224,6 +231,8 @@ class ScreenCurtain:
 				magnification.MagUninitialize()
 				log.debugWarning(f"Failed to enable Screen Curtain on attempt {attempt + 1}.", exc_info=e)
 				exception = e
+				if attempt < self._MAX_ENABLE_RETRIES - 1:
+					time.sleep(self._INITIAL_ENABLE_RETRY_DELAY * 2**attempt)
 		else:
 			log.debug(f"Failed to enable Screen Curtain after {self._MAX_ENABLE_RETRIES} attempts.")
 			raise RuntimeError("Failed to enable screen curtain") from exception

--- a/tests/unit/test_visionEnhancementProviders/test_screenCurtainRetry.py
+++ b/tests/unit/test_visionEnhancementProviders/test_screenCurtainRetry.py
@@ -1,0 +1,66 @@
+# A part of NonVisual Desktop Access (NVDA)
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+# Copyright (C) 2026 NV Access Limited.
+
+"""Unit tests for the Screen Curtain enable retry backoff."""
+
+import unittest
+from unittest.mock import patch
+
+from screenCurtain._screenCurtain import ScreenCurtain
+
+
+class Test_EnableRetryBackoff(unittest.TestCase):
+	"""Tests that failed attempts to enable Screen Curtain back off exponentially.
+
+	When NVDA starts immediately after sign-in, the screen may still be being
+	painted, so verifying that it is black fails. Retrying without any delay
+	fails for the same reason each time (#20688).
+	"""
+
+	def _enableWithBlackScreenCheck(self, isBlackResults: list[bool]) -> list[float]:
+		"""Call ScreenCurtain.enable, returning the delays it slept between attempts.
+
+		:param isBlackResults: The value isScreenFullyBlack should return per attempt.
+		:return: The arguments passed to time.sleep, in order.
+		"""
+		curtain = ScreenCurtain.__new__(ScreenCurtain)
+		curtain._enabled = False
+		curtain._settings = {"playToggleSounds": False, "enabled": False}
+		delays: list[float] = []
+		with (
+			patch("screenCurtain._screenCurtain.magnification"),
+			patch("screenCurtain._screenCurtain.isScreenFullyBlack", side_effect=isBlackResults),
+			patch("screenCurtain._screenCurtain.time.sleep", side_effect=delays.append),
+			patch.dict("sys.modules", {"_magnifier": unittest.mock.MagicMock(getMagnifier=lambda: None)}),
+		):
+			try:
+				curtain.enable(persist=False)
+			except RuntimeError:
+				pass
+		curtain._enabled = False
+		return delays
+
+	def test_noDelayWhenFirstAttemptSucceeds(self):
+		"""A successful first attempt should not sleep at all."""
+		self.assertEqual(self._enableWithBlackScreenCheck([True]), [])
+
+	def test_delaysDoubleBetweenAttempts(self):
+		"""Each retry should wait twice as long as the previous one."""
+		delays = self._enableWithBlackScreenCheck([False, False, False])
+		self.assertEqual(len(delays), ScreenCurtain._MAX_ENABLE_RETRIES - 1)
+		for i, delay in enumerate(delays):
+			self.assertAlmostEqual(delay, ScreenCurtain._INITIAL_ENABLE_RETRY_DELAY * 2**i)
+
+	def test_noDelayAfterFinalAttempt(self):
+		"""Giving up should not sleep after the last attempt."""
+		delays = self._enableWithBlackScreenCheck([False, False, False])
+		self.assertLess(len(delays), ScreenCurtain._MAX_ENABLE_RETRIES)
+
+	def test_stopsRetryingOnceScreenIsBlack(self):
+		"""A retry that succeeds should not be followed by further delays."""
+		self.assertEqual(
+			self._enableWithBlackScreenCheck([False, True]),
+			[ScreenCurtain._INITIAL_ENABLE_RETRY_DELAY],
+		)


### PR DESCRIPTION
### Link to issue number:

Closes #20688

### Summary of the issue:

Enabling Screen Curtain verifies that the screen is fully black, and retries up to three times if the check fails. The retries run back to back with no delay, so all three land while the screen is still being painted, and enabling fails. This was reported when NVDA starts automatically after PIN sign-in while the post sign-in Windows out of box experience is on screen.

### Description of user facing changes:

Screen Curtain succeeds in cases where a transient repaint previously made all three attempts fail.

### Description of developer facing changes:

None.

### Description of development approach:

Added `_INITIAL_ENABLE_RETRY_DELAY` and slept for it, doubled per attempt, after a failed attempt in `ScreenCurtain.enable`. No delay is added after the final attempt. This follows the exponential cooldown suggested in the issue rather than a flat 500ms, to keep the delay short on a path that may block.

### Testing strategy:

Added unit tests covering: no delay when the first attempt succeeds, delays doubling between attempts, no delay after the final attempt, and retries stopping once the screen is black. Confirmed the new tests fail without the change. Ran the full unit test suite: 1431 passed, 5 skipped.

The original report needs a machine in the post sign-in out of box experience, which I could not reproduce, so the tests cover the retry timing rather than that specific failure.

### Known issues with pull request:

The delay constants are a judgement call. 10ms and 20ms are short enough not to matter on a blocking path, but whether they are long enough for the repaint case cannot be confirmed without reproducing it.

### Code Review Checklist:

- [x] Documentation:
  - No user or developer documentation changes needed.
- [x] Testing:
  - Unit tests added.
- [x] UX of all users considered:
  - Affects only the failure path when enabling Screen Curtain; no change when it already succeeds.
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
