### PR TITLE
Prevent display timeout during braille automatic scrolling

### DIFF
--- a/source/braille/brailleHandler.py
+++ b/source/braille/brailleHandler.py
@@ -29,6 +29,7 @@ import inputCore
 import keyboardHandler
 import louisHelper
 import queueHandler
+import systemUtils
 import winBindings.kernel32
 import winKernel
 import wx
@@ -424,6 +425,7 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 		"""When a decider handler decides to disable the braille handler, ensure braille doesn't continue.
 		This should be called from the main thread to avoid wx assertions.
 		"""
+		self.autoScroll(enable=False)
 		if self._cursorBlinkTimer:
 			# A blinking cursor should be stopped
 			self._cursorBlinkTimer.Stop()
@@ -749,13 +751,15 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 		:param enable: ``True`` if automatic scroll should be enabled, ``False`` otherwise.
 		"""
 
-		if not self.enabled:
-			return
-		if enable and self._autoScrollCallLater is None:
+		if enable:
+			if not self.enabled or self._autoScrollCallLater is not None:
+				return
 			self._autoScrollCallLater = wx.CallLater(self._calculateAutoScrollTimeout(), self.scrollForward)
-		elif not enable and self._autoScrollCallLater is not None:
+			systemUtils.preventSystemIdle(persistent=True)
+		elif self._autoScrollCallLater is not None:
 			self._autoScrollCallLater.Stop()
 			self._autoScrollCallLater = None
+			systemUtils.resetThreadExecutionState()
 
 	def _calculateAutoScrollTimeout(self) -> int:
 		"""

--- a/source/speech/sayAll.py
+++ b/source/speech/sayAll.py
@@ -104,7 +104,7 @@ class _SayAllHandler:
 			self.startedFromScript = startedFromScript
 		reader = _ObjectsReader(self, obj)
 		self._getActiveSayAll = weakref.ref(reader)
