### PR TITLE
Allow NVDA to start when optional Windows components are unavailable

### DIFF
--- a/source/NVDAHelper/__init__.py
+++ b/source/NVDAHelper/__init__.py
@@ -746,38 +746,37 @@ class _RemoteLoader:
 	def __init__(self, loaderDir: str):
 		# Create a pipe so we can write to stdin of the loader process.
 		pipeReadOrig, self._pipeWrite = winKernel.CreatePipe(None, 0)
-		# Make the read end of the pipe inheritable.
-		pipeRead = self._duplicateAsInheritable(pipeReadOrig)
-		winKernel.closeHandle(pipeReadOrig)
-		# stdout/stderr of the loader process should go to nul.
-		# Though we aren't using pythonic functions to write to nul,
-		# open it in binary mode as opening it in text mode (the default) doesn't make sense.
-		with open("nul", "wb") as nul:
-			nulHandle = self._duplicateAsInheritable(msvcrt.get_osfhandle(nul.fileno()))
-		# Set the process to start with the appropriate std* handles.
-		si = winBindings.advapi32.STARTUPINFO(
-			dwFlags=winKernel.STARTF_USESTDHANDLES,
-			hSTDInput=pipeRead,
-			hSTDOutput=nulHandle,
-			hSTDError=nulHandle,
-		)
+		pipeRead = nulHandle = token = None
 		pi = winBindings.advapi32.PROCESS_INFORMATION()
-		# Even if we have uiAccess privileges, they will not be inherited by default.
-		# Therefore, explicitly specify our own process token, which causes them to be inherited.
-		token = winKernel.OpenProcessToken(winKernel.GetCurrentProcess(), winKernel.MAXIMUM_ALLOWED)
 		try:
+			# Make the read end of the pipe inheritable.
+			pipeRead = self._duplicateAsInheritable(pipeReadOrig)
+			winKernel.closeHandle(pipeReadOrig)
+			pipeReadOrig = None
+			# stdout/stderr of the loader process should go to nul.
+			with open("nul", "wb") as nul:
+				nulHandle = self._duplicateAsInheritable(msvcrt.get_osfhandle(nul.fileno()))
+			# Set the process to start with the appropriate std* handles.
+			si = winBindings.advapi32.STARTUPINFO(
+				dwFlags=winKernel.STARTF_USESTDHANDLES,
+				hSTDInput=pipeRead,
+				hSTDOutput=nulHandle,
+				hSTDError=nulHandle,
+			)
+			# Even if we have uiAccess privileges, they will not be inherited by default.
+			# Therefore, explicitly specify our own process token, which causes them to be inherited.
+			token = winKernel.OpenProcessToken(winKernel.GetCurrentProcess(), winKernel.MAXIMUM_ALLOWED)
 			loaderPath = os.path.join(loaderDir, "nvdaHelperRemoteLoader.exe")
 			log.debug(f"Starting {loaderPath}")
 			winKernel.CreateProcessAsUser(token, None, loaderPath, None, None, True, 0, None, None, si, pi)
-			# We don't need the thread handle.
-			winKernel.closeHandle(pi.hThread)
 			self._process = pi.hProcess
 		except:
 			winKernel.closeHandle(self._pipeWrite)
 			raise
 		finally:
-			winKernel.closeHandle(pipeRead)
-			winKernel.closeHandle(token)
+			for handle in (pipeReadOrig, pipeRead, nulHandle, token, pi.hThread):
+				if handle:
+					winKernel.closeHandle(handle)
 
 	def _duplicateAsInheritable(self, handle):
 		curProc = winKernel.GetCurrentProcess()
@@ -796,6 +795,14 @@ class _RemoteLoader:
 		# Wait until it's dead.
 		winKernel.waitForSingleObject(self._process, winKernel.INFINITE)
 		winKernel.closeHandle(self._process)
+
+
+def _tryStartRemoteLoader(loaderDir: str) -> _RemoteLoader | None:
+	try:
+		return _RemoteLoader(loaderDir)
+	except OSError:
+		log.error(f"Unable to start remote loader from {loaderDir}", exc_info=True)  # noqa: G201
+		return None
 
 
 def initialize() -> None:
@@ -875,19 +882,19 @@ def initialize() -> None:
 	arch = winVersion.getWinVer().processorArchitecture
 	if arch == "AMD64":
 		if ReadPaths.coreArchLibPath != ReadPaths.versionedLibX86Path:
-			_remoteLoaderX86 = _RemoteLoader(ReadPaths.versionedLibX86Path)
+			_remoteLoaderX86 = _tryStartRemoteLoader(ReadPaths.versionedLibX86Path)
 		if ReadPaths.coreArchLibPath != ReadPaths.versionedLibAMD64Path:
-			_remoteLoaderAMD64 = _RemoteLoader(ReadPaths.versionedLibAMD64Path)
+			_remoteLoaderAMD64 = _tryStartRemoteLoader(ReadPaths.versionedLibAMD64Path)
 	elif arch == "ARM64":
 		if ReadPaths.coreArchLibPath != ReadPaths.versionedLibX86Path:
-			_remoteLoaderX86 = _RemoteLoader(ReadPaths.versionedLibX86Path)
+			_remoteLoaderX86 = _tryStartRemoteLoader(ReadPaths.versionedLibX86Path)
 		if ReadPaths.coreArchLibPath != ReadPaths.versionedLibAMD64Path:  # noqa: SIM102
 			# Windows 10 on ARM does not support AMD64 emulation.
 			# Thus only start the AMD64 remote loader if on Windows 11 or above.
 			if winVersion.getWinVer() >= winVersion.WIN11:
-				_remoteLoaderAMD64 = _RemoteLoader(ReadPaths.versionedLibAMD64Path)
+				_remoteLoaderAMD64 = _tryStartRemoteLoader(ReadPaths.versionedLibAMD64Path)
 		if ReadPaths.coreArchLibPath != ReadPaths.versionedLibARM64Path:
-			_remoteLoaderARM64 = _RemoteLoader(ReadPaths.versionedLibARM64Path)
+			_remoteLoaderARM64 = _tryStartRemoteLoader(ReadPaths.versionedLibARM64Path)
 
 
 def terminate():

