### PR TITLE
Move process access rights from winKernel to winBindings.kernel32

### DIFF
--- a/source/appModuleHandler.py
+++ b/source/appModuleHandler.py
@@ -193,7 +193,7 @@ def getProcessHandleFromProcessId(processId: int, fallBackToTopLevelWindowEnumer
 	try:
 		if not (
 			processHandle := winKernel.openProcess(
-				winKernel.SYNCHRONIZE | winKernel.PROCESS_QUERY_INFORMATION,
+				winKernel.SYNCHRONIZE | winBindings.kernel32.PROCESS.QUERY_INFORMATION,
 				False,
 				processId,
 			)

--- a/source/appModules/wwahost.py
+++ b/source/appModules/wwahost.py
@@ -19,7 +19,7 @@ def getAppNameFromHost(processId):
 	# Some apps that come with Windows 8 and 8.1 are hosted by wwahost.exe.
 	# App modules for these are named after the hosted app name.
 	processHandle = winKernel.openProcess(
-		winKernel.SYNCHRONIZE | winKernel.PROCESS_QUERY_INFORMATION,
+		winKernel.SYNCHRONIZE | winBindings.kernel32.PROCESS.QUERY_INFORMATION,
 		False,
 		processId,
 	)

--- a/source/nvda.pyw
+++ b/source/nvda.pyw
@@ -136,7 +136,11 @@ def terminateRunningNVDA(window):
 		winKernel.closeHandle(h)
 
 	# The process is refusing to exit gracefully, so kill it forcefully.
-	h = winKernel.openProcess(winKernel.PROCESS_TERMINATE | winKernel.SYNCHRONIZE, False, processID)
+	h = winKernel.openProcess(
+		winBindings.kernel32.PROCESS.TERMINATE | winKernel.SYNCHRONIZE,
+		False,
+		processID,
+	)
 	if not h:
 		raise OSError("Could not open process for termination")
 	try:

--- a/source/winBindings/kernel32.py
+++ b/source/winBindings/kernel32.py
@@ -153,6 +153,27 @@ class GENERIC(IntEnum):
 	READ = 0x80000000
 
 
+class PROCESS(IntEnum):
+	"""Process-specific access rights.
+
+	.. seealso::
+		https://learn.microsoft.com/en-us/windows/win32/procthread/process-security-and-access-rights
+	"""
+
+	#: PROCESS_ALL_ACCESS: All possible access rights for a process object.
+	ALL_ACCESS = 0x001FFFFF
+	#: PROCESS_TERMINATE: Required to terminate a process using TerminateProcess.
+	TERMINATE = 0x0001
+	#: PROCESS_VM_OPERATION: Required to perform an operation on the address space of a process.
+	VM_OPERATION = 0x0008
+	#: PROCESS_VM_READ: Required to read memory in a process using ReadProcessMemory.
+	VM_READ = 0x0010
+	#: PROCESS_VM_WRITE: Required to write to memory in a process using WriteProcessMemory.
+	VM_WRITE = 0x0020
+	#: PROCESS_QUERY_INFORMATION: Required to retrieve certain information about a process, such as its token, exit code, and priority class.
+	QUERY_INFORMATION = 0x0400
+
+
 GetModuleHandle = WINFUNCTYPE(None)(("GetModuleHandleW", dll))
 """
 Retrieves a module handle for the specified module, which must have been loaded by the calling process.

--- a/source/winBindings/kernel32.py
+++ b/source/winBindings/kernel32.py
@@ -170,6 +170,8 @@ class PROCESS(IntEnum):
 	VM_READ = 0x0010
 	#: PROCESS_VM_WRITE: Required to write to memory in a process using WriteProcessMemory.
 	VM_WRITE = 0x0020
+	#: PROCESS_DUP_HANDLE: Required to duplicate a handle using DuplicateHandle.
+	DUP_HANDLE = 0x0040
 	#: PROCESS_QUERY_INFORMATION: Required to retrieve certain information about a process, such as its token, exit code, and priority class.
 	QUERY_INFORMATION = 0x0400
 

--- a/source/winKernel.py
+++ b/source/winKernel.py
@@ -72,19 +72,28 @@ __getattr__ = _deprecate.handleDeprecations(
 	_deprecate.MovedSymbol("DUPLICATE_SAME_ACCESS", "winBindings.kernel32", "DUPLICATE", "SAME_ACCESS"),
 	_deprecate.MovedSymbol("GENERIC_READ", "winBindings.kernel32", "GENERIC", "READ"),
 	_deprecate.MovedSymbol("GENERIC_WRITE", "winBindings.kernel32", "GENERIC", "WRITE"),
+	_deprecate.RemovedSymbol(
+		"PROCESS_ALL_ACCESS",
+		0x1F0FFF,
+		message="Use winBindings.kernel32.PROCESS.ALL_ACCESS instead.",
+	),
+	_deprecate.MovedSymbol("PROCESS_TERMINATE", "winBindings.kernel32", "PROCESS", "TERMINATE"),
+	_deprecate.MovedSymbol("PROCESS_VM_OPERATION", "winBindings.kernel32", "PROCESS", "VM_OPERATION"),
+	_deprecate.MovedSymbol("PROCESS_VM_READ", "winBindings.kernel32", "PROCESS", "VM_READ"),
+	_deprecate.MovedSymbol("PROCESS_VM_WRITE", "winBindings.kernel32", "PROCESS", "VM_WRITE"),
+	_deprecate.MovedSymbol(
+		"PROCESS_QUERY_INFORMATION",
+		"winBindings.kernel32",
+		"PROCESS",
+		"QUERY_INFORMATION",
+	),
 )
 
 
 # Constants
 INFINITE = 0xFFFFFFFF
 # Process control
-PROCESS_ALL_ACCESS = 0x1F0FFF
-PROCESS_TERMINATE = 0x1
-PROCESS_VM_OPERATION = 0x8
-PROCESS_VM_READ = 0x10
-PROCESS_VM_WRITE = 0x20
 SYNCHRONIZE = 0x100000
-PROCESS_QUERY_INFORMATION = 0x400
 READ_CONTROL = 0x20000
 MEM_COMMIT = 0x1000
 MEM_RELEASE = 0x8000

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -35,9 +35,11 @@ Please open a GitHub issue if your add-on has an issue with updating to the new 
 
 #### Deprecations
 
-* The following symbols from `winKernel` are deprecated: (#20784)
+* The following symbols from `winKernel` are deprecated: (#20784, #20836)
   * `DUPLICATE_SAME_ACCESS`: use `winBindings.kernel32.DUPLICATE.SAME_ACCESS` instead.
   * `GENERIC_READ` and `GENERIC_WRITE`: use `winBindings.kernel32.GENERIC.READ` and `winBindings.kernel32.GENERIC.WRITE` instead.
+  * `PROCESS_ALL_ACCESS`, `PROCESS_QUERY_INFORMATION`, `PROCESS_TERMINATE`, `PROCESS_VM_OPERATION`, `PROCESS_VM_READ` and `PROCESS_VM_WRITE`: use the `ALL_ACCESS`, `QUERY_INFORMATION`, `TERMINATE`, `VM_OPERATION`, `VM_READ` and `VM_WRITE` members of `winBindings.kernel32.PROCESS` instead.
+    * Note that `winKernel.PROCESS_ALL_ACCESS` uses the pre-Windows Vista access right, whereas `winBindings.kernel32.PROCESS.ALL_ACCESS` uses the updated one.
 
 <!-- Beyond this point, Markdown should not be automatically linted, as we don't modify old change log sections and lint rules may change over time. -->
 <!-- markdownlint-disable -->


### PR DESCRIPTION
### Link to issue number:

Follow-up to #20784

### Summary of the issue:

The ART project uses the `PROCESS_DUP_HANDLE` process access right. While that constant is not defined in NVDA, other process access rights are. In order to keep `master` and `try-art-staging` in sync as much as practical, this PR moves the existing process access rights that are used from `winKernel` to `winBindings.kernel32`, and drops those that are not used.

### Description of user facing changes:

None.

### Description of developer facing changes:

The `winKernel.PROCESS_QUERY_INFORMATION` and `PROCESS_TERMINATE` process access rights are deprecated, and the `winBindings.kernel32.PROCESS.` enum members should be used instead. The `winKernel.PROCESS_ALL_ACCESS` and `PROCESS_VM_*` access rights have been removed, as they are not used.

### Description of development approach:

Created a `winBindings.kernel32.PROCESS` `IntEnum`. Grepped `source` for each of the `PROCESS_*` constants. For each, if the constant was used elsewhere, added it to the enum, checking its definition against the official Microsoft documentation; and added a `MovedSymbol` entry to `winKernel`'s `__getattr__`. Also added the `PROCESS_DUP_HANDLE` process access right, which is currently not needed by NVDA, as was done for the `DUPLICATE_CLOSE_SOURCE` constant.

### Testing strategy:

Unit/system tests.

Ran from source and checked that importing `PROCESS_QUERY_INFORMATION` or `PROCESS_TERMINATE` from `winKernel` worked, logged a warning, and gave the right value. Checked that attempting to import `PROCESS_ALL_ACCESS`, `PROCESS_VM_OPERATION`, `PROCESS_VM_READ` or `PROCESS_VM_WRITE` raised an exception.

### Known issues with pull request:

None known.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
