### PR TITLE
Lazy load bleak and BLE initialisation

### DIFF
--- a/source/hwIo/__init__.py
+++ b/source/hwIo/__init__.py
@@ -29,11 +29,13 @@ def initialize():
 	bgThread = IoThread()
 	bgThread.start()
 	from . import ble
+
 	ble.initialize()
 
 
 def terminate():
 	from . import ble
+
 	ble.terminate()
 	global bgThread
 	bgThread.stop()

--- a/source/hwIo/__init__.py
+++ b/source/hwIo/__init__.py
@@ -1,7 +1,7 @@
 # A part of NonVisual Desktop Access (NVDA)
-# This file is covered by the GNU General Public License.
-# See the file COPYING for more details.
-# Copyright (C) 2015-2021 NV Access Limited, Babbage B.V.
+# Copyright (C) 2015-2026 NV Access Limited, Babbage B.V.
+# This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
+# For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
 
 
 """Raw input/output for braille displays via serial and HID.
@@ -20,7 +20,6 @@ from .base import (  # noqa: F401, I001
 )
 from .hid import Hid  # noqa: F401
 from .ioThread import IoThread
-from . import ble
 
 bgThread: IoThread
 
@@ -29,10 +28,12 @@ def initialize():
 	global bgThread
 	bgThread = IoThread()
 	bgThread.start()
+	from . import ble
 	ble.initialize()
 
 
 def terminate():
+	from . import ble
 	ble.terminate()
 	global bgThread
 	bgThread.stop()

--- a/source/hwIo/ble/__init__.py
+++ b/source/hwIo/ble/__init__.py
@@ -12,29 +12,36 @@ Only use this if you need access to a device that only implements BLE and not Bl
 Bluetooth Classic devices should be paired through Windows' Bluetooth settings and accessed through the related serial/HID device.
 """
 
-import time  # noqa: I001
-from bleak.exc import BleakError
-from bleak.backends.device import BLEDevice
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING
+
 from logHandler import log
 
-from ._scanner import Scanner
-from ._io import Ble
 from ..base import requiresBackgroundThread
+from ._io import Ble
+from ._scanner import Scanner
+
+if TYPE_CHECKING:
+	from bleak.backends.device import BLEDevice
 
 __all__ = ["Ble", "Scanner", "findDeviceByAddress", "scanner"]
 
 #: Module-level singleton scanner shared by all BLE consumers.
 #: Using a single scanner avoids contention over the Windows BLE stack and
 #: lets multiple callers share the set of already-discovered devices.
-#: None until initialize() is called.
+#: None until a BLE device lookup is first attempted.
 scanner: Scanner | None = None
 
 
 def initialize() -> None:
-	"""Initialize the hwIo.ble module, creating the shared BLE scanner singleton."""
+	"""Initialize the hwIo.ble module.
+
+	The BLE scanner singleton is created lazily on first use to avoid
+	importing the heavy bleak library at startup when no BLE device is connected.
+	"""
 	log.debug("Initializing BLE I/O")
-	global scanner
-	scanner = Scanner()
 
 
 def terminate() -> None:
@@ -45,6 +52,14 @@ def terminate() -> None:
 		if scanner.isScanning:
 			scanner.stop()
 		scanner = None
+
+
+def _ensureScanner() -> Scanner:
+	"""Return the shared scanner, creating it on first call."""
+	global scanner
+	if scanner is None:
+		scanner = Scanner()
+	return scanner
 
 
 @requiresBackgroundThread