--- a/source/_magnifier/commands.py
+++ b/source/_magnifier/commands.py
@@ -9,7 +9,7 @@ Contains the command functions and their logic for keyboard shortcuts.
 """
 
 from collections.abc import Callable  # noqa: I001
-from typing import Literal
+from typing import TYPE_CHECKING, Literal, cast
 import speech
 import ui
 from . import changeMagnifiedView, getMagnifier, start, stop
@@ -24,7 +24,6 @@ from .config import (
 	_isDebug,
 )
 from .magnifier import Magnifier
-from .fullscreenMagnifier import FullScreenMagnifier
 from .utils.errorHandling import MagnifierStartError
 from .utils.types import (
 	Filter,
@@ -35,6 +34,9 @@ from .utils.types import (
 	MagnifierTrackingType,
 )
 from logHandler import log
+
+if TYPE_CHECKING:
+	from .fullscreenMagnifier import FullScreenMagnifier
 
 PAN_ACTION_TO_EDGE_MESSAGES = {
 	MagnifierAction.PAN_LEFT: pgettext(
@@ -182,8 +184,7 @@ def toggleFilter() -> None:
 		idx = filters.index(magnifier.filterType)
 		magnifier.filterType = filters[(idx + 1) % len(filters)]
 		if magnifier._MAGNIFIED_VIEW == MagnifiedView.FULLSCREEN:
-			assert isinstance(magnifier, FullScreenMagnifier)
-			fullscreenMagnifier: FullScreenMagnifier = magnifier
+			fullscreenMagnifier = cast("FullScreenMagnifier", magnifier)
 			fullscreenMagnifier._applyFilter()
 		setFilter(magnifier.filterType)
 
@@ -290,7 +291,7 @@ def toggleFullscreenMode() -> None:
 			magnifier,
 			MagnifierAction.CHANGE_FULLSCREEN_MODE,
 		):
-			fullscreenMagnifier: FullScreenMagnifier = magnifier
+			fullscreenMagnifier = cast("FullScreenMagnifier", magnifier)
 			modes = list(FullScreenMode)
 			currentMode = fullscreenMagnifier._fullscreenMode
 			idx = modes.index(currentMode)
@@ -309,7 +310,7 @@ def toggleFullscreenMode() -> None:
 
 def startSpotlight() -> None:
 	"""Start spotlight mode in full-screen magnifier"""
-	magnifier: FullScreenMagnifier = getMagnifier()
+	magnifier: Magnifier | None = getMagnifier()
 	if magnifierIsActiveVerify(  # noqa: SIM102
 		magnifier,
 		MagnifierAction.START_SPOTLIGHT,
@@ -318,7 +319,7 @@ def startSpotlight() -> None:
 			magnifier,
 			MagnifierAction.START_SPOTLIGHT,
 		):
-			fullscreenMagnifier: FullScreenMagnifier = magnifier
+			fullscreenMagnifier = cast("FullScreenMagnifier", magnifier)
 			if _isDebug():
 				log.debug("trying to launch spotlight mode")
 			if fullscreenMagnifier._spotlightManager._spotlightIsActive:

--- a/source/_magnifier/fullscreenMagnifier.py
+++ b/source/_magnifier/fullscreenMagnifier.py
@@ -71,6 +71,14 @@ class FullScreenMagnifier(Magnifier):
 		"""
 		Start the Full-screen magnifier using windows DLL
 		"""
+		if not magnification.MAGNIFICATION_AVAILABLE:
+			raise MagnifierStartError(
+				pgettext(
+					"magnifier",
+					# Translators: Message when NVDA's Magnifier cannot start because the Windows Magnification API is unavailable.
+					"Cannot start magnifier because the Windows Magnification API is unavailable.",
+				),
+			)
 		super()._startMagnifier()
 		if not self._isActive:
 			return

--- a/source/_remoteClient/__init__.py
+++ b/source/_remoteClient/__init__.py
@@ -2,12 +2,16 @@
 # Copyright (C) 2015-2025 NV Access Limited, Christopher Toth, Tyler Spivey, Babbage B.V., David Sexton and others.
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
+from typing import TYPE_CHECKING
+
 from logHandler import log
 
-from .client import RemoteClient
 from .configuration import getRemoteConfig
 
-_remoteClient: RemoteClient = None
+if TYPE_CHECKING:
+	from .client import RemoteClient
+
+_remoteClient: "RemoteClient | None" = None
 
 
 def initialize():
@@ -15,6 +19,11 @@ def initialize():
 	global _remoteClient
 	if not getRemoteConfig()["enabled"]:
 		log.debug("Remote Access disabled. Not initializing.")
+		return
+	try:
+		from .client import RemoteClient
+	except (AttributeError, ImportError, OSError):
+		log.warning("Remote Access unavailable.", exc_info=True)
 		return
 	import globalCommands
 

--- a/source/audio/__init__.py
+++ b/source/audio/__init__.py
@@ -3,14 +3,50 @@
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
-from .soundSplit import (
-	SoundSplitState,
-	_setSoundSplitState,
-	_toggleSoundSplitState,
-)
+from logHandler import log
+
+from .soundSplitState import SoundSplitState
+
+try:
+	from . import soundSplit
+except (ImportError, OSError):
+	log.warning("Sound Split is unavailable.", exc_info=True)
+	soundSplit = None
+
+SOUND_SPLIT_AVAILABLE: bool = soundSplit is not None
+"""True if the dependencies required for Sound Split are available."""
 
 __all__ = [
+	"SOUND_SPLIT_AVAILABLE",
 	"SoundSplitState",
 	"_setSoundSplitState",
 	"_toggleSoundSplitState",
+	"initialize",
+	"terminate",
 ]
+
+
+def initialize() -> None:
+	if soundSplit is not None:
+		soundSplit.initialize()
+
+
+def terminate() -> None:
+	if soundSplit is not None:
+		soundSplit.terminate()
+
+
+def _setSoundSplitState(state: SoundSplitState, initial: bool = False) -> dict[str, bool]:
+	if soundSplit is None:
+		return {}
+	return soundSplit._setSoundSplitState(state, initial)
+
+
+def _toggleSoundSplitState() -> None:
+	if soundSplit is None:
+		import ui
+
+		# Translators: Message announced when Sound Split is unavailable.
+		ui.message(_("Sound Split is unavailable."))
+		return
+	soundSplit._toggleSoundSplitState()

--- a/source/audio/soundSplit.py
+++ b/source/audio/soundSplit.py
@@ -5,86 +5,18 @@
 
 import atexit  # noqa: I001
 import config
-from enum import IntEnum, unique
 import globalVars
 from logHandler import log
 from pycaw.api.audiopolicy import IAudioSessionManager2
 from pycaw.callbacks import AudioSessionNotification, AudioSessionEvents
 from pycaw.utils import AudioSession, AudioUtilities
 import ui
-from utils.displayString import DisplayStringIntEnum
 from dataclasses import dataclass
 from comtypes import COMError
 from threading import Lock
 import core
 
-VolumeTupleT = tuple[float, float]
-
-
-@unique
-class SoundSplitState(DisplayStringIntEnum):
-	OFF = 0
-	NVDA_BOTH_APPS_BOTH = 1
-	NVDA_LEFT_APPS_RIGHT = 2
-	NVDA_LEFT_APPS_BOTH = 3
-	NVDA_RIGHT_APPS_LEFT = 4
-	NVDA_RIGHT_APPS_BOTH = 5
-	NVDA_BOTH_APPS_LEFT = 6
-	NVDA_BOTH_APPS_RIGHT = 7
-
-	@property
-	def _displayStringLabels(self) -> dict[IntEnum, str]:
-		return {
-			# Translators: Sound split state
-			SoundSplitState.OFF: pgettext("SoundSplit", "Sound split disabled"),
-			SoundSplitState.NVDA_BOTH_APPS_BOTH: pgettext(
-				"SoundSplit",
-				# Translators: Sound split state
-				"NVDA in both channels and applications in both channels",
-			),
-			# Translators: Sound split state
-			SoundSplitState.NVDA_LEFT_APPS_RIGHT: _("NVDA on the left and applications on the right"),
-			# Translators: Sound split state
-			SoundSplitState.NVDA_LEFT_APPS_BOTH: _("NVDA on the left and applications in both channels"),
-			# Translators: Sound split state
-			SoundSplitState.NVDA_RIGHT_APPS_LEFT: _("NVDA on the right and applications on the left"),
-			# Translators: Sound split state
-			SoundSplitState.NVDA_RIGHT_APPS_BOTH: _("NVDA on the right and applications in both channels"),
-			# Translators: Sound split state
-			SoundSplitState.NVDA_BOTH_APPS_LEFT: _("NVDA in both channels and applications on the left"),
-			# Translators: Sound split state
-			SoundSplitState.NVDA_BOTH_APPS_RIGHT: _("NVDA in both channels and applications on the right"),
-		}
-
-	def getAppVolume(self) -> VolumeTupleT:
-		match self:
-			case (
-				SoundSplitState.NVDA_BOTH_APPS_BOTH
-				| SoundSplitState.NVDA_LEFT_APPS_BOTH
-				| SoundSplitState.NVDA_RIGHT_APPS_BOTH
-			):
-				return (1.0, 1.0)
-			case SoundSplitState.NVDA_RIGHT_APPS_LEFT | SoundSplitState.NVDA_BOTH_APPS_LEFT:
-				return (1.0, 0.0)
-			case SoundSplitState.NVDA_LEFT_APPS_RIGHT | SoundSplitState.NVDA_BOTH_APPS_RIGHT:
-				return (0.0, 1.0)
-			case _:
-				raise RuntimeError(f"Unexpected or unknown state {self=}")
-
-	def getNVDAVolume(self) -> VolumeTupleT:
-		match self:
-			case (
-				SoundSplitState.NVDA_BOTH_APPS_BOTH
-				| SoundSplitState.NVDA_BOTH_APPS_LEFT
-				| SoundSplitState.NVDA_BOTH_APPS_RIGHT
-			):
-				return (1.0, 1.0)
-			case SoundSplitState.NVDA_LEFT_APPS_RIGHT | SoundSplitState.NVDA_LEFT_APPS_BOTH:
-				return (1.0, 0.0)
-			case SoundSplitState.NVDA_RIGHT_APPS_LEFT | SoundSplitState.NVDA_RIGHT_APPS_BOTH:
-				return (0.0, 1.0)
-			case _:
-				raise RuntimeError(f"Unexpected or unknown state {self=}")
+from .soundSplitState import SoundSplitState, VolumeTupleT  # noqa: F401
 
 
 _audioSessionManager: IAudioSessionManager2 | None = None

--- a/source/audio/soundSplitState.py
+++ b/source/audio/soundSplitState.py
@@ -1,0 +1,76 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2024-2026 NV Access Limited
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+
+from enum import IntEnum, unique
+
+from utils.displayString import DisplayStringIntEnum
+
+VolumeTupleT = tuple[float, float]
+
+
+@unique
+class SoundSplitState(DisplayStringIntEnum):
+	OFF = 0
+	NVDA_BOTH_APPS_BOTH = 1
+	NVDA_LEFT_APPS_RIGHT = 2
+	NVDA_LEFT_APPS_BOTH = 3
+	NVDA_RIGHT_APPS_LEFT = 4
+	NVDA_RIGHT_APPS_BOTH = 5
+	NVDA_BOTH_APPS_LEFT = 6
+	NVDA_BOTH_APPS_RIGHT = 7
+
+	@property
+	def _displayStringLabels(self) -> dict[IntEnum, str]:
+		return {
+			# Translators: Sound split state
+			SoundSplitState.OFF: pgettext("SoundSplit", "Sound split disabled"),
+			SoundSplitState.NVDA_BOTH_APPS_BOTH: pgettext(
+				"SoundSplit",
+				# Translators: Sound split state
+				"NVDA in both channels and applications in both channels",
+			),
+			# Translators: Sound split state
+			SoundSplitState.NVDA_LEFT_APPS_RIGHT: _("NVDA on the left and applications on the right"),
+			# Translators: Sound split state
+			SoundSplitState.NVDA_LEFT_APPS_BOTH: _("NVDA on the left and applications in both channels"),
+			# Translators: Sound split state
+			SoundSplitState.NVDA_RIGHT_APPS_LEFT: _("NVDA on the right and applications on the left"),
+			# Translators: Sound split state
+			SoundSplitState.NVDA_RIGHT_APPS_BOTH: _("NVDA on the right and applications in both channels"),
+			# Translators: Sound split state
+			SoundSplitState.NVDA_BOTH_APPS_LEFT: _("NVDA in both channels and applications on the left"),
+			# Translators: Sound split state
+			SoundSplitState.NVDA_BOTH_APPS_RIGHT: _("NVDA in both channels and applications on the right"),
+		}
+
+	def getAppVolume(self) -> VolumeTupleT:
+		match self:
+			case (
+				SoundSplitState.NVDA_BOTH_APPS_BOTH
+				| SoundSplitState.NVDA_LEFT_APPS_BOTH
+				| SoundSplitState.NVDA_RIGHT_APPS_BOTH
+			):
+				return (1.0, 1.0)
+			case SoundSplitState.NVDA_RIGHT_APPS_LEFT | SoundSplitState.NVDA_BOTH_APPS_LEFT:
+				return (1.0, 0.0)
+			case SoundSplitState.NVDA_LEFT_APPS_RIGHT | SoundSplitState.NVDA_BOTH_APPS_RIGHT:
+				return (0.0, 1.0)
+			case _:
+				raise RuntimeError(f"Unexpected or unknown state {self=}")
+
+	def getNVDAVolume(self) -> VolumeTupleT:
+		match self:
+			case (
+				SoundSplitState.NVDA_BOTH_APPS_BOTH
+				| SoundSplitState.NVDA_BOTH_APPS_LEFT
+				| SoundSplitState.NVDA_BOTH_APPS_RIGHT
+			):
+				return (1.0, 1.0)
+			case SoundSplitState.NVDA_LEFT_APPS_RIGHT | SoundSplitState.NVDA_LEFT_APPS_BOTH:
+				return (1.0, 0.0)
+			case SoundSplitState.NVDA_RIGHT_APPS_LEFT | SoundSplitState.NVDA_RIGHT_APPS_BOTH:
+				return (0.0, 1.0)
+			case _:
+				raise RuntimeError(f"Unexpected or unknown state {self=}")

--- a/source/brailleDisplayDrivers/hims.py
+++ b/source/brailleDisplayDrivers/hims.py
@@ -17,6 +17,7 @@ from io import BytesIO
 import hwIo
 from hwIo import intToByte
 from hwIo.base import _isDebug as _isHwIoDebug
+from logHandler import log
 import winKernel
 from winAPI.constants import SystemErrorCodes
 from winBindings.setupapi import (
@@ -30,11 +31,14 @@ from winBindings.setupapi import (
 	SetupDiGetDeviceInterfaceDetail,
 	_Dummy as _SP_DEVICE_INTERFACE_DETAIL_DATA_PACKING,
 )
+
 from winBindings.winusb import (
 	USB_INTERFACE_DESCRIPTOR,
 	USBD_PIPE_TYPE,
-	WINUSB_PIPE_POLICY,
+	WINUSB_AVAILABLE,
+	WINUSB_LOAD_ERROR,
 	WINUSB_PIPE_INFORMATION,
+	WINUSB_PIPE_POLICY,
 	WinUsb_Free,
 	WinUsb_Initialize,
 	WinUsb_QueryInterfaceSettings,
@@ -43,19 +47,22 @@ from winBindings.winusb import (
 	WinUsb_SetPipePolicy,
 	WinUsb_WritePipe,
 )
-from winBindings import kernel32
+import math
+import time
+from collections import OrderedDict
+
+import bdDetect
 import braille
 import braille.display
 import braille.display.driver
 import braille.display.gesture
-from logHandler import log
-from collections import OrderedDict
-import inputCore
 import braille.input.gesture
+import inputCore
 from baseObject import AutoPropertyObject
-import time
-import bdDetect
-import math
+from winBindings import kernel32
+
+if not WINUSB_AVAILABLE:
+	log.warning("WinUSB support is unavailable.", exc_info=WINUSB_LOAD_ERROR)
 
 BAUD_RATE = 115200
 PARITY = serial.PARITY_NONE
@@ -636,6 +643,8 @@ class BrailleDisplayDriver(braille.display.driver.BrailleDisplayDriver):
 							# available -- e.g. Windows 11 blocks installation of unsigned/non-WHCP
 							# kernel drivers. Fall back to WinUSB (winusb.sys, an inbox driver) if
 							# the vendor's WinUSB INF (hims_winusb.inf) is installed for this device.
+							if not WINUSB_AVAILABLE:
+								raise
 							log.debug(
 								f"hwIo.Bulk(port={port!r}) failed ({bulkError}); trying WinUSB fallback",
 							)

--- a/source/core.py
+++ b/source/core.py
@@ -348,7 +348,7 @@ def resetConfiguration(factoryDefaults=False):
 	log.debug("terminating tones")
 	tones.terminate()
 	log.debug("terminating sound split")
-	audio.soundSplit.terminate()
+	audio.terminate()
 	log.debug("Terminating background braille display detection")
 	bdDetect.terminate()
 	log.debug("Terminating background i/o")
@@ -381,7 +381,7 @@ def resetConfiguration(factoryDefaults=False):
 	tones.initialize()
 	# Sound split
 	log.debug("initializing sound split")
-	audio.soundSplit.initialize()
+	audio.initialize()
 	# Character processing
 	log.debug("initializing character processing")
 	characterProcessing.initialize()
@@ -687,6 +687,16 @@ def _setUpWxApp() -> "wx.App":
 	return app
 
 
+def _getInitialBrailleMessage() -> str:
+	import screenCurtain
+
+	if screenCurtain.screenCurtain is not None and screenCurtain.screenCurtain.enabled:
+		# Translators: This is shown on a braille display (if one is connected) when NVDA starts with the screen curtain enabled.
+		return _("NVDA started with screen curtain enabled")
+	# Translators: This is shown on a braille display (if one is connected) when NVDA starts.
+	return _("NVDA started")
+
+
 def main():
 	"""NVDA's core main loop.
 	This initializes all modules such as audio, IAccessible, keyboard, mouse, and GUI.
