### PR TITLE
UIA: stop treating Muse framework non-text controls as editable text

### DIFF
--- a/source/NVDAObjects/UIA/__init__.py
+++ b/source/NVDAObjects/UIA/__init__.py
@@ -1490,6 +1490,11 @@ class UIA(Window):
 				clsList.append(WpfTextView)
 			clsList.append(EditableTextWithAutoSelectDetection)
 
+		if self.UIAElement.cachedFrameworkID == "Qt":
+			from . import qt
+
+			qt.findExtraOverlayClasses(self, clsList)
+
 		clsList.append(UIA)
 
 		if self.UIAIsWindowElement:

--- a/source/NVDAObjects/UIA/qt.py
+++ b/source/NVDAObjects/UIA/qt.py
@@ -1,0 +1,35 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2026 NV Access Limited, Leonard de Ruijter
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
+
+"""Overlay classes for Qt applications exposing UI Automation."""
+
+import controlTypes
+
+from NVDAObjects import NVDAObject
+from NVDAObjects.behaviors import EditableTextWithAutoSelectDetection
+
+from . import UIA
+
+MUSE_ACCESSIBLE_OBJECT_CLASS_NAME = "muse::accessibility::AccessibleObject"
+
+
+class MuseAccessibilityObjectWithNoopTextPattern(UIA):
+	"""A Muse framework control other than a text field that exposes a no-op UIA text pattern."""
+
+	def initOverlayClass(self):
+		self.UIATextPattern = None
+
+
+def findExtraOverlayClasses(obj: NVDAObject, clsList: list[type[NVDAObject]]) -> None:
+	if (
+		obj.UIAElement.cachedClassName == MUSE_ACCESSIBLE_OBJECT_CLASS_NAME
+		and obj.role != controlTypes.Role.EDITABLETEXT
+		and obj.UIATextPattern
+	):
+		try:
+			clsList.remove(EditableTextWithAutoSelectDetection)
+		except ValueError:
+			pass
+		clsList.insert(0, MuseAccessibilityObjectWithNoopTextPattern)

--- a/tests/unit/test_NVDAObjects_UIA.py
+++ b/tests/unit/test_NVDAObjects_UIA.py
@@ -1,5 +1,5 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2026 NV Access Limited, Cary-rowen
+# Copyright (C) 2026 NV Access Limited, Cary-rowen, Leonard de Ruijter
 # This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
 # For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
 
@@ -12,6 +12,8 @@ import api
 import controlTypes
 import eventHandler
 from NVDAObjects.UIA import ListItem, MenuItem, UIA, _NetFrameworkWinFormsComboBox
+from NVDAObjects.UIA import qt
+from NVDAObjects.behaviors import EditableTextWithAutoSelectDetection
 import oleacc
 import UIAHandler
 from winBindings import user32
@@ -202,3 +204,39 @@ class TestNetFrameworkWinFormsComboBox(unittest.TestCase):
 		):
 			listItem.event_UIA_elementSelected()
 		focus.event_valueChange.assert_not_called()
+
+
+class TestMuseFindExtraOverlayClasses(unittest.TestCase):
+	def _makeObj(self, role: controlTypes.Role, className: str, textPattern: object) -> UIA:
+		obj = object.__new__(UIA)
+		obj.UIAElement = Mock(cachedFrameworkID="Qt", cachedClassName=className)
+		obj.role = role
+		obj.UIATextPattern = textPattern
+		return obj
+
+	def test_nonEditableMuseControlLosesEditableTextAndTextPattern(self) -> None:
+		obj = self._makeObj(controlTypes.Role.BUTTON, qt.MUSE_ACCESSIBLE_OBJECT_CLASS_NAME, Mock())
+		clsList = [EditableTextWithAutoSelectDetection, UIA]
+		qt.findExtraOverlayClasses(obj, clsList)
+		self.assertEqual(clsList, [qt.MuseAccessibilityObjectWithNoopTextPattern, UIA])
+		obj.__class__ = qt.MuseAccessibilityObjectWithNoopTextPattern
+		obj.initOverlayClass()
+		self.assertIsNone(obj.UIATextPattern)
+
+	def test_editableMuseControlIsUnchanged(self) -> None:
+		obj = self._makeObj(controlTypes.Role.EDITABLETEXT, qt.MUSE_ACCESSIBLE_OBJECT_CLASS_NAME, Mock())
+		clsList = [EditableTextWithAutoSelectDetection, UIA]
+		qt.findExtraOverlayClasses(obj, clsList)
+		self.assertEqual(clsList, [EditableTextWithAutoSelectDetection, UIA])
+
+	def test_museControlWithoutTextPatternIsUnchanged(self) -> None:
+		obj = self._makeObj(controlTypes.Role.BUTTON, qt.MUSE_ACCESSIBLE_OBJECT_CLASS_NAME, None)
+		clsList = [UIA]
+		qt.findExtraOverlayClasses(obj, clsList)
+		self.assertEqual(clsList, [UIA])
+
+	def test_nonMuseQtControlIsUnchanged(self) -> None:
+		obj = self._makeObj(controlTypes.Role.BUTTON, "QWidgetWindow", Mock())
+		clsList = [EditableTextWithAutoSelectDetection, UIA]
+		qt.findExtraOverlayClasses(obj, clsList)
+		self.assertEqual(clsList, [EditableTextWithAutoSelectDetection, UIA])

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -20,6 +20,7 @@
 #### Applications
 
 * Fixed an issue where formulas and notes were not listed in Excel's elements list when it was opened from a sheet with multiple cells selected. (#20806, @CyrilleB79)
+* In applications built on the Muse framework, such as MuseScore Studio and Audacity 4, controls that are not text fields are no longer treated as editable text, so arrow keys no longer report "blank". (#20791, @LeonarddeR)
 
 ### Changes for Developers
 


### PR DESCRIPTION
### Link to issue number:
Fixes #20791.

### Summary of the issue:

Applications built on the Muse framework, such as MuseScore Studio and Audacity 4, expose the UI Automation Text pattern on every control. 
NVDA treats any control with a Text pattern as a text container and adds its editable text behaviour when the pattern supports selection.
Those controls then behave like empty edit fields: arrow keys report "blank", text review has nothing to review, etc.

### Description of user facing changes:

In MuseScore Studio and Audacity 4, controls that are not text fields are no longer treated as editable text.

### Description of developer facing changes:

New module `NVDAObjects.UIA.qt` with an overlay class `MuseAccessibilityObjectWithNoopTextPattern`.

### Description of development approach:

The overlay is applied to a Muse element that exposes a Text pattern and whose role is not editable text. For such an element, `EditableTextWithAutoSelectDetection` is removed from the class list. The overlay class then clears the stored Text pattern in `initOverlayClass`, which runs on the finished object. From then on `TextInfo`, braille and review see no Text pattern. Elements without a Text pattern are left alone, so the overlay disappears by itself once the framework stops exposing the pattern.

Muse elements are recognised by their UIA class name, `muse::accessibility::AccessibleObject`, which the framework reports for every item it exposes. Editable text is recognised by role.

### Testing strategy:

Manual testing with NVDA from source in MuseScore Studio:

Tab to the Cancel button in the New Score dialog and press Left arrow: nothing is reported. In the Python console the focus object no longer has `EditableTextWithAutoSelectDetection` in its class hierarchy and its `UIATextPattern` is `None`.

### Known issues with pull request:
This is a workaround for shipped Muse builds. The upstream fix suggested in musescore/muse_framework#284 limits the text interface to editable text on the framework side. Once that ships, this module still works but is no longer needed.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.


