### PR TITLE
Bundle winrt.windows.foundation.collections in frozen builds

### DIFF
--- a/source/setup.py
+++ b/source/setup.py
@@ -331,6 +331,10 @@ freeze(
 			"mdx_truly_sane_lists",
 			"mdx_gh_links",
 			"pymdownx",
+			# The compiled winrt projection modules import this at C level, where
+			# modulefinder cannot see it, so bleak raises ModuleNotFoundError as soon as
+			# a Bluetooth Low Energy device is discovered.
+			"winrt.windows.foundation.collections",
 		],
 		"includes": [
 			"nvdaBuiltin",


### PR DESCRIPTION
### Link to issue number:
Fixes #20808

### Summary of the issue:
In frozen builds, `winrt.windows.foundation.collections` is missing from `library.zip`, and `winrt._winrt_windows_foundation_collections.pyd` is absent from the distribution root. As soon as bleak discovers a Bluetooth Low Energy device, it fails with:

```
ModuleNotFoundError: No module named 'winrt.windows.foundation.collections'
```

This makes BLE device discovery unusable in released builds, including 2026.3 beta 1. It does not reproduce when running from source, where the package is importable from the virtual environment.

The other winrt projections bleak needs (`winrt.windows.foundation`, `winrt.windows.devices.bluetooth` and friends, `winrt.windows.storage.streams`) are all bundled correctly; this is the only one missing.

### Description of user facing changes:
Bluetooth Low Energy device discovery works in frozen builds, so BLE braille displays can be detected and connected.

### Description of developer facing changes:
None.

### Description of development approach:
`winrt.windows.foundation.collections` is never imported from Python source. The only importers are the compiled winrt projection modules, which import it at C level when they are initialised, so py2exe's `modulefinder` never sees a reference to it and leaves it out of the bundle.

The package is therefore listed explicitly in the `packages` option, alongside the other packages that have to be bundled because they are not reachable by static analysis. Its `__init__` imports `winrt._winrt_windows_foundation_collections`, so py2exe picks up the extension module from there; the package has no subpackages, so the py2exe issue 113 caveat noted above the list does not apply.

### Testing strategy:
Built `scons dist` on this branch and confirmed the distribution now contains both parts that were missing:

* `library.zip` contains `winrt/windows/foundation/collections/__init__.pyc`
* the distribution root contains `winrt._winrt_windows_foundation_collections.pyd`

For comparison, neither is present in the released 2026.3 beta 1 installation.

### Known issues with pull request:
None.

### Code Review Checklist:
- [x] Documentation:
  - Change log entry: not added. `hwIo.ble` and the bundled bleak are announced in the same unreleased `2026.3` section of `changes.md` that this would appear in, so relative to 2026.2 there is no user visible change to describe: the feature simply works as documented. Happy to add one if you would rather have it.
  - User Documentation: not applicable.
  - Developer / Technical Documentation: not applicable.
  - Context sensitive help for GUI changes: not applicable.
- [x] Testing:
  - Unit tests: not applicable; the packaging list cannot be exercised by the unit test suite.
  - System (end to end) tests: not applicable.
  - Manual testing: `scons dist` build inspected as described above.
- [x] UX of all users considered:
  - Speech, Braille, Low Vision, Different web browsers, Localization: no user interface changes; the effect is that BLE braille displays work in frozen builds.
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