@@ -795,7 +805,7 @@ def main():
 	log.debug("Initializing sound split")
 	import audio
 
-	audio.soundSplit.initialize()
+	audio.initialize()
 	import speechDictHandler
 
 	log.debug("Speech Dictionary processing")
@@ -965,14 +975,8 @@ def main():
 			warnForNonEmptyDirectory=warnForNonEmptyDirectory,
 		)
 	elif not globalVars.appArgs.minimal:
-		if screenCurtain.screenCurtain.enabled:
-			# Translators: This is shown on a braille display (if one is connected) when NVDA starts with the screen curtain enabled.
-			initialMessage = _("NVDA started with screen curtain enabled")
-		else:
-			# Translators: This is shown on a braille display (if one is connected) when NVDA starts.
-			initialMessage = _("NVDA started")
 		try:
-			braille.handler.message(initialMessage)
+			braille.handler.message(_getInitialBrailleMessage())
 		except:  # noqa: E722
 			log.error("", exc_info=True)  # noqa: G201
 		if globalVars.appArgs.launcher:

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -21,6 +21,8 @@ from enum import IntEnum
 from locale import strxfrm
 from typing import (
 	Any,
+	TYPE_CHECKING,
+	cast,
 )
 
 import audio
@@ -41,8 +43,7 @@ import logHandler
 from _magnifier import getMagnifier
 from _magnifier.commands import toggleMagnifier
 import _magnifier.config as magnifierConfig
-from _magnifier.utils.types import Filter, FullScreenMode, MagnifierTrackingType
-from _magnifier.fullscreenMagnifier import FullScreenMagnifier
+from _magnifier.utils.types import Filter, FullScreenMode, MagnifiedView, MagnifierTrackingType
 import queueHandler
 import requests
 import speech
@@ -108,6 +109,9 @@ from autoSettingsUtils.utils import UnsupportedConfigParameterError
 
 from . import nvdaControls
 from .dpiScalingHelper import DpiScalingHelperMixinWithoutInit
+
+if TYPE_CHECKING:
+	from _magnifier.fullscreenMagnifier import FullScreenMagnifier
 
 #: The size that settings panel text descriptions should be wrapped at.
 # Ensure self.scaleSize is used to adjust for OS scaling adjustments.
@@ -3716,6 +3720,7 @@ class AudioPanel(SettingsPanel):
 		self.soundSplitComboBox.SetSelection(index)
 
 		self._appendSoundSplitModesList(sHelper)
+		self._updateSoundSplitAvailability(sHelper)
 
 		self._onSoundVolChange(None)
 
@@ -3749,6 +3754,19 @@ class AudioPanel(SettingsPanel):
 			mIndex for mIndex in range(len(self._allSoundSplitModes)) if mIndex in includedModes
 		]
 		self.soundSplitModesList.Select(0)
+
+	def _updateSoundSplitAvailability(self, settingsSizerHelper: guiHelper.BoxSizerHelper) -> None:
+		if audio.SOUND_SPLIT_AVAILABLE:
+			return
+		self.soundSplitComboBox.Disable()
+		self.soundSplitModesList.Disable()
+		settingsSizerHelper.addItem(
+			wx.StaticText(
+				self,
+				# Translators: Explanation shown when the Sound Split feature cannot be used.
+				label=_("Sound Split is unavailable because required Windows audio components are missing."),
+			),
+		)
 
 	def onSave(self):
 		selectedOutputDevice = self._deviceIds[self.deviceList.GetSelection()]
@@ -6189,8 +6207,8 @@ class MagnifierPanel(SettingsPanel):
 			magnifier.zoomLevel = roundedZoom
 			magnifier._panStep = selectedPanStep
 			magnifier.filterType = selectedFilter
-			if isinstance(magnifier, FullScreenMagnifier):
-				magnifier._fullscreenMode = selectedMode
+			if magnifier._MAGNIFIED_VIEW == MagnifiedView.FULLSCREEN:
+				cast("FullScreenMagnifier", magnifier)._fullscreenMode = selectedMode
 
 	def _onImmediateSettingChange(self, evt: wx.CommandEvent):
 		"""Handle immediate updates for non-enable magnifier settings."""
@@ -6376,8 +6394,8 @@ class MagnifierPanel(SettingsPanel):
 			magnifier.zoomLevel = self._zoomInitially
 			magnifier._panStep = self._panStepInitially
 			magnifier.filterType = self._filterInitially
-			if isinstance(magnifier, FullScreenMagnifier):
-				magnifier._fullscreenMode = self._trackingModeInitially
+			if magnifier._MAGNIFIED_VIEW == MagnifiedView.FULLSCREEN:
+				cast("FullScreenMagnifier", magnifier)._fullscreenMode = self._trackingModeInitially
 
 		if self._magnifierEnabledInitially != magnifierConfig.getEnabled():
 			toggleMagnifier()

