### PR TITLE
Auto-fix pushes to nvaccess/nvda branches

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -29,15 +29,15 @@ concurrency:
 jobs:
   autofix:
     name: Auto-fix and lint gate
-    # On the base repo the pull_request run is the gate; skip its push run on non-Fork pushes to
-    # avoid a duplicate. Fork pushes still run for autofix.
-    if: github.event_name != 'push' || github.repository != 'nvaccess/nvda'
     runs-on: windows-2025-vs2026
     steps:
     - name: Checkout repository
       uses: actions/checkout@v7
       with:
         submodules: true
+        # A push made with this PAT triggers fresh push and pull_request runs on the fixed commit.
+        # The secret is empty outside nvaccess/nvda, so the default token is used there.
+        token: ${{ secrets.NVACCESSAUTO_PUSH_PAT || github.token }}
     - name: Set up python
       uses: actions/setup-python@v6
       with:
@@ -48,6 +48,7 @@ jobs:
       with:
         activate-environment: "false"
     # Autofix role: run the fixer hooks (the "autofix" group) and push the fixes.
+    # The fresh runs triggered by the pushed fix commit find nothing to fix.
     - name: Apply prek auto-fixes
       if: github.event_name == 'push'
       shell: bash
@@ -63,8 +64,8 @@ jobs:
           fi
         done
         if ! git diff --quiet; then
-          git config user.name "github-actions"
-          git config user.email "github-actions@github.com"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add -A
           git commit -m "Auto-fix: apply prek fixes"
           # Push via an explicit refspec so this works even if checkout left us
@@ -72,9 +73,11 @@ jobs:
           git push origin HEAD:"$REF_NAME"
         fi
     # Gate role: the merge-required blocking check (non-zero exit fails the job).
+    # On nvaccess/nvda the pull_request run is the gate; push runs there skip this step.
     # The skipped hooks are the heavy/env-bound ones with dedicated jobs in
     # testAndPublish.yml.
     - name: Lint gate
+      if: github.event_name != 'push' || github.repository != 'nvaccess/nvda'
       uses: j178/prek-action@v2
       with:
         extra-args: >-

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -35,9 +35,7 @@ jobs:
       uses: actions/checkout@v7
       with:
         submodules: true
-        # A push made with this PAT triggers fresh push and pull_request runs on the fixed commit.
-        # The secret is empty outside nvaccess/nvda, so the default token is used there.
-        token: ${{ secrets.NVACCESSAUTO_PUSH_PAT || github.token }}
+        persist-credentials: false
     - name: Set up python
       uses: actions/setup-python@v6
       with:
@@ -47,31 +45,39 @@ jobs:
       uses: astral-sh/setup-uv@v7
       with:
         activate-environment: "false"
-    # Autofix role: run the fixer hooks (the "autofix" group) and push the fixes.
-    # The fresh runs triggered by the pushed fix commit find nothing to fix.
+    # Autofix role: run the fixer hooks (the "autofix" group) and commit the fixes.
     - name: Apply prek auto-fixes
+      id: autofix
       if: github.event_name == 'push'
       shell: bash
-      env:
-        REF_NAME: ${{ github.ref_name }}
       run: |
         # Fixers exit non-zero when they change files. Some fixers' output feeds
         # another fixer, so a single pass may not reach a stable tree.
         # Re-run on the fixed tree until prek exits clean or we hit the cap.
         for attempt in 1 2 3; do
-          if uvx prek run --group autofix --all-files; then
+          status=0
+          uvx prek run --group autofix --all-files || status=$?
+          if [ "$status" -eq 0 ]; then
             break
           fi
         done
-        if ! git diff --quiet; then
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add -A
-          git commit -m "Auto-fix: apply prek fixes"
-          # Push via an explicit refspec so this works even if checkout left us
-          # in a detached HEAD state.
-          git push origin HEAD:"$REF_NAME"
+        if git diff --quiet; then
+          # Nothing to commit. A remaining non-zero status is a hook failure.
+          exit "$status"
         fi
