### PR TITLE
Decide browse mode alt+arrow dispatch from the control fields at the caret

### DIFF
--- a/source/browseMode.py
+++ b/source/browseMode.py
@@ -444,6 +444,15 @@ class BrowseModeTreeInterceptor(treeInterceptorHandler.TreeInterceptor):
 	singleLetterNavEnabled = True  #: Whether single letter navigation scripts should be active (true) or if these letters should fall to the application.
 
 	def getAlternativeScript(self, gesture, script):
+		"""Replace the script bound to a gesture before it is queued for execution.
+
+		This method is called on the input hook thread while the script for a gesture is being resolved.
+
+		:param gesture: The triggering gesture.
+		:param script: The script bound to the gesture, or ``None`` if there is none.
+		:return: The script to queue, which may be the one that was passed in,
+			or ``None`` to pass the gesture on to the application.
+		"""
 		if self.passThrough or not gesture.isCharacter:
 			return script
 		if not self.singleLetterNavEnabled:
@@ -2072,12 +2081,19 @@ class BrowseModeDocumentTreeInterceptor(
 
 		:return: ``True`` to collapse/expand the control, ``False`` to navigate by sentence.
 		"""
-		obj = self.currentFocusableNVDAObject
-		if obj is None or obj == self.rootNVDAObject:
-			return False
-		return obj.role in self.ALWAYS_SWITCH_TO_PASS_THROUGH_ROLES or not obj.states.isdisjoint(
-			self._EXPAND_OR_POPUP_STATES,
-		)
+		info = self.makeTextInfo(textInfos.POSITION_CARET)
+		info.expand(textInfos.UNIT_CHARACTER)
+		for field in reversed(info.getTextWithFields()):
+			if not (isinstance(field, textInfos.FieldCommand) and field.command == "controlStart"):
+				continue
+			states = field.field.get("states") or set()
+			if controlTypes.State.FOCUSABLE not in states:
+				continue
+			role = field.field.get("role")
+			return role in self.ALWAYS_SWITCH_TO_PASS_THROUGH_ROLES or not states.isdisjoint(
+				self._EXPAND_OR_POPUP_STATES,
+			)
+		return False
 
 	def getAlternativeScript(
 		self,

--- a/source/virtualBuffers/gecko_ia2.py
+++ b/source/virtualBuffers/gecko_ia2.py
@@ -346,6 +346,7 @@ class Gecko_ia2(VirtualBuffer):
 		try:
 			pacc = self.rootNVDAObject.IAccessibleObject.accChild(ID)
 		except COMError:
+			log.debug(f"accChild({ID}) failed", exc_info=True)
 			return None
 		return NVDAObjects.IAccessible.IAccessible(
 			windowHandle=docHandle,

--- a/tests/unit/test_browseModeSentenceDispatch.py
+++ b/tests/unit/test_browseModeSentenceDispatch.py
@@ -6,71 +6,150 @@
 """Unit tests for browse mode alt+up/down sentence-vs-collapse/expand dispatch.
 
 Covers ``BrowseModeDocumentTreeInterceptor._isExpandableControlAtCaret``, the discriminator
-that decides whether ``alt+upArrow``/``alt+downArrow`` should collapse/expand a control or
-navigate by sentence, and ``getAlternativeScript``, which swaps the script accordingly.
+that reads the control fields at the caret to decide whether ``alt+upArrow``/``alt+downArrow``
+should collapse/expand a control or navigate by sentence, and ``getAlternativeScript``,
+which swaps the script accordingly.
 """
 
 import unittest
 from types import SimpleNamespace
 
 import browseMode
+import textInfos
 from controlTypes import Role, State
 
-from .objectProvider import NVDAObjectWithRole
+
+class _CaretTextInfo:
+	"""A text info at the caret that yields a fixed field list."""
+
+	def __init__(self, fields: list[textInfos.FieldCommand | str]):
+		self._fields = fields
+		self.expandedUnit: str | None = None
+
+	def expand(self, unit: str) -> None:
+		self.expandedUnit = unit
+
+	def getTextWithFields(self, formatConfig: dict | None = None) -> list[textInfos.FieldCommand | str]:
+		return self._fields
 
 
 class _Interceptor(browseMode.BrowseModeDocumentTreeInterceptor):
-	"""An interceptor carrying only the two objects the discriminator reads.
+	"""An interceptor whose caret text info is the only thing the discriminator reads.
 
 	``super().__init__`` is skipped so that no virtual buffer is constructed.
 	"""
 
-	def __init__(self, focusable: NVDAObjectWithRole | None, root: NVDAObjectWithRole):
-		self.currentFocusableNVDAObject = focusable
-		self.rootNVDAObject = root
+	def __init__(self, fields: list[textInfos.FieldCommand | str]):
+		self._fields = fields
 		self._passThrough = False
+		self.textInfo: _CaretTextInfo | None = None
+
+	def makeTextInfo(self, position) -> _CaretTextInfo:
+		assert position == textInfos.POSITION_CARET
+		self.textInfo = _CaretTextInfo(self._fields)
+		return self.textInfo
 
 
-def _obj(role: Role, *states: State) -> NVDAObjectWithRole:
-	obj = NVDAObjectWithRole(role=role)
-	obj.states = frozenset(states)
-	return obj
+def _control(role: Role, *states: State) -> textInfos.ControlField:
+	return textInfos.ControlField(role=role, states=set(states))
+
+
+_DOCUMENT = _control(Role.DOCUMENT, State.FOCUSABLE, State.FOCUSED, State.READONLY)
+
+
+def _fields(*controls: textInfos.ControlField) -> list[textInfos.FieldCommand | str]:
+	"""Build the field list for one character at the caret, nested in the given controls, outermost first."""
+	return [
+		*(textInfos.FieldCommand("controlStart", control) for control in controls),
+		"x",
+		*(textInfos.FieldCommand("controlEnd", None) for _ in controls),
+	]
 
 
 class TestIsExpandableControlAtCaret(unittest.TestCase):
-	def setUp(self):
-		self.root = _obj(Role.DOCUMENT)
+	def test_expandsToCharacter(self):
+		interceptor = _Interceptor(_fields(_DOCUMENT))
+		interceptor._isExpandableControlAtCaret()
+		self.assertEqual(interceptor.textInfo.expandedUnit, textInfos.UNIT_CHARACTER)
 
 	def test_dispatch(self):
 		cases = (
-			("plain content, focusable is the root", self.root, False),
-			("no focusable object", None, False),
-			("combo box", _obj(Role.COMBOBOX), True),
-			("slider", _obj(Role.SLIDER), True),
-			("button offering autocompletion", _obj(Role.BUTTON, State.AUTOCOMPLETE), True),
-			("collapsed button", _obj(Role.BUTTON, State.COLLAPSED), True),
-			("expanded button", _obj(Role.BUTTON, State.EXPANDED), True),
-			("button with a popup", _obj(Role.BUTTON, State.HASPOPUP), True),
-			("button opening a list", _obj(Role.BUTTON, State.HASPOPUP_LIST), True),
-			("button opening a dialog", _obj(Role.BUTTON, State.HASPOPUP_DIALOG), True),
-			("button opening a grid", _obj(Role.BUTTON, State.HASPOPUP_GRID), True),
-			("button opening a tree", _obj(Role.BUTTON, State.HASPOPUP_TREE), True),
-			("plain link", _obj(Role.LINK), False),
-			("plain button", _obj(Role.BUTTON), False),
+			("plain content in the document", _fields(_DOCUMENT), False),
+			("plain content in a section", _fields(_DOCUMENT, _control(Role.SECTION)), False),
+			("no focusable control at all", _fields(_control(Role.SECTION)), False),
+			("combo box", _fields(_DOCUMENT, _control(Role.COMBOBOX, State.FOCUSABLE)), True),
+			("combo box that is not focusable", _fields(_DOCUMENT, _control(Role.COMBOBOX)), False),
+			("slider", _fields(_DOCUMENT, _control(Role.SLIDER, State.FOCUSABLE)), True),
+			(
+				"button offering autocompletion",
+				_fields(_DOCUMENT, _control(Role.BUTTON, State.FOCUSABLE, State.AUTOCOMPLETE)),
+				True,
+			),
+			(
+				"collapsed button",
+				_fields(_DOCUMENT, _control(Role.BUTTON, State.FOCUSABLE, State.COLLAPSED)),
+				True,
+			),
+			(
+				"expanded button",
+				_fields(_DOCUMENT, _control(Role.BUTTON, State.FOCUSABLE, State.EXPANDED)),
+				True,
+			),
+			(
+				"button with a popup",
+				_fields(_DOCUMENT, _control(Role.BUTTON, State.FOCUSABLE, State.HASPOPUP)),
+				True,
+			),
+			(
+				"button opening a list",
+				_fields(_DOCUMENT, _control(Role.BUTTON, State.FOCUSABLE, State.HASPOPUP_LIST)),
+				True,
+			),
+			(
+				"button opening a dialog",
+				_fields(_DOCUMENT, _control(Role.BUTTON, State.FOCUSABLE, State.HASPOPUP_DIALOG)),
+				True,
+			),
+			(
+				"button opening a grid",
+				_fields(_DOCUMENT, _control(Role.BUTTON, State.FOCUSABLE, State.HASPOPUP_GRID)),
+				True,
+			),
+			(
+				"button opening a tree",
+				_fields(_DOCUMENT, _control(Role.BUTTON, State.FOCUSABLE, State.HASPOPUP_TREE)),
+				True,
+			),
+			("plain link", _fields(_DOCUMENT, _control(Role.LINK, State.FOCUSABLE)), False),
+			("plain button", _fields(_DOCUMENT, _control(Role.BUTTON, State.FOCUSABLE)), False),
+			(
+				"combo box inside a link",
+				_fields(
+					_DOCUMENT,
+					_control(Role.LINK, State.FOCUSABLE),
+					_control(Role.COMBOBOX, State.FOCUSABLE),
+				),
+				True,
+			),
+			(
+				"span inside a link",
+				_fields(_DOCUMENT, _control(Role.LINK, State.FOCUSABLE), _control(Role.SECTION)),
+				False,
+			),
 		)
-		for description, focusable, expected in cases:
+		for description, fields, expected in cases:
 			with self.subTest(description):
-				interceptor = _Interceptor(focusable, self.root)
+				interceptor = _Interceptor(fields)
 				self.assertEqual(interceptor._isExpandableControlAtCaret(), expected)
 
 
 class TestGetAlternativeScript(unittest.TestCase):
 	def setUp(self):
-		self.root = _obj(Role.DOCUMENT)
 		self.gesture = SimpleNamespace(isCharacter=False)
+		self.comboBoxFields = _fields(_DOCUMENT, _control(Role.COMBOBOX, State.FOCUSABLE))
 
 	def test_expandableControl_swapsToCollapseOrExpand(self):
-		interceptor = _Interceptor(_obj(Role.COMBOBOX), self.root)
+		interceptor = _Interceptor(self.comboBoxFields)
 		for script in (
 			interceptor.script_moveBySentence_back,
 			interceptor.script_moveBySentence_forward,
@@ -82,11 +161,11 @@ class TestGetAlternativeScript(unittest.TestCase):
 				)
 
 	def test_plainContent_keepsSentenceScript(self):
-		interceptor = _Interceptor(self.root, self.root)
+		interceptor = _Interceptor(_fields(_DOCUMENT))
 		script = interceptor.script_moveBySentence_forward
 		self.assertEqual(interceptor.getAlternativeScript(self.gesture, script), script)
 
 	def test_otherScript_isUntouched(self):
-		interceptor = _Interceptor(_obj(Role.COMBOBOX), self.root)
+		interceptor = _Interceptor(self.comboBoxFields)
 		script = interceptor.script_collapseOrExpandControl
 		self.assertEqual(interceptor.getAlternativeScript(self.gesture, script), script)


### PR DESCRIPTION
### Link to issue number:

Fixup for #20751.

### Summary of the issue:

#20751 introduced sentence navigation in browse mode, unless a control is selected that supports collapsing/expanding, such as a combo box.
The expandable query is performed on the NVDAObject, however it runs in the `getAlternativeScript` function, which executes in the thread of the input hook. In browsers like Firefox, the lookup makes a COM call on an interface that belongs to the main thread. When that call fails, NVDA silently uses sentence navigation unexpectedly.

### Description of user facing changes:

In browse mode, `alt+upArrow` and `alt+downArrow` now collapse or expand combo boxes in more situations. Plain text still moves by sentence.

### Description of developer facing changes:

`BrowseModeDocumentTreeInterceptor._isExpandableControlAtCaret` now reads the control fields at the caret. It no longer uses `currentFocusableNVDAObject`.

Since the initial issue could occur silently (without any indication in the log), `Gecko_ia2.getNVDAObjectFromIdentifier` now logs a failed `accChild` call at debug level with the HRESULT.

### Description of development approach:

NVDA resolves which script a key belongs to inside the Windows low-level keyboard hook. That hook runs on its own thread and must return synchronously whether NVDA swallows the key. The tree interceptor's `getAlternativeScript` is part of that resolution, so it runs on the hook thread too. Only the chosen script is queued to the main thread.

The decision in #20751 created an NVDAObject for the control at the caret. For virtual buffers that ends in an `accChild` COM call on an interface that belongs to the main thread. On the hook thread that call fails with `RPC_E_WRONG_THREAD` (0x8001010E). The `except COMError` in `getNVDAObjectFromIdentifier` returned `None` without logging. The helper treated `None` as "no control" and chose sentence navigation.

The fix reads the same information from the control fields instead. The helper takes the caret text info, expands it to one character, and walks the `controlStart` fields from the innermost outward. The first field with the FOCUSABLE state is the control that `_focusLastFocusableObject` will focus. Its role and states are tested against the same roles and states as in #20751.

The docstring on `getAlternativeScript` records the thread constraint so that it is clear that no thread bound work should happen there.

### Testing strategy:

- Unit tests
- Manual testing in Firefox on a page with a native `select`

### Known issues with pull request:

None.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