-		reader.next()
+		reader.start()
 
 	def readText(
 		self,
@@ -138,7 +138,7 @@ class _SayAllHandler:
 			log.debugWarning("Unable to make reader", exc_info=True)
 			return
 		self._getActiveSayAll = weakref.ref(reader)
-		reader.next()
+		reader.start()
 
 
 class _Reader(garbageHandler.TrackedObject, metaclass=ABCMeta):
@@ -146,7 +146,12 @@ class _Reader(garbageHandler.TrackedObject, metaclass=ABCMeta):
 
 	def __init__(self, handler: _SayAllHandler):
 		self.handler = handler
+		self._systemIdlePreventionActive = False
+
+	def start(self):
 		systemUtils.preventSystemIdle(persistent=True)
+		self._systemIdlePreventionActive = True
+		self.next()
 
 	@abstractmethod
 	def next(self): ...
@@ -154,6 +159,9 @@ class _Reader(garbageHandler.TrackedObject, metaclass=ABCMeta):
 	@abstractmethod
 	def stop(self):
 		"""Stops the reader."""
+		if not self._systemIdlePreventionActive:
+			return
+		self._systemIdlePreventionActive = False
 		systemUtils.resetThreadExecutionState()
 
 	def __del__(self):

--- a/source/systemUtils.py
+++ b/source/systemUtils.py
@@ -253,6 +253,9 @@ class ExecAndPump(threading.Thread, Generic[_execAndPumpResT]):
 			log.debugWarning("task had errors", exc_info=True)
 
 
+_persistentSystemIdlePreventionRequests = 0
+
+
 def preventSystemIdle(preventDisplayTurningOff: bool | None = None, persistent: bool = False) -> None:
 	"""
 	Prevent the system from locking the screen or going to sleep.
@@ -265,6 +268,9 @@ def preventSystemIdle(preventDisplayTurningOff: bool | None = None, persistent: 
 		import config
 
 		preventDisplayTurningOff = config.conf["general"]["preventDisplayTurningOff"]
+	global _persistentSystemIdlePreventionRequests
+	if persistent:
+		_persistentSystemIdlePreventionRequests += 1
 	winBindings.kernel32.SetThreadExecutionState(
 		winKernel.ES_SYSTEM_REQUIRED
 		| (winKernel.ES_DISPLAY_REQUIRED if preventDisplayTurningOff else 0)
@@ -273,8 +279,12 @@ def preventSystemIdle(preventDisplayTurningOff: bool | None = None, persistent: 
 
 
 def resetThreadExecutionState() -> None:
-	"""Reset the thread execution state to the default."""
-	winBindings.kernel32.SetThreadExecutionState(winKernel.ES_CONTINUOUS)
+	"""Release a persistent system idle prevention request."""
+	global _persistentSystemIdlePreventionRequests
+	if _persistentSystemIdlePreventionRequests:
+		_persistentSystemIdlePreventionRequests -= 1
+	if not _persistentSystemIdlePreventionRequests:
+		winBindings.kernel32.SetThreadExecutionState(winKernel.ES_CONTINUOUS)
 
 
 @contextmanager

--- a/tests/unit/test_braille/test_autoScroll.py
+++ b/tests/unit/test_braille/test_autoScroll.py
@@ -1,0 +1,30 @@
+# A part of NonVisual Desktop Access (NVDA)
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+# Copyright (C) 2026 NV Access Limited
+
+"""Unit tests for braille automatic scrolling."""
+
+import unittest
+from unittest.mock import Mock, patch
+
+from braille.brailleHandler import BrailleHandler
+
+
+class TestAutoScroll(unittest.TestCase):
+	@patch("braille.brailleHandler.systemUtils")
+	@patch("braille.brailleHandler.wx.CallLater")
+	def test_preventsSystemIdleUntilDisabled(self, callLater: Mock, systemUtils: Mock) -> None:
+		handler = Mock()
+		handler.enabled = True
+		handler._autoScrollCallLater = None
+
+		BrailleHandler.autoScroll(handler, enable=True)
+
+		systemUtils.preventSystemIdle.assert_called_once_with(persistent=True)
+
+		handler.enabled = False
+		BrailleHandler.autoScroll(handler, enable=False)
+
+		callLater.return_value.Stop.assert_called_once_with()
+		systemUtils.resetThreadExecutionState.assert_called_once_with()

--- a/tests/unit/test_speechSayAll.py
+++ b/tests/unit/test_speechSayAll.py
@@ -15,7 +15,9 @@ class TestReader(unittest.TestCase):
 	@patch("speech.sayAll.systemUtils.preventSystemIdle")
 	@patch.object(sayAll._CaretTextReader, "getInitialTextInfo", side_effect=NotImplementedError)
 	def test_failedConstructionDoesNotPreventSystemIdle(
-		self, getInitialTextInfo: Mock, preventSystemIdle: Mock
+		self,
+		getInitialTextInfo: Mock,
+		preventSystemIdle: Mock,
 	) -> None:
 		with self.assertRaises(NotImplementedError):
 			sayAll._CaretTextReader(Mock())

--- a/tests/unit/test_speechSayAll.py
+++ b/tests/unit/test_speechSayAll.py
@@ -1,0 +1,23 @@
+# A part of NonVisual Desktop Access (NVDA)
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+# Copyright (C) 2026 NV Access Limited
+
+"""Unit tests for say all."""
+
+import unittest
+from unittest.mock import Mock, patch
+
+from speech import sayAll
+
+
+class TestReader(unittest.TestCase):
+	@patch("speech.sayAll.systemUtils.preventSystemIdle")
+	@patch.object(sayAll._CaretTextReader, "getInitialTextInfo", side_effect=NotImplementedError)
+	def test_failedConstructionDoesNotPreventSystemIdle(
+		self, getInitialTextInfo: Mock, preventSystemIdle: Mock
+	) -> None:
+		with self.assertRaises(NotImplementedError):
+			sayAll._CaretTextReader(Mock())
+
+		preventSystemIdle.assert_not_called()

--- a/tests/unit/test_systemUtils.py
+++ b/tests/unit/test_systemUtils.py
@@ -1,0 +1,29 @@
+# A part of NonVisual Desktop Access (NVDA)
+# This file is covered by the GNU General Public License.
+# See the file COPYING for more details.
+# Copyright (C) 2026 NV Access Limited
+
+"""Unit tests for system utilities."""
+
+import unittest
+from unittest.mock import patch
+
+import systemUtils
+import winKernel
+
+
+class TestPreventSystemIdle(unittest.TestCase):
+	def setUp(self) -> None:
+		systemUtils._persistentSystemIdlePreventionRequests = 0
+
+	@patch("systemUtils.winBindings.kernel32.SetThreadExecutionState")
+	def test_overlappingPersistentRequests(self, setThreadExecutionState) -> None:
+		systemUtils.preventSystemIdle(preventDisplayTurningOff=True, persistent=True)
+		systemUtils.preventSystemIdle(preventDisplayTurningOff=True, persistent=True)
+		setThreadExecutionState.reset_mock()
+
+		systemUtils.resetThreadExecutionState()
+		setThreadExecutionState.assert_not_called()
+
+		systemUtils.resetThreadExecutionState()
+		setThreadExecutionState.assert_called_once_with(winKernel.ES_CONTINUOUS)

--- a/user_docs/en/changes.md
+++ b/user_docs/en/changes.md
@@ -15,6 +15,8 @@
 
 #### Braille
 
+* The "Prevent display from turning off during say all or reading with braille" setting now also applies while braille automatic scrolling is active. (#20790, @cary-rowen)
+
 #### Web browsers
 
 #### Applications


### PR DESCRIPTION
### Link to issue number:
Fixes #20790

### Summary of the issue:
When the "Prevent display from turning off during say all or reading with braille" setting is enabled, braille automatic scrolling does not keep the display awake. The display can therefore turn off after the Windows display timeout while automatic scrolling is active.

### Description of user facing changes:
The setting now also keeps the display awake during braille automatic scrolling. Normal display timeout behavior resumes when automatic scrolling and any other active reading operation have stopped.

### Description of developer facing changes:
Persistent system idle prevention requests are reference-counted so Say All and braille automatic scrolling can overlap without releasing each other's request. Say All now acquires its request when reading starts, avoiding a request being left active if reader construction fails. No public API changes are intended.

### Description of development approach:
Braille automatic scrolling acquires a persistent system idle prevention request when it starts and releases it when it stops or is disabled. `systemUtils` tracks overlapping persistent requests and resets the Windows thread execution state only after the final request is released. Say All uses the same lifecycle while preserving its existing behavior.

### Testing strategy:
Manual testing: Tested with a Focus 40; further testing with additional braille displays is pending.

### Known issues with pull request:
No known implementation issues. Physical-device manual validation is still pending.

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [ ] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [ ] UX of all users considered:
  - Speech
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [ ] API is compatible with existing add-ons.
- [ ] Security precautions taken.