+        git config user.name "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git add -A
+        git commit -m "Auto-fix: apply prek fixes"
+        echo "changed=true" >> "$GITHUB_OUTPUT"
+    - name: Push auto-fixes
+      if: steps.autofix.outputs.changed == 'true'
+      shell: bash
+      env:
+        REF_NAME: ${{ github.ref_name }}
+        TOKEN: ${{ secrets.NVACCESSAUTO_PUSH_PAT || github.token }}
+      run: |
+        git push "https://x-access-token:${TOKEN}@github.com/${GITHUB_REPOSITORY}.git" HEAD:"$REF_NAME"
     # Gate role: the merge-required blocking check (non-zero exit fails the job).
     # On nvaccess/nvda the pull_request run is the gate; push runs there skip this step.
     # The skipped hooks are the heavy/env-bound ones with dedicated jobs in

--- a/projectDocs/dev/contributing.md
+++ b/projectDocs/dev/contributing.md
@@ -117,7 +117,8 @@ Refer to ["Proposing Major Changes"](./proposingMajorChanges.md) before opening 
 	1. CI/CD testing:
 		* Every time a PR has a commit pushed to it, CI/CD checks will be run
 		* GitHub Actions runs a lint check on every PR, which fails until any lint issues are fixed.
-			* To have lint fixes applied and pushed automatically, enable GitHub Actions on your fork so the autofix workflow runs on your branch pushes.
+			* For PRs from branches in the nvaccess/nvda repository, lint fixes are applied and pushed automatically.
+			* For PRs from a fork, enable GitHub Actions on your fork so the autofix workflow runs on your branch pushes.
 				* When the autofix workflow pushes a fix commit, your PR's checks do re-run, but since that commit is authored by the GitHub Actions bot the run is held for maintainer approval (it shows as "action required" / "approve and run").
 				To get the checks running without waiting for approval, push any follow-up commit yourself.
 			* Otherwise, fix the reported lint issues manually.


### PR DESCRIPTION
### Link to issue number:
Closes #20305, see https://github.com/nvaccess/nvda/issues/20305#issuecomment-5628686879

### Summary of the issue:
Pull requests from branches inside nvaccess/nvda never receive prek auto-fix commits.

### Description of user facing changes:
None.

### Description of developer facing changes:
A push to a branch inside nvaccess/nvda now gets lint fixes pushed back automatically. The fix commit triggers a fresh run of the checks.

Pull requests from forks keep the existing behaviour. They receive fixes only when GitHub Actions is enabled on the fork.

### Description of development approach:
Two runs of the autofix workflow fire for every push to a branch inside nvaccess/nvda. The `push` run was skipped on nvaccess/nvda, so it did not duplicate the `pull_request` run. The `pull_request` run does gate, but the auto-fix step only runs for `push` events. So no run ever pushed fixes.

This PR removes that skip. The `push` run now applies and pushes fixes on nvaccess/nvda, as it already does on forks. The `pull_request` run keeps the gate. Push runs on nvaccess/nvda skip the gate step, so each push still produces one gate result.

The checkout uses the existing `NVACCESSAUTO_PUSH_PAT` secret as its token. A push made with a personal access token triggers workflows, unlike a push made with the default `GITHUB_TOKEN`. The same token already pushes to `beta` from the xliff regeneration workflow. On a fork the secret is empty and the default token is used.

The cycle therefore is: the push run fixes and pushes, the fix commit triggers a new push run and a new `pull_request` run. The new push run finds nothing to fix. The new `pull_request` run gates the fixed commit. The concurrency groups cancel the runs on the previous commit. The cycle ends after one fix commit.

The contributing guide now describes the two cases: branches inside nvaccess/nvda get fixes automatically, forks need GitHub Actions enabled.

### Testing strategy:

The change was exercised end to end on my fork with a personal access token.

* The `push` run applied a ruff-format fix and pushed one commit. Its gate step was skipped.
* The fix commit started a new `push` run and a new `pull_request` run. The concurrency groups cancelled both runs on the previous commit.
* The new `push` run found nothing to fix. The new `pull_request` run passed the lint gate. No further commit was pushed.

### Known issues with pull request:

A push to a branch inside nvaccess/nvda with an open pull request now produces two runs of this workflow: a push run that only fixes, and a `pull_request` run that only gates.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.
