### PR TITLE
Don't send CharacterModeCommand when unsupported by the synthesizer

### DIFF
--- a/source/mathPres/MathCAT/speech.py
+++ b/source/mathPres/MathCAT/speech.py
@@ -68,8 +68,7 @@ def convertSSMLTextForNVDA(text: str) -> list[str | SpeechCommand]:
 	useBreak: bool = BreakCommand in supportedCommands
 	usePitch: bool = PitchCommand in supportedCommands
 	usePhoneme: bool = PhonemeCommand in supportedCommands
-	# as of 7/23, oneCore voices do not implement the CharacterModeCommand despite it being in supported_commands
-	useCharacter: bool = CharacterModeCommand in supportedCommands and synth.name != "oneCore"
+	useCharacter: bool = CharacterModeCommand in supportedCommands
 	out: list[str | SpeechCommand] = []
 	if language != nvdaLanguage:
 		out.append(LangChangeCommand(language))

--- a/source/speech/shortcutKeys.py
+++ b/source/speech/shortcutKeys.py
@@ -1,7 +1,7 @@
 # A part of NonVisual Desktop Access (NVDA)
-# This file is covered by the GNU General Public License.
-# See the file COPYING for more details.
-# Copyright (C) 2023 NV Access Limited, Cyrille Bougot
+# Copyright (C) 2023-2026 NV Access Limited, Cyrille Bougot
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
 
 """Functions to create speech sequences for shortcut keys."""
 
@@ -77,7 +77,10 @@ def _getKeyboardShortcutSpeech(keyboardShortcut: str) -> SpeechSequence:
 
 def shouldUseSpellingFunctionality() -> bool:
 	synth = getSynth()
-	return config.conf["speech"][synth.name]["useSpellingFunctionality"]
+	return (
+		CharacterModeCommand in synth.supportedCommands
+		and config.conf["speech"][synth.name]["useSpellingFunctionality"]
+	)
 
 
 def _getKeySpeech(key: str) -> SpeechSequence:

--- a/source/speech/speech.py
+++ b/source/speech/speech.py
@@ -1,8 +1,8 @@
 # A part of NonVisual Desktop Access (NVDA)
-# This file is covered by the GNU General Public License.
-# See the file COPYING for more details.
-# Copyright (C) 2006-2025 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Babbage B.V., Bill Dengler,
+# Copyright (C) 2006-2026 NV Access Limited, Peter Vágner, Aleksey Sadovoy, Babbage B.V., Bill Dengler,
 # Julien Cochuyt, Derek Riemer, Cyrille Bougot, Leonard de Ruijter, Łukasz Golonka, Cary-rowen
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
 
 """High-level functions to speak information."""
 
@@ -603,11 +603,13 @@ def getSpellingSpeech(
 ) -> Generator[SequenceItemT]:
 	"""
 	Gets a speech sequence for spelling text.
+
 	:param text: The text to be spelled.
 	:param locale: The locale to use for character descriptions, if applicable.
 	:param useCharacterDescriptions: Whether or not to use character descriptions, e.g. speak "a" as "alpha".
 	:param endsUtterance: Whether an EndUtteranceCommand should be yielded at the end.
-	:param useCharMode: Whether to wrap the sequence in CharacterModeCommand.
+	:param useCharMode: Whether to wrap the sequence in CharacterModeCommand,
+		if supported by the synthesizer and enabled by the user.
 	:returns: A speech sequence generator.
 	"""
 	synth = getSynth()
@@ -633,7 +635,11 @@ def getSpellingSpeech(
 		],
 		endsUtterance=endsUtterance,
 	)
-	if useCharMode and synthConfig["useSpellingFunctionality"]:
+	if (
+		useCharMode
+		and CharacterModeCommand in synth.supportedCommands
+		and synthConfig["useSpellingFunctionality"]
+	):
 		seq = _getSpellingSpeechAddCharMode(seq)
 	# This function applies Unicode normalization as appropriate.
 	# Therefore, suppress the global normalization that might still occur

--- a/source/synthDrivers/oneCore.py
+++ b/source/synthDrivers/oneCore.py
@@ -1,7 +1,7 @@
 # A part of NonVisual Desktop Access (NVDA)
-# Copyright (C) 2016-2025 Tyler Spivey, NV Access Limited, James Teh, Leonard de Ruijter
-# This file is covered by the GNU General Public License.
-# See the file COPYING for more details.
+# Copyright (C) 2016-2026 Tyler Spivey, NV Access Limited, James Teh, Leonard de Ruijter
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
 
 """Synth driver for Windows OneCore voices."""
 
@@ -36,7 +36,6 @@ import NVDAHelper
 
 from speech.commands import (
 	IndexCommand,
-	CharacterModeCommand,
 	LangChangeCommand,
 	BreakCommand,
 	PitchCommand,
@@ -176,7 +175,6 @@ class OneCoreSynthDriver(SynthDriver):
 	description = _("Windows OneCore voices")
 	supportedCommands = {  # noqa: RUF012
 		IndexCommand,
-		CharacterModeCommand,
 		LangChangeCommand,
 		BreakCommand,
 		PitchCommand,

--- a/tests/system/robot/startupShutdownNVDA.py
+++ b/tests/system/robot/startupShutdownNVDA.py
@@ -82,7 +82,7 @@ def quits_from_menu(showExitDialog=True):
 			"\n".join(  # noqa: FLY002
 				[
 					"Exit NVDA  dialog",
-					"What would you like to do?  combo box  Exit  collapsed  Alt plus  d",
+					"What would you like to do?  combo box  Exit  collapsed  Alt plus d",
 				],
 			),
 		)
@@ -113,7 +113,7 @@ def quits_from_keyboard():
 		"\n".join(  # noqa: FLY002
 			[
 				"Exit NVDA  dialog",
-				"What would you like to do?  combo box  Exit  collapsed  Alt plus  d",
+				"What would you like to do?  combo box  Exit  collapsed  Alt plus d",
 			],
 		),
 	)
