### PR TITLE
Do not tear down and recreate Magnifier on configuration reload (closes #20786)

### DIFF
--- a/source/_magnifier/__init__.py
+++ b/source/_magnifier/__init__.py
@@ -101,6 +101,48 @@ def terminate() -> None:
 	_magnifier = None
 
 
+def reconfigure() -> None:
+	"""
+	Reconcile the magnifier with a reloaded configuration (e.g. NVDA+Ctrl+R).
+
+	If the magnifier is already running and remains enabled in the reloaded
+	configuration, its active magnification session and viewport position are
+	preserved and only the changed settings are applied (see
+	L{Magnifier.reconfigure}). If it is explicitly disabled in the new
+	configuration it is stopped normally, and if it becomes enabled it is
+	started.
+	"""
+	global _magnifier  # noqa: PLW0602
+
+	if _magnifier is None:
+		log.debug("Reconfiguring magnifier, but it is not initialized; initializing.")
+		initialize()
+		return
+
+	wasActive = isActive()
+	configuredEnabled = getEnabled()
+	configuredView = getMagnifiedView()
+
+	# A change of magnified view requires recreating the magnifier instance.
+	if configuredView != _magnifier._MAGNIFIED_VIEW:
+		_setMagnifiedView(configuredView)
+		# The previous session was torn down by _setMagnifiedView.
+		wasActive = False
+
+	if wasActive and not configuredEnabled:
+		# Explicitly disabled in the new configuration: terminate normally.
+		stop(persist=False)
+	elif not wasActive and configuredEnabled:
+		# Enabled in the new configuration and not currently running: start.
+		try:
+			start()
+		except MagnifierStartError:
+			log.warning("Magnifier is enabled in config but failed to start.", exc_info=True)
+	elif isActive():
+		# Still running and still enabled: preserve session, apply changes.
+		_magnifier.reconfigure()
+
+
 def start() -> None:
 	"""Start the magnifier.
 

--- a/source/_magnifier/fullscreenMagnifier.py
+++ b/source/_magnifier/fullscreenMagnifier.py
@@ -44,6 +44,17 @@ class FullScreenMagnifier(Magnifier):
 		self._displaySize = Size(self._displayOrientation.width, self._displayOrientation.height)
 		self._inputTransformSupported = systemUtils.hasUiAccess()
 
+	@override
+	def reconfigure(self) -> None:
+		"""
+		Update the full-screen magnifier's settings that are not read live from
+		the configuration on each update (the full-screen tracking mode), then
+		delegate to the base implementation for the shared settings.
+		This preserves the active session and viewport position.
+		"""
+		self._fullscreenMode = getFullscreenMode()
+		super().reconfigure()
+
 	@staticmethod
 	def _isAccessDeniedError(error: OSError) -> bool:
 		"""Return True when OSError represents Windows access denied (WinError 5)."""

--- a/source/_magnifier/magnifier.py
+++ b/source/_magnifier/magnifier.py
@@ -326,6 +326,34 @@ class Magnifier:
 		# Unregister from display changes
 		_displayTracking.displayChanged.unregister(self._onDisplayChanged)
 
+	def reconfigure(self) -> None:
+		"""
+		Re-read the configuration and apply any changed settings to the running
+		magnifier session.
+
+		Called on a configuration reload (e.g. NVDA+Ctrl+R) for a magnifier that
+		is already running and remains enabled. This preserves the current
+		magnification session and viewport position, updating only the settings
+		that changed in the reloaded configuration (zoom level, color filter and
+		pan step).
+
+		Tracking modes (follow mouse / focus / review cursor / navigator object)
+		are read from the configuration on each update, so no action is needed
+		here for them.
+		"""
+		try:
+			newZoom = getZoomLevel()
+			if newZoom != self._zoomLevel:
+				self.zoomLevel = newZoom
+		except ValueError:
+			log.warning(
+				f"Invalid zoom level ({getZoomLevel()}) in configuration; keeping current zoom.",
+			)
+		self._panStep = getPanStep()
+		self.filterType = getFilter()
+		if self._isActive:
+			self._doUpdate()
+
 	def onScreenCurtainEnabled(self) -> None:
 		"""
 		Called when screen curtain is being enabled.

--- a/source/core.py
+++ b/source/core.py
@@ -328,9 +328,12 @@ def resetConfiguration(factoryDefaults=False):
 	import textUtils._wordSeg
 	import _magnifier as magnifier
 
-	magnifier.terminate()
-	log.debug("Terminating vision")
-	vision.terminate()
+	# The vision handler and magnifier are NOT torn down here.
+	# Their providers/sessions are reconciled after the configuration is
+	# reloaded (see the "Reloading config" section below), so that providers
+	# which are already running and remain enabled in the new configuration
+	# (e.g. the magnifier) keep their runtime session and viewport position
+	# instead of being terminated and re-initialized.
 	log.debug("Terminating Screen Curtain")
 	screenCurtain.terminate()
 	log.debug("Terminating math presentation")
@@ -401,11 +404,25 @@ def resetConfiguration(factoryDefaults=False):
 	log.debug("Initializing math presentation")
 	mathPres.initialize()
 	# Vision
-	log.debug("initializing vision")
-	vision.initialize()
+	# Reuse the already-running vision handler (kept alive above). Its
+	# handleConfigProfileSwitch reconciles the set of running providers with
+	# the newly configured providers: it terminates only those that are no
+	# longer enabled and initializes only newly enabled ones, while leaving
+	# providers that are both running and still enabled alive (preserving
+	# runtime state such as the magnifier's viewport position).
+	if vision.handler is not None:
+		log.debug("Reconciling vision providers with reloaded configuration")
+		vision.handler.handleConfigProfileSwitch()
+	else:
+		log.debug("initializing vision")
+		vision.initialize()
 	log.debug("initializing Screen Curtain")
 	screenCurtain.initialize()
-	magnifier.initialize()
+	# Magnifier
+	# Reconcile the magnifier with the reloaded configuration rather than
+	# tearing it down and re-initializing it, so an already-running magnifier
+	# keeps its session and viewport and only changed settings are applied.
+	magnifier.reconfigure()
 	log.debug("Reloading user and locale input gesture maps")
 	inputCore.manager.loadUserGestureMap()
 	inputCore.manager.loadLocaleGestureMap()


### PR DESCRIPTION
Fixes #20786.

### Link to issue
Closes #20786.

### Summary of the issue
When a user reloads configuration settings (via `NVDA+Ctrl+R`), `core.resetConfiguration()` unconditionally tears down both `magnifier` and `vision` subsystems before recreating them. 
This causes a ~500ms screen flash (breaking dark/inverted color filters for photophobic users) and resets the active magnified viewport position and tracking state.

### Description of user facing changes
Reloading NVDA settings now preserves an active magnifier session:
- The screen background will not flash or lose its color inversion filter when settings are reloaded.
- The magnified view maintains its current screen position and coordinates.
- If magnifier settings (such as zoom level, color filter, or tracking mode) were modified in the reloaded configuration, they are applied dynamically to the live session.
- If the magnifier was disabled in the reloaded configuration, it terminates as expected.

### Description of development changes
1. **`source/core.py` (`resetConfiguration`):**
   - Removed the unconditional calls to `magnifier.terminate()`, `vision.terminate()`, `vision.initialize()`, and `magnifier.initialize()`.
   - Replaced with `vision.handler.handleConfigProfileSwitch()` and `magnifier.reconfigure()` to reconcile active providers against the reloaded configuration.
2. **`source/_magnifier/`:**
   - Implemented `reconfigure()` on `Magnifier` and `FullscreenMagnifier` to update only modified runtime attributes (zoom, filter matrix, tracking) while reusing existing `currentCoordinates`.
   - Handled state transitions in `__init__.py`: preserved if running and still enabled, stopped if disabled, initialized if newly enabled.

### Testing strategy
- Tested configuration reloads (`NVDA+Ctrl+R`) with inverted color filter and 5x zoom active: verified the live display session remains continuous with no screen flash or coordinate loss.
- Tested modifying speech/braille settings followed by reload: verified non-magnifier settings restore while the magnified viewport remains intact.
- Verified disabling magnifier in settings followed by reload cleanly shuts down the magnification session.