### PR TITLE
Excel - NVDA correctly populates the elements list with notes and formulas when multiple cells are selected in the sheet

### DIFF
--- a/source/NVDAObjects/window/excel.py
+++ b/source/NVDAObjects/window/excel.py
@@ -1556,7 +1556,7 @@ class ExcelCellInfoQuicknavIterator(metaclass=abc.ABCMeta):
 		self.itemType = itemType
 		self.direction = direction if direction else "next"
 		self.includeCurrent = includeCurrent
-		self.selectedCellInfo = self.document._getSelection().excelCellInfo
+		self.selectedCellInfo = self.document._getActiveCell().excelCellInfo
 
 	@abc.abstractmethod
 	def collectionFromWorksheet(self, worksheetObject):

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -17,6 +17,10 @@
 
 #### Web browsers
 
+#### Applications
+
+* Fixed an issue where formulas and notes were not listed in Excel's elements list when it was opened from a sheet with multiple cells selected. (#20806, @CyrilleB79)
+
 ### Changes for Developers
 
 Please refer to [the developer guide](https://download.nvaccess.org/documentation/developerGuide.html#API) for information on NVDA's API deprecation and removal process.


### PR DESCRIPTION
### Link to issue number:
Closes #20806

### Summary of the issue:
If multiple cells were selected in an Excel sheet and the elements list was opened from it, NVDA could not list formulas or notes in it.

### Description of user facing changes:
NVDA can now list formulas or notes in the elements list, no matter if multiple cells were selected in the sheet the script was called from.
### Description of developer facing changes:
N/A
### Description of development approach:
Retrieved the active cell (`_getActiveCell`) instead of selection (`_getSelection`), since the `excelCellInfo` property is only defined for a single cell, not a range (e.g. selection).

### Testing strategy:
manual test: Tested the elements list in all these cases:
* opening the elements list from a sheet where single cell was selected (normal case) vs. selection covering more than one cell
* listing formulas and notes

### Known issues with pull request:
There are other issues with Excel's element list (e.g. too many formulas/notes). This PR does not fix them.

### Code Review Checklist:


- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
