### PR TITLE
Update cppjieba to v5.6.7 to fix startup crashes from Chinese paths

### DIFF
--- a/projectDocs/dev/createDevEnvironment.md
+++ b/projectDocs/dev/createDevEnvironment.md
@@ -97,7 +97,7 @@ If you aren't sure, run `git submodule update` after every git pull, merge or ch
 * [Nullsoft Install System](https://nsis.sourceforge.io), version 3.11
 * [Java Access Bridge 64 bit, from Zulu Community OpenJDK build 17.0.16+8 Zulu (17.60.17)](https://github.com/nvaccess/javaAccessBridge32-bin)
 * [Windows Implementation Library (WIL)](https://github.com/microsoft/wil/), commit `7cf41936c5b4ab79daf0d9437211380dc69fa958`
-* [cppjieba - Chinese word segmentation](https://github.com/yanyiwu/cppjieba), commit `f7f8199dfad026d84f2862193c7d747db4416293`
+* [cppjieba - Chinese word segmentation](https://github.com/yanyiwu/cppjieba), commit `b3602bef7d1f67521a61788a74fb5801a0e62cd3`
 
 #### Build time dependencies
 

--- a/projectDocs/dev/createDevEnvironment.md
+++ b/projectDocs/dev/createDevEnvironment.md
@@ -97,7 +97,7 @@ If you aren't sure, run `git submodule update` after every git pull, merge or ch
 * [Nullsoft Install System](https://nsis.sourceforge.io), version 3.11
 * [Java Access Bridge 64 bit, from Zulu Community OpenJDK build 17.0.16+8 Zulu (17.60.17)](https://github.com/nvaccess/javaAccessBridge32-bin)
 * [Windows Implementation Library (WIL)](https://github.com/microsoft/wil/), commit `7cf41936c5b4ab79daf0d9437211380dc69fa958`
-* [cppjieba - Chinese word segmentation](https://github.com/yanyiwu/cppjieba), commit `9408c1d08facc6e324dc90260e8cb20ecceebf70`
+* [cppjieba - Chinese word segmentation](https://github.com/yanyiwu/cppjieba), commit `f7f8199dfad026d84f2862193c7d747db4416293`
 
 #### Build time dependencies
 


### PR DESCRIPTION
### Link to issue number:

Fixes #20826.

### Summary of the issue:

NVDA can crash during startup when its portable directory contains Chinese characters and Chinese word segmentation is initialized.

NVDA passes dictionary paths as UTF-8, but the bundled cppjieba revision opens them using narrow-character file operations. On systems using an incompatible Windows ANSI code page, the dictionary cannot be opened, causing cppjieba to call `abort()` and terminate NVDA.

### Description of user facing changes:

Portable copies of NVDA can start normally from directories containing Chinese characters when Chinese word segmentation is enabled.

### Description of developer facing changes:

Update the cppjieba submodule to v5.6.7 and the corresponding dependency revision in the developer documentation.
- [cppjieba changes](https://github.com/yanyiwu/cppjieba/compare/9408c1d08facc6e324dc90260e8cb20ecceebf70...v5.6.7?w=1): All commits and file changes from NVDA’s previous revision to v5.6.7.
- [limonp changes](https://github.com/yanyiwu/limonp/compare/5c82a3f17e4e0adc6a5decfe245054b0ed533d1a...v1.0.2): Changes to cppjieba’s limonp dependency.
- [cppjieba release notes](https://github.com/yanyiwu/cppjieba/releases): Release notes for cppjieba versions.

### Description of development approach:

Use the upstream Windows Unicode path fix from [cppjieba PR #218](https://github.com/yanyiwu/cppjieba/pull/218), first released in v5.6.4 and included in v5.6.7. This converts UTF-8 paths to wide-character paths before opening resource files on Windows.

This PR targets `beta` because Chinese word segmentation was introduced in NVDA 2026.3, and the release policy allows fixes for bugs introduced in the current release cycle.

### Testing strategy:


Manual verification steps for the final portable build:

1. Place the portable copy in `D:\nvdaPortable`.
2. Set NVDA's interface language to Simplified Chinese, then exit NVDA.
3. Copy the portable directory to `D:\nvda九月`, preserving its configuration.
4. Start `D:\nvda九月\nvda.exe` and confirm that NVDA starts without crashing.
5. Exit NVDA and confirm that the copy in `D:\nvdaPortable` also starts normally.

Full manual startup verification of the final v5.6.7 build is pending.

### Known issues with pull request:

None known.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [ ] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [ ] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [ ] API is compatible with existing add-ons.
- [ ] Security precautions taken.