@@ -171,7 +171,7 @@ def read_welcome_dialog():
 					"NVDA, get help, and access other NVDA functions."
 				),
 				"Options  grouping",
-				"Keyboard layout:  combo box  desktop  collapsed  Alt plus  k",
+				"Keyboard layout:  combo box  desktop  collapsed  Alt plus k",
 			],
 		),
 	)

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -11,6 +11,8 @@
 
 ### Bug Fixes
 
+* When using Windows OneCore voices, numbers in keyboard shortcuts are no longer run together with numbers immediately following them, such as a menu item's position in its menu. (#20828)
+
 #### Performance
 
 #### Braille
@@ -23,6 +25,7 @@ Please refer to [the developer guide](https://download.nvaccess.org/documentatio
 
 * Note: this is an Add-on API compatibility breaking release.
 Add-ons will need to be re-tested and have their manifest updated.
+* `speech.speech.getSpellingSpeech` and `speech.shortcutKeys.shouldUseSpellingFunctionality` now only use spelling functionality if the active synthesizer declares support for `CharacterModeCommand` in its `supportedCommands`. (#20831)
 
 #### API Breaking Changes
 


### PR DESCRIPTION
### Link to issue number:

Fixes #20828

### Summary of the issue:

When using Windows OneCore voices, a keyboard shortcut ending in a digit is run together with the number spoken after it. In the example from the issue, a check menu item with `aria-keyshortcuts="control+1"` is announced as "Action two not checked control plus twelve of four", rather than "Action two not checked control plus one two of four".

`OneCoreSynthDriver` declares `CharacterModeCommand` in its `supportedCommands`, but `_OcSsmlConverter.convertCharacterModeCommand` deliberately returns `None`, because "OneCore's character speech sounds weird and doesn't support pitch alteration". The command was therefore discarded, and since `XmlBalancer` concatenates adjacent text items, the shortcut's trailing digit ran directly into the position information that followed it.

This false declaration was already noted elsewhere in core, with MathCAT special-casing the synthesizer by name when deciding whether to emit character mode commands, noting "as of 7/23, oneCore voices do not implement the CharacterModeCommand despite it being in supportedCommands".

### Description of user facing changes:

NVDA no longer uses spelling functionality with synthesizers which do not support it, such as Windows OneCore voices.
When using OneCore voices, single character keys in keyboard shortcuts are now spoken as ordinary text, so a digit in a shortcut is no longer run together with a number spoken after it.

### Description of developer facing changes:

* `CharacterModeCommand` has been removed from `OneCoreSynthDriver.supportedCommands`, as the driver does not implement it.
* `speech.speech.getSpellingSpeech` and `speech.shortcutKeys.shouldUseSpellingFunctionality` now only use spelling functionality if the active synthesizer declares support for `CharacterModeCommand` in its `supportedCommands`.
* Code which special cased the OneCore synthesizer when deciding whether to send a `CharacterModeCommand` can now rely on `supportedCommands` instead; the special case in MathCAT's SSML conversion has been removed accordingly.

### Description of development approach:

Removed `CharacterModeCommand` from `OneCoreSynthDriver.supportedCommands`, rather than removing the override which stops `_OcSsmlConverter` from supporting the command.

Updated `speech.speech.getSpellingSpeech` and `shortcutKeys.shouldUseSpellingFunctionality` to check whether the current synth supports the `CharacterModeCommand`, as well as the state of the `useSpellingFunctionality` configuration option. This means that the config option acts as a user preference on top of synthesizer capability, matching the "if supported" wording of its label in the Speech settings panel.

With the driver's declaration now accurate, MathCAT's `synth.name != "oneCore"` check is redundant and has been removed, so add-ons and math presentation providers no longer need to special case individual drivers.

### Testing strategy:

* Manual testing with Windows OneCore voices, using the CodePen from the issue: navigated the "Actions" menu button and confirmed each item's shortcut and position are now announced separately, e.g. "control+1  2 of 4".
* Manual testing with eSpeak NG (which does support `CharacterModeCommand`) to confirm spelling functionality is unchanged: reviewed characters with `numpad2` / `leftArrow` / `rightArrow`, spelled the current line with `NVDA+upArrow` twice, and checked that "a" and other single character keys are still spoken in character mode.
* Manual testing with "Use spelling functionality if supported" both enabled and disabled, to confirm the option still takes effect for synthesizers which support character mode.
* Manual testing of math content with MathCAT under both OneCore and eSpeak NG, to confirm the removed special case has not changed OneCore math speech.

### Known issues with pull request:

* The "Use spelling functionality if supported" checkbox in the Speech settings panel is still shown and settable for synthesizers which do not support `CharacterModeCommand`, where it now has no effect.
* Add-on synthesizer drivers which declare `CharacterModeCommand` without implementing it will continue to behave as before; the capability check can only be as accurate as each driver's declaration.
* OneCore does actually support the SSML `<speak-as>` tag with the `interpret-as` attribute set to `characters`, so declaring that it doesn't support spelling functionality is technically incorrect. While its character mode does sound odd when it's all that an utterance contains, that's not really something we can fix, but refusing to send it such SSML means that users cannot decide if the benefits outweigh the drawbacks for them. If that is the approach we want to take, #8237 and #13596 should be closed as not planned, and #15301 will never get better for OneCore voices. If, on the other hand, we want to go with the in my opinion much more defensible position of allowing the OneCore driver to use character mode, I think that the bulk of the changes in this PR should still be kept, and I can change the OneCore driver to send `<speak-as interpret-as="characters">` where appropriate.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