@@ -58,20 +73,22 @@ def findDeviceByAddress(address: str, timeout: float = 5.0, pollInterval: float 
 	:param pollInterval: How often to check results in seconds (default 0.1)
 	:return: The BLE device object if found, None otherwise
 	"""
-	if scanner is None:
-		raise RuntimeError("hwIo.ble.initialize() must be called before using findDeviceByAddress")
+	_scanner = _ensureScanner()
 	log.debug(f"Searching for BLE device with address {address}")
 
 	# Check if device already discovered
-	for device in scanner.results():
+	for device in _scanner.results():
 		if device.address == address:
 			log.debug(f"Found BLE device {address} in existing results")
 			return device
 
 	# Not found - start scanning if not already running
-	if not scanner.isScanning:
+	if not _scanner.isScanning:
+		# Delayed import of bleak to avoid importing it at NVDA startup,
+		# slowing down the startup time when no BLE device is connected.
+		from bleak.exc import BleakError
 		try:
-			scanner.start()  # Start in background mode
+			_scanner.start()  # Start in background mode
 		except (BleakError, OSError):
 			log.error(f"Failed to start BLE scanner while searching for device {address}", exc_info=True)  # noqa: G201
 			return None
@@ -81,7 +98,7 @@ def findDeviceByAddress(address: str, timeout: float = 5.0, pollInterval: float 
 		time.sleep(pollInterval)
 
 		# Check if device appeared
-		for device in scanner.results():
+		for device in _scanner.results():
 			if device.address == address:
 				elapsed = time.time() - startTime
 				log.debug(f"Found BLE device {address} after {elapsed:.2f}s")

--- a/source/hwIo/ble/__init__.py
+++ b/source/hwIo/ble/__init__.py
@@ -87,6 +87,7 @@ def findDeviceByAddress(address: str, timeout: float = 5.0, pollInterval: float 
 		# Delayed import of bleak to avoid importing it at NVDA startup,
 		# slowing down the startup time when no BLE device is connected.
 		from bleak.exc import BleakError
+
 		try:
 			_scanner.start()  # Start in background mode
 		except (BleakError, OSError):

--- a/source/hwIo/ble/_io.py
+++ b/source/hwIo/ble/_io.py
@@ -129,6 +129,7 @@ class Ble(IoBase):
 		# slowing down the startup time when no BLE device is connected.
 		import bleak
 		from bleak.args.winrt import WinRTClientArgs
+
 		winrtClientArgs = WinRTClientArgs(use_cached_services=True)
 		if isinstance(device, str):
 			# String address provided - Bleak will perform implicit discovery

--- a/source/hwIo/ble/_io.py
+++ b/source/hwIo/ble/_io.py
@@ -3,25 +3,28 @@
 # This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
 # For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
 
-import time  # noqa: I001
+from __future__ import annotations
+
+import time
+import weakref
+from collections.abc import Callable, Iterator
 from itertools import count, takewhile
 from queue import Empty, Queue
 from threading import Event, Thread
-from collections.abc import Callable, Iterator
-import weakref
+from typing import TYPE_CHECKING
 
 from _asyncioEventLoop.utils import runCoroutineSync
-from ..base import _isDebug, IoBase, requiresBackgroundThread
-from ..ioThread import IoThread
 from logHandler import log
 
-import bleak
-from bleak.backends.device import BLEDevice
-from bleak.backends.characteristic import BleakGATTCharacteristic
-from bleak.backends.winrt.client import WinRTClientArgs
+from ..base import IoBase, _isDebug, requiresBackgroundThread
+from ..ioThread import IoThread
+
+if TYPE_CHECKING:
+	import bleak
+	from bleak.backends.characteristic import BleakGATTCharacteristic
+	from bleak.backends.device import BLEDevice
 
 CONNECT_TIMEOUT_SECONDS: int = 2
-WINRT_CLIENT_ARGS = WinRTClientArgs(use_cached_services=True)
 
 
 @requiresBackgroundThread
@@ -122,15 +125,20 @@ class Ble(IoBase):
 		onReceive: Callable[[bytes], None],
 		ioThread: IoThread | None = None,
 	) -> None:
+		# Delayed import of bleak to avoid importing it at NVDA startup,
+		# slowing down the startup time when no BLE device is connected.
+		import bleak
+		from bleak.args.winrt import WinRTClientArgs
+		winrtClientArgs = WinRTClientArgs(use_cached_services=True)
 		if isinstance(device, str):
 			# String address provided - Bleak will perform implicit discovery
 			address = device
 			log.info(f"Connecting to BLE device at address {address}")
-			self._client = bleak.BleakClient(address, winrt=WINRT_CLIENT_ARGS)
+			self._client = bleak.BleakClient(address, winrt=winrtClientArgs)
 		else:
 			# BLEDevice object provided (preferred)
 			log.info(f"Connecting to {device.name} ({device.address})")
-			self._client = bleak.BleakClient(device, winrt=WINRT_CLIENT_ARGS)
+			self._client = bleak.BleakClient(device, winrt=winrtClientArgs)
 		self._writeServiceUuid = writeServiceUuid
 		self._writeCharacteristicUuid = writeCharacteristicUuid
 		self._readServiceUuid = readServiceUuid

--- a/source/hwIo/ble/_scanner.py
+++ b/source/hwIo/ble/_scanner.py
@@ -3,17 +3,21 @@
 # This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
 # For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
 
-import time  # noqa: I001
-from threading import Event
-from collections.abc import Callable
+from __future__ import annotations
 
-from _asyncioEventLoop.utils import runCoroutine
+import time
+from collections.abc import Callable
+from threading import Event
+from typing import TYPE_CHECKING
+
 import extensionPoints
+from _asyncioEventLoop.utils import runCoroutine
 from logHandler import log
 
-import bleak
-from bleak.backends.device import BLEDevice
-from bleak.backends.scanner import AdvertisementData
+if TYPE_CHECKING:
+	import bleak
+	from bleak.backends.device import BLEDevice
+	from bleak.backends.scanner import AdvertisementData
 
 
 class Scanner:
@@ -28,7 +32,10 @@ class Scanner:
 	_isScanning: Event
 
 	def __init__(self):
-		self._discoveredDevices = {}
+		# Delayed import of bleak to avoid importing it at NVDA startup,
+		# slowing down the startup time when no BLE device is connected.
+		import bleak
+		self._discoveredDevices: dict[str, BLEDevice] = {}
 		self._scanner = bleak.BleakScanner(self._onDeviceAdvertised)
 		self._isScanning = Event()
 		#: Action called when a BLE device is discovered or re-advertises.

--- a/source/hwIo/ble/_scanner.py
+++ b/source/hwIo/ble/_scanner.py
@@ -35,6 +35,7 @@ class Scanner:
 		# Delayed import of bleak to avoid importing it at NVDA startup,
 		# slowing down the startup time when no BLE device is connected.
 		import bleak
+
 		self._discoveredDevices: dict[str, BLEDevice] = {}
 		self._scanner = bleak.BleakScanner(self._onDeviceAdvertised)
 		self._isScanning = Event()


### PR DESCRIPTION

### Link to issue number:
Fixes #20824 

### Summary of the issue:
BLE initialisation added about 3s to startup time
### Description of user facing changes:
delayed BLE initialisation 
### Description of developer facing changes:
none
### Description of development approach:
lazy load BLE initialisation when scanning first occurs
### Testing strategy:
- [ ] unsure how test the BLE code without the dotpad implementation of it.
- [ ] Ensured start up time speeds were restored

### Known issues with pull request:

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