--- a/source/hwPortUtils.py
+++ b/source/hwPortUtils.py
@@ -21,6 +21,7 @@ from winAPI.constants import SystemErrorCodes
 from winBindings.advapi32 import RegCloseKey as _RegCloseKey
 from winBindings.bthprops import (
 	BLUETOOTH_DEVICE_INFO as _BLUETOOTH_DEVICE_INFO,
+	BLUETOOTH_LOAD_ERROR as _BLUETOOTH_LOAD_ERROR,
 	BluetoothGetDeviceInfo as _BluetoothGetDeviceInfo,
 )
 from winBindings.hid import (
@@ -54,6 +55,9 @@ from winBindings.setupapi import (
 	SetupDiOpenDevRegKey as _SetupDiOpenDevRegKey,
 	_Dummy,
 )
+
+if _BLUETOOTH_LOAD_ERROR is not None:
+	log.warning("Bluetooth support is unavailable.", exc_info=_BLUETOOTH_LOAD_ERROR)
 
 
 def _ValidHandle(value):

--- a/source/mathPres/__init__.py
+++ b/source/mathPres/__init__.py
@@ -110,12 +110,12 @@ def terminate() -> None:
 def initialize() -> None:
 	# Register builtin providers if a plugin hasn't registered others.
 	if not speechProvider or not brailleProvider or not interactionProvider:
-		from .MathCAT import MathCAT
-
 		try:
+			from .MathCAT import MathCAT
+
 			provider = MathCAT.MathCAT()
 		except:  # noqa: E722
-			log.warning("MathCAT not available.")
+			log.warning("MathCAT not available.", exc_info=True)
 		else:
 			MathCAT.MathCATInteraction._createNavScripts()
 			registerProvider(

--- a/source/screenCurtain/__init__.py
+++ b/source/screenCurtain/__init__.py
@@ -5,6 +5,9 @@
 
 """Screen curtain implementation based on the windows magnification API."""
 
+from logHandler import log
+from winBindings.magnification import MAGNIFICATION_AVAILABLE, MAGNIFICATION_LOAD_ERROR
+
 from ._screenCurtain import ScreenCurtain
 
 __all__ = (
@@ -21,6 +24,12 @@ screenCurtain: ScreenCurtain | None = None
 def initialize():
 	"""Initialize theScreen Curtain."""
 	global screenCurtain
+	if not MAGNIFICATION_AVAILABLE:
+		log.warning(
+			"Screen Curtain unavailable because the Windows Magnification API is unavailable.",
+			exc_info=MAGNIFICATION_LOAD_ERROR,
+		)
+		return
 	if screenCurtain is None:
 		screenCurtain = ScreenCurtain()
 

--- a/source/utils/mmdevice.py
+++ b/source/utils/mmdevice.py
@@ -9,8 +9,14 @@ from collections.abc import Generator
 from typing import NamedTuple, cast
 
 import config
+from logHandler import log
 from pycaw.constants import DEVICE_STATE, EDataFlow
-from pycaw.utils import AudioUtilities
+
+try:
+	from pycaw.utils import AudioUtilities
+except (ImportError, OSError):
+	log.warning("Audio device enumeration is unavailable.", exc_info=True)
+	AudioUtilities = None
 
 
 class AudioOutputDevice(NamedTuple):
@@ -43,6 +49,8 @@ def getOutputDevices(
 			# Translators: Value to show when choosing to use the default audio output device.
 			friendlyName=_("Default output device"),
 		)
+	if AudioUtilities is None:
+		return
 	endpointCollection = AudioUtilities.GetDeviceEnumerator().EnumAudioEndpoints(
 		EDataFlow.eRender.value,
 		stateMask.value,

--- a/source/winAPI/sessionTracking.py
+++ b/source/winAPI/sessionTracking.py
@@ -71,6 +71,8 @@ _wasLockedPreviousPumpAll = False
 Each core pump cycle, the Windows lock state is updated.
 The previous value is tracked, so that changes to the lock state can be detected.
 """
+_loggedSessionQueryFailures: set[str] = set()
+"""Session query failures already logged during this NVDA session."""
 
 
 class WindowsTrackedSession(enum.IntEnum):
@@ -172,14 +174,21 @@ def _isWindowsLocked_checkViaSessionQuery() -> bool:
 	try:
 		sessionQueryLockState = _getSessionLockedValue()
 	except RuntimeError:
-		log.exception("Failure querying session locked state")
+		_logSessionQueryFailureOnce("Failure querying session locked state", excInfo=True)
 		return False
 	if sessionQueryLockState == WTS_LockState.WTS_SESSIONSTATE_UNKNOWN:
-		log.error(
+		_logSessionQueryFailureOnce(
 			f"Unable to determine lock state via Session Query. Lock state value: {sessionQueryLockState!r}",
 		)
 		return False
 	return sessionQueryLockState == WTS_LockState.WTS_SESSIONSTATE_LOCK
+
+
+def _logSessionQueryFailureOnce(message: str, *, excInfo: bool = False) -> None:
+	if message in _loggedSessionQueryFailures:
+		return
+	log.error(message, exc_info=excInfo)
+	_loggedSessionQueryFailures.add(message)
 
 
 _WTS_INFO_POINTER_T = ctypes.POINTER(WTSINFOEXW)
@@ -192,8 +201,6 @@ def WTSCurrentSessionInfoEx() -> Generator[_WTS_INFO_POINTER_T]:
 	@raises RuntimeError: On failure
 	"""
 	info = _getCurrentSessionInfoEx()
-	if info is None:
-		return
 	try:
 		yield info
 	finally:
@@ -202,7 +209,7 @@ def WTSCurrentSessionInfoEx() -> Generator[_WTS_INFO_POINTER_T]:
 		)
 
 
-def _getCurrentSessionInfoEx() -> _WTS_INFO_POINTER_T | None:
+def _getCurrentSessionInfoEx() -> _WTS_INFO_POINTER_T:
 	"""
 	Gets the WTSINFOEXW for the current server/session or raises a RuntimeError
 	on failure.
@@ -213,7 +220,6 @@ def _getCurrentSessionInfoEx() -> _WTS_INFO_POINTER_T | None:
 	"""
 	ppBuffer = LPWSTR(None)
 	pBytesReturned = DWORD(0)
-	info = None
 
 	res = WTSQuerySessionInformation(
 		WTS_CURRENT_SERVER_HANDLE,  # WTS_CURRENT_SERVER_HANDLE to indicate the RD Session Host server on
@@ -252,12 +258,11 @@ def _getCurrentSessionInfoEx() -> _WTS_INFO_POINTER_T | None:
 				f"Unexpected Level data, got {info.contents.Level}.",
 			)
 		return info
-	except Exception as e:
-		log.exception("Unexpected WTSQuerySessionInformation value:", exc_info=e)
-		WTSFreeMemory(  # should this be moved to a finally block?
+	except Exception:
+		WTSFreeMemory(
 			ctypes.cast(ppBuffer, ctypes.c_void_p),
 		)
-		return None
+		raise
 
 
 def _getSessionLockedValue() -> WTS_LockState:

--- a/source/winBindings/bthprops.py
+++ b/source/winBindings/bthprops.py
@@ -3,7 +3,10 @@
 # This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
 # For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
 
-"""Functions exported by bthprops.cpl, and supporting data structures and enumerations."""
+"""Functions exported by bthprops.cpl, and supporting data structures and enumerations.
+
+When Bluetooth support is unavailable, function bindings raise :class:`OSError`.
+"""
 
 from ctypes import (
 	POINTER,
@@ -13,10 +16,20 @@ from ctypes import (
 	windll,
 )
 from ctypes.wintypes import BOOL, DWORD, HANDLE, ULONG, WCHAR
+from typing import Any
 
 from winBindings.kernel32 import SYSTEMTIME
 
-cpl = windll["bthprops.cpl"]
+try:
+	cpl = windll["bthprops.cpl"]
+except (AttributeError, OSError) as e:
+	cpl = None
+	BLUETOOTH_LOAD_ERROR: Exception | None = e
+else:
+	BLUETOOTH_LOAD_ERROR = None
+
+BLUETOOTH_AVAILABLE: bool = cpl is not None
+"""True if the Windows Bluetooth API is available."""
 
 BLUETOOTH_ADDRESS = c_ulonglong
 BLUETOOTH_MAX_NAME_SIZE = 248
@@ -49,15 +62,20 @@ class BLUETOOTH_DEVICE_INFO(Structure):
 BLUETOOTH_DEVICE_INFO_P = POINTER(BLUETOOTH_DEVICE_INFO)
 
 
-BluetoothGetDeviceInfo = cpl.BluetoothGetDeviceInfo
+def _unavailableBluetoothGetDeviceInfo(*args: Any, **kwargs: Any) -> None:
+	raise OSError("The Bluetooth API is not available")
+
+
+BluetoothGetDeviceInfo = cpl.BluetoothGetDeviceInfo if cpl is not None else _unavailableBluetoothGetDeviceInfo
 """
 Retrieves information about a remote Bluetooth device which has been identified through a successful device inquiry function call.
 
 ..seealso::
 	https://learn.microsoft.com/en-us/windows/win32/api/bluetoothapis/nf-bluetoothapis-bluetoothgetdeviceinfo
 """
-BluetoothGetDeviceInfo.argtypes = (
-	HANDLE,  # hRadio
-	BLUETOOTH_DEVICE_INFO_P,  # pbtdi
-)
-BluetoothGetDeviceInfo.restype = DWORD
+if cpl is not None:
+	BluetoothGetDeviceInfo.argtypes = (
+		HANDLE,  # hRadio
+		BLUETOOTH_DEVICE_INFO_P,  # pbtdi
+	)
+	BluetoothGetDeviceInfo.restype = DWORD

--- a/source/winBindings/magnification.py
+++ b/source/winBindings/magnification.py
@@ -3,14 +3,26 @@
 # This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
 # For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
 
-"""Functions exported by magnification.dll, and supporting data structures and enumerations."""
+"""Functions exported by magnification.dll, and supporting data structures and enumerations.
+
+When the Magnification API is unavailable, function bindings raise :class:`OSError`.
+"""
 
 from ctypes import POINTER, WINFUNCTYPE, Structure, WinError, c_float, c_int, windll  # noqa: I001
 from ctypes.wintypes import BOOL, LPRECT
 from _ctypes import CFuncPtr
 from typing import Any
 
-dll = windll.Magnification
+try:
+	dll = windll.Magnification
+except (AttributeError, OSError) as e:
+	dll = None
+	MAGNIFICATION_LOAD_ERROR: Exception | None = e
+else:
+	MAGNIFICATION_LOAD_ERROR = None
+
+MAGNIFICATION_AVAILABLE: bool = dll is not None
+"""True if the Windows Magnification API is available."""
 
 
 class MAGCOLOREFFECT(Structure):
@@ -33,8 +45,21 @@ def _errCheck[T: tuple[Any]](result: int, func: CFuncPtr, args: T) -> T:
 	return args
 
 
-MagSetFullscreenColorEffect = WINFUNCTYPE(BOOL, PMAGCOLOREFFECT)(
-	("MagSetFullscreenColorEffect", dll),
+def _unavailable(*args: Any, **kwargs: Any) -> None:
+	raise OSError("The Magnification API is not available")
+
+
+def _bind(name: str, prototype: Any, paramFlags: tuple[Any, ...] | None = None) -> Any:
+	if dll is None:
+		return _unavailable
+	function = prototype((name, dll), paramFlags) if paramFlags is not None else prototype((name, dll))
+	function.errcheck = _errCheck
+	return function
+
+
+MagSetFullscreenColorEffect = _bind(
+	"MagSetFullscreenColorEffect",
+	WINFUNCTYPE(BOOL, PMAGCOLOREFFECT),
 	((1, "pEffect"),),
 )
 """
@@ -43,10 +68,10 @@ Changes the color transformation matrix associated with the full-screen magnifie
 .. seealso::
 	https://learn.microsoft.com/en-us/windows/win32/api/magnification/nf-magnification-magsetfullscreencoloreffect
 """
-MagSetFullscreenColorEffect.errcheck = _errCheck
 
-MagGetFullscreenColorEffect = WINFUNCTYPE(BOOL, PMAGCOLOREFFECT)(
-	("MagGetFullscreenColorEffect", dll),
+MagGetFullscreenColorEffect = _bind(
+	"MagGetFullscreenColorEffect",
+	WINFUNCTYPE(BOOL, PMAGCOLOREFFECT),
 	((2, "effect"),),
 )
 """
@@ -55,10 +80,10 @@ Retrieves the color transformation matrix associated with the full-screen magnif
 .. seealso::
 	https://learn.microsoft.com/en-us/windows/win32/api/magnification/nf-magnification-maggetfullscreencoloreffect
 """
-MagGetFullscreenColorEffect.errcheck = _errCheck
 
-MagShowSystemCursor = WINFUNCTYPE(BOOL, BOOL)(
-	("MagShowSystemCursor", dll),
+MagShowSystemCursor = _bind(
+	"MagShowSystemCursor",
+	WINFUNCTYPE(BOOL, BOOL),
 	((1, "showCursor"),),
 )
 """
@@ -67,28 +92,26 @@ Shows or hides the system cursor.
 .. seealso::
 	https://learn.microsoft.com/en-us/windows/win32/api/magnification/nf-magnification-magshowsystemcursor
 """
-MagShowSystemCursor.errcheck = _errCheck
 
-MagInitialize = WINFUNCTYPE(BOOL)(("MagInitialize", dll))
+MagInitialize = _bind("MagInitialize", WINFUNCTYPE(BOOL))
 """
 Creates and initializes the magnifier run-time objects.
 
 .. seealso::
 	https://learn.microsoft.com/en-us/windows/win32/api/magnification/nf-magnification-maginitialize
 """
-MagInitialize.errcheck = _errCheck
 
-MagUninitialize = WINFUNCTYPE(BOOL)(("MagUninitialize", dll))
+MagUninitialize = _bind("MagUninitialize", WINFUNCTYPE(BOOL))
 """
 Destroys the magnifier run-time objects.
 
 .. seealso::
 	https://learn.microsoft.com/en-us/windows/win32/api/magnification/nf-magnification-maguninitialize
 """
-MagUninitialize.errcheck = _errCheck
 
-MagSetFullscreenTransform = WINFUNCTYPE(BOOL, c_float, c_int, c_int)(
-	("MagSetFullscreenTransform", dll),
+MagSetFullscreenTransform = _bind(
+	"MagSetFullscreenTransform",
+	WINFUNCTYPE(BOOL, c_float, c_int, c_int),
 	((1, "magLevel"), (1, "xOffset"), (1, "yOffset")),
 )
 """
@@ -97,10 +120,10 @@ Sets the magnification settings for the full-screen magnifier.
 .. seealso::
 	https://learn.microsoft.com/en-us/windows/win32/api/magnification/nf-magnification-magsetfullscreentransform
 """
-MagSetFullscreenTransform.errcheck = _errCheck
 
-MagSetInputTransform = WINFUNCTYPE(BOOL, BOOL, LPRECT, LPRECT)(
-	("MagSetInputTransform", dll),
+MagSetInputTransform = _bind(
+	"MagSetInputTransform",
+	WINFUNCTYPE(BOOL, BOOL, LPRECT, LPRECT),
 	((1, "fEnabled"), (1, "pRectSource"), (1, "pRectDest")),
 )
 """
@@ -109,4 +132,3 @@ Sets the mapping between magnified coordinates and screen coordinates for pen an
 .. seealso::
 	https://learn.microsoft.com/en-us/windows/win32/api/magnification/nf-magnification-magsetinputtransform
 """
-MagSetInputTransform.errcheck = _errCheck

--- a/source/winBindings/winusb.py
+++ b/source/winBindings/winusb.py
@@ -3,7 +3,10 @@
 # This file may be used under the terms of the GNU General Public License, version 2 or later, as modified by the NVDA license.
 # For full terms and any additional permissions, see the NVDA license file: https://github.com/nvaccess/nvda/blob/master/copying.txt
 
-"""Functions exported by winusb.dll, and supporting data structures and enumerations."""
+"""Functions exported by winusb.dll, and supporting data structures and enumerations.
+
+When WinUSB is unavailable, function bindings raise :class:`OSError`.
+"""
 
 from ctypes import (  # noqa: I001
 	WINFUNCTYPE,
@@ -17,8 +20,18 @@ from ctypes import (  # noqa: I001
 from ctypes.wintypes import BOOL, HANDLE, PULONG, ULONG, USHORT
 from enum import IntEnum
 from serial.win32 import LPOVERLAPPED
+from typing import Any
 
-dll = windll.winusb
+try:
+	dll = windll.winusb
+except (AttributeError, OSError) as e:
+	dll = None
+	WINUSB_LOAD_ERROR: Exception | None = e
+else:
+	WINUSB_LOAD_ERROR = None
+
+WINUSB_AVAILABLE: bool = dll is not None
+"""True if WinUSB is available."""
 
 WINUSB_INTERFACE_HANDLE = c_void_p
 PWINUSB_INTERFACE_HANDLE = POINTER(c_void_p)
@@ -83,106 +96,133 @@ class WINUSB_PIPE_INFORMATION(Structure):
 	)
 
 
-WinUsb_Initialize = WINFUNCTYPE(None)(("WinUsb_Initialize", dll))
+def _unavailable(*args: Any, **kwargs: Any) -> None:
+	raise OSError("WinUSB is not available")
+
+
+def _bind(name: str, argtypes: tuple[Any, ...], restype: Any) -> Any:
+	if dll is None:
+		return _unavailable
+	function = WINFUNCTYPE(None)((name, dll))
+	function.argtypes = argtypes
+	function.restype = restype
+	return function
+
+
+WinUsb_Initialize = _bind(
+	"WinUsb_Initialize",
+	(
+		HANDLE,  # DeviceHandle
+		PWINUSB_INTERFACE_HANDLE,  # InterfaceHandle
+	),
+	BOOL,
+)
 """
 Creates a WinUSB handle for the device specified by a file handle.
 
 ..seealso::
 	https://learn.microsoft.com/en-us/windows/win32/api/winusb/nf-winusb-winusb_initialize
 """
-WinUsb_Initialize.argtypes = (
-	HANDLE,  # DeviceHandle
-	PWINUSB_INTERFACE_HANDLE,  # InterfaceHandle
-)
-WinUsb_Initialize.restype = BOOL
 
-WinUsb_Free = WINFUNCTYPE(None)(("WinUsb_Free", dll))
+WinUsb_Free = _bind(
+	"WinUsb_Free",
+	(
+		WINUSB_INTERFACE_HANDLE,  # InterfaceHandle
+	),
+	BOOL,
+)
 """
 Frees the resources allocated by ``WinUsb_Initialize``.
 
 ..seealso::
 	https://learn.microsoft.com/en-us/windows/win32/api/winusb/nf-winusb-winusb_free
 """
-WinUsb_Free.argtypes = (
-	WINUSB_INTERFACE_HANDLE,  # InterfaceHandle
-)
-WinUsb_Free.restype = BOOL
 
-WinUsb_QueryInterfaceSettings = WINFUNCTYPE(None)(("WinUsb_QueryInterfaceSettings", dll))
+WinUsb_QueryInterfaceSettings = _bind(
+	"WinUsb_QueryInterfaceSettings",
+	(
+		WINUSB_INTERFACE_HANDLE,  # InterfaceHandle
+		c_ubyte,  # AlternateInterfaceNumber
+		POINTER(USB_INTERFACE_DESCRIPTOR),  # UsbAltInterfaceDescriptor
+	),
+	BOOL,
+)
 """
 Retrieves the interface descriptor for the specified alternate interface settings for a particular interface handle.
 
 ..seealso::
 	https://learn.microsoft.com/en-us/windows/win32/api/winusb/nf-winusb-winusb_queryinterfacesettings
 """
-WinUsb_QueryInterfaceSettings.argtypes = (
-	WINUSB_INTERFACE_HANDLE,  # InterfaceHandle
-	c_ubyte,  # AlternateInterfaceNumber
-	POINTER(USB_INTERFACE_DESCRIPTOR),  # UsbAltInterfaceDescriptor
-)
-WinUsb_QueryInterfaceSettings.restype = BOOL
 
-WinUsb_QueryPipe = WINFUNCTYPE(None)(("WinUsb_QueryPipe", dll))
+WinUsb_QueryPipe = _bind(
+	"WinUsb_QueryPipe",
+	(
+		WINUSB_INTERFACE_HANDLE,  # InterfaceHandle
+		c_ubyte,  # AlternateInterfaceNumber
+		c_ubyte,  # PipeIndex
+		POINTER(WINUSB_PIPE_INFORMATION),  # PipeInformation
+	),
+	BOOL,
+)
 """
 Retrieves information about a pipe that is associated with an interface.
 
 ..seealso::
 	https://learn.microsoft.com/en-us/windows/win32/api/winusb/nf-winusb-winusb_querypipe
 """
-WinUsb_QueryPipe.argtypes = (
-	WINUSB_INTERFACE_HANDLE,  # InterfaceHandle
-	c_ubyte,  # AlternateInterfaceNumber
-	c_ubyte,  # PipeIndex
-	POINTER(WINUSB_PIPE_INFORMATION),  # PipeInformation
-)
-WinUsb_QueryPipe.restype = BOOL
 
-WinUsb_ReadPipe = WINFUNCTYPE(None)(("WinUsb_ReadPipe", dll))
+WinUsb_ReadPipe = _bind(
+	"WinUsb_ReadPipe",
+	(
+		WINUSB_INTERFACE_HANDLE,  # InterfaceHandle
+		c_ubyte,  # PipeID
+		c_void_p,  # Buffer
+		ULONG,  # BufferLength
+		PULONG,  # LengthTransferred
+		LPOVERLAPPED,  # Overlapped
+	),
+	BOOL,
+)
 """
 Reads data from the specified pipe.
 
 ..seealso::
 	https://learn.microsoft.com/en-us/windows/win32/api/winusb/nf-winusb-winusb_readpipe
 """
-WinUsb_ReadPipe.argtypes = (
-	WINUSB_INTERFACE_HANDLE,  # InterfaceHandle
-	c_ubyte,  # PipeID
-	c_void_p,  # Buffer
-	ULONG,  # BufferLength
-	PULONG,  # LengthTransferred
-	LPOVERLAPPED,  # Overlapped
-)
-WinUsb_ReadPipe.restype = BOOL
 
-WinUsb_WritePipe = WINFUNCTYPE(None)(("WinUsb_WritePipe", dll))
+WinUsb_WritePipe = _bind(
+	"WinUsb_WritePipe",
+	(
+		WINUSB_INTERFACE_HANDLE,  # InterfaceHandle
+		c_ubyte,  # PipeID
+		c_void_p,  # Buffer
+		ULONG,  # BufferLength
+		PULONG,  # LengthTransferred
+		LPOVERLAPPED,  # Overlapped
+	),
+	BOOL,
+)
 """
 Writes data to a pipe.
 
 ..seealso::
 	https://learn.microsoft.com/en-us/windows/win32/api/winusb/nf-winusb-winusb_writepipe
 """
-WinUsb_WritePipe.argtypes = (
-	WINUSB_INTERFACE_HANDLE,  # InterfaceHandle
-	c_ubyte,  # PipeID
-	c_void_p,  # Buffer
-	ULONG,  # BufferLength
-	PULONG,  # LengthTransferred
-	LPOVERLAPPED,  # Overlapped
-)
-WinUsb_WritePipe.restype = BOOL
 
-WinUsb_SetPipePolicy = WINFUNCTYPE(None)(("WinUsb_SetPipePolicy", dll))
+WinUsb_SetPipePolicy = _bind(
+	"WinUsb_SetPipePolicy",
+	(
+		WINUSB_INTERFACE_HANDLE,  # InterfaceHandle
+		c_ubyte,  # PipeID
+		ULONG,  # PolicyType
+		ULONG,  # ValueLength
+		c_void_p,  # Value
+	),
+	BOOL,
+)
 """
 Sets the policy for a specific pipe associated with an endpoint on the device.
 
 ..seealso::
 	https://learn.microsoft.com/en-us/windows/win32/api/winusb/nf-winusb-winusb_setpipepolicy
 """
-WinUsb_SetPipePolicy.argtypes = (
-	WINUSB_INTERFACE_HANDLE,  # InterfaceHandle
-	c_ubyte,  # PipeID
-	ULONG,  # PolicyType
-	ULONG,  # ValueLength
-	c_void_p,  # Value
-)
-WinUsb_SetPipePolicy.restype = BOOL

--- a/tests/unit/test_NVDAHelper.py
+++ b/tests/unit/test_NVDAHelper.py
@@ -1,0 +1,69 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2026 NV Access Limited
+# This file may be used under the terms of the GNU General Public License, version 2 or later.
+# For more details see: https://www.gnu.org/licenses/gpl-2.0.html
+
+import unittest
+from unittest import mock
+
+import NVDAHelper
+
+
+class TestTryStartRemoteLoader(unittest.TestCase):
+	def test_loaderFailureIsLoggedAndIgnored(self):
+		with (
+			mock.patch.object(NVDAHelper, "_RemoteLoader", side_effect=OSError),
+			mock.patch.object(NVDAHelper.log, "error") as logError,
+		):
+			loader = NVDAHelper._tryStartRemoteLoader("loaderPath")
+
+		self.assertIsNone(loader)
+		logError.assert_called_once_with(
+			"Unable to start remote loader from loaderPath",
+			exc_info=True,
+		)
+
+
+class TestRemoteLoaderHandles(unittest.TestCase):
+	def test_handlesAreClosedWhenSetupFails(self):
+		with (
+			mock.patch.object(NVDAHelper.winKernel, "CreatePipe", return_value=(10, 11)),
+			mock.patch.object(
+				NVDAHelper._RemoteLoader,
+				"_duplicateAsInheritable",
+				side_effect=OSError,
+			),
+			mock.patch.object(NVDAHelper.winKernel, "closeHandle") as closeHandle,
+			self.assertRaises(OSError),
+		):
+			NVDAHelper._RemoteLoader("loaderPath")
+
+		self.assertEqual([mock.call(11), mock.call(10)], closeHandle.call_args_list)
+
+	def test_parentHandlesAreClosedAfterStartup(self):
+		def createProcess(*args):
+			processInformation = args[-1]
+			processInformation.hProcess = 16
+			processInformation.hThread = 17
+
+		with (
+			mock.patch.object(NVDAHelper.winKernel, "CreatePipe", return_value=(10, 11)),
+			mock.patch.object(
+				NVDAHelper._RemoteLoader,
+				"_duplicateAsInheritable",
+				side_effect=(12, 13),
+			),
+			mock.patch.object(NVDAHelper.msvcrt, "get_osfhandle", return_value=14),
+			mock.patch.object(NVDAHelper.winKernel, "OpenProcessToken", return_value=15),
+			mock.patch.object(NVDAHelper.winKernel, "CreateProcessAsUser", side_effect=createProcess),
+			mock.patch.object(NVDAHelper.winKernel, "closeHandle") as closeHandle,
+			mock.patch("builtins.open", mock.mock_open()),
+		):
+			loader = NVDAHelper._RemoteLoader("loaderPath")
+
+		self.assertEqual(11, loader._pipeWrite)
+		self.assertEqual(16, loader._process)
+		self.assertEqual(
+			[mock.call(10), mock.call(12), mock.call(13), mock.call(15), mock.call(17)],
+			closeHandle.call_args_list,
+		)

--- a/tests/unit/test_audioFallback.py
+++ b/tests/unit/test_audioFallback.py
@@ -1,0 +1,83 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2026 NV Access Limited
+# This file may be used under the terms of the GNU General Public License, version 2 or later.
+# For more details see: https://www.gnu.org/licenses/gpl-2.0.html
+
+import importlib
+import sys
+import unittest
+from unittest import mock
+
+import audio
+from gui import settingsDialogs
+from utils import mmdevice
+
+
+class TestUnavailableSoundSplit(unittest.TestCase):
+	def test_importHandlesUnavailablePycaw(self):
+		soundSplit = audio.soundSplit
+		soundSplitAvailable = audio.SOUND_SPLIT_AVAILABLE
+		soundSplitModule = sys.modules.pop("audio.soundSplit", None)
+
+		def restoreAudioModule() -> None:
+			if soundSplitModule is not None:
+				sys.modules["audio.soundSplit"] = soundSplitModule
+			audio.soundSplit = soundSplit
+			audio.SOUND_SPLIT_AVAILABLE = soundSplitAvailable
+
+		self.addCleanup(restoreAudioModule)
+		del audio.soundSplit
+		with mock.patch.dict(sys.modules, {"pycaw.utils": None}):
+			importlib.reload(audio)
+		self.assertFalse(audio.SOUND_SPLIT_AVAILABLE)
+		self.assertIsNone(audio.soundSplit)
+
+	def test_lifecycleAndStateChangeAreNoOps(self):
+		with mock.patch.object(audio, "soundSplit", None):
+			audio.initialize()
+			audio.terminate()
+			self.assertEqual({}, audio._setSoundSplitState(audio.SoundSplitState.OFF))
+
+	def test_toggleReportsUnavailable(self):
+		with (
+			mock.patch.object(audio, "soundSplit", None),
+			mock.patch("ui.message") as message,
+		):
+			audio._toggleSoundSplitState()
+
+			message.assert_called_once_with("Sound Split is unavailable.")
+
+
+class TestUnavailableAudioDeviceEnumeration(unittest.TestCase):
+	def test_importHandlesUnavailablePycaw(self):
+		self.addCleanup(importlib.reload, mmdevice)
+		with mock.patch.dict(sys.modules, {"pycaw.utils": None}):
+			importlib.reload(mmdevice)
+		self.assertIsNone(mmdevice.AudioUtilities)
+
+	def test_noDevicesAreReturned(self):
+		with mock.patch.object(mmdevice, "AudioUtilities", None):
+			self.assertEqual([], list(mmdevice.getOutputDevices()))
+
+
+class TestUnavailableSoundSplitSettings(unittest.TestCase):
+	def test_controlsAreDisabledWithExplanation(self):
+		panel = mock.MagicMock()
+		settingsSizerHelper = mock.MagicMock()
+		unavailableText = mock.sentinel.unavailableText
+		with (
+			mock.patch.object(settingsDialogs.audio, "SOUND_SPLIT_AVAILABLE", False),
+			mock.patch.object(settingsDialogs.wx, "StaticText", return_value=unavailableText) as staticText,
+		):
+			settingsDialogs.AudioPanel._updateSoundSplitAvailability(
+				panel,
+				settingsSizerHelper,
+			)
+
+		panel.soundSplitComboBox.Disable.assert_called_once_with()
+		panel.soundSplitModesList.Disable.assert_called_once_with()
+		staticText.assert_called_once_with(
+			panel,
+			label="Sound Split is unavailable because required Windows audio components are missing.",
+		)
+		settingsSizerHelper.addItem.assert_called_once_with(unavailableText)

--- a/tests/unit/test_braille/test_hims.py
+++ b/tests/unit/test_braille/test_hims.py
@@ -1,0 +1,31 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2026 NV Access Limited
+# This file may be used under the terms of the GNU General Public License, version 2 or later.
+# For more details see: https://www.gnu.org/licenses/gpl-2.0.html
+
+import unittest
+from unittest import mock
+
+import bdDetect
+import braille.display.driver
+from brailleDisplayDrivers import hims
+
+
+class TestWinUsbFallback(unittest.TestCase):
+	def test_unavailableWinUsbContinuesAfterBulkFailure(self):
+		port = "customPort"
+		with (
+			mock.patch.object(braille.display.driver.BrailleDisplayDriver, "__init__", return_value=None),
+			mock.patch.object(
+				hims.BrailleDisplayDriver,
+				"_getTryPorts",
+				return_value=[(bdDetect.ProtocolType.CUSTOM, "", port, {})],
+			),
+			mock.patch.object(hims.hwIo, "Bulk", side_effect=OSError),
+			mock.patch.object(hims, "WINUSB_AVAILABLE", False),
+			mock.patch.object(hims, "_WinUsbBulk") as winUsbBulk,
+			self.assertRaisesRegex(RuntimeError, "No Hims display found"),
+		):
+			hims.BrailleDisplayDriver()
+
+		winUsbBulk.assert_not_called()

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -1,0 +1,27 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2026 NV Access Limited
+# This file may be used under the terms of the GNU General Public License, version 2 or later.
+# For more details see: https://www.gnu.org/licenses/gpl-2.0.html
+
+import unittest
+from unittest import mock
+
+import core
+import screenCurtain
+
+
+class TestInitialBrailleMessage(unittest.TestCase):
+	def test_screenCurtainUnavailable(self):
+		with mock.patch.object(screenCurtain, "screenCurtain", None):
+			self.assertEqual("NVDA started", core._getInitialBrailleMessage())
+
+	def test_screenCurtainEnabled(self):
+		with mock.patch.object(
+			screenCurtain,
+			"screenCurtain",
+			mock.Mock(enabled=True),
+		):
+			self.assertEqual(
+				"NVDA started with screen curtain enabled",
+				core._getInitialBrailleMessage(),
+			)

--- a/tests/unit/test_hwPortUtils.py
+++ b/tests/unit/test_hwPortUtils.py
@@ -1,0 +1,26 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2026 NV Access Limited
+# This file may be used under the terms of the GNU General Public License, version 2 or later.
+# For more details see: https://www.gnu.org/licenses/gpl-2.0.html
+
+import unittest
+from unittest import mock
+
+import hwPortUtils
+from winBindings import bthprops
+
+
+class TestBluetoothDeviceInfo(unittest.TestCase):
+	def test_cplCompatibilityAliasIsAvailable(self):
+		self.assertTrue(hasattr(bthprops, "cpl"))
+
+	def test_unavailableBluetoothApiRaisesOSError(self):
+		with (
+			mock.patch.object(
+				hwPortUtils,
+				"_BluetoothGetDeviceInfo",
+				bthprops._unavailableBluetoothGetDeviceInfo,
+			),
+			self.assertRaisesRegex(OSError, "Bluetooth API is not available"),
+		):
+			hwPortUtils.getBluetoothDeviceInfo(0)

--- a/tests/unit/test_magnifier/test_fullscreenMagnifier.py
+++ b/tests/unit/test_magnifier/test_fullscreenMagnifier.py
@@ -372,6 +372,16 @@ class TestFullScreenMagnifierApi(_TestMagnifier):
 		self.assertFalse(magnifier._isActive)
 		self.assertIsNone(magnifier._timer)
 
+	def testCannotStartWhenMagnificationApiIsUnavailable(self):
+		self.mock_mag_fs.MAGNIFICATION_AVAILABLE = False
+		magnifier = FullScreenMagnifier()
+
+		with self.assertRaisesRegex(MagnifierStartError, "Windows Magnification API is unavailable"):
+			magnifier._startMagnifier()
+
+		self.assertFalse(magnifier._isActive)
+		self.assertIsNone(magnifier._timer)
+
 	def testRecoveryCapStopsMagnifier(self):
 		"""After _MAX_RECOVERY_ATTEMPTS failed attempts, the magnifier stops and the user is notified."""
 		magnifier = FullScreenMagnifier()

--- a/tests/unit/test_remote/test_remoteClient.py
+++ b/tests/unit/test_remote/test_remoteClient.py
@@ -3,8 +3,10 @@
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
-import unittest  # noqa: I001
+import sys  # noqa: I001
+import unittest
 from unittest.mock import MagicMock, patch
+import _remoteClient
 import _remoteClient.client as rcClient
 from _remoteClient.connectionInfo import ConnectionInfo, ConnectionMode
 from _remoteClient.protocol import RemoteMessageType
@@ -355,6 +357,20 @@ class TestRemoteClient(unittest.TestCase):
 		self.client.followerTransport = fakeTransport
 		onConnectAsFollowerFailed(self.client)
 		self.uiDelayedMessage.assert_called_once()
+
+
+class TestRemoteInitialization(unittest.TestCase):
+	def test_importError_marksRemoteAccessUnavailable(self):
+		with (
+			patch.dict(sys.modules, {"_remoteClient.client": None}),
+			patch.object(_remoteClient, "_remoteClient", None),
+			patch.object(_remoteClient, "getRemoteConfig", return_value={"enabled": True}),
+			patch.object(_remoteClient.log, "warning") as logWarning,
+		):
+			_remoteClient.initialize()
+
+			logWarning.assert_called_once_with("Remote Access unavailable.", exc_info=True)
+			self.assertIsNone(_remoteClient._remoteClient)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_visionEnhancementProviders/test_magnificationAPI.py
+++ b/tests/unit/test_visionEnhancementProviders/test_magnificationAPI.py
@@ -6,7 +6,9 @@
 """Unit tests for the magnification Windows API."""
 
 import unittest
+from unittest import mock
 
+import screenCurtain
 from screenCurtain._screenCurtain import TRANSFORM_BLACK
 from winBindings import magnification
 from winBindings.magnification import MAGCOLOREFFECT
@@ -18,6 +20,26 @@ class _Test_MagnificationAPI(unittest.TestCase):
 
 	def tearDown(self):
 		self.assertTrue(magnification.MagUninitialize())
+
+
+class TestScreenCurtainAvailability(unittest.TestCase):
+	def test_unavailableMagnificationPreventsInitialization(self):
+		loadError = OSError("missing Magnification.dll")
+		with (
+			mock.patch.object(screenCurtain, "MAGNIFICATION_AVAILABLE", False),
+			mock.patch.object(screenCurtain, "MAGNIFICATION_LOAD_ERROR", loadError),
+			mock.patch.object(screenCurtain, "screenCurtain", None),
+			mock.patch.object(screenCurtain, "ScreenCurtain") as screenCurtainClass,
+			mock.patch.object(screenCurtain.log, "warning") as logWarning,
+		):
+			screenCurtain.initialize()
+
+			screenCurtainClass.assert_not_called()
+			self.assertIsNone(screenCurtain.screenCurtain)
+			logWarning.assert_called_once_with(
+				"Screen Curtain unavailable because the Windows Magnification API is unavailable.",
+				exc_info=loadError,
+			)
 
 
 class Test_ScreenCurtain(_Test_MagnificationAPI):

--- a/tests/unit/test_winAPI/test_sessionTracking.py
+++ b/tests/unit/test_winAPI/test_sessionTracking.py
@@ -1,0 +1,71 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2026 NV Access Limited
+# This file may be used under the terms of the GNU General Public License, version 2 or later.
+# For more details see: https://www.gnu.org/licenses/gpl-2.0.html
+
+import unittest
+from unittest import mock
+
+from winAPI import sessionTracking
+from winAPI._wtsApi32 import WTS_LockState
+
+
+class TestIsWindowsLockedCheckViaSessionQuery(unittest.TestCase):
+	def test_unknownLockState_isTreatedAsUnlockedAndLoggedOnce(self):
+		with (
+			mock.patch.object(sessionTracking, "_loggedSessionQueryFailures", set()),
+			mock.patch.object(
+				sessionTracking,
+				"_getSessionLockedValue",
+				return_value=WTS_LockState.WTS_SESSIONSTATE_UNKNOWN,
+			),
+			mock.patch.object(sessionTracking.log, "error") as logError,
+		):
+			self.assertFalse(sessionTracking._isWindowsLocked_checkViaSessionQuery())
+			self.assertFalse(sessionTracking._isWindowsLocked_checkViaSessionQuery())
+
+			logError.assert_called_once_with(
+				f"Unable to determine lock state via Session Query. "
+				f"Lock state value: {WTS_LockState.WTS_SESSIONSTATE_UNKNOWN!r}",
+				exc_info=False,
+			)
+
+	def test_queryFailure_isTreatedAsUnlockedAndLoggedOnce(self):
+		with (
+			mock.patch.object(sessionTracking, "_loggedSessionQueryFailures", set()),
+			mock.patch.object(sessionTracking, "WTSQuerySessionInformation", return_value=False),
+			mock.patch.object(sessionTracking, "WTSFreeMemory"),
+			mock.patch.object(sessionTracking.log, "error") as logError,
+		):
+			self.assertFalse(sessionTracking._isWindowsLocked_checkViaSessionQuery())
+			self.assertFalse(sessionTracking._isWindowsLocked_checkViaSessionQuery())
+
+			logError.assert_called_once_with("Failure querying session locked state", exc_info=True)
+
+	def test_distinctFailuresAreEachLoggedOnce(self):
+		with (
+			mock.patch.object(sessionTracking, "_loggedSessionQueryFailures", set()),
+			mock.patch.object(sessionTracking.log, "error") as logError,
+		):
+			sessionTracking._logSessionQueryFailureOnce("query failed", excInfo=True)
+			sessionTracking._logSessionQueryFailureOnce("unknown state")
+			sessionTracking._logSessionQueryFailureOnce("query failed", excInfo=True)
+
+		self.assertEqual(
+			[
+				mock.call("query failed", exc_info=True),
+				mock.call("unknown state", exc_info=False),
+			],
+			logError.call_args_list,
+		)
+
+	def test_queryFailurePreservesSpecificError(self):
+		with (
+			mock.patch.object(sessionTracking, "WTSQuerySessionInformation", return_value=False),
+			mock.patch.object(sessionTracking, "WTSFreeMemory"),
+			self.assertRaisesRegex(
+				RuntimeError,
+				"Failure calling WTSQuerySessionInformationW",
+			),
+		):
+			sessionTracking._getCurrentSessionInfoEx()

--- a/tests/unit/test_winBindings.py
+++ b/tests/unit/test_winBindings.py
@@ -1,0 +1,29 @@
+# A part of NonVisual Desktop Access (NVDA)
+# Copyright (C) 2026 NV Access Limited
+# This file may be used under the terms of the GNU General Public License, version 2 or later.
+# For more details see: https://www.gnu.org/licenses/gpl-2.0.html
+
+import unittest
+from unittest import mock
+
+from winBindings import magnification, winusb
+
+
+class TestUnavailableMagnification(unittest.TestCase):
+	def test_bindReturnsCallableStub(self):
+		with mock.patch.object(magnification, "dll", None):
+			binding = magnification._bind("MissingFunction", mock.sentinel.prototype)
+
+		self.assertIs(binding, magnification._unavailable)
+		with self.assertRaisesRegex(OSError, "Magnification API is not available"):
+			binding(showCursor=True)
+
+
+class TestUnavailableWinUsb(unittest.TestCase):
+	def test_bindReturnsCallableStub(self):
+		with mock.patch.object(winusb, "dll", None):
+			binding = winusb._bind("MissingFunction", (), None)
+
+		self.assertIs(binding, winusb._unavailable)
+		with self.assertRaisesRegex(OSError, "WinUSB is not available"):
+			binding(buffer=None)

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -11,6 +11,12 @@
 
 ### Bug Fixes
 
+* NVDA can now start in Windows PE when optional Windows APIs and components are unavailable.
+  Depending on the image contents, affected features can include the Magnifier, Screen Curtain, Remote Access,
+  MathCAT, Bluetooth device identification, the HIMS WinUSB fallback, Sound Split, and audio device enumeration.
+  Sound Split and audio device enumeration are unavailable without `pdh.dll`.
+  Users must still add compatible audio components to their Windows PE image for NVDA audio output. (#19537, @akash07k)
+
 #### Performance
 
 #### Braille
@@ -27,6 +33,12 @@ Please refer to [the developer guide](https://download.nvaccess.org/documentatio
 
 * Note: this is an Add-on API compatibility breaking release.
 Add-ons will need to be re-tested and have their manifest updated.
+* Optional Windows API bindings now expose `MAGNIFICATION_AVAILABLE`, `BLUETOOTH_AVAILABLE`, and `WINUSB_AVAILABLE`.
+  Their function bindings remain callable and raise `OSError` when the corresponding API is unavailable. (#19537)
+* `audio.SOUND_SPLIT_AVAILABLE` indicates whether Sound Split dependencies loaded successfully.
+  Use `audio.initialize()` and `audio.terminate()` rather than calling through `audio.soundSplit`,
+  which can be `None`.
+  `SoundSplitState` remains available from `audio` without Sound Split dependencies. (#19537)
 
 #### API Breaking Changes
 


### PR DESCRIPTION
### Link to issue number:

Fixes #19537

Related ADR: #20843

### Summary of the issue:

NVDA currently fails during startup on Windows PE when optional Windows DLLs, APIs, native extensions, or packaged dependencies are unavailable.

The original failure reported in #19537 occurs while importing `winBindings.bthprops`, because Windows PE may not provide `bthprops.cpl`. Further investigation identified additional optional dependencies that may also be unavailable in a minimal Windows image:

1. The Windows Magnification API.
2. Bluetooth APIs.
3. WinUSB.
4. Architecture-specific NVDA remote loaders.
5. WTS session information and `wtsapi32.dll`.
6. Optional Remote Access and MathCAT dependencies.
7. `pdh.dll`, which is statically imported by the native `psutil` extension used through `pycaw.utils`.

These failures previously occurred while importing modules or initializing services, allowing one unavailable optional capability to prevent NVDA from starting.

### Description of user facing changes:

NVDA can now continue starting when supported optional Windows APIs or components are unavailable.

Only features that depend on a missing component are disabled:

1. If the Windows Magnification API is unavailable, NVDA's Magnifier and Screen Curtain are unavailable.
2. If Bluetooth support is unavailable, Bluetooth device identification is unavailable.
3. If WinUSB is unavailable, the optional HIMS WinUSB fallback is skipped while other HIMS connection methods remain available.
4. If Remote Access dependencies cannot load, Remote Access is skipped and the failure is logged.
5. If MathCAT cannot initialize, math presentation is skipped, the failure is logged, and the Math settings category is omitted.
6. If `pdh.dll` prevents `pycaw.utils` from loading, Sound Split and optional audio-device enumeration are unavailable.
7. If an architecture-specific remote loader cannot start, NVDA continues without injection support for that loader.
8. If WTS cannot load or session information cannot be queried, NVDA continues and reports each distinct failure only once per session.

The Audio settings panel disables Sound Split controls and explains why the feature is unavailable.

Normal behavior is unchanged when all supported Windows components are present.

Windows PE images must still include compatible audio components for NVDA speech and other audio output. This PR does not supply or emulate those components.

### Description of developer facing changes:

The optional native bindings now expose explicit capability information:

1. `winBindings.magnification.MAGNIFICATION_AVAILABLE`
2. `winBindings.bthprops.BLUETOOTH_AVAILABLE`
3. `winBindings.winusb.WINUSB_AVAILABLE`
4. `winBindings.wtsapi32.WTSAPI32_AVAILABLE`
5. `audio.SOUND_SPLIT_AVAILABLE`

The corresponding native function names remain callable when a DLL is unavailable, but raise `OSError` rather than being set to `None`. This preserves a consistent callable API and allows consumers to either check the capability constant or handle `OSError`.

The original DLL-loading exceptions are retained for diagnostic logging.

The existing `winBindings.bthprops.cpl` symbol remains available for add-on compatibility.

`SoundSplitState` was moved to the dependency-free `audio.soundSplitState` module so configuration and GUI code can use it without importing `pycaw`. It remains available through both `audio.SoundSplitState` and `audio.soundSplit.SoundSplitState`. `VolumeTupleT` also remains available from its original `audio.soundSplit` location.

Consumers should use:

```python
audio.initialize()
audio.terminate()
```

rather than calling through `audio.soundSplit`, which can be `None` when its dependencies are unavailable.

### Description of development approach:

The implementation detects individual capabilities rather than detecting Windows PE itself. Windows PE images can contain different optional components, so checking the actual API or dependency avoids maintaining an environment-specific exclusion list.

Optional native binding modules guard DLL loading, retain the original exception, expose an availability constant, and keep existing function symbols callable through stubs that raise `OSError`. Feature consumers check availability before enabling functionality or handle the explicit failure at their boundary.

Optional Python and native-extension dependency chains are isolated behind their feature packages. Sound Split configuration state is kept in a dependency-free module, while Remote Access and MathCAT implementations are imported only during guarded initialization. Settings controls are disabled when part of a panel remains useful, while the Math category is omitted when its implementation cannot load.

Architecture-specific remote loaders start independently. A loader failure does not abort the main process, and temporary pipe, token, thread, and process handles are closed on success and failure.

WTS binding and query failures use the existing fallback that treats an indeterminate lock state as unlocked. Failures recurring during the core pump are logged once per distinct category. The security policy for an entirely unavailable WTS component is called out for explicit confirmation in #20843.

The proposed architecture and three-part integration plan are documented in #20843. This PR remains a draft implementation reference while that ADR is reviewed.

### Testing strategy:

Manual end-to-end testing was completed on an actual x64 Windows PE image based on Windows 11 25H2. The image included compatible audio components. NVDA started successfully and provided audio output while unsupported optional features degraded without preventing startup.

Automated regression tests cover:

1. Unavailable Magnification, Bluetooth, WinUSB, and WTS bindings.
2. Screen Curtain and Magnifier behavior without the Magnification API.
3. HIMS fallback behavior without WinUSB.
4. Sound Split and audio-device enumeration without their optional dependencies.
5. Remote Access and MathCAT initialization failures, including Math settings registration.
6. Architecture-specific remote-loader failures and handle cleanup.
7. WTS query and binding failures, unlocked fallback behavior, and deduplicated logging.

Local validation completed successfully with Ruff, Pyright, ty, and the focused unit tests. GitHub Actions is green on the current revision, including the complete Windows 2022 and Windows 2025 system-test matrices.

### Known issues with pull request:

1. Windows PE must still contain compatible audio components for NVDA speech and sound output.
2. Features available in Windows PE depend on the components included in the individual image.
3. When WTS information is unavailable, NVDA preserves the existing behavior of treating the lock state as unlocked. Confirmation of this security-sensitive fallback is requested in #20843.
4. The overall diff is larger than the project's preferred PR size because it includes focused regression coverage for each unavailable path. Approximately half of the additions are tests, while the production changes remain near the project guideline. #20843 proposes a three-part split if NV Access prefers smaller review units.

### Code Review Checklist:

- [x] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] API is compatible with existing add-ons.
- [x] Security precautions taken.