### PR TITLE
Start dev cycle for 2027.1

### DIFF
--- a/source/addonAPIVersion.py
+++ b/source/addonAPIVersion.py
@@ -1,12 +1,11 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2018-2025 NV Access Limited
-# This file is covered by the GNU General Public License.
-# See the file COPYING for more details.
+# Copyright (C) 2018-2026 NV Access Limited
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
 
-
-import buildVersion  # noqa: I001
 import re
 
+import buildVersion
 
 """
 This module contains add-on API version information for this build of NVDA. This file provides information on
@@ -21,12 +20,13 @@ CURRENT: AddonApiVersionT = (
 	buildVersion.version_minor,
 )
 
-BACK_COMPAT_TO: AddonApiVersionT = (2026, 1, 0)
+BACK_COMPAT_TO: AddonApiVersionT = (2027, 1, 0)
 """
 As BACK_COMPAT_TO is incremented, the changed / removed parts / or reasoning should be added below.
 These only serve to act as a reminder, the changelog should be consulted for a comprehensive listing.
 EG: (x, y, z): Large changes to speech.py
 ---
+(2027, 1, 0): Upgrade to python 3.14.
 (2026, 1, 0): Upgrade to python 3.13 and migration to 64bit from 32bit
 (2025, 1, 0): HTML passed to browsableMessage is now sanitised, and various changes to the settings schema
 (2024, 1, 0): upgrade to python 3.11

--- a/source/buildVersion.py
+++ b/source/buildVersion.py
@@ -1,7 +1,7 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2006-2025 NV Access Limited
-# This file is covered by the GNU General Public License.
-# See the file COPYING for more details.
+# Copyright (C) 2006-2026 NV Access Limited
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
 
 import os
 
@@ -63,13 +63,13 @@ def formatVersionForGUI(year, major, minor):
 
 # Version information for NVDA
 name = "NVDA"
-version_year = 2026
-version_major = 3
+version_year = 2027
+version_major = 1
 version_minor = 0
 version_build = 0  # Should not be set manually. Set in 'sconscript'.
 version = _formatDevVersionString()
 publisher = "unknown"
-copyrightYears = "2006-2026"
+copyrightYears = "2006-2027"
 url = "https://www.nvaccess.org"
 updateVersionType = None
 try:

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -1,5 +1,39 @@
 # What's New in NVDA
 
+## 2027.1
+
+### Important notes
+
+### New Features
+<!-- Note we are in a feature freeze, only features related to API breaking changes should be listed here -->
+
+### Changes
+
+### Bug Fixes
+
+#### Performance
+
+#### Braille
+
+#### Web browsers
+
+### Changes for Developers
+
+Please refer to [the developer guide](https://download.nvaccess.org/documentation/developerGuide.html#API) for information on NVDA's API deprecation and removal process.
+
+* Note: this is an Add-on API compatibility breaking release.
+Add-ons will need to be re-tested and have their manifest updated.
+
+#### API Breaking Changes
+
+These are breaking API changes.
+Please open a GitHub issue if your add-on has an issue with updating to the new API.
+
+#### Deprecations
+
+<!-- Beyond this point, Markdown should not be automatically linted, as we don't modify old change log sections and lint rules may change over time. -->
+<!-- markdownlint-disable -->
+
 ## 2026.3
 
 This release includes significant performance improvements, improvements to NVDA's dialogs, and expanded touch screen input.


### PR DESCRIPTION
Start the dev cycle for the 2027.1 release.
This will be a compatibility breaking release.

Complete:
- [x] New section in the change log.
- [x] Update NVDA version in `master`
- [x] Bump the add-on API compatibility in `master`
- [x] Update [`nvdaAPIVersions.json`](https://github.com/nvaccess/addon-datastore/blob/master/transform/nvdaAPIVersions.json) to include the next version
  - Re-run the last "Transform NVDA addons to views" on [addon-datastore](https://github.com/nvaccess/addon-datastore/actions/workflows/transformDataToViews.yml) to regenerate projections (views) for the add-on datastore API.

On merge:
- [x] [Update auto milestone ID](https://github.com/nvaccess/nvda/settings/variables/actions)